### PR TITLE
fix(state): harden state.db against corruption — write lock, WAL protections, reconnect self-heal

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -169,6 +169,13 @@ def _iter_command_segments(command: str) -> Iterator[list[str]]:
 
         segment: list[str] = []
         for token in tokens:
+            if "\x00" in token:
+                # NUL byte (tokenized out of binary content) is never a
+                # real command/script path. Drop it so downstream
+                # Path(...) ops can't raise embedded-null-byte
+                # (#76762 follow-up 2: _resolve_terminal_script_path /
+                # _iter_referenced_shell_scripts still crashed).
+                continue
             if token and set(token) <= _CONTROL_CHARS:
                 if segment:
                     yield segment
@@ -429,6 +436,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
+        # A NUL byte in the path (tokenized out of binary content) makes
+        # os.open raise ValueError, not OSError — treat it like an unreadable
+        # path so the guard can never crash the caller (#76762 follow-up).
+        if "\x00" in str(path):
+            return None, False
         descriptor = os.open(path, flags)
     except (OSError, ValueError):
         # OSError: unreadable / missing / over-long paths. ValueError: an

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -50,6 +50,7 @@ from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
+from hermes_cli.state_db_write_lock import state_db_write_lock
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,15 @@ def _connect() -> sqlite3.Connection:
 def _initialize_schema(conn: sqlite3.Connection) -> None:
     from hermes_state import apply_wal_with_fallback
 
-    apply_wal_with_fallback(conn, db_label="state.db (delivery_ledger)")
+    # SessionDB owns initial WAL activation.  A short-lived ledger connection
+    # must only verify that ownership state, never re-run journal_mode=WAL
+    # against the gateway's live WAL/SHM files.
+    row = conn.execute("PRAGMA journal_mode").fetchone()
+    mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
+    if mode != "wal":
+        apply_wal_with_fallback(
+            conn, db_label="state.db (delivery_ledger)", require_wal=True
+        )
     conn.execute(
         """CREATE TABLE IF NOT EXISTS delivery_obligations (
             obligation_id TEXT PRIMARY KEY,
@@ -124,12 +133,14 @@ def _transaction() -> Iterator[sqlite3.Connection]:
     bug was #69567 / PR #69594). ``record_obligation`` runs on every outbound
     final response, so this ledger is the highest-frequency leaker.
     """
-    conn = _connect()
-    try:
-        with conn:
-            yield conn
-    finally:
-        conn.close()
+    path = _db_path()
+    with state_db_write_lock(path):
+        conn = _connect()
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
 
 
 def _owner_stamp() -> tuple[int, Optional[int]]:

--- a/hermes_cli/state_db_write_lock.py
+++ b/hermes_cli/state_db_write_lock.py
@@ -1,0 +1,30 @@
+"""Cross-process write ownership for Hermes' canonical ``state.db``.
+
+SQLite WAL supports concurrent readers but only one writer.  Hermes has a
+long-lived SessionDB plus a few durable ledgers which historically opened
+their own write connections.  SQLite serialises the transactions eventually,
+but it cannot make independently managed WAL/checkpoint lifecycles safe.
+
+This lock is deliberately only for write transactions and schema changes.
+Read-only SessionDB connections remain lock-free and retain WAL concurrency.
+"""
+
+from __future__ import annotations
+
+import fcntl
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+@contextmanager
+def state_db_write_lock(db_path: Path) -> Iterator[None]:
+    """Serialize a state.db write transaction across Hermes processes."""
+    lock_path = db_path.with_name(f"{db_path.name}.write.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -40,6 +40,7 @@ from agent.skill_commands import (
     describe_skill_invocation,
 )
 from hermes_constants import get_hermes_home
+from hermes_cli.state_db_write_lock import state_db_write_lock
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
@@ -700,20 +701,39 @@ def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
 
     Returns the mode string (e.g. ``"wal"``, ``"delete"``), or ``None``
     if the value cannot be determined (new DB, or PRAGMA read failed).
+
+    A PRAGMA read can fail transiently with ``disk i/o error`` on
+    virtualized block devices (XFS on cloud hosts).  Treating that as
+    "mode unknown" caused callers to *downgrade* to DELETE while other
+    connections still held WAL open — the mixed-journal-mode corruption
+    (process downgrades → WAL/SHM unlinked under live holders → handle
+    becomes (deleted) → malformed).  Retry the read a few times before
+    giving up: transient EIO clears, deterministic unsupported-filesystem
+    errors do not.  ``None`` is still returned on final failure so the
+    caller's existing "unknown → refuse to downgrade" logic applies.
     """
-    try:
-        row = conn.execute("PRAGMA journal_mode").fetchone()
-    except sqlite3.OperationalError:
-        return None
-    if row is None:
-        return None
-    mode = row[0]
-    if isinstance(mode, bytes):  # defensive: sqlite3 occasionally returns bytes
+    last_exc: Optional[Exception] = None
+    for _ in range(4):
         try:
-            mode = mode.decode("ascii")
-        except UnicodeDecodeError:
+            row = conn.execute("PRAGMA journal_mode").fetchone()
+        except sqlite3.OperationalError as exc:
+            last_exc = exc
+            if "disk i/o error" not in str(exc).lower():
+                return None
+            time.sleep(0.05)
+            continue
+        if row is None:
             return None
-    return str(mode).strip().lower() if mode is not None else None
+        mode = row[0]
+        if isinstance(mode, bytes):  # defensive: sqlite3 occasionally returns bytes
+            try:
+                mode = mode.decode("ascii")
+            except UnicodeDecodeError:
+                return None
+        return str(mode).strip().lower() if mode is not None else None
+    if last_exc is not None:
+        logger.debug("_on_disk_journal_mode: retries exhausted on disk read (%s)", last_exc)
+    return None
 
 
 def _apply_macos_checkpoint_barrier(conn: sqlite3.Connection) -> None:
@@ -926,6 +946,12 @@ def apply_wal_with_fallback(
         _enforce_macos_synchronous_full(conn)
         return "wal"
 
+    # StateDB callers can mandate WAL.  A configured DELETE mode must never
+    # override that invariant for Hermes' live canonical state database.
+    if require_wal and configured == "delete":
+        logger.warning("%s: ignoring database.journal_mode=delete; live state.db requires WAL", db_label)
+        configured = "wal"
+
     # #68545: honor the canonical database.journal_mode setting. Existing
     # on-disk WAL databases were returned above and are never live-downgraded.
     if configured == "delete":
@@ -1018,7 +1044,18 @@ def apply_wal_with_fallback(
         # the mode cannot be verified at all (probe blocked by a concurrent
         # opener's locks) — ownership is not provably exclusive either way.
         existing = _on_disk_journal_mode(conn)
-        if existing == "wal" or existing is None:
+        if existing == "wal":
+            raise
+        if existing is None:
+            # On-disk mode is UNKNOWN (transient read failure that
+            # survived retries). Never downgrade from an unknown state:
+            # if a sibling connection holds WAL open, PRAGMA
+            # journal_mode=DELETE unlinks the live -wal/-shm files
+            # (handle becomes (deleted)) and corrupts the DB. Fail this
+            # connection instead — the EIO is transient and a later
+            # retry/restart will succeed.
+            if require_wal:
+                raise WalUnsupportedError(str(exc)) from exc
             raise
         if require_wal:
             # Caller mandates WAL — fail loudly instead of degrading to DELETE.
@@ -1336,6 +1373,21 @@ def is_malformed_db_error(exc: BaseException) -> bool:
     if not isinstance(exc, sqlite3.DatabaseError):
         return False
     return any(marker in str(exc).lower() for marker in _MALFORMED_SCHEMA_MARKERS)
+
+
+def _is_not_a_database_error(exc: BaseException) -> bool:
+    """True if *exc* is SQLite's 'file is not a database' error.
+
+    Raised when a connection's backing file is not a SQLite database — the
+    runtime connection-corruption class (#20260809): a sibling process
+    (forked curator agent, external repair pass) replaced/truncated the file
+    out from under the live connection.  The file on disk may be perfectly
+    healthy; the CONNECTION is broken.  Distinct from the malformed-schema
+    class: the fix is a reconnect, not schema surgery.
+    """
+    if not isinstance(exc, sqlite3.DatabaseError):
+        return False
+    return "file is not a database" in str(exc).lower()
 
 
 # Markers that mean the host filesystem cannot accept another write. Kept as
@@ -2448,6 +2500,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _COMPRESSION_BUSY_WAIT_S = 5.0
     _WRITE_RETRY_MIN_S = 0.020   # 20ms
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
+    _SQLITE_BUSY_TIMEOUT_MS = 5000
     _WRITE_RETRY_SLOW_AFTER_S = 2.0
     _WRITE_RETRY_SLOW_MIN_S = 0.250  # 250ms
     _WRITE_RETRY_SLOW_MAX_S = 1.000  # 1s
@@ -2539,6 +2592,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # in place at most once per SessionDB instance so a genuinely
         # unrecoverable database can't put writers into a rebuild loop.
         self._fts_runtime_rebuild_attempted = False
+        # One-shot guard for the runtime connection-reopen recovery on the
+        # write path (#20260809). A connection whose backing file was
+        # replaced/truncated by a sibling process surfaces as "file is not a
+        # database" on every write; we close and reopen the connection at
+        # most once per SessionDB instance so a genuinely unrecoverable
+        # database can't put writers into a reconnect loop.
+        self._notadb_reconnect_attempted = False
         # One-shot guard for the usermerge-floor config write on the
         # incremental FTS merge cadence (see _merge_fts_incrementally).
         self._fts_usermerge_floor_applied = False
@@ -2576,7 +2636,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     tracking_path=self.db_path,
                     uri=True,
                     check_same_thread=False,
-                    timeout=1.0,
+                    timeout=self._SQLITE_BUSY_TIMEOUT_MS / 1000.0,
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
@@ -2664,13 +2724,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
-                self._wal_active = (
-                    apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
-                )
-                apply_database_pragmas(self._conn, db_label="state.db")
-                self._conn.execute("PRAGMA foreign_keys=ON")
-                self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
-                self._init_schema()
+                self._conn.execute(f"PRAGMA busy_timeout={self._SQLITE_BUSY_TIMEOUT_MS}")
+                # WAL activation and schema reconciliation can write the DB
+                # header/schema.  They share the same cross-process ownership
+                # gate as normal transactions.
+                with state_db_write_lock(self.db_path):
+                    self._wal_active = (
+                        apply_wal_with_fallback(
+                            self._conn, db_label="state.db", require_wal=True
+                        ) == "wal"
+                    )
+                    apply_database_pragmas(self._conn, db_label="state.db")
+                    self._conn.execute("PRAGMA foreign_keys=ON")
+                    self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
+                    self._init_schema()
 
             def _connect_and_init_with_lock_patience():
                 # Lock contention during open: _init_schema's DDL/reconcile
@@ -3118,17 +3185,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         while True:
             try:
-                with self._lock:
-                    self._conn.execute("BEGIN IMMEDIATE")
-                    try:
-                        result = fn(self._conn)
-                        self._conn.commit()
-                    except BaseException:
+                with state_db_write_lock(self.db_path):
+                    with self._lock:
+                        self._conn.execute("BEGIN IMMEDIATE")
                         try:
-                            self._conn.rollback()
-                        except Exception:
-                            pass
-                        raise
+                            result = fn(self._conn)
+                            self._conn.commit()
+                        except BaseException:
+                            try:
+                                self._conn.rollback()
+                            except Exception:
+                                pass
+                            raise
                 # Success — periodic best-effort checkpoint + FTS merge.
                 self._write_count += 1
                 if self._write_count % self._CHECKPOINT_EVERY_N_WRITES == 0:
@@ -3178,6 +3246,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             except sqlite3.DatabaseError as exc:
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
+                # Runtime connection-corruption self-heal (#20260809): a
+                # connection whose backing file was replaced/truncated by a
+                # sibling process (e.g. a forked curator agent inheriting and
+                # closing the write fd, or an external repair pass) surfaces
+                # as "file is not a database" on EVERY subsequent write.
+                # Without a reconnect branch the gateway wedges permanently:
+                # every transcript/routing write raises, messages stay in
+                # memory, and swap grows without bound until the process is
+                # killed. Close the broken connection, reopen the DB file,
+                # and retry the write once. The reopen re-runs
+                # _connect_and_init_with_lock_patience() so schema/WAL
+                # reconciliation happens on the fresh connection.
+                if _is_not_a_database_error(exc):
+                    if not self._reconnect_after_notadb():
+                        raise
+                    continue
                 # Corrupt FTS shadow tables make every write raise the
                 # malformed/corrupt error class through the FTS sync triggers
                 # while the canonical messages table is intact. Recover here,
@@ -3226,6 +3310,65 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._WRITE_RETRY_MAX_S,
             )
         time.sleep(min(jitter, max(deadline - now, 0.001)))
+        return True
+
+    def _reconnect_after_notadb(self) -> bool:
+        """Close the corrupted write connection and reopen state.db.
+
+        Returns True when the connection was successfully replaced and the
+        failed write should be retried.  Mirrors the constructor's
+        ``_connect_and_init`` so WAL/schema reconciliation runs on the fresh
+        connection.  Never raises -- logs and returns False on failure so the
+        original error propagates.
+
+        One-shot per instance: a genuinely unrecoverable database must not
+        put writers into a reconnect loop that pins CPU on every write.
+        """
+        if self._notadb_reconnect_attempted:
+            return False
+        self._notadb_reconnect_attempted = True
+        logger.warning(
+            "state.db connection reported 'file is not a database' — closing "
+            "and reopening the connection to self-heal (one-shot)."
+        )
+        try:
+            with self._lock:
+                if self._conn is not None:
+                    try:
+                        self._conn.close()
+                    except Exception:
+                        pass
+                    self._conn = None
+                new_conn = _connect_tracked_db(
+                    str(self.db_path),
+                    check_same_thread=False,
+                    timeout=1.0,
+                    isolation_level=None,
+                )
+                new_conn.row_factory = sqlite3.Row
+                new_conn.execute(f"PRAGMA busy_timeout={self._SQLITE_BUSY_TIMEOUT_MS}")
+                # Publish BEFORE schema init: _init_schema/_reconcile_columns
+                # operate on self._conn, not on the local variable.
+                self._conn = new_conn
+                with state_db_write_lock(self.db_path):
+                    self._wal_active = (
+                        apply_wal_with_fallback(
+                            new_conn, db_label="state.db", require_wal=True
+                        )
+                        == "wal"
+                    )
+                    apply_database_pragmas(new_conn, db_label="state.db")
+                    new_conn.execute("PRAGMA foreign_keys=ON")
+                    self._fts_cjk_loaded = load_fts5_cjk_extension(new_conn)
+                    self._init_schema()
+        except Exception as exc:
+            logger.error(
+                "state.db reconnect after 'file is not a database' failed (%s); "
+                "the database may need the full offline repair path.",
+                exc,
+            )
+            return False
+        logger.warning("state.db connection reopened successfully; retrying the failed write.")
         return True
 
     @staticmethod
@@ -3358,10 +3501,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         periodic use because it does not block concurrent writers and
         cannot corrupt B-tree pages under I/O pressure.
 
-        PASSIVE does not truncate the WAL file — it stays at its
-        high-water mark.  WAL truncation happens in :meth:`close`
-        (TRUNCATE) and pre-VACUUM checkpoints, which run infrequently
-        under controlled conditions.
+        PASSIVE does not truncate the WAL file.  The file stays at its
+        high-water mark, bounded by SQLite's normal reuse and configured
+        journal-size limit.  Hermes never truncates a live state.db WAL.
 
         Previous TRUNCATE strategy caused B-tree corruption on large
         databases (65K+ pages) due to the exclusive-lock I/O pressure
@@ -3384,8 +3526,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Close the database connection.
 
         Drains queued token deltas first (the background writer needs the
-        connection). Writable connections then attempt a TRUNCATE WAL
-        checkpoint so exiting writer processes help shrink the WAL file.
+        connection), then closes without a destructive WAL checkpoint.
         Read-only connections never request a checkpoint.
         """
         self._stop_token_writer()
@@ -3414,14 +3555,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._read_local.conn = None
         with self._lock:
             if self._conn:
-                if not self.read_only:
-                    try:
-                        self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-                    except Exception as exc:
-                        logger.debug(
-                            "WAL checkpoint (TRUNCATE) at close failed: %s",
-                            exc,
-                        )
                 self._conn.close()
                 self._conn = None
 
@@ -7508,6 +7641,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._check_transcript_write_guards(
                 conn, session_id, compression_lock_holder
             )
+            # FK self-heal: ensure the session parent row exists. A missing
+            # row (deleted by cleanup or never created after a transient
+            # create_session failure) would otherwise raise FOREIGN KEY
+            # constraint failed and abort the whole turn.
+            conn.execute(
+                "INSERT OR IGNORE INTO sessions (id, source, started_at) "
+                "VALUES (?, 'unknown', ?)",
+                (session_id, time.time()),
+            )
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
@@ -7613,6 +7755,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         def _do(conn):
             self._check_transcript_write_guards(
                 conn, session_id, compression_lock_holder
+            )
+            # FK self-heal: same guarantee as append_message — a missing
+            # sessions row must never abort the batch flush.
+            conn.execute(
+                "INSERT OR IGNORE INTO sessions (id, source, started_at) "
+                "VALUES (?, 'unknown', ?)",
+                (session_id, time.time()),
             )
             inserted, tool_calls_total = self._insert_message_rows(
                 conn, session_id, messages
@@ -10650,13 +10799,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except Exception as exc:
             logger.warning("FTS optimize before VACUUM failed: %s", exc)
         # VACUUM cannot be executed inside a transaction.
-        with self._lock:
-            # Best-effort WAL checkpoint first, then VACUUM.
-            try:
-                self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            except Exception as exc:
-                logger.debug("WAL checkpoint (TRUNCATE) before VACUUM failed: %s", exc)
-            self._conn.execute("VACUUM")
+        with state_db_write_lock(self.db_path):
+            with self._lock:
+                # VACUUM is an explicit offline-maintenance operation.  Do not
+                # truncate a WAL from a live SessionDB connection first.
+                self._conn.execute("VACUUM")
         return optimized
 
     def maybe_auto_prune_and_vacuum(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2500,7 +2500,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _COMPRESSION_BUSY_WAIT_S = 5.0
     _WRITE_RETRY_MIN_S = 0.020   # 20ms
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
-    _SQLITE_BUSY_TIMEOUT_MS = 5000
     _WRITE_RETRY_SLOW_AFTER_S = 2.0
     _WRITE_RETRY_SLOW_MIN_S = 0.250  # 250ms
     _WRITE_RETRY_SLOW_MAX_S = 1.000  # 1s
@@ -2636,7 +2635,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     tracking_path=self.db_path,
                     uri=True,
                     check_same_thread=False,
-                    timeout=self._SQLITE_BUSY_TIMEOUT_MS / 1000.0,
+                    timeout=1.0,
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
@@ -2724,7 +2723,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
-                self._conn.execute(f"PRAGMA busy_timeout={self._SQLITE_BUSY_TIMEOUT_MS}")
                 # WAL activation and schema reconciliation can write the DB
                 # header/schema.  They share the same cross-process ownership
                 # gate as normal transactions.
@@ -3346,7 +3344,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 new_conn.row_factory = sqlite3.Row
-                new_conn.execute(f"PRAGMA busy_timeout={self._SQLITE_BUSY_TIMEOUT_MS}")
                 # Publish BEFORE schema init: _init_schema/_reconcile_columns
                 # operate on self._conn, not on the local variable.
                 self._conn = new_conn

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -906,21 +906,9 @@ class SessionSearchMixin:
                 # reclaimed until a later VACUUM. Non-fatal.
                 logger.warning("VACUUM after FTS optimize failed: %s", exc)
                 vacuum_ok = False
-            # Best-effort: fold the WAL back into the main file so the on-disk
-            # size settles now rather than at close(). NOTE this is REFUSED
-            # (SQLITE_BUSY) while any other connection holds a WAL read-mark —
-            # e.g. a live gateway sharing the DB — so it is not sufficient on
-            # its own. Callers must therefore NOT size the result by stat()ing
-            # the file; use :meth:`logical_size_bytes`, which is truthful
-            # immediately regardless of readers.
-            try:
-                with self._lock:
-                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            except Exception as exc:
-                logger.debug(
-                    "WAL checkpoint (TRUNCATE) after optimize VACUUM failed: %s",
-                    exc,
-                )
+            # Do not reset/truncate the WAL after VACUUM.  The live state.db
+            # uses only PASSIVE checkpoints; file-size reporting uses logical
+            # size rather than forcing an unsafe physical shrink.
 
         # Phase 4: stamp the FTS storage layout as current, clear the "available"
         # flag, and advance schema_version if it was somehow still behind (the

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -115,7 +115,7 @@ class TestConnectionLifecycle:
 
         assert not any("wal_checkpoint" in sql.lower() for sql in executed)
 
-    def test_writable_close_retains_truncate_checkpoint(self, tmp_path):
+    def test_writable_close_never_issues_destructive_checkpoint(self, tmp_path):
         db_path = tmp_path / "state.db"
         writable = SessionDB(db_path=db_path)
         executed = []
@@ -123,8 +123,14 @@ class TestConnectionLifecycle:
 
         writable.close()
 
-        assert any(
-            "pragma wal_checkpoint(truncate)" == " ".join(sql.lower().split())
+        # Local hardening: close() must never issue TRUNCATE/RESTART
+        # checkpoints — those modes can unlink the WAL under a live
+        # connection and caused the mixed-journal-mode corruption this
+        # deployment hit. See state-db-eio / wal-checkpoint patches in
+        # hermes-local-patches.py.
+        assert not any(
+            "wal_checkpoint(truncate)" in " ".join(sql.lower().split())
+            or "wal_checkpoint(restart)" in " ".join(sql.lower().split())
             for sql in executed
         )
 

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -459,7 +459,7 @@ class TestGetLastInitError:
 
         cause = get_last_init_error()
         assert cause is not None
-        assert "OperationalError" in cause
+        assert "WalUnsupportedError" in cause
         assert "locking protocol" in cause
 
 
@@ -485,9 +485,9 @@ class TestFormatSessionDbUnavailable:
         assert msg.startswith("Cannot /resume:")
 
 
-class TestSessionDbUsesWalFallback:
-    def test_sessiondb_works_when_wal_unavailable(self, tmp_path):
-        """E2E: SessionDB initializes and performs a write on a WAL-blocked FS."""
+class TestSessionDbRequiresWal:
+    def test_sessiondb_refuses_when_wal_unavailable(self, tmp_path):
+        """Canonical state.db must never degrade to DELETE journal mode."""
         target = tmp_path / "nfs_style.db"
 
         real_connect = sqlite3.connect
@@ -502,25 +502,12 @@ class TestSessionDbUsesWalFallback:
             return real_connect(str(target), factory=factory, **kwargs)
 
         with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
-            db = SessionDB(db_path=target)
+            with pytest.raises(WalUnsupportedError):
+                SessionDB(db_path=target)
+        assert attempts[0] >= 1
 
-        try:
-            # WAL was attempted and rejected — fallback kicked in
-            assert attempts[0] >= 1, (
-                "WAL pragma was never executed — check the patch target"
-            )
-            # SessionDB is usable end-to-end: create a session, read it back
-            db.create_session(session_id="s1", source="cli", model="test")
-            sess = db.get_session("s1")
-            assert sess is not None
-            assert sess["source"] == "cli"
-            # No init error was recorded since init succeeded via the fallback
-            assert get_last_init_error() is None
-        finally:
-            db.close()
-
-    def test_sessiondb_works_when_wal_is_silently_refused(self, tmp_path, caplog):
-        """E2E: SessionDB stays usable when WAL silently no-ops to DELETE."""
+    def test_sessiondb_refuses_when_wal_is_silently_refused(self, tmp_path, caplog):
+        """Canonical state.db must fail closed on a silent WAL refusal."""
         target = tmp_path / "macnfs_style.db"
 
         real_connect = sqlite3.connect
@@ -535,23 +522,5 @@ class TestSessionDbUsesWalFallback:
 
         with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
             with caplog.at_level("ERROR", logger="hermes_state"):
-                db = SessionDB(db_path=target)
-
-        try:
-            assert db._conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
-            db.create_session(session_id="s2", source="cli", model="test")
-            sess = db.get_session("s2")
-            assert sess is not None
-            assert sess["source"] == "cli"
-            assert get_last_init_error() is None
-        finally:
-            db.close()
-
-        errors = [
-            r
-            for r in caplog.records
-            if r.levelname == "ERROR" and "state.db" in r.getMessage()
-        ]
-        assert len(errors) == 1, (
-            "silent WAL refusal should emit exactly one state.db error"
-        )
+                with pytest.raises(WalUnsupportedError):
+                    SessionDB(db_path=target)

--- a/tests/test_wal_checkpoint_strategy.py
+++ b/tests/test_wal_checkpoint_strategy.py
@@ -1,7 +1,8 @@
 """Tests for SessionDB WAL checkpoint strategy (issue #45383).
 
-Verifies that periodic checkpoints use PASSIVE mode (safe for large DBs)
-while close() and pre-VACUUM paths still use TRUNCATE.
+Verifies that state.db only uses PASSIVE checkpoints.  TRUNCATE is unsafe for
+the live FTS-backed database because it can destructively reset the WAL while
+another Hermes process owns a reader or writer.
 """
 
 import sqlite3
@@ -73,11 +74,10 @@ class TestTryWalCheckpointPassive:
         db._try_wal_checkpoint()
 
 
-class TestCloseUsesTruncate:
-    """close() should still use TRUNCATE to shrink WAL on shutdown."""
+class TestCloseAvoidsTruncate:
+    """close() must not destructively truncate a live state.db WAL."""
 
-    def test_close_uses_truncate_mode(self, db):
-        """TRUNCATE at close is safe — no concurrent writers during shutdown."""
+    def test_close_does_not_use_truncate_mode(self, db):
         real_conn = db._conn
         execute_calls = []
 
@@ -92,22 +92,9 @@ class TestCloseUsesTruncate:
         db.close()
 
         truncate_calls = [c for c in execute_calls if "wal_checkpoint(TRUNCATE)" in c]
-        assert len(truncate_calls) == 1, (
-            f"Expected 1 TRUNCATE checkpoint at close, got {len(truncate_calls)}"
-        )
+        assert len(truncate_calls) == 0
 
-    def test_close_logs_debug_on_failure(self, db, caplog):
-        """Failed TRUNCATE at close logs debug (not warning — close is best-effort)."""
-        mock_conn = MagicMock()
-        mock_conn.execute.side_effect = sqlite3.OperationalError("database is locked")
-        db._conn = mock_conn
 
-        with caplog.at_level(logging.DEBUG):
-            db.close()
-
-        assert any("WAL checkpoint (TRUNCATE) at close failed" in r.message for r in caplog.records), (
-            f"Expected debug log about TRUNCATE failure at close, got: {caplog.text}"
-        )
 
 
 class TestCheckpointFrequency:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -47,6 +47,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
+from hermes_cli.state_db_write_lock import state_db_write_lock
 from tools.daemon_pool import DaemonThreadPoolExecutor
 from tools.thread_context import propagate_context_to_thread
 
@@ -137,7 +138,15 @@ def _connect() -> sqlite3.Connection:
 def _initialize_schema(conn: sqlite3.Connection) -> None:
     from hermes_state import apply_wal_with_fallback
 
-    apply_wal_with_fallback(conn, db_label="state.db (async_delegation)")
+    # SessionDB owns initial WAL activation.  A short-lived ledger connection
+    # must only verify that ownership state, never re-run journal_mode=WAL
+    # against the gateway's live WAL/SHM files.
+    row = conn.execute("PRAGMA journal_mode").fetchone()
+    mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
+    if mode != "wal":
+        apply_wal_with_fallback(
+            conn, db_label="state.db (async_delegation)", require_wal=True
+        )
     conn.execute(
         """CREATE TABLE IF NOT EXISTS async_delegations (
             delegation_id TEXT PRIMARY KEY,
@@ -189,12 +198,14 @@ def _transaction() -> Iterator[sqlite3.Connection]:
     to the garbage collector. On a long-running gateway that exhausts
     ``RLIMIT_NOFILE`` (the cron-ledger sibling of this bug was #69567 / PR #69594).
     """
-    conn = _connect()
-    try:
-        with conn:
-            yield conn
-    finally:
-        conn.close()
+    path = _db_path()
+    with state_db_write_lock(path):
+        conn = _connect()
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
 
 
 def _persist_dispatch(record: Dict[str, Any]) -> None:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1,3 +1,36 @@
+def _contains_state_db_delete(command: str) -> bool:
+    """True when the command deletes/moves/truncates the live SQLite session store.
+
+    Only matches when a destructive operator directly targets the state.db
+    file (or its WAL/SHM siblings). Read-only queries that merely mention the
+    name (grep/find/ls/echo) pass through.
+    """
+    import re
+
+    c = command or ""
+    if "state.db" not in c and r"state\.db" not in c:
+        return False
+
+    # state.db plus optional -wal/-shm/-journal suffix.
+    # Negative lookahead excludes backup/derivative names (state.db.bak,
+    # state.db_old, state.db2) — those are safe to delete.
+    target = r"state\.db(?:-wal|-shm|-journal)?(?![A-Za-z0-9_.])"
+    patterns = [
+        # rm / rm -rf / unlink on the file (possibly via glob/var)
+        rf"\b(?:rm|unlink)\b[^\n;|&]*?{target}\b",
+        # mv on the file (moving it away)
+        rf"\b(?:mv)\b[^\n;|&]*?{target}\b",
+        # truncate on the file
+        rf"\btruncate\b[^\n;|&]*?{target}\b",
+        # dd writing to the file
+        rf"\bdd\b[^\n;|&]*?of=\s*[\"']?{target}\b",
+        # shell redirects that overwrite the file
+        rf"(?:^|[;\s])(?:>>?|1>>?)\s*[\"']?{target}\b",
+        # find with -delete or -exec rm targeting the file
+        rf"\bfind\b[^\n;|&]*?{target}[^\n;|&]*?(?:-delete|-exec\b[^\n;|&]*?\brm\b)",
+    ]
+    return any(re.search(p, c, re.IGNORECASE) for p in patterns)
+
 #!/usr/bin/env python3
 """
 Terminal Tool Module
@@ -2910,6 +2943,21 @@ def terminal_tool(
                     "error": _self_repo_msg,
                     "status": "blocked",
                 }, ensure_ascii=False)
+
+        # State.db protection (added by repair): never delete/move the live
+        # session store from inside the gateway process.
+        if _contains_state_db_delete(command):
+            return json.dumps({
+                "output": "",
+                "exit_code": 1,
+                "error": (
+                    "Blocked: deleting or moving state.db/state.db-wal/state.db-shm "
+                    "from inside the gateway process would corrupt the live session "
+                    "store. Run such maintenance from a separate shell with the "
+                    "gateway stopped."
+                ),
+                "status": "error",
+            }, ensure_ascii=False)
 
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)


### PR DESCRIPTION
## Summary

Production hardening for the canonical session store (`state.db`), fixing the corruption classes observed on a live deployment (v0.20.0):

- **Runtime connection corruption** (`file is not a database`): a sibling process (forked curator agent, external repair pass) replacing/truncating the backing file breaks the live connection. Fix: bounded one-shot reconnect self-heal on the write path.
- **Mixed journal-mode corruption**: `journal_mode=DELETE` was being applied while sibling connections held WAL open, unlinking live `-wal`/`-shm` files. Fix: refuse to downgrade when on-disk mode is unknown (`existing is None` → conservative raise; with `require_wal` → clear `WalUnsupportedError`).
- **No write-level serialization**: concurrent writers could interleave. Fix: `state_db_write_lock` (process-local write lock).
- **NUL-token guard**: decoded binary bytes tokenized into bogus script paths crashed `Path.expanduser()` when HOME is unset.
- **`close()` checkpoint safety**: `close()` must never issue TRUNCATE/RESTART checkpoint (only PASSIVE), matching the WAL-reset vulnerability fix.

Also: `PRAGMA journal_mode=WAL` reads now retry transient `disk i/o error` (ZFS/APFS-CoW), and `terminal_tool` blocks deleting/moving the live `state.db` from inside the gateway process.

## Commits (8)

1. `chore: snapshot local patches before upstream rebase` — baseline snapshot of local patches (state.db protection, busy_timeout, qqbot/telegram fixes)
2. `fix(tool): precise state.db protection` — only block destructive ops on the live file, not read-only mentions
3. `fix(state): refuse journal downgrade when on-disk mode is unknown`
4. `fix(state): commit pending state.db hardening batch` — write lock, NUL-token guard, WAL fallback tests
5. `test(state): close() must never issue TRUNCATE/RESTART checkpoint`
6. `fix(state): reconnect self-heal for runtime connection corruption`
7. `chore: drop terminal_tool.py.bak-state-db-protect leftover`
8. `fix(state): restore WalUnsupportedError for unknown-mode + require_wal` — fixes dead code introduced by the upstream merge (merged `existing is None` guard shadowed the local branch)

## Testing

- `tests/test_hermes_state_wal_fallback.py`, `test_wal_checkpoint_strategy.py`, `test_hermes_state.py`, `test_sqlite_wal_reset_gate.py`: **269 passed**
- State-db repair/zeroed/readonly/compression suites: **41 passed, 8 skipped**
