### PR TITLE
docs(batch-runner): align docstring defaults with the actual signature values

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -570,7 +570,7 @@ class BatchRunner:
             num_workers (int): Number of parallel workers
             verbose (bool): Enable verbose logging
             ephemeral_system_prompt (str): System prompt used during agent execution but NOT saved to trajectories (optional)
-            log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 20)
+            log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 100)
             providers_allowed (List[str]): OpenRouter providers to allow (optional)
             providers_ignored (List[str]): OpenRouter providers to ignore (optional)
             providers_order (List[str]): OpenRouter providers to try in order (optional)
@@ -1186,7 +1186,7 @@ def main(
         batch_size (int): Number of prompts per batch
         run_name (str): Name for this run (used for output and checkpointing)
         distribution (str): Toolset distribution to use (default: "default")
-        model (str): Model name to use (default: "claude-opus-4-20250514")
+        model (str): Model name to use (default: "anthropic/claude-sonnet-4.6")
         api_key (str): API key for model authentication
         base_url (str): Base URL for model API
         max_turns (int): Maximum number of tool calling iterations per prompt (default: 10)
@@ -1195,7 +1195,7 @@ def main(
         verbose (bool): Enable verbose logging (default: False)
         list_distributions (bool): List available toolset distributions and exit
         ephemeral_system_prompt (str): System prompt used during agent execution but NOT saved to trajectories (optional)
-        log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 20)
+        log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 100)
         providers_allowed (str): Comma-separated list of OpenRouter providers to allow (e.g. "anthropic,openai")
         providers_ignored (str): Comma-separated list of OpenRouter providers to ignore (e.g. "together,deepinfra")
         providers_order (str): Comma-separated list of OpenRouter providers to try in order (e.g. "anthropic,openai,google")


### PR DESCRIPTION
## Summary

Three docstring-only corrections in `batch_runner.py`:

1. `log_prefix_chars`: both `BatchRunner.__init__` (line ~547) and `main()` (line ~1170) default to `100`, but both docstrings quote `(default: 20)` — stale from an earlier version.
2. `model`: `main()`'s signature defaults to `"anthropic/claude-sonnet-4.6"`, but the docstring quotes `"claude-opus-4-20250514"` (copied from `BatchRunner.__init__`, whose default really is the older model).

No behavior change — docs only.