### PR TITLE
fix(telegram): preserve conflict retry ladder

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3150,12 +3150,14 @@ class TelegramAdapter(BasePlatformAdapter):
             # that immediately gets 409'd by the previous one, creating
             # the very conflict we are trying to recover from (#75017).
             self._polling_conflict_recovery_generation = expected_generation
+            polling_started = False
             try:
                 await self._start_polling_once(
                     app,
                     drop_pending_updates=True,
                     error_callback=self._polling_error_callback_ref,
                 )
+                polling_started = True
                 logger.info(
                     "[%s] Telegram polling restarted after conflict retry %d/%d; "
                     "health pending getUpdates progress",
@@ -3195,7 +3197,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     return
                 # Fall through to fatal on the last retry.
             finally:
-                if self._polling_conflict_recovery_generation == expected_generation:
+                if (
+                    not polling_started
+                    and self._polling_conflict_recovery_generation
+                    == expected_generation
+                ):
                     self._polling_conflict_recovery_generation = None
 
         if getattr(self, "_polling_teardown_started", False):

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -217,6 +217,38 @@ async def test_conflict_retry_progress_does_not_reset_retry_ladder(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_conflict_retry_keeps_recovery_marker_until_background_progress(
+    monkeypatch,
+):
+    """Progress arriving after start_polling returns must preserve the ladder."""
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.set_fatal_error_handler(AsyncMock())
+    adapter._drain_polling_connections = AsyncMock()
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    adapter._app = SimpleNamespace(updater=updater)
+
+    conflict = type("Conflict", (Exception,), {})
+    error = conflict("Conflict: terminated by other getUpdates request")
+
+    await adapter._handle_polling_conflict(error)
+    recovered_generation = adapter._polling_generation
+
+    # PTB starts getUpdates in the background, so progress normally arrives
+    # only after start_polling() and the conflict handler have returned.
+    adapter._record_polling_progress(recovered_generation)
+    await adapter._handle_polling_conflict(error)
+
+    assert updater.start_polling.await_count == 2
+    assert adapter._polling_conflict_count == 2
+
+
+@pytest.mark.asyncio
 async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
     """After exhausting retries, the conflict should become fatal."""
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))


### PR DESCRIPTION
## Summary

Keep Telegram conflict recovery marked as pending after `start_polling()` returns, until the background `getUpdates` loop reports actual progress. This prevents a delayed progress callback from resetting the retry counter between repeated 409 conflicts.

The marker is still cleared when startup fails or is aborted, so failed recovery attempts do not leave stale state behind.

Closes #82303

## Testing

- `tests/gateway/test_telegram_conflict.py`: 11 passed
- related Telegram polling and reconnect tests: 27 passed
- full suite: all related tests passed; one existing Linux-only systemd abstract socket test fails on macOS
- Ruff, Windows footgun check, and `git diff --check` passed