### PR TITLE
feat(skills): probe prerequisite commands on PATH at view time

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -702,6 +702,39 @@ class TestSkillViewPrerequisites:
         assert result["missing_required_environment_variables"] == ["SHELL_ONLY_KEY"]
         assert result["readiness_status"] == "setup_needed"
 
+    def test_missing_prerequisite_command_marks_setup_needed(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "cmd-gated-skill",
+                frontmatter_extra="prerequisites:\n  commands: [definitely_missing_cmd_xyz]\n",
+            )
+            raw = skill_view("cmd-gated-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["setup_needed"] is True
+        assert result["readiness_status"] == "setup_needed"
+        assert result["required_commands"] == ["definitely_missing_cmd_xyz"]
+        assert result["missing_required_commands"] == ["definitely_missing_cmd_xyz"]
+        assert "definitely_missing_cmd_xyz" in result.get("setup_note", "")
+
+    def test_present_prerequisite_command_stays_available(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "cmd-ready-skill",
+                frontmatter_extra="prerequisites:\n  commands: [python3]\n",
+            )
+            raw = skill_view("cmd-ready-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["setup_needed"] is False
+        assert result["readiness_status"] == "available"
+        assert result["required_commands"] == ["python3"]
+        assert result["missing_required_commands"] == []
+
     @pytest.mark.parametrize(
         "backend",
         ["ssh", "daytona", "docker", "singularity", "modal", "vercel_sandbox"],

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -37,7 +37,8 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
     prerequisites:                # Optional — legacy runtime requirements
       env_vars: [API_KEY]         #   Legacy env var names are normalized into
                                   #   required_environment_variables on load.
-      commands: [curl, jq]        #   Command checks remain advisory only.
+      commands: [curl, jq]        #   Commands are probed on PATH at view time;
+                                  #   missing ones mark the skill setup_needed.
     compatibility: Requires X     # Optional (agentskills.io)
     metadata:                     # Optional, arbitrary key-value (agentskills.io)
       hermes:
@@ -74,6 +75,7 @@ import threading
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
 import re
+import shutil
 from enum import Enum
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, Any, List, Optional, Set, Tuple
@@ -1580,7 +1582,7 @@ def skill_view(
         skill_name = frontmatter.get(
             "name", skill_md.stem if not skill_dir else skill_dir.name
         )
-        legacy_env_vars, _ = _collect_prerequisite_values(frontmatter)
+        legacy_env_vars, required_commands = _collect_prerequisite_values(frontmatter)
         required_env_vars = _get_required_environment_variables(
             frontmatter, legacy_env_vars
         )
@@ -1645,6 +1647,14 @@ def skill_view(
                     skill_name,
                     exc_info=True,
                 )
+
+        # Probe declared prerequisite commands on PATH. A missing command marks
+        # the skill setup_needed so the payload and cron preflight can name it.
+        missing_required_commands = [
+            cmd for cmd in required_commands if shutil.which(cmd) is None
+        ]
+        if missing_required_commands:
+            setup_needed = True
 
         rendered_content = content
         if preprocess:
@@ -1743,10 +1753,10 @@ def skill_view(
             if linked_files
             else None,
             "required_environment_variables": required_env_vars,
-            "required_commands": [],
+            "required_commands": required_commands,
             "missing_required_environment_variables": remaining_missing_required_envs,
             "missing_credential_files": missing_cred_files,
-            "missing_required_commands": [],
+            "missing_required_commands": missing_required_commands,
             "setup_needed": setup_needed,
             "setup_skipped": capture_result["setup_skipped"],
             "readiness_status": SkillReadinessStatus.SETUP_NEEDED.value
@@ -1780,6 +1790,8 @@ def skill_view(
                 f"env ${env_name}" for env_name in remaining_missing_required_envs
             ] + [
                 f"file {path}" for path in missing_cred_files
+            ] + [
+                f"command '{cmd}'" for cmd in missing_required_commands
             ]
             setup_note = _build_setup_note(
                 SkillReadinessStatus.SETUP_NEEDED,


### PR DESCRIPTION
## What does this PR do?

Skills can declare `prerequisites.commands: [curl, jq]` in SKILL.md frontmatter, but `skill_view` hard-reported `required_commands: []` and never probed PATH — so a command-gated skill looked `available` right up until the agent hit the missing binary mid-task (or a cron run failed on a headless box).

`skill_view` now probes each declared command with `shutil.which`:

- `required_commands` / `missing_required_commands` are populated in the payload
- a missing command flips `setup_needed` / `readiness_status: setup_needed`
- `setup_note` names the missing command (alongside missing env vars and credential files), so cron preflight and operators see the gap before the run

The SKILL.md format docstring is updated to match (command checks are now real probes, not advisory-only).

## Related Issue

None filed — found while auditing skill readiness output: declared command prerequisites were silently dropped.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/skills_tool.py` — collect `prerequisites.commands`, probe with `shutil.which`, populate `required_commands` / `missing_required_commands`, mark `setup_needed`, and include missing commands in `setup_note`.
- `tests/tools/test_skills_tool.py` — missing-command marks `setup_needed` and is named in `setup_note`; present command (`python3`) stays `available` with empty missing list.

## How to Test

1. `pytest tests/tools/test_skills_tool.py`
2. Manual: add `prerequisites: {commands: [definitely_missing_cmd_xyz]}` to a scratch skill's frontmatter, `skill_view` it — payload reports `missing_required_commands: ["definitely_missing_cmd_xyz"]` and `readiness_status: setup_needed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused suite for the changed surface (`pytest tests/tools/test_skills_tool.py` — 43 passed, including the two new cases); full `pytest tests/ -q` is running and I'll confirm in a follow-up comment
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the SKILL.md format docstring in `tools/skills_tool.py` now describes the probe behaviour
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — `shutil.which` is stdlib and honours PATHEXT on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — payload fields already existed; they are now populated instead of hard-empty
