### PR TITLE
fix(langfuse): finalize open root spans at exit so short-lived processes export complete traces

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -225,6 +225,19 @@ def _get_langfuse() -> Optional[Langfuse]:
         _LANGFUSE_CLIENT = _INIT_FAILED
         return None
 
+    # atexit is LIFO: registering AFTER the SDK's constructor (which installs
+    # its own shutdown flush) means our finalizer runs FIRST at exit — root
+    # spans ended there are still picked up by the SDK's exporter. Closes the
+    # short-lived-process gap (kanban workers / hermes chat -q / cron): exit
+    # with tool calls still queued left the root span un-ended → anonymous
+    # trace with no name/session/metadata on the backend.
+    try:
+        import atexit
+
+        atexit.register(_finalize_all_traces)
+    except Exception:  # pragma: no cover - fail-open
+        pass
+
     return _LANGFUSE_CLIENT
 
 
@@ -732,6 +745,46 @@ def _evict_stale_locked() -> None:
             state.root_span.end()
         except Exception as exc:  # pragma: no cover - fail-open
             _debug(f"evict stale trace failed: {exc}")
+
+
+def _finalize_all_traces() -> None:
+    """End every open root span so short-lived processes export complete traces.
+
+    Gateway turns normally end their root span via ``_finish_trace`` (final
+    assistant message with no tool calls). But short-lived CLI processes —
+    kanban workers, ``hermes chat -q`` one-shots, cron jobs — can exit while
+    the last LLM call still has tool calls queued, leaving the root span
+    un-ended. Ended children DO export via the SDK's own atexit flush, so the
+    backend shows an anonymous trace (no name/session/metadata) whose
+    observations all point at a root that never arrived (observed live
+    2026-08-08: kanban workers produced 4 such traces in one tick).
+
+    Registered with ``atexit`` AFTER the Langfuse client is constructed:
+    atexit is LIFO, so this runs BEFORE the SDK's own shutdown hook — spans
+    ended here still get flushed by the SDK's exporter.
+    """
+    with _STATE_LOCK:
+        states = list(_TRACE_STATE.items())
+        _TRACE_STATE.clear()
+    for _key, state in states:
+        try:
+            for observation in state.generations.values():
+                _end_observation(observation)
+            for observation in state.tools.values():
+                _end_observation(observation)
+            for queue in state.pending_tools_by_name.values():
+                for observation in queue:
+                    _end_observation(observation)
+            state.root_span.end()
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug(f"atexit finalize failed for {_key}: {exc}")
+    if states:
+        client = _get_langfuse()
+        if client is not None:
+            try:
+                client.flush()
+            except Exception:
+                pass
 
 
 def _finish_trace(task_key: str, *, output: Any = None) -> None:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -779,3 +779,55 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+class TestAtexitFinalization(TestTurnTraceIsolation):
+    """Short-lived processes (kanban workers, `hermes chat -q`, cron) can exit
+    with tool calls still queued — the root span never ends and the backend
+    shows an anonymous trace (no name/session/metadata). _finalize_all_traces
+    (registered atexit after client construction) must end every open root."""
+
+    def test_finalize_all_ends_open_roots_and_clears_state(self, monkeypatch):
+        mod = self._fresh_plugin()
+        started: list = []
+        ended: list = []
+        client = self._fake_client(started)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(
+            mod, "_end_observation", lambda obs, **k: ended.append(obs)
+        )
+        mod._TRACE_STATE.clear()
+
+        # Three worker-style turns that never finalize (tool calls pending).
+        for n in range(3):
+            self._run_turn(mod, session=f"worker-{n}", turn_n=0, finalize=False)
+        assert len(mod._TRACE_STATE) == 3
+
+        root_ends: list = []
+        for state in mod._TRACE_STATE.values():
+            real_end = state.root_span.end
+            state.root_span.end = lambda *a, _r=real_end, **k: root_ends.append(1)
+
+        mod._finalize_all_traces()
+
+        assert len(root_ends) == 3, "every open root span must be ended"
+        assert mod._TRACE_STATE == {}, "state must be drained"
+        # Idempotent: a second call (SDK/atexit re-entry) is a no-op.
+        mod._finalize_all_traces()
+        assert len(root_ends) == 3
+
+    def test_atexit_hook_is_registered_on_client_init(self, monkeypatch):
+        mod = self._fresh_plugin()
+        registered: list = []
+        import atexit as _atexit
+
+        monkeypatch.setattr(mod, "Langfuse", lambda **kw: object())
+        monkeypatch.setattr(
+            _atexit, "register", lambda fn, *a, **k: registered.append(fn)
+        )
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-0123456789abcdef")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-0123456789abcdef")
+        mod._LANGFUSE_CLIENT = None
+
+        assert mod._get_langfuse() is not None
+        assert mod._finalize_all_traces in registered


### PR DESCRIPTION
## What

Short-lived Hermes processes (kanban workers, `hermes chat -q` one-shots, cron jobs) export **anonymous traces** to Langfuse: no name, no `sessionId`, empty metadata — just a bag of orphaned observations. On a board running a few parallel workers this quickly becomes the majority of traces (33 of the most recent 50 on the instance where this was diagnosed).

Root cause: the plugin ends the root span in `_finish_trace()`, which only runs when a turn finalizes (final assistant message with no tool calls). A process that exits while the last LLM response still has tool calls queued never reaches it. The SDK's own atexit flush then exports the ENDED child observations, but the root span never lands — so the backend renders a nameless trace shell around orphaned children.

Fix: `_finalize_all_traces()` drains `_TRACE_STATE` and ends every open root span (children first), registered with `atexit` immediately after the Langfuse client is constructed. atexit is LIFO, so it runs BEFORE the SDK's own shutdown hook and the spans ended here are still picked up by the exporter. Idempotent; fail-open per span; no-op when nothing is pending.

## Why

- Anonymous traces are unusable for debugging: they can't be found by session, carry no model/platform metadata, and pollute every trace listing.
- Any deployment that runs workers/cron alongside the gateway hits this constantly.

## How to test

```
scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py -- -q
```

29 tests (2 new): `_finalize_all_traces` ends every open root and drains state (idempotent on re-entry), and the atexit hook is registered on client init. Both new tests fail without the fix (verified by stashing it).

Live verification on the diagnosed instance: after the fix, a `hermes chat -q` one-shot exports a complete "Hermes turn" trace with session id; before, the same flow produced a nameless trace with 17+ orphaned observations.

Tested on Linux (aarch64).
