### PR TITLE
feat(mcp): propagate per-request metadata from /v1/runs to MCP tool calls

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6481,6 +6481,15 @@ class APIServerAdapter(BasePlatformAdapter):
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
 
+        # Extract per-request metadata (e.g. external-system tokens) to
+        # propagate through to MCP tool calls via _request_meta ContextVar.
+        request_metadata = body.get("metadata")
+        if request_metadata is not None and not isinstance(request_metadata, dict):
+            return web.json_response(
+                _openai_error("'metadata' must be an object"),
+                status=400,
+            )
+
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, str]] = []
@@ -6655,9 +6664,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         set_current_session_key,
                         unregister_gateway_notify,
                     )
+                    from tools.mcp_tool import _request_meta
 
                     effective_task_id = session_id or run_id
                     approval_token = None
+                    meta_token = None
                     session_tokens = []
                     with self._profile_scope(request_profile):
                         try:
@@ -6679,6 +6690,10 @@ class APIServerAdapter(BasePlatformAdapter):
                                 session_id=session_id or "",
                             )
                             register_gateway_notify(approval_session_key, _approval_notify)
+                            # Propagate per-request metadata (e.g. external tokens) into
+                            # the ContextVar so MCP tool calls can forward it as _meta.
+                            if request_metadata:
+                                meta_token = _request_meta.set(request_metadata)
                             # /v1/runs runs its own agent lifecycle (no
                             # TurnRunner, no _run_agent) — record turn process
                             # ownership so stop/cancel can reap only the
@@ -6699,6 +6714,11 @@ class APIServerAdapter(BasePlatformAdapter):
                             try:
                                 unregister_gateway_notify(approval_session_key)
                             finally:
+                                if meta_token is not None:
+                                    try:
+                                        _request_meta.reset(meta_token)
+                                    except Exception:
+                                        pass
                                 if approval_token is not None:
                                     try:
                                         reset_current_session_key(approval_token)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4423,6 +4423,14 @@ _mcp_tool_server_names: Dict[str, str] = {}
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
 _mcp_thread: Optional[threading.Thread] = None
 
+# Per-request metadata propagated from /v1/runs to MCP tool calls.
+# Set in the request handler's executor thread, then carried into the
+# MCP background event-loop task via _wrap_with_request_meta (same
+# propagation pattern as _wrap_with_home_override).
+_request_meta: contextvars.ContextVar = contextvars.ContextVar(
+    "_request_meta", default=None,
+)
+
 # Protects _mcp_loop, _mcp_thread, _servers, MCP connection status maps,
 # _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
 _lock = threading.Lock()
@@ -4735,6 +4743,29 @@ def _wrap_with_dashboard_oauth_flow(coro):
     return _scoped()
 
 
+def _wrap_with_request_meta(coro):
+    """Carry the caller's per-request metadata into ``coro``.
+
+    Tasks scheduled via run_coroutine_threadsafe copy the loop thread's
+    context, not the scheduling thread's.  This wrapper snapshots
+    _request_meta on the calling thread and re-sets it inside the
+    coroutine's task-local context on the MCP loop — same pattern as
+    _wrap_with_home_override.
+    """
+    meta = _request_meta.get()
+    if meta is None:
+        return coro
+
+    async def _scoped():
+        token = _request_meta.set(meta)
+        try:
+            return await coro
+        finally:
+            _request_meta.reset(token)
+
+    return _scoped()
+
+
 def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
     """Schedule a coroutine on the MCP event loop and block until done.
 
@@ -4770,6 +4801,7 @@ def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
     # scopes don't interfere). No-op when no override is active.
     coro = _wrap_with_home_override(coro)
     coro = _wrap_with_dashboard_oauth_flow(coro)
+    coro = _wrap_with_request_meta(coro)
 
     future = safe_schedule_threadsafe(
         coro, loop,
@@ -5267,7 +5299,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    result = await server.session.call_tool(
+                        tool_name, arguments=args,
+                        meta=_request_meta.get(),
+                    )
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably


### PR DESCRIPTION
## Summary

Enable external systems to pass authentication tokens and other metadata through the `/v1/runs` API to MCP tool servers via the MCP protocol's `_meta` field.

Closes #64890

## Problem

When external systems call `POST /v1/runs`, there is no mechanism to propagate per-request identity credentials (e.g. JWT tokens) through to MCP tool invocations. The `call_tool()` call in the MCP handler never passes a `meta` parameter, so MCP servers have no way to authenticate the originating request.

## Solution

Use `contextvars.ContextVar` to carry per-request metadata from the API handler into the MCP tool call, crossing two thread boundaries (asyncio → executor thread → MCP event-loop thread). This follows the exact same propagation pattern already used by `_wrap_with_home_override` and `_wrap_with_dashboard_oauth_flow`.

### Data Flow

```
POST /v1/runs { "metadata": { "token": "..." } }
  → _handle_runs: request_metadata = body.get("metadata")
  → _run_sync [executor thread]: _request_meta.set(metadata)
  → agent → handle_function_call → MCP _handler → _run_on_mcp_loop
  → _wrap_with_request_meta(coro)  # snapshot ContextVar, restore in MCP task
  → call_tool(name, args, meta=_request_meta.get())
  → MCP server receives: CallToolRequestParams { name, arguments, _meta: { "token": "..." } }
```

## Changes

### `tools/mcp_tool.py`

1. **New `_request_meta` ContextVar** — stores per-request metadata dict, defaulting to `None`
2. **New `_wrap_with_request_meta(coro)`** — cross-thread propagation wrapper that snapshots `_request_meta` on the calling thread and re-sets it inside the coroutine's task-local context on the MCP event loop (same pattern as `_wrap_with_home_override` and `_wrap_with_dashboard_oauth_flow`)
3. **Hook into `_run_on_mcp_loop`** — added `coro = _wrap_with_request_meta(coro)` to the existing wrapper chain
4. **Pass `meta=` to `call_tool()`** — `server.session.call_tool(tool_name, arguments=args, meta=_request_meta.get())`. When `metadata` is absent, `_request_meta.get()` returns `None` and the SDK omits `_meta` from the JSON-RPC request — zero impact on existing callers

### `gateway/platforms/api_server.py`

5. **Parse `metadata` field in `_handle_runs`** — validates it as a `dict` object; returns 400 if an invalid type is provided
6. **Set/reset `_request_meta` ContextVar in `_run_sync`** — imports `_request_meta` from `tools.mcp_tool`, sets it before agent execution, resets in the `finally` block

## Thread Safety

| Boundary | Mechanism |
|---|---|
| asyncio main thread → executor thread (`run_in_executor`) | `_request_meta.set()` inside `_run_sync` |
| executor thread → MCP loop thread (`run_coroutine_threadsafe`) | `_wrap_with_request_meta` snapshots and restores in task-local context |

Each concurrent `/v1/runs` request runs on an independent executor thread with its own ContextVar value. MCP loop thread tasks each have their own `asyncio.Task` context copy. No cross-talk between concurrent requests.

## Backward Compatibility

- The `metadata` field is **optional** in the `/v1/runs` request body
- When absent, `_request_meta.get()` returns `None`, and `call_tool(meta=None)` is the SDK default — no `_meta` field is included in the JSON-RPC request
- No changes to `/v1/chat/completions` or `/v1/responses` endpoints; the same ContextVar mechanism can be reused for those endpoints in a follow-up PR if needed

## API Example

**Request:**

```bash
POST /v1/runs
Content-Type: application/json

{
  "input": "查询订单状态",
  "metadata": {
    "token": "external-system-jwt-token"
  }
}
```

**MCP server receives (Python SDK):**

```python
@mcp.tool()
async def query_order(order_id: str, ctx: Context) -> str:
    token = ctx.meta.get("token") if ctx.meta else None
    # Use token to call external API...
```

**MCP server receives (TypeScript SDK):**

```typescript
server.tool("query_order", { order_id: z.string() }, async (args, extra) => {
    const token = extra?.meta?.token;
    // Use token to call external API...
});
```