### PR TITLE
Fix Desktop and web JSON failures on lone surrogates

### DIFF
--- a/hermes_cli/json_safety.py
+++ b/hermes_cli/json_safety.py
@@ -1,0 +1,27 @@
+"""UTF-8-safe JSON serialization for user-controlled transport payloads."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def dumps_utf8_safe(value: Any, **kwargs: Any) -> str:
+    """Serialize JSON while preserving valid Unicode and repairing surrogates.
+
+    ``json.dumps(..., ensure_ascii=False)`` can return a Python string that
+    still contains lone UTF-16 surrogate code units. The failure arrives one
+    step later when an HTTP or WebSocket library encodes that string as UTF-8.
+    Keep the normal serialized form unchanged and repair only that invalid
+    output, without mutating the caller's object.
+    """
+    serialized = json.dumps(value, **kwargs)
+    try:
+        serialized.encode("utf-8")
+    except UnicodeEncodeError:
+        serialized = _SURROGATE_RE.sub("\ufffd", serialized)
+    return serialized

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -135,6 +135,21 @@ except ImportError:
 WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
 _log = logging.getLogger(__name__)
 
+
+class UTF8SafeJSONResponse(JSONResponse):
+    """JSON response that repairs lone surrogates without escaping valid text."""
+
+    def render(self, content: Any) -> bytes:
+        from hermes_cli.json_safety import dumps_utf8_safe
+
+        return dumps_utf8_safe(
+            content,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=None,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
 # ---------------------------------------------------------------------------
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
@@ -310,7 +325,12 @@ def _get_pty_active_session_files(app: "FastAPI") -> dict[str, Path]:
         return app.state.pty_active_session_files
 
 
-app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
+app = FastAPI(
+    title="Hermes Agent",
+    version=__version__,
+    lifespan=_lifespan,
+    default_response_class=UTF8SafeJSONResponse,
+)
 
 # Memory-provider OAuth connect routes live in the memory layer, not here.
 from hermes_cli.memory_oauth import router as _memory_oauth_router  # noqa: E402

--- a/tests/hermes_cli/test_json_transport_safety.py
+++ b/tests/hermes_cli/test_json_transport_safety.py
@@ -1,0 +1,39 @@
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli.json_safety import dumps_utf8_safe
+from hermes_cli.web_server import UTF8SafeJSONResponse
+
+
+def test_dumps_utf8_safe_repairs_keys_and_values_without_mutating_input():
+    payload = {"key\udfff": ["value\ud800", "中文"]}
+
+    serialized = dumps_utf8_safe(payload, ensure_ascii=False)
+
+    serialized.encode("utf-8")
+    assert json.loads(serialized) == {"key�": ["value�", "中文"]}
+    assert next(iter(payload)) == "key\udfff"
+
+
+def test_dumps_utf8_safe_leaves_valid_unicode_serialization_unchanged():
+    payload = {"message": "Hello, 世界 👋"}
+
+    assert dumps_utf8_safe(payload, ensure_ascii=False) == json.dumps(
+        payload, ensure_ascii=False
+    )
+
+
+def test_fastapi_default_response_survives_lone_surrogate():
+    app = FastAPI(default_response_class=UTF8SafeJSONResponse)
+
+    @app.get("/payload")
+    def payload():
+        return {"message": "Hello \ud83d 世界"}
+
+    response = TestClient(app).get("/payload")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello � 世界"}
+    assert "世界".encode() in response.content

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -228,3 +228,23 @@ def test_ws_transport_preserves_cross_batch_order():
     asyncio.run(scenario())
 
 
+def test_ws_transport_repairs_surrogates_but_preserves_valid_unicode():
+    async def scenario():
+        sent = []
+
+        class FakeWS:
+            async def send_text(self, line):
+                line.encode("utf-8")
+                sent.append(line)
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="unicode-test"
+        )
+        assert await transport.write_async({"text": "Hermes \ud83d 中文"}) is True
+
+        assert "中文" in sent[0]
+        assert json.loads(sent[0]) == {"text": "Hermes � 中文"}
+        assert transport._closed is False
+
+    asyncio.run(scenario())
+

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -31,6 +31,7 @@ import socket
 import threading
 from typing import Any
 
+from hermes_cli.json_safety import dumps_utf8_safe
 from tui_gateway import server
 
 _log = logging.getLogger(__name__)
@@ -119,7 +120,7 @@ class WSTransport:
         if self._closed:
             return False
 
-        line = json.dumps(obj, ensure_ascii=False)
+        line = dumps_utf8_safe(obj, ensure_ascii=False)
 
         try:
             on_loop = asyncio.get_running_loop() is self._loop
@@ -221,7 +222,7 @@ class WSTransport:
         with self._token_lock:
             batch = self._pending_tokens
             self._pending_tokens = []
-            batch.append(json.dumps(obj, ensure_ascii=False))
+            batch.append(dumps_utf8_safe(obj, ensure_ascii=False))
         await self._safe_send_many(batch)
         return not self._closed
 


### PR DESCRIPTION
## What

- add a UTF-8-safe JSON serializer that replaces only lone surrogate code units
- use it for TUI gateway WebSocket payloads
- make it the default response renderer for the Hermes web API
- add regression coverage for WebSocket and FastAPI response paths

## Why

User-controlled history can contain lone UTF-16 surrogate code units. Python's
`json.dumps(..., ensure_ascii=False)` accepts them, but the later UTF-8 encode in
Starlette/WebSocket transport raises `UnicodeEncodeError`. That closes Desktop
gateway connections and turns affected web API requests into HTTP 500 responses.

Globally enabling ASCII escaping avoids the encode error but unnecessarily changes
all valid Unicode output. This patch preserves normal Unicode byte-for-byte and
repairs only payloads that cannot be encoded as UTF-8.

## Impact

Desktop gateway messages and web responses containing malformed surrogate data
remain deliverable. Valid multilingual text remains unescaped and unchanged. The
serializer does not mutate the input object.

## Checks

- `scripts/run_tests.sh tests/test_tui_gateway_ws.py tests/hermes_cli/test_json_transport_safety.py` (10 passed)
- `ruff check hermes_cli/json_safety.py hermes_cli/web_server.py tui_gateway/ws.py tests/test_tui_gateway_ws.py tests/hermes_cli/test_json_transport_safety.py`
- `git diff --check`
