### PR TITLE
fix(sessions): wait on compression lease before appending

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3137,8 +3137,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._conn.execute("BEGIN IMMEDIATE")
                     try:
                         if compression_error is not None:
-                            self._check_observed_compression_lock_resolved(
-                                self._conn, compression_error
+                            self._check_or_reclaim_foreign_compression_lock(
+                                self._conn,
+                                compression_error.session_id,
+                                compression_lock_holder=None,
                             )
                         result = fn(self._conn)
                         self._conn.commit()
@@ -3161,7 +3163,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # seconds the original retry assumed (#77386). The lock row's
                 # expires_at is the authoritative correctness boundary. Follow
                 # same-holder lease refreshes up to a bounded total wait; never
-                # cross to a different owner or append after the lease expires.
+                # cross to a different owner. At expiry, the retry transaction
+                # atomically deletes the stale row before admitting the append,
+                # so the old holder cannot revive and publish its old snapshot.
                 now_monotonic = time.monotonic()
                 if compression_wait_started is None:
                     compression_wait_started = now_monotonic
@@ -3176,10 +3180,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if exc.expires_at is not None:
                     lease_remaining = max(0.0, exc.expires_at - time.time())
                     if lease_remaining <= 0.0:
-                        # The row still exists but its lease is expired. Its
-                        # holder may revive it, so this append cannot safely
-                        # proceed or fall back to a fresh fixed wait.
-                        raise
+                        # Re-enter the write transaction once so the expiry is
+                        # resolved atomically: either refresh already won and
+                        # the live lease blocks, or this writer deletes the
+                        # expired row before appending.
+                        continue
                     candidate_deadline = now_monotonic + lease_remaining
                 else:
                     candidate_deadline = (
@@ -7016,21 +7021,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (this guard has already needed targeted fixes — see the #74478
         patience note below).
         """
-        active_lock = conn.execute(
-            "SELECT holder, expires_at FROM compression_locks "
-            "WHERE session_id = ? AND expires_at > ?",
-            (session_id, time.time()),
-        ).fetchone()
-        if (
-            active_lock is not None
-            and active_lock["holder"] != compression_lock_holder
-        ):
-            raise SessionCompressionInProgressError(
-                f"Session {session_id!r} is being compressed by another writer",
-                session_id=session_id,
-                holder=active_lock["holder"],
-                expires_at=float(active_lock["expires_at"]),
-            )
+        self._check_or_reclaim_foreign_compression_lock(
+            conn,
+            session_id,
+            compression_lock_holder=compression_lock_holder,
+        )
         session = conn.execute(
             "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
             (session_id,),
@@ -7043,31 +7038,42 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             raise CompressionSessionClosedError(session_id)
 
     @staticmethod
-    def _check_observed_compression_lock_resolved(
+    def _check_or_reclaim_foreign_compression_lock(
         conn,
-        observed: SessionCompressionInProgressError,
+        session_id: Optional[str],
+        compression_lock_holder: Optional[str],
     ) -> None:
-        """Fence a waited append against an expired-but-revivable lease row.
+        """Block a live foreign lease or atomically invalidate an expired one.
 
-        This runs inside the same ``BEGIN IMMEDIATE`` transaction as the
-        eventual append. A deleted row means the compressor explicitly
-        released its lease and the write may proceed. Any row that remains —
-        even an expired one — still belongs to a holder that can refresh and
-        publish its old snapshot, so the append must remain blocked.
+        This runs inside the same ``BEGIN IMMEDIATE`` transaction as the append.
+        When the foreign lease is expired, deleting its row and appending are
+        one serialized operation: the old holder's later refresh matches no
+        row, and publication fails closed. If refresh wins first, this query
+        sees the extended live lease and blocks instead.
         """
-        if observed.session_id is None:
+        if session_id is None:
             return
         row = conn.execute(
             "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
-            (observed.session_id,),
+            (session_id,),
         ).fetchone()
-        if row is None:
+        if row is None or row["holder"] == compression_lock_holder:
             return
+        expires_at = float(row["expires_at"])
+        now = time.time()
+        if expires_at <= now:
+            deleted = conn.execute(
+                "DELETE FROM compression_locks "
+                "WHERE session_id = ? AND holder = ? AND expires_at <= ?",
+                (session_id, row["holder"], now),
+            )
+            if deleted.rowcount == 1:
+                return
         raise SessionCompressionInProgressError(
-            f"Session {observed.session_id!r} is being compressed by another writer",
-            session_id=observed.session_id,
+            f"Session {session_id!r} is being compressed by another writer",
+            session_id=session_id,
             holder=row["holder"],
-            expires_at=float(row["expires_at"]),
+            expires_at=expires_at,
         )
 
     @staticmethod

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3120,6 +3120,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         compression_deadline: Optional[float] = None
         compression_holder: Optional[str] = None
         compression_error: Optional[SessionCompressionInProgressError] = None
+        sqlite_deadline_needs_rearm = False
 
         # Transient engine-level error observed on contended WAL appends
         # (dual gateway/agent writers; FTS5 trigram sync holds the write
@@ -3177,6 +3178,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     raise
 
                 compression_error = exc
+                # Compression has an independent lease-aware wait budget. Do
+                # not let that wait consume the ordinary SQLite contention
+                # budget needed once the lease boundary is reached.
+                sqlite_deadline_needs_rearm = True
                 if exc.expires_at is not None:
                     lease_remaining = max(0.0, exc.expires_at - time.time())
                     if lease_remaining <= 0.0:
@@ -3211,6 +3216,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             except sqlite3.OperationalError as exc:
                 err_msg = str(exc).lower()
                 if "locked" in err_msg or "busy" in err_msg:
+                    if sqlite_deadline_needs_rearm:
+                        deadline = time.monotonic() + patience_s
+                        sqlite_deadline_needs_rearm = False
                     if self._sleep_before_write_retry(deadline, patience_s):
                         continue
                     # Patience exhausted — say what actually happened so the
@@ -7050,8 +7058,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         one serialized operation: the old holder's later refresh matches no
         row, and publication fails closed. If refresh wins first, this query
         sees the extended live lease and blocks instead. Holder-qualified
-        compressor writes additionally require their own live row; a stale
-        owner cannot flush into the parent after another writer invalidates it.
+        compressor writes require their own row, but may flush while that row
+        is expired: owner-first flush remains serialized before a later refresh
+        and publication, while writer-first invalidation removes the row and
+        makes the stale owner fail closed.
         """
         if session_id is None:
             return
@@ -7064,7 +7074,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if (
                 row is None
                 or row["holder"] != compression_lock_holder
-                or float(row["expires_at"]) <= now
             ):
                 raise CompressionSessionBusyError(
                     f"Compression lease lost before transcript append: {session_id}"

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3132,6 +3132,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         def _is_no_more_rows(exc: sqlite3.Error) -> bool:
             return "no more rows available" in str(exc).lower()
 
+        def _sqlite_retry_deadline() -> float:
+            """Return the ordinary contention deadline, re-armed once if needed."""
+            nonlocal deadline, sqlite_deadline_needs_rearm
+            if sqlite_deadline_needs_rearm:
+                deadline = time.monotonic() + patience_s
+                sqlite_deadline_needs_rearm = False
+            return deadline
+
         while True:
             try:
                 with self._lock:
@@ -3216,10 +3224,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             except sqlite3.OperationalError as exc:
                 err_msg = str(exc).lower()
                 if "locked" in err_msg or "busy" in err_msg:
-                    if sqlite_deadline_needs_rearm:
-                        deadline = time.monotonic() + patience_s
-                        sqlite_deadline_needs_rearm = False
-                    if self._sleep_before_write_retry(deadline, patience_s):
+                    if self._sleep_before_write_retry(
+                        _sqlite_retry_deadline(), patience_s
+                    ):
                         continue
                     # Patience exhausted — say what actually happened so the
                     # surfaced error doesn't read as disk/permission damage.
@@ -3230,12 +3237,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         "a large WAL checkpoint, or an older pre-update "
                         "process; the database itself is healthy)"
                     ) from exc
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_no_more_rows(exc) and self._sleep_before_write_retry(
+                    _sqlite_retry_deadline(), patience_s
+                ):
                     continue
                 # Non-lock error or patience exhausted — propagate.
                 raise
             except sqlite3.DatabaseError as exc:
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_no_more_rows(exc) and self._sleep_before_write_retry(
+                    _sqlite_retry_deadline(), patience_s
+                ):
                     continue
                 # Corrupt FTS shadow tables make every write raise the
                 # malformed/corrupt error class through the FTS sync triggers
@@ -3255,7 +3266,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # subclass) or another sqlite3.Error class outside the two
                 # handlers above. Message-scoped: anything else propagates
                 # untouched.
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_no_more_rows(exc) and self._sleep_before_write_retry(
+                    _sqlite_retry_deadline(), patience_s
+                ):
                     continue
                 raise
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2025,6 +2025,18 @@ class SessionCompressionInProgressError(CompressionSessionBusyError):
     handler working unchanged.
     """
 
+    def __init__(
+        self,
+        *args,
+        session_id: Optional[str] = None,
+        holder: Optional[str] = None,
+        expires_at: Optional[float] = None,
+    ) -> None:
+        self.session_id = session_id
+        self.holder = holder
+        self.expires_at = expires_at
+        super().__init__(*args)
+
 
 def _connect_tracked_db(path, tracking_path=None, **kwargs):
     """``sqlite3.connect`` that registers the open fd for lock-safety.
@@ -2436,15 +2448,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # wait out the full routine patience under contention. Sub-second budget;
     # a skipped write is retried naturally at the next heartbeat window.
     _ACTIVITY_WRITE_PATIENCE_S = 0.5
-    # A live compression lock gets its own, much shorter budget than the write
-    # lock. Compression publishes in a couple of seconds, so a brief wait saves
-    # the overwhelming majority of concurrent turns (#75083). It deliberately
-    # stays short: the lease is a correctness boundary, not just a busy signal
-    # (see test_compression_lease_blocks_non_owner_but_allows_owner_flush), so
-    # a writer that is still locked out after this budget must still be
-    # refused rather than allowed to land a stale turn in a session whose
-    # compression is genuinely long-running or wedged.
+    # A live compression lock carries the correctness boundary writers need:
+    # its durable ``expires_at`` lease. Wait against that lease instead of the
+    # old fixed five-second assumption — healthy LLM-streamed compressions can
+    # run for minutes (#77386). The fixed budget remains only as a compatibility
+    # fallback for an exception produced without lease metadata.
     _COMPRESSION_BUSY_WAIT_S = 5.0
+    # A live holder can refresh its lease while compression is making progress.
+    # Follow same-holder refreshes, but never wait forever for a wedged worker.
+    # This matches the default compression total ceiling.
+    _COMPRESSION_BUSY_WAIT_MAX_S = 600.0
     _WRITE_RETRY_MIN_S = 0.020   # 20ms
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     _WRITE_RETRY_SLOW_AFTER_S = 2.0
@@ -3100,9 +3113,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if patience_s is None:
             patience_s = self._WRITE_PATIENCE_S
         deadline = time.monotonic() + patience_s
-        # Set on the first compression-busy collision so the short wait is
-        # measured from then, not from the start of the write.
+        # Set on the first compression-busy collision. A live holder may refresh
+        # its lease, but the total wait stays bounded from this first collision.
+        compression_wait_started: Optional[float] = None
+        compression_max_deadline: Optional[float] = None
         compression_deadline: Optional[float] = None
+        compression_holder: Optional[str] = None
+        compression_error: Optional[SessionCompressionInProgressError] = None
 
         # Transient engine-level error observed on contended WAL appends
         # (dual gateway/agent writers; FTS5 trigram sync holds the write
@@ -3119,6 +3136,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 with self._lock:
                     self._conn.execute("BEGIN IMMEDIATE")
                     try:
+                        if compression_error is not None:
+                            self._check_observed_compression_lock_resolved(
+                                self._conn, compression_error
+                            )
                         result = fn(self._conn)
                         self._conn.commit()
                     except BaseException:
@@ -3134,24 +3155,51 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if self._write_count % self._FTS_MERGE_EVERY_N_WRITES == 0:
                     self._try_incremental_merge_fts()
                 return result
-            except SessionCompressionInProgressError:
-                # A live foreign compression lock is transient: the compressor
-                # publishes in a couple of seconds. Without any wait, a steer
-                # that lands mid-compression aborts the user's turn as
-                # session_persistence_failed and sends the operator hunting
-                # disk space that was never the problem (#75083).
-                #
-                # The budget is _COMPRESSION_BUSY_WAIT_S, not the write-lock
-                # patience: the lease is a correctness boundary, so a writer
-                # still locked out after a short wait must be refused rather
-                # than left to land a stale turn once a long-running or wedged
-                # compression finally lets go.
-                if compression_deadline is None:
-                    compression_deadline = min(
-                        time.monotonic() + self._COMPRESSION_BUSY_WAIT_S, deadline
+            except SessionCompressionInProgressError as exc:
+                # A live foreign compression lock is transient, but real
+                # LLM-streamed compression takes minutes rather than the five
+                # seconds the original retry assumed (#77386). The lock row's
+                # expires_at is the authoritative correctness boundary. Follow
+                # same-holder lease refreshes up to a bounded total wait; never
+                # cross to a different owner or append after the lease expires.
+                now_monotonic = time.monotonic()
+                if compression_wait_started is None:
+                    compression_wait_started = now_monotonic
+                    compression_max_deadline = (
+                        now_monotonic + self._COMPRESSION_BUSY_WAIT_MAX_S
                     )
+                    compression_holder = exc.holder
+                elif exc.holder != compression_holder:
+                    raise
+
+                compression_error = exc
+                if exc.expires_at is not None:
+                    lease_remaining = max(0.0, exc.expires_at - time.time())
+                    if lease_remaining <= 0.0:
+                        # The row still exists but its lease is expired. Its
+                        # holder may revive it, so this append cannot safely
+                        # proceed or fall back to a fresh fixed wait.
+                        raise
+                    candidate_deadline = now_monotonic + lease_remaining
+                else:
+                    candidate_deadline = (
+                        now_monotonic + self._COMPRESSION_BUSY_WAIT_S
+                    )
+                assert compression_max_deadline is not None
+                candidate_deadline = min(
+                    candidate_deadline, compression_max_deadline
+                )
+                # Follow both extensions and contractions. Keeping a cached
+                # later deadline after the holder shortens its lease would let
+                # this writer append after the durable row expires, while the
+                # holder can still revive and publish a stale snapshot.
+                compression_deadline = candidate_deadline
+                compression_patience = max(
+                    compression_deadline - compression_wait_started,
+                    0.001,
+                )
                 if self._sleep_before_write_retry(
-                    compression_deadline, self._COMPRESSION_BUSY_WAIT_S
+                    compression_deadline, compression_patience
                 ):
                     continue
                 raise
@@ -6969,7 +7017,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         patience note below).
         """
         active_lock = conn.execute(
-            "SELECT holder FROM compression_locks "
+            "SELECT holder, expires_at FROM compression_locks "
             "WHERE session_id = ? AND expires_at > ?",
             (session_id, time.time()),
         ).fetchone()
@@ -6978,7 +7026,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             and active_lock["holder"] != compression_lock_holder
         ):
             raise SessionCompressionInProgressError(
-                f"Session {session_id!r} is being compressed by another writer"
+                f"Session {session_id!r} is being compressed by another writer",
+                session_id=session_id,
+                holder=active_lock["holder"],
+                expires_at=float(active_lock["expires_at"]),
             )
         session = conn.execute(
             "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
@@ -6990,6 +7041,34 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             and session["end_reason"] == "compression"
         ):
             raise CompressionSessionClosedError(session_id)
+
+    @staticmethod
+    def _check_observed_compression_lock_resolved(
+        conn,
+        observed: SessionCompressionInProgressError,
+    ) -> None:
+        """Fence a waited append against an expired-but-revivable lease row.
+
+        This runs inside the same ``BEGIN IMMEDIATE`` transaction as the
+        eventual append. A deleted row means the compressor explicitly
+        released its lease and the write may proceed. Any row that remains —
+        even an expired one — still belongs to a holder that can refresh and
+        publish its old snapshot, so the append must remain blocked.
+        """
+        if observed.session_id is None:
+            return
+        row = conn.execute(
+            "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
+            (observed.session_id,),
+        ).fetchone()
+        if row is None:
+            return
+        raise SessionCompressionInProgressError(
+            f"Session {observed.session_id!r} is being compressed by another writer",
+            session_id=observed.session_id,
+            holder=row["holder"],
+            expires_at=float(row["expires_at"]),
+        )
 
     @staticmethod
     def _decode_display_metadata(raw: Any) -> Optional[Dict[str, Any]]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7049,7 +7049,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         When the foreign lease is expired, deleting its row and appending are
         one serialized operation: the old holder's later refresh matches no
         row, and publication fails closed. If refresh wins first, this query
-        sees the extended live lease and blocks instead.
+        sees the extended live lease and blocks instead. Holder-qualified
+        compressor writes additionally require their own live row; a stale
+        owner cannot flush into the parent after another writer invalidates it.
         """
         if session_id is None:
             return
@@ -7057,10 +7059,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
             (session_id,),
         ).fetchone()
-        if row is None or row["holder"] == compression_lock_holder:
+        now = time.time()
+        if compression_lock_holder is not None:
+            if (
+                row is None
+                or row["holder"] != compression_lock_holder
+                or float(row["expires_at"]) <= now
+            ):
+                raise CompressionSessionBusyError(
+                    f"Compression lease lost before transcript append: {session_id}"
+                )
+            return
+        if row is None:
             return
         expires_at = float(row["expires_at"])
-        now = time.time()
         if expires_at <= now:
             deleted = conn.execute(
                 "DELETE FROM compression_locks "

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -282,7 +282,9 @@ def test_publish_compression_child_rejects_lost_or_expired_lease(db: SessionDB) 
 
 def test_compression_lease_blocks_non_owner_but_allows_owner_flush(
     db: SessionDB,
+    monkeypatch,
 ) -> None:
+    monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 0.0)
     db.create_session("leased", source="webui")
     assert db.try_acquire_compression_lock("leased", "winner", ttl_seconds=60)
 

--- a/tests/test_hermes_state_compression_busy_retry.py
+++ b/tests/test_hermes_state_compression_busy_retry.py
@@ -170,6 +170,13 @@ def test_fresh_retry_invalidates_expired_row_before_appending(
     db.append_message("sess1", role="user", content="fresh retry")
 
     assert db.refresh_compression_lock("sess1", "compressor") is False
+    with pytest.raises(CompressionSessionBusyError, match="lease lost"):
+        db.append_message(
+            "sess1",
+            role="assistant",
+            content="stale owner flush",
+            compression_lock_holder="compressor",
+        )
     with pytest.raises(CompressionSessionBusyError):
         db.publish_compression_child(
             parent_session_id="sess1",
@@ -179,6 +186,9 @@ def test_fresh_retry_invalidates_expired_row_before_appending(
             compression_lock_holder="compressor",
         )
     assert db.get_session("stale-child") is None
+    assert all(
+        row["content"] != "stale owner flush" for row in db.get_messages("sess1")
+    )
     assert any(
         row["content"] == "fresh retry" for row in db.get_messages("sess1")
     )

--- a/tests/test_hermes_state_compression_busy_retry.py
+++ b/tests/test_hermes_state_compression_busy_retry.py
@@ -15,6 +15,7 @@ and must still fail fast rather than spin out the whole budget.
 
 from __future__ import annotations
 
+import sqlite3
 import threading
 import time
 from pathlib import Path
@@ -191,6 +192,99 @@ def test_fresh_retry_invalidates_expired_row_before_appending(
     )
     assert any(
         row["content"] == "fresh retry" for row in db.get_messages("sess1")
+    )
+
+
+def test_expired_owner_flushes_before_refresh_and_publication(db: SessionDB) -> None:
+    """Owner-first keeps the row, so its exact current turn is not omitted."""
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=0.1
+    ) is True
+    time.sleep(0.12)
+
+    db.append_message(
+        "sess1",
+        role="assistant",
+        content="current turn",
+        compression_lock_holder="compressor",
+    )
+    assert db.refresh_compression_lock(
+        "sess1", "compressor", ttl_seconds=1.0
+    ) is True
+    db.publish_compression_child(
+        parent_session_id="sess1",
+        child_session_id="child1",
+        source="test",
+        messages=[{"role": "assistant", "content": "summary"}],
+        compression_lock_holder="compressor",
+    )
+
+    parent = db.get_session("sess1")
+    assert parent is not None
+    assert parent["end_reason"] == "compression"
+    assert [row["content"] for row in db.get_messages("sess1")] == [
+        "current turn"
+    ]
+    assert [row["content"] for row in db.get_messages("child1")] == ["summary"]
+
+
+def test_compression_wait_preserves_sqlite_retry_budget(
+    db: SessionDB, monkeypatch
+) -> None:
+    """Post-lease SQLite contention receives a fresh ordinary retry budget."""
+    monkeypatch.setattr(SessionDB, "_TRANSCRIPT_WRITE_PATIENCE_S", 0.2)
+    monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 2.0)
+    assert db._conn is not None
+    db._conn.execute("PRAGMA busy_timeout=100")
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=0.3
+    ) is True
+
+    compression_observed = threading.Event()
+    holder_ready = threading.Event()
+    holder_errors: list[BaseException] = []
+    original_sleep = db._sleep_before_write_retry
+    first_retry = True
+
+    def _sleep_after_holder_starts(deadline: float, patience_s: float) -> bool:
+        nonlocal first_retry
+        if first_retry:
+            first_retry = False
+            compression_observed.set()
+            assert holder_ready.wait(timeout=2), "test bug: SQLite holder never started"
+        return original_sleep(deadline, patience_s)
+
+    monkeypatch.setattr(db, "_sleep_before_write_retry", _sleep_after_holder_starts)
+
+    def _hold_write_transaction() -> None:
+        conn = sqlite3.connect(db.db_path, isolation_level=None, timeout=2.0)
+        try:
+            assert compression_observed.wait(timeout=2)
+            conn.execute("BEGIN IMMEDIATE")
+            # Consume the original transcript patience before allowing the
+            # writer to proceed into SQLite contention.
+            time.sleep(0.25)
+            holder_ready.set()
+            time.sleep(0.3)
+            conn.commit()
+        except BaseException as exc:
+            holder_errors.append(exc)
+            holder_ready.set()
+        finally:
+            conn.close()
+
+    holder = threading.Thread(target=_hold_write_transaction, daemon=True)
+    holder.start()
+    try:
+        db.append_message("sess1", role="user", content="landed after both waits")
+    finally:
+        holder.join(timeout=3)
+
+    assert not holder.is_alive(), "test bug: SQLite holder did not finish"
+    assert holder_errors == []
+    assert any(
+        row["content"] == "landed after both waits"
+        for row in db.get_messages("sess1")
     )
 
 

--- a/tests/test_hermes_state_compression_busy_retry.py
+++ b/tests/test_hermes_state_compression_busy_retry.py
@@ -6,8 +6,8 @@ compression lock. The conversation loop turns that into
 permissions, when in fact the store is healthy and busy for a few seconds.
 
 The write lock already gets a patience budget for exactly this reason (#74478).
-A compression hold is even more bounded, since the lock row carries its own
-``expires_at``, so the same budget applies here.
+A compression hold carries its own ``expires_at`` lease, so the writer waits on
+that correctness boundary instead of a fixed five-second assumption.
 
 The sibling condition, a compressor finding its own lease gone, is permanent
 and must still fail fast rather than spin out the whole budget.
@@ -21,7 +21,11 @@ from pathlib import Path
 
 import pytest
 
-from hermes_state import CompressionSessionBusyError, SessionDB
+from hermes_state import (
+    CompressionSessionBusyError,
+    SessionCompressionInProgressError,
+    SessionDB,
+)
 
 
 @pytest.fixture
@@ -69,6 +73,9 @@ def test_append_still_gives_up_when_the_lock_never_clears(
     compression must not end with a stale turn landing in the parent.
     """
     monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_S", 0.5)
+    monkeypatch.setattr(
+        SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 0.5, raising=False
+    )
     assert db.try_acquire_compression_lock("sess1", "compressor") is True
 
     started = time.monotonic()
@@ -78,6 +85,201 @@ def test_append_still_gives_up_when_the_lock_never_clears(
 
     assert elapsed >= 0.4, "gave up before spending the patience budget"
     assert elapsed < 10, "did not give up within a bounded time"
+
+
+def test_append_waits_past_fixed_budget_until_live_lease_clears(
+    db: SessionDB, monkeypatch
+) -> None:
+    """A healthy multi-minute compression must not be cut off at five seconds.
+
+    Small timings model the production ratio: the durable lease outlives both
+    the old fixed compression wait and the transcript write patience.
+    """
+    monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_S", 0.1)
+    monkeypatch.setattr(
+        SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 2.0, raising=False
+    )
+    monkeypatch.setattr(SessionDB, "_TRANSCRIPT_WRITE_PATIENCE_S", 0.2)
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=1.0
+    ) is True
+
+    released = threading.Event()
+
+    def _release_after_old_budgets():
+        time.sleep(0.6)
+        db.release_compression_lock("sess1", "compressor")
+        released.set()
+
+    t = threading.Thread(target=_release_after_old_budgets, daemon=True)
+    t.start()
+    try:
+        started = time.monotonic()
+        db.append_message("sess1", role="user", content="waited on the lease")
+        elapsed = time.monotonic() - started
+    finally:
+        t.join(timeout=5)
+
+    assert released.is_set(), "test bug: lock was never released"
+    assert elapsed >= 0.5, "append was still capped by a fixed patience budget"
+    assert any(
+        row["content"] == "waited on the lease" for row in db.get_messages("sess1")
+    )
+
+
+def test_append_refuses_to_cross_expired_lease_boundary(
+    db: SessionDB, monkeypatch
+) -> None:
+    """A stale compressor snapshot must not admit a post-expiry append."""
+    monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_S", 0.1)
+    monkeypatch.setattr(
+        SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 2.0, raising=False
+    )
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=0.4
+    ) is True
+
+    started = time.monotonic()
+    with pytest.raises(CompressionSessionBusyError):
+        db.append_message("sess1", role="user", content="must never land")
+    elapsed = time.monotonic() - started
+
+    assert elapsed >= 0.3, "gave up before the live lease boundary"
+    assert elapsed < 2.0, "wait crossed its bounded lease deadline"
+    assert all(
+        row["content"] != "must never land" for row in db.get_messages("sess1")
+    )
+
+
+def test_append_follows_same_holder_lease_refresh(
+    db: SessionDB, monkeypatch
+) -> None:
+    """Progress heartbeats may extend one holder's lease within the hard cap."""
+    monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_S", 0.1)
+    monkeypatch.setattr(
+        SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 2.0, raising=False
+    )
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=0.3
+    ) is True
+
+    released = threading.Event()
+
+    def _refresh_then_release():
+        time.sleep(0.15)
+        assert db.refresh_compression_lock(
+            "sess1", "compressor", ttl_seconds=0.5
+        ) is True
+        time.sleep(0.35)
+        db.release_compression_lock("sess1", "compressor")
+        released.set()
+
+    t = threading.Thread(target=_refresh_then_release, daemon=True)
+    t.start()
+    try:
+        started = time.monotonic()
+        db.append_message("sess1", role="user", content="followed refresh")
+        elapsed = time.monotonic() - started
+    finally:
+        t.join(timeout=5)
+
+    assert released.is_set(), "test bug: refreshed lock was never released"
+    assert elapsed >= 0.4, "writer ignored the refreshed lease"
+    assert any(
+        row["content"] == "followed refresh" for row in db.get_messages("sess1")
+    )
+
+
+def test_append_follows_same_holder_lease_contraction(
+    db: SessionDB, monkeypatch
+) -> None:
+    """A shortened lease must not leave a later cached admission deadline."""
+    monkeypatch.setattr(
+        SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 2.0, raising=False
+    )
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MIN_S", 0.05)
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MAX_S", 0.05)
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=1.0
+    ) is True
+
+    shortened = threading.Event()
+
+    def _shorten_lease():
+        time.sleep(0.1)
+        assert db.refresh_compression_lock(
+            "sess1", "compressor", ttl_seconds=0.2
+        ) is True
+        shortened.set()
+
+    t = threading.Thread(target=_shorten_lease, daemon=True)
+    t.start()
+    try:
+        started = time.monotonic()
+        with pytest.raises(CompressionSessionBusyError):
+            db.append_message("sess1", role="user", content="must never land")
+        elapsed = time.monotonic() - started
+    finally:
+        t.join(timeout=5)
+
+    assert shortened.is_set(), "test bug: lease was never shortened"
+    assert elapsed < 0.8, "writer retained the original, later lease deadline"
+    assert all(
+        row["content"] != "must never land" for row in db.get_messages("sess1")
+    )
+
+
+def test_append_rechecks_release_at_lease_deadline(
+    db: SessionDB, monkeypatch
+) -> None:
+    """A release during the final sleep must beat stale cached metadata."""
+    monkeypatch.setattr(
+        SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 2.0, raising=False
+    )
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MIN_S", 1.0)
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MAX_S", 1.0)
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=0.6
+    ) is True
+
+    released = threading.Event()
+
+    def _release_before_deadline():
+        time.sleep(0.4)
+        db.release_compression_lock("sess1", "compressor")
+        released.set()
+
+    t = threading.Thread(target=_release_before_deadline, daemon=True)
+    t.start()
+    try:
+        db.append_message("sess1", role="user", content="release won")
+    finally:
+        t.join(timeout=5)
+
+    assert released.is_set(), "test bug: lock was never released"
+    assert any(
+        row["content"] == "release won" for row in db.get_messages("sess1")
+    )
+
+
+def test_busy_error_carries_authoritative_lease_metadata(
+    db: SessionDB, monkeypatch
+) -> None:
+    before = time.time()
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=30.0
+    ) is True
+    monkeypatch.setattr(
+        SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 0.0, raising=False
+    )
+
+    with pytest.raises(SessionCompressionInProgressError) as caught:
+        db.append_message("sess1", role="user", content="blocked")
+
+    assert caught.value.session_id == "sess1"
+    assert caught.value.holder == "compressor"
+    assert caught.value.expires_at is not None
+    assert caught.value.expires_at >= before + 29.0
 
 
 def test_the_lock_owner_is_never_delayed_by_its_own_lock(db: SessionDB) -> None:
@@ -95,9 +297,9 @@ def test_the_lock_owner_is_never_delayed_by_its_own_lock(db: SessionDB) -> None:
 
 def test_transient_error_is_a_subclass_of_the_original(db: SessionDB) -> None:
     """Existing `except CompressionSessionBusyError` handlers must still catch."""
-    from hermes_state import SessionCompressionInProgressError
-
     assert issubclass(SessionCompressionInProgressError, CompressionSessionBusyError)
+    assert SessionCompressionInProgressError().args == ()
+    assert SessionCompressionInProgressError("one", "two").args == ("one", "two")
 
 
 def test_no_lock_means_no_delay(db: SessionDB) -> None:

--- a/tests/test_hermes_state_compression_busy_retry.py
+++ b/tests/test_hermes_state_compression_busy_retry.py
@@ -127,10 +127,10 @@ def test_append_waits_past_fixed_budget_until_live_lease_clears(
     )
 
 
-def test_append_refuses_to_cross_expired_lease_boundary(
+def test_append_atomically_invalidates_expired_lease(
     db: SessionDB, monkeypatch
 ) -> None:
-    """A stale compressor snapshot must not admit a post-expiry append."""
+    """Expiry and append are serialized so the old holder cannot revive."""
     monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_S", 0.1)
     monkeypatch.setattr(
         SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 2.0, raising=False
@@ -140,14 +140,47 @@ def test_append_refuses_to_cross_expired_lease_boundary(
     ) is True
 
     started = time.monotonic()
-    with pytest.raises(CompressionSessionBusyError):
-        db.append_message("sess1", role="user", content="must never land")
+    db.append_message("sess1", role="user", content="landed after invalidation")
     elapsed = time.monotonic() - started
 
     assert elapsed >= 0.3, "gave up before the live lease boundary"
     assert elapsed < 2.0, "wait crossed its bounded lease deadline"
-    assert all(
-        row["content"] != "must never land" for row in db.get_messages("sess1")
+    assert db.refresh_compression_lock("sess1", "compressor") is False
+    assert any(
+        row["content"] == "landed after invalidation"
+        for row in db.get_messages("sess1")
+    )
+
+
+def test_fresh_retry_invalidates_expired_row_before_appending(
+    db: SessionDB, monkeypatch
+) -> None:
+    """A later gateway retry must not bypass a revivable expired row."""
+    monkeypatch.setattr(
+        SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 0.1, raising=False
+    )
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=0.4
+    ) is True
+
+    with pytest.raises(CompressionSessionBusyError):
+        db.append_message("sess1", role="user", content="first attempt")
+
+    time.sleep(0.35)
+    db.append_message("sess1", role="user", content="fresh retry")
+
+    assert db.refresh_compression_lock("sess1", "compressor") is False
+    with pytest.raises(CompressionSessionBusyError):
+        db.publish_compression_child(
+            parent_session_id="sess1",
+            child_session_id="stale-child",
+            source="test",
+            messages=[{"role": "assistant", "content": "stale snapshot"}],
+            compression_lock_holder="compressor",
+        )
+    assert db.get_session("stale-child") is None
+    assert any(
+        row["content"] == "fresh retry" for row in db.get_messages("sess1")
     )
 
 
@@ -216,16 +249,17 @@ def test_append_follows_same_holder_lease_contraction(
     t.start()
     try:
         started = time.monotonic()
-        with pytest.raises(CompressionSessionBusyError):
-            db.append_message("sess1", role="user", content="must never land")
+        db.append_message("sess1", role="user", content="followed contraction")
         elapsed = time.monotonic() - started
     finally:
         t.join(timeout=5)
 
     assert shortened.is_set(), "test bug: lease was never shortened"
     assert elapsed < 0.8, "writer retained the original, later lease deadline"
-    assert all(
-        row["content"] != "must never land" for row in db.get_messages("sess1")
+    assert db.refresh_compression_lock("sess1", "compressor") is False
+    assert any(
+        row["content"] == "followed contraction"
+        for row in db.get_messages("sess1")
     )
 
 

--- a/tests/test_hermes_state_compression_busy_retry.py
+++ b/tests/test_hermes_state_compression_busy_retry.py
@@ -288,6 +288,41 @@ def test_compression_wait_preserves_sqlite_retry_budget(
     )
 
 
+def test_compression_wait_rearms_no_more_rows_retry_budget(
+    db: SessionDB, monkeypatch
+) -> None:
+    """The sibling InterfaceError contention path gets the same fresh budget."""
+    monkeypatch.setattr(SessionDB, "_TRANSCRIPT_WRITE_PATIENCE_S", 0.1)
+    monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_MAX_S", 1.0)
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MIN_S", 0.001)
+    monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MAX_S", 0.005)
+    assert db.try_acquire_compression_lock(
+        "sess1", "compressor", ttl_seconds=0.25
+    ) is True
+
+    original_insert = db._insert_message_rows
+    insert_calls = 0
+
+    def _transient_insert(conn, session_id, messages):
+        nonlocal insert_calls
+        insert_calls += 1
+        if insert_calls == 1:
+            raise sqlite3.InterfaceError("no more rows available")
+        return original_insert(conn, session_id, messages)
+
+    monkeypatch.setattr(db, "_insert_message_rows", _transient_insert)
+
+    inserted = db.append_messages_batch(
+        "sess1", [{"role": "user", "content": "landed after InterfaceError"}]
+    )
+
+    assert inserted == 1
+    assert insert_calls == 2
+    assert [row["content"] for row in db.get_messages("sess1")] == [
+        "landed after InterfaceError"
+    ]
+
+
 def test_append_follows_same_holder_lease_refresh(
     db: SessionDB, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #77386.

Session transcript writes currently give a foreign compression lock a fixed five-second retry budget. Real provider-backed compression can stream for minutes, so healthy sessions abort turns with `SessionCompressionInProgressError` even though SQLite and the session store are healthy.

This change:

- carries the compression lock's durable `session_id`, `holder`, and `expires_at` metadata on `SessionCompressionInProgressError`;
- waits against the authoritative lease instead of a fixed five-second guess;
- follows same-holder lease refreshes in either direction, bounded by a 600-second hard ceiling;
- performs the final lease check inside the same `BEGIN IMMEDIATE` transaction as the append;
- permits the append after explicit release, or atomically deletes an expired foreign row before appending;
- prevents an expired holder from reviving, flushing into the parent, or publishing a stale snapshot after either the original write or a later gateway retry;
- preserves owner-first ordering by allowing the holder to flush its exact current turn while its expired row still exists, before refresh and publication;
- re-arms the normal SQLite contention budget after compression waiting for both lock/busy and `no more rows available` retries, so the two independent waits do not consume each other;
- preserves the exception's normal `*args` construction compatibility.

This is intentionally narrower than changing compression/session routing. It only fixes transient write admission while preserving the existing compression correctness boundary.

## Why lease-aware instead of a larger constant

A fixed 300-second or 420-second timeout still guesses how long compression may take and can diverge from configured/provider behavior. The lock row already carries the protocol boundary. Using `expires_at` lets a healthy compressor extend its lease, lets a shortened lease take effect immediately, and still fails closed when the holder wedges or ownership changes.

The transaction fence matters: simply waiting until wall-clock expiry is unsafe because `refresh_compression_lock()` may revive an expired row. A writer that appended after expiry but before revival could be omitted by the compressor's stale snapshot. This patch resolves that race under `BEGIN IMMEDIATE`: refresh-first extends the live lease and keeps blocking; writer-first deletes the expired row and appends atomically, so later refresh and stale publication both fail closed.

## Tests

- `scripts/run_tests.sh tests/test_hermes_state_compression_busy_retry.py tests/state/test_compression_lineage_guard.py -q` — **31 passed**
- `uv run --extra dev pytest -q tests/test_hermes_state_compression_busy_retry.py tests/state/test_compression_lineage_guard.py tests/state/test_write_lock_patience.py tests/state/test_no_more_rows_retry.py tests/run_agent/test_turn_completion_explainer.py` — **57 passed**
- five repeated focused runs — **80/80 passed**
- `ruff check hermes_state.py tests/test_hermes_state_compression_busy_retry.py tests/state/test_compression_lineage_guard.py` — **passed**
- `python -m py_compile hermes_state.py tests/test_hermes_state_compression_busy_retry.py tests/state/test_compression_lineage_guard.py` — **passed**
- `git diff --check` — **passed**

Regression proof: the new long-live-lease test fails on current `origin/main` at the old fixed wait, and the lease-contraction test demonstrates the stale append (`DID NOT RAISE`) on current `origin/main`. The owner-first and post-compression SQLite-lock tests both fail on prior PR head `660248387`; the post-compression `InterfaceError("no more rows available")` test fails on prior head `f0693ff22`. All pass with this patch.

## Safety coverage

Regression tests cover:

- release after both the old compression wait and transcript write patience;
- bounded refusal while a lease remains live;
- atomic invalidation at an expired-but-revivable lease boundary;
- a fresh gateway retry invalidating the expired row before append, with old-holder refresh, stale owner flush, and stale publication all refused;
- owner-first expired-row flush preserving the current turn before refresh and publication;
- post-compression SQLite contention receiving a fresh ordinary retry budget;
- post-compression `no more rows available` contention receiving that same one-shot rearm;
- same-holder lease extension;
- same-holder lease contraction;
- release during the final deadline sleep;
- lock-owner writes remaining immediate;
- lost compressor leases still failing fast;
- exception inheritance and construction compatibility.
