### PR TITLE
fix(terminal): keep background workers in a private session under systemd scope (#70716)

### DIFF
--- a/contributors/emails/drissman@gmail.com
+++ b/contributors/emails/drissman@gmail.com
@@ -1,0 +1,2 @@
+drissman
+# PR #82061 salvage (terminal: systemd scope session isolation fix)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1717,8 +1717,12 @@ class TestSystemdCgroupIsolation:
         sep_idx = argv.index("--")
         assert "/bin/bash" in argv[sep_idx:]
         assert "set +m; echo hello" in argv[sep_idx:]
-        # systemd-run owns session/cgroup creation — no start_new_session.
-        assert captured["start_new_session"] is False
+        # systemd-run --scope gives the worker a new cgroup but NOT a new
+        # session (#70716 regression: start_new_session was False, so the
+        # worker kept the parent's session + controlling terminal → SIGTTIN/
+        # SIGTTOU stopped the TUI).  start_new_session=True gives systemd-run
+        # (and the scoped worker below it) a private session.
+        assert captured["start_new_session"] is True
         # The session must record the unit name so kill_process can stop it.
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
@@ -1779,7 +1783,7 @@ class TestSystemdCgroupIsolation:
     def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
         self, registry, monkeypatch
     ):
-        """The scope wrapper shares the gateway PG, so cleanup must not killpg."""
+        """Cleanup must not killpg: scope teardown is the authoritative path."""
         fake_popen, _captured = self._fake_popen_capture()
         fake_proc = fake_popen(["placeholder"])
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1104,10 +1104,17 @@ class ProcessRegistry:
                 shell_argv, unit_suffix=unit_suffix,
             )
             session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
-            # systemd-run creates the new session/cgroup for us; do NOT also
-            # set start_new_session (harmless, but redundant and it can mask
-            # scope-creation failures in some systemd versions).
-            popen_start_new_session = False
+            # CRITICAL (#70716 regression): systemd-run --scope does NOT give
+            # the worker a new session — the invoked process keeps the
+            # parent's session and inherits its controlling terminal.  From an
+            # interactive TUI this drops the worker into the same session as
+            # the foreground process group: background spawns then stop the
+            # whole session (observed as 5 dead TUIs in state T / "Arrêté").
+            # start_new_session=True gives systemd-run (and the scoped worker
+            # below it) a private session.  Cgroup isolation is preserved:
+            # the scope is attached to the invoked process, not to the
+            # spawning session.
+            popen_start_new_session = True
         else:
             spawn_argv = shell_argv
             popen_start_new_session = True
@@ -1163,10 +1170,12 @@ class ProcessRegistry:
             # leak as untracked background processes.
             try:
                 if session.systemd_unit:
-                    # systemd-run --scope shares the gateway's process group
-                    # because start_new_session=False.  Never killpg here: that
-                    # can signal the gateway itself.  Stop the sibling cgroup,
-                    # then safely terminate the wrapper PID tree as fallback.
+                    # The worker runs in its own systemd scope and, since the
+                    # #70716 session-isolation fix, its own session.  Stop the
+                    # scope (kills every process in the worker cgroup), then
+                    # terminate the systemd-run wrapper PID as fallback.
+                    # Never killpg: scope teardown is the authoritative
+                    # cleanup for the worker cgroup.
                     _stop_systemd_unit(session.systemd_unit)
                     self._terminate_host_pid(proc.pid, session.host_start_time)
                 elif not _IS_WINDOWS:


### PR DESCRIPTION
## Summary

Background workers spawned under `systemd-run --user --scope` from an interactive TUI no longer stop the TUI session. Since #70716, `popen_start_new_session` was `False` in the systemd-scope branch on the assumption that `systemd-run --scope` creates a new session — it does not; the invoked process keeps the parent's session and controlling terminal, so background spawns trigger SIGTTIN/SIGTTOU on the shared terminal, stopping the TUI (observed as 5 dead sessions in state `T`).

Fix: `popen_start_new_session = True` in the systemd-scope branch. The worker (and the `systemd-run` wrapper) get a private session. Cgroup isolation is preserved — the scope is attached to the invoked process, not the spawning session.

## Changes

- `tools/process_registry.py`: flip `popen_start_new_session` from `False` to `True` in the systemd-scope branch; update the cleanup-path comment (scope teardown remains authoritative, `killpg` still never used for systemd-scoped workers)
- `tests/tools/test_process_registry.py`: update assertion from `is False` to `is True`; update docstring on the killpg guard test
- `contributors/emails/drissman@gmail.com`: AUTHOR_MAP entry for @drissman

## Validation

| | Before | After |
|---|---|---|
| `start_new_session` (systemd scope) | `False` (bug) | `True` |
| test_process_registry.py | 1 failure (assert `is False`) | 72/72 passed |
| ruff | clean | clean |

Salvage of #82061 by @drissman — cherry-picked with authorship preserved.

Closes #82061
