### PR TITLE
fix(gateway): prevent duplicate Codex final replies after commentary delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -93,6 +93,65 @@ _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
+
+def _stream_confirmed_final_delivery(
+    consumer,
+    final_text: str,
+    *,
+    previewed: bool = False,
+) -> bool:
+    """Return True only when the exact final reply reached the user."""
+    if consumer is None:
+        return False
+    if getattr(consumer, "final_response_sent", False):
+        # A successful finalize call is not proof the *content* was final: the
+        # edit may have carried only the last preview snapshot while the tail
+        # generated between that snapshot and stream completion never reached
+        # any API call (#71643).
+        matcher = getattr(consumer, "delivered_final_matches", None)
+        if callable(matcher):
+            try:
+                if matcher(final_text) is False:
+                    return False
+            except Exception:
+                pass
+        return True
+
+    # Codex app-server can deliver its completed answer through the live
+    # commentary callback without setting response_previewed.  The consumer's
+    # exact-text ledger is stronger evidence than that provenance flag: an
+    # exact match means the user already received this final text, while normal
+    # progress commentary does not match and still permits the final send.
+    has_delivered_text = getattr(consumer, "has_delivered_text", None)
+    if callable(has_delivered_text):
+        try:
+            return bool(has_delivered_text(final_text))
+        except Exception:
+            return False
+    return False
+
+
+def _resolve_assistant_delivery_modes(
+    user_config: dict[str, Any] | None,
+    platform_key: str | None,
+    *,
+    streaming_enabled: bool,
+    interim_enabled: bool,
+) -> tuple[bool, bool]:
+    """Resolve text delivery modes while preserving a one-reply footer."""
+    from gateway.runtime_footer import resolve_footer_config
+
+    footer_enabled = bool(
+        resolve_footer_config(user_config, platform_key).get("enabled")
+    )
+    if footer_enabled:
+        # Footer fields include completed-turn data such as final context usage
+        # and latency. They cannot be correct during token or commentary
+        # streaming. Buffer assistant text so the gateway can publish one
+        # complete body-plus-footer reply after the turn finishes.
+        return False, False
+    return bool(streaming_enabled), bool(interim_enabled)
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
@@ -4555,8 +4614,14 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
-        _want_stream_deltas = _streaming_enabled
-        _want_interim_messages = ctx.interim_assistant_messages_enabled
+        _want_stream_deltas, _want_interim_messages = (
+            _resolve_assistant_delivery_modes(
+                ctx.user_config,
+                platform_key,
+                streaming_enabled=_streaming_enabled,
+                interim_enabled=ctx.interim_assistant_messages_enabled,
+            )
+        )
         _want_interim_consumer = _want_interim_messages
         if _want_stream_deltas or _want_interim_consumer:
             try:
@@ -18212,9 +18277,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
-            # Off by default (display.runtime_footer.enabled=false).  When
-            # streaming already delivered the body, we can't mutate the sent
-            # text, so we fire a separate trailing send below.
+            # Off by default (display.runtime_footer.enabled=false). Footer-
+            # enabled turns buffer assistant text, so this body-plus-footer is
+            # delivered once through the normal final-send path.
             _footer_line = ""
             try:
                 from gateway.runtime_footer import build_footer_line as _bfl
@@ -18607,21 +18672,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
-                # Streaming already delivered the body text, but the footer was
-                # intentionally held back (see the `not already_sent` gate above).
-                # Send it now as a small trailing message so Telegram/Discord/etc.
-                # still surface the runtime metadata on the final reply.
-                if _footer_line:
-                    try:
-                        _foot_adapter = self._adapter_for_source(source)
-                        if _foot_adapter:
-                            await _foot_adapter.send(
-                                source.chat_id,
-                                _footer_line,
-                                metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
-                            )
-                    except Exception as _e:
-                        logger.debug("trailing footer send failed: %s", _e)
                 return None
 
             return response
@@ -25735,43 +25785,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.debug("Long-running notification error: %s", _ne)
 
         _notify_task = asyncio.create_task(_notify_long_running())
-
-        def _stream_confirmed_final_delivery(
-            consumer,
-            final_text: str,
-            *,
-            previewed: bool = False,
-        ) -> bool:
-            """Return True only when the actual final reply reached the user."""
-            if consumer is None:
-                return False
-            if getattr(consumer, "final_response_sent", False):
-                # A successful finalize call is not proof the *content* was
-                # final: the edit may have carried only the last preview
-                # snapshot while the tail generated between that snapshot and
-                # stream completion never reached any API call (#71643).
-                # Reconcile the recorded turn-final payload against the
-                # completed response; only a demonstrable mismatch (False)
-                # overrides the flag — including payload-less multi-message
-                # split delivery (#78541). None (no record on a non-split
-                # legacy path) keeps the legacy trust so ambiguous-timeout
-                # dedup is not regressed.
-                matcher = getattr(consumer, "delivered_final_matches", None)
-                if callable(matcher):
-                    try:
-                        if matcher(final_text) is False:
-                            return False
-                    except Exception:
-                        pass
-                return True
-            if previewed:
-                has_delivered_text = getattr(consumer, "has_delivered_text", None)
-                if callable(has_delivered_text):
-                    try:
-                        return bool(has_delivered_text(final_text))
-                    except Exception:
-                        return False
-            return False
 
         try:
             # Run in thread pool to not block.  Use an *inactivity*-based

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -245,6 +245,9 @@ class GatewayStreamConsumer:
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
+        # A failed finalize may leave an older preview visible.  Do not retain
+        # that preview as proof of final delivery across the next segment reset.
+        self._last_finalize_failed = False
         # True when the most recent _send_or_edit split-and-delivered across
         # continuation messages (the adapter adopted a new message id).
         self._last_edit_overflowed = False
@@ -554,8 +557,10 @@ class GatewayStreamConsumer:
             return
         # Retain the finalized visible text of the current segment before
         # clearing ``_last_sent_text``, so ``has_delivered_text`` can still
-        # match it after a segment break. (#65919 review)
-        if self._last_sent_text:
+        # match it after a segment break. A failed finalize may leave an older
+        # preview visible; it is not proof that the completed segment landed.
+        # (#65919 review)
+        if self._last_sent_text and not self._last_finalize_failed:
             finalized = self._clean_for_display(self._last_sent_text).strip()
             if finalized:
                 self._delivered_segment_texts.append(finalized)
@@ -564,6 +569,7 @@ class GatewayStreamConsumer:
         self._accumulated = ""
         self._stream_ledger = ""
         self._last_sent_text = ""
+        self._last_finalize_failed = False
         self._fallback_final_send = False
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
@@ -2090,6 +2096,11 @@ class GatewayStreamConsumer:
             return True  # cursor-only / whitespace-only update
         if not text.strip():
             return True  # nothing to send is "success"
+        if finalize:
+            # A segment reset must not treat a stale preview as delivered when
+            # this finalize attempt fails.  Successful send/edit paths below
+            # leave this cleared; failure paths set it before returning.
+            self._last_finalize_failed = False
         # Guard: do not create a brand-new standalone message when the only
         # visible content is a handful of characters alongside the streaming
         # cursor.  During rapid tool-calling the model often emits 1-2 tokens
@@ -2244,6 +2255,8 @@ class GatewayStreamConsumer:
                         self._flood_strikes = 0
                         return True
                     else:
+                        if finalize:
+                            self._last_finalize_failed = True
                         immediate_final_fallback = False
                         if (
                             finalize
@@ -2361,6 +2374,8 @@ class GatewayStreamConsumer:
                 else:
                     # Editing not supported — skip intermediate updates.
                     # The final response will be sent by the fallback path.
+                    if finalize:
+                        self._last_finalize_failed = True
                     return False
             else:
                 # First message — send new, threaded to the original user message
@@ -2404,7 +2419,11 @@ class GatewayStreamConsumer:
                 else:
                     # Initial send failed — disable streaming for this session
                     self._edit_supported = False
+                    if finalize:
+                        self._last_finalize_failed = True
                     return False
         except Exception as e:
             logger.error("Stream send/edit error: %s", e)
+            if finalize:
+                self._last_finalize_failed = True
             return False

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -23,6 +23,7 @@ from gateway.platforms.base import (
     MessageEvent,
     SendResult,
 )
+from gateway.run import _stream_confirmed_final_delivery
 from gateway.session import SessionSource, build_session_key
 
 
@@ -158,6 +159,34 @@ class TestOnlyFinalStreamDeliverySuppressesFinalSend:
                 response["already_sent"] = True
 
         assert "already_sent" not in response
+
+    def test_exact_codex_commentary_suppresses_duplicate_final_send(self):
+        """An exact commentary delivery is proof even when the agent does not
+        label it as a final-response preview."""
+        final_text = "The requested change is complete."
+        sc = SimpleNamespace(
+            final_response_sent=False,
+            has_delivered_text=lambda text: text == final_text,
+        )
+
+        assert _stream_confirmed_final_delivery(
+            sc,
+            final_text,
+            previewed=False,
+        ) is True
+
+    def test_different_codex_commentary_does_not_suppress_final_send(self):
+        """Ordinary progress commentary must not hide a different answer."""
+        sc = SimpleNamespace(
+            final_response_sent=False,
+            has_delivered_text=lambda text: text == "I am checking that now.",
+        )
+
+        assert _stream_confirmed_final_delivery(
+            sc,
+            "The check completed successfully.",
+            previewed=False,
+        ) is False
 
 
 # ===================================================================
@@ -319,4 +348,3 @@ class TestFinalContentDeliveredSuppression:
             response["already_sent"] = True
 
         assert response.get("already_sent") is True
-

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -14,6 +14,7 @@ from gateway.runtime_footer import (
     format_runtime_footer,
     resolve_footer_config,
 )
+from gateway.run import _resolve_assistant_delivery_modes
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +110,35 @@ def test_resolve_platform_can_add_fields_only():
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]
+
+
+def test_footer_enabled_buffers_stream_and_interim_text_for_one_final_reply():
+    user = {"display": {"runtime_footer": {"enabled": True}}}
+
+    assert _resolve_assistant_delivery_modes(
+        user,
+        "telegram",
+        streaming_enabled=True,
+        interim_enabled=True,
+    ) == (False, False)
+
+
+def test_platform_footer_override_preserves_normal_streaming_policy():
+    user = {
+        "display": {
+            "runtime_footer": {"enabled": True},
+            "platforms": {
+                "telegram": {"runtime_footer": {"enabled": False}},
+            },
+        },
+    }
+
+    assert _resolve_assistant_delivery_modes(
+        user,
+        "telegram",
+        streaming_enabled=True,
+        interim_enabled=True,
+    ) == (True, True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1391,6 +1391,31 @@ class TestHasDeliveredTextAfterSegmentBreak:
         # After the reset, has_delivered_text must still find it
         assert c.has_delivered_text("Here is the first segment") is True
 
+    @pytest.mark.asyncio
+    async def test_failed_segment_finalize_does_not_claim_preview_delivered(self):
+        """A failed final edit must leave the gateway free to resend the answer."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = True
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="temporary failure")
+        )
+        c = GatewayStreamConsumer(adapter, "chat_test")
+        c._message_id = "preview-1"
+        c._last_sent_text = "The complete answer"
+
+        assert (
+            await c._send_or_edit(
+                "The complete answer",
+                finalize=True,
+                is_turn_final=False,
+            )
+            is False
+        )
+
+        c._reset_segment_state()
+
+        assert c.has_delivered_text("The complete answer") is False
+
 
 # ── Flush barrier (clarify-ordering) tests ───────────────────────────────
 
@@ -1487,4 +1512,3 @@ class TestFlushPendingSync:
 
         consumer.finish()
         await task
-


### PR DESCRIPTION
## What does this PR do?

This is a complementary gateway-side fix for Codex app-server duplicate final replies. When Codex delivers the completed answer through the commentary path, `response_previewed` can remain false even though the gateway exact-delivery ledger has the final text. The normal final path then sends the same body again. With the runtime footer enabled, the second copy also carries the footer.

It also closes the Telegram Rich Message interaction on the finalized segment path: if a segment finalization fails after a legacy streaming preview, the preview is no longer recorded as confirmed final delivery. The normal final path can retry the rich send instead of suppressing it.

This complements [#75077](https://github.com/NousResearch/hermes-agent/pull/75077) and the merged rich draft fix [#82041](https://github.com/NousResearch/hermes-agent/pull/82041). The related reports are [#80519](https://github.com/NousResearch/hermes-agent/issues/80519) and [#78524](https://github.com/NousResearch/hermes-agent/issues/78524).

## Related Issue

Related to #74248
Related to #80519
Related to #78524
Related to #75077

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Move the final-delivery predicate to a shared gateway helper and consult `has_delivered_text(final_text)` even when `response_previewed` is false.
- Buffer assistant streaming/interim delivery when the runtime footer is enabled so the body and footer are sent once through the normal final path.
- Track failed segment finalization so stale preview text cannot suppress a required final retry.
- Add regressions for exact Codex commentary delivery, unrelated commentary, footer delivery-mode resolution, and failed segment finalization.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_stream_consumer.py` — 78 tests passed locally.
2. `scripts/run_tests.sh tests/gateway/test_stale_finalize_suppression.py tests/gateway/test_telegram_rich_messages.py tests/agent/test_codex_app_server_event_bridge.py tests/run_agent/test_codex_app_server_integration.py` — 90 tests passed locally.
3. Ruff and Python compilation checks pass for the changed source and tests.

## Checklist

- [x] I have read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`).
- [x] I searched existing issues and PRs; this PR is complementary to #75077, #80519, #78524, and merged #82041.
- [x] This PR contains only changes related to this fix.
- [ ] Full `pytest tests/ -q` equivalent is not green in this environment: `tests/agent/test_auxiliary_main_first.py::TestResolveVisionCustomProvider::test_custom_main_forwards_runtime_endpoint` failed (`1 failed, 694 passed, 8 skipped, 86 deselected`); focused gateway suites are listed above.
- [x] I have added tests for the bug fix.
- [x] I have tested on macOS.
- [x] Documentation/config updates are not applicable.

## Screenshots / Logs

Not applicable; this is a gateway delivery-state fix.
