### PR TITLE
feat(desktop): forward remote SSH previews through Browser pane

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -32,11 +32,13 @@ import {
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,
+  profileExplicitlyNonSsh,
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveSshTerminalRoute,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
@@ -217,6 +219,49 @@ test('saved SSH drafts are inactive and explicit overrides take precedence', () 
   config.profiles.coder = { mode: 'ssh', host: 'active' }
   assert.deepEqual(profileSshOverride(config, 'coder'), { mode: 'ssh', host: 'active' })
   assert.equal(profileHasRemoteConnection(config, 'coder'), true)
+})
+
+test('profileExplicitlyNonSsh blocks global SSH fallback for explicit non-SSH modes', () => {
+  const config = {
+    profiles: {
+      local: { mode: 'local' },
+      remote: { mode: 'remote', url: 'https://remote.example' },
+      cloud: { mode: 'cloud', url: 'https://cloud.example' },
+      ssh: { mode: 'ssh', host: 'box' }
+    }
+  }
+
+  assert.equal(profileExplicitlyNonSsh(config, 'local'), true)
+  assert.equal(profileExplicitlyNonSsh(config, 'remote'), true)
+  assert.equal(profileExplicitlyNonSsh(config, 'cloud'), true)
+  assert.equal(profileExplicitlyNonSsh(config, 'ssh'), false)
+  assert.equal(profileExplicitlyNonSsh(config, 'missing'), false)
+  assert.equal(profileExplicitlyNonSsh(config, ''), false)
+})
+
+test('resolveSshTerminalRoute preserves active SSH target precedence', () => {
+  const config = {
+    mode: 'ssh',
+    profiles: {
+      local: { mode: 'local' },
+      remote: { mode: 'remote', url: 'https://remote.example' },
+      cloud: { mode: 'cloud', url: 'https://cloud.example' },
+      other: { mode: 'other' },
+      ssh: { mode: 'ssh', host: 'profile-box' }
+    }
+  }
+
+  assert.equal(resolveSshTerminalRoute(config, 'local'), 'none')
+  assert.equal(resolveSshTerminalRoute(config, 'remote'), 'none')
+  assert.equal(resolveSshTerminalRoute(config, 'cloud'), 'none')
+  assert.equal(resolveSshTerminalRoute(config, 'other'), 'none')
+  assert.equal(resolveSshTerminalRoute(config, 'ssh'), 'profile-ssh')
+  assert.equal(resolveSshTerminalRoute(config, 'ssh', true), 'profile-ssh')
+  assert.equal(resolveSshTerminalRoute(config, 'missing'), 'global-ssh')
+  assert.equal(resolveSshTerminalRoute(config, ''), 'global-ssh')
+  assert.equal(resolveSshTerminalRoute(config, 'missing', true), 'none')
+  assert.equal(resolveSshTerminalRoute({ mode: 'remote' }, 'missing'), 'none')
+  assert.equal(resolveSshTerminalRoute({ mode: 'local' }, 'missing'), 'none')
 })
 
 // --- resolveProfileBackendRoute ---

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -304,6 +304,33 @@ function profileSshOverride(config, profile) {
   return normalizeSshConfig(entry)
 }
 
+function profileExplicitlyNonSsh(config, profile) {
+  const key = connectionScopeKey(profile)
+  const entry = key ? config?.profiles?.[key] : null
+
+  return Boolean(entry && typeof entry === 'object' && entry.mode !== 'ssh')
+}
+
+function resolveSshTerminalRoute(config, profile, hasEnvRemoteUrl = false) {
+  if (profileSshOverride(config, profile)) {
+    return 'profile-ssh'
+  }
+
+  if (profileRemoteOverride(config, profile)) {
+    return 'none'
+  }
+
+  if (profileExplicitlyNonSsh(config, profile)) {
+    return 'none'
+  }
+
+  if (hasEnvRemoteUrl) {
+    return 'none'
+  }
+
+  return config?.mode === 'ssh' ? 'global-ssh' : 'none'
+}
+
 function savedProfileSsh(config, profile) {
   const key = connectionScopeKey(profile)
   const entry = key ? config?.profiles?.[key] : null
@@ -577,11 +604,13 @@ export {
   normAuthMode,
   pathWithGlobalRemoteProfile,
   PRIVY_SESSION_COOKIE_VARIANTS,
+  profileExplicitlyNonSsh,
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveSshTerminalRoute,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -72,6 +72,7 @@ import {
   profileSshOverride,
   resolveAuthMode,
   resolveProfileBackendRoute,
+  resolveSshTerminalRoute,
   resolveTestWsUrl,
   savedProfileSsh,
   tokenPreview
@@ -168,6 +169,7 @@ import {
   revalidatePooledRemoteBackends,
   revalidateRemoteConnection
 } from './remote-liveness'
+import { normalizeRemotePreviewTarget } from './remote-preview-target'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -186,6 +188,11 @@ import {
   redactSecrets,
   SshConnection
 } from './ssh-connection'
+import {
+  createOrReplaceSshPreviewForwarder,
+  isRemotePreviewForwardingRequested,
+  remotePreviewTargetForForwarding
+} from './ssh-preview-forwarding'
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
@@ -4930,7 +4937,7 @@ function previewUrlTarget(rawTarget) {
   }
 }
 
-async function normalizePreviewTarget(rawTarget, baseDir) {
+async function normalizePreviewTarget(rawTarget, baseDir, optionalProfile, remoteForward) {
   const raw = String(rawTarget || '').trim()
 
   if (!raw) {
@@ -4939,6 +4946,30 @@ async function normalizePreviewTarget(rawTarget, baseDir) {
 
   try {
     if (/^https?:\/\//i.test(raw)) {
+      const sshTarget = activeSshTerminalTarget(optionalProfile)
+
+      const rewritten = await remotePreviewTargetForForwarding(
+        raw,
+        remoteForward,
+        sshTarget && sshTarget !== 'pending' ? sshTarget.previewForwarder : undefined
+      )
+
+      if (isRemotePreviewForwardingRequested(remoteForward)) {
+        if (!rewritten) {
+          return null
+        }
+
+        const publicTarget = normalizeRemotePreviewTarget(raw, rewritten)
+
+        if (publicTarget) {
+          return publicTarget
+        }
+
+        const target = previewUrlTarget(rewritten)
+
+        return target ? { ...target, source: raw } : null
+      }
+
       return previewUrlTarget(raw)
     }
 
@@ -7297,6 +7328,12 @@ async function teardownSshConnection(profile) {
   }
 
   try {
+    await state.previewForwarder?.close()
+  } catch {
+    // best effort
+  }
+
+  try {
     if (state.localPort && state.remotePort) {
       await state.ssh.cancelForward(state.localPort, state.remotePort)
     }
@@ -7314,30 +7351,30 @@ async function teardownSshConnection(profile) {
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
 // any cached SSH state. A per-profile token/OAuth override wins over a global
 // SSH connection — so if the active profile resolves to a NON-SSH backend, the
-// terminal must NOT fall through to a global SSH host.
-function activeSshTerminalTarget() {
-  const profile = primaryProfileKey()
+// terminal/preview must NOT fall through to a global SSH host.
+function activeSshTerminalTarget(optionalProfile) {
+  const profile = optionalProfile && String(optionalProfile).trim() ? String(optionalProfile).trim() : primaryProfileKey()
   const config = readDesktopConnectionConfig()
 
-  if (profileSshOverride(config, profile)) {
+  const route = resolveSshTerminalRoute(config, profile, Boolean(process.env.HERMES_DESKTOP_REMOTE_URL))
+
+  if (route === 'profile-ssh') {
     const scope = sshScopeKey(profile)
     const state = sshConnections.get(scope)
 
-    return state && state.ssh ? { ssh: state.ssh, scope } : 'pending'
+    return state && state.ssh
+      ? { previewForwarder: state.previewForwarder, ssh: state.ssh, scope }
+      : 'pending'
   }
 
-  if (profileRemoteOverride(config, profile)) {
-    return null
-  }
-
-  if (process.env.HERMES_DESKTOP_REMOTE_URL) {
+  if (route !== 'global-ssh') {
     return null
   }
 
   if (config.mode === 'ssh') {
     const state = sshConnections.get('')
 
-    return state && state.ssh ? { ssh: state.ssh, scope: '' } : 'pending'
+    return state && state.ssh ? { previewForwarder: state.previewForwarder, ssh: state.ssh, scope: '' } : 'pending'
   }
 
   return null
@@ -7379,23 +7416,19 @@ async function bootstrapSshConnection(profile, sshConfig, reuseToken, source) {
 async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, source, fingerprint, lease) {
   const scope = sshScopeKey(profile)
   const hostLabel = sshConfig.user ? `${sshConfig.user}@${sshConfig.host}` : sshConfig.host
-  const existing = sshConnections.get(scope)
+  let existing = sshConnections.get(scope)
 
   if (existing && existing.fingerprint !== fingerprint) {
     await teardownSshConnection(profile)
+    existing = undefined
   }
 
-  let ssh = sshConnections.get(scope)?.ssh
+  let ssh = existing?.ssh
 
   if (ssh && !(await ssh.isAlive())) {
-    try {
-      await ssh.close()
-    } catch {
-      void 0
-    }
-
+    await teardownSshConnection(profile)
+    existing = undefined
     ssh = null
-    sshConnections.delete(scope)
   }
 
   const created = !ssh
@@ -7477,7 +7510,12 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     hostLabel,
     hermesVersion: result.hermesVersion || '',
     remotePlatform: result.platform?.os || '',
-    reused: result.reused
+    reused: result.reused,
+    previewForwarder: await createOrReplaceSshPreviewForwarder(existing?.previewForwarder, {
+      cancelForward: (localPort, remotePort) => ssh.cancelForward(localPort, remotePort),
+      forward: (localPort, remotePort) => ssh.forward(localPort, remotePort),
+      pickLocalPort: async () => Number(await pickLocalPort())
+    }, result.reused === true)
   })
 
   sshRememberLog(
@@ -10988,8 +11026,13 @@ ipcMain.handle('hermes:saveClipboardImage', async () => {
   return ''
 })
 
-ipcMain.handle('hermes:normalizePreviewTarget', (_event, target, baseDir) =>
-  normalizePreviewTarget(String(target || ''), baseDir ? String(baseDir) : '')
+ipcMain.handle('hermes:normalizePreviewTarget', (_event, target, baseDir, profile, remoteForward) =>
+  normalizePreviewTarget(
+    String(target || ''),
+    baseDir ? String(baseDir) : '',
+    profile ? String(profile) : undefined,
+    remoteForward
+  )
 )
 
 ipcMain.handle('hermes:watchPreviewFile', (_event, url) => watchPreviewFile(String(url || '')))

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -164,7 +164,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       return ''
     }
   },
-  normalizePreviewTarget: (target, baseDir) => ipcRenderer.invoke('hermes:normalizePreviewTarget', target, baseDir),
+  normalizePreviewTarget: (target, baseDir, profile, remoteForward) =>
+    ipcRenderer.invoke('hermes:normalizePreviewTarget', target, baseDir, profile, remoteForward),
   watchPreviewFile: url => ipcRenderer.invoke('hermes:watchPreviewFile', url),
   watchDirectory: dir => ipcRenderer.invoke('hermes:watchDirectory', dir),
   stopPreviewFileWatch: id => ipcRenderer.invoke('hermes:stopPreviewFileWatch', id),

--- a/apps/desktop/electron/remote-preview-classifier.ts
+++ b/apps/desktop/electron/remote-preview-classifier.ts
@@ -1,0 +1,141 @@
+const DEFAULT_PREVIEW_PORTS: Record<string, number> = {
+  'http:': 80,
+  'https:': 443
+}
+
+export interface RemotePreviewTargetClassification {
+  isHttp: boolean
+  isLocal: boolean
+  remotePort: number | null
+  url: URL
+}
+
+function normalizedHostname(hostname: string) {
+  return hostname.replace(/^\[|\]$/g, '').toLowerCase().replace(/\.+$/, '')
+}
+
+function isNumericIpv4Loopback(hostname: string) {
+  const octets = hostname.split('.')
+
+  if (octets.length !== 4 || octets.some(octet => !/^\d{1,3}$/.test(octet))) {
+    return false
+  }
+
+  const values = octets.map(Number)
+
+  return values.every(value => value >= 0 && value <= 255) && values[0] === 127
+}
+
+function parseIpv6Groups(hostname: string): number[] | null {
+  const parts = hostname.split('::')
+
+  if (parts.length > 2) {
+    return null
+  }
+
+  function parsePart(part: string) {
+    if (!part) {
+      return []
+    }
+
+    const values: number[] = []
+
+    for (const group of part.split(':')) {
+      if (group.includes('.')) {
+        const octets = group.split('.')
+
+        if (octets.length !== 4 || octets.some(octet => !/^\d{1,3}$/.test(octet))) {
+          return null
+        }
+
+        const ipv4 = octets.map(Number)
+
+        if (!ipv4.every(value => value >= 0 && value <= 255)) {
+          return null
+        }
+
+        values.push((ipv4[0] << 8) | ipv4[1], (ipv4[2] << 8) | ipv4[3])
+      } else {
+        if (!/^[0-9a-f]{1,4}$/.test(group)) {
+          return null
+        }
+
+        values.push(Number.parseInt(group, 16))
+      }
+    }
+
+    return values
+  }
+
+  const left = parsePart(parts[0])
+  const right = parts.length === 2 ? parsePart(parts[1]) : []
+
+  if (!left || !right) {
+    return null
+  }
+
+  if (parts.length === 1) {
+    return left.length === 8 ? left : null
+  }
+
+  const compressed = 8 - left.length - right.length
+
+  return compressed > 0 ? [...left, ...Array(compressed).fill(0), ...right] : null
+}
+
+function isNumericIpv6Loopback(hostname: string) {
+  const groups = parseIpv6Groups(hostname)
+
+  if (!groups) {
+    return false
+  }
+
+  if (groups.every(group => group === 0)) {
+    return true
+  }
+
+  if (groups.every((group, index) => (index === 7 ? group === 1 : group === 0))) {
+    return true
+  }
+
+  return (
+    groups.slice(0, 5).every(group => group === 0) &&
+    groups[5] === 0xffff &&
+    groups[6] >= 0x7f00 &&
+    groups[6] <= 0x7fff
+  )
+}
+
+function isLocalPreviewHostname(hostname: string) {
+  const normalized = normalizedHostname(hostname)
+
+  return (
+    normalized === 'localhost' ||
+    normalized === '0.0.0.0' ||
+    isNumericIpv4Loopback(normalized) ||
+    isNumericIpv6Loopback(normalized)
+  )
+}
+
+export function classifyRemotePreviewTarget(rawTarget: string): RemotePreviewTargetClassification | null {
+  let url: URL
+
+  try {
+    url = new URL(String(rawTarget || '').trim())
+  } catch {
+    return null
+  }
+
+  const isHttp = Object.hasOwn(DEFAULT_PREVIEW_PORTS, url.protocol)
+  const remotePort = isHttp ? Number(url.port || DEFAULT_PREVIEW_PORTS[url.protocol]) : null
+
+  return {
+    isHttp,
+    isLocal: isHttp && isLocalPreviewHostname(url.hostname),
+    remotePort:
+      remotePort !== null && Number.isInteger(remotePort) && remotePort >= 1 && remotePort <= 65535
+        ? remotePort
+        : null,
+    url
+  }
+}

--- a/apps/desktop/electron/remote-preview-loopback.test.ts
+++ b/apps/desktop/electron/remote-preview-loopback.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { normalizeRemotePreviewTarget } from './remote-preview-target'
+import { remotePreviewTargetForForwarding } from './ssh-preview-forwarding'
+
+test('does not treat localhost trailing dots as public on an allowed port', async () => {
+  const target = 'http://localhost.:5173/'
+
+  assert.equal(await remotePreviewTargetForForwarding(target, true, undefined), null)
+  assert.equal(normalizeRemotePreviewTarget(target, target), null)
+})
+
+test('requires forwarding for every IPv4 loopback address on an allowed port', async () => {
+  const target = 'http://127.0.0.2:5173/'
+
+  assert.equal(await remotePreviewTargetForForwarding(target, true, undefined), null)
+  assert.equal(normalizeRemotePreviewTarget(target, target), null)
+})
+
+test('requires forwarding for IPv4-mapped IPv6 loopback on an allowed port', async () => {
+  const target = 'http://[::ffff:127.0.0.1]:5173/'
+
+  assert.equal(await remotePreviewTargetForForwarding(target, true, undefined), null)
+  assert.equal(normalizeRemotePreviewTarget(target, target), null)
+})
+
+test('requires forwarding for the IPv6 unspecified address on an allowed port', async () => {
+  const target = 'http://[::]:5173/'
+
+  assert.equal(await remotePreviewTargetForForwarding(target, true, undefined), null)
+  assert.equal(normalizeRemotePreviewTarget(target, target), null)
+})
+
+test('keeps a public HTTPS URL unchanged', async () => {
+  const target = 'https://example.com/docs?x=1#top'
+
+  assert.equal(await remotePreviewTargetForForwarding(target, true, undefined), target)
+  assert.deepEqual(normalizeRemotePreviewTarget(target, target), {
+    kind: 'url',
+    label: 'example.com/docs',
+    source: target,
+    url: target
+  })
+})

--- a/apps/desktop/electron/remote-preview-target.test.ts
+++ b/apps/desktop/electron/remote-preview-target.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { normalizeRemotePreviewTarget } from './remote-preview-target'
+
+test('preserves a public URL when explicit remote forwarding is requested', () => {
+  const raw = 'https://example.com/docs?x=1#top'
+
+  assert.deepEqual(normalizeRemotePreviewTarget(raw, raw), {
+    kind: 'url',
+    label: 'example.com/docs',
+    source: raw,
+    url: raw
+  })
+})

--- a/apps/desktop/electron/remote-preview-target.ts
+++ b/apps/desktop/electron/remote-preview-target.ts
@@ -1,0 +1,23 @@
+import { classifyRemotePreviewTarget } from './remote-preview-classifier'
+
+export function normalizeRemotePreviewTarget(rawTarget: string, rewrittenTarget: string | null | undefined) {
+  const raw = String(rawTarget || '').trim()
+  const rewritten = String(rewrittenTarget || '').trim()
+
+  if (!raw || !rewritten) {
+    return null
+  }
+
+  const classification = classifyRemotePreviewTarget(rewritten)
+
+  if (!classification?.isHttp || classification.isLocal) {
+    return null
+  }
+
+  return {
+    kind: 'url' as const,
+    label: `${classification.url.host}${classification.url.pathname === '/' ? '' : classification.url.pathname}`,
+    source: raw,
+    url: rewritten
+  }
+}

--- a/apps/desktop/electron/ssh-preview-forwarding.test.ts
+++ b/apps/desktop/electron/ssh-preview-forwarding.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  createOrReplaceSshPreviewForwarder,
+  createOrReuseSshPreviewForwarder,
+  createSshPreviewForwarder,
+  isLocalPreviewUrl,
+  isRemotePreviewForwardingRequested,
+  remotePreviewTargetForForwarding
+} from './ssh-preview-forwarding'
+
+test('gates SSH preview rewriting on the literal true flag', () => {
+  assert.equal(isRemotePreviewForwardingRequested(true), true)
+  assert.equal(isRemotePreviewForwardingRequested(false), false)
+  assert.equal(isRemotePreviewForwardingRequested(undefined), false)
+  assert.equal(isRemotePreviewForwardingRequested(1), false)
+  assert.equal(isRemotePreviewForwardingRequested('true'), false)
+})
+
+test('fails closed when explicit remote forwarding cannot provide a rewrite', async () => {
+  assert.equal(await remotePreviewTargetForForwarding('http://localhost:5173/', true, undefined), null)
+  assert.equal(
+    await remotePreviewTargetForForwarding(
+      'http://localhost:5174/',
+      true,
+      createSshPreviewForwarder({
+        pickLocalPort: async () => 45175,
+        forward: async () => {},
+        cancelForward: async () => {}
+      })
+    ),
+    'http://127.0.0.1:45175/'
+  )
+  assert.equal(
+    await remotePreviewTargetForForwarding('http://localhost:45176/', true, {
+      rewrite: async () => null,
+      close: async () => {}
+    }),
+    null
+  )
+  assert.equal(
+    await remotePreviewTargetForForwarding('https://example.com/docs', true, undefined),
+    'https://example.com/docs'
+  )
+  assert.equal(await remotePreviewTargetForForwarding('http://localhost:5173/', false, undefined), undefined)
+})
+
+test('rejects an unsupported remote preview port before invoking SSH', async () => {
+  let forwards = 0
+
+  const preview = createSshPreviewForwarder({
+    pickLocalPort: async () => 45175,
+    forward: async () => {
+      forwards += 1
+    },
+    cancelForward: async () => {}
+  })
+
+  assert.equal(await remotePreviewTargetForForwarding('http://localhost:45173/app?x=1#top', true, preview), null)
+  assert.equal(forwards, 0)
+})
+
+test('reuses an existing forwarder for a live SSH state', () => {
+  const existing = createSshPreviewForwarder({
+    pickLocalPort: async () => 44000,
+    forward: async () => {},
+    cancelForward: async () => {}
+  })
+
+  assert.equal(
+    createOrReuseSshPreviewForwarder(existing, {
+      pickLocalPort: async () => 44001,
+      forward: async () => {},
+      cancelForward: async () => {}
+    }),
+    existing
+  )
+})
+
+test('closes an old forwarder before replacing it after dashboard recovery', async () => {
+  const events: string[] = []
+
+  const existing = {
+    rewrite: async () => null,
+    close: async () => {
+      events.push('close')
+    }
+  }
+
+  const replacement = await createOrReplaceSshPreviewForwarder(
+    existing,
+    {
+      pickLocalPort: async () => {
+        events.push('pick')
+
+        return 45178
+      },
+      forward: async () => {
+        events.push('forward')
+      },
+      cancelForward: async () => {}
+    },
+    false
+  )
+
+  assert.notEqual(replacement, existing)
+  assert.equal(await replacement.rewrite('http://localhost:5173/'), 'http://127.0.0.1:45178/')
+  assert.deepEqual(events, ['close', 'pick', 'forward'])
+})
+
+test('classifies only local HTTP(S) preview hosts and keeps the remote port', () => {
+  assert.deepEqual(isLocalPreviewUrl('http://localhost:5173/app?x=1#top'), { remotePort: 5173 })
+  assert.deepEqual(isLocalPreviewUrl('https://[::1]/app'), { remotePort: 443 })
+  assert.deepEqual(isLocalPreviewUrl('http://0.0.0.0/app'), { remotePort: 80 })
+  assert.equal(isLocalPreviewUrl('https://preview.example/app'), null)
+  assert.equal(isLocalPreviewUrl('file:///tmp/app.html'), null)
+})
+
+test('rewrites a local preview while preserving path, query, and hash', async () => {
+  const forward = createSshPreviewForwarder({
+    pickLocalPort: async () => 44001,
+    forward: async () => {},
+    cancelForward: async () => {}
+  })
+
+  await assert.doesNotReject(async () => {
+    assert.equal(await forward.rewrite('http://localhost:5173/app?a=1#top'), 'http://127.0.0.1:44001/app?a=1#top')
+  })
+})
+
+test('reuses one local forward for repeated URLs to the same remote port', async () => {
+  let picks = 0
+  let forwards = 0
+
+  const preview = createSshPreviewForwarder({
+    pickLocalPort: async () => {
+      picks += 1
+
+      return 44002
+    },
+    forward: async () => {
+      forwards += 1
+    },
+    cancelForward: async () => {}
+  })
+
+  assert.equal(await preview.rewrite('http://127.0.0.1:5173/one'), 'http://127.0.0.1:44002/one')
+  assert.equal(
+    await preview.rewrite('http://localhost:5173/two?tab=logs#bottom'),
+    'http://127.0.0.1:44002/two?tab=logs#bottom'
+  )
+  assert.equal(picks, 1)
+  assert.equal(forwards, 1)
+})
+
+test('retries bind collisions and cleans up the failed candidate', async () => {
+  const picked = [44003, 44004]
+  const forwarded: number[] = []
+  const cancelled: number[] = []
+
+  const preview = createSshPreviewForwarder({
+    pickLocalPort: async () => picked.shift()!,
+    forward: async localPort => {
+      forwarded.push(localPort)
+
+      if (localPort === 44003) {
+        throw new Error('bind: address already in use')
+      }
+    },
+    cancelForward: async localPort => {
+      cancelled.push(localPort)
+    }
+  })
+
+  assert.equal(await preview.rewrite('http://localhost:8080/'), 'http://127.0.0.1:44004/')
+  assert.deepEqual(forwarded, [44003, 44004])
+  assert.deepEqual(cancelled, [44003])
+})
+
+test('cleans up a failed non-collision forward before surfacing the error', async () => {
+  const cancelled: number[] = []
+
+  const preview = createSshPreviewForwarder({
+    pickLocalPort: async () => 44005,
+    forward: async () => {
+      throw new Error('SSH connection dropped')
+    },
+    cancelForward: async localPort => {
+      cancelled.push(localPort)
+    }
+  })
+
+  await assert.rejects(() => preview.rewrite('http://localhost:8081/'), /SSH connection dropped/)
+  assert.deepEqual(cancelled, [44005])
+})
+
+test('teardown cancels every preview forward and is idempotent', async () => {
+  const cancelled: Array<[number, number]> = []
+  let nextPort = 44006
+
+  const preview = createSshPreviewForwarder({
+    pickLocalPort: async () => nextPort++,
+    forward: async () => {},
+    cancelForward: async (localPort, remotePort) => {
+      cancelled.push([localPort, remotePort])
+    }
+  })
+
+  await preview.rewrite('http://localhost:5173/one')
+  await preview.rewrite('http://localhost:5174/two')
+  await preview.close()
+  await preview.close()
+
+  assert.deepEqual(cancelled, [
+    [44006, 5173],
+    [44007, 5174]
+  ])
+})

--- a/apps/desktop/electron/ssh-preview-forwarding.ts
+++ b/apps/desktop/electron/ssh-preview-forwarding.ts
@@ -1,0 +1,200 @@
+import { classifyRemotePreviewTarget } from './remote-preview-classifier'
+
+const COMMON_DEV_SERVER_PORTS = new Set([
+  4173, 4174, 4200, 4321, 5000, 5173, 5174, 8000, 8080, 8081, 8888, 9000
+])
+
+export interface SshPreviewForwardDeps {
+  pickLocalPort: () => Promise<number>
+  forward: (localPort: number, remotePort: number) => Promise<void>
+  cancelForward: (localPort: number, remotePort: number) => Promise<void>
+}
+
+export interface SshPreviewForwarder {
+  rewrite: (rawTarget: string) => Promise<string | null>
+  close: () => Promise<void>
+}
+
+export function isRemotePreviewForwardingRequested(value: unknown): value is true {
+  return value === true
+}
+
+export function createOrReuseSshPreviewForwarder(
+  existing: SshPreviewForwarder | undefined,
+  deps: SshPreviewForwardDeps
+): SshPreviewForwarder {
+  return existing ?? createSshPreviewForwarder(deps)
+}
+
+export async function createOrReplaceSshPreviewForwarder(
+  existing: SshPreviewForwarder | undefined,
+  deps: SshPreviewForwardDeps,
+  reuseExisting: boolean
+): Promise<SshPreviewForwarder> {
+  if (reuseExisting) {
+    return createOrReuseSshPreviewForwarder(existing, deps)
+  }
+
+  if (existing) {
+    try {
+      await existing.close()
+    } catch {
+      // best effort; replacing the dashboard must not be blocked by stale preview cleanup
+    }
+  }
+
+  return createSshPreviewForwarder(deps)
+}
+
+export async function remotePreviewTargetForForwarding(
+  rawTarget: string,
+  remoteForward: unknown,
+  forwarder: SshPreviewForwarder | undefined
+): Promise<string | null | undefined> {
+  if (!isRemotePreviewForwardingRequested(remoteForward)) {
+    return undefined
+  }
+
+  const classification = isLocalPreviewUrl(rawTarget)
+
+  if (!classification) {
+    return rawTarget
+  }
+
+  if (!COMMON_DEV_SERVER_PORTS.has(classification.remotePort)) {
+    return null
+  }
+
+  if (!forwarder) {
+    return null
+  }
+
+  return forwarder.rewrite(rawTarget)
+}
+
+function isForwardBindCollision(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error || '')
+
+  return /address already in use|cannot listen to port|bind.*failed/i.test(message)
+}
+
+function defaultRemotePort(protocol: string) {
+  return protocol === 'https:' ? 443 : 80
+}
+
+export function isLocalPreviewUrl(rawTarget: string): { remotePort: number } | null {
+  const classification = classifyRemotePreviewTarget(rawTarget)
+
+  if (!classification?.isHttp || !classification.isLocal || classification.remotePort === null) {
+    return null
+  }
+
+  return { remotePort: classification.remotePort }
+}
+
+export function createSshPreviewForwarder(
+  deps: SshPreviewForwardDeps,
+  { attempts = 3 }: { attempts?: number } = {}
+): SshPreviewForwarder {
+  const forwards = new Map<number, { localPort: number; remotePort: number }>()
+  const pending = new Map<number, Promise<number>>()
+  let closed = false
+
+  async function openForward(remotePort: number) {
+    let lastError: unknown
+
+    for (let attempt = 0; attempt < Math.max(1, attempts); attempt += 1) {
+      const localPort = await deps.pickLocalPort()
+
+      try {
+        await deps.forward(localPort, remotePort)
+        forwards.set(remotePort, { localPort, remotePort })
+
+        return localPort
+      } catch (error) {
+        lastError = error
+
+        // A forward can fail after the SSH side has accepted the request. Always
+        // make the candidate disposable before retrying or surfacing the error.
+        try {
+          await deps.cancelForward(localPort, remotePort)
+        } catch {
+          // best effort; the owning SSH connection teardown remains authoritative
+        }
+
+        if (!isForwardBindCollision(error) || attempt === Math.max(1, attempts) - 1) {
+          throw error
+        }
+      }
+    }
+
+    throw lastError
+  }
+
+  async function ensureForward(remotePort: number) {
+    if (closed) {
+      throw new Error('SSH preview forwarding has been closed.')
+    }
+
+    const existing = forwards.get(remotePort)
+
+    if (existing) {
+      return existing.localPort
+    }
+
+    const active = pending.get(remotePort)
+
+    if (active) {
+      return active
+    }
+
+    const operation = openForward(remotePort)
+    pending.set(remotePort, operation)
+
+    try {
+      return await operation
+    } finally {
+      if (pending.get(remotePort) === operation) {
+        pending.delete(remotePort)
+      }
+    }
+  }
+
+  return {
+    async rewrite(rawTarget) {
+      const classification = isLocalPreviewUrl(rawTarget)
+
+      if (!classification || !COMMON_DEV_SERVER_PORTS.has(classification.remotePort)) {
+        return null
+      }
+
+      const localPort = await ensureForward(classification.remotePort)
+      const url = new URL(String(rawTarget || '').trim())
+      url.hostname = '127.0.0.1'
+      url.port = String(localPort)
+
+      return url.toString()
+    },
+
+    async close() {
+      if (closed) {
+        return
+      }
+
+      closed = true
+      await Promise.allSettled([...pending.values()])
+      const activeForwards = [...forwards.values()]
+      forwards.clear()
+
+      await Promise.all(
+        activeForwards.map(async ({ localPort, remotePort }) => {
+          try {
+            await deps.cancelForward(localPort, remotePort)
+          } catch {
+            // best effort; SSH close drops any remaining forwards
+          }
+        })
+      )
+    }
+  }
+}

--- a/apps/desktop/src/app/chat/preview-tile.test.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.test.tsx
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as TreeStore from '@/components/pane-shell/tree/store'
+
+const { revealTreePane } = vi.hoisted(() => ({ revealTreePane: vi.fn() }))
+
+vi.mock('@/components/pane-shell/tree/store', async importOriginal => {
+  const actual = await importOriginal<typeof TreeStore>()
+
+  return { ...actual, revealTreePane }
+})
+
+vi.mock('./pane-mirror', () => ({
+  paneMirror: () => () => undefined
+}))
+
+import { $rightRailActiveTabId } from '@/store/layout'
+import { $previewTabs, closeRightRail, type PreviewTarget } from '@/store/preview'
+
+import { watchPreviewTiles } from './preview-tile'
+
+const target: PreviewTarget = {
+  kind: 'url',
+  label: 'Browser',
+  source: 'http://127.0.0.1:5173',
+  url: 'http://127.0.0.1:48231/'
+}
+
+describe('watchPreviewTiles', () => {
+  beforeEach(() => {
+    closeRightRail()
+    revealTreePane.mockClear()
+  })
+
+  it('reveals a restored active Browser tab during initial wiring', () => {
+    $previewTabs.set([{ id: 'url:browser', target }])
+    $rightRailActiveTabId.set('url:browser')
+
+    watchPreviewTiles()
+
+    expect(revealTreePane).toHaveBeenCalledWith('preview-tile:url:browser')
+  })
+})

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -93,6 +93,7 @@ export function watchPreviewTiles(): void {
 
   $rightRailActiveTabId.listen(reveal)
   $previewTabs.listen(reveal)
+  reveal()
 
   // And the reverse: clicking a preview TAB activates its pane in the TREE
   // only, so the store's selection must follow or `$previewTarget` (⌘L quote

--- a/apps/desktop/src/app/session/hooks/preview-open.test.tsx
+++ b/apps/desktop/src/app/session/hooks/preview-open.test.tsx
@@ -35,10 +35,11 @@ function Harness() {
   return null
 }
 
-async function emitPreviewOpen(url = '/tmp/artifact-test.html') {
+async function emitPreviewOpen(url = '/tmp/artifact-test.html', profile?: string, remoteForward?: unknown) {
   await act(async () => {
     handleEvent({
-      payload: { label: 'hi bestie', url },
+      payload: { label: 'hi bestie', url, ...(remoteForward !== undefined ? { remote_forward: remoteForward } : {}) },
+      ...(profile ? { profile } : {}),
       session_id: RUNTIME_SESSION_ID,
       type: 'preview.open'
     } as unknown as RpcEvent)
@@ -82,6 +83,29 @@ describe('open_preview', () => {
 
     await waitFor(() => expect($previewTarget.get()?.path).toBe('/tmp/artifact-test.html'))
     expect($previewTabs.get()).toHaveLength(1)
+  })
+
+  it('passes the preview event profile to desktop normalization', async () => {
+    render(<Harness />)
+
+    await emitPreviewOpen('/tmp/profile.html', 'compass')
+
+    await waitFor(() => expect($previewTarget.get()?.path).toBe('/tmp/profile.html'))
+    expect(window.hermesDesktop.normalizePreviewTarget).toHaveBeenCalledWith('/tmp/profile.html', '/work', 'compass', false)
+  })
+
+  it('passes an explicit remote forwarding request to desktop normalization', async () => {
+    render(<Harness />)
+
+    await emitPreviewOpen('http://localhost:5173', 'compass', true)
+
+    await waitFor(() => expect($previewTarget.get()?.source).toBe('http://localhost:5173'))
+    expect(window.hermesDesktop.normalizePreviewTarget).toHaveBeenCalledWith(
+      'http://localhost:5173',
+      '/work',
+      'compass',
+      true
+    )
   })
 
   it('keeps the tab when the stored session id arrives afterwards', async () => {

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -72,8 +72,9 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
         // session that is NOT visible anywhere still can't yank the pane
         // open (offer, don't hijack). Routes through the same normalizer as
         // the file browser so URLs, localhost, and file paths all resolve.
-        const { url, label } = asRecord(event.payload)
+        const { remote_forward, url, label } = asRecord(event.payload)
         const target = typeof url === 'string' ? url.trim() : ''
+        const remoteForward = remote_forward === true
 
         const onScreen = (sid: string) =>
           sid === $focusedRuntimeId.get() ||
@@ -81,7 +82,12 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
           $sessionTiles.get().some(tile => tile.runtimeId === sid)
 
         if (target && (!event.session_id || onScreen(event.session_id))) {
-          void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(resolved => {
+          void normalizeOrLocalPreviewTarget(
+            target,
+            $currentCwd.get() || currentCwd || undefined,
+            event.profile,
+            remoteForward
+          ).then(resolved => {
             if (resolved) {
               const trimmedLabel = typeof label === 'string' ? label.trim() : ''
               openPreview(trimmedLabel ? { ...resolved, label: trimmedLabel } : resolved, 'tool-result')

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -168,7 +168,12 @@ declare global {
       saveImageBuffer: (data: ArrayBuffer | Uint8Array, ext: string) => Promise<string>
       saveClipboardImage: () => Promise<string>
       getPathForFile: (file: File) => string
-      normalizePreviewTarget: (target: string, baseDir?: string) => Promise<HermesPreviewTarget | null>
+      normalizePreviewTarget: (
+        target: string,
+        baseDir?: string,
+        profile?: string,
+        remoteForward?: boolean
+      ) => Promise<HermesPreviewTarget | null>
       watchPreviewFile: (url: string) => Promise<HermesPreviewWatch>
       /** Watch a directory for entry churn (disk-plugin door); same watcher
        *  registry + onPreviewFileChanged channel as watchPreviewFile. Optional:

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -44,6 +44,24 @@ describe('remote HTML previews', () => {
     expect(readDesktopFileDataUrl).toHaveBeenCalledWith('/srv/report.html')
   })
 
+  it('fails closed when explicit remote forwarding normalization returns null', async () => {
+    const normalizePreviewTarget = vi.fn(async () => null)
+    window.hermesDesktop = { normalizePreviewTarget } as never
+
+    await expect(
+      normalizeOrLocalPreviewTarget('http://localhost:5173', '/work', 'compass', true)
+    ).resolves.toBeNull()
+    expect(normalizePreviewTarget).toHaveBeenCalledWith('http://localhost:5173', '/work', 'compass', true)
+  })
+
+  it('passes the owning profile through the desktop normalizer', async () => {
+    const normalizePreviewTarget = vi.fn(async () => remoteTarget)
+    window.hermesDesktop = { normalizePreviewTarget } as never
+
+    await normalizeOrLocalPreviewTarget('/srv/report.html', '/work', 'compass')
+    expect(normalizePreviewTarget).toHaveBeenCalledWith('/srv/report.html', '/work', 'compass', false)
+  })
+
   it('falls back to source mode when the transport is not canonical HTML', async () => {
     readDesktopFileDataUrl.mockResolvedValue('data:text/plain;base64,SGVsbG8=')
 

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -259,10 +259,17 @@ async function enrichPreviewTarget(target: PreviewTarget | null): Promise<Previe
 
 export async function normalizeOrLocalPreviewTarget(
   rawTarget: string,
-  cwd?: string | null
+  cwd?: string | null,
+  profile?: string | null,
+  remoteForward = false
 ): Promise<PreviewTarget | null> {
   try {
-    const normalized = await window.hermesDesktop?.normalizePreviewTarget?.(rawTarget, cwd || undefined)
+    const normalized = await window.hermesDesktop?.normalizePreviewTarget?.(
+      rawTarget,
+      cwd || undefined,
+      profile || undefined,
+      remoteForward === true
+    )
 
     if (normalized) {
       return enrichPreviewTarget(normalized)
@@ -270,6 +277,10 @@ export async function normalizeOrLocalPreviewTarget(
   } catch {
     // Running Electron may still have the old HTML-only preview IPC. Fall
     // through to renderer-side local classification so text/images still open.
+  }
+
+  if (remoteForward === true) {
+    return null
   }
 
   return enrichPreviewTarget(localPreviewTarget(rawTarget, cwd))

--- a/tests/tools/test_open_preview_tool.py
+++ b/tests/tools/test_open_preview_tool.py
@@ -33,3 +33,29 @@ def test_emitter_failure_is_reported():
 
     desktop_ui.set_emitter(_boom)
     assert "no window" in json.loads(op.open_preview_tool("https://x.example"))["error"]
+
+
+def test_remote_forward_defaults_to_false_and_is_emitted_only_when_requested():
+    emitted = []
+
+    desktop_ui.set_emitter(lambda *_args: emitted.append(_args))
+
+    assert json.loads(op.open_preview_tool("http://localhost:5173"))["remote_forward"] is False
+    assert emitted[-1][2] == {"url": "http://localhost:5173", "label": "", "remote_forward": False}
+
+    assert json.loads(op.open_preview_tool("http://localhost:5173", remote_forward=True))["remote_forward"] is True
+    assert emitted[-1][2] == {"url": "http://localhost:5173", "label": "", "remote_forward": True}
+
+
+def test_registry_handler_passes_remote_forward_option():
+    emitted = []
+    desktop_ui.set_emitter(lambda *_args: emitted.append(_args))
+
+    entry = registry.get_entry("open_preview")
+    assert entry is not None
+
+    entry.handler({"url": "http://localhost:5173", "remote_forward": True})
+
+    assert emitted[-1][2]["remote_forward"] is True
+    assert op.OPEN_PREVIEW_SCHEMA["parameters"]["properties"]["remote_forward"]["type"] == "boolean"
+    assert "user-requested remote dev server" in op.OPEN_PREVIEW_SCHEMA["parameters"]["properties"]["remote_forward"]["description"]

--- a/tools/open_preview_tool.py
+++ b/tools/open_preview_tool.py
@@ -33,7 +33,7 @@ def _normalize_target(raw: str) -> str:
     return v
 
 
-def open_preview_tool(url: str, label: str = "") -> str:
+def open_preview_tool(url: str, label: str = "", remote_forward: bool = False) -> str:
     """Ask the desktop GUI to show ``url`` in the preview pane beside the chat."""
     target = _normalize_target(url or "")
     if not target:
@@ -43,14 +43,20 @@ def open_preview_tool(url: str, label: str = "") -> str:
         )
 
     label = (label or "").strip()
+    remote_forward = remote_forward is True
     try:
-        ok = desktop_ui.emit("preview.open", {"url": target, "label": label})
+        ok = desktop_ui.emit(
+            "preview.open", {"url": target, "label": label, "remote_forward": remote_forward}
+        )
     except Exception as exc:
         return tool_error(f"Failed to open the preview pane: {exc}")
     if not ok:
         return tool_error("The preview pane is only available in the Hermes desktop app.")
 
-    return json.dumps({"success": True, "url": target, "label": label}, ensure_ascii=False)
+    return json.dumps(
+        {"success": True, "url": target, "label": label, "remote_forward": remote_forward},
+        ensure_ascii=False,
+    )
 
 
 OPEN_PREVIEW_SCHEMA = {
@@ -61,7 +67,11 @@ OPEN_PREVIEW_SCHEMA = {
         "preview pane — e.g. \"open cnn.com in the preview pane\" or \"preview "
         "localhost:3000\". Accepts a web URL (a bare domain like www.cnn.com is fine), "
         "a localhost dev-server URL, or a file path (HTML renders live; other files "
-        "show their contents). The pane opens for the current window only."
+        "show their contents). The pane opens for the current window only. Set "
+        "remote_forward only when the user explicitly requests a remote dev server; "
+        "only supported common dev-server ports (4173, 4174, 4200, 4321, 5000, "
+        "5173, 5174, 8000, 8080, 8081, 8888, and 9000) are forwarded, never "
+        "arbitrary internal services."
     ),
     "parameters": {
         "type": "object",
@@ -77,6 +87,16 @@ OPEN_PREVIEW_SCHEMA = {
                 "type": "string",
                 "description": "Optional tab label; defaults to the target's name.",
             },
+            "remote_forward": {
+                "type": "boolean",
+                "description": (
+                    "Only for a user-requested remote dev server. Forwarding is limited "
+                    "to supported common dev-server ports (4173, 4174, 4200, 4321, "
+                    "5000, 5173, 5174, 8000, 8080, 8081, 8888, and 9000); do not "
+                    "use this to expose arbitrary internal services. Defaults to false."
+                ),
+                "default": False,
+            },
         },
         "required": ["url"],
     },
@@ -87,6 +107,10 @@ registry.register(
     name="open_preview",
     toolset="desktop_ui",
     schema=OPEN_PREVIEW_SCHEMA,
-    handler=lambda args, **kw: open_preview_tool(url=args.get("url", ""), label=args.get("label", "")),
+    handler=lambda args, **kw: open_preview_tool(
+        url=args.get("url", ""),
+        label=args.get("label", ""),
+        remote_forward=args.get("remote_forward", False),
+    ),
     emoji="🖼️",
 )


### PR DESCRIPTION
## What does this PR do?

Adds transparent SSH loopback forwarding for explicitly requested remote development previews in Hermes Desktop, and restores the Browser pane after a renderer reload when preview state was already persisted.

## Why

When Desktop is connected to a remote Hermes backend through SSH, a preview target such as `http://127.0.0.1:5173` belongs to the remote host, not the computer displaying the Desktop window. This change forwards approved remote development ports through the existing SSH connection so the normal Browser pane can render them. The temporary terminal-launched Mac canary was only used for validation; the intended user path is the regular Desktop app.

## Changes

- Reuse the existing `SshConnection.forward`, `cancelForward`, local-port selection, and SSH lifecycle; no second SSH client or general HTTP/WebSocket proxy.
- Gate forwarding on the exact boolean `remote_forward: true`.
- Preserve public URLs and ordinary local previews unchanged.
- Default-deny unsupported remote loopback ports; common development ports remain allowlisted.
- Classify hostile loopback aliases syntactically without DNS resolution, including numeric `127/8`, IPv6 loopback and unspecified/wildcard addresses, IPv4-mapped loopback, and localhost variants.
- Fail closed when an explicitly requested forward cannot be created; never fall back to the viewer machine's localhost.
- Prevent explicit non-SSH profiles from inheriting a global SSH connection.
- Restore the persisted Browser pane during renderer startup after `Cmd+R`.

## How to test

1. Connect Desktop using **Connect via SSH**.
2. Request a remote development preview with `remote_forward: true` and target `http://127.0.0.1:5173`.
3. Confirm the page loads and interacts normally in the Browser pane.
4. Press `Cmd+R` while the Browser pane is focused.
5. Confirm the Browser pane and page remain available.

## Verification evidence

- Real macOS canary: SSH-forwarded VPS preview loaded; interaction worked; Browser pane remained after `Cmd+R`.
- Electron focused/current suite: 80 files passed; 949 tests passed; 1 file and 2 tests skipped.
- UI project suite: 57 files passed; 433 tests passed.
- Python preview-tool tests: 4 passed.
- Desktop typecheck: passed.
- Changed-file ESLint: passed with zero errors and zero warnings.
- Desktop production build and `assert-dist-built`: passed.
- `git diff --check`: passed.

## Review follow-up

- Added regression coverage for `http://[::]:5173`, which initially failed (RED) and now fails closed as expected (GREEN).
- The final current commit is `86ed86a22c63e92281cf93006a0af84bcd8c7c25`; the two-file follow-up was test-first and limited to IPv6 wildcard classification.

## Security and scope notes

- No credentials, private keys, passwords, or tokens are included.
- Remote forwarding is intentionally not enabled for every `localhost` target: localhost may refer to a private viewer-machine service, database, or administrative endpoint. The agent/tool must explicitly request `remote_forward: true` for an SSH remote development preview.
- Public URLs and ordinary local previews retain their existing behavior.
- Full application restart or SSH reconnect may require a later follow-up to re-normalize a persisted ephemeral forwarded URL. The validated `Cmd+R` path keeps the Electron main process and live forwarder, and is covered here.
