### PR TITLE
feat(desktop): add Kanban Specify and Decompose actions

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.test.ts
+++ b/apps/desktop/src/plugins/kanban/api.test.ts
@@ -1,0 +1,71 @@
+import type { PluginStorage } from '@hermes/plugin-sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $boardSlug, bindApi, decomposeTask, specifyTask } from './api'
+
+const rest = vi.fn()
+const storageGet = vi.fn()
+const storageRemove = vi.fn()
+const storageSet = vi.fn()
+const storage: PluginStorage = {
+  get<T>(key: string, fallback: T): T {
+    storageGet(key, fallback)
+
+    return fallback
+  },
+  remove: (key: string) => storageRemove(key),
+  set: (key: string, value: unknown) => storageSet(key, value)
+}
+const socket = vi.fn(() => vi.fn())
+let dispose: () => void
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  rest.mockReset()
+  storageGet.mockClear()
+  storageRemove.mockClear()
+  storageSet.mockClear()
+  socket.mockClear()
+  dispose = bindApi(rest, storage, socket)
+  $boardSlug.set('product')
+})
+
+afterEach(() => {
+  dispose()
+  vi.useRealTimers()
+})
+
+describe('triage actions', () => {
+  it('posts Specify through the selected board route', async () => {
+    const outcome = { ok: true, task_id: 't_1', reason: null, new_title: 'Specified task' }
+    rest.mockResolvedValue(outcome)
+
+    await expect(specifyTask('t_1')).resolves.toBe(outcome)
+    expect(rest).toHaveBeenCalledWith('/tasks/t_1/specify?board=product', { method: 'POST', body: {} })
+  })
+
+  it('posts Decompose through the selected board route', async () => {
+    const outcome = {
+      ok: true,
+      task_id: 't_1',
+      reason: null,
+      fanout: true,
+      child_ids: ['t_2'],
+      new_title: 'Root task'
+    }
+    rest.mockResolvedValue(outcome)
+
+    await expect(decomposeTask('t_1')).resolves.toBe(outcome)
+    expect(rest).toHaveBeenCalledWith('/tasks/t_1/decompose?board=product', { method: 'POST', body: {} })
+  })
+
+  it('wakes the dispatcher after triage actions change runnable work', async () => {
+    rest.mockResolvedValue({ ok: true, task_id: 't_1' })
+
+    await specifyTask('t_1')
+    await decomposeTask('t_1')
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(rest).toHaveBeenLastCalledWith('/dispatch?board=product', { method: 'POST', body: {} })
+  })
+})

--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -215,6 +215,24 @@ export const reassignTask = (id: string, profile: string) =>
 
 export const reclaimTask = (id: string) => nudged(call(withBoard(`/tasks/${id}/reclaim`), { method: 'POST', body: {} }))
 
+export interface SpecifyOutcome {
+  ok: boolean
+  task_id: string
+  reason?: null | string
+  new_title?: null | string
+}
+
+export interface DecomposeOutcome extends SpecifyOutcome {
+  fanout: boolean
+  child_ids: string[]
+}
+
+export const specifyTask = (id: string) =>
+  nudged(call<SpecifyOutcome>(withBoard(`/tasks/${id}/specify`), { method: 'POST', body: {} }))
+
+export const decomposeTask = (id: string) =>
+  nudged(call<DecomposeOutcome>(withBoard(`/tasks/${id}/decompose`), { method: 'POST', body: {} }))
+
 export const uploadAttachment = (id: string, upload: { filename: string; contentType?: string; bytes: ArrayBuffer }) =>
   call(withBoard(`/tasks/${id}/attachments`), { method: 'POST', upload })
 

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -32,6 +32,8 @@ import { type ReactNode, useEffect, useRef, useState } from 'react'
 import {
   $boardSlug,
   addComment,
+  BOARDS_KEY,
+  decomposeTask,
   deleteTask,
   estimateTask,
   fetchLog,
@@ -42,10 +44,12 @@ import {
   PROFILES_KEY,
   reassignTask,
   reclaimTask,
+  specifyTask,
   taskKey,
   uploadAttachment
 } from './api'
 import { ModelOverrideField, overridePatch } from './model-override'
+import { TriageActions } from './triage-actions'
 import {
   type Diagnostic,
   type DiagnosticAction,
@@ -586,6 +590,7 @@ export function TaskDrawer({
   const invalidate = () => {
     void qc.invalidateQueries({ queryKey: taskKey(slug, id!) })
     void qc.invalidateQueries({ queryKey: ['kanban', 'board', slug] })
+    void qc.invalidateQueries({ queryKey: BOARDS_KEY })
   }
 
   // Optimistic status change against the task cache; rolls back + toasts on a
@@ -790,6 +795,29 @@ export function TaskDrawer({
               <Callout title={k.readyUnassignedTitle} tone={SEVERITY_TONE.warning}>
                 <p className="text-[0.71rem] leading-relaxed text-(--ui-text-secondary)">{k.readyUnassignedBody}</p>
               </Callout>
+            )}
+
+            {task.status === 'triage' && (
+              <Section label={k.triageActions}>
+                <TriageActions
+                  labels={{
+                    failed: k.actionFailed,
+                    decompose: k.decompose,
+                    decomposed: k.decomposed,
+                    decomposedSingle: k.decomposedSingle,
+                    decomposing: k.decomposing,
+                    specify: k.specify,
+                    specified: k.specified,
+                    specifiedRetitled: k.specifiedRetitled,
+                    specifying: k.specifying,
+                    unknownError: k.unknownError
+                  }}
+                  onDecompose={() => decomposeTask(task.id)}
+                  onRefresh={invalidate}
+                  onSpecify={() => specifyTask(task.id)}
+                  status={task.status}
+                />
+              </Section>
             )}
 
             {task.diagnostics && task.diagnostics.length > 0 && (

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -146,6 +146,17 @@ type KanbanMessages = {
   deliveredLive: string
   requeueWithNote: string
   notePosted: string
+  triageActions: string
+  specify: string
+  specifying: string
+  specified: string
+  specifiedRetitled: (title: string) => string
+  decompose: string
+  decomposing: string
+  decomposed: (count: number) => string
+  decomposedSingle: string
+  actionFailed: (action: string, reason: string) => string
+  unknownError: string
   activity: (n: number) => string
   runs: (n: number) => string
   workerLog: string
@@ -338,6 +349,17 @@ const en: KanbanMessages = {
   deliveredLive: 'Delivered to the running worker within a few seconds.',
   requeueWithNote: 'Requeue with note',
   notePosted: 'Note posted — worker requeued',
+  triageActions: 'Triage actions',
+  specify: 'Specify',
+  specifying: 'Specifying…',
+  specified: 'Specified',
+  specifiedRetitled: title => `Specified — retitled: ${title}`,
+  decompose: 'Decompose',
+  decomposing: 'Decomposing…',
+  decomposed: count => `Decomposed into ${count} children`,
+  decomposedSingle: 'Single task (no fanout)',
+  actionFailed: (action, reason) => `${action} failed: ${reason}`,
+  unknownError: 'unknown error',
   activity: n => `Activity · ${n}`,
   runs: n => `Runs · ${n}`,
   workerLog: 'Worker log',
@@ -529,6 +551,17 @@ const ja: KanbanMessages = {
   deliveredLive: '数秒以内に実行中のワーカーへ届きます。',
   requeueWithNote: 'メモを付けて再キュー',
   notePosted: 'メモを投稿しました — ワーカーを再キューしました',
+  triageActions: 'トリアージ操作',
+  specify: '仕様化',
+  specifying: '仕様化中…',
+  specified: '仕様化しました',
+  specifiedRetitled: title => `仕様化しました — 新しいタイトル: ${title}`,
+  decompose: '分解',
+  decomposing: '分解中…',
+  decomposed: count => `${count} 件の子タスクに分解しました`,
+  decomposedSingle: '単一タスク（分解なし）',
+  actionFailed: (action, reason) => `${action}に失敗しました: ${reason}`,
+  unknownError: '不明なエラー',
   activity: n => `アクティビティ・${n}`,
   runs: n => `実行・${n}`,
   workerLog: 'ワーカーログ',
@@ -718,6 +751,17 @@ const zh: KanbanMessages = {
   deliveredLive: '几秒内送达运行中的工作单元。',
   requeueWithNote: '附带备注重新入队',
   notePosted: '备注已发布 — 工作单元已重新入队',
+  triageActions: '分诊操作',
+  specify: '细化',
+  specifying: '正在细化…',
+  specified: '已细化',
+  specifiedRetitled: title => `已细化 — 新标题：${title}`,
+  decompose: '分解',
+  decomposing: '正在分解…',
+  decomposed: count => `已分解为 ${count} 个子任务`,
+  decomposedSingle: '单个任务（未拆分）',
+  actionFailed: (action, reason) => `${action}失败：${reason}`,
+  unknownError: '未知错误',
   activity: n => `活动・${n}`,
   runs: n => `运行・${n}`,
   workerLog: '工作单元日志',
@@ -906,6 +950,17 @@ const zhHant: KanbanMessages = {
   deliveredLive: '幾秒內送達執行中的工作單元。',
   requeueWithNote: '附上備註重新排入佇列',
   notePosted: '備註已發布 — 工作單元已重新排入佇列',
+  triageActions: '分診操作',
+  specify: '細化',
+  specifying: '正在細化…',
+  specified: '已細化',
+  specifiedRetitled: title => `已細化 — 新標題：${title}`,
+  decompose: '分解',
+  decomposing: '正在分解…',
+  decomposed: count => `已分解為 ${count} 個子任務`,
+  decomposedSingle: '單一任務（未拆分）',
+  actionFailed: (action, reason) => `${action}失敗：${reason}`,
+  unknownError: '未知錯誤',
   activity: n => `活動・${n}`,
   runs: n => `執行・${n}`,
   workerLog: '工作單元日誌',

--- a/apps/desktop/src/plugins/kanban/triage-actions.test.tsx
+++ b/apps/desktop/src/plugins/kanban/triage-actions.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { type TriageActionLabels, TriageActions } from './triage-actions'
+
+const labels: TriageActionLabels = {
+  specify: 'Specify',
+  specifying: 'Specifying…',
+  specified: 'Specified',
+  specifiedRetitled: title => `Specified — retitled: ${title}`,
+  decompose: 'Decompose',
+  decomposing: 'Decomposing…',
+  decomposed: count => `Decomposed into ${count} children`,
+  decomposedSingle: 'Single task (no fanout)',
+  failed: (action, reason) => `${action} failed: ${reason}`,
+  unknownError: 'unknown error'
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('TriageActions', () => {
+  it('is hidden outside the Triage status', () => {
+    render(
+      <TriageActions labels={labels} onDecompose={vi.fn()} onRefresh={vi.fn()} onSpecify={vi.fn()} status="ready" />
+    )
+
+    expect(screen.queryByRole('button', { name: 'Specify' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Decompose' })).toBeNull()
+  })
+
+  it('prevents duplicate actions while Specify is pending and refreshes on success', async () => {
+    let resolve!: (value: { ok: boolean; task_id: string; reason: null; new_title: string }) => void
+    const onSpecify = vi.fn(
+      () => new Promise<{ ok: boolean; task_id: string; reason: null; new_title: string }>(done => (resolve = done))
+    )
+    const onRefresh = vi.fn()
+
+    render(
+      <TriageActions
+        labels={labels}
+        onDecompose={vi.fn()}
+        onRefresh={onRefresh}
+        onSpecify={onSpecify}
+        status="triage"
+      />
+    )
+
+    const specify = screen.getByRole('button', { name: 'Specify' })
+    fireEvent.click(specify)
+    fireEvent.click(specify)
+
+    expect(onSpecify).toHaveBeenCalledTimes(1)
+    expect((screen.getByRole('button', { name: 'Specifying…' }) as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByRole('button', { name: 'Decompose' }) as HTMLButtonElement).disabled).toBe(true)
+
+    resolve({ ok: true, task_id: 't_1', reason: null, new_title: 'Concrete task' })
+
+    expect(await screen.findByText('Specified — retitled: Concrete task')).not.toBeNull()
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a backend failure reason without refreshing', async () => {
+    const onRefresh = vi.fn()
+
+    render(
+      <TriageActions
+        labels={labels}
+        onDecompose={vi.fn().mockResolvedValue({
+          ok: false,
+          task_id: 't_1',
+          reason: 'no auxiliary client configured',
+          fanout: false,
+          child_ids: [],
+          new_title: null
+        })}
+        onRefresh={onRefresh}
+        onSpecify={vi.fn()}
+        status="triage"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Decompose' }))
+
+    expect(await screen.findByText('Decompose failed: no auxiliary client configured')).not.toBeNull()
+    await waitFor(() =>
+      expect((screen.getByRole('button', { name: 'Decompose' }) as HTMLButtonElement).disabled).toBe(false)
+    )
+    expect(onRefresh).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/triage-actions.test.tsx
+++ b/apps/desktop/src/plugins/kanban/triage-actions.test.tsx
@@ -59,6 +59,11 @@ describe('TriageActions', () => {
 
     expect(await screen.findByText('Specified — retitled: Concrete task')).not.toBeNull()
     expect(onRefresh).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Specify' }))
+
+    expect(onSpecify).toHaveBeenCalledTimes(1)
+    expect((screen.getByRole('button', { name: 'Specify' }) as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('shows a backend failure reason without refreshing', async () => {

--- a/apps/desktop/src/plugins/kanban/triage-actions.tsx
+++ b/apps/desktop/src/plugins/kanban/triage-actions.tsx
@@ -1,0 +1,123 @@
+import { Button } from '@hermes/plugin-sdk'
+import { useState } from 'react'
+
+import type { DecomposeOutcome, SpecifyOutcome } from './api'
+
+export interface TriageActionLabels {
+  specify: string
+  specifying: string
+  specified: string
+  specifiedRetitled: (title: string) => string
+  decompose: string
+  decomposing: string
+  decomposed: (count: number) => string
+  decomposedSingle: string
+  failed: (action: string, reason: string) => string
+  unknownError: string
+}
+
+interface TriageActionsProps {
+  labels: TriageActionLabels
+  onDecompose: () => Promise<DecomposeOutcome>
+  onRefresh: () => void
+  onSpecify: () => Promise<SpecifyOutcome>
+  status: string
+}
+
+type Action = 'decompose' | 'specify'
+type Feedback = null | { kind: 'error' | 'success'; message: string }
+
+function errorText(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : String(error || fallback)
+}
+
+export function TriageActions({ labels, onDecompose, onRefresh, onSpecify, status }: TriageActionsProps) {
+  const [pending, setPending] = useState<null | Action>(null)
+  const [feedback, setFeedback] = useState<Feedback>(null)
+
+  if (status !== 'triage') {
+    return null
+  }
+
+  const run = async (action: Action) => {
+    if (pending) {
+      return
+    }
+
+    setPending(action)
+    setFeedback(null)
+
+    try {
+      const outcome = action === 'specify' ? await onSpecify() : await onDecompose()
+
+      if (!outcome.ok) {
+        setFeedback({
+          kind: 'error',
+          message: labels.failed(
+            action === 'specify' ? labels.specify : labels.decompose,
+            outcome.reason || labels.unknownError
+          )
+        })
+
+        return
+      }
+
+      let message: string
+
+      if (action === 'specify') {
+        message = outcome.new_title ? labels.specifiedRetitled(outcome.new_title) : labels.specified
+      } else {
+        const decomposed = outcome as DecomposeOutcome
+        message = decomposed.fanout ? labels.decomposed(decomposed.child_ids.length) : labels.decomposedSingle
+      }
+
+      setFeedback({ kind: 'success', message })
+      onRefresh()
+    } catch (error) {
+      setFeedback({
+        kind: 'error',
+        message: labels.failed(
+          action === 'specify' ? labels.specify : labels.decompose,
+          errorText(error, labels.unknownError)
+        )
+      })
+    } finally {
+      setPending(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-2">
+        <Button
+          aria-label={pending === 'specify' ? labels.specifying : labels.specify}
+          disabled={pending !== null}
+          onClick={() => void run('specify')}
+          size="sm"
+          variant="secondary"
+        >
+          {pending === 'specify' ? labels.specifying : `✨ ${labels.specify}`}
+        </Button>
+        <Button
+          aria-label={pending === 'decompose' ? labels.decomposing : labels.decompose}
+          disabled={pending !== null}
+          onClick={() => void run('decompose')}
+          size="sm"
+          variant="secondary"
+        >
+          {pending === 'decompose' ? labels.decomposing : `⚗ ${labels.decompose}`}
+        </Button>
+      </div>
+      {feedback && (
+        <p
+          aria-live="polite"
+          className={
+            feedback.kind === 'error' ? 'text-[0.71rem] text-destructive' : 'text-[0.71rem] text-(--ui-text-secondary)'
+          }
+        >
+          {feedback.message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/kanban/triage-actions.tsx
+++ b/apps/desktop/src/plugins/kanban/triage-actions.tsx
@@ -32,6 +32,7 @@ function errorText(error: unknown, fallback: string): string {
 }
 
 export function TriageActions({ labels, onDecompose, onRefresh, onSpecify, status }: TriageActionsProps) {
+  const [completed, setCompleted] = useState(false)
   const [pending, setPending] = useState<null | Action>(null)
   const [feedback, setFeedback] = useState<Feedback>(null)
 
@@ -40,7 +41,7 @@ export function TriageActions({ labels, onDecompose, onRefresh, onSpecify, statu
   }
 
   const run = async (action: Action) => {
-    if (pending) {
+    if (completed || pending) {
       return
     }
 
@@ -71,6 +72,7 @@ export function TriageActions({ labels, onDecompose, onRefresh, onSpecify, statu
         message = decomposed.fanout ? labels.decomposed(decomposed.child_ids.length) : labels.decomposedSingle
       }
 
+      setCompleted(true)
       setFeedback({ kind: 'success', message })
       onRefresh()
     } catch (error) {
@@ -91,7 +93,7 @@ export function TriageActions({ labels, onDecompose, onRefresh, onSpecify, statu
       <div className="flex flex-wrap gap-2">
         <Button
           aria-label={pending === 'specify' ? labels.specifying : labels.specify}
-          disabled={pending !== null}
+          disabled={completed || pending !== null}
           onClick={() => void run('specify')}
           size="sm"
           variant="secondary"
@@ -100,7 +102,7 @@ export function TriageActions({ labels, onDecompose, onRefresh, onSpecify, statu
         </Button>
         <Button
           aria-label={pending === 'decompose' ? labels.decomposing : labels.decompose}
-          disabled={pending !== null}
+          disabled={completed || pending !== null}
           onClick={() => void run('decompose')}
           size="sm"
           variant="secondary"


### PR DESCRIPTION
## Summary

- expose the existing board-scoped Specify and Decompose routes through the native Desktop Kanban API client
- add Triage-only drawer actions with pending, success, and backend-failure feedback
- refresh the authoritative task and board queries after successful actions
- localize the new controls and messages in every Desktop locale
- cover route scoping, visibility, duplicate prevention, success, and failure behavior

Closes #82276

## Verification

- `npm --workspace apps/desktop test -- --project ui src/plugins/kanban/api.test.ts src/plugins/kanban/triage-actions.test.tsx src/plugins/kanban/model-override.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run lint -- --quiet`
- `npx prettier --check apps/desktop/src/plugins/kanban/api.ts apps/desktop/src/plugins/kanban/api.test.ts apps/desktop/src/plugins/kanban/drawer.tsx apps/desktop/src/plugins/kanban/i18n.ts apps/desktop/src/plugins/kanban/triage-actions.tsx apps/desktop/src/plugins/kanban/triage-actions.test.tsx`
- `npm --workspace apps/desktop run build`

## Full-suite note

`npm --workspace apps/desktop run test:ui` was also attempted. The unrelated existing `src/lib/markdown-blocks.test.ts` property-fuzz case exceeded its 30-second timeout; a targeted rerun reproduced the same timeout. No Markdown parser files are changed by this PR.
