### PR TITLE
fix(kanban): jail workers in their own systemd scope so they can't starve the dispatcher's cgroup

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9254,6 +9254,13 @@ def _default_spawn(
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
+    # Jail the worker tree in its own transient cgroup scope so its memory
+    # bills against itself, not against the dispatcher's service (the
+    # 2026-08-06/2026-08-08 gateway-freeze class). Empty prefix = unwrapped
+    # spawn, byte-for-byte the historical behavior.
+    scope_prefix = _worker_scope_prefix(task.id)
+    if scope_prefix:
+        cmd = scope_prefix + cmd
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,
@@ -9282,6 +9289,63 @@ def _default_spawn(
 # ---------------------------------------------------------------------------
 # Long-lived dispatcher daemon
 # ---------------------------------------------------------------------------
+
+def _worker_scope_prefix(task_id: str, kanban_cfg: Optional[dict] = None) -> list[str]:
+    """systemd-run argv prefix that jails a worker in its own transient scope.
+
+    WHY (incident 2026-08-08, second of its class after 2026-08-06): workers
+    spawned with a bare ``Popen(start_new_session=True)`` inherit the
+    dispatcher's cgroup. When the dispatcher is the gateway, every worker —
+    plus its MCP servers, language servers, and any browser it launches —
+    bills against ``hermes-gateway.service``'s MemoryMax. Three QA workers
+    drove the gateway cgroup to its 14G ceiling; with swap not yet exhausted
+    the kernel chose direct-reclaim thrashing over OOM, freezing the event
+    loop for 20 minutes until the external watchdog restarted it.
+
+    ``systemd-run --user --scope`` gives the worker tree its own cgroup and
+    memory ceiling, so a runaway worker OOM-kills ALONE and the gateway's
+    budget protects only the gateway. Probe-verified on this host
+    (2026-08-08, /tmp/probe_systemd_scope2.py): the payload is EXEC'd (the
+    returned PID is the worker, so crash detection and SIGTERM reclaim are
+    unchanged), grandchildren cannot escape the scope, MemoryMax lands on
+    the scope cgroup, scope OOM leaves the spawner untouched, exit codes
+    propagate, and the transient scope self-collects on exit.
+
+    Fail-open: an empty list (Windows, systemd-run absent, or scoping
+    disabled via ``kanban.worker_scope_enabled: false``) spawns the worker
+    unwrapped, exactly as before. A worker that dies instantly because scope
+    creation failed is caught by the existing spawn-failure circuit breaker.
+    """
+    if _IS_WINDOWS:
+        return []
+    if kanban_cfg is None:
+        try:
+            from hermes_cli.config import load_config
+
+            kanban_cfg = (load_config().get("kanban") or {})
+        except Exception:
+            kanban_cfg = {}
+    if not (kanban_cfg or {}).get("worker_scope_enabled", True):
+        return []
+    if shutil.which("systemd-run") is None:
+        return []
+    memory_max = str((kanban_cfg or {}).get("worker_memory_max") or "4G")
+    # Unit names must be unique per spawn: re-runs of the same task would
+    # otherwise collide with a still-collecting previous scope. A random
+    # token, not a timestamp — two spawns in the same millisecond (dispatcher
+    # batch tick) must still get distinct units.
+    safe_task = re.sub(r"[^a-zA-Z0-9_.-]", "-", str(task_id))
+    unit = f"hermes-kanban-{safe_task}-{secrets.token_hex(4)}"
+    return [
+        "systemd-run", "--user", "--quiet", "--scope",
+        "--unit", unit,
+        "--property", f"MemoryMax={memory_max}",
+        # No swap thrash inside the jail either: a worker that overruns its
+        # budget should die promptly, not grind the host through swap first.
+        "--property", "MemorySwapMax=0",
+        "--",
+    ]
+
 
 def run_daemon(
     *,

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -344,3 +344,65 @@ class TestCLI:
 
 
 
+
+
+class TestWorkerScopeJail:
+    """Workers must spawn inside their own systemd scope (cgroup jail) so
+    their memory bills against themselves, not the dispatcher's service.
+    Incident class 2026-08-06 / 2026-08-08: bare Popen children inherited
+    hermes-gateway.service's cgroup and froze the gateway at its ceiling."""
+
+    def _task(self):
+        return kb.Task(
+            id="t_scope1", title="jail test", body=None, assignee="p",
+            status="ready", priority=0, created_by="user", created_at=0,
+            started_at=None, completed_at=None, workspace_kind="scratch",
+            workspace_path=None, claim_lock=None, claim_expires=None,
+            tenant=None,
+        )
+
+    def test_spawn_wraps_worker_in_systemd_scope(self, fresh_home, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            pid = 4242
+
+        monkeypatch.setattr(
+            subprocess, "Popen",
+            lambda cmd, *a, **kw: captured.update(cmd=cmd) or FakeProc(),
+        )
+        monkeypatch.setattr(kb.shutil, "which", lambda n: "/usr/bin/systemd-run")
+        monkeypatch.setattr(kb, "_IS_WINDOWS", False)
+        kb.create_board("scopetest")
+
+        kb._default_spawn(self._task(), str(fresh_home / "ws"), board="scopetest")
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "systemd-run", f"worker not jailed: {cmd[:4]}"
+        assert "--scope" in cmd and "--user" in cmd
+        sep = cmd.index("--")
+        props = [cmd[i + 1] for i, t in enumerate(cmd) if t == "--property"]
+        assert any(p.startswith("MemoryMax=") for p in props)
+        # The real worker argv survives intact after the separator.
+        assert "chat" in cmd[sep:] and "-q" in cmd[sep:]
+        unit = cmd[cmd.index("--unit") + 1]
+        assert "t_scope1" in unit
+
+    def test_scope_prefix_unique_per_spawn(self, monkeypatch):
+        monkeypatch.setattr(kb.shutil, "which", lambda n: "/usr/bin/systemd-run")
+        monkeypatch.setattr(kb, "_IS_WINDOWS", False)
+        a = kb._worker_scope_prefix("t_x", {})
+        b = kb._worker_scope_prefix("t_x", {})
+        assert a[a.index("--unit") + 1] != b[b.index("--unit") + 1]
+
+    def test_scope_disabled_or_unavailable_spawns_unwrapped(self, fresh_home, monkeypatch):
+        assert kb._worker_scope_prefix("t_x", {"worker_scope_enabled": False}) == []
+        monkeypatch.setattr(kb.shutil, "which", lambda n: None)
+        assert kb._worker_scope_prefix("t_x", {}) == []
+
+    def test_worker_memory_max_configurable(self, monkeypatch):
+        monkeypatch.setattr(kb.shutil, "which", lambda n: "/usr/bin/systemd-run")
+        monkeypatch.setattr(kb, "_IS_WINDOWS", False)
+        pfx = kb._worker_scope_prefix("t_x", {"worker_memory_max": "6G"})
+        props = [pfx[i + 1] for i, t in enumerate(pfx) if t == "--property"]
+        assert "MemoryMax=6G" in props

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -123,11 +123,18 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     kb._default_spawn(task, str(workspace))
 
     parser, _subparsers, _chat_parser = build_top_level_parser()
+    # The worker argv may be jailed in a systemd scope (2026-08-08 gateway
+    # freeze fix): the hermes command then starts after the wrapper's `--`
+    # separator. The model-override contract applies to the worker argv
+    # either way.
+    cmd = captured["cmd"]
+    if cmd and cmd[0] == "systemd-run":
+        cmd = cmd[cmd.index("--") + 1:]
     # Profile selection is attached by the outer CLI bootstrap rather than
     # build_top_level_parser(); remove that already-validated prefix and parse
     # the worker flags/subcommand through the real shared parser.
-    assert captured["cmd"][1:3] == ["-p", "elias"]
-    args = parser.parse_args(captured["cmd"][3:])
+    assert cmd[1:3] == ["-p", "elias"]
+    args = parser.parse_args(cmd[3:])
 
     assert args.command == "chat"
     assert args.model == "gpt-5.6-sol"


### PR DESCRIPTION
## What

Kanban workers spawned by the embedded dispatcher run **inside the gateway's cgroup**. `_default_spawn` uses a bare `subprocess.Popen(start_new_session=True)` — a new session is not a new cgroup, so every worker (plus its MCP servers, language servers, and any browser it launches) bills against `hermes-gateway.service`'s memory budget.

Observed failure (2026-08-08, 4-core/24G host, systemd `MemoryMax=14G` on the gateway unit): three QA workers drove the gateway cgroup to **exactly its 14G ceiling** (`systemd` accounting: "14.0G memory peak"). With swap not yet exhausted the kernel chose direct-reclaim thrashing over OOM-kill — the asyncio event loop froze for 20 minutes (no crash, no OOM log line, every health check green except log mtime) until an external watchdog restarted the unit. The `systemctl stop` itself failed (`status=1/FAILURE`): the loop was too starved to run its own drain.

Fix: `_worker_scope_prefix()` wraps the worker argv in a transient systemd scope:

```
systemd-run --user --quiet --scope --unit hermes-kanban-<task>-<rand> \
  --property MemoryMax=<kanban.worker_memory_max, default 4G> \
  --property MemorySwapMax=0 -- <hermes worker argv>
```

Each worker tree gets its own cgroup and ceiling: a runaway worker is OOM-killed **alone**, the gateway's budget protects only the gateway, and (side benefit) workers no longer die when the gateway restarts — previously every `systemctl restart` SIGKILLed the whole board's workers along with the unit.

Probe-verified on the target host before building (P1–P6, all pass):
- `systemd-run --scope` **execs** the payload: `Popen.pid` IS the worker, so the dispatcher's crash detection (PID tracking) and reclaim (SIGTERM→SIGKILL) contracts are unchanged.
- Grandchildren cannot escape the scope cgroup.
- Scope OOM kills the worker tree alone; the spawner survives untouched.
- Exit codes propagate; transient scopes self-collect after exit.
- A bad property fails loudly at spawn time (the existing spawn-failure circuit breaker catches it).

Fail-open: on Windows, when `systemd-run` is absent, or with `kanban.worker_scope_enabled: false`, the prefix is empty and the spawn is byte-for-byte the historical `Popen`.

## Why

- This is the second incident of the same class on that deployment (a heavy background build starved the messaging stack for 7 hours two days prior). The class is structural: any memory-hungry child inherits the dispatcher's cgroup and competes with the message loop for the same budget.
- The guarantee belongs in the mechanism (cgroup isolation), not in worker discipline.

## How to test

```
scripts/run_tests.sh tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py -- -q
```

4 new tests: worker argv is wrapped in a scope with `MemoryMax`; unit names are unique per spawn (re-runs and same-tick batch spawns can't collide); disabled/unavailable paths spawn unwrapped; `worker_memory_max` is configurable. All 4 fail without the fix (verified by stashing it). The model-override CLI-parse contract test was taught to skip the wrapper prefix when present.

Live verification: with the fix deployed, `systemd-cgls` shows each worker in its own `hermes-kanban-t_*.scope` with `memory.max=4G`, and the gateway cgroup dropped from 6G+ (workers inside) to 2.4G (gateway only).

Tested on Linux (aarch64). Windows path is the unchanged fallback (guarded by `_IS_WINDOWS`).
