### PR TITLE
fix(datagen): correct stale probability comments and wrong type annotation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ symlink this clone's venv explicitly:
 
 ```bash
 mkdir -p ~/.local/bin
-ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
+ln -sf "$HOME/.hermes/venvs/hermes-dev/bin/hermes" ~/.local/bin/hermes
 ```
 
 ### Run tests

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -44,9 +44,9 @@ DISTRIBUTIONS = {
     "image_gen": {
         "description": "Heavy focus on image generation with vision and web support",
         "toolsets": {
-            "image_gen": 90,  # 80% chance of image generation tools
-            "vision": 90,      # 60% chance of vision tools
-            "web": 55,         # 40% chance of web tools
+            "image_gen": 90,  # 90% chance of image generation tools
+            "vision": 90,     # 90% chance of vision tools
+            "web": 55,        # 55% chance of web tools
             "terminal": 45
         }
     },
@@ -192,10 +192,10 @@ DISTRIBUTIONS = {
         "toolsets": {
             "terminal": 97,   # 97% - terminal almost always available
             "file": 97,       # 97% - file tools almost always available
-            "web": 97,        # 15% - web search/scrape for documentation
-            "browser": 75,    # 10% - browser occasionally for web interaction
-            "vision": 50,      # 8% - vision analysis rarely
-            "image_gen": 10    # 3% - image generation very rarely
+            "web": 97,        # 97% - web search/scrape for documentation
+            "browser": 75,    # 75% - browser occasionally for web interaction
+            "vision": 50,     # 50% - vision analysis rarely
+            "image_gen": 10   # 10% - image generation very rarely
         }
     },
     
@@ -214,7 +214,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
## Summary

Small, behavior-preserving cleanup:

1. **`toolset_distributions.py`** — inline comments in the `image_gen` (80/60/40 vs. actual 90/90/55) and `terminal_tasks` (15/10/8/3 vs. actual 97/75/50/10) distributions quote probabilities that no longer match the literals on the same lines. Since these comments document the sampling probability, they are actively misleading.
2. **`toolset_distributions.py`** — `get_distribution()` annotates with the builtin `any` instead of `typing.Any`; fixed both the annotation and the import line.
3. **`CONTRIBUTING.md`** — the manual-clone fallback symlinks `$(pwd)/venv/bin/hermes` (inside the checkout), but the section explicitly creates the venv `outside` the source tree at `~/.hermes/venvs/hermes-dev`. The documented command fails with `No such file or directory`.

## Verification

- `toolset_distributions.py` imports cleanly; `get_distribution`/sample behavior unchanged.
- No code paths changed — comments, one annotation, and docs only.
- `tests/test_toolset_distributions.py` unaffected.

No behavior change.