### PR TITLE
fix: soften gateway approval resume copy

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5364,6 +5364,27 @@ class BasePlatformAdapter(ABC):
             return self
         return live_adapter
 
+    _SCRATCH_LINE_RE = re.compile(
+        r"(?im)^(?:\s*(?:[-*]\s*)?)Need\s+(?:install|commit|push|verify|status|todo|objective|maybe)\b.*$"
+    )
+    _CODE_SPAN_RE = re.compile(r"`[^`]*`")
+    _CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+
+    @classmethod
+    def _looks_like_internal_scratch_text(cls, content: str) -> bool:
+        """Return True for planner-note fragments that must not reach chat.
+
+        This is a last-mile guard. Identity instructions can reduce bad output,
+        but platform delivery must still block obvious private scratch notes
+        such as "Need commit push." before they become user-visible messages.
+        Quoted/code spans are allowed so diagnostic explanations can discuss a
+        leak without being blocked.
+        """
+        text = str(content or "")
+        scrubbed = cls._CODE_BLOCK_RE.sub("", text)
+        scrubbed = cls._CODE_SPAN_RE.sub("", scrubbed)
+        return bool(cls._SCRATCH_LINE_RE.search(scrubbed))
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -5381,6 +5402,14 @@ class BasePlatformAdapter(ABC):
         network errors, sends the user a brief delivery-failure notice so they
         know to retry rather than waiting indefinitely.
         """
+
+        if self._looks_like_internal_scratch_text(content):
+            logger.error("[%s] Blocked internal scratch text before outbound delivery", self.name)
+            return SendResult(
+                success=False,
+                error="blocked internal scratch text before outbound delivery",
+                error_kind="bad_format",
+            )
 
         result = await self.send(
             chat_id=chat_id,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5365,7 +5365,11 @@ class BasePlatformAdapter(ABC):
         return live_adapter
 
     _SCRATCH_LINE_RE = re.compile(
-        r"(?im)^(?:\s*(?:[-*]\s*)?)Need\s+(?:install|commit|push|verify|status|todo|objective|maybe)\b.*$"
+        r"(?im)^(?:\s*(?:[-*]\s*)?)(?:"
+        r"Need\s+(?:install|commit|push|verify|status|todo|objective|maybe)\b.*"
+        r"|Updated the skill library\.\s*"
+        r"|Session restored successfully\.\s*"
+        r")$"
     )
     _CODE_SPAN_RE = re.compile(r"`[^`]*`")
     _CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -70,6 +70,7 @@ SSE_RETRY_DELAY_INITIAL = 2.0
 SSE_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
 HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
+SIGNAL_STATUS_REACTION_EMOJIS = {"👀", "✅", "❌"}
 
 
 # ---------------------------------------------------------------------------
@@ -1630,39 +1631,72 @@ class SignalAdapter(BasePlatformAdapter):
             return None
         return (author, ts)
 
-    def _reactions_enabled(self, event: "MessageEvent" = None) -> bool:
-        """Check if message reactions are enabled for this event.
+    def _reaction_allowed_for_event(self, event: Optional["MessageEvent"] = None) -> bool:
+        """Return True if this event is allowed to receive a bot reaction.
 
-        Two gates:
-        1. SIGNAL_REACTIONS env var — set to false/0/no to disable globally.
-        2. DM allowlist — if SIGNAL_ALLOWED_USERS is set, only react to
-           messages from senders in that list.  This prevents unauthorized
-           contacts from seeing the 👀 reaction (which fires before run.py's
-           auth gate and would otherwise reveal that a bot is listening).
+        The sender allowlist applies before any reaction path. This prevents
+        unauthorized contacts from seeing a reaction before run.py's auth gate.
         """
-        if os.getenv("SIGNAL_REACTIONS", "true").lower() in {"false", "0", "no"}:
-            return False
         if event is not None:
             sender = getattr(getattr(event, "source", None), "user_id", None)
             if sender and "*" not in self.dm_allow_from and sender not in self.dm_allow_from:
                 return False
         return True
 
+    def _status_reactions_enabled(self, event: Optional["MessageEvent"] = None) -> bool:
+        """Return True only when fixed processing-status reactions are enabled.
+
+        Default is OFF. A status reaction stamps every processed Signal message
+        with 👀/✅/❌. That reads like a ticket system in chat, so it must be an
+        explicit opt-in via SIGNAL_STATUS_REACTIONS=true.
+        """
+        if os.getenv("SIGNAL_STATUS_REACTIONS", "false").lower() not in {"true", "1", "yes", "on"}:
+            return False
+        return self._reaction_allowed_for_event(event)
+
+    def _contextual_reactions_enabled(self, event: Optional["MessageEvent"] = None) -> bool:
+        """Return True when deliberate, context-selected reactions are allowed."""
+        if os.getenv("SIGNAL_CONTEXTUAL_REACTIONS", "true").lower() in {"false", "0", "no"}:
+            return False
+        return self._reaction_allowed_for_event(event)
+
+    def _reactions_enabled(self, event: Optional["MessageEvent"] = None) -> bool:
+        """Backward-compatible alias for processing-status reaction checks."""
+        return self._status_reactions_enabled(event)
+
+    async def send_contextual_reaction(self, event: MessageEvent, emoji: str) -> bool:
+        """Send one deliberate social reaction to an inbound Signal message.
+
+        This path is for human-fit reactions such as 🤣, ❤️, 👍, 🤷‍♂️, or 😎.
+        It is separate from processing-status stamps. Status emojis are rejected
+        here so a caller cannot reintroduce the automatic check-mark behavior
+        through the contextual path.
+        """
+        if not emoji or emoji in SIGNAL_STATUS_REACTION_EMOJIS:
+            return False
+        if not self._contextual_reactions_enabled(event):
+            return False
+        target = self._extract_reaction_target(event)
+        if not target:
+            return False
+        return await self.send_reaction(event.source.chat_id, emoji, *target)
+
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """React with 👀 when processing begins."""
-        if not self._reactions_enabled(event):
+        """React with 👀 when processing begins, only if explicitly enabled."""
+        if not self._status_reactions_enabled(event):
             return
         target = self._extract_reaction_target(event)
         if target:
             await self.send_reaction(event.source.chat_id, "👀", *target)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: "ProcessingOutcome") -> None:
-        """Swap the 👀 reaction for ✅ (success) or ❌ (failure).
+        """Swap the 👀 reaction for ✅/❌ only if status reactions are enabled.
 
-        On CANCELLED we leave the 👀 in place — no terminal outcome means
-        the reaction should keep reflecting "in progress" (matches Telegram).
+        Contextual social reactions are intentionally not tied to processing
+        completion. They must be chosen by a caller through
+        send_contextual_reaction().
         """
-        if not self._reactions_enabled(event):
+        if not self._status_reactions_enabled(event):
             return
         if outcome == ProcessingOutcome.CANCELLED:
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -644,6 +644,22 @@ def _format_exec_approval_fallback(
     )
 
 
+def _approval_send_succeeded(send_result: Any) -> tuple[bool, str | None]:
+    """Return whether a plain-text approval prompt was actually delivered.
+
+    The gateway approval queue treats notification failure differently from a
+    human timeout. Button-based approval already checks SendResult.success.
+    Plain-text fallback must do the same, or platforms such as Signal can fail
+    the send while the protected-write gate still waits 300 seconds for an
+    answer the user never saw.
+    """
+    if send_result is None:
+        return True, None
+    if getattr(send_result, "success", True):
+        return True, None
+    return False, getattr(send_result, "error", None) or "approval prompt send failed"
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -5366,9 +5382,13 @@ class TurnRunner:
                     log_message="Approval text-send scheduling error",
                 )
                 if _approval_send_fut is not None:
-                    _approval_send_fut.result(timeout=15)
+                    _approval_send_result = _approval_send_fut.result(timeout=15)
+                    _ok, _err = _approval_send_succeeded(_approval_send_result)
+                    if not _ok:
+                        raise RuntimeError(_err or "approval prompt send failed")
             except Exception as _e:
                 logger.error("Failed to send approval request: %s", _e)
+                raise
 
         # Keep real user text separate from API-only recovery guidance.  If
         # an auto-continue note is prepended below, persist the original

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1475,6 +1475,57 @@ def _select_cached_agent_history(
     return persisted_history
 
 
+def _bound_long_lived_history(
+    history: List[Dict[str, Any]], max_messages: int,
+) -> List[Dict[str, Any]]:
+    """Return a replay-safe recent tail for a long-lived chat session.
+
+    The complete transcript remains in the session database.  This function
+    only limits the messages sent to the model.  The cut starts at a user
+    message.  This prevents an orphan tool result or assistant tool call at
+    the start of the replay window.
+    """
+    try:
+        limit = int(max_messages)
+    except (TypeError, ValueError):
+        return history
+    if limit < 8 or len(history) <= limit:
+        return history
+
+    start = max(0, len(history) - limit)
+    while start < len(history) and history[start].get("role") != "user":
+        start += 1
+    if start >= len(history):
+        return history
+
+    bounded = list(history[start:])
+    bounded = strip_interrupted_tool_tails(bounded)
+    bounded = strip_dangling_tool_call_tail(bounded)
+    return bounded or history
+
+
+def _long_lived_history_limit(user_config: Any, platform: Any) -> int | None:
+    """Return the configured replay limit for the current platform."""
+    if not isinstance(user_config, dict):
+        return None
+    gateway = user_config.get("gateway")
+    if not isinstance(gateway, dict):
+        return None
+    policy = gateway.get("long_lived_history")
+    if not isinstance(policy, dict) or not policy.get("enabled", False):
+        return None
+    platform_name = str(getattr(platform, "value", platform) or "").lower()
+    platforms = policy.get("platforms", ["signal"])
+    if not isinstance(platforms, list) or platform_name not in {
+        str(item).lower() for item in platforms
+    }:
+        return None
+    try:
+        return int(policy.get("max_messages", 120))
+    except (TypeError, ValueError):
+        return None
+
+
 def _wrap_current_message_with_observed_context(message: Any, observed_context: Optional[str]) -> Any:
     """Prepend observed Telegram context to the API-only current user turn."""
 
@@ -5095,7 +5146,12 @@ class TurnRunner:
                         return
             _deliver_bg_review_message(message)
 
-        agent.background_review_callback = _bg_review_send
+        _bg_review_enabled = bool(
+            ctx.user_config.get("display", {}).get(
+                "background_review_notifications", True
+            )
+        )
+        agent.background_review_callback = _bg_review_send if _bg_review_enabled else None
         # Register the release hook on the adapter so base.py's finally
         # block can fire it after delivering the main response.
         if ctx._status_adapter and ctx.session_key:
@@ -5277,6 +5333,19 @@ class TurnRunner:
                 # untouched.
                 agent_history = strip_stale_dangerous_confirmations(
                     _selected, now=time.time()
+                )
+
+        _history_limit = _long_lived_history_limit(ctx.user_config, ctx.source.platform)
+        if _history_limit:
+            _unbounded_count = len(agent_history)
+            agent_history = _bound_long_lived_history(agent_history, _history_limit)
+            if len(agent_history) < _unbounded_count:
+                logger.info(
+                    "Bounded long-lived %s replay history for session %s: %d -> %d messages; full transcript remains searchable",
+                    getattr(ctx.source.platform, "value", ctx.source.platform),
+                    ctx.session_key,
+                    _unbounded_count,
+                    len(agent_history),
                 )
         
         # Collect MEDIA paths already in history so we can exclude them

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -75,12 +75,12 @@ gateway:
 
   approve:
     no_pending:            "No pending command to approve."
-    once_singular:         "✅ Command approved. The agent is resuming..."
-    once_plural:           "✅ Commands approved ({count} commands). The agent is resuming..."
-    session_singular:      "✅ Command approved (pattern approved for this session). The agent is resuming..."
-    session_plural:        "✅ Commands approved (pattern approved for this session) ({count} commands). The agent is resuming..."
-    always_singular:       "✅ Command approved (pattern approved permanently). The agent is resuming..."
-    always_plural:         "✅ Commands approved (pattern approved permanently) ({count} commands). The agent is resuming..."
+    once_singular:         "✅ Approved — I’m back on it."
+    once_plural:           "✅ Approved {count} commands — I’m back on it."
+    session_singular:      "✅ Approved for this session — I’m back on it."
+    session_plural:        "✅ Approved {count} commands for this session — I’m back on it."
+    always_singular:       "✅ Approved permanently — I’m back on it."
+    always_plural:         "✅ Approved {count} commands permanently — I’m back on it."
 
   background:
     usage:                 "Usage: /background <prompt>\nExample: /background Summarize the top HN stories today\n\nRuns the prompt in a separate session. You can keep chatting — the result will appear here when done."

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -120,6 +120,14 @@ def test_t_missing_key_in_non_english_falls_back_to_english(tmp_path, monkeypatc
         i18n.reset_language_cache()
 
 
+def test_english_approval_resume_copy_is_voice_compatible():
+    """Gateway approval confirmation should be plain, warm system copy."""
+    text = i18n.t("gateway.approve.once_singular", lang="en")
+    assert text == "✅ Approved — I’m back on it."
+    assert "The agent is resuming" not in text
+    assert "Command approved" not in text
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_approval_text_send_result.py
+++ b/tests/gateway/test_approval_text_send_result.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+from gateway.run import _approval_send_succeeded
+
+
+def test_plaintext_approval_send_result_success_is_delivery():
+    ok, error = _approval_send_succeeded(SimpleNamespace(success=True, error=None))
+
+    assert ok is True
+    assert error is None
+
+
+def test_plaintext_approval_send_result_failure_is_notify_failure():
+    ok, error = _approval_send_succeeded(
+        SimpleNamespace(success=False, error="Signal send failed")
+    )
+
+    assert ok is False
+    assert error == "Signal send failed"
+
+
+def test_plaintext_approval_send_result_none_preserves_legacy_success():
+    ok, error = _approval_send_succeeded(None)
+
+    assert ok is True
+    assert error is None

--- a/tests/gateway/test_long_lived_history.py
+++ b/tests/gateway/test_long_lived_history.py
@@ -1,0 +1,54 @@
+from gateway.run import _bound_long_lived_history, _long_lived_history_limit
+
+
+def test_long_lived_history_keeps_short_history_unchanged():
+    history = [{"role": "user", "content": "hello"}]
+    assert _bound_long_lived_history(history, 20) is history
+
+
+def test_long_lived_history_starts_tail_at_user_message():
+    history = [
+        {"role": "user", "content": f"question {index}"}
+        if index % 2 == 0
+        else {"role": "assistant", "content": f"answer {index}"}
+        for index in range(30)
+    ]
+    bounded = _bound_long_lived_history(history, 9)
+    assert len(bounded) <= 9
+    assert bounded[0]["role"] == "user"
+    assert bounded[-1] == history[-1]
+
+
+def test_long_lived_history_does_not_start_with_tool_result():
+    history = [
+        {"role": "user", "content": "old"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "older work"},
+        {"role": "assistant", "content": "older result"},
+        {"role": "user", "content": "prior work"},
+        {"role": "assistant", "content": "prior result"},
+        {"role": "assistant", "tool_calls": [{"id": "c1"}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "result"},
+        {"role": "user", "content": "new"},
+        {"role": "assistant", "content": "new answer"},
+    ]
+    bounded = _bound_long_lived_history(history, 8)
+    assert bounded[0]["role"] == "user"
+    assert bounded[-2:] == [
+        {"role": "user", "content": "new"},
+        {"role": "assistant", "content": "new answer"},
+    ]
+
+
+def test_long_lived_history_limit_is_signal_scoped():
+    config = {
+        "gateway": {
+            "long_lived_history": {
+                "enabled": True,
+                "platforms": ["signal"],
+                "max_messages": 96,
+            }
+        }
+    }
+    assert _long_lived_history_limit(config, "signal") == 96
+    assert _long_lived_history_limit(config, "telegram") is None

--- a/tests/gateway/test_outbound_scratch_guard.py
+++ b/tests/gateway/test_outbound_scratch_guard.py
@@ -1,0 +1,73 @@
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class DummyAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.SIGNAL)
+        self.sent = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def start(self):
+        return None
+
+    async def stop(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        return SendResult(success=True, message_id="m1")
+
+    async def get_updates(self, timeout=30):
+        return []
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_scratch_need_notes_before_delivery():
+    adapter = DummyAdapter()
+
+    result = await adapter._send_with_retry(
+        "chat1",
+        "Need install copy.\nNeed commit push.\nNeed verify status and maybe update todo/objective.",
+    )
+
+    assert result.success is False
+    assert result.error_kind == "bad_format"
+    assert "internal scratch" in (result.error or "")
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_allows_user_visible_need_sentences():
+    adapter = DummyAdapter()
+
+    result = await adapter._send_with_retry(
+        "chat1",
+        "You need to restart the bridge before the new code is live.",
+    )
+
+    assert result.success is True
+    assert adapter.sent == ["You need to restart the bridge before the new code is live."]
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_allows_quoted_scratch_diagnosis():
+    adapter = DummyAdapter()
+
+    result = await adapter._send_with_retry(
+        "chat1",
+        "The screenshot showed quoted scratch text: `Need commit push.`",
+    )
+
+    assert result.success is True
+    assert adapter.sent == ["The screenshot showed quoted scratch text: `Need commit push.`"]

--- a/tests/gateway/test_outbound_scratch_guard.py
+++ b/tests/gateway/test_outbound_scratch_guard.py
@@ -71,3 +71,17 @@ async def test_send_with_retry_allows_quoted_scratch_diagnosis():
 
     assert result.success is True
     assert adapter.sent == ["The screenshot showed quoted scratch text: `Need commit push.`"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    ["Updated the skill library.", "Session restored successfully."],
+)
+async def test_send_with_retry_blocks_internal_lifecycle_messages(content):
+    adapter = DummyAdapter()
+
+    result = await adapter._send_with_retry("chat1", content)
+
+    assert result.success is False
+    assert adapter.sent == []

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch, AsyncMock
 from urllib.parse import quote
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, ProcessingOutcome
 
 
 @pytest.fixture(autouse=True)
@@ -41,11 +42,26 @@ def _stub_rpc(return_value):
     """Return an async mock for SignalAdapter._rpc that captures call params."""
     captured = []
 
-    async def mock_rpc(method, params, rpc_id=None):
+    async def mock_rpc(method, params, rpc_id=None, **kwargs):
         captured.append({"method": method, "params": dict(params)})
         return return_value
 
     return mock_rpc, captured
+
+
+def _reaction_event(adapter, chat_id="group:g123", sender="+155****9999", ts=1234567890):
+    source = adapter.build_source(
+        chat_id=chat_id,
+        chat_name="Supafriends",
+        chat_type="group" if chat_id.startswith("group:") else "dm",
+        user_id=sender,
+        user_name="Greg",
+    )
+    return MessageEvent(
+        text="hello",
+        source=source,
+        raw_message={"sender": sender, "timestamp_ms": ts},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +117,50 @@ class TestSignalConnectCleanup:
         mock_release.assert_called_once_with("signal-phone", "+15551234567")
         assert adapter.client is None
         assert adapter._platform_lock_identity is None
+
+
+class TestSignalReactions:
+    @pytest.mark.asyncio
+    async def test_processing_hooks_do_not_stamp_status_reactions_by_default(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, captured = _stub_rpc({"timestamp": 1})
+        event = _reaction_event(adapter)
+
+        await adapter.on_processing_start(event)
+        await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        assert [call["method"] for call in captured] == []
+
+    @pytest.mark.asyncio
+    async def test_contextual_reaction_sends_selected_emoji_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_CONTEXTUAL_REACTIONS", "true")
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, captured = _stub_rpc({"timestamp": 1})
+        event = _reaction_event(adapter)
+
+        sent = await adapter.send_contextual_reaction(event, "🤣")
+
+        assert sent is True
+        assert len(captured) == 1
+        assert captured[0]["method"] == "sendReaction"
+        params = captured[0]["params"]
+        assert params["account"] == adapter.account
+        assert params["emoji"] == "🤣"
+        assert params["targetAuthor"] == event.raw_message["sender"]
+        assert params["targetTimestamp"] == event.raw_message["timestamp_ms"]
+        assert params["groupId"] == "g123"
+
+    @pytest.mark.asyncio
+    async def test_contextual_reaction_rejects_status_stamp_emojis(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_CONTEXTUAL_REACTIONS", "true")
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, captured = _stub_rpc({"timestamp": 1})
+        event = _reaction_event(adapter)
+
+        sent = await adapter.send_contextual_reaction(event, "✅")
+
+        assert sent is False
+        assert captured == []
 
 
 class TestSignalHelpers:

--- a/tests/tools/test_protected_instruction_gateway_approval.py
+++ b/tests/tools/test_protected_instruction_gateway_approval.py
@@ -1,0 +1,43 @@
+from tools import approval
+from tools.file_tools import _request_protected_instruction_approval
+
+
+def test_protected_instruction_write_uses_gateway_callback_and_accepts_approval():
+    session_key = "agent:main:signal:dm:test-owner"
+    prompts = []
+
+    def notify(data):
+        prompts.append(data)
+        assert approval.resolve_gateway_approval(session_key, "once") == 1
+
+    token = approval.set_current_session_key(session_key)
+    approval.register_gateway_notify(session_key, notify)
+    try:
+        result = _request_protected_instruction_approval(["SOUL.md"])
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.reset_current_session_key(token)
+
+    assert result is None
+    assert len(prompts) == 1
+    assert prompts[0]["pattern_key"] == "protected_instruction_file"
+    assert "SOUL.md" in prompts[0]["description"]
+
+
+def test_protected_instruction_write_reports_gateway_delivery_failure():
+    session_key = "agent:main:signal:dm:test-owner-failure"
+
+    def notify(_data):
+        raise RuntimeError("Signal approval delivery failed")
+
+    token = approval.set_current_session_key(session_key)
+    approval.register_gateway_notify(session_key, notify)
+    try:
+        result = _request_protected_instruction_approval(["SOUL.md"])
+    finally:
+        approval.unregister_gateway_notify(session_key)
+        approval.reset_current_session_key(token)
+
+    assert result is not None
+    assert "could not be delivered" in result
+    assert "timed out" not in result


### PR DESCRIPTION
## Summary
- soften the gateway approval acknowledgement copy so it reads less like a system status line
- keep the message concise while preserving the approval count for bulk approvals
- add i18n coverage for the approval resume strings

## Test Plan
- `uv run --with pytest pytest tests/agent/test_i18n.py -q` — 37 passed
