### PR TITLE
fix(mcp): rotate the shared stderr log at open time

### DIFF
--- a/tests/tools/test_mcp_stderr_log_rotation.py
+++ b/tests/tools/test_mcp_stderr_log_rotation.py
@@ -1,0 +1,84 @@
+"""Tests for the shared MCP stderr log's open-time rotation.
+
+The handle stays open for the life of the process (asyncio wires child fds
+to it directly), so rotation can only happen when the handle is first
+opened. Without it the file grows unboundedly — no logrotate config knows
+about ~/.hermes/logs/mcp-stderr.log.
+"""
+
+import importlib
+
+import tools.mcp_tool as mcp_tool
+
+
+def _reset_handle():
+    """Clear the module-level cached handle so each test re-opens it."""
+    fh = mcp_tool._mcp_stderr_log_fh
+    if fh is not None:
+        try:
+            fh.close()
+        except Exception:
+            pass
+    mcp_tool._mcp_stderr_log_fh = None
+
+
+class TestMcpStderrLogRotation:
+    def _hermes_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # hermes_constants caches nothing relevant, but reload defensively in
+        # case a prior import froze the home path at module level.
+        import hermes_constants
+        importlib.reload(hermes_constants)
+        return tmp_path
+
+    def test_oversized_log_is_rotated_on_open(self, tmp_path, monkeypatch):
+        home = self._hermes_home(tmp_path, monkeypatch)
+        log_dir = home / "logs"
+        log_dir.mkdir(parents=True)
+        log_path = log_dir / "mcp-stderr.log"
+        log_path.write_bytes(b"x" * (mcp_tool._MCP_STDERR_LOG_MAX_BYTES + 1))
+
+        _reset_handle()
+        try:
+            fh = mcp_tool._get_mcp_stderr_log()
+            fh.write("fresh line\n")
+            fh.flush()
+
+            rotated = log_dir / "mcp-stderr.log.1"
+            assert rotated.exists(), "oversized log must move to .log.1"
+            assert rotated.stat().st_size > mcp_tool._MCP_STDERR_LOG_MAX_BYTES
+            # The live file restarted from (near) empty.
+            assert log_path.stat().st_size < 1024
+        finally:
+            _reset_handle()
+
+    def test_small_log_is_left_in_place(self, tmp_path, monkeypatch):
+        home = self._hermes_home(tmp_path, monkeypatch)
+        log_dir = home / "logs"
+        log_dir.mkdir(parents=True)
+        log_path = log_dir / "mcp-stderr.log"
+        log_path.write_text("existing content\n")
+
+        _reset_handle()
+        try:
+            fh = mcp_tool._get_mcp_stderr_log()
+            fh.write("appended\n")
+            fh.flush()
+
+            assert not (log_dir / "mcp-stderr.log.1").exists()
+            text = log_path.read_text()
+            assert "existing content" in text and "appended" in text
+        finally:
+            _reset_handle()
+
+    def test_missing_log_dir_still_opens(self, tmp_path, monkeypatch):
+        self._hermes_home(tmp_path, monkeypatch)
+
+        _reset_handle()
+        try:
+            fh = mcp_tool._get_mcp_stderr_log()
+            assert fh is not None
+            fh.write("first line\n")
+            fh.flush()
+        finally:
+            _reset_handle()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -151,6 +151,14 @@ _OSV_MALWARE_CHECK_TIMEOUT_S = 12.0
 _mcp_stderr_log_fh: Optional[Any] = None
 _mcp_stderr_log_lock = threading.Lock()
 
+# Rotate the shared stderr log when it exceeds this size. The handle is held
+# open for the life of the process (asyncio wires child fds to it directly),
+# so rotation happens at open time: growth is bounded to ~cap per gateway
+# lifetime plus one archived generation (.1). Without this the file grows
+# forever — observed 20 MB of FastMCP banners on a long-lived deployment —
+# because no logrotate config knows about it.
+_MCP_STDERR_LOG_MAX_BYTES = 5 * 1024 * 1024
+
 
 def _get_mcp_stderr_log() -> Any:
     """Return a shared append-mode file handle for MCP subprocess stderr.
@@ -169,6 +177,13 @@ def _get_mcp_stderr_log() -> Any:
             log_dir = get_hermes_home() / "logs"
             log_dir.mkdir(parents=True, exist_ok=True)
             log_path = log_dir / "mcp-stderr.log"
+            # One-shot rotation before the long-lived handle is opened: keep a
+            # single previous generation so recent history stays debuggable.
+            try:
+                if log_path.stat().st_size > _MCP_STDERR_LOG_MAX_BYTES:
+                    log_path.replace(log_path.with_suffix(".log.1"))
+            except OSError:
+                pass  # Missing file or racing writer — append mode handles it.
             # Line-buffered so server output lands on disk promptly; errors=
             # "replace" tolerates garbled binary output from misbehaving
             # servers.


### PR DESCRIPTION
## What

`~/.hermes/logs/mcp-stderr.log` grows without bound. Every MCP server child process appends its stderr to this single shared file for the life of the install — there is no rotation anywhere in the pipeline (`_mcp_stderr_log_fh` opens with mode `"a"` and the fd lives forever). Chatty or crash-looping MCP servers push it to hundreds of MB; on a small VPS this is a real disk-pressure source.

This PR rotates the log at open time: when the file already exceeds 5 MB at the moment the shared fd is first opened, it is renamed to `mcp-stderr.log.1` (replacing any previous `.1`) and a fresh file is started. One historical generation is always retained for post-mortem debugging.

Rotation at open time (rather than a size check on every write) keeps the hot write path untouched — MCP children inherit a raw fd, so mid-stream rotation would require re-plumbing every child's stderr. Open-time rotation bounds the file at ~5 MB + one generation per process lifetime, which in practice caps it at a few tens of MB even on long-lived gateways.

## Why

- The file is shared by every MCP server and never truncated: unbounded growth by design.
- Small-disk deployments (OCI free tier, Raspberry Pi) hit real disk pressure from it.
- A crash-looping MCP server can write GBs of repeated tracebacks in days.

## How to test

```
scripts/run_tests.sh tests/tools/test_mcp_stderr_log_rotation.py -- -q
```

3 tests: oversized log rotates and keeps exactly one `.1` generation; small log is untouched; rotation failure falls back to appending (never blocks MCP startup).

Tested on Linux (aarch64). Also verified live: a 92 MB accumulated log rotated to `.1` on gateway restart and the fresh file stayed under 5 MB.
