### PR TITLE
test(desktop): guard HUD composer containment on both axes

### DIFF
--- a/apps/desktop/e2e/launch-packaged-app.spec.ts
+++ b/apps/desktop/e2e/launch-packaged-app.spec.ts
@@ -71,17 +71,45 @@ test('HUD composer remains fully inside the transparent window', async () => {
 
     return {
       viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
       dockLeft: dockRect.left,
       dockRight: dockRect.right,
+      dockTop: dockRect.top,
+      dockBottom: dockRect.bottom,
       inputLeft: inputRect.left,
       inputRight: inputRect.right,
+      inputTop: inputRect.top,
+      inputBottom: inputRect.bottom,
+      // The bug class this guards: a build-time CSS optimization folding the
+      // dock's identity `translate` override into `transform`, leaving
+      // Tailwind's standalone `translate: -50%` live and shifting the dock
+      // half a window off-screen. Surface the computed value so a failure
+      // says WHY the dock moved, not just that it did.
+      dockTranslate: getComputedStyle(dock).translate,
     }
   })
 
+  // Horizontal containment — the composer shifted half a window left when the
+  // standalone `translate: -50%` survived optimization (#82214, #82233).
   expect(geometry.dockLeft).toBeGreaterThanOrEqual(0)
   expect(geometry.inputLeft).toBeGreaterThanOrEqual(0)
   expect(geometry.dockRight).toBeLessThanOrEqual(geometry.viewportWidth)
   expect(geometry.inputRight).toBeLessThanOrEqual(geometry.viewportWidth)
+
+  // Vertical containment — the toolbar/transcript clipping reported on
+  // Windows (#82203) and macOS (#82214) is the same "composer escapes the
+  // window" class on the other axis.
+  expect(geometry.dockTop).toBeGreaterThanOrEqual(0)
+  expect(geometry.inputTop).toBeGreaterThanOrEqual(0)
+  expect(geometry.dockBottom).toBeLessThanOrEqual(geometry.viewportHeight)
+  expect(geometry.inputBottom).toBeLessThanOrEqual(geometry.viewportHeight)
+
+  // The dock's centering translate must be fully neutralized. Any live
+  // percentage translate means the HUD override lost to the app's centering.
+  // (Computed `translate` keeps percentages as-is, so this is assertable;
+  // computed `transform` resolves to a matrix and is covered by the
+  // geometric containment checks above.)
+  expect(geometry.dockTranslate ?? 'none').not.toContain('%')
 
   await hudPage.close()
 })


### PR DESCRIPTION
## Summary

Widens the packaged-app HUD containment test from horizontal-only to both axes plus an explicit computed-`translate` probe.

The CSS fix itself landed in #82233 by @kerpopule — `apps/desktop/src/styles.css` on this branch is identical to `main`, so this PR is test coverage only.

## Why the extra assertions

Lightning CSS folds the literal identity value in `translate: none !important` into `transform: translate(0) !important` during the production build. The `transform` longhand does not override Tailwind's standalone `translate: -50%` on the composer dock, so the dock rendered half a HUD width off-screen; dev builds (no minification) were unaffected, which is why it survived review. #82233 fixed that with a var indirection (`--hud-composer-translate: 0` + `translate: var(...)`) the optimizer can't fold.

The old test only checked the horizontal axis, which is the one shape of the failure we already know about. What it adds:

- **Both axes.** A dock that escapes the window vertically fails the same containment contract; there is no reason to assert only one direction.
- **A computed-`translate` probe.** Computed `translate` keeps percentages as-is, while computed `transform` resolves to a matrix. Asserting no live `%` survives means a future optimizer regression fails with a diagnosis instead of a bare coordinate mismatch.

## Scope

- Unrelated to issue 82203. The Lightning fold only ever touched the horizontal `-translate-x-1/2`; the Windows vertical toolbar clipping at 100% scaling is a separate mechanism and that issue stays open.
- Does not run in CI today. The `Desktop E2E` lane is disabled in `.github/workflows/ci.yml` (tracking #76627), so this is banked coverage that starts guarding when the lane comes back.

## Validation

| Check | Result |
|---|---|
| Diff vs `main` | `e2e/launch-packaged-app.spec.ts` only |
| `tsc -p tsconfig.e2e.json --noEmit` | pass |
| `npm run lint --workspace apps/desktop -- --quiet` | pass |
| `npm run test:ui` | 405 files / 3,620 tests pass |

