### PR TITLE
fix(telegram): avoid MDV2 draft preview when rich_messages lacks rich_drafts

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -738,6 +738,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Rich draft previews use a separate opt-in. Telegram macOS / Desktop
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
+        # When rich_messages is on but rich_drafts is off, supports_draft_streaming
+        # declines drafts so transport=auto uses edit-in-place + rich finalize
+        # instead of MDV2 drafts that jump to sendRichMessage at the end.
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
@@ -5346,8 +5349,22 @@ class TelegramAdapter(BasePlatformAdapter):
         We additionally require ``self._bot`` to expose ``send_message_draft``
         (added to python-telegram-bot in 22.6); older PTB installs gracefully
         fall back to the edit path even on DMs.
+
+        When ``rich_messages`` is enabled but ``rich_drafts`` is not, decline
+        drafts even on DMs.  Final delivery then uses ``sendRichMessage`` /
+        rich ``editMessageText``, while the default draft path still renders
+        MarkdownV2 (tables → bullet lists).  That mismatch makes the streaming
+        preview look unformatted/"crooked" and the finalized reply a second
+        beautiful wiki-style bubble.  Prefer edit-in-place streaming so the
+        same message upgrades via rich finalize.  Operators who want animated
+        rich drafts opt in with ``rich_drafts: true``.
         """
         if not self._bot or not hasattr(self._bot, "send_message_draft"):
+            return False
+        if (
+            getattr(self, "_rich_messages_enabled", False)
+            and not getattr(self, "_rich_drafts_enabled", False)
+        ):
             return False
         return (chat_type or "").lower() in {"dm", "private"}
 

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -389,7 +389,10 @@ def test_prefers_fresh_final_streaming_stays_disabled_when_rich_enabled():
 async def test_legacy_draft_stream_finalizes_with_persistent_rich_message():
     """A MarkdownV2 draft must not force the persistent final to MarkdownV2."""
     adapter = _make_adapter()  # rich messages on, rich drafts off
-    assert adapter.supports_draft_streaming(chat_type="dm") is True
+    # With the gate in supports_draft_streaming, draft streaming is declined
+    # when rich_drafts is off.  The test force-enables it to verify that even
+    # a legacy MDV2 draft still finalizes as a rich message.
+    assert adapter.supports_draft_streaming(chat_type="dm") is False
 
     consumer = GatewayStreamConsumer(
         adapter,
@@ -429,9 +432,6 @@ def test_supports_draft_streaming_enabled_when_rich_drafts_opt_in():
 
 def test_supports_draft_streaming_legacy_when_rich_messages_off():
     adapter = _make_adapter(extra={"rich_messages": False})
-    # _make_adapter always injects rich_messages True via default; force off.
-    adapter._rich_messages_enabled = False
-    adapter._rich_drafts_enabled = False
     assert adapter.supports_draft_streaming(chat_type="dm") is True
 
 

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -409,6 +409,33 @@ async def test_legacy_draft_stream_finalizes_with_persistent_rich_message():
 
 
 # ----------------------------------------------------------------------
+# supports_draft_streaming: rich_messages without rich_drafts must NOT use
+# MDV2 sendMessageDraft previews that later snap to sendRichMessage (wiki)
+# finals — that is the "first bubble crooked, second bubble beautiful" bug.
+# ----------------------------------------------------------------------
+
+
+def test_supports_draft_streaming_disabled_when_rich_without_rich_drafts():
+    adapter = _make_adapter()  # rich_messages True, rich_drafts default False
+    assert adapter.supports_draft_streaming(chat_type="dm") is False
+    assert adapter.supports_draft_streaming(chat_type="private") is False
+
+
+def test_supports_draft_streaming_enabled_when_rich_drafts_opt_in():
+    adapter = _make_adapter(extra={"rich_drafts": True})
+    assert adapter.supports_draft_streaming(chat_type="dm") is True
+    assert adapter.supports_draft_streaming(chat_type="group") is False
+
+
+def test_supports_draft_streaming_legacy_when_rich_messages_off():
+    adapter = _make_adapter(extra={"rich_messages": False})
+    # _make_adapter always injects rich_messages True via default; force off.
+    adapter._rich_messages_enabled = False
+    adapter._rich_drafts_enabled = False
+    assert adapter.supports_draft_streaming(chat_type="dm") is True
+
+
+# ----------------------------------------------------------------------
 # streaming_overflow_limit: with rich on, the stream consumer may accumulate up
 # to the 32,768-char rich cap before splitting, so a reply that fits one
 # sendRichMessage / sendRichMessageDraft isn't fragmented at the 4,096 limit.


### PR DESCRIPTION
## Summary
Telegram DM streaming no longer shows a "crooked first bubble, beautiful second bubble" — when `rich_messages` is enabled but `rich_drafts` is not, `supports_draft_streaming()` now returns `False` so `transport: auto` uses edit-in-place streaming + rich finalize instead of an MDV2 draft (tables degraded to bullets) that then snaps to a `sendRichMessage` final.

## Changes
- `plugins/platforms/telegram/adapter.py`: gate in `supports_draft_streaming()` — returns `False` when `rich_messages` and not `rich_drafts`, so edit-in-place + `_try_edit_rich` is used instead of mismatched draft → rich final.
- `tests/gateway/test_telegram_rich_messages.py`: 3 new tests for the gate (rich without drafts / rich+drafts / legacy). Updated existing `test_legacy_draft_stream_finalizes_with_persistent_rich_message` to reflect the new return value (the test already force-sets `_use_draft_streaming=True`, so the assertion was redundant). Removed redundant manual attribute overrides in the legacy test.

## Validation
| | Before | After |
|---|---|---|
| `test_telegram_rich_messages.py` | 29 passed, 1 failed | 30 passed, 0 failed |
| Stream consumer tests | 77 passed | 77 passed |
| Ruff lint | clean | clean |

Closes #78524. Based on #78525 by @Slobaka — cherry-picked with authorship preserved.
