### PR TITLE
fix(auxiliary): honor task endpoint for named providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6235,8 +6235,14 @@ def resolve_provider_client(
         if custom_entry is None:
             custom_entry = _get_named_custom_provider(provider)
         if custom_entry:
-            custom_base = (custom_entry.get("base_url") or "").strip()
-            custom_key = (custom_entry.get("api_key") or "").strip()
+            # A task-specific endpoint is an explicit routing decision.  Keep
+            # the named provider identity for its credentials, transport, and
+            # API mode, but let `auxiliary.<task>.base_url` override the
+            # provider default.  Without this, the resolver correctly carries
+            # the task endpoint to this layer, then silently discards it here
+            # and routes back through the provider-level endpoint.
+            custom_base = (explicit_base_url or custom_entry.get("base_url") or "").strip()
+            custom_key = (explicit_api_key or custom_entry.get("api_key") or "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = _scoped_key_env(custom_key_env)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -106,6 +106,40 @@ class TestAuxiliaryMaxTokensParam:
 
 
 
+class TestNamedCustomProviderTaskEndpoint:
+    def test_task_endpoint_overrides_named_provider_endpoint_but_keeps_provider_key(self):
+        """A per-task endpoint must not be reset to the named provider URL.
+
+        The compression route needs to bypass an admission proxy while reusing
+        the named provider's credentials. Regression: resolution carried the
+        task endpoint to ``resolve_provider_client`` then the named-custom
+        branch silently overwrote it with ``providers.<name>.base_url``.
+        """
+        task_config = {
+            "provider": "custom:litellm",
+            "model": "nim-compact",
+            "base_url": "http://127.0.0.1:14010/v1",
+        }
+        provider_config = {
+            "name": "litellm",
+            "base_url": "http://127.0.0.1:14001/v1",
+            "api_key": "provider-key",
+        }
+        raw_client = MagicMock()
+
+        with (
+            patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=task_config),
+            patch("hermes_cli.runtime_provider._get_named_custom_provider", return_value=provider_config),
+            patch("agent.auxiliary_client._create_openai_client", return_value=raw_client) as create_client,
+        ):
+            client, model = get_text_auxiliary_client("compression")
+
+        assert client is raw_client
+        assert model == "nim-compact"
+        assert create_client.call_args.kwargs["base_url"] == "http://127.0.0.1:14010/v1"
+        assert create_client.call_args.kwargs["api_key"] == "provider-key"
+
+
 class TestResolveTaskProviderModel:
     @pytest.mark.parametrize(
         "provider",


### PR DESCRIPTION
## Summary
- honor `auxiliary.<task>.base_url` after named-provider resolution
- retain the named provider credentials and transport behavior
- add a compression-route regression test

## Verification
- `PYTHONPATH=. /usr/bin/pytest tests/agent/test_auxiliary_client.py -q` → 178 passed
- fresh resolver against the real config resolves `compression` to `http://127.0.0.1:14010/v1/`

## Scope
This is distinct from the open PRs that preserve a named provider during task resolution. This change fixes the later named-provider branch that discarded an already-resolved task endpoint.

No runtime restart or deployment is included.