### PR TITLE
fix(agent): preserve foreground resources after background review

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1377,16 +1377,14 @@ def _run_review_in_thread(
             # summary still needs the completed review agent's tool results.
             review_messages = list(getattr(review_agent, "_session_messages", []))
 
-            # Tear down memory providers while stdout is still
-            # redirected so background thread teardown (Honcho flush,
-            # Hindsight sync, etc.) stays silent.  The finally block
-            # below is a safety net for the exception path.
+            # The fork shares the foreground session ID for prompt-cache
+            # parity.  Do not call close() or shutdown_memory_provider():
+            # both are session-bound lifecycle operations, and close() also
+            # kills registered terminal processes and cleans environments for
+            # that ID.  Releasing only this fork's clients leaves the live
+            # session and its child processes untouched.
             try:
-                review_agent.shutdown_memory_provider()
-            except Exception:
-                pass
-            try:
-                review_agent.close()
+                review_agent.release_clients()
             except Exception:
                 pass
             review_agent = None
@@ -1445,11 +1443,10 @@ def _run_review_in_thread(
             _log_review_completion(review_usage, "error")
         agent._emit_auxiliary_failure("background review", e)
     finally:
-        # Safety-net cleanup for the exception path.  Normal completion already
-        # shut down inside the thread-scoped silence above.  Re-enter the
-        # thread-scoped silence here so teardown output (Honcho flush, Hindsight
-        # sync, background thread joins) stays quiet even on the exception path,
-        # without blanking other threads' streams.
+        # Safety-net cleanup for the exception path. Normal completion already
+        # released its clients inside the thread-scoped silence above. Re-enter
+        # the thread-scoped silence here so exception-path cleanup output stays
+        # quiet without blanking other threads' streams.
         # Also a safety-net completion: covers exceptions raised during setup
         # before the request-phase finally. Both tracking cleanup and the
         # per-run completion publication are identity-scoped and idempotent.
@@ -1458,11 +1455,7 @@ def _run_review_in_thread(
             try:
                 with thread_scoped_silence():
                     try:
-                        review_agent.shutdown_memory_provider()
-                    except Exception:
-                        pass
-                    try:
-                        review_agent.close()
+                        review_agent.release_clients()
                     except Exception:
                         pass
             except Exception:

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -995,16 +995,14 @@ def _run_review_in_thread(
             # summary still needs the completed review agent's tool results.
             review_messages = list(getattr(review_agent, "_session_messages", []))
 
-            # Tear down memory providers while stdout is still
-            # redirected so background thread teardown (Honcho flush,
-            # Hindsight sync, etc.) stays silent.  The finally block
-            # below is a safety net for the exception path.
+            # The fork shares the foreground session ID for prompt-cache
+            # parity.  Do not call close() or shutdown_memory_provider():
+            # both are session-bound lifecycle operations, and close() also
+            # kills registered terminal processes and cleans environments for
+            # that ID.  Releasing only this fork's clients leaves the live
+            # session and its child processes untouched.
             try:
-                review_agent.shutdown_memory_provider()
-            except Exception:
-                pass
-            try:
-                review_agent.close()
+                review_agent.release_clients()
             except Exception:
                 pass
             review_agent = None
@@ -1058,10 +1056,9 @@ def _run_review_in_thread(
         agent._emit_auxiliary_failure("background review", e)
     finally:
         # Safety-net cleanup for the exception path.  Normal completion already
-        # shut down inside the thread-scoped silence above.  Re-enter the
-        # thread-scoped silence here so teardown output (Honcho flush, Hindsight
-        # sync, background thread joins) stays quiet even on the exception path,
-        # without blanking other threads' streams.
+        # released its clients inside the thread-scoped silence above. Re-enter
+        # the thread-scoped silence here so exception-path cleanup output stays
+        # quiet without blanking other threads' streams.
         # Also a safety-net unregister: covers exceptions raised during setup
         # (between registration and the run_conversation try/finally above)
         # that the primary _unregister_review_agent call site never reaches.
@@ -1073,11 +1070,7 @@ def _run_review_in_thread(
             try:
                 with thread_scoped_silence():
                     try:
-                        review_agent.shutdown_memory_provider()
-                    except Exception:
-                        pass
-                    try:
-                        review_agent.close()
+                        review_agent.release_clients()
                     except Exception:
                         pass
             except Exception:

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -185,7 +185,13 @@ def _install_relay_recorder(monkeypatch, review_run=None):
     return calls
 
 
-def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
+def test_background_review_releases_clients_without_closing_shared_session(monkeypatch):
+    """The review fork must not clean up resources owned by its parent session.
+
+    The fork uses the foreground session ID for prefix-cache parity.  Calling
+    ``close()`` would therefore kill that session's registered terminal
+    processes and tear down its environment when the review completes.
+    """
     events = []
 
     class FakeReviewAgent:
@@ -196,11 +202,11 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
         def run_conversation(self, **kwargs):
             events.append(("run_conversation", kwargs))
 
-        def shutdown_memory_provider(self):
-            events.append(("shutdown_memory_provider", None))
-
         def close(self):
             events.append(("close", None))
+
+        def release_clients(self):
+            events.append(("release_clients", None))
 
     monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
     monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
@@ -216,8 +222,7 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
     assert [name for name, _payload in events] == [
         "init",
         "run_conversation",
-        "shutdown_memory_provider",
-        "close",
+        "release_clients",
     ]
 
 
@@ -725,7 +730,7 @@ def test_stale_review_cleanup_cannot_clear_or_signal_newer_review(monkeypatch):
             self.index = instance_count
             instance_count += 1
 
-        def shutdown_memory_provider(self):
+        def release_clients(self):
             if self.index == 0:
                 first_cleanup_entered.set()
                 assert allow_first_cleanup.wait(2.0)

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -45,7 +45,13 @@ class ImmediateThread:
         self._target()
 
 
-def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
+def test_background_review_releases_clients_without_closing_shared_session(monkeypatch):
+    """The review fork must not clean up resources owned by its parent session.
+
+    The fork uses the foreground session ID for prefix-cache parity.  Calling
+    ``close()`` would therefore kill that session's registered terminal
+    processes and tear down its environment when the review completes.
+    """
     events = []
 
     class FakeReviewAgent:
@@ -56,11 +62,11 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
         def run_conversation(self, **kwargs):
             events.append(("run_conversation", kwargs))
 
-        def shutdown_memory_provider(self):
-            events.append(("shutdown_memory_provider", None))
-
         def close(self):
             events.append(("close", None))
+
+        def release_clients(self):
+            events.append(("release_clients", None))
 
     monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
     monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
@@ -76,8 +82,7 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
     assert [name for name, _payload in events] == [
         "init",
         "run_conversation",
-        "shutdown_memory_provider",
-        "close",
+        "release_clients",
     ]
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents a background self-improvement review from tearing down resources owned by the live foreground session. The review fork reuses the foreground session ID for prompt-cache parity, while `AIAgent.close()` kills registered terminal processes and cleans session environments for that ID. The fork now releases only its own LLM clients after review completion.

## Related Issue

Fixes #82192

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/background_review.py`: replace shared-session lifecycle teardown with client-only release on both normal and exception paths.
- `tests/run_agent/test_background_review.py`: assert review cleanup releases clients without calling the destructive shared-session close path.

## How to Test

1. Run the background-review and importer-path suites:
   `/opt/homebrew/bin/timeout -k 30 480 "$VIRTUAL_ENV/bin/python" -m pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_background_review_cost_controls.py tests/run_agent/test_background_review_summary.py tests/run_agent/test_background_review_toolset_restriction.py tests/agent/test_skip_background_review.py tests/test_background_review_list_shapes.py tests/test_background_review_session_isolation.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_refine_focus.py tests/agent/test_codex_app_server_event_bridge.py tests/run_agent/test_codex_app_server_integration.py tests/tui_gateway/test_review_summary_callback.py -q --timeout=60`
2. Confirm the suites pass (42 focused tests passed; the importer-path suite passed).
3. Run `python3 scripts/check-windows-footguns.py --diff $(git merge-base origin/main HEAD)` and scoped `ruff check` on both changed Python files.

### What platforms tested on

- macOS (darwin-arm64)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (collection is blocked by missing FastAPI; the sandboxed lazy installer cannot initialize its uv cache)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

Not applicable.

## Screenshots / Logs

Not applicable.

<!-- autocontrib:worker-id=issue-new-b154605a kind=pr-open -->