### PR TITLE
fix(desktop): keep the HUD composer on screen and its exit chip clickable

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2667,6 +2667,22 @@ button[data-slot='aui_msg-reactions'] svg {
   /* The one surface that is always there, so the one that always takes the
      mouse — everything else in the shell earns it by being on screen. */
   pointer-events: auto;
+
+  /* The dock centres itself with `left-1/2` + `-translate-x-1/2`: half the
+     parent across, then half its OWN width back. Only the second half of that
+     pair survives here — `left` resolves to 0 in the HUD, so the translate
+     subtracts from zero and the dock lands at -50% of its own width (measured
+     x=-310 in a 620px HUD). The composer's text then starts off screen to the
+     left, and typing far enough walks the caret into view, which is why it
+     presents as "the composer is cut off" rather than as a layout bug.
+
+     Anchor both edges and centre with auto margins so the pairing cannot come
+     apart: nothing to cancel, and it still centres if the dock is ever
+     narrower than the HUD. */
+  left: 0;
+  right: 0;
+  translate: none;
+  margin-inline: auto;
 }
 
 /* HUD mode is the input and the log — nothing else. The dock stacks
@@ -2807,14 +2823,18 @@ button[data-slot='aui_msg-reactions'] svg {
   background: transparent !important;
   border: 0;
   color: var(--ui-text-primary) !important;
-  /* Focus only. A turn landing brings the transcript up but doesn't mean you
-     are reaching for the window controls, and at rest this is a lone chip
-     hovering over whatever you're actually working in. */
-  opacity: 0;
+  /* Always interactive, dim at rest. Gating the clicks on composer :focus made
+     the only visible way out of HUD mode depend on the thing most likely to be
+     broken when a user wants out: if focus never lands (see #81893) you cannot
+     type AND the exit chip silently ignores clicks, so the window is a dead
+     rectangle floating over the desktop with no in-app way to dismiss it.
+
+     Dim rather than invisible keeps the original intent — this should not be a
+     loud chip over the app behind — without making the escape hatch conditional
+     on the failure mode it exists for. */
+  opacity: 0.45;
   transition: opacity var(--hud-fade) var(--hud-ease-exit);
-  /* Clicks on exactly the same terms as the paint — a faded-out control that
-     still takes them is an invisible button floating over the app behind. */
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 /* Flipped, "above the composer" is the reserved strip at the top of the
@@ -2824,9 +2844,12 @@ button[data-slot='aui_msg-reactions'] svg {
   top: 0;
 }
 
-[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-exit] {
-  opacity: 0.75;
-  pointer-events: auto;
+/* Hover and focus-visible brighten it too, so pointing at the chip confirms it
+   is a control before you commit the click. */
+[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-exit],
+[data-hud-shell] [data-hud-exit]:hover,
+[data-hud-shell] [data-hud-exit]:focus-visible {
+  opacity: 0.9;
   transition-duration: var(--hud-reveal);
   transition-delay: 0s;
 }


### PR DESCRIPTION
Two CSS defects in HUD mode that compound into a window you can neither type into nor leave. Found on Windows against a build of `3dcbe9001`; both are platform-independent by construction.

## 1. The composer starts off screen (the "cut off" report)

`[data-slot='composer-dock']` centres itself with the Tailwind idiom `left-1/2` + `-translate-x-1/2`: half the parent across, then half its own width back. In HUD mode only the second half of that pair survives.

Measured on the live window (CDP, 620px HUD):

| | `left` | `translate` | dock x | composer x | on screen |
|---|---|---|---|---|---|
| before | `0px` | `-50%` | **-310** | **-273** | no |
| after | `0px` | `none` | 0 | +37 | yes |

`left` resolves to `0`, so the `-50%` translate subtracts from zero instead of from the intended midpoint and the dock lands at exactly minus half its own width. The start of the composer's text sits ~273px off screen to the left, so the first characters you type are invisible and typing far enough eventually walks the caret into view. That behaviour is why this reads as "the composer box is cut off" rather than as a centring bug, and it is invisible in the stylesheet — it only exists in the computed values, where a Tailwind utility and a HUD override meet.

Fixed by anchoring both edges and centring with auto margins, so there is no translate left to cancel. It still centres if the dock is ever narrower than the HUD.

## 2. The exit chip is unclickable exactly when you need it

`[data-hud-exit]` was `pointer-events: none` until `[data-slot='composer-rich-input']` had `:focus`. That makes the only visible way out of HUD mode conditional on the thing most likely to be broken when a user wants out: if focus never lands — which is #81893 on macOS — you cannot type *and* clicks on the exit chip are silently ignored. The result is a transparent always-on-top rectangle over the desktop with no in-app way to dismiss it.

It is now always clickable and dim (`0.45`) at rest, brightening on hover/`:focus-visible`. That keeps the original intent (not a loud chip over the app behind) without making the escape hatch depend on the failure mode it exists for.

## Related

- **#82214** — "HUD transcript is misaligned and clipped". The dock offset above is a plausible mechanism: it is a horizontal displacement of the whole composer/band column, present on every platform, and it reads as clipping rather than as mis-centring.
- **#81893** — "HUD mode: floating window opens but keyboard focus never arrives". Fix 2 is the other half of that trap, seen from the exit side. This PR does not attempt to fix the focus race itself.
- **#82285** — HUD opens on the wrong profile. Unrelated, listed for completeness.

## Scope

CSS only, no behaviour changes outside HUD mode. I deliberately left out a focus workaround (forcing `webContents.focus()` + re-focusing the composer on mount with retries): it papers over the race in #81893 rather than fixing it, and it does not belong in the same change as two one-line layout fixes.

## Two things noticed while measuring, not proposed here

Recording these because they came out of the same investigation; happy to open a separate issue if either is worth pursuing, or to drop them.

- **`:focus` is not a usable reveal trigger in HUD mode.** The HUD focuses its composer on mount, so `:has([data-slot='composer-rich-input']:focus)` is true from the moment it opens. Anything gated on it — currently the band and the exit chip's brightening — is effectively always revealed. Hover is the only signal that distinguishes states today.
- **The bar spends most of itself on chrome.** The row is `[menu | input | controls]`, measured 24px / 344px / 226px in a 620px HUD, and the bar is 66px tall for a 28px input (the rest is `--hud-chip-strip` plus padding). Locally I collapsed the side columns until the pointer is on the bar, which took the input from 344px to 594px and made idle HUD mode read as a single input line. That is a design call rather than a bug fix, so it is not in this PR.
