### PR TITLE
feat(skills): add graph-engineering optional skill (knowledge graphs + task graphs)

### DIFF
--- a/optional-skills/data-science/graph-engineering/LICENSE
+++ b/optional-skills/data-science/graph-engineering/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 codejunkie99
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/optional-skills/data-science/graph-engineering/SKILL.md
+++ b/optional-skills/data-science/graph-engineering/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: graph-engineering
-description: Build knowledge graphs and task graphs for agents — ontology design, entity/relation/event extraction, fusion, GraphRAG/graph memory, and multi-agent orchestration patterns (parallel fan-out, verifier separation, the stop rule, human gates). Use when asked to build a knowledge graph, extract entities/relations from text, design an ontology, dedupe/merge entities, add graph memory or GraphRAG to an agent, orchestrate multi-agent workflows as a graph, or LEARN graph engineering — teaching mode explains each stage with worked examples and visual diagram artifacts.
+description: Build knowledge graphs and agent task graphs.
 version: 1.0.0
 author: codejunkie99 (ported to Hermes by Hermes Agent)
 license: MIT
+platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [knowledge-graph, graphrag, ontology, extraction, orchestration, data-science]
-    related_skills: [gitnexus-explorer, deepresearch, excalidraw]
+    related_skills: [gitnexus-explorer, excalidraw]
 ---
 
 # Graph Engineering
+
+Use when asked to build a knowledge graph, extract entities/relations/events from text, design
+an ontology, dedupe/merge entities, add graph memory or GraphRAG to an agent, orchestrate
+multi-agent workflows as a task graph, or teach graph engineering (teaching mode explains each
+stage with worked examples and visual diagram artifacts).
 
 > **Hermes adaptation notes** (read once, then follow the original body below):
 > - **Task-graph half → Hermes primitives.** The diamond pattern maps directly onto

--- a/optional-skills/data-science/graph-engineering/SKILL.md
+++ b/optional-skills/data-science/graph-engineering/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: graph-engineering
+description: Build knowledge graphs and task graphs for agents — ontology design, entity/relation/event extraction, fusion, GraphRAG/graph memory, and multi-agent orchestration patterns (parallel fan-out, verifier separation, the stop rule, human gates). Use when asked to build a knowledge graph, extract entities/relations from text, design an ontology, dedupe/merge entities, add graph memory or GraphRAG to an agent, orchestrate multi-agent workflows as a graph, or LEARN graph engineering — teaching mode explains each stage with worked examples and visual diagram artifacts.
+version: 1.0.0
+author: codejunkie99 (ported to Hermes by Hermes Agent)
+license: MIT
+metadata:
+  hermes:
+    tags: [knowledge-graph, graphrag, ontology, extraction, orchestration, data-science]
+    related_skills: [gitnexus-explorer, deepresearch, excalidraw]
+---
+
+# Graph Engineering
+
+> **Hermes adaptation notes** (read once, then follow the original body below):
+> - **Task-graph half → Hermes primitives.** The diamond pattern maps directly onto
+>   `delegate_task` batch mode (parallel workers) with a separate verifier task — never let a
+>   worker grade its own output in its own context. The plan node is your `todo` list; the
+>   human gate is Hermes' approval flow (route irreversible actions — send, publish, delete,
+>   deploy — through the user, not around them). "One writer per file" and loop caps apply
+>   verbatim to subagent fan-outs.
+> - **Small-scale storage default.** For stage 2 at agent scale, plain typed edges in
+>   JSON/JSONL or SQLite (queried via `execute_code`) beats standing up Neo4j — reach for a
+>   graph database only when multi-hop query volume justifies it.
+> - **Diagrams.** Teaching mode's visual artifacts work well as mermaid blocks in chat, or as
+>   Excalidraw/self-contained HTML files for keepable artifacts (see the `excalidraw` skill).
+> - **Fusion pitfall (stage 8).** Initial-letter acronym matching misses intra-word acronyms —
+>   "SEU" for "So·uth·east University" yields "SU" under a naive first-letters rule. Use alias
+>   lists, subsequence matching, or LLM adjudication for acronym candidates, not initial-letter
+>   rules alone.
+> - **Quality gate at pilot scale (stage 7).** "≥90% precision on a 50-item sample" means
+>   *all* items when the pilot has fewer than 50.
+> - Ported from [codejunkie99/graph-engineering](https://github.com/codejunkie99/graph-engineering)
+>   (MIT), itself distilled and translated from Southeast University's graduate Knowledge
+>   Graph course (npubird/KnowledgeGraphCourse, Prof. Peng Wang).
+
+Graph engineering is the discipline of designing the structures agents work through — not the
+prompts. It has two halves:
+
+1. **Knowledge graphs** — what agents remember. Nodes are entities and facts, edges are
+   relationships with time and provenance. This file's 9-stage pipeline covers it, distilled
+   from Southeast University's graduate KG course
+   (https://github.com/npubird/KnowledgeGraphCourse, Prof. Peng Wang), translated to English
+   and adapted for LLM-era agents.
+2. **Task graphs** — how agents work. Nodes are jobs, edges are execution dependencies:
+   parallel fan-out, separate verifier contexts, the stop rule, the human gate.
+   Read [references/task-graphs.md](references/task-graphs.md) when the request is about
+   orchestrating agents rather than building memory.
+
+Core mental model: a knowledge graph is a **product with a schema**, not a pile of triples.
+Quality comes from the pipeline order — model the domain BEFORE extracting, fuse BEFORE storing,
+evaluate at every stage.
+
+## Teaching Mode
+
+When the user wants to LEARN graph engineering (rather than build something), teach it — do
+not just execute. Rules:
+
+1. Anchor every stage in the user's own domain: ask for one real project or dataset, then use
+   it as the running example through all stages.
+2. **Generate visual artifacts as you teach.** Concepts in this discipline are shapes; show
+   them. For each major concept, produce a small diagram the user can keep — mermaid diagrams
+   (flowchart for the pipeline and task graphs, `graph LR` for example ontologies and
+   subgraphs) or a single self-contained HTML page when interactivity helps. At minimum:
+   the 9-stage pipeline, a 3-type ontology drawn from the user's domain, one extracted
+   subgraph (5-10 nodes) from a real sample, and the diamond pattern with the user's own jobs
+   as nodes.
+3. Teach in the pipeline's order, one stage per exchange, each ending with a small exercise
+   ("write 3 competency questions for your project") before moving on.
+4. Close by assembling what was built during the lesson into a starter `ontology.yaml` and a
+   drawn task graph for the user's first real build.
+
+## The 9-Stage Pipeline
+
+Run stages in order. For small projects stages 4-6 collapse into one extraction pass, but never
+skip stages 3 (ontology) or 8 (fusion) — they are where real-world graphs fail.
+
+1. **Scope & value test** — Confirm a graph beats a simpler structure. A graph pays off when
+   queries are multi-hop ("who worked with X on projects using Y"), when entities recur across
+   documents, or when relationships ARE the data. If lookups are single-hop, use a table and stop.
+
+2. **Knowledge representation choice** — Pick how facts are encoded: property graph
+   (Neo4j-style, pragmatic default), RDF triples (interop/standards), or plain typed edges in
+   JSON/SQLite (small scale). Decide now how time and provenance attach to every fact.
+
+3. **Ontology modeling** — Define entity types, relation types (with domain/range), and
+   attributes BEFORE extraction. Start minimal: 5-15 entity types, 10-30 relation types.
+   Two rules from the course: every relation gets a precise verb name (`ACQUIRED`, not
+   `RELATED_TO`), and if two types are always queried together, merge them.
+   Details and worked examples: [references/modeling.md](references/modeling.md)
+
+4. **Entity extraction (NER)** — Extract typed entities from sources. Method ladder: exact
+   rules/dictionaries for closed vocabularies → LLM extraction with the ontology in the prompt
+   for open text. Always extract with span + source pointer for provenance.
+
+5. **Relation extraction** — Extract typed edges between recognized entities. Constrain the
+   LLM to the ontology's relation list with domain/range checks; reject edges whose endpoints
+   have incompatible types. This one validation step removes most hallucinated structure.
+
+6. **Event extraction** — For dynamic domains (news, logs, transactions), extract events as
+   first-class nodes (trigger + typed arguments + time), not just static edges.
+   Extraction methods, prompt patterns, and failure modes for stages 4-6:
+   [references/extraction.md](references/extraction.md)
+
+7. **Quality gate** — Before fusion, sample and score: entity precision (are extracted
+   entities real and correctly typed?), relation precision (does the source sentence actually
+   assert the edge?). Fix the prompt/rules, not the output, then re-run. Target ≥90% precision
+   on a 50-item sample before proceeding — recall improves with more passes; bad precision
+   poisons the graph permanently.
+
+8. **Knowledge fusion** — Merge duplicates within and across sources: same real-world entity,
+   different surface forms ("SEU" = "Southeast University" = "东南大学"). Blocking + matching +
+   merge policy. Skipping this is the #1 cause of useless graphs.
+   Matching strategies: [references/fusion-and-llm.md](references/fusion-and-llm.md)
+
+9. **Serve to LLMs (KG × LLM)** — Make the graph useful to agents: GraphRAG retrieval
+   (subgraph → context), graph-as-memory (agent writes facts back through stages 4-8), and
+   LLM-as-reasoner over paths. Patterns and pitfalls:
+   [references/fusion-and-llm.md](references/fusion-and-llm.md)
+
+## Working Rules
+
+- **Schema first, always.** Extraction without an ontology produces a "graph" that is really a
+  word cloud with arrows. If the user resists schema design, build the minimal 5-type ontology
+  from 3 sample documents and show it for approval.
+- **Provenance on every fact.** Each node/edge stores `source`, `extracted_at`, and confidence.
+  Non-negotiable — fusion (stage 8) and trust both depend on it.
+- **Incremental over big-bang.** Process a 10-document pilot through all 9 stages before
+  scaling. The pilot exposes ontology gaps at 1% of the cost.
+- **LLM extraction is stage machinery, not the pipeline.** The LLM slots into stages 4-6;
+  the surrounding schema, validation, and fusion are what make the output a knowledge graph.
+
+## Reference Files
+
+- [references/curriculum.md](references/curriculum.md) — Full translated curriculum of the
+  source course with per-lecture summaries and links to the original Chinese slide decks.
+  Read when the user wants theory depth, the academic grounding, or the original materials.
+- [references/modeling.md](references/modeling.md) — Knowledge representation & ontology
+  engineering (course lectures 2-3). Read during stages 2-3.
+- [references/extraction.md](references/extraction.md) — Entity, relation, and event
+  extraction from rules to LLM prompting (lectures 4-7). Read during stages 4-7.
+- [references/fusion-and-llm.md](references/fusion-and-llm.md) — Knowledge fusion and
+  KG × LLM integration (lectures 8-9). Read during stages 8-9.
+
+## Credits
+
+Ported from [codejunkie99/graph-engineering](https://github.com/codejunkie99/graph-engineering)
+(MIT). That project is distilled and translated from 东南大学《知识图谱》研究生课程 (Southeast
+University graduate course on Knowledge Graphs), Prof. Peng Wang —
+https://github.com/npubird/KnowledgeGraphCourse. All original lecture PDFs are in Chinese;
+the skill is an independent English distillation adapted for AI-agent workflows.

--- a/optional-skills/data-science/graph-engineering/references/curriculum.md
+++ b/optional-skills/data-science/graph-engineering/references/curriculum.md
@@ -1,0 +1,88 @@
+# Source Course — Translated Curriculum
+
+Southeast University graduate course《知识图谱》(Knowledge Graphs), Prof. Peng Wang.
+Repo: https://github.com/npubird/KnowledgeGraphCourse (4.4K★, running since 2019, updated yearly).
+All slide decks are Chinese PDFs in the repo root; 2025 decks are prefixed `2025-pub-`.
+This file is the English map of the 2025 edition.
+
+## Lecture 1 — Knowledge Graphs: Theory, Technology, Practice, Challenges
+*(2025-pub-1 …A.pdf / …B.pdf)*
+
+- 1.1 The KG view of cognitive intelligence: what "knowledge" adds to machine cognition;
+  the essence of a knowledge graph; how KGs evolved (semantic networks → expert systems →
+  Semantic Web → Google's 2012 Knowledge Graph); KG vs deep learning; KG vs traditional
+  knowledge bases vs databases; application scenarios; core value.
+- 1.2 The technology stack, which the rest of the course expands:
+  **knowledge extraction → knowledge fusion → representation learning → reasoning → storage.**
+- 1.3 Bottlenecks: knowledge acquisition (coverage/cost), knowledge quality
+  (noise/consistency), and intelligent application (making the graph actually useful).
+
+## Lecture 2 — Knowledge Representation (2025-pub-2)
+
+Concepts, then the method inventory: semantic networks, production (rule) systems, frame
+systems, conceptual graphs, formal concept analysis, description logic, ontologies, ontology
+languages (RDF/RDFS/OWL), and KG representation learning (embeddings).
+→ Distilled in [modeling.md](modeling.md).
+
+## Lecture 3 — Knowledge Modeling (2025-pub-3)
+
+Ontology deep-dive: ontology engineering methodology, ontology learning (semi-automatic schema
+induction), modeling tools (Protégé et al.), and a hands-on modeling practicum.
+→ Distilled in [modeling.md](modeling.md).
+
+## Lecture 4 — Knowledge Extraction: Problems & Methods (2025-pub-4)
+
+Problem analysis (scenarios, why extraction is hard) and methods by source type:
+structured data (D2R mapping), semi-structured data (wrappers, web tables), and
+unstructured text (the NLP pipeline the next three lectures cover).
+→ Distilled in [extraction.md](extraction.md).
+
+## Lecture 5 — Entity Recognition (2025-pub-5, plus 2025 frontier deck 5-1)
+
+The full method ladder: rule/dictionary-based → classical ML (HMM/CRF) → deep learning
+(BiLSTM-CRF) → semi-supervised → transfer learning → pretrained models (BERT-era) →
+LLM-era paradigm. Frontier-progress deck updated yearly.
+→ Distilled in [extraction.md](extraction.md).
+
+## Lecture 6 — Relation Extraction (2025-pub-6)
+
+Semantic relations, feature design, benchmark datasets; methods: template/pattern-based,
+supervised, weakly supervised, distant supervision, unsupervised (open IE), and
+deep/reinforcement-learning approaches.
+→ Distilled in [extraction.md](extraction.md).
+
+## Lecture 7 — Event Extraction (2024-pub-7; includes Huawei industry lecture "From Classic
+to LLM Paradigms")
+
+Event concepts (trigger, arguments, event types), extraction methods, a finance-domain event
+extraction system walkthrough, and event-logic graphs (事理图谱) — graphs whose nodes are
+events and edges are causal/temporal/conditional links.
+→ Distilled in [extraction.md](extraction.md).
+
+## Lecture 8 — Knowledge Fusion (2024-pub-8, plus frontier-progress deck)
+
+Knowledge heterogeneity; ontology matching; match extraction and tuning; instance matching;
+large-scale entity matching (blocking, scaling); real fusion case studies.
+→ Distilled in [fusion-and-llm.md](fusion-and-llm.md).
+
+## Lecture 9 — Knowledge Graphs × Large Language Models (2025-pub-9)
+
+Both directions: **KG for LLM** (grounding, retrieval, hallucination reduction, structured
+memory) and **LLM for KG** (LLM-powered extraction, schema induction, fusion). The 2024
+edition also includes decks on ChatGPT for information extraction, prompt engineering, and
+quality evaluation.
+→ Distilled in [fusion-and-llm.md](fusion-and-llm.md).
+
+## How the course maps to this skill's 9-stage pipeline
+
+| Skill stage | Course source |
+|---|---|
+| 1 Scope & value | Lecture 1.1, 1.3 |
+| 2 Representation choice | Lecture 2 |
+| 3 Ontology modeling | Lecture 3 |
+| 4 Entity extraction | Lectures 4-5 |
+| 5 Relation extraction | Lecture 6 |
+| 6 Event extraction | Lecture 7 |
+| 7 Quality gate | Lecture 1.3 + evaluation material in 9 |
+| 8 Knowledge fusion | Lecture 8 |
+| 9 Serve to LLMs | Lecture 9 |

--- a/optional-skills/data-science/graph-engineering/references/extraction.md
+++ b/optional-skills/data-science/graph-engineering/references/extraction.md
@@ -1,0 +1,108 @@
+# Knowledge Extraction: Entities, Relations, Events
+*(Course lectures 4-7, translated and adapted)*
+
+## Contents
+- [Extraction by source type](#extraction-by-source-type)
+- [Entity extraction](#entity-extraction)
+- [Relation extraction](#relation-extraction)
+- [Event extraction](#event-extraction)
+- [LLM extraction prompt pattern](#llm-extraction-prompt-pattern)
+- [Failure modes](#failure-modes)
+
+## Extraction by source type
+
+(Lecture 4.) Match method to source structure — using NLP on data that is already structured
+is the classic beginner waste:
+
+- **Structured (databases, CSVs, APIs):** direct mapping, no NLP. Write a per-source mapping
+  from columns → ontology types (the course's D2R idea). Deterministic code, not LLM.
+- **Semi-structured (HTML tables, infoboxes, wikis, JSON blobs):** wrappers/parsers per
+  layout family; LLM only for the messy cells.
+- **Unstructured (text, transcripts, PDFs):** the NER → RE → EE pipeline below.
+
+## Entity extraction
+
+(Lecture 5's method ladder, compressed for the LLM era.)
+
+The course traces: rules/dictionaries → HMM/CRF → BiLSTM-CRF → semi-supervised → transfer →
+pretrained (BERT) → LLM. What survives into practice:
+
+1. **Dictionary/rule extraction first** for closed vocabularies you already have (your product
+   names, team roster, ticker symbols, ontology enum values). Exact match beats any model —
+   free, deterministic, 100% precision.
+2. **LLM extraction** for everything open-ended, with the ontology's entity types + definitions
+   + examples in the prompt (pattern below).
+3. **Always capture:** surface form, canonical form (best guess), type, source pointer
+   (doc id + char span or sentence), confidence.
+
+Classical lesson that still applies to LLM output: **nested and discontinuous mentions**
+("University of California, Berkeley professor John Smith" contains an ORG inside a PERSON
+context) and **type ambiguity** ("Apple") drive most errors — require the model to quote its
+evidence sentence, which forces disambiguation from context.
+
+## Relation extraction
+
+(Lecture 6.) Course inventory: template-based → supervised → weakly supervised → distant
+supervision → unsupervised open IE → deep/RL methods. Modern distillation:
+
+- Extract relations **only between entities that passed stage 4** — never let relation
+  extraction invent new entities. This single constraint kills most compounding errors.
+- Constrain output to the ontology's relation list; **validate domain/range in code**
+  (an `EMPLOYED_BY` edge from Org → Org is auto-rejected).
+- Distant supervision's core insight still matters for evaluation: if two entities co-occur,
+  a model will happily assert the relation the prior suggests. Guard: require an evidence
+  quote that *asserts* the relation, not just co-occurrence ("Musk discussed Twitter" is not
+  `OWNS`).
+- Keep un-modeled but repeated relations in a `candidate_relations` side-list — review weekly;
+  promote real ones into the ontology rather than forcing them into wrong types.
+
+## Event extraction
+
+(Lecture 7.) Use when the domain is dynamic — news, incidents, transactions, funding rounds.
+
+An event = **trigger** (the word/phrase signaling it) + **typed arguments** (participants,
+time, place, values) + **event type** from the ontology. Events are first-class nodes with
+edges to their arguments — never flatten a 4-argument event into 6 pairwise edges (you lose
+which acquisition happened at which price).
+
+The course's finance case study generalizes: define per-event-type argument schemas
+(`Acquisition: {acquirer, target, price, date}`), extract into that schema, reject events
+missing the trigger evidence.
+
+**Event-logic graphs (事理图谱):** a distinctive idea from the course worth knowing — graphs
+whose nodes are events and edges are causal/temporal/conditional relations between events
+("rate hike → bond selloff"). Build one when the user asks "what leads to what," not just
+"what is related to what."
+
+## LLM extraction prompt pattern
+
+One pass per stage (entities, then relations, then events), not one mega-prompt:
+
+```
+You are extracting knowledge for a graph with this ontology:
+<ontology>   (verbatim from the project's ontology file)
+
+From the text below, extract every entity matching the ontology types.
+For each: {surface, canonical, type, evidence: "<exact sentence>", confidence: high|med|low}
+Rules:
+- Only types from the ontology. Unknown-but-recurring concepts → list separately under "candidates".
+- Evidence must be a verbatim quote containing the mention.
+- Do not merge distinct mentions; deduplication happens later.
+<text>
+```
+
+Relation pass adds: the recognized-entity list, the relation inventory with domain/range, and
+"assert only relations the evidence sentence states directly."
+
+Chunking: overlap chunks by 10-15% so sentence-boundary entities aren't lost; extract per
+chunk; fusion (stage 8) reconciles.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Graph full of `Concept`/`Thing` nodes | Extracting without ontology | Stage 3 first; re-extract |
+| Same person as 4 nodes | Skipped canonical-form rule | Define rule in ontology; fusion pass |
+| Confident wrong relations | Co-occurrence treated as assertion | Evidence-quote requirement + domain/range validation |
+| Events flattened to edge soup | No event schema | First-class event nodes with argument schemas |
+| Precision collapses at scale | Prompt drift across doc types | Per-source-type prompts; stage 7 gate per source |

--- a/optional-skills/data-science/graph-engineering/references/fusion-and-llm.md
+++ b/optional-skills/data-science/graph-engineering/references/fusion-and-llm.md
@@ -1,0 +1,86 @@
+# Knowledge Fusion & Serving the Graph to LLMs
+*(Course lectures 8-9, translated and adapted)*
+
+## Contents
+- [Why fusion is the make-or-break stage](#why-fusion-is-the-make-or-break-stage)
+- [The fusion pipeline](#the-fusion-pipeline)
+- [Ontology matching](#ontology-matching)
+- [KG for LLM](#kg-for-llm)
+- [LLM for KG](#llm-for-kg)
+- [Graph-as-memory loop](#graph-as-memory-loop)
+
+## Why fusion is the make-or-break stage
+
+(Lecture 8.) Every extraction pass produces duplicates: "SEU", "Southeast University",
+"东南大学" are one university; "Bob Smith (doc 3)" and "Robert Smith (doc 41)" may or may not
+be one person. An unfused graph answers multi-hop queries wrongly *with confidence* — paths
+break at duplicate boundaries. This is the #1 reason real-world KG projects produce something
+useless.
+
+## The fusion pipeline
+
+Three steps, from the course's large-scale entity-matching material:
+
+1. **Blocking** — never compare all pairs (O(n²)). Group candidates cheaply first: same type +
+   (shared token | matching acronym expansion | embedding similarity above threshold | same
+   normalized key). Only pairs within a block get full comparison.
+2. **Matching** — score candidate pairs on layered evidence:
+   - String layer: normalized/alias/acronym match.
+   - Attribute layer: compatible attributes (same founding year, same email domain).
+   - **Structure layer** (the course's emphasis, and what naive dedup misses): compare
+     neighborhoods — two "J. Smith" nodes sharing 3 coauthors and an affiliation are the same
+     person; identical names with disjoint neighborhoods are not.
+   - LLM adjudication for the ambiguous middle band only (cheap heuristics for the clear
+     cases; the model sees both nodes' attributes + neighborhoods + evidence quotes).
+3. **Merge policy** — deterministic code, not model judgment: keep canonical name, union
+   aliases and edges, keep per-source attribute values with provenance when they conflict
+   (do NOT silently overwrite — conflicting values are signal), record `merged_from` for undo.
+
+Thresholds: auto-merge only above high confidence; auto-reject below low; queue the middle for
+LLM adjudication or human review. An erroneous merge is far more damaging than a missed one —
+it silently fuses two entities' entire edge sets.
+
+## Ontology matching
+
+When fusing two graphs (not just instances), align schemas first: map entity types and
+relation types between sources (course: 本体匹配 + match tuning). Practical order — align
+types by name+definition with an LLM, verify with instance overlap (if source A's `Firm` nodes
+mostly match source B's `Company` nodes, the type mapping is confirmed), then translate
+source B's edges through the mapping before instance fusion.
+
+## KG for LLM
+
+(Lecture 9, direction 1.) Making the graph reduce hallucination and extend context:
+
+- **GraphRAG retrieval:** entity-link the query → expand k hops (k=1-2; beyond 2 is noise
+  without re-ranking) → serialize the subgraph as compact triples/paths with provenance →
+  that is the LLM's context. Answers cite graph facts, not vibes.
+- **Serialization that works:** `(head)-[REL {time, source}]->(tail)` lines, grouped by head
+  entity, deduplicated. Tables of triples beat prose summaries — the LLM can quote exact facts.
+- **Multi-hop questions:** retrieve *paths* between the query's entities, not neighborhoods
+  around each. The path IS the answer skeleton; the LLM narrates it.
+- **Community summaries** for "what are the big themes" questions: cluster the graph,
+  summarize per cluster offline, retrieve summaries at query time.
+
+## LLM for KG
+
+(Lecture 9, direction 2.) Already embedded in stages 3-8 of the pipeline: schema induction
+(with human pruning), extraction (with ontology constraints + evidence quotes), fusion
+adjudication (middle band only). The course's framing to keep: the LLM is a component inside
+each stage with validation around it — not a replacement for the pipeline.
+
+## Graph-as-memory loop
+
+For agents that accumulate knowledge across sessions:
+
+1. After each session/task, run extraction (stages 4-6) over new information with the same
+   ontology.
+2. Fuse new facts into the existing graph (stage 8) — same blocking/matching/merge machinery,
+   incremental.
+3. At session start or on demand, retrieve via GraphRAG (above) instead of dumping the whole
+   graph into context.
+4. **Contradiction handling:** when a new fact conflicts with a stored one, keep both with
+   time + provenance and prefer the newer at retrieval time — facts change ("works at X"
+   becomes stale); the graph should record the change, not fight it.
+5. Periodic hygiene pass: re-run fusion over the full graph and re-score stale confidences.
+   Unmaintained memory graphs rot the same way unfused extractions do.

--- a/optional-skills/data-science/graph-engineering/references/modeling.md
+++ b/optional-skills/data-science/graph-engineering/references/modeling.md
@@ -1,0 +1,86 @@
+# Knowledge Representation & Ontology Modeling
+*(Course lectures 2-3, translated and adapted)*
+
+## Contents
+- [Choosing a representation](#choosing-a-representation)
+- [Ontology engineering method](#ontology-engineering-method)
+- [Schema design rules](#schema-design-rules)
+- [Worked example](#worked-example)
+- [Ontology learning](#ontology-learning)
+
+## Choosing a representation
+
+The course surveys the historical inventory — semantic networks, production rules, frames,
+conceptual graphs, formal concept analysis, description logic — converging on two survivors
+plus one pragmatic shortcut:
+
+| Representation | Choose when | Cost |
+|---|---|---|
+| **Property graph** (Neo4j, Kùzu, NetworkX) | Default for products and agent memory. Nodes/edges with arbitrary key-value properties. | No formal semantics; consistency is your job. |
+| **RDF/OWL triples** | Interop with existing ontologies, standards compliance, need for description-logic reasoning (subsumption, consistency checking). | Verbose; reification needed for edge properties; steeper tooling. |
+| **Typed edges in JSON/SQLite** | <50K nodes, single application, agent-local memory. | Query power capped; migrate when multi-hop queries get slow or frequent. |
+
+Decide at this stage (not later) how every fact carries:
+- **Time** — validity interval or event timestamp (`since`, `until`).
+- **Provenance** — source document/URL + extraction timestamp + confidence.
+
+In property graphs these are edge properties; in RDF use reification or RDF-star; in JSON just
+add the fields. Retrofitting provenance after fusion is effectively impossible.
+
+## Ontology engineering method
+
+Condensed from the course's ontology-engineering process:
+
+1. **Competency questions.** Write the 10-20 questions the graph must answer
+   ("Which suppliers does product X depend on transitively?"). These are the ontology's spec
+   AND its test suite.
+2. **Enumerate core entity types** from the competency questions. Start with 5-15. Each type
+   needs a one-line definition and 2-3 real examples.
+3. **Enumerate relation types** with **domain and range** (e.g. `EMPLOYED_BY: Person → Org`).
+   Start with 10-30. Add cardinality notes where they matter (a Person has one birthplace).
+4. **Attributes vs entities.** If it has its own relationships, it's an entity ("City" — has
+   country, population). If it's a value you filter on, it's an attribute ("founding year").
+5. **Type hierarchy only when queries need it.** `Company ⊂ Organization` is worth having if
+   some queries span all organizations; otherwise skip subclassing — flat is easier to extract
+   against.
+6. **Validate against the competency questions** — walk each question through the schema on
+   paper. Any question you can't path through the schema = missing type or relation.
+
+## Schema design rules
+
+- Precise verb names for relations: `ACQUIRED`, `CITES`, `DEPENDS_ON` — never `RELATED_TO`,
+  `HAS_LINK`. Vague relations make every downstream query ambiguous.
+- If two entity types are always queried together, merge them into one.
+- If one entity type keeps needing qualifier attributes to disambiguate usage
+  (`role: "author" | "editor"`), split it into two relation types instead.
+- Name entities canonically at modeling time (define the canonical-form rule: full legal name?
+  lowercase? language?) — fusion (stage 8) enforces whatever rule you state here.
+- Keep an `ontology.md` (or `.yaml`) file in the project as the single source of truth; every
+  extraction prompt embeds it verbatim.
+
+## Worked example
+
+Competency question: "Which engineers contributed to services that had incidents last quarter?"
+
+```yaml
+entities:
+  Person:   {desc: engineer or manager, ex: [Jane Doe]}
+  Service:  {desc: deployable software unit, ex: [payments-api]}
+  Incident: {desc: production failure event, ex: [INC-4012]}
+relations:
+  CONTRIBUTED_TO: {domain: Person,  range: Service}
+  AFFECTED:       {domain: Incident, range: Service, attrs: [severity]}
+events:
+  Incident: {trigger: outage/alert, args: [service, start_time, resolved_time, severity]}
+```
+
+Three types, two relations, one event type — fully answers the question. Resist adding more
+until a competency question demands it.
+
+## Ontology learning
+
+The course covers semi-automatic schema induction (terms → concepts → hierarchy → relations).
+LLM-era shortcut that preserves the same discipline: give an LLM 3-5 representative documents,
+ask it to propose entity/relation types **with evidence quotes**, then manually prune to the
+minimal set that answers the competency questions. Never auto-accept an induced schema —
+induced ontologies overfit the sample documents.

--- a/optional-skills/data-science/graph-engineering/references/task-graphs.md
+++ b/optional-skills/data-science/graph-engineering/references/task-graphs.md
@@ -1,0 +1,75 @@
+# Task Graphs: Orchestrating Agents
+*(The execution half of graph engineering — how agents work, as opposed to what they remember)*
+
+## Contents
+- [What a task graph is](#what-a-task-graph-is)
+- [Fake edges](#fake-edges)
+- [The diamond pattern](#the-diamond-pattern)
+- [The stop rule](#the-stop-rule)
+- [The human gate](#the-human-gate)
+- [Guardrails](#guardrails)
+
+## What a task graph is
+
+Nodes are jobs — each one something you would hand to a single assistant (research one
+competitor, write one draft, check one claim). Draw an arrow only when a job needs another
+job's *result* before it can start. The drawing is the plan; agents flow through it.
+A small state object (what was found, what was decided, what remains) travels with the work.
+
+This is a DAG — the pattern that has run data infrastructure for decades (Airflow, Prefect,
+Temporal) now applied to agents (LangGraph, CrewAI, AutoGen). The age of the pattern is a
+feature: trust your business to machinery with decades of production history.
+
+## Fake edges
+
+The first optimization costs nothing: for every "and then" in an existing pipeline, ask
+whether the next job actually reads the previous job's output. "Summarize this file and then
+check my calendar" — the calendar step never uses the summary; the edge is fake. Delete fake
+edges and those jobs run in parallel. Most hand-built pipelines contain two or three.
+
+## The diamond pattern
+
+The shape serious systems converge to:
+
+```
+        ┌─ worker 1 ─┐
+plan ───┼─ worker 2 ─┼─→ verify ─→ merge ─→ result
+        └─ worker 3 ─┘
+```
+
+Split the task into independent angles, run workers in parallel, **verify in a separate
+context**, merge survivors. The verification node is non-negotiable: a model grading its own
+work in its own context misses most of its own mistakes. Give each verifier a different
+question (is it correct? is it current? is the source real?) — diverse skeptics catch what
+identical ones cannot.
+
+## The stop rule
+
+From the Google DeepMind × MIT study "Towards a Science of Scaling Agent Systems"
+(180 controlled configurations): coordinated teams beat a single agent by ~80% on work that
+splits into independent pieces — and **every** multi-agent configuration lost on sequential
+work where each step needs the full picture (degrading 39-70%). Uncoordinated agents
+amplified each other's errors 17.2×; a single coordinator owning the merge cut it to 4.4×.
+
+The decision procedure:
+1. Ask: *where does my work split into pieces that never read each other's results?*
+2. Split only that. Everything sequential stays with one agent.
+3. Never let findings merge without one owner of the merge.
+
+More agents is not a strategy. The shape of the work decides.
+
+## The human gate
+
+The human is a node. Route every irreversible edge — send, publish, refund, delete, deploy —
+through explicit approval. Placement rule: **put the gate where a mistake is expensive to
+undo, not on every step.** A gate on everything makes the human the bottleneck; a gate on
+nothing means nobody is watching. Judge the system on numbers that cannot argue back (tests
+that ran, money that landed), never on its own self-reports.
+
+## Guardrails
+
+Four caps that keep a graph from becoming an expensive accident:
+1. Every loop gets a maximum number of rounds.
+2. One writer per file — no two jobs mutate the same artifact.
+3. The routing lives in written steps; the model fills the jobs, not the plan.
+4. A hard cap on how many agents can spawn.

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -74,7 +74,7 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
-| [**graph-engineering**](/docs/user-guide/skills/optional/data-science/data-science-graph-engineering) | Build knowledge graphs and task graphs for agents — ontology design, entity/relation/event extraction, fusion, GraphRAG/graph memory, and multi-agent orchestration patterns (parallel fan-out, verifier separation, the stop rule, human gat... |
+| [**graph-engineering**](/docs/user-guide/skills/optional/data-science/data-science-graph-engineering) | Build knowledge graphs and agent task graphs. |
 | [**jupyter-notebook**](/docs/user-guide/skills/optional/data-science/data-science-jupyter-notebook) | Iterative Python via live Jupyter kernel (hamelnb). |
 
 ## devops

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -74,6 +74,7 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
+| [**graph-engineering**](/docs/user-guide/skills/optional/data-science/data-science-graph-engineering) | Build knowledge graphs and task graphs for agents — ontology design, entity/relation/event extraction, fusion, GraphRAG/graph memory, and multi-agent orchestration patterns (parallel fan-out, verifier separation, the stop rule, human gat... |
 | [**jupyter-notebook**](/docs/user-guide/skills/optional/data-science/data-science-jupyter-notebook) | Iterative Python via live Jupyter kernel (hamelnb). |
 
 ## devops

--- a/website/docs/user-guide/skills/optional/data-science/data-science-graph-engineering.md
+++ b/website/docs/user-guide/skills/optional/data-science/data-science-graph-engineering.md
@@ -1,14 +1,14 @@
 ---
-title: "Graph Engineering"
+title: "Graph Engineering — Build knowledge graphs and agent task graphs"
 sidebar_label: "Graph Engineering"
-description: "Build knowledge graphs and task graphs for agents — ontology design, entity/relation/event extraction, fusion, GraphRAG/graph memory, and multi-agent orchest..."
+description: "Build knowledge graphs and agent task graphs"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Graph Engineering
 
-Build knowledge graphs and task graphs for agents — ontology design, entity/relation/event extraction, fusion, GraphRAG/graph memory, and multi-agent orchestration patterns (parallel fan-out, verifier separation, the stop rule, human gates). Use when asked to build a knowledge graph, extract entities/relations from text, design an ontology, dedupe/merge entities, add graph memory or GraphRAG to an agent, orchestrate multi-agent workflows as a graph, or LEARN graph engineering — teaching mode explains each stage with worked examples and visual diagram artifacts.
+Build knowledge graphs and agent task graphs.
 
 ## Skill metadata
 
@@ -19,8 +19,9 @@ Build knowledge graphs and task graphs for agents — ontology design, entity/re
 | Version | `1.0.0` |
 | Author | codejunkie99 (ported to Hermes by Hermes Agent) |
 | License | MIT |
+| Platforms | linux, macos, windows |
 | Tags | `knowledge-graph`, `graphrag`, `ontology`, `extraction`, `orchestration`, `data-science` |
-| Related skills | [`gitnexus-explorer`](/docs/user-guide/skills/optional/research/research-gitnexus-explorer), `deepresearch`, [`excalidraw`](/docs/user-guide/skills/bundled/creative/creative-excalidraw) |
+| Related skills | [`gitnexus-explorer`](/docs/user-guide/skills/optional/research/research-gitnexus-explorer), [`excalidraw`](/docs/user-guide/skills/bundled/creative/creative-excalidraw) |
 
 ## Reference: full SKILL.md
 
@@ -29,6 +30,11 @@ The following is the complete skill definition that Hermes loads when this skill
 :::
 
 # Graph Engineering
+
+Use when asked to build a knowledge graph, extract entities/relations/events from text, design
+an ontology, dedupe/merge entities, add graph memory or GraphRAG to an agent, orchestrate
+multi-agent workflows as a task graph, or teach graph engineering (teaching mode explains each
+stage with worked examples and visual diagram artifacts).
 
 > **Hermes adaptation notes** (read once, then follow the original body below):
 > - **Task-graph half → Hermes primitives.** The diamond pattern maps directly onto
@@ -42,7 +48,13 @@ The following is the complete skill definition that Hermes loads when this skill
 >   graph database only when multi-hop query volume justifies it.
 > - **Diagrams.** Teaching mode's visual artifacts work well as mermaid blocks in chat, or as
 >   Excalidraw/self-contained HTML files for keepable artifacts (see the `excalidraw` skill).
-> - Ported from [codejunkie99/graph-engineering](https://github.com/codejunkey99/graph-engineering)
+> - **Fusion pitfall (stage 8).** Initial-letter acronym matching misses intra-word acronyms —
+>   "SEU" for "So·uth·east University" yields "SU" under a naive first-letters rule. Use alias
+>   lists, subsequence matching, or LLM adjudication for acronym candidates, not initial-letter
+>   rules alone.
+> - **Quality gate at pilot scale (stage 7).** "≥90% precision on a 50-item sample" means
+>   *all* items when the pilot has fewer than 50.
+> - Ported from [codejunkie99/graph-engineering](https://github.com/codejunkie99/graph-engineering)
 >   (MIT), itself distilled and translated from Southeast University's graduate Knowledge
 >   Graph course (npubird/KnowledgeGraphCourse, Prof. Peng Wang).
 

--- a/website/docs/user-guide/skills/optional/data-science/data-science-graph-engineering.md
+++ b/website/docs/user-guide/skills/optional/data-science/data-science-graph-engineering.md
@@ -1,0 +1,163 @@
+---
+title: "Graph Engineering"
+sidebar_label: "Graph Engineering"
+description: "Build knowledge graphs and task graphs for agents — ontology design, entity/relation/event extraction, fusion, GraphRAG/graph memory, and multi-agent orchest..."
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Graph Engineering
+
+Build knowledge graphs and task graphs for agents — ontology design, entity/relation/event extraction, fusion, GraphRAG/graph memory, and multi-agent orchestration patterns (parallel fan-out, verifier separation, the stop rule, human gates). Use when asked to build a knowledge graph, extract entities/relations from text, design an ontology, dedupe/merge entities, add graph memory or GraphRAG to an agent, orchestrate multi-agent workflows as a graph, or LEARN graph engineering — teaching mode explains each stage with worked examples and visual diagram artifacts.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/data-science/graph-engineering` |
+| Path | `optional-skills/data-science/graph-engineering` |
+| Version | `1.0.0` |
+| Author | codejunkie99 (ported to Hermes by Hermes Agent) |
+| License | MIT |
+| Tags | `knowledge-graph`, `graphrag`, `ontology`, `extraction`, `orchestration`, `data-science` |
+| Related skills | [`gitnexus-explorer`](/docs/user-guide/skills/optional/research/research-gitnexus-explorer), `deepresearch`, [`excalidraw`](/docs/user-guide/skills/bundled/creative/creative-excalidraw) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Graph Engineering
+
+> **Hermes adaptation notes** (read once, then follow the original body below):
+> - **Task-graph half → Hermes primitives.** The diamond pattern maps directly onto
+>   `delegate_task` batch mode (parallel workers) with a separate verifier task — never let a
+>   worker grade its own output in its own context. The plan node is your `todo` list; the
+>   human gate is Hermes' approval flow (route irreversible actions — send, publish, delete,
+>   deploy — through the user, not around them). "One writer per file" and loop caps apply
+>   verbatim to subagent fan-outs.
+> - **Small-scale storage default.** For stage 2 at agent scale, plain typed edges in
+>   JSON/JSONL or SQLite (queried via `execute_code`) beats standing up Neo4j — reach for a
+>   graph database only when multi-hop query volume justifies it.
+> - **Diagrams.** Teaching mode's visual artifacts work well as mermaid blocks in chat, or as
+>   Excalidraw/self-contained HTML files for keepable artifacts (see the `excalidraw` skill).
+> - Ported from [codejunkie99/graph-engineering](https://github.com/codejunkey99/graph-engineering)
+>   (MIT), itself distilled and translated from Southeast University's graduate Knowledge
+>   Graph course (npubird/KnowledgeGraphCourse, Prof. Peng Wang).
+
+Graph engineering is the discipline of designing the structures agents work through — not the
+prompts. It has two halves:
+
+1. **Knowledge graphs** — what agents remember. Nodes are entities and facts, edges are
+   relationships with time and provenance. This file's 9-stage pipeline covers it, distilled
+   from Southeast University's graduate KG course
+   (https://github.com/npubird/KnowledgeGraphCourse, Prof. Peng Wang), translated to English
+   and adapted for LLM-era agents.
+2. **Task graphs** — how agents work. Nodes are jobs, edges are execution dependencies:
+   parallel fan-out, separate verifier contexts, the stop rule, the human gate.
+   Read [references/task-graphs.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/task-graphs.md) when the request is about
+   orchestrating agents rather than building memory.
+
+Core mental model: a knowledge graph is a **product with a schema**, not a pile of triples.
+Quality comes from the pipeline order — model the domain BEFORE extracting, fuse BEFORE storing,
+evaluate at every stage.
+
+## Teaching Mode
+
+When the user wants to LEARN graph engineering (rather than build something), teach it — do
+not just execute. Rules:
+
+1. Anchor every stage in the user's own domain: ask for one real project or dataset, then use
+   it as the running example through all stages.
+2. **Generate visual artifacts as you teach.** Concepts in this discipline are shapes; show
+   them. For each major concept, produce a small diagram the user can keep — mermaid diagrams
+   (flowchart for the pipeline and task graphs, `graph LR` for example ontologies and
+   subgraphs) or a single self-contained HTML page when interactivity helps. At minimum:
+   the 9-stage pipeline, a 3-type ontology drawn from the user's domain, one extracted
+   subgraph (5-10 nodes) from a real sample, and the diamond pattern with the user's own jobs
+   as nodes.
+3. Teach in the pipeline's order, one stage per exchange, each ending with a small exercise
+   ("write 3 competency questions for your project") before moving on.
+4. Close by assembling what was built during the lesson into a starter `ontology.yaml` and a
+   drawn task graph for the user's first real build.
+
+## The 9-Stage Pipeline
+
+Run stages in order. For small projects stages 4-6 collapse into one extraction pass, but never
+skip stages 3 (ontology) or 8 (fusion) — they are where real-world graphs fail.
+
+1. **Scope & value test** — Confirm a graph beats a simpler structure. A graph pays off when
+   queries are multi-hop ("who worked with X on projects using Y"), when entities recur across
+   documents, or when relationships ARE the data. If lookups are single-hop, use a table and stop.
+
+2. **Knowledge representation choice** — Pick how facts are encoded: property graph
+   (Neo4j-style, pragmatic default), RDF triples (interop/standards), or plain typed edges in
+   JSON/SQLite (small scale). Decide now how time and provenance attach to every fact.
+
+3. **Ontology modeling** — Define entity types, relation types (with domain/range), and
+   attributes BEFORE extraction. Start minimal: 5-15 entity types, 10-30 relation types.
+   Two rules from the course: every relation gets a precise verb name (`ACQUIRED`, not
+   `RELATED_TO`), and if two types are always queried together, merge them.
+   Details and worked examples: [references/modeling.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/modeling.md)
+
+4. **Entity extraction (NER)** — Extract typed entities from sources. Method ladder: exact
+   rules/dictionaries for closed vocabularies → LLM extraction with the ontology in the prompt
+   for open text. Always extract with span + source pointer for provenance.
+
+5. **Relation extraction** — Extract typed edges between recognized entities. Constrain the
+   LLM to the ontology's relation list with domain/range checks; reject edges whose endpoints
+   have incompatible types. This one validation step removes most hallucinated structure.
+
+6. **Event extraction** — For dynamic domains (news, logs, transactions), extract events as
+   first-class nodes (trigger + typed arguments + time), not just static edges.
+   Extraction methods, prompt patterns, and failure modes for stages 4-6:
+   [references/extraction.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/extraction.md)
+
+7. **Quality gate** — Before fusion, sample and score: entity precision (are extracted
+   entities real and correctly typed?), relation precision (does the source sentence actually
+   assert the edge?). Fix the prompt/rules, not the output, then re-run. Target ≥90% precision
+   on a 50-item sample before proceeding — recall improves with more passes; bad precision
+   poisons the graph permanently.
+
+8. **Knowledge fusion** — Merge duplicates within and across sources: same real-world entity,
+   different surface forms ("SEU" = "Southeast University" = "东南大学"). Blocking + matching +
+   merge policy. Skipping this is the #1 cause of useless graphs.
+   Matching strategies: [references/fusion-and-llm.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/fusion-and-llm.md)
+
+9. **Serve to LLMs (KG × LLM)** — Make the graph useful to agents: GraphRAG retrieval
+   (subgraph → context), graph-as-memory (agent writes facts back through stages 4-8), and
+   LLM-as-reasoner over paths. Patterns and pitfalls:
+   [references/fusion-and-llm.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/fusion-and-llm.md)
+
+## Working Rules
+
+- **Schema first, always.** Extraction without an ontology produces a "graph" that is really a
+  word cloud with arrows. If the user resists schema design, build the minimal 5-type ontology
+  from 3 sample documents and show it for approval.
+- **Provenance on every fact.** Each node/edge stores `source`, `extracted_at`, and confidence.
+  Non-negotiable — fusion (stage 8) and trust both depend on it.
+- **Incremental over big-bang.** Process a 10-document pilot through all 9 stages before
+  scaling. The pilot exposes ontology gaps at 1% of the cost.
+- **LLM extraction is stage machinery, not the pipeline.** The LLM slots into stages 4-6;
+  the surrounding schema, validation, and fusion are what make the output a knowledge graph.
+
+## Reference Files
+
+- [references/curriculum.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/curriculum.md) — Full translated curriculum of the
+  source course with per-lecture summaries and links to the original Chinese slide decks.
+  Read when the user wants theory depth, the academic grounding, or the original materials.
+- [references/modeling.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/modeling.md) — Knowledge representation & ontology
+  engineering (course lectures 2-3). Read during stages 2-3.
+- [references/extraction.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/extraction.md) — Entity, relation, and event
+  extraction from rules to LLM prompting (lectures 4-7). Read during stages 4-7.
+- [references/fusion-and-llm.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/data-science/graph-engineering/references/fusion-and-llm.md) — Knowledge fusion and
+  KG × LLM integration (lectures 8-9). Read during stages 8-9.
+
+## Credits
+
+Ported from [codejunkie99/graph-engineering](https://github.com/codejunkie99/graph-engineering)
+(MIT). That project is distilled and translated from 东南大学《知识图谱》研究生课程 (Southeast
+University graduate course on Knowledge Graphs), Prof. Peng Wang —
+https://github.com/npubird/KnowledgeGraphCourse. All original lecture PDFs are in Chinese;
+the skill is an independent English distillation adapted for AI-agent workflows.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -395,6 +395,7 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-optional-data-science',
                   collapsed: true,
                   items: [
+                    'user-guide/skills/optional/data-science/data-science-graph-engineering',
                     'user-guide/skills/optional/data-science/data-science-jupyter-notebook',
                   ],
                 },


### PR DESCRIPTION
## Summary
Adds `graph-engineering` to the optional skills catalog (data-science) — a two-half skill: build knowledge graphs (9-stage pipeline: scope, representation, ontology, entity/relation/event extraction, quality gate, fusion, GraphRAG serving) and design task graphs for multi-agent orchestration (diamond pattern, stop rule, human gate).

Port of [codejunkie99/graph-engineering](https://github.com/codejunkie99/graph-engineering) (MIT, 353★ / 50 forks in ~2 weeks), itself distilled and translated from Southeast University's graduate Knowledge Graph course ([npubird/KnowledgeGraphCourse](https://github.com/npubird/KnowledgeGraphCourse), 4.4k★, Prof. Peng Wang).

## Changes
- `optional-skills/data-science/graph-engineering/`: SKILL.md (+ Hermes adaptation notes header), 5 reference files (curriculum, modeling, extraction, fusion-and-llm, task-graphs), upstream MIT LICENSE
- Hermes adaptations: task-graph half mapped onto `delegate_task` batch fan-out + separate-verifier + `todo` planning + approval-flow human gates; small-scale storage default is JSON/SQLite via `execute_code` (not Neo4j); diagram output via mermaid/excalidraw
- Docs: catalog row, generated skill page, sidebar entry

## Validation
Live-tested cold by a fresh subagent: executed the full 9-stage pipeline on a 3-doc corpus — ontology (6 entity/12 relation types), 17 entities + 14 relations extracted with span-level provenance, stage-7 gate scored 100% precision programmatically, stage-8 fusion merged deliberate duplicates ("SEU"/"Southeast University", "QD"/"Quanta Dynamics"; 17 mentions → 12 nodes), and a 3-hop query resolved **only because fusion merged the alias** — exactly the failure mode the skill warns about. Verdict: PASS.

Subagent friction findings folded in pre-PR:
- Fixed a typo'd upstream URL (`codejunkey99` → `codejunkie99`)
- Added a fusion pitfall note (initial-letter acronym matching yields "SU" not "SEU" — the skill's own canonical example defeats the naive implementation)
- Clarified the stage-7 sample-size rule at pilot scale (<50 items ⇒ check all)

## Trust / cost notes
- Prose-only skill: zero dependencies, zero credentials, no network access, no scripts
- ~32 KB total; SKILL.md ~9 KB, references loaded on demand per stage
- License: MIT upstream, preserved verbatim with credit chain (port → distillation → original course)

## Comparison vs existing
No existing skill covers KG construction methodology. `gitnexus-explorer` (code KG via a specific tool) and open PR #77084 (ontology-context-layer, an MCP storage layer) are adjacent but orthogonal — this teaches the *discipline* (ontology-first pipeline + orchestration patterns) rather than wrapping a storage backend; cross-linked via related_skills.

## Infographic

![graph-engineering infographic](https://v3b.fal.media/files/b/0aa59adf/byyGE-E_bvLgiIonCoCn2_5Qkkf8dn.png)
