### PR TITLE
fix(whatsapp): make read receipts actually render — assert presence and enforce receipt privacy

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -468,6 +468,47 @@ async function startSocket() {
       if (!PAIR_JSON) {
         console.log('✅ WhatsApp connected!');
       }
+      // Read receipts need TWO account-side conditions beyond the /read
+      // endpoint, or SEND_READ_RECEIPTS half-works forever:
+      //
+      //  1. PRIVACY: the account's readreceipts privacy setting must be
+      //     'all' — otherwise readMessages() silently downgrades a real
+      //     'read' receipt to 'read-self' and the sender never sees blue
+      //     ticks.
+      //  2. PRESENCE: Baileys holds an internal sendActiveReceipts=false
+      //     until a GLOBAL 'available' presence is sent (messages-recv.js
+      //     flips it only on connection.update{isOnline}, which only
+      //     sendPresenceUpdate('available') emits — the per-chat
+      //     'composing' typing indicator takes the chatstate branch and
+      //     never touches it). With markOnlineOnConnect:false and no
+      //     presence assert, every inbound auto-ack goes out as
+      //     type='inactive': the sender never even sees the delivered
+      //     double-tick, and reads can't upgrade to blue — regardless of
+      //     the privacy setting or the /read flow.
+      //
+      // Both re-run on every reconnect because Baileys resets the flag on
+      // socket close. Trade-off, documented: while the bridge is up the
+      // account shows "online" — gated behind the same opt-in so default
+      // installs are unaffected.
+      if (SEND_READ_RECEIPTS && !PAIR_ONLY) {
+        (async () => {
+          try {
+            const privacy = await sock.fetchPrivacySettings(true);
+            if (privacy?.readreceipts !== 'all') {
+              await sock.updateReadReceiptsPrivacy('all');
+              console.log(`🔵 Read receipts privacy was '${privacy?.readreceipts}', set to 'all' (blue ticks enabled).`);
+            }
+          } catch (err) {
+            console.error('[bridge] Could not verify/set read-receipts privacy:', err?.message || err);
+          }
+          try {
+            await sock.sendPresenceUpdate('available');
+            console.log('🟢 Presence asserted available (delivery/read receipts active).');
+          } catch (err) {
+            console.error('[bridge] Could not assert available presence:', err?.message || err);
+          }
+        })();
+      }
       if (PAIR_ONLY) {
         if (!PAIR_JSON) {
           console.log('✅ Pairing complete. Credentials saved.');


### PR DESCRIPTION
## What

The `SEND_READ_RECEIPTS` feature ships complete plumbing — env flag, bridge `/read` endpoint, adapter posting after its intake policy accepts a message — **but no tick ever renders for the sender**. Not blue ticks, and not even the delivered double-tick. The feature has been cosmetically enabled but functionally inert.

Two account-side conditions are missing, and either one alone keeps receipts invisible:

1. **Presence (the delivered-tick killer).** Baileys 7.x holds an internal `sendActiveReceipts = false` until a **global** `'available'` presence is sent: `messages-recv.js` flips it only on `connection.update({isOnline})`, which only `sendPresenceUpdate('available')` emits. The per-chat `'composing'` typing indicator takes the chatstate branch and never touches it. The bridge sets `markOnlineOnConnect: false` and never asserts presence, so **every inbound auto-ack goes out `type='inactive'`** — the sender never sees the delivered double-tick, and a read can never upgrade to blue, regardless of the `/read` flow.

2. **Privacy (the blue-tick killer).** When the account's `readreceipts` privacy setting isn't `'all'`, `readMessages()` silently downgrades the receipt to `read-self`.

Fix: on connection open, when `SEND_READ_RECEIPTS` is enabled (and not pair-only), enforce `readreceipts='all'` account-side and assert `'available'` presence once. Both re-run on every reconnect because Baileys resets the flag on socket close. Both are best-effort with loud console errors on failure.

**Documented trade-off:** while the bridge is connected the account shows "online". That's arguably honest for a bot account, and it's gated behind the existing opt-in — default installs (flag unset) get zero behavior change and no presence assert.

## Why

Users who opt into read receipts get nothing today, with no error anywhere — the bridge logs success, `/read` returns `{success: true}`, and WhatsApp discards every receipt upstream. This was diagnosed live only because the missing *delivered* tick proved the break was below the `/read` flow entirely.

## How to test

1. Set `send_read_receipts: true` on the WhatsApp platform config and restart the gateway.
2. Bridge log shows `🟢 Presence asserted available (delivery/read receipts active).` (plus a `🔵` line if the privacy setting needed fixing).
3. Message the agent from another number: the **delivered double-tick appears immediately**; ticks **turn blue** when the adapter's intake policy accepts the message and posts `/read`.
4. Regression: with the flag unset, no presence assert runs (account does not appear online) — identical to pre-fix behavior.
5. `node --check scripts/whatsapp-bridge/bridge.js` and the bridge test suites pass (`node --test scripts/whatsapp-bridge/`).

Verified live on a Baileys 7.0.0-rc13 bridge (Linux): before the fix, zero receipts rendered even with privacy already `'all'` and `/read` returning success on every accepted message; after it, both tick stages render.
