### PR TITLE
Fix MCP elicitation context propagation

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -564,6 +564,59 @@ class TestToolHandler:
         finally:
             _servers.pop("test_srv", None)
 
+    def test_captures_context_before_mcp_loop_handoff(self):
+        """Gateway context must survive scheduling onto the MCP loop thread."""
+        import contextvars
+
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        platform = contextvars.ContextVar("mcp_test_platform", default="")
+        observed = []
+        server = _make_mock_server("test_srv")
+
+        async def call_tool(_name, arguments=None):
+            captured = server._pending_call_context
+            assert captured is not None
+            observed.append(captured.copy().run(platform.get))
+            return _make_call_result("ok", is_error=False)
+
+        server.session = SimpleNamespace(call_tool=call_tool)
+        _servers["test_srv"] = server
+
+        def run_on_background_context(coro_or_factory, timeout=30):
+            del timeout
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            result = []
+            errors = []
+
+            def worker():
+                try:
+                    result.append(contextvars.Context().run(asyncio.run, coro))
+                except BaseException as exc:  # pragma: no cover - surfaced below
+                    errors.append(exc)
+
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join()
+            if errors:
+                raise errors[0]
+            return result[0]
+
+        token = platform.set("gateway:webui")
+        try:
+            handler = _make_tool_handler("test_srv", "greet", 120)
+            with patch(
+                "tools.mcp_tool._run_on_mcp_loop",
+                side_effect=run_on_background_context,
+            ):
+                result = json.loads(handler({"name": "world"}))
+        finally:
+            platform.reset(token)
+            _servers.pop("test_srv", None)
+
+        assert result["result"] == "ok"
+        assert observed == ["gateway:webui"]
+
 
     def test_recycled_stdio_server_reconnects_lazily_on_tool_call(self):
         from tools.mcp_tool import _make_tool_handler, _servers

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5310,14 +5310,17 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
+        # Capture the agent context in the synchronous caller before the MCP
+        # coroutine crosses onto the dedicated background event loop. Tasks
+        # created there inherit the loop thread's context, not this caller's.
+        call_context = contextvars.copy_context()
+
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                # Snapshot the agent's context so an elicitation callback
-                # triggered during this call (fired on the MCP recv loop
-                # task, which doesn't inherit our contextvars) can replay
-                # it and detect the gateway platform / session for routing.
-                server._pending_call_context = contextvars.copy_context()
+                # Replay this caller-owned snapshot if the MCP server requests
+                # elicitation while the tool call is in flight.
+                server._pending_call_context = call_context
                 try:
                     result = await server.session.call_tool(tool_name, arguments=args)
                 finally:


### PR DESCRIPTION
## Summary

Capture the calling agent context before an MCP tool coroutine is scheduled onto the dedicated MCP event-loop thread. This lets elicitation callbacks replay the gateway session context and route approval prompts back to the correct surface.

## Root cause

The existing handler calls contextvars.copy_context() from inside the scheduled coroutine. Tasks created on the MCP loop inherit that loop thread context rather than the thread that invoked the synchronous tool handler. As a result, gateway session variables are absent when an MCP server sends elicitation/create, and consent can fall back to a local CLI/TUI prompt instead of the gateway approval continuation.

## Change

- Snapshot context in the synchronous tool handler before the loop handoff.
- Store that caller-owned snapshot while session.call_tool is in flight.
- Add a regression test that executes the MCP coroutine in a fresh thread context and verifies the original gateway value remains observable.

## Validation

- uv run --extra dev pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_elicitation.py -q (109 passed)
- uv run ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py
- Searched open and closed issues and PRs for duplicate elicitation context propagation fixes; none found.