### PR TITLE
fix(install): provision the VC++ runtime before the Windows desktop build

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3276,6 +3276,110 @@ function Try-RestoreElectronDist {
     return Restore-ElectronDist -InstallDir $InstallDir -Mirror $script:DesktopElectronFallbackMirror
 }
 
+function Test-VCRuntimePresent {
+    # The MSVC runtime (vcruntime140.dll and, on 64-bit, vcruntime140_1.dll)
+    # is required by every MSVC-built native Node module -- including
+    # @electron-internal/extract-zip, which Electron >=40.10.3's install.js
+    # loads to unpack its dist. Fresh Windows VMs often lack it; the failure
+    # then surfaces as ERR_DLOPEN_FAILED "The specified module could not be
+    # found" (the .node file EXISTS -- its dependent DLL doesn't).
+    #
+    # Probe the REAL System32: a 32-bit PowerShell host on 64-bit Windows gets
+    # redirected to SysWOW64, so prefer Sysnative when it exists.
+    $sysDirs = @()
+    $sysnative = Join-Path $env:SystemRoot "Sysnative"
+    if (Test-Path (Join-Path $sysnative "kernel32.dll")) { $sysDirs += $sysnative }
+    $sysDirs += (Join-Path $env:SystemRoot "System32")
+    foreach ($dir in $sysDirs) {
+        $core = Join-Path $dir "vcruntime140.dll"
+        if (-not (Test-Path $core)) { continue }
+        if ((Get-WindowsArch) -eq "x86") { return $true }
+        # 64-bit (x64 + arm64): vcruntime140_1.dll is a separate DLL that
+        # newer MSVC-built binaries also link; require both.
+        if (Test-Path (Join-Path $dir "vcruntime140_1.dll")) { return $true }
+    }
+    return $false
+}
+
+function Ensure-VCRedist {
+    # Ensure the Visual C++ 2015-2022 runtime is present before the desktop
+    # npm install. Best-effort and NON-FATAL: most machines already have it
+    # (this is then a millisecond DLL probe), and a redist install hiccup must
+    # not fail an otherwise-good install -- the desktop build failure hint
+    # names the manual fix.
+    if (Test-VCRuntimePresent) { return $true }
+
+    $arch = Get-WindowsArch
+    $slug = switch ($arch) {
+        "arm64" { "arm64" }
+        "x86"   { "x86" }
+        default { "x64" }
+    }
+    Write-Info "Visual C++ runtime (vcruntime140) not found -- installing the VC++ 2015-2022 Redistributable ($slug)..."
+
+    $prevEAP = $ErrorActionPreference
+    # 1. winget, when available (no direct download, honors org policy).
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        $wingetId = "Microsoft.VCRedist.2015+.$slug"
+        try {
+            $ErrorActionPreference = "Continue"
+            winget install --exact --id $wingetId --source winget --silent `
+                --accept-package-agreements --accept-source-agreements 2>&1 | Out-Null
+            $code = $LASTEXITCODE
+            $ErrorActionPreference = $prevEAP
+            if ($code -eq 0 -and (Test-VCRuntimePresent)) {
+                Write-Success "VC++ Redistributable installed via winget"
+                return $true
+            }
+            Write-Info "  winget VC++ install did not complete (exit $code) -- trying direct download..."
+        } catch {
+            $ErrorActionPreference = $prevEAP
+            Write-Info "  winget VC++ install failed ($($_.Exception.Message)) -- trying direct download..."
+        }
+    }
+
+    # 2. Direct download from Microsoft's permanent alias. ~25MB.
+    $url = "https://aka.ms/vs/17/release/vc_redist.$slug.exe"
+    $tmpExe = Join-Path $env:TEMP ("vc_redist_{0}_{1}.exe" -f $slug, (Get-Random))
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $tmpExe -UseBasicParsing
+        $ErrorActionPreference = "Continue"
+        # /quiet needs elevation on most systems; if this PowerShell is not
+        # elevated the exe self-elevates via UAC consent. -Wait blocks until
+        # the installer (and its elevated child) exits.
+        $proc = Start-Process -FilePath $tmpExe -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru
+        $code = $proc.ExitCode
+        $ErrorActionPreference = $prevEAP
+        # 0 = ok, 3010 = ok + reboot pending, 1638 = newer version already
+        # installed (fine -- runtime present).
+        if (($code -in 0, 3010, 1638) -and (Test-VCRuntimePresent)) {
+            Write-Success "VC++ Redistributable installed"
+            return $true
+        }
+        Write-Warn "VC++ Redistributable installer returned exit $code"
+    } catch {
+        if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+        Write-Warn "Could not download/run the VC++ Redistributable: $($_.Exception.Message)"
+    } finally {
+        Remove-Item $tmpExe -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Warn "Continuing without the VC++ runtime -- the desktop build may fail with 'Cannot find native binding'."
+    Write-Info  "  Manual fix: install https://aka.ms/vs/17/release/vc_redist.$slug.exe and re-run the installer."
+    return $false
+}
+
+function Test-NativeBindingFailure {
+    # Signature of an MSVC-built native module failing to load during npm
+    # install (Electron's install.js via @electron-internal/extract-zip is
+    # the common case). Distinct from a compile failure -- the prebuilt
+    # .node exists but a dependent DLL (vcruntime140*.dll) doesn't.
+    param([string]$NpmOutput)
+    if (-not $NpmOutput) { return $false }
+    return ($NpmOutput -match "Cannot find native binding") `
+        -or ($NpmOutput -match "ERR_DLOPEN_FAILED")
+}
+
 function Install-DesktopVoiceDeps {
     # Desktop ships with working voice out of the box: eagerly install the
     # wake-word + local-STT stacks ([wake] + [voice] extras) instead of
@@ -3354,6 +3458,14 @@ function Install-Desktop {
         if (Test-Path $sibling) { $npmExe = $sibling }
     }
 
+    # 0. Ensure the MSVC runtime before touching npm: Electron >=40.10.3's
+    # postinstall loads an MSVC-built native binding
+    # (@electron-internal/extract-zip) and dies with ERR_DLOPEN_FAILED on
+    # machines without the VC++ Redistributable (field report: fresh
+    # Windows VM, Aug 2026). Best-effort -- failure here only means the
+    # npm step below may hit the hinted error.
+    Ensure-VCRedist | Out-Null
+
     # 1. Workspace-level install so apps/desktop's deps (Electron, Vite,
     # node-pty prebuilds, etc.) actually land in node_modules. This is
     # the SAME `npm install` Install-NodeDeps does for browser tools,
@@ -3408,6 +3520,12 @@ function Install-Desktop {
                 # summary above rarely contains the postinstall stderr
                 # (e.g. Electron's install.js) that explains the failure.
                 Write-NpmDebugLogTail -NpmOutput ($npmOut -join "`n")
+                if (Test-NativeBindingFailure ($npmOut -join "`n")) {
+                    Write-Warn "A native module failed to load (ERR_DLOPEN_FAILED / 'Cannot find native binding')."
+                    Write-Info  "  This usually means the Visual C++ runtime is missing or incomplete."
+                    Write-Info  "  Install https://aka.ms/vs/17/release/vc_redist.x64.exe (arm64: vc_redist.arm64.exe)"
+                    Write-Info  "  and re-run the installer."
+                }
                 throw "desktop workspace npm install failed (exit $code) -- see lines above for cause"
             }
         } else {

--- a/tests/test_install_ps1_vcredist.py
+++ b/tests/test_install_ps1_vcredist.py
@@ -1,0 +1,95 @@
+"""Regression: install.ps1 must provision the VC++ runtime for the desktop build.
+
+Field report (Aug 2026, fresh Windows VM): Electron >=40.10.3's postinstall
+loads an MSVC-built native binding (``@electron-internal/extract-zip``) and
+dies with ``ERR_DLOPEN_FAILED`` / "Cannot find native binding" when
+``vcruntime140.dll`` is missing -- i.e. the machine has never had the
+Visual C++ 2015-2022 Redistributable. The desktop stage then fails with an
+opaque exit 1.
+
+install.ps1 must (a) detect + install the redist BEFORE the desktop npm
+install, (b) stay non-fatal when provisioning fails, and (c) name the manual
+fix when the native-binding failure signature shows up anyway.
+
+These tests are source-level because Linux CI cannot execute the PowerShell
+installer (same convention as test_install_ps1_web_server_syntax_probe.py).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_vcruntime_probe_checks_both_64bit_dlls() -> None:
+    text = _install_ps1()
+    assert "function Test-VCRuntimePresent" in text
+    # 64-bit MSVC binaries link BOTH vcruntime140.dll and vcruntime140_1.dll;
+    # probing only the first passes on machines that still fail to dlopen.
+    assert "vcruntime140.dll" in text
+    assert "vcruntime140_1.dll" in text
+    # A 32-bit PowerShell host on 64-bit Windows gets System32 redirected to
+    # SysWOW64 -- the probe must prefer Sysnative when present.
+    assert "Sysnative" in text
+
+
+def test_ensure_vcredist_runs_before_desktop_npm_install() -> None:
+    text = _install_ps1()
+    assert "function Ensure-VCRedist" in text
+    install_desktop = text[text.index("function Install-Desktop") :]
+    ensure_pos = install_desktop.index("Ensure-VCRedist")
+    npm_ci_pos = install_desktop.index("ci 2>&1")
+    assert ensure_pos < npm_ci_pos, (
+        "Ensure-VCRedist must run before the desktop workspace npm install, "
+        "otherwise Electron's postinstall can ERR_DLOPEN_FAILED on machines "
+        "without the VC++ runtime."
+    )
+
+
+def test_ensure_vcredist_has_winget_and_direct_download_paths() -> None:
+    text = _install_ps1()
+    fn = re.search(r"function Ensure-VCRedist[\s\S]+?\nfunction ", text)
+    assert fn is not None
+    body = fn.group(0)
+    assert "Microsoft.VCRedist.2015+" in body
+    assert "https://aka.ms/vs/17/release/vc_redist." in body
+    # Exit 3010 (reboot pending) and 1638 (newer already installed) are
+    # success shapes for the redist exe -- treating them as failure would
+    # warn on perfectly healthy machines.
+    assert "3010" in body and "1638" in body
+
+
+def test_ensure_vcredist_is_non_fatal() -> None:
+    text = _install_ps1()
+    fn = re.search(r"function Ensure-VCRedist[\s\S]+?\nfunction ", text)
+    assert fn is not None
+    body = fn.group(0)
+    assert "throw" not in body, (
+        "Ensure-VCRedist must be best-effort: a redist download hiccup must "
+        "not fail an otherwise-good install (most machines already have the "
+        "runtime)."
+    )
+    # The call site must swallow the boolean, not gate the stage on it.
+    assert re.search(r"Ensure-VCRedist \| Out-Null", text)
+
+
+def test_native_binding_failure_gets_vcredist_hint() -> None:
+    text = _install_ps1()
+    assert "function Test-NativeBindingFailure" in text
+    assert "Cannot find native binding" in text
+    assert "ERR_DLOPEN_FAILED" in text
+    # The desktop npm failure path must surface the manual fix.
+    hint = re.search(
+        r"Test-NativeBindingFailure[\s\S]{0,600}?vc_redist", text
+    )
+    assert hint is not None, (
+        "the desktop npm failure path must name the VC++ redist manual fix "
+        "when the native-binding failure signature is present"
+    )


### PR DESCRIPTION
# Summary

Fresh Windows machines can now build the desktop app: `install.ps1` detects a missing Visual C++ runtime and installs the VC++ 2015-2022 Redistributable before the desktop npm install, instead of letting Electron's postinstall die with an opaque `exit 1`.

Root cause: the Electron 40.10.2 → 40.10.6 bump (CVE patch wave, `7537de9e74`) crossed the version where Electron's `install.js` switched from pure-JS `extract-zip` to `@electron-internal/extract-zip` — an MSVC-built native binding that dynamically links `vcruntime140.dll`/`vcruntime140_1.dll`. Machines that never had the VC++ Redistributable (typical fresh VM) fail with `ERR_DLOPEN_FAILED` / "Cannot find native binding". Field report Aug 9 on a fresh Windows VM; reporter confirmed installing the redist fixed it.

## Changes

- `scripts/install.ps1`:
  - `Test-VCRuntimePresent` — probes `vcruntime140.dll` + `vcruntime140_1.dll` (64-bit links both) in the real System32, Sysnative-aware so a WoW64 PowerShell host isn't fooled by redirection.
  - `Ensure-VCRedist` — winget (`Microsoft.VCRedist.2015+.<arch>`) first, direct download of `https://aka.ms/vs/17/release/vc_redist.<arch>.exe` as fallback; arch via the existing emulation-safe `Get-WindowsArch` (x64/arm64/x86). Treats exit 3010 (reboot pending) and 1638 (newer installed) as success. **Best-effort and non-fatal** — a redist hiccup never fails an otherwise-good install; on most machines it's a millisecond DLL probe.
  - Wired into `Install-Desktop` before the workspace `npm ci` (step 0).
  - `Test-NativeBindingFailure` + failure hint — if the desktop npm install still fails with the native-binding signature, the error output names the redist and the manual download link (pairs with the debug-log tail from #82289, which is what surfaces the signature in the first place).
- `tests/test_install_ps1_vcredist.py` — 5 source-level contract tests (probe shape incl. both DLLs + Sysnative, Ensure-VCRedist ordered before `npm ci`, both provisioning paths + success exit codes, non-fatality, failure hint). Sabotage-verified: removing the `Ensure-VCRedist` call site makes the ordering test fail.

## Validation

| Check | Result |
|---|---|
| `tests/test_install_ps1_vcredist.py` | 5/5 pass |
| ascii-only + syntax probe + stderr EAP suites | 7/7 pass |
| New test fails without the fix (sabotage run) | verified |
| Attribution audit | clean |
| vision verification of infographic | DEGRADED — vision_analyze runtime bug (asyncio loop error), image unverified |

## Infographic

![VC++ runtime provisioned for Windows desktop installs](https://v3b.fal.media/files/b/0aa59bfb/GZIOtpr7nRovH_Ib7A72D_MfmXxvO1.png)
