### PR TITLE
fix(desktop): hand HUD mode the active profile, not just the session id

### DIFF
--- a/apps/desktop/electron/hud-url.test.ts
+++ b/apps/desktop/electron/hud-url.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { buildHudWindowUrl } from './hud-url'
+
+test('buildHudWindowUrl puts win=hud before the hash route (dev server)', () => {
+  const url = buildHudWindowUrl('abc123', { devServer: 'http://localhost:5173' })
+
+  assert.equal(url, 'http://localhost:5173/?win=hud#/abc123')
+  assert.ok(url.indexOf('?win=hud') < url.indexOf('#'))
+})
+
+test('buildHudWindowUrl carries the handoff profile in the query before the hash', () => {
+  const url = buildHudWindowUrl('sess-1', {
+    devServer: 'http://localhost:5173',
+    profile: 'hudrepro'
+  })
+
+  assert.equal(url, 'http://localhost:5173/?win=hud&profile=hudrepro#/sess-1')
+  assert.ok(url.indexOf('profile=hudrepro') < url.indexOf('#'))
+})
+
+test('buildHudWindowUrl encodes profile and session id', () => {
+  const url = buildHudWindowUrl('a b/c', {
+    devServer: 'http://localhost:5173',
+    profile: 'my profile'
+  })
+
+  assert.equal(url, 'http://localhost:5173/?win=hud&profile=my%20profile#/a%20b%2Fc')
+})
+
+test('buildHudWindowUrl omits profile when empty/whitespace (legacy handoff)', () => {
+  assert.equal(
+    buildHudWindowUrl('abc', { devServer: 'http://localhost:5173', profile: '  ' }),
+    'http://localhost:5173/?win=hud#/abc'
+  )
+  assert.equal(
+    buildHudWindowUrl(null, { devServer: 'http://localhost:5173' }),
+    'http://localhost:5173/?win=hud#/'
+  )
+})
+
+test('buildHudWindowUrl builds a packaged file URL with flags before the hash', () => {
+  const url = buildHudWindowUrl('abc', {
+    profile: 'coder',
+    rendererIndexPath: '/opt/app/index.html'
+  })
+
+  assert.match(url, /^file:\/\/.*index\.html\?win=hud&profile=coder#\/abc$/)
+})

--- a/apps/desktop/electron/hud-url.ts
+++ b/apps/desktop/electron/hud-url.ts
@@ -1,0 +1,37 @@
+import { pathToFileURL } from 'node:url'
+
+/**
+ * Build the renderer URL for HUD mode.
+ *
+ * Same query-before-hash contract as `buildSessionWindowUrl`: `?win=hud` (and
+ * optional `profile=`) must sit in the search string before `#`, or HashRouter
+ * swallows them as the route. The profile is what the HUD renderer adopts on
+ * boot so a non-primary conversation lands on the right backend — session id
+ * alone is not enough across profiles (see #82285).
+ */
+export function buildHudWindowUrl(
+  sessionId: null | string | undefined,
+  {
+    devServer,
+    profile,
+    rendererIndexPath
+  }: {
+    devServer?: null | string
+    profile?: null | string
+    rendererIndexPath?: string
+  } = {}
+): string {
+  const profileKey = typeof profile === 'string' ? profile.trim() : ''
+  const query = profileKey
+    ? `?win=hud&profile=${encodeURIComponent(profileKey)}`
+    : '?win=hud'
+  const route = sessionId ? `#/${encodeURIComponent(sessionId)}` : '#/'
+
+  if (devServer) {
+    const base = devServer.endsWith('/') ? devServer.slice(0, -1) : devServer
+
+    return `${base}/${query}${route}`
+  }
+
+  return `${pathToFileURL(rendererIndexPath!).toString()}${query}${route}`
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -168,6 +168,7 @@ import {
   revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
+import { buildHudWindowUrl } from './hud-url'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -9059,6 +9060,11 @@ let hudRestoreMainWindow = false
 // the id and hands it over in the close broadcast.
 let hudSessionId = null
 
+// Profile the HUD window was opened against. Session ids are per-profile, so a
+// retarget that crosses profiles must reload the HUD URL rather than only
+// sending hermes:hud:goto (which would resolve the id on the wrong backend).
+let hudProfile = null
+
 // A wide, short bar parked near the bottom of the active display — the shape
 // of a game chat frame, and where one belongs. Defaults only: once the user
 // moves or resizes the HUD, hud-state.json wins (same pattern as the main
@@ -9193,15 +9199,16 @@ function hudBounds() {
   }
 }
 
-function hudUrl(sessionId) {
-  const query = '?win=hud'
-  const route = sessionId ? `#/${encodeURIComponent(sessionId)}` : '#/'
+function hudUrl(sessionId, profile) {
+  return buildHudWindowUrl(sessionId, {
+    devServer: DEV_SERVER,
+    profile,
+    rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex()
+  })
+}
 
-  if (DEV_SERVER) {
-    return `${DEV_SERVER.endsWith('/') ? DEV_SERVER.slice(0, -1) : DEV_SERVER}/${query}${route}`
-  }
-
-  return `${pathToFileURL(resolveRendererIndex()).toString()}${query}${route}`
+function normalizeHudProfile(profile) {
+  return typeof profile === 'string' && profile.trim() ? profile.trim() : null
 }
 
 // Tell every window whether the HUD is up, so a toggle in any of them reads
@@ -9218,7 +9225,7 @@ function broadcastHudState(open) {
   }
 }
 
-function spawnHudWindow(sessionId) {
+function spawnHudWindow(sessionId, profile) {
   const win = new BrowserWindow({
     ...hudBounds(),
     minWidth: 380,
@@ -9293,6 +9300,7 @@ function spawnHudWindow(sessionId) {
   win.on('closed', () => {
     if (hudWindow === win) {
       hudWindow = null
+      hudProfile = null
     }
 
     // Closed from its own side (⌘W) — put the app back so the user is never
@@ -9301,7 +9309,7 @@ function spawnHudWindow(sessionId) {
     broadcastHudState(false)
   })
 
-  loadWindowUrl(win, hudUrl(sessionId), 'HUD')
+  loadWindowUrl(win, hudUrl(sessionId, profile), 'HUD')
 
   return win
 }
@@ -9319,12 +9327,24 @@ function restoreMainWindowFromHud() {
   }
 }
 
-function openHudWindow(sessionId) {
+function openHudWindow(sessionId, profile) {
+  const nextProfile = normalizeHudProfile(profile)
+
   if (hudWindow && !hudWindow.isDestroyed()) {
     // Already up, but pointed somewhere else — switch it rather than just
     // raising it. Asking for HUD mode from another tab means "put THIS
     // conversation in the HUD", and a plain focus leaves the wrong one there.
-    if (sessionId && sessionId !== hudSessionId) {
+    // A profile change must reload: session ids are scoped per profile, and
+    // the HUD's gateway was adopted for the previous one at boot.
+    const profileChanged = nextProfile !== hudProfile
+    const sessionChanged = Boolean(sessionId) && sessionId !== hudSessionId
+
+    if (profileChanged) {
+      hudSessionId = sessionId || null
+      hudProfile = nextProfile
+      loadWindowUrl(hudWindow, hudUrl(hudSessionId, hudProfile), 'HUD')
+      broadcastHudState(true)
+    } else if (sessionChanged) {
       hudSessionId = sessionId
       hudWindow.webContents.send('hermes:hud:goto', sessionId)
       // Keep every window's idea of where the HUD is pointed in step, so the
@@ -9339,7 +9359,8 @@ function openHudWindow(sessionId) {
 
   hudRestoreMainWindow = Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible())
   hudSessionId = sessionId || null
-  hudWindow = spawnHudWindow(sessionId)
+  hudProfile = nextProfile
+  hudWindow = spawnHudWindow(sessionId, nextProfile)
   broadcastHudState(true)
 
   return hudWindow
@@ -9348,6 +9369,7 @@ function openHudWindow(sessionId) {
 function closeHudWindow() {
   const win = hudWindow
   hudWindow = null
+  hudProfile = null
 
   if (win && !win.isDestroyed()) {
     // Null'd first so the 'closed' handler doesn't broadcast a second time.
@@ -10035,7 +10057,10 @@ ipcMain.on('hermes:pet-overlay:control', (_event, payload) => {
 
 // --- HUD mode (chrome-free floating chat) -----------------------------------
 ipcMain.handle('hermes:hud:open', async (_event, request) => {
-  openHudWindow(typeof request?.sessionId === 'string' ? request.sessionId : null)
+  openHudWindow(
+    typeof request?.sessionId === 'string' ? request.sessionId : null,
+    typeof request?.profile === 'string' ? request.profile : null
+  )
 
   return { ok: true }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -135,6 +135,7 @@ import {
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
 import { cursorPointInWindow } from './hud-cursor'
+import { buildHudWindowUrl } from './hud-url'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
@@ -168,7 +169,6 @@ import {
   revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
-import { buildHudWindowUrl } from './hud-url'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -39,6 +39,7 @@ import {
   setSessionsLoading
 } from '@/store/session'
 import { $attentionSessionIds, $workingSessionIds, resetTileRuntimeBindings } from '@/store/session-states'
+import { hudWindowProfile, isHudWindow } from '@/store/windows'
 import type { RpcEvent } from '@/types/hermes'
 
 import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './gateway-hmr-survivor'
@@ -250,11 +251,34 @@ export function useGatewayBoot({
       }
     }
 
-    // Adopt the profile the primary (window) backend booted as, so same-profile
-    // resumes are no-op swaps and reconnects target the right backend.
-    // Best-effort: a missing preference means "default". Shared by boot + soft
-    // switch.
+    // HUD handoff carries `?profile=` so a non-primary conversation opens on
+    // the backend that owns it. Session ids alone are not enough across
+    // profiles (#82285).
+    function hudHandoffProfile(): null | string {
+      if (!isHudWindow()) {
+        return null
+      }
+
+      const raw = hudWindowProfile()
+
+      return raw ? normalizeProfileKey(raw) : null
+    }
+
+    // Adopt the profile this window should talk to. HUD windows prefer the
+    // handoff profile from the URL; the main window adopts the desktop's
+    // primary preference. Best-effort: a missing preference means "default".
+    // Shared by boot + soft switch.
     async function adoptPrimaryProfile() {
+      const handoff = hudHandoffProfile()
+
+      if (handoff) {
+        $activeGatewayProfile.set(handoff)
+        setPrimaryGateway(gateway, handoff)
+        void ensureGatewayForProfile(handoff)
+
+        return
+      }
+
       try {
         const pref = await desktop.profile?.get?.()
         const profileKey = (pref?.profile ?? '').trim() || 'default'
@@ -298,7 +322,10 @@ export function useGatewayBoot({
         gateway.close()
         closeSecondaryGateways()
 
-        const conn = await desktop.getConnection()
+        // Seed the handoff/primary profile before dialing so getConnection
+        // hits the right backend (same order as boot()).
+        await adoptPrimaryProfile()
+        const conn = await desktop.getConnection($activeGatewayProfile.get())
 
         if (cancelled) {
           return
@@ -312,9 +339,7 @@ export function useGatewayBoot({
           return
         }
 
-        // Same shape as boot(): profile first (session scope depends on it),
-        // then the independent fetches concurrently.
-        await adoptPrimaryProfile()
+        // Profile already adopted above; refresh the independent fetches.
         await Promise.all([
           seedDefaultCwd(),
           callbacksRef.current.refreshHermesConfig().catch(() => undefined),
@@ -488,7 +513,11 @@ export function useGatewayBoot({
 
     async function boot() {
       try {
-        const conn = await desktop.getConnection()
+        // Profile before dial: HUD windows must connect to the handoff
+        // profile's backend, not the primary preference, or the session in the
+        // hash is resolved against the wrong state.db (#82285).
+        await adoptPrimaryProfile()
+        const conn = await desktop.getConnection($activeGatewayProfile.get())
 
         if (cancelled) {
           return
@@ -525,13 +554,6 @@ export function useGatewayBoot({
         if (cancelled) {
           return
         }
-
-        // Profile adoption must land first: refreshSessions scopes its fetch by
-        // $profileScope ← $activeGatewayProfile. The remaining three fetches
-        // (cwd seed, config, sessions) are independent REST calls — running
-        // them serially added their sum to time-to-populated-sidebar when only
-        // the max is needed.
-        await adoptPrimaryProfile()
 
         setDesktopBootStep({
           phase: 'renderer.config',

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -67,7 +67,7 @@ declare global {
       // bar — so it mounts the real composer rather than a lookalike. Main
       // owns the window; `onChanged` keeps every window's toggle truthful.
       hud?: {
-        open: (request?: { sessionId?: null | string }) => Promise<{ ok: boolean }>
+        open: (request?: { sessionId?: null | string; profile?: null | string }) => Promise<{ ok: boolean }>
         close: () => Promise<{ ok: boolean }>
         setIgnoreMouse: (ignore: boolean) => void
         moveBy: (delta: { x: number; y: number }) => void

--- a/apps/desktop/src/store/hud-profile-handoff.test.ts
+++ b/apps/desktop/src/store/hud-profile-handoff.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+
+import { openHud } from './hud'
+import { hudWindowProfile } from './windows'
+
+describe('hudWindowProfile', () => {
+  const original = window.location
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: original
+    })
+  })
+
+  it('reads ?profile= from the query before the hash', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { search: '?win=hud&profile=hudrepro', hash: '#/sess-1' }
+    })
+
+    expect(hudWindowProfile()).toBe('hudrepro')
+  })
+
+  it('returns null when the handoff omitted a profile', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { search: '?win=hud', hash: '#/sess-1' }
+    })
+
+    expect(hudWindowProfile()).toBeNull()
+  })
+})
+
+describe('openHud profile handoff', () => {
+  beforeEach(() => {
+    $activeGatewayProfile.set('hudrepro')
+  })
+
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    // @ts-expect-error test cleanup
+    delete window.hermesDesktop
+  })
+
+  it('passes the active gateway profile with the session id', () => {
+    const open = vi.fn(async () => ({ ok: true }))
+    window.hermesDesktop = {
+      hud: { open }
+    } as unknown as Window['hermesDesktop']
+
+    openHud('20260809_092408_d30862')
+
+    expect(open).toHaveBeenCalledWith({
+      sessionId: '20260809_092408_d30862',
+      profile: 'hudrepro'
+    })
+  })
+})

--- a/apps/desktop/src/store/hud.ts
+++ b/apps/desktop/src/store/hud.ts
@@ -16,6 +16,7 @@
 import { atom } from 'nanostores'
 
 import { requestComposerDraftSync } from '@/store/composer'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { isHudWindow } from '@/store/windows'
 
 /** Whether a HUD window is currently up. In the HUD's own renderer this is
@@ -53,9 +54,14 @@ export function openHud(sessionId?: null | string): void {
   // a cross-window storage event that lands after it has already painted.
   requestComposerDraftSync('flush')
 
+  // Carry the active gateway profile with the session id. HUD boot adopts it
+  // from the URL; without it the HUD dials the primary/default backend and
+  // the focused non-primary conversation is not found (#82285).
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+
   $hudActive.set(true)
   $hudSession.set(sessionId ?? null)
-  void api.open({ sessionId: sessionId ?? null })
+  void api.open({ sessionId: sessionId ?? null, profile })
 }
 
 /** Leave HUD mode. Callable from either window — main closes the child, the

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -54,6 +54,25 @@ export function isHudWindow(): boolean {
   return result
 }
 
+/**
+ * Profile the HUD window was opened against (`?profile=` in the query before
+ * the hash). Empty when the opener did not carry one — boot then falls back to
+ * the primary preference (legacy single-profile path).
+ */
+export function hudWindowProfile(): null | string {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const raw = new URLSearchParams(window.location.search).get('profile')
+
+    return raw && raw.trim() ? raw.trim() : null
+  } catch {
+    return null
+  }
+}
+
 // A "watch" window spectates a session that is being driven elsewhere (a
 // running subagent). It resumes lazily — the gateway registers history + a
 // transport for the live mirror without building an agent, so opening it is


### PR DESCRIPTION
## What does this PR do?

HUD mode (`Ctrl/Cmd+Shift+H`) was opening against the primary/`default` profile even when the focused conversation belonged to another profile. Session ids are per-profile, so the HUD dialed the wrong backend and fell back to that backend's last session.

This carries the active gateway profile through the HUD handoff (`openHud` → IPC → `?win=hud&profile=` URL) and makes HUD boot adopt that profile before `getConnection`, so the floating window lands on the same conversation/profile that was in focus.

## Related Issue

Fixes #82285

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/hud-url.ts` — extract `buildHudWindowUrl` so HUD URLs can include `profile=` before the hash (same query-before-hash contract as secondary windows)
- `apps/desktop/electron/main.ts` — pass profile into HUD open/spawn; reload the HUD URL on cross-profile retarget instead of only sending `hermes:hud:goto`
- `apps/desktop/src/store/hud.ts` — `openHud` sends `$activeGatewayProfile` with the session id
- `apps/desktop/src/store/windows.ts` — `hudWindowProfile()` reads `?profile=` from the query
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` — HUD windows adopt the URL handoff profile before connecting; main window still uses the primary preference
- `apps/desktop/src/global.d.ts` — HUD open request type includes optional `profile`
- Tests: `electron/hud-url.test.ts`, `src/store/hud-profile-handoff.test.ts`

## How to Test

1. Configure at least two profiles (e.g. `default` + a second profile). Put a distinctive conversation on the non-primary profile and focus it in Desktop.
2. Enter HUD mode (`Ctrl/Cmd+Shift+H` or the titlebar toggle).
3. Confirm the HUD opens on that same conversation/profile (not the primary profile's last session). HUD URL should look like `?win=hud&profile=<name>#/<sessionId>`.
4. Unit checks from `apps/desktop`:
   `npx vitest run electron/hud-url.test.ts src/store/hud-profile-handoff.test.ts src/app/gateway/hooks/use-gateway-boot.test.tsx`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Desktop Electron + CDP against a multi-profile setup)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before: HUD URL was `?win=hud#/<sessionId>` (no profile) → boot adopted primary/`default` → non-primary session not found.

After: HUD URL is `?win=hud&profile=<active>#/<sessionId>` → boot adopts that profile before connect → focused conversation's profile/session is present.


Made with [Cursor](https://cursor.com)