### PR TITLE
fix(gateway): drain timeout=0 must still wait for in-flight cron/API work

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2500,6 +2500,13 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
 
+# Minimum drain budget (seconds) when the only active work is cron jobs
+# or API-server runs.  ``restart_drain_timeout=0`` (the default) means
+# "don't wait for chat sessions" but should not kill background jobs
+# with zero grace — those have no pre-stop protection via
+# ``restart_after_turn_timeout`` (#82161).
+_MIN_DRAIN_FOR_BACKGROUND_WORK: float = 30.0
+
 # Conversation-scoped per-session state registry (legacy contract).
 # The state itself now lives in ``SessionState.conversation`` (see
 # gateway/session_state.py) and boundaries clear it structurally via
@@ -9379,7 +9386,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         _maybe_update_status(force=True)
         if timeout <= 0:
-            return snapshot, True
+            # When drain_timeout is 0 (the default), chat sessions are
+            # handled by the pre-stop ``restart_after_turn_timeout`` wait,
+            # so a zero drain budget is intentional.  Cron jobs and
+            # API-server runs, however, live outside _running_agents and
+            # have no pre-stop protection — killing them with zero grace
+            # is a data-loss bug (#82161).  Apply a minimum drain budget
+            # when background work is the only active thing.
+            _background_only = (
+                not self._running_agents
+                and (last_cron_count > 0 or last_api_count > 0)
+            )
+            if not _background_only:
+                return snapshot, True
+            timeout = _MIN_DRAIN_FOR_BACKGROUND_WORK
 
         deadline = asyncio.get_running_loop().time() + timeout
         while (

--- a/tests/gateway/test_update_cron_drain.py
+++ b/tests/gateway/test_update_cron_drain.py
@@ -37,3 +37,33 @@ async def test_drain_active_agents_waits_for_in_flight_cron_jobs():
     assert _snapshot == {}
 
 
+@pytest.mark.asyncio
+async def test_drain_zero_timeout_still_waits_for_cron_jobs():
+    """Regression test for #82161.
+
+    ``restart_drain_timeout=0`` (the default) must not kill in-flight cron
+    jobs with zero grace.  When only cron/API work is active the drain should
+    apply a minimum budget instead of returning immediately.
+    """
+    runner, _adapter = make_restart_runner()
+    runner._running_agents = {}
+
+    cron_count = [1]
+
+    def _cron_in_flight():
+        return frozenset(f"job-{i}" for i in range(cron_count[0]))
+
+    async def finish_cron():
+        await asyncio.sleep(0.15)
+        cron_count[0] = 0
+
+    with patch("cron.scheduler.get_running_job_ids", side_effect=_cron_in_flight):
+        task = asyncio.create_task(finish_cron())
+        # timeout=0 is the default — drain should NOT return immediately
+        _snapshot, timed_out = await runner._drain_active_agents(0)
+        await task
+
+    assert timed_out is False
+    assert _snapshot == {}
+
+


### PR DESCRIPTION
## Summary

When ``restart_drain_timeout`` is 0 (the default), the drain phase returns immediately with ``timed_out=True`` — even when cron jobs or API-server runs are the only active work.  Cron jobs live outside ``_running_agents`` and have no pre-stop protection via ``restart_after_turn_timeout``, so the zero-budget drain kills them with no grace period.

## Root Cause

In ``_drain_active_agents()`` (``gateway/run.py:9381``), the check ``if timeout <= 0: return snapshot, True`` fires even when only background work (cron/API) is active.  The early-return at line 9376 (``not self._running_agents and cron_count == 0 and api_count == 0``) correctly falls through when cron is running, but the zero-timeout check immediately kills it.

The design intent of ``restart_drain_timeout=0`` is "don't wait for chat sessions" (they are protected by the pre-stop ``restart_after_turn_timeout``).  But cron jobs have no pre-stop protection — they run on the scheduler's thread pool, entirely outside ``_running_agents``.

## Fix

Apply a minimum drain budget (30s) when the only active work is background (cron/API) and the configured timeout is 0.  Chat sessions still get the immediate drain behavior when timeout=0.

## Changes

- ``gateway/run.py``: Add ``_MIN_DRAIN_FOR_BACKGROUND_WORK`` constant and use it when ``timeout <= 0`` with active cron/API work.
- ``tests/gateway/test_update_cron_drain.py``: Add regression test ``test_drain_zero_timeout_still_waits_for_cron_jobs``.

Fixes #82161