### PR TITLE
feat(gateway): surface injected turn context in the tool-progress feed

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1265,6 +1265,106 @@ def build_turn_context(
         if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
             agent._pending_cli_user_message = None
 
+    # ── Injection observability ──
+    # Two injection families can make the API-bound user message diverge from
+    # the clean transcript text:
+    #   suffix — memory prefetch / plugin context appended by
+    #     ``compose_user_api_content`` (stamped as the ``api_content`` sidecar
+    #     above);
+    #   prefix — gateway envelope text (interruption system notes, voice
+    #     prefixes) carried in the live content while the clean text arrives as
+    #     ``persist_user_message``.
+    # Emit one ``context.injected`` event carrying the exact bytes added around
+    # the clean text, so the gateway can render them in the tool-progress feed
+    # instead of the model silently seeing a different message than the user
+    # sent. Runs after the stamp/persist and before the first model call, only
+    # on API paths where the composed content is actually sent (same gate as
+    # the sidecar stamp: MoA and codex_app_server bypass the api_messages
+    # build, so claiming an injection there would be a lie).
+    _progress_callback = getattr(agent, "tool_progress_callback", None)
+    if (
+        not moa_active
+        and getattr(agent, "api_mode", None) != "codex_app_server"
+        and callable(_progress_callback)
+        and 0 <= current_turn_user_idx < len(messages)
+        and isinstance(messages[current_turn_user_idx], dict)
+        and messages[current_turn_user_idx].get("role") == "user"
+    ):
+        try:
+            _turn_msg = messages[current_turn_user_idx]
+            _clean = (
+                persist_user_message
+                if isinstance(persist_user_message, str)
+                else _turn_msg.get("content")
+            )
+            _sidecar = _turn_msg.get("api_content")
+            _api = (
+                _sidecar
+                if isinstance(_sidecar, str)
+                else _turn_msg.get("content")
+            )
+            if (
+                isinstance(_clean, str)
+                and isinstance(_api, str)
+                and _clean
+                and _api != _clean
+            ):
+                # Split into the exact bytes added around the clean text.
+                # Observed constructions only; anything else is skipped rather
+                # than misreported:
+                #   clean + suffix           (memory/plugin compose)
+                #   prefix + clean           (gateway envelope note)
+                #   prefix + clean + suffix  (envelope + compose combined)
+                _prefix = ""
+                _suffix = ""
+                _ok = False
+                if _api.startswith(_clean):
+                    _suffix = _api[len(_clean):]
+                    _ok = True
+                elif _api.endswith(_clean):
+                    _prefix = _api[:-len(_clean)]
+                    _ok = True
+                else:
+                    _content = _turn_msg.get("content")
+                    if (
+                        isinstance(_content, str)
+                        and _content.endswith(_clean)
+                        and _api.startswith(_content)
+                    ):
+                        _prefix = _content[:-len(_clean)]
+                        _suffix = _api[len(_content):]
+                        _ok = True
+                if not _ok or not (_prefix or _suffix):
+                    # Unrecognised divergence shape: show nothing.
+                    pass
+                else:
+                    _sources: list[str] = []
+                    if _prefix:
+                        _sources.append("gateway")
+                    if ext_prefetch_cache:
+                        _sources.append("memory")
+                    if plugin_user_context:
+                        _sources.append("plugin/gateway")
+                    if not _sources:
+                        _sources.append("gateway")
+                    if _prefix and _suffix:
+                        _display = _prefix + "\n[your message]\n" + _suffix
+                    else:
+                        _display = _prefix or _suffix
+                    _progress_callback(
+                        "context.injected",
+                        "context",
+                        None,
+                        {
+                            "content": _display,
+                            "injected_chars": len(_api) - len(_clean),
+                            "sources": _sources,
+                        },
+                    )
+        except Exception:
+            # Display plumbing must never block the model call.
+            logger.debug("context injection progress callback failed", exc_info=True)
+
     return TurnContext(
         user_message=user_message,
         original_user_message=original_user_message,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3728,6 +3728,99 @@ def _reconnect_backoff(attempt: int) -> int:
     return min(30 * (2 ** (attempt - 1)), _RECONNECT_BACKOFF_CAP)
 
 
+def _split_context_progress_text(text: str, budget: int) -> list[str]:
+    """Split display text into bounded chunks, preferring line boundaries."""
+    if not text:
+        return []
+    budget = max(1, int(budget))
+    chunks: list[str] = []
+    remaining = text
+    while len(remaining) > budget:
+        cut = remaining.rfind("\n", 0, budget + 1)
+        if cut < max(1, budget // 2):
+            cut = budget
+        chunks.append(remaining[:cut])
+        remaining = remaining[cut:]
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+def _format_context_injection_progress(
+    *,
+    content: str,
+    injected_chars: int,
+    sources: list[str],
+    message_limit: int,
+    supports_code_blocks: bool,
+) -> list[str]:
+    """Render API-bound ephemeral context as tool-style progress cards.
+
+    ``content`` is the exact suffix appended to the clean user message. The
+    display copy is force-redacted and mention-neutralised before it leaves the
+    gateway; the model still receives the untouched API content. Long blocks
+    are split below the adapter's message cap so Discord/Telegram edits cannot
+    fail merely because Honcho returned a healthy amount of autobiography.
+    """
+    if not isinstance(content, str) or not content:
+        return []
+
+    from agent.redact import redact_sensitive_text
+
+    visible = redact_sensitive_text(
+        content,
+        force=True,
+        file_read=True,
+        redact_url_credentials=True,
+    )
+    # Context can quote old Discord messages containing literal mention tokens.
+    # Neutralise them even inside code blocks: adapter allowed-mention settings
+    # differ, and recalled text must never wake another user by accident.
+    visible = visible.replace("@", "@\u200b")
+
+    source_label = " + ".join(str(s) for s in sources if s) or "turn"
+    header = f"🧠 {source_label} context injected (+{max(0, int(injected_chars)):,} chars)"
+    continuation = f"🧠 {source_label} context injected (continued)"
+
+    try:
+        raw_limit = max(1, int(message_limit))
+    except (TypeError, ValueError):
+        raw_limit = 4000
+    # Mirror send_progress_messages' 64-char formatting margin.
+    limit = max(1, raw_limit - (64 if raw_limit > 128 else 0))
+
+    # Some test/plugin adapters advertise caps smaller than the card header.
+    # Rich framing is mathematically impossible there, so degrade to bounded
+    # plain chunks while preserving every display byte. Real chat adapters have
+    # much larger limits, but the helper's cap contract should still be true.
+    rich_overhead = len("\n```\n\n```") if supports_code_blocks else 1
+    if max(len(header), len(continuation)) + rich_overhead >= limit:
+        return (
+            _split_context_progress_text(header, limit)
+            + _split_context_progress_text(visible, limit)
+        )
+
+    if supports_code_blocks:
+        from gateway.stream_consumer import escape_code_fences_for_display
+
+        visible = escape_code_fences_for_display(visible)
+        overhead = max(len(header), len(continuation)) + len("\n```\n\n```")
+        budget = max(1, limit - overhead)
+        chunks = _split_context_progress_text(visible, budget)
+        return [
+            f"{header if index == 0 else continuation}\n```\n{chunk}\n```"
+            for index, chunk in enumerate(chunks)
+        ]
+
+    overhead = max(len(header), len(continuation)) + 1
+    budget = max(1, limit - overhead)
+    chunks = _split_context_progress_text(visible, budget)
+    return [
+        f"{header if index == 0 else continuation}\n{chunk}"
+        for index, chunk in enumerate(chunks)
+    ]
+
+
 class TurnRunner:
     """Per-turn collaborator carrying the tool-progress callbacks that used to
     be nested closures inside ``GatewayRunner._run_agent_inner``.
@@ -3784,6 +3877,47 @@ class TurnRunner:
             if not ctx.progress_queue:
                 return
         if not ctx.progress_queue or not ctx._run_still_current():
+            return
+
+        # Ephemeral memory/plugin context is composed before the first model
+        # call and is otherwise invisible: it is not a tool call and does not
+        # enter the clean transcript. Render it through the SAME editable
+        # progress queue as tool calls so the user sees exactly what the model
+        # received without needing a separate slash command.
+        if event_type == "context.injected":
+            if not ctx.tool_progress_enabled or not isinstance(args, dict):
+                return
+            content = args.get("content")
+            if not isinstance(content, str) or not content:
+                return
+            try:
+                adapter = self._runner._adapter_for_source(ctx.source)
+            except Exception:
+                adapter = None
+            if adapter is None:
+                return
+            try:
+                message_limit = int(
+                    adapter.max_message_length_for_chat(ctx.source.chat_id)
+                    if isinstance(adapter, BasePlatformAdapter)
+                    else getattr(adapter, "MAX_MESSAGE_LENGTH", 4000)
+                )
+            except Exception:
+                message_limit = 4000
+            messages = _format_context_injection_progress(
+                content=content,
+                injected_chars=args.get("injected_chars", len(content)),
+                sources=args.get("sources") if isinstance(args.get("sources"), list) else [],
+                message_limit=message_limit,
+                supports_code_blocks=bool(getattr(adapter, "supports_code_blocks", False)),
+            )
+            for message in messages:
+                ctx.progress_queue.put(message)
+            # A context card is its own progress beat. Do not let terminal-card
+            # header suppression or ordinary tool dedup bleed across it.
+            ctx.last_was_terminal_block[0] = False
+            ctx.last_progress_msg[0] = messages[-1] if messages else None
+            ctx.repeat_count[0] = 0
             return
 
         # First-touch onboarding: the first time a tool takes longer than

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -192,6 +192,10 @@ class _FakeAgent:
         # Captures the user message's api_content at persist time, proving
         # the stamp lands BEFORE the early persist writes the row.
         self.api_content_at_persist = "<unset>"
+        self.tool_progress_events = []
+        self.tool_progress_callback = (
+            lambda *args, **kwargs: self.tool_progress_events.append((args, kwargs))
+        )
 
     def _ensure_db_session(self):
         pass
@@ -261,6 +265,107 @@ class TestPrologueStamping:
         assert msg["api_content"] == "hello\n\nPLUGIN-CTX"
         # The early persist saw the stamped sidecar (written in one insert).
         assert agent.api_content_at_persist == "hello\n\nPLUGIN-CTX"
+        assert len(agent.tool_progress_events) == 1
+        args, kwargs = agent.tool_progress_events[0]
+        assert kwargs == {}
+        assert args[:3] == ("context.injected", "context", None)
+        assert args[3] == {
+            "content": "\n\nPLUGIN-CTX",
+            "injected_chars": len("\n\nPLUGIN-CTX"),
+            "sources": ["plugin/gateway"],
+        }
+
+    def test_emits_combined_memory_and_plugin_suffix_exactly_once(self):
+        class _MemoryManager:
+            def on_turn_start(self, *_args):
+                pass
+
+            def prefetch_all(self, _query):
+                return "RECALLED-MEMORY"
+
+        agent = _FakeAgent()
+        agent._memory_manager = _MemoryManager()
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            ctx = _build(agent, user_message="explain agent communication")
+
+        msg = ctx.messages[ctx.current_turn_user_idx]
+        assert len(agent.tool_progress_events) == 1
+        args, _kwargs = agent.tool_progress_events[0]
+        payload = args[3]
+        expected_suffix = msg["api_content"][len(msg["content"]):]
+        assert payload["content"] == expected_suffix
+        assert "<memory-context>" in payload["content"]
+        assert "RECALLED-MEMORY" in payload["content"]
+        assert payload["content"].endswith("PLUGIN-CTX")
+        assert payload["sources"] == ["memory", "plugin/gateway"]
+        assert payload["injected_chars"] == len(msg["api_content"]) - len(msg["content"])
+
+    def test_callback_failure_never_blocks_api_content_stamp(self):
+        agent = _FakeAgent()
+
+        def _broken_callback(*_args, **_kwargs):
+            raise RuntimeError("presentation broke")
+
+        agent.tool_progress_callback = _broken_callback
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            ctx = _build(agent)
+        msg = ctx.messages[ctx.current_turn_user_idx]
+        assert msg["api_content"] == "hello\n\nPLUGIN-CTX"
+        assert agent.api_content_at_persist == "hello\n\nPLUGIN-CTX"
+
+    def test_emits_gateway_envelope_prefix_injection(self):
+        """Interruption system notes are PREPENDED to the user message
+        (gateway envelope), with the clean text carried as
+        persist_user_message. The event must surface the exact prefix."""
+        agent = _FakeAgent()
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            _build(
+                agent,
+                user_message="[System note: restarted]\n\nhello",
+                persist_user_message="hello",
+            )
+        assert len(agent.tool_progress_events) == 1
+        args, _kwargs = agent.tool_progress_events[0]
+        assert args[:3] == ("context.injected", "context", None)
+        assert args[3] == {
+            "content": "[System note: restarted]\n\n",
+            "injected_chars": len("[System note: restarted]\n\n"),
+            "sources": ["gateway"],
+        }
+
+    def test_emits_combined_envelope_prefix_and_memory_suffix(self):
+        class _MemoryManager:
+            def on_turn_start(self, *_args):
+                pass
+
+            def prefetch_all(self, _query):
+                return "RECALLED-MEMORY"
+
+        agent = _FakeAgent()
+        agent._memory_manager = _MemoryManager()
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(
+                agent,
+                user_message="[System note: restarted]\n\nexplain agent communication",
+                persist_user_message="explain agent communication",
+            )
+        msg = ctx.messages[ctx.current_turn_user_idx]
+        assert len(agent.tool_progress_events) == 1
+        args, _kwargs = agent.tool_progress_events[0]
+        payload = args[3]
+        assert payload["sources"] == ["gateway", "memory"]
+        assert payload["content"].startswith("[System note: restarted]\n\n")
+        assert "\n[your message]\n" in payload["content"]
+        assert payload["content"].endswith("</memory-context>")
+        assert payload["injected_chars"] == (
+            len(msg["api_content"]) - len("explain agent communication")
+        )
 
     def test_no_stamp_without_injections(self):
         agent = _FakeAgent()
@@ -268,6 +373,7 @@ class TestPrologueStamping:
             ctx = _build(agent)
         assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
         assert agent.api_content_at_persist is None
+        assert agent.tool_progress_events == []
 
     def test_no_stamp_for_codex_app_server(self):
         """codex_app_server turns bypass the api_messages build, so the
@@ -280,6 +386,7 @@ class TestPrologueStamping:
         ):
             ctx = _build(agent)
         assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
+        assert agent.tool_progress_events == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_turn_context.py
+++ b/tests/gateway/test_turn_context.py
@@ -10,18 +10,19 @@ itself (that's covered by test_run_progress_topics.py et al.).
 
 import asyncio
 import queue as queue_mod
+from types import SimpleNamespace
 
 import pytest
 
 from gateway.turn_context import TurnContext
 
 
-def _make_runner(ctx):
+def _make_runner(ctx, adapter=None):
     from gateway.run import TurnRunner
 
     class _StubGatewayRunner:
         def _adapter_for_source(self, source):
-            return None
+            return adapter
 
     return TurnRunner(_StubGatewayRunner(), ctx)
 
@@ -64,3 +65,102 @@ class TestTurnRunner:
         ctx = TurnContext(progress_queue=queue_mod.Queue())
         runner = _make_runner(ctx)  # stub adapter resolver returns None
         assert asyncio.run(runner.send_progress_messages()) is None
+
+    def test_context_injection_uses_tool_progress_queue_with_full_redacted_content(self):
+        class _DiscordLikeAdapter:
+            MAX_MESSAGE_LENGTH = 2000
+            supports_code_blocks = True
+
+        progress_queue = queue_mod.Queue()
+        ctx = TurnContext(
+            source=SimpleNamespace(chat_id="c1"),
+            _run_still_current=lambda: True,
+            progress_mode="all",
+            tool_progress_enabled=True,
+            progress_queue=progress_queue,
+        )
+        runner = _make_runner(ctx, _DiscordLikeAdapter())
+        secret = "ghp_" + ("a" * 36)
+        content = (
+            "\n\n<memory-context>\n"
+            f"token={secret}\n"
+            "quoted mention: <@1234567890>\n"
+            + ("remembered observation\n" * 300)
+            + "</memory-context>"
+        )
+
+        runner.progress_callback(
+            "context.injected",
+            "context",
+            None,
+            {
+                "content": content,
+                "injected_chars": len(content) + 2,
+                "sources": ["memory"],
+            },
+        )
+
+        messages = []
+        while not progress_queue.empty():
+            messages.append(progress_queue.get_nowait())
+        assert len(messages) > 1  # 5k-ish context is split for Discord
+        assert all(len(message) <= 1936 for message in messages)  # 2000 - safety margin
+        rendered = "\n".join(messages)
+        assert rendered.startswith(f"🧠 memory context injected (+{len(content) + 2:,} chars)")
+        assert "<memory-context>" in rendered
+        assert "</memory-context>" in rendered
+        assert secret not in rendered
+        assert "«redacted:ghp_…»" in rendered
+        assert "<@1234567890>" not in rendered
+        assert "<@\u200b1234567890>" in rendered
+        assert all(message.count("```") == 2 for message in messages)
+
+        from agent.redact import redact_sensitive_text
+        from gateway.stream_consumer import escape_code_fences_for_display
+
+        displayed_chunks = []
+        for message in messages:
+            body = message.split("\n", 1)[1]
+            displayed_chunks.append(body[4:-4])  # outer ```\n ... \n```
+        expected_display = escape_code_fences_for_display(
+            redact_sensitive_text(
+                content,
+                force=True,
+                file_read=True,
+                redact_url_credentials=True,
+            ).replace("@", "@\u200b")
+        )
+        assert "".join(displayed_chunks) == expected_display
+
+    @pytest.mark.parametrize("message_limit", [1, 8, 40, 64, 128])
+    def test_context_injection_respects_even_tiny_adapter_caps(self, message_limit):
+        from gateway.run import _format_context_injection_progress
+
+        messages = _format_context_injection_progress(
+            content="x" * 334,
+            injected_chars=336,
+            sources=["source-" + ("y" * 200)],
+            message_limit=message_limit,
+            supports_code_blocks=True,
+        )
+        assert messages
+        assert all(len(message) <= message_limit for message in messages)
+
+    def test_context_injection_follows_tool_progress_visibility(self):
+        progress_queue = queue_mod.Queue()
+        ctx = TurnContext(
+            source=SimpleNamespace(chat_id="c1"),
+            _run_still_current=lambda: True,
+            progress_mode="off",
+            tool_progress_enabled=False,
+            progress_queue=progress_queue,
+        )
+        adapter = SimpleNamespace(MAX_MESSAGE_LENGTH=2000, supports_code_blocks=True)
+        runner = _make_runner(ctx, adapter)
+        runner.progress_callback(
+            "context.injected",
+            "context",
+            None,
+            {"content": "hidden", "injected_chars": 8, "sources": ["memory"]},
+        )
+        assert progress_queue.empty()


### PR DESCRIPTION
## What does this PR do?

Every turn, Hermes appends ephemeral context to the API-bound user message — external-memory prefetch, `pre_llm_call` plugin context, and gateway envelope notes (interruption system notes, voice prefixes) — with no user-facing trace. The model reads a materially different message than the user sent; today the only way to see it is querying `state.db` for the `api_content` sidecar.

This PR emits a `context.injected` event from the turn prologue carrying the **exact bytes** added around the clean transcript text, and renders it through the existing editable tool-progress queue — the same surface as tool calls:

```
🧠 memory + gateway context injected (+5,022 chars)
<the injected content, in a fenced block, chunked to the platform limit>
```

Design notes:

- **Truthful by construction.** Emission happens only on API paths that actually send the composed content (skipped for MoA and `codex_app_server`, same predicate as the sidecar stamp), and covers all three observed constructions: `clean+suffix` (memory/plugin compose), `prefix+clean` (gateway envelope), and `prefix+clean+suffix`. Unrecognised divergence shapes emit nothing rather than misreport.
- **Safe to display.** The display copy is force-redacted via `agent.redact.redact_sensitive_text(force=True, file_read=True, redact_url_credentials=True)` and `@`-mentions are neutralised with a zero-width space (recalled context routinely quotes old messages). Fences are escaped; chunks respect the adapter's real per-chat message cap with the existing 64-char margin, degrading to plain bounded chunks under tiny caps. Full content is preserved.
- **No new surface.** Rides the existing `display.tool_progress` mode (`off`/`log`/`new`/`all`/`verbose`) and the existing progress queue — no new config keys, no new model tools, no history mutation, no prompt-cache impact (presentation layer only).

**Relation to #15412:** that PR previews *memory prefetch only*, Discord-only, via new `memory_context*` config keys and Hindsight-specific noise stripping, and has been idle since April. This PR covers every injection family on all platforms with exact-byte fidelity, forced secret redaction, and zero new config. Happy to reconcile either direction.

## Related Issue

None filed — discovered while dogfooding: injected context was invisible until inspected in the session DB.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/turn_context.py` — emit one `context.injected` event per turn when the API-bound user message diverges from the clean transcript text, with the exact added bytes and source labels (`gateway`, `memory`, `plugin/gateway`). Callback failures are swallowed; stamping/persistence unaffected.
- `gateway/run.py` — `_format_context_injection_progress()` + a `context.injected` branch in `TurnRunner.progress_callback` routing the rendered card(s) into the existing editable progress queue.
- `tests/agent/test_api_content_sidecar.py` — emission shapes (suffix/prefix/combined), exact-byte payloads, source labels, callback-failure isolation, no-injection and `codex_app_server` suppression.
- `tests/gateway/test_turn_context.py` — queue routing, `tool_progress`-off suppression, forced redaction, mention neutralisation, Discord-cap chunking including tiny synthetic caps (1/8/40/64/128) with full content preservation.

## How to Test

1. `pytest tests/agent/test_api_content_sidecar.py tests/gateway/test_turn_context.py`
2. Live: configure a memory provider, set `display.tool_progress: all`, send a non-trivial message on Discord/Telegram — a 🧠 card with the injected bytes appears in the progress feed before the reply. Restart-interruption system notes also render (envelope-prefix path).

Verified live on a production gateway (Discord): after a restart, the resumed turn rendered `🧠 gateway context injected (+375 chars)` with the full interruption system note, in-thread, ahead of the assistant reply.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (nearest: #15412 — relationship discussed above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suites for every changed surface (`pytest tests/agent/test_api_content_sidecar.py tests/gateway/test_turn_context.py tests/agent/test_gateway_turn_sidecar.py tests/gateway/test_run_progress_topics.py tests/gateway/test_discord_edit_message_overflow.py tests/gateway/test_runtime_footer.py tests/test_hermes_state.py` — 310 passed); full `pytest tests/ -q` is running and I'll confirm in a follow-up comment
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (bare-metal gateway serving Discord)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no new config keys; behaviour follows the existing `display.tool_progress` docs)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (none added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure presentation-layer change; adapters without message editing keep their existing drop behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Live Discord render after a gateway restart (envelope-prefix case):

```
🧠 gateway context injected (+375 chars)
[System note: The previous turn was interrupted by a gateway shutdown; the
gateway is now back online. ...]
```
