### PR TITLE
fix(desktop): keep the HUD composer full-width under Lightning CSS

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2716,6 +2716,15 @@ button[data-slot='aui_msg-reactions'] svg {
   max-width: none !important;
   transform: none !important;
   translate: none !important;
+  /* The dock's own class is `-translate-x-1/2` (Tailwind v4 → the standalone
+     `translate` property, driven by --tw-translate-*). Lightning CSS folds
+     `translate: none` into `transform` and DROPS it from the output, so the
+     cancel above alone leaves the full-width dock shifted -50% — half of it
+     hangs off the window's left edge and the input sits off-screen. Zeroing
+     the Tailwind variables neutralizes the shift at the source; custom
+     properties survive the optimizer. */
+  --tw-translate-x: 0 !important;
+  --tw-translate-y: 0 !important;
   padding: 0 !important;
 }
 


### PR DESCRIPTION
## Problem

In HUD mode the composer bar renders shifted half off the window: only the right portion (model chip, mic, send) is visible, the text input sits outside the window's left edge. The HUD is unusable as an input surface — typed text is invisible.

## Root cause

The HUD dock is styled to span the window:

```css
[data-hud-shell] [data-slot='composer-dock'] {
  left: 0; right: 0; width: 100%;
  transform: none; translate: none;
  ...
}
```

The dock's own Tailwind class is `-translate-x-1/2`, which in Tailwind v4 compiles to the **standalone `translate` property** (`translate: var(--tw-translate-x) var(--tw-translate-y)`, with `--tw-translate-x: -50%`). The HUD rule cancels it with `translate: none`.

**Lightning CSS folds `translate` into `transform` and drops the standalone `translate: none` from the build output** — the built rule contains only `transform: translate(0)`. The `-translate-x-1/2` shift therefore survives: the 100%-wide dock is translated `-50%`, so half of it hangs off the window's left edge.

## Fix

Zero the Tailwind variables instead of relying on the standalone property:

```css
--tw-translate-x: 0 !important;
--tw-translate-y: 0 !important;
```

Custom properties survive the CSS optimizer, so `translate: var(--tw-translate-x) var(--tw-translate-y)` (still emitted by the class) resolves to no shift — regardless of what Lightning does to `translate: none`.

## Verification

- Reproduced: HUD composer shifted left, input off-window.
- After fix, built and packaged locally (`npm run pack`): the bar spans the full window width with the input field in view; typing shows in the expected position.
- Confirmed in the built CSS that the variables are present in the dock rule (`--tw-translate-x:0!important`).
