### PR TITLE
fix(approval): block MSYS process substitution on Windows with quote-aware detection

### DIFF
--- a/tests/tools/test_windows_msys_process_substitution.py
+++ b/tests/tools/test_windows_msys_process_substitution.py
@@ -1,0 +1,161 @@
+"""Tests for the Windows-only MSYS process substitution guard.
+
+On Windows git-bash, bash process substitution ``<(cmd)`` / ``>(cmd)``
+expands to ``/dev/fd/N`` — an MSYS pipe handle that native Windows programs
+(python, git, curl, uv, ...) cannot open. The guard in
+``check_all_command_guards`` blocks these commands unconditionally on win32
+(before the yolo / mode=off bypass) and must stay completely inert on POSIX,
+where process substitution is a legitimate, working feature.
+
+v2 (2026-08-09): shell-aware state machine (quotes / comments / escapes).
+Quoted literals, escaped ``\<(``, and comment bodies are DATA, not process
+substitution — v1's bare substring regex false-positived on all three.
+"""
+
+import os
+
+import pytest
+
+import tools.approval as approval_module
+from tools.approval import check_all_command_guards
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Clear approval state and relevant env vars between tests."""
+    approval_module._session_approved.clear()
+    approval_module._pending.clear()
+    approval_module._permanent_approved.clear()
+    saved = {}
+    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION",
+              "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+        if k in os.environ:
+            saved[k] = os.environ.pop(k)
+    yield
+    approval_module._session_approved.clear()
+    approval_module._pending.clear()
+    approval_module._permanent_approved.clear()
+    for k, v in saved.items():
+        os.environ[k] = v
+    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION",
+              "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+        os.environ.pop(k, None)
+
+
+class TestWindowsBlocksProcessSubstitution:
+    """On win32 the guard fires for code-position process substitution."""
+
+    @pytest.fixture(autouse=True)
+    def _force_windows(self, monkeypatch):
+        monkeypatch.setattr(approval_module, "_IS_WINDOWS", True)
+
+    def test_blocks_input_process_substitution(self):
+        # The cst_runtime --args-file <(...) failure class: native consumer
+        # receiving an MSYS pipe handle as a path argument.
+        result = check_all_command_guards("python x.py <(cat a)", "local")
+        assert result["approved"] is False
+        assert "MSYS process substitution" in result["message"]
+        # Message must teach the L0 R1 alternative (write a real file).
+        assert "mktemp" in result["message"] or "write_file" in result["message"]
+
+    def test_blocks_output_process_substitution(self):
+        result = check_all_command_guards("diff >(sort b) other.txt", "local")
+        assert result["approved"] is False
+
+    def test_blocks_dev_fd_reference(self):
+        result = check_all_command_guards("grep -l pattern /dev/fd/63", "local")
+        assert result["approved"] is False
+
+    def test_blocks_nested_mid_argument(self):
+        # Not just at command position: nested mid-argument is also doomed.
+        result = check_all_command_guards(
+            "cst_runtime --args-file <(cat /tmp/x.json)", "local")
+        assert result["approved"] is False
+
+    def test_blocks_after_command_separator(self):
+        result = check_all_command_guards("ls; python x.py <(cat a)", "local")
+        assert result["approved"] is False
+
+    def test_blocks_parameter_expansion_default(self):
+        # ${x:-<(a)} genuinely executes process substitution in bash — the
+        # state machine has no way to know x is unset, so this stays blocked.
+        result = check_all_command_guards("echo ${x:-<(a)}", "local")
+        assert result["approved"] is False
+
+    def test_blocks_standalone_output_substitution_word(self):
+        # Bare >(b) with no quotes is a real output process substitution.
+        result = check_all_command_guards("echo a >(b)", "local")
+        assert result["approved"] is False
+
+    def test_blocks_even_when_yolo_frozen(self):
+        # Like the hardline floor: a structurally doomed command is not a
+        # risk trade-off the user opted into, so yolo cannot bypass it.
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+        try:
+            result = check_all_command_guards("python x.py <(cat a)", "local")
+        finally:
+            monkeypatch.undo()
+        assert result["approved"] is False
+
+    def test_allows_plain_input_redirection(self):
+        # `< file` (no paren) is ordinary redirection — must not be caught.
+        result = check_all_command_guards("python x.py < input.txt", "local")
+        assert result["approved"] is True
+
+    def test_allows_normal_commands(self):
+        result = check_all_command_guards("ls -la", "local")
+        assert result["approved"] is True
+
+    def test_allows_windows_native_flags(self):
+        # #56700 regression: tasklist /FO must stay untouched.
+        result = check_all_command_guards("tasklist /FO CSV", "local")
+        assert result["approved"] is True
+
+
+class TestWindowsAllowsLiteralData:
+    """Quoted / escaped / comment occurrences are DATA, not process substitution (v2)."""
+
+    @pytest.fixture(autouse=True)
+    def _force_windows(self, monkeypatch):
+        monkeypatch.setattr(approval_module, "_IS_WINDOWS", True)
+
+    def test_allows_double_quoted_literal(self):
+        result = check_all_command_guards('echo "literal <( text"', "local")
+        assert result["approved"] is True
+
+    def test_allows_single_quoted_grep_pattern(self):
+        result = check_all_command_guards("grep '<(' file.txt", "local")
+        assert result["approved"] is True
+
+    def test_allows_escaped_literal(self):
+        # v1 blocked `\<(` — wrong: bash treats the backslash-escaped <( as
+        # a literal. v2 correctly allows it (escape consumed before match).
+        result = check_all_command_guards(r"python x.py \<(cat a)", "local")
+        assert result["approved"] is True
+
+    def test_allows_comment_occurrence(self):
+        result = check_all_command_guards(
+            "# comment with <( here\necho ok", "local")
+        assert result["approved"] is True
+
+    def test_allows_piped_single_quoted_pattern(self):
+        result = check_all_command_guards("echo hi | grep '<('", "local")
+        assert result["approved"] is True
+
+
+class TestPosixUnaffected:
+    """On POSIX the guard must be completely inert."""
+
+    @pytest.fixture(autouse=True)
+    def _force_posix(self, monkeypatch):
+        monkeypatch.setattr(approval_module, "_IS_WINDOWS", False)
+
+    def test_process_substitution_allowed_on_posix(self):
+        # On Linux <(...) is a legitimate feature — never blocked.
+        result = check_all_command_guards("diff <(sort a) <(sort b)", "local")
+        assert result["approved"] is True
+
+    def test_dev_fd_reference_allowed_on_posix(self):
+        result = check_all_command_guards("grep -l pattern /dev/fd/63", "local")
+        assert result["approved"] is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -35,6 +35,10 @@ logger = logging.getLogger(__name__)
 # instantly bypass all approval checks — a prompt-injection escalation path.
 _YOLO_MODE_FROZEN: bool = is_truthy_value(os.getenv("HERMES_YOLO_MODE", ""))
 
+# Platform gate for the Windows-only MSYS process-substitution guard. Read at
+# import time; a process does not change platform mid-flight.
+_IS_WINDOWS: bool = sys.platform == "win32"
+
 # Per-thread/per-task gateway session identity.
 # Gateway runs agent turns concurrently in executor threads, so reading a
 # process-global env var for session identity is racy. Keep env fallback for
@@ -515,6 +519,105 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     if _SUDO_STDIN_RE.search(normalized):
         return (True, "sudo password guessing via stdin (sudo -S)")
     return (False, None)
+
+
+# ---------------------------------------------------------------------------
+# MSYS process substitution guard (Windows-only, unconditional)
+# ---------------------------------------------------------------------------
+# On Windows git-bash, bash process substitution ``<(cmd)`` / ``>(cmd)``
+# expands to ``/dev/fd/N`` — an MSYS pipe handle. Native Windows programs
+# (python, git, curl, uv, …) have NO access to that handle and fail with
+# "file not found", even with MSYS_NO_PATHCONV / MSYS2_ARG_CONV_EXCL fully
+# configured: the fd object does not cross the process boundary, so no path
+# conversion can rescue it (the same structural dead end as #56700/#56147 —
+# see hermes-troubleshooting MSYS section). This is a command class that is
+# GUARANTEED to fail on Windows, so like the hardline/sudo-stdin floors it
+# fires BEFORE the yolo / mode=off bypass: letting it through is not a risk
+# trade-off, it just re-produces the same confusing "file not found" error.
+#
+# v1 was a bare substring regex and false-positived on quoted literals
+# (echo "<( text"), single-quoted grep patterns, comments, and backslash
+# escapes — all legitimate data, not process substitution. v2 scans the RAW
+# command (before _normalize_command_for_detection, whose backslash-strip
+# would corrupt quote state — same lesson as upstream d127fb219) with a
+# shell-aware state machine: single quotes are literal, double quotes honour
+# backslash escapes, a ``#`` at a word boundary starts a comment to end of
+# line, and a backslash outside quotes escapes the next character. Only
+# code-position occurrences of ``<(``, ``>(``, ``/dev/fd/`` count.
+#
+# Known limitation (accepted): MSYS-to-MSYS process substitution (diff
+# <(a) <(b) where every consumer is an MSYS program) actually works on
+# git-bash, but the guard blocks it too — determining whether a consumer is
+# native vs MSYS needs an unbounded whitelist, and agent commands almost
+# always feed native programs, so the block is kept wholesale and the block
+# message teaches the always-available rewrite (pipe / real file).
+def _find_msys_process_substitution(command: str) -> bool:
+    """Return True if ``command`` contains code-position process substitution."""
+    cmd = command.lower()
+    n = len(cmd)
+    i = 0
+    quote: str | None = None  # None | "'" | '"'
+    while i < n:
+        ch = cmd[i]
+        if quote == "'":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == '"':
+                quote = None
+            i += 1
+            continue
+        # Unquoted code position.
+        if ch == "\\":
+            i += 2  # backslash escapes the next char (literal)
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "#" and (i == 0 or cmd[i - 1] in " \t\n;|&("):
+            nl = cmd.find("\n", i)
+            i = n if nl == -1 else nl + 1
+            continue
+        if cmd.startswith("<(", i) or cmd.startswith(">(", i) \
+                or cmd.startswith("/dev/fd/", i):
+            return True
+        i += 1
+    return False
+
+
+def _check_msys_process_substitution(command: str) -> tuple:
+    """Detect bash process substitution syntax on Windows/MSYS hosts.
+
+    Returns:
+        (is_blocked: bool, description: str | None)
+    """
+    if not _IS_WINDOWS:
+        return (False, None)
+    if _find_msys_process_substitution(command):
+        return (True, "bash process substitution (<(...), >(...), /dev/fd/)")
+    return (False, None)
+
+
+def _msys_process_substitution_block_result(description: str) -> dict:
+    """Build the standard block result for the MSYS process substitution guard."""
+    return {
+        "approved": False,
+        "message": (
+            f"BLOCKED (MSYS process substitution): {description}. On Windows "
+            "this syntax expands to /dev/fd/N — an MSYS pipe handle that "
+            "native programs (python, git, curl, uv, …) cannot open, so the "
+            "command cannot succeed. Write the data to a real file first "
+            "(write_file / mktemp) and pass its path, or restructure with a "
+            "pipe. This block is not a security risk — it is a command class "
+            "that is structurally broken on Windows and cannot be bypassed."
+        ),
+    }
 
 
 def detect_hardline_command(command: str) -> tuple:
@@ -3769,6 +3872,16 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("Sudo stdin guard block: %s (command: %s)",
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
+
+    # == MSYS process substitution guard (Windows-only) ==
+    # `<(...)`/`>(...)`/`/dev/fd/` expand to MSYS pipe handles that native
+    # Windows programs cannot open — the command is structurally doomed, so
+    # like the hardline floor this fires BEFORE the yolo / mode=off bypass.
+    is_msys_psub, msys_psub_desc = _check_msys_process_substitution(command)
+    if is_msys_psub:
+        logger.warning("MSYS process substitution block: %s (command: %s)",
+                       msys_psub_desc, command[:200])
+        return _msys_process_substitution_block_result(msys_psub_desc)
 
     # User-defined deny rules (approvals.deny in config.yaml): like the
     # hardline floor, these fire BEFORE the yolo / mode=off bypass — a deny


### PR DESCRIPTION
## What does this PR do?

On Windows git-bash, bash process substitution (`<(cmd)` / `>(cmd)`) expands to `/dev/fd/N` — an MSYS pipe handle that **native Windows programs** (python, git, curl, uv, ...) cannot open. Any command feeding such a handle to a native consumer fails with "file not found" regardless of path-conversion settings: the fd object does not cross the process boundary, so no argv conversion can rescue it. `#56700`/`#56147` cover the argv-conversion dead end; this closes the process-substitution failure class structurally.

The guard is **Windows-only**, **unconditional** (fires before the yolo / mode=off bypass — a structurally doomed command is not a risk trade-off), and **shell-aware**:

- single quotes are literal
- double quotes honour backslash escapes
- `#` at a word boundary starts a comment
- unquoted backslash escapes the next character

Quoted literals, comments, and escaped `\<(` are DATA, not process substitution — a bare substring regex (v1, discarded) false-positived on all three. `${x:-<(a)}` stays blocked because bash genuinely executes the substitution there.

## Related Issue

No open issue covers this exact class (the existing `#280` pattern only guards `<(curl|wget)` remote-execution vectors). This PR fixes the sibling failure class behind `#56700`/`#56147` on the approval-guard path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py` — new `_find_msys_process_substitution()` shell-aware state machine + `_check_msys_process_substitution()` + block result, wired into `check_all_command_guards()` between the sudo-stdin floor and the user-deny rules (i.e. before the yolo / mode=off bypass, like the hardline floor).
- `tests/tools/test_windows_msys_process_substitution.py` — 18 cases: block (input/output substitution, `/dev/fd` references, nested mid-argument, after command separators, parameter-expansion defaults, yolo-frozen), allow (double/single-quoted literals, comment bodies, escaped `\<(`, plain `< file` redirection, `tasklist /FO` #56700 regression), POSIX-inert.

## How to Test

1. `pytest tests/tools/test_windows_msys_process_substitution.py` → 18/18 pass on win32.
2. Guard chain regression: `test_command_guards.py`, `test_subprocess_stdin_guard.py`, `test_cron_approval_mode.py` → green (one pre-existing platform-fixed failure in `test_subprocess_stdin_guard.py::test_all_tui_subprocess_calls_have_stdin` — scans bundled plugin teaching examples, unrelated to this change; fails identically without the patch).
3. Manual on Windows: `python x.py <(cat a)` → BLOCKED with a message teaching the rewrite (write_file/mktemp real file or pipe). `echo "literal <( text"` → allowed (v2 quote awareness).

## Known limitations (documented in code)

- **MSYS-to-MSYS process substitution** (all consumers MSYS programs, e.g. `diff <(a) <(b)`) actually works on git-bash but is blocked wholesale: distinguishing native vs MSYS consumers needs an unbounded whitelist, and agent commands almost always feed native programs — block + teach-the-rewrite is the pragmatic trade-off.
- **heredoc bodies** containing `<(` are false-positived (rare; heredocs for complex inline payloads are discouraged anyway).
- **`"$(...)"`-nested process substitution** is missed (the state machine skips double-quoted regions) — pathological shape, accepted.

## Checklist

- [x] I have read the CONTRIBUTING guide and searched for prior duplicates
- [x] My code follows the project's style and lint passes
- [x] I have added tests that prove my fix is effective and that it works on Windows
- [x] I have documented the known limitations in code comments
