### PR TITLE
fix(anthropic): track the current fast-mode model matrix (Opus 4.8 / Opus 5)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -130,7 +130,7 @@ def _is_claude_model(model: str | None) -> bool:
     return "claude" in (model or "").lower()
 
 
-_FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
+_FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-8", "opus-4.8", "opus-5")
 
 # ── Max output token limits per Anthropic model ───────────────────────
 # Source: Anthropic docs + Cline model catalog.  Anthropic's API requires
@@ -311,13 +311,28 @@ def _forbids_sampling_params(model: str) -> bool:
 
 
 def _supports_fast_mode(model: str) -> bool:
-    """Return True for models that support Anthropic Fast Mode (speed=fast).
+    """Return True for models that accept the ``speed: "fast"`` request param.
 
-    Per Anthropic docs, fast mode is currently supported on Opus 4.6 only.
-    Sending ``speed: "fast"`` to any other Claude model (including Opus 4.7)
-    returns HTTP 400. This guard prevents silently 400'ing when stale config
-    or older callers leave fast mode enabled across a model upgrade.
+    Per the Anthropic fast-mode docs (research preview), the ``speed`` param
+    is supported on Opus 4.8 and Opus 5 — Claude API only. The matrix has
+    changed with nearly every Opus release, in both directions:
+
+    - Opus 4.6 HAD fast mode at launch and LOST it (2026-06-29): requests
+      with ``speed: "fast"`` do not error — they silently run at standard
+      speed and bill standard rates (``usage.speed: "standard"``). Keeping
+      4.6 in this allowlist would show users a fast toggle that does
+      nothing.
+    - Opus 4.7 never had it and hard-400s on the parameter.
+    - Dedicated ``…-fast`` model ids (e.g. OpenRouter's
+      ``claude-opus-4.8-fast``) select fast inference via the model field
+      itself and must NOT also receive the speed parameter.
+
+    Keep this an explicit allowlist rather than a version-floor check so a
+    model that drops fast mode again fails closed (standard speed) instead
+    of silently 400'ing.
     """
+    if "-fast" in model:
+        return False
     return any(v in model for v in _FAST_MODE_SUPPORTED_SUBSTRINGS)
 
 
@@ -2862,9 +2877,9 @@ def build_anthropic_kwargs(
     thinking block signatures are stripped (they are Anthropic-proprietary).
 
     When *fast_mode* is True, adds ``extra_body["speed"] = "fast"`` and the
-    fast-mode beta header for ~2.5x faster output throughput on Opus 4.6.
-    Currently only supported on native Anthropic endpoints (not third-party
-    compatible ones).
+    fast-mode beta header for ~2.5x faster output throughput on Opus 4.8 /
+    Opus 5. Currently only supported on native Anthropic endpoints (not
+    third-party compatible ones).
     """
     system, anthropic_messages = convert_messages_to_anthropic(
         messages, base_url=base_url, model=model
@@ -3031,12 +3046,15 @@ def build_anthropic_kwargs(
         for _sampling_key in ("temperature", "top_p", "top_k"):
             kwargs.pop(_sampling_key, None)
 
-    # ── Fast mode (Opus 4.6 only) ────────────────────────────────────
+    # ── Fast mode (Opus 4.8 / Opus 5) ────────────────────────────────
     # Adds extra_body.speed="fast" + the fast-mode beta header for ~2.5x
-    # output speed. Per Anthropic docs, fast mode is only supported on
-    # Opus 4.6 — Opus 4.7 and other models 400 on the speed parameter.
+    # output speed. Per Anthropic docs the speed param is supported on
+    # Opus 4.8 and Opus 5 (research preview); Opus 4.7 400s on it and
+    # Opus 4.6 silently ignores it (standard speed, standard billing).
     # Only for native Anthropic endpoints — third-party providers would
-    # reject the unknown beta header and speed parameter.
+    # reject the unknown beta header and speed parameter, and Anthropic
+    # itself scopes fast mode to the Claude API (not Bedrock/Vertex/
+    # Foundry).
     if (
         fast_mode
         and not _is_third_party_anthropic_endpoint(base_url)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2613,20 +2613,28 @@ def model_supports_fast_mode(model_id: Optional[str]) -> bool:
 def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:
     """Return True if the model accepts the Anthropic Fast Mode ``speed`` param.
 
-    This gates the *speed=fast request parameter*, which Anthropic supports on
-    Opus 4.6 only (Opus 4.7 explicitly 400s). It is deliberately NOT a general
-    "is this a fast model" check: for Opus 4.8 the fast offering is a SEPARATE
-    model id (``…-opus-4.8-fast``) selected via the model field, not the speed
-    parameter — see ``agent.anthropic_adapter._supports_fast_mode`` and its
-    test. Keep this in lock-step with that adapter gate so the UI never shows a
-    Fast toggle that the runtime would silently drop.
+    This gates the *speed=fast request parameter*, which Anthropic supports
+    on Opus 4.8 and Opus 5 (research preview, Claude API only). It is
+    deliberately NOT a general "is this a fast model" check:
+
+    - Opus 4.6 had fast mode at launch and LOST it (2026-06-29) — the param
+      is silently ignored (standard speed, standard billing), so exposing a
+      toggle for it would show users a switch that does nothing.
+    - Opus 4.7 hard-400s on the parameter.
+    - Dedicated ``…-fast`` model ids (e.g. OpenRouter's
+      ``claude-opus-4.8-fast``) select fast inference via the model field
+      and must not also receive the speed parameter.
+
+    Keep this in lock-step with ``agent.anthropic_adapter._supports_fast_mode``
+    so the UI never shows a Fast toggle that the runtime would drop.
     """
     raw = _strip_vendor_prefix(str(model_id or ""))
     base = raw.split(":")[0]
     if not base.startswith("claude-"):
         return False
-    # Only Opus 4.6 supports the speed=fast parameter at present.
-    return "opus-4-6" in base or "opus-4.6" in base
+    if "-fast" in base:
+        return False
+    return any(v in base for v in ("opus-4-8", "opus-4.8", "opus-5"))
 
 
 def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | None:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -962,19 +962,23 @@ class TestBuildAnthropicKwargs:
 
 
     def test_supports_fast_mode_predicate(self):
-        """Fast mode is Opus 4.6 only — Opus 4.7 and others must be excluded.
+        """The speed-param allowlist tracks the live fast-mode docs.
 
-        For Opus 4.8 the fast variant is a separate model ID
-        (anthropic/claude-opus-4.8-fast) routed through the normal model
-        field, NOT via the ``speed: "fast"`` request parameter. So
-        ``_supports_fast_mode`` (which gates the parameter) must stay
-        False for both opus-4-8 and opus-4-8-fast.
+        Per https://platform.claude.com/docs/en/build-with-claude/fast-mode:
+        Opus 4.8 and Opus 5 support ``speed: "fast"``. Opus 4.6 LOST fast
+        mode (param silently ignored → standard speed at standard billing);
+        Opus 4.7 hard-400s. Dedicated ``…-fast`` model ids select fast
+        inference via the model field and must not also get the param.
         """
         from agent.anthropic_adapter import _supports_fast_mode
-        assert _supports_fast_mode("claude-opus-4-6") is True
-        assert _supports_fast_mode("anthropic/claude-opus-4-6") is True
+        assert _supports_fast_mode("claude-opus-4-8") is True
+        assert _supports_fast_mode("claude-opus-4.8") is True
+        assert _supports_fast_mode("anthropic/claude-opus-4-8") is True
+        assert _supports_fast_mode("claude-opus-5") is True
+        assert _supports_fast_mode("anthropic/claude-opus-5") is True
+        assert _supports_fast_mode("claude-opus-4-6") is False
+        assert _supports_fast_mode("anthropic/claude-opus-4-6") is False
         assert _supports_fast_mode("claude-opus-4-7") is False
-        assert _supports_fast_mode("claude-opus-4-8") is False
         assert _supports_fast_mode("claude-opus-4-8-fast") is False
         assert _supports_fast_mode("claude-sonnet-4-6") is False
         assert _supports_fast_mode("claude-haiku-4-5") is False

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -191,28 +191,36 @@ class TestAnthropicFastMode(unittest.TestCase):
     def test_anthropic_opus_supported(self):
         from hermes_cli.models import model_supports_fast_mode
 
+        # Per the live fast-mode docs: Opus 4.8 + Opus 5, Claude API only.
         # Native Anthropic format (hyphens)
-        assert model_supports_fast_mode("claude-opus-4-6") is True
+        assert model_supports_fast_mode("claude-opus-4-8") is True
         # OpenRouter format (dots)
-        assert model_supports_fast_mode("claude-opus-4.6") is True
+        assert model_supports_fast_mode("claude-opus-4.8") is True
         # With vendor prefix
-        assert model_supports_fast_mode("anthropic/claude-opus-4-6") is True
-        assert model_supports_fast_mode("anthropic/claude-opus-4.6") is True
+        assert model_supports_fast_mode("anthropic/claude-opus-4-8") is True
+        assert model_supports_fast_mode("anthropic/claude-opus-4.8") is True
+        assert model_supports_fast_mode("claude-opus-5") is True
+        assert model_supports_fast_mode("anthropic/claude-opus-5") is True
 
-    def test_anthropic_non_opus46_models_excluded(self):
-        """The speed=fast parameter is gated to Opus 4.6 — others excluded.
+    def test_anthropic_unsupported_models_excluded(self):
+        """The speed=fast parameter is gated to Opus 4.8 / Opus 5.
 
-        Per https://platform.claude.com/docs/en/build-with-claude/fast-mode,
-        sending speed=fast to Opus 4.7, Sonnet, or Haiku returns HTTP 400.
-        Opus 4.8 uses a separate ``…-fast`` model id, not this parameter.
+        Per https://platform.claude.com/docs/en/build-with-claude/fast-mode:
+        Opus 4.6 LOST fast mode 2026-06-29 (the param is silently ignored —
+        standard speed at standard billing — so a toggle would do nothing);
+        Opus 4.7 hard-400s; Sonnet/Haiku never had it; dedicated ``…-fast``
+        ids select fast inference via the model field, not the parameter.
         """
         from hermes_cli.models import model_supports_fast_mode
 
         assert model_supports_fast_mode("claude-sonnet-4-6") is False
         assert model_supports_fast_mode("claude-sonnet-4.6") is False
         assert model_supports_fast_mode("claude-haiku-4-5") is False
+        assert model_supports_fast_mode("claude-opus-4-6") is False
+        assert model_supports_fast_mode("claude-opus-4.6") is False
         assert model_supports_fast_mode("claude-opus-4-7") is False
-        assert model_supports_fast_mode("claude-opus-4-8") is False
+        assert model_supports_fast_mode("claude-opus-4-8-fast") is False
+        assert model_supports_fast_mode("anthropic/claude-opus-4.8-fast") is False
         assert model_supports_fast_mode("anthropic/claude-sonnet-4.6") is False
         assert model_supports_fast_mode("anthropic/claude-opus-4-7") is False
 
@@ -221,10 +229,10 @@ class TestAnthropicFastMode(unittest.TestCase):
     def test_resolve_overrides_returns_speed_for_anthropic(self):
         from hermes_cli.models import resolve_fast_mode_overrides
 
-        result = resolve_fast_mode_overrides("claude-opus-4-6")
+        result = resolve_fast_mode_overrides("claude-opus-4-8")
         assert result == {"speed": "fast"}
 
-        result = resolve_fast_mode_overrides("anthropic/claude-opus-4.6")
+        result = resolve_fast_mode_overrides("anthropic/claude-opus-4.8")
         assert result == {"speed": "fast"}
 
 
@@ -232,7 +240,7 @@ class TestAnthropicFastMode(unittest.TestCase):
 
 
     def test_fast_command_hidden_for_anthropic_sonnet(self):
-        """Sonnet doesn't support fast mode (Opus 4.6 only) — /fast must be hidden."""
+        """Sonnet doesn't support fast mode (Opus 4.8/5 only) — /fast must be hidden."""
         cli_mod = _import_cli()
         stub = SimpleNamespace(
             provider="anthropic", requested_provider="anthropic",
@@ -246,7 +254,7 @@ class TestAnthropicFastMode(unittest.TestCase):
         """Anthropic models should get speed:'fast' override, not service_tier."""
         cli_mod = _import_cli()
         stub = SimpleNamespace(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             api_key="sk-ant-test",
             base_url="https://api.anthropic.com",
             provider="anthropic",
@@ -270,7 +278,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         from agent.anthropic_adapter import build_anthropic_kwargs, _FAST_MODE_BETA
 
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
             tools=None,
             max_tokens=None,
@@ -286,7 +294,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         from agent.anthropic_adapter import build_anthropic_kwargs
 
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
             tools=None,
             max_tokens=None,
@@ -301,7 +309,7 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         from agent.anthropic_adapter import build_anthropic_kwargs
 
         kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-6",
+            model="claude-opus-4-8",
             messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
             tools=None,
             max_tokens=None,


### PR DESCRIPTION
## What

The Anthropic fast-mode allowlist (`_FAST_MODE_SUPPORTED_SUBSTRINGS` in the adapter, `_is_anthropic_fast_model` in the CLI) still gates `speed: "fast"` on **Opus 4.6** — but the fast-mode matrix has changed twice since that was written. Per the [live fast-mode docs](https://platform.claude.com/docs/en/build-with-claude/fast-mode):

- **Opus 4.8 and Opus 5 support fast mode** (research preview, Claude API only — not Bedrock/Vertex/Foundry).
- **Opus 4.6 LOST fast mode on 2026-06-29.** The parameter doesn't error: requests silently run at standard speed and bill standard rates (`usage.speed: "standard"`).
- Opus 4.7 never had it and hard-400s (unchanged).
- Dedicated `…-fast` model ids (e.g. OpenRouter's `claude-opus-4.8-fast`) select fast inference via the model field and are explicitly excluded from the param gate.

So today's allowlist is stale in **both directions**: Opus 4.6 users see a `/fast` toggle that does nothing (standard speed, no error, no signal), while Opus 4.8/5 users — the models that actually support it — can't turn it on.

This PR moves both gates (adapter param gate + CLI toggle gate, kept in lock-step as before) to `(opus-4-8, opus-4.8, opus-5)`, excludes `…-fast` ids explicitly, and rewrites the predicate/matrix tests against the current docs. Docstrings record the history in both directions so the next matrix change has context — this allowlist has now needed correcting twice, and the fail-closed direction differs per model (4.6 silently no-ops, 4.7 hard-400s).

## Why

- Showing a fast toggle that silently does nothing is worse than not showing it: users believe they're getting 2.5x output speed and premium billing semantics they aren't getting.
- The two models that DO support fast mode can't enable it at all.

## How to test

```
scripts/run_tests.sh tests/agent/test_anthropic_adapter.py tests/cli/test_fast_command.py -- -q
```

113 tests pass. The updated predicate/matrix tests fail against the previous allowlist (verified by stashing the source changes — RED confirmed). Tested on Linux (aarch64).

Note: I previously opened #48342 for an earlier iteration of this matrix (4.6+4.8); it auto-closed when its head fork was deleted, and the matrix has since changed again (4.6 dropped). This PR supersedes it against the current docs.
