### PR TITLE
fix: drop empty tool_calls arrays on assistant messages (strict providers 400)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3458,7 +3458,14 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    # All calls were duplicate ids — drop the key entirely.
+                    # Setting tool_calls: [] makes strict providers (DeepSeek)
+                    # 400 with "empty array" even though the early sanitizer
+                    # pass already ran.
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()
@@ -3476,6 +3483,28 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # Final pass: dedup can leave assistant messages with tool_calls: [] when
+    # every call in a turn was a duplicate id. Strict providers reject that.
+    final: List[Dict[str, Any]] = []
+    dropped_empty_after_dedup = 0
+    for msg in messages:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and "tool_calls" in msg
+            and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
+        ):
+            msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+            dropped_empty_after_dedup += 1
+        final.append(msg)
+    if dropped_empty_after_dedup:
+        _ra().logger.debug(
+            "Pre-call sanitizer: dropped empty tool_calls on %d assistant "
+            "message(s) after dedup",
+            dropped_empty_after_dedup,
+        )
+        messages = final
     return messages
 
 


### PR DESCRIPTION
## Problem

DeepSeek (and other strict OpenAI-compatible providers) rejects assistant messages carrying `tool_calls: []` with an HTTP 400 (`tool_calls` must be a non-empty array or absent).

This happens in `sanitize_api_messages`: the pre-call sanitizer dedups duplicate `tool_call_id`s across assistant/tool pairs. When **every** tool call in a turn was a duplicate id, the dedup left `tool_calls: []` on the assistant message — and the earlier sanitizer pass that drops empty arrays had already run, so the empty array reached the wire.

## Fix

- When dedup removes all calls from a message, drop the `tool_calls` key entirely instead of leaving `[]`.
- Add a final pass before send that strips any surviving `tool_calls: []` on assistant messages (belt-and-braces for other paths that can produce the same shape).

## Verification

Reproduced locally with DeepSeek as the primary provider: 400 on `tool_calls: []` before the change; long-running sessions with duplicate-id turns proceed cleanly after. Existing sanitizer behavior for non-empty calls is unchanged.