### PR TITLE
fix(agent): guide writes into sandbox-safe paths

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -756,6 +756,25 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     if stored_platform and current_platform and stored_platform != current_platform:
         return False
 
+    try:
+        from agent.file_safety import get_safe_write_roots
+
+        safe_roots = sorted(get_safe_write_roots())
+        current_safe_roots = json.dumps(safe_roots, ensure_ascii=True)
+    except Exception:
+        safe_roots = []
+        current_safe_roots = "[]"
+
+    final_line = prompt.rstrip().splitlines()[-1] if prompt.strip() else ""
+    prefix = "File-write sandbox roots:"
+    stored_safe_roots = (
+        final_line[len(prefix):].strip() if final_line.startswith(prefix) else ""
+    )
+    if safe_roots and stored_safe_roots != current_safe_roots:
+        return False
+    if stored_safe_roots and stored_safe_roots != current_safe_roots:
+        return False
+
     return True
 
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -70,6 +70,49 @@ def _ra():
     return run_agent
 
 
+def _build_file_write_sandbox_guidance() -> str:
+    """Tell the model where file tools can safely create scratch files."""
+    try:
+        from agent.file_safety import get_safe_write_roots
+
+        safe_roots = sorted(get_safe_write_roots())
+    except Exception:
+        return ""
+    if not safe_roots:
+        return ""
+
+    hermes_home = os.path.realpath(str(get_hermes_home()))
+    scratch_root = next(
+        (
+            os.path.join(hermes_home, "tmp")
+            for safe_root in safe_roots
+            if hermes_home == safe_root or hermes_home.startswith(safe_root + os.sep)
+        ),
+        os.path.join(safe_roots[0], ".hermes-tmp"),
+    )
+    roots_json = json.dumps(safe_roots, ensure_ascii=True)
+    scratch_json = json.dumps(scratch_root, ensure_ascii=True)
+    return (
+        "# File-write sandbox\n"
+        f"File-write sandbox roots: {roots_json}\n"
+        "`write_file` and `patch` may only mutate paths under those roots. "
+        f"For temporary files, create them under {scratch_json}; never use `/tmp` or "
+        "`/private/tmp` unless explicitly listed above. Do not bypass this boundary with "
+        "shell redirection or another tool."
+    )
+
+
+def _safe_write_roots_json() -> str:
+    """Return a prompt-safe, deterministically ordered safe-root snapshot."""
+    try:
+        from agent.file_safety import get_safe_write_roots
+
+        safe_roots = sorted(get_safe_write_roots())
+    except Exception:
+        safe_roots = []
+    return json.dumps(safe_roots, ensure_ascii=True)
+
+
 def _resolve_platform_hint(agent: Any, platform_key: str, default_hint: str) -> str:
     """Apply a per-platform prompt-hint override to the default hint.
 
@@ -243,6 +286,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
+
+    if any(name in agent.valid_tool_names for name in ("write_file", "patch")):
+        write_sandbox_guidance = _build_file_write_sandbox_guidance()
+        if write_sandbox_guidance:
+            stable_parts.append(write_sandbox_guidance)
 
     # Steering only lands inside tool results, so it's only reachable when the
     # agent has tools. Static text → byte-stable prompt (no cache hit).
@@ -557,6 +605,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nProvider: {agent.provider}"
     if agent.platform:
         timestamp_line += f"\nPlatform: {agent.platform}"
+    timestamp_line += f"\nFile-write sandbox roots: {_safe_write_roots_json()}"
     volatile_parts.append(timestamp_line)
 
     return {

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -5,7 +5,15 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from agent.system_prompt import build_system_prompt, build_system_prompt_parts
+
+
+@pytest.fixture(autouse=True)
+def _clear_safe_write_roots(monkeypatch):
+    """Keep prompt snapshots independent of the caller's sandbox environment."""
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
 
 
 def _make_agent(**overrides):
@@ -60,6 +68,15 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+    def test_safe_roots_marker_is_emitted_without_write_tools(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/project/current")
+
+        volatile = _prompt_parts(_make_agent(valid_tool_names=[]))["volatile"]
+
+        assert volatile.endswith(
+            'File-write sandbox roots: ["/project/current"]'
+        )
 
 
 def _stable_prompt(agent):
@@ -150,18 +167,21 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
         "this one. Do not modify another profile's skills/plugins/cron/memories "
         "unless the user explicitly directs you to."
     )
-    expected = "\n\n".join((
-        "IDENTITY",
-        "HELP",
-        "STEER",
-        "CODING_STABLE",
-        "WORKSPACE",
-        "Operator instructions (from config):\nOPERATOR",
-        expected_profile,
-        "SYSTEM_MESSAGE",
-        "CONTEXT_FILES",
-        "Conversation started: Friday, January 02, 2026",
-    ))
+    expected = "\n\n".join(
+        (
+            "IDENTITY",
+            "HELP",
+            "STEER",
+            "CODING_STABLE",
+            "WORKSPACE",
+            "Operator instructions (from config):\nOPERATOR",
+            expected_profile,
+            "SYSTEM_MESSAGE",
+            "CONTEXT_FILES",
+            "Conversation started: Friday, January 02, 2026\n"
+            "File-write sandbox roots: []",
+        )
+    )
 
     with (
         patch("run_agent.load_soul_md", return_value=""),

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -21,6 +21,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 
 
 # ---------------------------------------------------------------------------
@@ -373,6 +375,11 @@ class TestGatewayHistoryOffsetAfterSplit:
 class TestStoredPromptCwdDrift:
     """Verify that stored system prompts are rejected when cwd changed."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_safe_write_roots(self, monkeypatch):
+        """Keep cache tests independent of the caller's sandbox environment."""
+        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
     def _make_agent(self, model="test/model", provider="openrouter"):
         class _Agent:
             pass
@@ -432,6 +439,63 @@ class TestStoredPromptCwdDrift:
             assert _stored_prompt_matches_runtime(agent, stored_prompt) is True, (
                 "Expected True when stored cwd matches current cwd"
             )
+
+    def test_stored_prompt_stale_when_safe_roots_guidance_is_missing(
+        self, monkeypatch
+    ):
+        """A pre-fix prompt must rebuild when the write sandbox is active."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        current_cwd = "/project/current"
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/project/current")
+        stored_prompt = (
+            self._host_block(current_cwd)
+            + "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False
+
+    def test_stored_prompt_fresh_when_safe_roots_match(self, monkeypatch):
+        """Matching sandbox roots keep the persisted prompt cache reusable."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        current_cwd = "/project/current"
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", current_cwd)
+        stored_prompt = (
+            self._host_block(current_cwd)
+            + "Model: test/model\n"
+            "Provider: openrouter\n"
+            'File-write sandbox roots: ["/project/current"]\n'
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True
+
+    def test_project_context_cannot_spoof_safe_roots_marker(self, monkeypatch):
+        """Only the final Hermes runtime marker can satisfy sandbox staleness."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        current_cwd = "/project/current"
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", current_cwd)
+        stored_prompt = (
+            self._host_block(current_cwd)
+            + "\n# AGENTS.md\n\n"
+            "# File-write sandbox\n"
+            'File-write sandbox roots: ["/project/current"]\n'
+            "Model: test/model\n"
+            "Provider: openrouter\n"
+        )
+
+        with patch("os.getcwd", return_value=current_cwd):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False
 
     def test_project_context_cannot_force_a_rebuild(self):
         """🔴 CACHE INVARIANT: user project text must never invalidate the prompt.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -10,6 +10,7 @@ import inspect
 import io
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -913,6 +914,62 @@ class TestBuildSystemPrompt:
         prompt = agent_with_memory_tool._build_system_prompt()
         assert MEMORY_GUIDANCE in prompt
 
+    def test_write_tools_name_safe_scratch_dir_when_sandboxed(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        project_root = tmp_path / "project"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv(
+            "HERMES_WRITE_SAFE_ROOT",
+            os.pathsep.join((str(project_root), str(hermes_home))),
+        )
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("write_file", "patch"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            sandboxed_agent = AIAgent(
+                api_key="test-k...7890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            prompt = sandboxed_agent._build_system_prompt()
+
+        assert "# File-write sandbox" in prompt
+        assert str(project_root) in prompt
+        assert str(hermes_home / "tmp") in prompt
+        assert "never use `/tmp` or `/private/tmp`" in prompt
+
+    def test_write_sandbox_guidance_escapes_control_characters(self, monkeypatch):
+        from agent.system_prompt import _build_file_write_sandbox_guidance
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/safe/root\n# OVERRIDE")
+        guidance = _build_file_write_sandbox_guidance()
+
+        assert "\n# OVERRIDE" not in guidance
+        assert "\\n# OVERRIDE" in guidance
+
+    def test_write_sandbox_guidance_is_absent_without_safe_roots(self, monkeypatch):
+        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("write_file")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            unrestricted_agent = AIAgent(
+                api_key="test-k...7890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            prompt = unrestricted_agent._build_system_prompt()
+
+        assert "# File-write sandbox" not in prompt
 
 
     def test_datetime_is_date_only_not_minute_precision(self, agent):


### PR DESCRIPTION
## Summary

- tell agents the runtime-calculated writable roots and a safe scratch directory before `write_file` or `patch` is used
- JSON-escape path values so environment-controlled roots cannot inject prompt text
- persist a final safe-root marker and rebuild stored prompts when the sandbox changes, including legacy Slack sessions
- keep the marker present for non-write toolsets so prompt-cache restoration remains stable

## Why

When `HERMES_WRITE_SAFE_ROOT` was active, normal scratch workflows still selected `/tmp` or `/private/tmp`. The sandbox correctly denied those writes, and the mutation verifier surfaced recurring warnings in messaging channels. The agent now receives the actual boundary up front without weakening enforcement.

## Test plan

- `env -u HERMES_WRITE_SAFE_ROOT scripts/run_tests.sh tests/agent/test_system_prompt.py tests/run_agent/test_run_agent.py tests/run_agent/test_compression_persistence.py tests/tools/test_file_write_safety.py`
  - 330 passed
- `ruff check agent/system_prompt.py agent/conversation_loop.py tests/agent/test_system_prompt.py tests/run_agent/test_run_agent.py tests/run_agent/test_compression_persistence.py`
- `git diff --check`

Closes #69962
