### PR TITLE
fix(image-gen): fail closed on explicit provider, add vendor-neutral setup schema

### DIFF
--- a/agent/image_gen_registry.py
+++ b/agent/image_gen_registry.py
@@ -115,15 +115,17 @@ def get_active_provider() -> Optional[ImageGenProvider]:
 
     # 1. Explicit config wins — return regardless of is_available() so the
     #    user gets a precise downstream error message rather than a silent
-    #    backend switch.
+    #    backend switch. A missing registration also fails closed: selecting
+    #    one provider must never authorize a different paid provider.
     if configured:
         provider = snapshot.get(configured)
         if provider is not None:
             return provider
         logger.debug(
-            "image_gen.provider='%s' configured but not registered; falling back",
+            "image_gen.provider='%s' configured but not registered; failing closed",
             configured,
         )
+        return None
 
     # 2. Fallback: single registered provider — but only if it's actually
     #    available (no credentials = don't surface it as "active").

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional, Set
 
 
 from hermes_cli.config import (
+    _set_nested,
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
 )
@@ -2807,6 +2808,133 @@ def _configure_toolset(
         _configure_simple_requirements(ts_key)
 
 
+def _normalize_provider_config_field(
+    field: dict,
+    value: object,
+) -> tuple[str, Optional[str]]:
+    """Apply a provider-owned normalizer to one non-secret setup value.
+
+    A ``config_fields`` entry may expose ``normalize(value) -> str``. The
+    callback owns provider-specific validation and canonicalization; raising
+    ``ValueError`` returns its concise correction to the shared setup UI.
+    """
+    normalized = value.strip() if isinstance(value, str) else ""
+    if not normalized:
+        return "", None
+
+    callback = field.get("normalize")
+    if not callable(callback):
+        return normalized, None
+
+    try:
+        result = callback(normalized)
+    except ValueError as exc:
+        correction = str(exc).strip()
+        return "", correction or "Enter a valid value for this provider."
+    except Exception:  # noqa: BLE001 - plugin callbacks must not break setup
+        logger.exception("Provider config field normalization failed")
+        return "", "This value could not be validated. Please try again."
+
+    if not isinstance(result, str) or not result.strip():
+        return "", "Enter a valid value for this provider."
+    return result.strip(), None
+
+
+def _required_provider_config_fields_present(provider: dict, config: dict) -> bool:
+    """Return whether all required non-secret fields are present and valid."""
+    fields = provider.get("config_fields", [])
+    if not isinstance(fields, list):
+        return True
+    for field in fields:
+        if not isinstance(field, dict) or not field.get("required"):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key.strip():
+            continue
+        value = cfg_get(config, *key.strip().split("."), default=None)
+        normalized, correction = _normalize_provider_config_field(field, value)
+        if not normalized or correction:
+            return False
+    return True
+
+
+def _configure_provider_config_fields(
+    provider: dict,
+    config: dict,
+    *,
+    reconfigure: bool = False,
+) -> bool:
+    """Prompt for provider-declared non-secret ``config.yaml`` fields.
+
+    Backends can expose dotted ``config_fields`` alongside secret
+    ``env_vars`` in their setup schema. A field may provide a provider-owned
+    ``normalize`` callback for validation and canonicalization. Invalid input
+    is never written: the shared UI shows the callback's correction and
+    re-prompts. Values never pass through credential storage or password UX.
+
+    Returns ``True`` when every required field has a valid non-blank value.
+    """
+    fields = provider.get("config_fields", [])
+    if not isinstance(fields, list):
+        return True
+
+    all_configured = True
+    for field in fields:
+        if not isinstance(field, dict):
+            continue
+        key = field.get("key")
+        if not isinstance(key, str) or not key.strip():
+            continue
+        key = key.strip()
+
+        existing = cfg_get(config, *key.split("."), default=None)
+        existing_text, existing_error = _normalize_provider_config_field(
+            field, existing
+        )
+        required = bool(field.get("required"))
+
+        if existing_text and not existing_error and not reconfigure:
+            if existing_text != existing:
+                _set_nested(config, key, existing_text)
+            _print_success(f"  {key}: already configured")
+            continue
+
+        default = (
+            existing_text if not existing_error else ""
+        ) or str(field.get("default") or "").strip()
+        prompt = str(field.get("prompt") or key)
+        if reconfigure:
+            prompt = f"{prompt} (Enter to keep current)"
+
+        while True:
+            # These values are explicitly non-secret. Ignore password-shaped
+            # metadata so provider config never enters credential storage/UX.
+            value = _prompt(f"    {prompt}", default or None, password=False)
+            entered = value.strip() if isinstance(value, str) else ""
+            if not entered:
+                if required and not existing_text:
+                    _print_warning(f"    Skipped required setting: {key}")
+                    all_configured = False
+                else:
+                    _print_info(
+                        "    Kept current" if existing_text else "    Skipped"
+                    )
+                break
+
+            normalized, correction = _normalize_provider_config_field(
+                field, entered
+            )
+            if correction:
+                _print_warning(f"    {correction}")
+                continue
+
+            _set_nested(config, key, normalized)
+            _print_success("    Saved")
+            break
+
+    return all_configured
+
+
 def _plugin_image_gen_providers() -> list[dict]:
     """Build picker-row dicts from plugin-registered image gen providers.
 
@@ -2839,8 +2967,11 @@ def _plugin_image_gen_providers() -> list[dict]:
             "badge": schema.get("badge", ""),
             "tag": schema.get("tag", ""),
             "env_vars": schema.get("env_vars", []),
+            "config_fields": schema.get("config_fields", []),
             "image_gen_plugin_name": provider.name,
         }
+        if callable(schema.get("readiness_check")):
+            row["readiness_check"] = schema["readiness_check"]
         if schema.get("post_setup"):
             row["post_setup"] = schema["post_setup"]
         rows.append(row)
@@ -3300,8 +3431,9 @@ def provider_readiness_status(
     - ``"needs_auth"``  — needs a sign-in: Nous Portal login/entitlement for
       managed Tool Gateway rows, or xAI Grok OAuth / XAI_API_KEY for
       ``post_setup: "xai_grok"`` rows.
-    - ``"needs_setup"`` — keyless row whose ``post_setup`` install hook has
-      verifiably not run yet (see ``_POST_SETUP_READY``).
+    - ``"needs_setup"`` — a required non-secret config field is empty, or a
+      keyless row's ``post_setup`` install hook has verifiably not run yet
+      (see ``_POST_SETUP_READY``).
 
     Keyless ≠ usable: this is the server-side truth the GUI "Ready" pill
     renders from (the old client-side heuristic showed Ready for every
@@ -3313,10 +3445,37 @@ def provider_readiness_status(
     (selecting a row runs its hook, so the active row has been set up).
     """
     env_vars = provider.get("env_vars", [])
-    if env_vars:
-        if all(get_env_value(e["key"]) for e in env_vars):
-            return "ready"
+    required_env_vars = [
+        entry
+        for entry in env_vars
+        if isinstance(entry, dict) and entry.get("required", True)
+    ]
+    if required_env_vars and not all(
+        get_env_value(entry["key"]) for entry in required_env_vars
+    ):
         return "needs_keys"
+
+    # Required config.yaml settings are setup state, not credentials. Check
+    # them only after credential presence so the UI can give the right action.
+    if not _required_provider_config_fields_present(provider, config):
+        return "needs_setup"
+
+    # Plugin setup metadata may provide a configuration-aware readiness
+    # predicate when a credential is optional only for some configurations.
+    # Keeping that decision at the provider edge avoids making a key
+    # globally mandatory.
+    readiness_check = provider.get("readiness_check")
+    if callable(readiness_check):
+        try:
+            status = readiness_check(config, get_env_value)
+        except Exception:
+            return "needs_setup"
+        if status in {"ready", "needs_keys", "needs_auth", "needs_setup"}:
+            return status
+        return "needs_setup"
+
+    if env_vars and all(get_env_value(e["key"]) for e in env_vars):
+        return "ready"
 
     managed_feature = provider.get("managed_nous_feature")
     if provider.get("requires_nous_auth") or managed_feature:
@@ -4145,8 +4304,9 @@ def _configure_provider(
     *,
     force_fresh: bool = True,
 ):
-    """Configure a single provider - prompt for API keys and set config."""
+    """Configure a single provider - prompt for secrets and non-secret settings."""
     env_vars = provider.get("env_vars", [])
+    config_fields = provider.get("config_fields", [])
     managed_feature = provider.get("managed_nous_feature")
 
     # Nous-managed Tool Gateway backends are always listed (see
@@ -4214,7 +4374,7 @@ def _configure_provider(
     # there is a single source of truth for these writes.
     _write_provider_config(provider, config, managed_feature=managed_feature)
 
-    if not env_vars:
+    if not env_vars and not config_fields:
         if provider.get("post_setup"):
             _run_post_setup(provider["post_setup"])
         _print_success(f"  {provider['name']} - no configuration needed!")
@@ -4299,7 +4459,14 @@ def _configure_provider(
                 _print_success("    Saved")
             else:
                 _print_warning("    Skipped")
-                all_configured = False
+                if var.get("required", True):
+                    all_configured = False
+
+    if config_fields:
+        all_configured = (
+            _configure_provider_config_fields(provider, config)
+            and all_configured
+        )
 
     # Run post-setup hooks if needed
     if provider.get("post_setup") and all_configured:
@@ -4658,8 +4825,9 @@ def _reconfigure_provider(
     *,
     force_fresh: bool = True,
 ):
-    """Reconfigure a provider - update API keys."""
+    """Reconfigure a provider's secrets and non-secret settings."""
     env_vars = provider.get("env_vars", [])
+    config_fields = provider.get("config_fields", [])
     managed_feature = provider.get("managed_nous_feature")
 
     # Same inline Nous Portal login + entitlement gate as _configure_provider:
@@ -4740,7 +4908,7 @@ def _reconfigure_provider(
                     section["use_gateway"] = False
                 break
 
-    if not env_vars:
+    if not env_vars and not config_fields:
         if provider.get("post_setup"):
             _run_post_setup(provider["post_setup"])
         _print_success(f"  {provider['name']} - no configuration needed!")
@@ -4783,6 +4951,9 @@ def _reconfigure_provider(
             _print_success("    Updated")
         else:
             _print_info("    Kept current")
+
+    if config_fields:
+        _configure_provider_config_fields(provider, config, reconfigure=True)
 
     if provider.get("post_setup"):
         _run_post_setup(provider["post_setup"])

--- a/tests/agent/test_image_gen_registry.py
+++ b/tests/agent/test_image_gen_registry.py
@@ -70,6 +70,22 @@ class TestGetActiveProvider:
         assert active is not None and active.name == "openai"
 
 
+    def test_missing_configured_provider_does_not_select_another_backend(
+        self, tmp_path, monkeypatch
+    ):
+        """Selecting one backend must never authorize a different paid one."""
+        import yaml
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"provider": "missing-provider"}})
+        )
+        image_gen_registry.register_provider(_FakeProvider("fal"))
+        image_gen_registry.register_provider(_FakeProvider("openai"))
+
+        assert image_gen_registry.get_active_provider() is None
+
+
     def test_none_when_empty(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         assert image_gen_registry.get_active_provider() is None

--- a/tests/hermes_cli/test_image_gen_picker.py
+++ b/tests/hermes_cli/test_image_gen_picker.py
@@ -6,6 +6,7 @@ Covers `_plugin_image_gen_providers`, `_visible_providers`, and
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -170,3 +171,226 @@ class TestConfigWriting:
         assert tools_config._is_provider_active(openai_row, config) is True
         assert tools_config._is_provider_active(nous_row, config) is False
 
+
+
+class TestProviderSetupSchemaPassthrough:
+    def test_rows_preserve_config_fields_and_readiness_check(self):
+        from hermes_cli import tools_config
+
+        fields = [
+            {
+                "key": "image_gen.external.endpoint",
+                "prompt": "Provider endpoint",
+                "required": True,
+            },
+        ]
+
+        def readiness_check(config, get_secret):
+            return "ready"
+
+        image_gen_registry.register_provider(
+            _FakeProvider(
+                "config-fields-provider",
+                schema={
+                    "name": "External Image Provider",
+                    "env_vars": [{"key": "EXTERNAL_IMAGE_KEY"}],
+                    "config_fields": fields,
+                    "readiness_check": readiness_check,
+                },
+            )
+        )
+
+        row = next(
+            row
+            for row in tools_config._plugin_image_gen_providers()
+            if row["image_gen_plugin_name"] == "config-fields-provider"
+        )
+
+        assert row["config_fields"] == fields
+        assert row["env_vars"] == [{"key": "EXTERNAL_IMAGE_KEY"}]
+        assert row["readiness_check"] is readiness_check
+
+
+class TestNonSecretProviderConfigFields:
+    def test_setup_writes_normalized_fields_to_active_profile(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli import tools_config
+        from hermes_cli.config import read_raw_config
+
+        profile_home = tmp_path / ".hermes" / "profiles" / "external"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        def normalize_endpoint(value):
+            if not value.startswith("https://"):
+                raise ValueError("Endpoint must use HTTPS.")
+            return value.rstrip("/")
+
+        image_gen_registry.register_provider(
+            _FakeProvider(
+                "external-provider",
+                schema={
+                    "name": "External Image Provider",
+                    "env_vars": [
+                        {
+                            "key": "EXTERNAL_IMAGE_KEY",
+                            "prompt": "External image API key",
+                            "password": True,
+                            "required": False,
+                        },
+                    ],
+                    "config_fields": [
+                        {
+                            "key": "image_gen.external.endpoint",
+                            "prompt": "Provider endpoint",
+                            "required": True,
+                            "normalize": normalize_endpoint,
+                        },
+                        {
+                            "key": "image_gen.external.deployment",
+                            "prompt": "Image deployment",
+                            "required": True,
+                        },
+                    ],
+                },
+            )
+        )
+        provider_row = next(
+            row
+            for row in tools_config._plugin_image_gen_providers()
+            if row.get("image_gen_plugin_name") == "external-provider"
+        )
+
+        prompts = []
+        values = iter([
+            "",                       # optional secret skipped
+            "http://invalid.example",  # rejected by normalize
+            "https://images.example/",
+            "image-deployment",
+        ])
+
+        def prompt(question, default=None, password=False):
+            prompts.append((question, default, password))
+            return next(values)
+
+        monkeypatch.setattr(tools_config, "_prompt", prompt)
+        monkeypatch.setattr(tools_config, "get_env_value", lambda key: None)
+        monkeypatch.setattr(
+            tools_config,
+            "save_env_value",
+            lambda *a, **kw: pytest.fail(
+                "config fields must not use credential storage"
+            ),
+        )
+
+        config = {}
+        tools_config._configure_provider(provider_row, config)
+        tools_config.save_config(config)
+
+        saved = read_raw_config()
+        assert saved["image_gen"]["external"] == {
+            "endpoint": "https://images.example",
+            "deployment": "image-deployment",
+        }
+        assert saved["image_gen"]["provider"] == "external-provider"
+        assert prompts[0][2] is True
+        assert all(password is False for _, _, password in prompts[1:])
+
+    def test_reconfigure_updates_fields_and_keeps_blank_existing_value(
+        self, monkeypatch
+    ):
+        from hermes_cli import tools_config
+
+        answers = iter(["https://new.example", "", "v2"])
+        prompts = []
+
+        def prompt(question, default=None, password=False):
+            prompts.append((question, default, password))
+            return next(answers)
+
+        monkeypatch.setattr(tools_config, "_prompt", prompt)
+
+        config = {
+            "image_gen": {
+                "provider": "external-provider",
+                "external": {
+                    "endpoint": "https://old.example",
+                    "deployment": "existing-deployment",
+                },
+            },
+        }
+        provider_row = {
+            "name": "External Image Provider",
+            "env_vars": [],
+            "config_fields": [
+                {"key": "image_gen.external.endpoint", "required": True},
+                {"key": "image_gen.external.deployment", "required": True},
+                {"key": "image_gen.external.api_version", "required": False},
+            ],
+            "image_gen_plugin_name": "external-provider",
+        }
+
+        tools_config._reconfigure_provider(provider_row, config)
+
+        external = config["image_gen"]["external"]
+        assert external["endpoint"] == "https://new.example"
+        assert external["deployment"] == "existing-deployment"
+        assert external["api_version"] == "v2"
+        assert all(password is False for _, _, password in prompts)
+
+
+def test_readiness_reports_needs_setup_until_required_fields_present(monkeypatch):
+    from hermes_cli import tools_config
+
+    credentials = {"EXTERNAL_IMAGE_KEY": None}
+    monkeypatch.setattr(
+        tools_config, "get_env_value", lambda key: credentials.get(key)
+    )
+
+    def readiness_check(config, get_secret):
+        return "ready" if get_secret("EXTERNAL_IMAGE_KEY") else "needs_auth"
+
+    provider = {
+        "env_vars": [{"key": "EXTERNAL_IMAGE_KEY", "required": False}],
+        "config_fields": [
+            {"key": "image_gen.external.endpoint", "required": True},
+        ],
+        "readiness_check": readiness_check,
+    }
+    configured = {"image_gen": {"external": {"endpoint": "https://images.example"}}}
+
+    assert tools_config.provider_readiness_status(provider, {}) == "needs_setup"
+    assert (
+        tools_config.provider_readiness_status(provider, configured) == "needs_auth"
+    )
+
+    credentials["EXTERNAL_IMAGE_KEY"] = "secret"
+    assert tools_config.provider_readiness_status(provider, configured) == "ready"
+
+
+def test_readiness_still_reports_needs_keys_for_required_secret(monkeypatch):
+    from hermes_cli import tools_config
+
+    monkeypatch.setattr(tools_config, "get_env_value", lambda key: None)
+
+    provider = {"env_vars": [{"key": "EXTERNAL_IMAGE_KEY"}]}
+
+    assert tools_config.provider_readiness_status(provider, {}) == "needs_keys"
+
+
+def test_readiness_fails_closed_on_invalid_readiness_callback(monkeypatch):
+    from hermes_cli import tools_config
+
+    monkeypatch.setattr(tools_config, "get_env_value", lambda key: "set")
+
+    provider = {
+        "env_vars": [],
+        "config_fields": [],
+        "readiness_check": lambda config, get_secret: "unknown-status",
+    }
+    assert tools_config.provider_readiness_status(provider, {}) == "needs_setup"
+
+    provider["readiness_check"] = lambda config, get_secret: 1 / 0
+    assert tools_config.provider_readiness_status(provider, {}) == "needs_setup"

--- a/tests/tools/test_image_generation_artifacts.py
+++ b/tests/tools/test_image_generation_artifacts.py
@@ -147,3 +147,134 @@ def test_handle_image_generate_postprocesses_plugin_result(monkeypatch, tmp_path
 
     assert seen_task_ids == ["plugin-task"]
     assert result["agent_visible_image"] == "/home/remote/.hermes/cache/images/plugin.png"
+
+
+def test_postprocess_preserves_raw_text_and_non_success_json_strings():
+    from tools import image_generation_tool
+
+    unchanged_results = (
+        "provider returned unparseable raw text",
+        json.dumps({"success": False, "error": "generation failed"}),
+        json.dumps("provider returned serialized text"),
+    )
+
+    for raw in unchanged_results:
+        result = image_generation_tool._postprocess_image_generate_result(raw)
+
+        assert isinstance(result, str)
+        assert result == raw
+
+
+def test_postprocess_requires_normalized_string_input():
+    import pytest
+
+    from tools import image_generation_tool
+
+    with pytest.raises(TypeError, match="requires a normalized string"):
+        image_generation_tool._postprocess_image_generate_result(
+            {"success": True, "image": "/tmp/image.png"}
+        )
+
+
+def test_postprocess_transformed_result_is_valid_json_and_preserves_fields(
+    monkeypatch, tmp_path
+):
+    from tools import image_generation_tool
+
+    hermes_home = tmp_path / ".hermes"
+    image_path = hermes_home / "cache" / "images" / "generated-雪.png"
+    image_path.parent.mkdir(parents=True)
+    image_path.write_bytes(b"png")
+    env = SimpleNamespace(_remote_home="/home/remote", _sync_manager=None)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        image_generation_tool, "_active_terminal_env", lambda task_id: env
+    )
+
+    original = {
+        "success": True,
+        "image": str(image_path),
+        "provider": "external-provider",
+        "metadata": {"prompt": "draw 雪"},
+    }
+    raw = image_generation_tool._postprocess_image_generate_result(
+        json.dumps(original, ensure_ascii=False)
+    )
+    result = json.loads(raw)
+
+    assert isinstance(raw, str)
+    assert result == {
+        **original,
+        "host_image": str(image_path),
+        "agent_visible_image": "/home/remote/.hermes/cache/images/generated-雪.png",
+    }
+
+
+def test_normalize_image_tool_result_preserves_raw_unicode_string():
+    from tools import image_generation_tool
+
+    raw = '  {"message": "雪"}  '
+
+    assert image_generation_tool._normalize_image_tool_result(raw) == raw
+
+
+def test_normalize_image_tool_result_serializes_mapping_as_unicode_json():
+    from tools import image_generation_tool
+
+    result = image_generation_tool._normalize_image_tool_result(
+        {"success": True, "image": "https://example.com/雪.png"}
+    )
+
+    assert "雪" in result
+    assert json.loads(result) == {
+        "success": True,
+        "image": "https://example.com/雪.png",
+    }
+
+
+def test_normalize_image_tool_result_rejects_unsupported_and_unserializable_values():
+    from tools import image_generation_tool
+
+    for value in (["unexpected"], {"success": True, "bad": {1, 2}}):
+        raw = image_generation_tool._normalize_image_tool_result(value)
+        result = json.loads(raw)
+
+        assert isinstance(raw, str)
+        assert result["error_type"] == "tool_result_contract"
+        assert result["tool"] == "image_generate"
+        assert result["result_type"] == type(value).__name__
+
+
+def test_handle_image_generate_normalizes_all_provider_branches(monkeypatch):
+    from tools import image_generation_tool
+
+    mapping_result = {
+        "success": True,
+        "image": "https://example.com/雪.png",
+        "provider": "test",
+    }
+
+    for branch in ("plugin", "managed_krea", "fal"):
+        with monkeypatch.context() as scoped:
+            scoped.setattr(
+                image_generation_tool,
+                "_dispatch_to_plugin_provider",
+                lambda *a, **kw: mapping_result if branch == "plugin" else None,
+            )
+            scoped.setattr(
+                image_generation_tool,
+                "_maybe_route_managed_krea",
+                lambda *a, **kw: mapping_result if branch == "managed_krea" else None,
+            )
+            scoped.setattr(
+                image_generation_tool,
+                "image_generate_tool",
+                lambda *a, **kw: mapping_result,
+            )
+
+            raw = image_generation_tool._handle_image_generate({"prompt": "draw"})
+
+            assert isinstance(raw, str)
+            assert "雪" in raw
+            assert json.loads(raw) == mapping_result

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -70,3 +70,142 @@ class TestPluginDispatch:
             image_generation_tool, "_read_configured_image_provider", lambda: None
         )
         assert image_generation_tool.check_image_generation_requirements() is False
+
+
+class _MisconfiguredProvider(ImageGenProvider):
+    """An explicitly selected provider whose credentials are missing."""
+
+    @property
+    def name(self) -> str:
+        return "external-provider"
+
+    def is_available(self) -> bool:
+        return False
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {
+            "success": False,
+            "image": None,
+            "error": "The selected image provider is not configured.",
+            "error_type": "auth_required",
+            "provider": self.name,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "setup_action": "Configure EXTERNAL_IMAGE_KEY with `hermes tools`.",
+        }
+
+
+class _ForbiddenFallbackProvider(ImageGenProvider):
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        raise AssertionError(f"{self.name} fallback must not be called")
+
+
+class TestExplicitProviderFailsClosed:
+    def test_misconfigured_provider_surfaces_its_error_without_fallback(
+        self, monkeypatch
+    ):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        image_gen_registry.register_provider(_MisconfiguredProvider())
+        image_gen_registry.register_provider(_ForbiddenFallbackProvider("openai"))
+        image_gen_registry.register_provider(_ForbiddenFallbackProvider("fal"))
+
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_read_configured_image_provider",
+            lambda: "external-provider",
+        )
+        monkeypatch.setattr(
+            image_generation_tool, "_read_configured_image_model", lambda: None
+        )
+        monkeypatch.setattr(
+            plugins_module, "_ensure_plugins_discovered", lambda **kw: None
+        )
+        monkeypatch.setattr(
+            image_generation_tool,
+            "image_generate_tool",
+            lambda **kw: (_ for _ in ()).throw(
+                AssertionError("legacy FAL fallback must not be called")
+            ),
+        )
+
+        payload = json.loads(
+            image_generation_tool._handle_image_generate(
+                {"prompt": "draw a fox", "aspect_ratio": "square"}
+            )
+        )
+
+        assert payload["success"] is False
+        assert payload["provider"] == "external-provider"
+        assert payload["error_type"] == "auth_required"
+        assert "EXTERNAL_IMAGE_KEY" in payload["setup_action"]
+
+    def test_misconfigured_provider_remains_exposed(self, monkeypatch):
+        """The tool stays available so the provider's own error reaches the user."""
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        image_gen_registry.register_provider(_MisconfiguredProvider())
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_read_configured_image_provider",
+            lambda: "external-provider",
+        )
+        monkeypatch.setattr(
+            plugins_module, "_ensure_plugins_discovered", lambda **kw: None
+        )
+        monkeypatch.setattr(
+            image_generation_tool, "check_fal_api_key", lambda: False
+        )
+
+        assert image_generation_tool.check_image_generation_requirements() is True
+
+    def test_discovery_failure_does_not_fall_through_to_another_backend(
+        self, monkeypatch
+    ):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_read_configured_image_provider",
+            lambda: "external-provider",
+        )
+        monkeypatch.setattr(
+            image_generation_tool, "_read_configured_image_model", lambda: None
+        )
+        monkeypatch.setattr(
+            plugins_module,
+            "_ensure_plugins_discovered",
+            lambda **kw: (_ for _ in ()).throw(RuntimeError("discovery failed")),
+        )
+        monkeypatch.setattr(
+            image_generation_tool,
+            "_maybe_route_managed_krea",
+            lambda *a, **kw: (_ for _ in ()).throw(
+                AssertionError("managed Krea fallback must not be called")
+            ),
+        )
+        monkeypatch.setattr(
+            image_generation_tool,
+            "image_generate_tool",
+            lambda **kw: (_ for _ in ()).throw(
+                AssertionError("legacy FAL fallback must not be called")
+            ),
+        )
+
+        payload = json.loads(
+            image_generation_tool._handle_image_generate({"prompt": "draw a fox"})
+        )
+
+        assert payload["success"] is False
+        assert payload["error_type"] == "provider_unavailable"
+        assert "no fallback provider was attempted" in payload["error"]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1037,16 +1037,47 @@ def _force_artifact_sync(env: Any) -> None:
         logger.warning("Could not force-sync generated image artifact: %s", exc)
 
 
+def _normalize_image_tool_result(value: object) -> str:
+    """Return an image tool result as raw text or a valid JSON string.
+
+    Every provider branch funnels through here so downstream post-processing
+    and the tool contract (handlers MUST return a JSON string) hold even when
+    a backend returns a mapping or an unsupported type.
+    """
+    if isinstance(value, str):
+        return value
+
+    from collections.abc import Mapping
+
+    if isinstance(value, Mapping):
+        try:
+            return json.dumps(dict(value), ensure_ascii=False)
+        except Exception:
+            pass
+
+    result_type = type(value).__name__
+    return json.dumps({
+        "error": f"Image tool returned unsupported result type: {result_type}",
+        "error_type": "tool_result_contract",
+        "tool": "image_generate",
+        "result_type": result_type,
+    }, ensure_ascii=False)
+
+
 def _postprocess_image_generate_result(raw: str, task_id: str | None = None) -> str:
     """Annotate successful local image results with backend-visible paths.
 
+    ``raw`` must already have passed through ``_normalize_image_tool_result``.
     ``image`` remains the host/gateway-deliverable path.  When the active
     terminal backend has a different filesystem, ``agent_visible_image`` gives
     the path the agent can use with terminal/file tools.
     """
+    if not isinstance(raw, str):
+        raise TypeError("image_generate post-processing requires a normalized string")
+
     try:
-        payload = json.loads(raw) if isinstance(raw, str) else raw
-    except Exception:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return raw
 
     if not isinstance(payload, dict) or not payload.get("success"):
@@ -1318,33 +1349,36 @@ def _build_no_backend_setup_message() -> str:
 
 
 def check_image_generation_requirements() -> bool:
-    """True if FAL or the explicitly configured image backend is available."""
+    """True when the selected image backend can handle a tool call.
+
+    An explicitly selected plugin remains exposed even when ``is_available()``
+    is false so its own actionable configuration error reaches the user.  It
+    must never borrow FAL availability and silently route to that paid backend.
+    """
+    configured = _read_configured_image_provider()
+    if configured and configured != "fal":
+        # Probe only the explicitly selected plugin. Merely possessing a cloud
+        # provider key must not opt a user into a paid image-generation backend.
+        try:
+            from agent.image_gen_registry import get_provider
+            from hermes_cli.plugins import _ensure_plugins_discovered
+
+            _ensure_plugins_discovered()
+            return get_provider(configured) is not None
+        except Exception:
+            return False
+
     try:
         if check_fal_api_key():
             # Trigger the lazy fal_client import here as the SDK presence
             # check. Raises ImportError if the optional ``fal-client``
             # package isn't installed; the caller's except ImportError
-            # below catches that and continues to plugin probing.
+            # below treats the FAL path as unavailable.
             _load_fal_client()
             return True
     except ImportError:
         pass
-
-    configured = _read_configured_image_provider()
-    if not configured or configured == "fal":
-        return False
-
-    # Probe only the explicitly selected plugin. Merely possessing a cloud
-    # provider key must not opt a user into a paid image-generation backend.
-    try:
-        from agent.image_gen_registry import get_provider
-        from hermes_cli.plugins import _ensure_plugins_discovered
-
-        _ensure_plugins_discovered()
-        provider = get_provider(configured)
-        return bool(provider and provider.is_available())
-    except Exception:
-        return False
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -1530,8 +1564,18 @@ def _dispatch_to_plugin_provider(
         _ensure_plugins_discovered()
         provider = get_provider(configured)
     except Exception as exc:
-        logger.debug("image_gen plugin dispatch skipped: %s", exc)
-        return None
+        # Fail closed: an explicitly selected backend that cannot be resolved
+        # must not silently fall through to a different (paid) provider.
+        logger.debug("image_gen plugin dispatch failed closed: %s", exc)
+        return json.dumps({
+            "success": False,
+            "image": None,
+            "error": (
+                f"Configured image provider '{configured}' could not be loaded; "
+                "no fallback provider was attempted."
+            ),
+            "error_type": "provider_unavailable",
+        })
 
     if provider is None:
         try:
@@ -1801,7 +1845,8 @@ def _handle_image_generate(args, **kw):
         reference_image_urls=reference_image_urls,
     )
     if dispatched is not None:
-        return _postprocess_image_generate_result(dispatched, task_id=task_id)
+        normalized = _normalize_image_tool_result(dispatched)
+        return _postprocess_image_generate_result(normalized, task_id=task_id)
 
     # Managed-mode Krea routing: when no explicit plugin provider is configured
     # but the selected model is a native ``krea-2-*`` id, a portal user routes to
@@ -1814,7 +1859,8 @@ def _handle_image_generate(args, **kw):
         reference_image_urls=reference_image_urls,
     )
     if krea_routed is not None:
-        return _postprocess_image_generate_result(krea_routed, task_id=task_id)
+        normalized = _normalize_image_tool_result(krea_routed)
+        return _postprocess_image_generate_result(normalized, task_id=task_id)
 
     raw = image_generate_tool(
         prompt=prompt,
@@ -1822,7 +1868,8 @@ def _handle_image_generate(args, **kw):
         image_url=image_url,
         reference_image_urls=reference_image_urls,
     )
-    return _postprocess_image_generate_result(raw, task_id=task_id)
+    normalized = _normalize_image_tool_result(raw)
+    return _postprocess_image_generate_result(normalized, task_id=task_id)
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/developer-guide/image-gen-provider-plugin.md
+++ b/website/docs/developer-guide/image-gen-provider-plugin.md
@@ -109,6 +109,9 @@ class MyBackendImageGenProvider(ImageGenProvider):
                     "key": "MY_BACKEND_API_KEY",
                     "prompt": "My Backend API key",
                     "url": "https://my-backend.example.com/api-keys",
+                    # Optional; defaults to True. Set False when the key is
+                    # only needed for some configurations (e.g. keyless SSO).
+                    "required": True,
                 },
             ],
         }
@@ -220,6 +223,54 @@ requires_env:
 ```
 
 `kind: backend` is what routes the plugin to the image-gen registration path. `requires_env` is prompted during `hermes plugins install`.
+
+## Non-secret settings: `config_fields`
+
+`.env` is for credentials only. Everything else a backend needs — endpoints, deployment names, region ids, API versions — belongs in `config.yaml`. Declare those in `config_fields` and `hermes tools` prompts for them alongside your `env_vars`, then writes them to the active profile's `config.yaml` at the dotted key you name:
+
+```python
+def get_setup_schema(self) -> Dict[str, Any]:
+    return {
+        "name": "My Backend",
+        "env_vars": [{"key": "MY_BACKEND_API_KEY", "required": False}],
+        "config_fields": [
+            {
+                "key": "image_gen.my_backend.endpoint",
+                "prompt": "Endpoint URL",
+                "required": True,
+                "normalize": normalize_my_endpoint,   # optional
+            },
+            {
+                "key": "image_gen.my_backend.deployment",
+                "prompt": "Deployment name",
+                "required": True,
+            },
+        ],
+    }
+```
+
+| Field key | Purpose |
+|---|---|
+| `key` | Dotted `config.yaml` path the value is written to |
+| `prompt` | Label shown at setup |
+| `required` | A missing value reports `needs_setup` in the picker |
+| `default` | Pre-filled suggestion |
+| `normalize` | `normalize(value) -> str` — validate/canonicalize |
+
+These values never pass through credential storage or password-masked input. A `normalize` callback owns provider-specific validation: return the canonical string, or raise `ValueError("<short correction>")` to have the setup UI show your correction and re-prompt. Nothing invalid is written.
+
+## Endpoint-aware readiness: `readiness_check`
+
+By default a row is `needs_keys` until every required `env_var` is present. When a credential is optional for *some* configurations (keyless SSO against one endpoint family, an API key against another), that decision belongs to your provider, not to a globally mandatory key. Return `readiness_check` from your setup schema:
+
+```python
+def picker_readiness_status(self, config, get_secret) -> str:
+    if get_secret("MY_BACKEND_API_KEY"):
+        return "ready"
+    return "ready" if supports_keyless(config) else "needs_auth"
+```
+
+The callback receives the loaded config plus a secret accessor, and must return one of `ready`, `needs_keys`, `needs_auth`, or `needs_setup`. It runs after credential and `config_fields` presence checks, and fails closed to `needs_setup` if it raises or returns anything else. Do not mint tokens or make network calls here — the picker calls it while rendering.
 
 ## ABC reference
 


### PR DESCRIPTION
## Summary

This is the vendor-neutral half of #70753, split out on request and rebased onto current `main`. There is no vendor-specific code here — the Azure backend that motivated this work now ships as a [standalone plugin repo](https://github.com/playwise0307-sudo/hermes-image-gen-azure-openai), per AGENTS.md:126-136.

Four independent fixes to the shared image-generation edge:

**1. Explicit provider selection now fails closed.** `get_active_provider()` fell through to the single-provider shortcut and the legacy FAL preference when `image_gen.provider` named a backend that wasn't registered. Selecting one paid backend could therefore authorize billing on a different one. It now returns `None`. `_dispatch_to_plugin_provider()` had the same hole from a different direction: an exception during plugin discovery returned `None` and fell through to FAL. It now returns a `provider_unavailable` error instead.

**2. A misconfigured selected provider stays exposed.** `check_image_generation_requirements()` gated the explicit-plugin branch behind `is_available()`, so a provider missing its credential was hidden from the toolset and the call silently routed to FAL. The explicit branch is now evaluated first and only requires registration, so the provider's own actionable setup error reaches the user rather than a surprise charge on another backend.

**3. Tool results are normalized once, before post-processing.** `_normalize_image_tool_result()` converts mappings to JSON and rejects unsupported types; every provider branch passes through it. `_postprocess_image_generate_result()` now requires a string and narrows a bare `except` that could swallow a real error while treating a valid result as unparseable.

**4. Backends can declare non-secret settings and configuration-aware readiness.** `config_fields` prompts for dotted `config.yaml` keys alongside `env_vars` — never through credential storage or password-masked input — with an optional provider-owned `normalize` callback, so invalid input is corrected and re-prompted rather than written. `readiness_check` lets a provider answer readiness when a credential is optional for only some configurations, and `env_vars` entries now accept `required: False`. Both fail closed to `needs_setup`. Documented in the image-gen provider plugin guide.

## Why `config_fields` / `readiness_check` isn't speculative

Both have a concrete consumer: the standalone Azure plugin linked above uses them and cannot express its endpoint + deployment setup without them. `.env` is for secrets only, so an endpoint and a deployment name have nowhere else to go, and a key that's mandatory for one endpoint family but optional for another can't be expressed by a global `env_vars` gate. The consumer ships separately by design.

## A note on rebasing

The original branch was 3678 commits behind `main`, and both `hermes_cli/tools_config.py` and `tools/image_generation_tool.py` had been substantially refactored upstream in that window. Squash-merging the original diff would have silently reverted that work, so these changes were rebuilt against current `main` rather than replayed. I also re-verified that none of the four fixes had already landed upstream before rewriting them.

## Testing

`scripts/run_tests.sh tests/agent/test_image_gen_registry.py tests/hermes_cli/test_image_gen_picker.py tests/tools/test_image_generation.py tests/tools/test_image_generation_artifacts.py tests/tools/test_image_generation_plugin_dispatch.py`

70 passed. Tests assert behavior — fail-closed routing, normalization contracts, readiness transitions — not source shape, catalog snapshots, or enumeration counts.

Known pre-existing failures on my Windows box, confirmed identical on a clean `main` checkout and unrelated to this change: `test_openai_provider.py` (broken local `openai` import) and `test_krea_provider.py` / `test_openrouter_compat_provider.py` (tests assert POSIX `/tmp` paths).

## Blocked / not included

Windows path-portability fixes for those provider tests are deliberately left out — they're unrelated to image routing and belong in their own focused PR. Happy to open one if wanted.
