### PR TITLE
fix(cli): resolve --model config aliases before building the interactive agent

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2528,11 +2528,45 @@ def _resolve_use_tui(args) -> bool:
         return False
 
 
+def _resolve_model_alias_arg(args) -> None:
+    """Resolve ``--model`` config aliases before the agent is built.
+
+    ``hermes -m <alias>`` was forwarding the raw alias string to the
+    provider API (404), while ``hermes -q`` (oneshot) and the in-session
+    ``/model`` command both resolve ``model_aliases:`` / ``model.aliases:``
+    entries from config.yaml (#82275).  Mutates args in place so both the
+    TUI and the CLI agent build see the resolved model/provider/base_url.
+    """
+    raw = getattr(args, "model", None)
+    if not raw or not isinstance(raw, str) or not raw.strip():
+        return
+    try:
+        from hermes_cli import model_switch as _ms
+
+        _ms._ensure_direct_aliases()
+        direct = _ms.DIRECT_ALIASES.get(raw.strip().lower())
+    except Exception:
+        direct = None
+    if direct is None:
+        return
+    args.model = direct.model
+    if not getattr(args, "provider", None):
+        args.provider = direct.provider
+    if direct.base_url and not getattr(args, "base_url", None):
+        args.base_url = direct.base_url
+
+
 def cmd_chat(args):
     """Run interactive chat CLI."""
     use_tui = _resolve_use_tui(args)
 
     _apply_safe_mode(args)
+
+    # Resolve `--model` config aliases (config.yaml `model_aliases:` /
+    # `model.aliases:`) before the agent is built — the interactive path
+    # was sending the raw alias string to the provider, unlike `hermes -q`
+    # and the in-session `/model` command (#82275).
+    _resolve_model_alias_arg(args)
 
     # --in DIR: run in DIR. Must happen before any session resolution so the
     # workspace-scoped "latest"/-c lookups key off DIR, and it pins the
@@ -2750,6 +2784,7 @@ def cmd_chat(args):
     kwargs = {
         "model": args.model,
         "provider": getattr(args, "provider", None),
+        "base_url": getattr(args, "base_url", None),
         "reasoning": getattr(args, "reasoning", None),
         "toolsets": args.toolsets,
         "skills": getattr(args, "skills", None),

--- a/tests/hermes_cli/test_82275_model_alias_arg.py
+++ b/tests/hermes_cli/test_82275_model_alias_arg.py
@@ -1,0 +1,90 @@
+"""Regression tests for `hermes -m <alias>` resolving config aliases (#82275).
+
+`hermes -m <alias>` was forwarding the raw alias string to the provider
+API (404 error), while `hermes -q` (oneshot) and the in-session `/model`
+command both resolve `model_aliases:` / `model.aliases:` entries from
+config.yaml. `_resolve_model_alias_arg` must apply the same resolution to
+the `--model` flag before the interactive agent is built.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hermes_cli import main as cli_main
+from hermes_cli import model_switch as ms
+
+
+def _make_args(model=None, provider=None, base_url=None):
+    return SimpleNamespace(model=model, provider=provider, base_url=base_url)
+
+
+def _install_alias(monkeypatch, alias):
+    monkeypatch.setattr(ms, "DIRECT_ALIASES", {"glm": alias})
+    monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+
+
+def test_alias_resolved(monkeypatch):
+    alias = ms.DirectAlias(
+        model="z-ai/glm-5.2",
+        provider="nvidia",
+        base_url="https://integrate.api.nvidia.com/v1",
+    )
+    _install_alias(monkeypatch, alias)
+
+    args = _make_args(model="glm")
+    cli_main._resolve_model_alias_arg(args)
+
+    assert args.model == "z-ai/glm-5.2"
+    assert args.provider == "nvidia"
+    assert args.base_url == "https://integrate.api.nvidia.com/v1"
+
+
+def test_alias_case_insensitive(monkeypatch):
+    alias = ms.DirectAlias(model="z-ai/glm-5.2", provider="nvidia", base_url="")
+    _install_alias(monkeypatch, alias)
+
+    args = _make_args(model="GLM")
+    cli_main._resolve_model_alias_arg(args)
+
+    assert args.model == "z-ai/glm-5.2"
+    assert args.provider == "nvidia"
+
+
+def test_explicit_provider_and_base_url_win(monkeypatch):
+    alias = ms.DirectAlias(
+        model="z-ai/glm-5.2",
+        provider="nvidia",
+        base_url="https://integrate.api.nvidia.com/v1",
+    )
+    _install_alias(monkeypatch, alias)
+
+    args = _make_args(
+        model="glm", provider="anthropic", base_url="https://custom.example/v1"
+    )
+    cli_main._resolve_model_alias_arg(args)
+
+    # The alias resolves the model id, but an explicit --provider /
+    # --base-url on the command line keeps winning.
+    assert args.model == "z-ai/glm-5.2"
+    assert args.provider == "anthropic"
+    assert args.base_url == "https://custom.example/v1"
+
+
+def test_non_alias_model_untouched(monkeypatch):
+    alias = ms.DirectAlias(model="z-ai/glm-5.2", provider="nvidia", base_url="")
+    _install_alias(monkeypatch, alias)
+
+    args = _make_args(model="anthropic/claude-sonnet-4")
+    cli_main._resolve_model_alias_arg(args)
+
+    assert args.model == "anthropic/claude-sonnet-4"
+    assert args.provider is None
+    assert args.base_url is None
+
+
+def test_empty_model_noop(monkeypatch):
+    args = _make_args(model="")
+    cli_main._resolve_model_alias_arg(args)
+    assert args.model == ""
+    assert args.provider is None


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes -m <alias>` failing to resolve configuration aliases before the interactive agent is built. The interactive CLI now resolves `model_aliases:` / `model.aliases:` entries, including `DirectAlias` entries with custom provider and base URL settings, while preserving explicit command-line provider/base URL overrides.

## Related Issue

Fixes #82275

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`
  - Resolve config-file model aliases before building the interactive agent.
  - Preserve explicit `--provider` / `--base-url` command-line precedence.
- `tests/hermes_cli/test_82275_model_alias_arg.py`
  - Add 5 regression tests for the alias argument path.
- Catalog aliases from models.dev remain outside this PR because the issue concerns config-file aliases.

## How to Test

1. Run `tests/hermes_cli/test_82275_model_alias_arg.py`.
2. Result: 5 tests passed.
3. Run `ruff check` on both changed files; result: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (isolated Hermes worktree)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable: this PR does not add a skill. -->

## Screenshots / Logs

Not applicable; this is CLI behavior and regression-test coverage.
