### PR TITLE
fix(tui): 修复 Windows TUI gateway stdin EINVAL 崩溃（recover from Windows stdin EINVAL in gateway child）

### DIFF
--- a/tests/tui_gateway/test_entry_stdin_einval.py
+++ b/tests/tui_gateway/test_entry_stdin_einval.py
@@ -1,0 +1,73 @@
+"""Regression tests: ``_read_stdin_line`` recovers from Windows EINVAL.
+
+On Windows, ``sys.stdin.readline()`` can raise ``OSError: [Errno 22]
+Invalid argument`` when the console/pipe state is disturbed. This used to
+crash the stdio TUI gateway child ("gateway exited — recovering your
+session"); the helper must retry transient failures and give up cleanly
+when a broken stdin exceeds the recovery budget.
+"""
+
+import sys
+import time as _time
+from unittest import mock
+
+from tui_gateway import entry
+
+
+def _fake_time_module():
+    """time module twin with a no-op ``sleep`` so tests don't actually wait."""
+    class FakeTime:
+        @staticmethod
+        def time():
+            return _time.time()
+
+        @staticmethod
+        def sleep(_seconds):
+            return None
+
+    return FakeTime()
+
+
+def test_reads_line_normally(monkeypatch):
+    monkeypatch.setattr(entry, "time", _fake_time_module())
+    monkeypatch.setattr(sys, "stdin", mock.Mock())
+    entry.sys.stdin.readline.return_value = '{"jsonrpc":"2.0"}\n'
+
+    assert entry._read_stdin_line([], lambda _m: None) == '{"jsonrpc":"2.0"}\n'
+
+
+def test_recovers_after_transient_oserror(monkeypatch):
+    monkeypatch.setattr(entry, "time", _fake_time_module())
+    monkeypatch.setattr(sys, "stdin", mock.Mock())
+    logs = []
+    entry.sys.stdin.readline.side_effect = [
+        OSError(22, "Invalid argument"),
+        '{"ok":true}\n',
+    ]
+
+    assert entry._read_stdin_line([], logs.append) == '{"ok":true}\n'
+    assert any("retrying" in m for m in logs)
+
+
+def test_gives_up_after_repeated_oserror(monkeypatch):
+    monkeypatch.setattr(entry, "time", _fake_time_module())
+    monkeypatch.setattr(sys, "stdin", mock.Mock())
+    logs = []
+    entry.sys.stdin.readline.side_effect = OSError(22, "Invalid argument")
+
+    # 11 consecutive failures exceed MAX_RECOVERIES_PER_MINUTE (10).
+    assert entry._read_stdin_line([], logs.append) is None
+    assert any("giving up" in m for m in logs)
+
+
+def test_recovery_budget_shared_with_spurious_eof(monkeypatch):
+    monkeypatch.setattr(entry, "time", _fake_time_module())
+    monkeypatch.setattr(sys, "stdin", mock.Mock())
+    logs = []
+    # A window already holding 10 recent recoveries (e.g. from
+    # handle_spurious_eof) must make the next OSError give up immediately.
+    now = _time.time()
+    recovery = [now - i for i in range(10)]
+    entry.sys.stdin.readline.side_effect = OSError(22, "Invalid argument")
+
+    assert entry._read_stdin_line(recovery, logs.append) is None

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -16,8 +16,9 @@ import signal
 import threading
 import time
 import traceback
+from typing import Optional
 
-from tui_gateway._stdin_recovery import handle_spurious_eof
+from tui_gateway._stdin_recovery import MAX_RECOVERIES_PER_MINUTE, handle_spurious_eof
 
 from tui_gateway import server
 from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
@@ -418,6 +419,36 @@ def ensure_mcp_discovery_started() -> None:
         )
 
 
+def _read_stdin_line(
+    recovery_times: list,
+    log_fn: object,
+) -> Optional[str]:
+    """Read one stdin line, recovering from Windows EINVAL (Errno 22).
+
+    On Windows, ``sys.stdin.readline()`` can raise ``OSError: [Errno 22]
+    Invalid argument`` when the console/pipe state is disturbed — previously
+    this crashed the gateway child, surfacing "gateway exited — recovering
+    your session" in the TUI. Retry with a rate limit (shared with
+    ``handle_spurious_eof``): a permanently broken stdin still exits
+    cleanly instead of spinning forever.
+
+    Returns the line read, or ``None`` when the recovery budget is exceeded
+    (caller should treat it as fatal).
+    """
+    while True:
+        try:
+            return sys.stdin.readline()
+        except OSError as e:
+            now = time.time()
+            recovery_times.append(now)
+            recovery_times[:] = [t for t in recovery_times if t > now - 60]
+            if len(recovery_times) > MAX_RECOVERIES_PER_MINUTE:
+                log_fn(f"stdin read keeps failing ({e!r}); giving up")  # type: ignore[operator]
+                return None
+            log_fn(f"stdin read OSError ({e!r}); retrying")  # type: ignore[operator]
+            time.sleep(0.5)
+
+
 def main():
     _install_sidecar_publisher()
 
@@ -458,7 +489,11 @@ def main():
         logger.debug("picker cache prewarm (tui) failed to start", exc_info=True)
 
     while True:
-        raw = sys.stdin.readline()
+        raw = _read_stdin_line(_recovery_times, _log_exit)
+        if raw is None:
+            # Repeated OSError failures exceeded the recovery budget — a
+            # permanently broken stdin must not spin forever.
+            break
         if not raw:
             # Stdin fell through — check if spurious (O_NONBLOCK flip by a
             # child on the shared open file description) or genuine EOF.


### PR DESCRIPTION
## What does this PR do? / 这个 PR 做了什么

**EN:** Fixes a crash in the stdio TUI gateway on Windows. `sys.stdin.readline()` in `tui_gateway/entry.py` can raise `OSError: [Errno 22] Invalid argument` when the console/pipe state is disturbed; the unhandled exception crashes the gateway child and the TUI parent respawns it — the same crash then recurs, leaving the user in a `gateway exited — recovering your session` loop. The fix wraps the read in a rate-limited retry helper that recovers from transient EINVAL and gives up cleanly on a permanently broken stdin (the parent respawns with fresh state instead of spinning).

**中文：** 修复 Windows 上 stdio TUI gateway 的崩溃。`tui_gateway/entry.py` 中的 `sys.stdin.readline()` 在控制台/管道状态被干扰时会抛出 `OSError: [Errno 22] Invalid argument`；未捕获的异常导致 gateway 子进程崩溃，TUI 父进程自动重启后同样崩溃复发，用户陷入 `gateway exited — recovering your session` 循环。修复将读取封装为带限流的重试助手：瞬时 EINVAL 自动恢复，stdin 永久损坏时干净退出（父进程以全新状态重启，而不是无限重试）。

## Related Issue / 相关问题

**EN:** No open issue. This is the Windows counterpart of #26077 (merged: "fix(cli): fall back to SelectSelector when kqueue can't watch stdin on macOS"), which fixed the same `OSError: [Errno 22] Invalid argument` crash class on macOS (kqueue stdin) but is explicitly a no-op on Linux/Windows. The Windows variant crashes in the stdio TUI gateway (`tui_gateway/entry.py`, not `cli.py`) and was reproduced on Windows 10.

Why not reuse #26077's approach? Its fix probes `KqueueSelector.register(0, EVENT_READ)` at startup and falls back to `SelectSelector` — that addresses macOS's selector-registration failure inside prompt_toolkit. On Windows there is no kqueue (the default event loop is ProactorEventLoop and prompt_toolkit reads the console via the Win32 API, not a selector), and the crash happens one layer lower: the `sys.stdin.readline()` call itself raises EINVAL when the console/pipe state is disturbed. A selector fallback cannot help there, so this PR handles the failure at the read site (rate-limited retry + clean give-up).

**中文：** 无 open issue。本修复是 #26077（已合并："fix(cli): fall back to SelectSelector when kqueue can't watch stdin on macOS"）的 Windows 对应版本——#26077 修复了同一 `OSError: [Errno 22] Invalid argument` 崩溃类在 macOS（kqueue stdin）上的表现，且明确对 Linux/Windows 无操作（no-op）。Windows 变体在 stdio TUI gateway（`tui_gateway/entry.py`，非 `cli.py`）中崩溃，已在 Windows 10 上复现。

为什么不复用 #26077 的方案？它的修复是启动时探测 `KqueueSelector.register(0, EVENT_READ)` 并在失败时回退到 `SelectSelector`——解决的是 macOS 上 prompt_toolkit 内部的 selector 注册失败。Windows 没有 kqueue（默认事件循环是 ProactorEventLoop，prompt_toolkit 通过 Win32 API 读控制台，不走 selector），而且崩溃发生在更底层：`sys.stdin.readline()` 调用本身在控制台/管道状态被干扰时抛 EINVAL。selector 回退在这里帮不上忙，所以本 PR 在读取点处理失败（限流重试 + 干净放弃）。

## Type of Change / 变更类型

- [x] 🐛 Bug fix (non-breaking change that fixes an issue) / 缺陷修复
- [ ] ✨ New feature / 新功能
- [ ] 🔒 Security fix / 安全修复
- [ ] 📝 Documentation update / 文档更新
- [x] ✅ Tests (adding or improving test coverage) / 测试

## Changes Made / 改动内容

**EN:**
- `tui_gateway/entry.py` — new `_read_stdin_line()` helper: retries transient `OSError` (EINVAL) with 0.5s backoff, shares the recovery budget with `handle_spurious_eof` (10 recoveries per 60s window), returns `None` to signal give-up; the main loop treats `None` as fatal and exits cleanly.
- `tests/tui_gateway/test_entry_stdin_einval.py` — 4 regression tests: normal read, transient recovery, budget exhaustion, budget sharing with the spurious-EOF path.

**中文：**
- `tui_gateway/entry.py` — 新增 `_read_stdin_line()` 助手函数：以 0.5 秒退避重试瞬时 `OSError`（EINVAL），与 `handle_spurious_eof` 共享恢复预算（60 秒窗口内 10 次），返回 `None` 表示放弃；主循环将 `None` 视为致命并干净退出。
- `tests/tui_gateway/test_entry_stdin_einval.py` — 4 个回归测试：正常读取、瞬时恢复、预算耗尽、与 spurious-EOF 路径共享预算。

## How to Test / 如何测试

**EN:**
1. Windows 10/11, run `hermes --tui`; reproduce the disturbed-stdin condition (the crash previously appeared within minutes to seconds of entering the TUI).
2. Verify the gateway no longer crashes with `OSError: [Errno 22]`; transient failures are retried silently.
3. `scripts/run_tests.sh tests/tui_gateway/test_entry_stdin_einval.py tests/test_tui_entry_mcp_owner.py tests/test_tui_gateway_loop_noise.py` → 16 passed.

**中文：**
1. Windows 10/11 运行 `hermes --tui`；复现 stdin 被干扰的条件（此前崩溃在进入 TUI 数分钟至数秒内出现）。
2. 确认 gateway 不再以 `OSError: [Errno 22]` 崩溃；瞬时故障被静默重试。
3. `scripts/run_tests.sh tests/tui_gateway/test_entry_stdin_einval.py tests/test_tui_entry_mcp_owner.py tests/test_tui_gateway_loop_noise.py` → 16 通过。

## Checklist

### Code / 代码

- [x] I've read the Contributing Guide / 已阅读贡献指南
- [x] My commit messages follow Conventional Commits (`fix(tui): ...`) / 提交信息符合规范
- [x] I searched for existing PRs — no duplicate open PR; #26077 (merged, macOS) referenced above as the platform sibling / 已搜索现有 PR，无重复；#26077（已合并，macOS）作为平台对应版本引用
- [x] My PR contains only changes related to this fix / 仅包含本次修复相关改动
- [ ] I've run the full `pytest tests/ -q` — ran the touched-area suite instead (16 passed); full-suite run pending CI / 仅跑了相关范围测试（16 通过），全量由 CI 执行
- [x] I've added tests for my changes (required for bug fixes) / 已为修复添加测试
- [x] I've tested on my platform: Windows 10 / 已在 Windows 10 上测试

### Documentation & Housekeeping / 文档与维护

- [x] Documentation: N/A (no docs/config/CLI surface changed) / 不适用
- [x] Cross-platform impact considered: fix is Windows-specific (POSIX path unchanged — `handle_spurious_eof` already guards POSIX, and #26077 covers macOS) / 已考虑跨平台影响：修复仅影响 Windows（POSIX 路径不变——`handle_spurious_eof` 已覆盖 POSIX，macOS 由 #26077 覆盖）

## Screenshots / Logs / 截图与日志

**EN:** Crash log from the reporter's machine (reproduced 3 times in one session):

**中文：** 报告者机器上的崩溃日志（单次会话内复现 3 次）：

```
=== unhandled exception · 2026-08-09 11:09:48 ===
  File "tui_gateway/entry.py", line 461, in main
    raw = sys.stdin.readline()
OSError: [Errno 22] Invalid argument
```

## Authorship / 作者声明

**EN:** This PR was authored by the DeepSeek V4 Flash (0731, think MAX) model running inside Hermes Agent (Nous Research), driven end-to-end by @Sam-dancing-nu1 — his very first PR submission on GitHub: he hit the crash in daily TUI use (re-entering twice both immediately dropped with "gateway exited — recovering your session"), provided the crash logs, and reviewed every step of the fix, its tests, and this description.

**中文：** 本 PR 由运行在 Hermes Agent（Nous Research）中的 DeepSeek V4 Flash（0731 版本，think MAX 模式）模型编写，由 @Sam-dancing-nu1 全程驱动——**这是他第一次在 GitHub 提交 PR**：他在日常 TUI 使用中遇到该崩溃（两次重进都立即提示 "gateway exited — recovering your session"），提供了崩溃日志，并审阅了修复、测试及本描述的每一步。

