### PR TITLE
fix(delegation): flag stale source completions

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -202,6 +202,35 @@ def test_rich_reinjection_block_is_self_contained():
         assert needle in text, f"missing {needle!r}"
 
 
+def test_batch_reinjection_marks_changed_source_as_stale():
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_stale",
+        "is_batch": True,
+        "goals": ["Review mutable repository"],
+        "results": [
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Historical review",
+                "source_freshness": "stale",
+                "stale_input_paths": ["/repo/source.py"],
+            }
+        ],
+        "status": "completed",
+    }
+
+    text = format_process_notification(evt)
+
+    assert text is not None
+    assert "ASYNC DELEGATION BATCH COMPLETE" in text
+    assert "SOURCE FRESHNESS: STALE" in text
+    assert "historical evidence, not current instructions" in text
+    assert "Treat affected findings as historical" in text
+    assert "do not resume or duplicate superseded work" in text
+    assert "act on these or re-dispatch" not in text
+
+
 def test_dispatch_rejected_at_capacity():
     ev = threading.Event()
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,6 +11,7 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import tempfile
 import threading
 import time
 import types
@@ -960,6 +961,47 @@ class TestChildCredentialLeasing(unittest.TestCase):
 
         self.assertEqual(result["status"], "error")
         child._credential_pool.release_lease.assert_called_once_with("cred-a")
+
+    def test_run_single_child_marks_late_result_stale_when_input_changes(self):
+        from tools import file_state
+        from tools.delegate_tool import _run_single_child
+
+        fd, path = tempfile.mkstemp(prefix="hermes_delegate_stale_", suffix=".txt")
+        os.close(fd)
+        child = MagicMock()
+        child._subagent_id = "child-stale-source"
+        child._credential_pool = None
+
+        def finish_after_parent_write(**_kwargs):
+            file_state.record_read(child._subagent_id, path)
+            time.sleep(0.01)
+            file_state.note_write("parent-task", path)
+            return {
+                "final_response": "reviewed the old source",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        child.run_conversation.side_effect = finish_after_parent_write
+        file_state.get_registry().clear()
+        try:
+            result = _run_single_child(
+                task_index=0,
+                goal="Review mutable source",
+                child=child,
+                parent_agent=_make_mock_parent(),
+            )
+        finally:
+            file_state.get_registry().clear()
+            os.unlink(path)
+
+        self.assertEqual(result["status"], "completed")
+        self.assertEqual(result["source_freshness"], "stale")
+        self.assertEqual(result["stale_input_paths"], [path])
+        self.assertIn("STALE SOURCE", result["summary"])
+        self.assertIn("do not resume superseded work", result["summary"])
 
 
 class TestDelegateHeartbeat(unittest.TestCase):

--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -74,6 +74,37 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         self.assertIn("B", warn)
         self.assertIn("sibling", warn.lower())
 
+    def test_stale_reads_reports_only_writes_after_the_read(self):
+        p = self._mk()
+        file_state.note_write("B", p)
+        file_state.record_read("A", p)
+        self.assertEqual(file_state.stale_reads("A"), [])
+
+        time.sleep(0.01)
+        file_state.note_write("B", p)
+        self.assertEqual(file_state.stale_reads("A"), [p])
+
+    def test_stale_reads_ignores_the_readers_own_write(self):
+        p = self._mk()
+        file_state.record_read("A", p)
+        time.sleep(0.01)
+        file_state.note_write("A", p)
+        self.assertEqual(file_state.stale_reads("A"), [])
+
+    def test_stale_reads_detects_external_change_and_deletion(self):
+        changed = self._mk("before\n")
+        deleted = self._mk("present\n")
+        file_state.record_read("A", changed)
+        file_state.record_read("A", deleted)
+
+        previous = os.stat(changed).st_mtime_ns
+        with open(changed, "w") as handle:
+            handle.write("after\n")
+        os.utime(changed, ns=(previous + 1_000_000, previous + 1_000_000))
+        os.unlink(deleted)
+
+        self.assertEqual(file_state.stale_reads("A"), sorted([changed, deleted]))
+
 
     def test_lock_path_serializes_same_path(self):
         p = self._mk()
@@ -136,6 +167,7 @@ class FileStateRegistryUnitTests(unittest.TestCase):
                 file_state.writes_since("A", 0.0, [p]),
                 {},
             )
+            self.assertEqual(file_state.stale_reads("A"), [])
         finally:
             del os.environ["HERMES_DISABLE_FILE_STATE_GUARD"]
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2665,6 +2665,37 @@ def _run_single_child(
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
+        # Completion freshness guard. A background child may finish after the
+        # parent (or an external git/editor operation) has changed files the
+        # child read. Surface that fact structurally and in the summary so a
+        # late completion cannot silently revive superseded work. This checks
+        # each file's read stamp, not merely "any write since dispatch", which
+        # avoids flagging writes that happened before the child's final read.
+        try:
+            stale_inputs = file_state.stale_reads(child_task_id)
+        except Exception:
+            logger.debug("file_state stale-read check failed", exc_info=True)
+            stale_inputs = []
+        if stale_inputs:
+            entry["source_freshness"] = "stale"
+            entry["stale_input_paths"] = stale_inputs[:40]
+            shown_paths = stale_inputs[:8]
+            freshness_note = (
+                "[STALE SOURCE: "
+                f"{len(stale_inputs)} file(s) this subagent read changed before "
+                "it finished. Treat these findings as historical; re-read the "
+                "current source before acting, and do not resume superseded work "
+                "solely from this completion. Files: "
+                + ", ".join(shown_paths)
+                + (f" (+{len(stale_inputs) - 8} more)" if len(stale_inputs) > 8 else "")
+                + "]"
+            )
+            entry["summary"] = (
+                f"{entry['summary']}\n\n{freshness_note}"
+                if entry.get("summary")
+                else freshness_note
+            )
+
         # T1-24: schema-validation outcome — emitted ONLY when a schema was
         # requested, so legacy (schema-less) payloads keep their exact shape.
         if isinstance(_output_schema, dict):

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -23,6 +23,9 @@ Three public hooks are used by the file tools:
 Plus ``lock_path(path)`` — a context-manager returning a per-path lock to
 wrap the whole read→modify→write block. And ``writes_since(task_id,
 since_ts, paths)`` for the subagent-completion reminder in delegate_tool.
+``stale_reads(task_id)`` closes the inverse race: it reports files a child
+read that changed before the child returned, so late delegation results are
+not mistaken for current repository evidence.
 
 All methods are no-ops when ``HERMES_DISABLE_FILE_STATE_GUARD=1`` is set.
 
@@ -248,6 +251,44 @@ class FileStateRegistry:
         with self._state_lock:
             return list(self._reads.get(task_id, {}).keys())
 
+    def stale_reads(self, task_id: str) -> List[str]:
+        """Return files read by ``task_id`` that changed afterward.
+
+        This is the completion-side inverse of :meth:`check_stale`. A child
+        can finish a correct review of revision A after the parent has already
+        advanced the same worktree to revision B. Without a hard signal, the
+        late summary re-enters the conversation looking current and can revive
+        superseded work.
+
+        Registry-tracked sibling writes are compared to each file's exact
+        read timestamp. Untracked changes (terminal-driven git operations,
+        editor saves, checkout/reset) are detected by mtime drift. A deleted
+        input is stale too. The child's own writes refresh its read stamp in
+        ``note_write`` and therefore do not self-invalidate.
+        """
+        if _disabled():
+            return []
+        with self._state_lock:
+            reads = dict(self._reads.get(task_id, {}))
+            writers = dict(self._last_writer)
+
+        stale: List[str] = []
+        for path, (read_mtime, read_ts, _partial) in reads.items():
+            writer = writers.get(path)
+            if writer is not None:
+                writer_task_id, writer_ts = writer
+                if writer_task_id != task_id and writer_ts > read_ts:
+                    stale.append(path)
+                    continue
+            try:
+                current_mtime = os.path.getmtime(path)
+            except OSError:
+                stale.append(path)
+                continue
+            if current_mtime != read_mtime:
+                stale.append(path)
+        return sorted(stale)
+
     # ── Testing hooks ───────────────────────────────────────────────
     def clear(self) -> None:
         """Reset all state.  Intended for tests only."""
@@ -320,6 +361,10 @@ def known_reads(task_id: str) -> List[str]:
     return _registry.known_reads(task_id)
 
 
+def stale_reads(task_id: str) -> List[str]:
+    return _registry.stale_reads(task_id)
+
+
 __all__ = [
     "FileStateRegistry",
     "get_registry",
@@ -329,4 +374,5 @@ __all__ = [
     "lock_path",
     "writes_since",
     "known_reads",
+    "stale_reads",
 ]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2648,14 +2648,39 @@ def _format_async_delegation(evt: dict) -> str:
         goals = evt.get("goals") or []
         n = len(results) if results else len(goals)
         total_dur = evt.get("total_duration_seconds", duration)
+        stale_results = [
+            r for r in results
+            if isinstance(r, dict) and r.get("source_freshness") == "stale"
+        ]
+        completion_guidance = (
+            f"A background fan-out of {n} subagent(s) you dispatched earlier "
+            "has finished, but the source-freshness guard found changed inputs. "
+            "The results below are historical evidence, not current instructions."
+            if stale_results
+            else (
+                f"A background fan-out of {n} subagent(s) you dispatched earlier "
+                "has finished. All ran in parallel and waited on each other; their "
+                "consolidated results are below. You may have moved on since "
+                "dispatching — act on these or re-dispatch if things have changed."
+            )
+        )
         lines = [
             f"[ASYNC DELEGATION BATCH COMPLETE — {deleg_id}]",
-            f"A background fan-out of {n} subagent(s) you dispatched earlier "
-            "has finished. All ran in parallel and waited on each other; their "
-            "consolidated results are below. You may have moved on since "
-            "dispatching — act on these or re-dispatch if things have changed.",
+            completion_guidance,
             "",
         ]
+        if stale_results:
+            lines.extend(
+                [
+                    "SOURCE FRESHNESS: STALE — "
+                    f"{len(stale_results)} result(s) were produced from files "
+                    "that changed before the subagent finished.",
+                    "Treat affected findings as historical. Re-ground on the "
+                    "current source before acting; do not resume or duplicate "
+                    "superseded work solely because this completion arrived.",
+                    "",
+                ]
+            )
         if isinstance(dispatched_at, (int, float)):
             ts = _time.strftime("%Y-%m-%d %H:%M:%S", _time.localtime(dispatched_at))
             age = f" ({_format_age(completed_at - dispatched_at)} ago)"


### PR DESCRIPTION
## Summary
- detect files a child read that changed before it returned
- mark affected delegation results as stale structured evidence
- replace the generic act-on-this reinjection guidance with historical-only guidance for stale batches

## Verification
- 115 focused delegation, completion-delivery, gateway-notification, and CLI tests passed
- Ruff passed on all changed Python files
- git diff --check passed
- direct stale-source guard smoke passed

## Failure this prevents
A background repository review can finish after the parent has advanced the source. The late result previously re-entered as apparently current advice. Affected completions are now explicitly historical and cannot carry the generic instruction to act or re-dispatch.