### PR TITLE
fix(desktop): let Windows ARM64 builds finish without get-windows bindings

### DIFF
--- a/apps/desktop/scripts/before-pack.mjs
+++ b/apps/desktop/scripts/before-pack.mjs
@@ -144,11 +144,10 @@ export default async function beforePack(context) {
         await stageNodePty({ platform, arch: archName })
         console.log(`[before-pack] re-staged node-pty for target ${platform}-${archName}`)
       }
-      // get-windows' native payload is per-platform, not per-arch (the macOS
-      // helper is universal, Windows stages every prebuilt binding dir), so
-      // it re-stages for the universal target too.
-      stageGetWindows({ platform })
-      console.log(`[before-pack] re-staged get-windows for target ${platform}`)
+      // The macOS helper is universal, while Windows bindings are arch-specific.
+      // Pass the target arch so an ARM64 package never stages an x64 binding.
+      stageGetWindows({ platform, arch: archName })
+      console.log(`[before-pack] re-staged get-windows for target ${platform}-${archName}`)
     }
   } catch (err) {
     // This one SHOULD fail the build — a missing/wrong native binary for the

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -429,7 +429,7 @@ const GET_WINDOWS_VERSION = '9.3.0'
 export function stageGetWindowsInto(
   srcRoot,
   destRoot,
-  { platform = process.platform, rebuild } = {}
+  { platform = process.platform, arch = process.arch, rebuild } = {}
 ) {
   // The STAGED_WINDOWS_JS rewrite mirrors this exact version's export surface.
   // A version bump must fail the build here until the rewrite is re-verified —
@@ -482,11 +482,20 @@ export function stageGetWindowsInto(
         ? readdirSync(bindingRoot).filter(
             (dir) =>
               dir.includes(`-${platform}-`) &&
+              dir.endsWith(`-${arch}`) &&
               existsSync(join(bindingRoot, dir, 'node-get-windows.node'))
           )
         : []
     let bindingDirs = scanBindingDirs()
-    if (bindingDirs.length === 0 && typeof rebuild === 'function') {
+    if (bindingDirs.length === 0 && arch === 'arm64') {
+      // get-windows 9.3.0 publishes win32 prebuilds for ia32/x64 only.
+      // The staged windows.js deliberately fails soft when binding/ is absent,
+      // so preserve the desktop build and disable only window enumeration.
+      console.warn(
+        '[stage-native-deps] get-windows has no win32-arm64 prebuilt binding; ' +
+          'staging the fail-soft JS surface without native window enumeration.'
+      )
+    } else if (bindingDirs.length === 0 && typeof rebuild === 'function') {
       // A plain `npm install` won't re-run an install script for a package
       // that is already on disk, so every checkout that installed while
       // get-windows was missing from allowScripts stays bricked even after
@@ -497,9 +506,9 @@ export function stageGetWindowsInto(
       rebuild()
       bindingDirs = scanBindingDirs()
     }
-    if (bindingDirs.length === 0) {
+    if (bindingDirs.length === 0 && arch !== 'arm64') {
       throw new Error(
-        '[stage-native-deps] get-windows has no win32 prebuilt binding under lib/binding. ' +
+        `[stage-native-deps] get-windows has no win32-${arch} prebuilt binding under lib/binding. ` +
           'Recover from the checkout root with:\n' +
           '  npm install-scripts approve get-windows\n' +
           '  npm rebuild get-windows'
@@ -537,19 +546,19 @@ function rebuildGetWindowsViaNpm() {
   }
 }
 
-export function stageGetWindows({ platform = process.platform } = {}) {
+export function stageGetWindows({ platform = process.platform, arch = process.arch } = {}) {
   const srcRoot = resolveGetWindowsRoot()
   const destRoot = resolve(projectRoot, 'dist/node_modules/get-windows')
   // Only a win32 host can produce the win32 binding, so a cross-platform pack
   // has nothing to gain from the rebuild.
   const rebuild =
     platform === 'win32' && process.platform === 'win32' ? rebuildGetWindowsViaNpm : undefined
-  return stageGetWindowsInto(srcRoot, destRoot, { platform, rebuild })
+  return stageGetWindowsInto(srcRoot, destRoot, { platform, arch, rebuild })
 }
 
 // Allow direct CLI invocation: node scripts/stage-native-deps.mjs [platform] [arch]
 if (isMain(import.meta.url)) {
   const [platform, arch] = process.argv.slice(2)
   stageNodePty({ platform, arch })
-  stageGetWindows({ platform })
+  stageGetWindows({ platform, arch })
 }

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -390,7 +390,7 @@ test('win32 staging skips the darwin binding the tarball bundles on every platfo
       ]
     })
 
-    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32' })
+    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64' })
 
     assert.ok(existsSync(join(destRoot, 'lib', 'binding', 'napi-9-win32-unknown-x64', 'node-get-windows.node')))
     assert.ok(!existsSync(join(destRoot, 'lib', 'binding', 'napi-9-darwin-unknown-arm64')))
@@ -410,7 +410,7 @@ test('win32 staging rejects a binding dir that claims win32 but holds a foreign 
     })
 
     assert.throws(
-      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32' }),
+      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64' }),
       /expected win32, got darwin/
     )
   } finally {
@@ -418,7 +418,7 @@ test('win32 staging rejects a binding dir that claims win32 but holds a foreign 
   }
 })
 
-test('win32 staging fails when only foreign bindings exist', () => {
+test('win32-x64 staging fails when only foreign bindings exist', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
   try {
     const srcRoot = join(tmp, 'get-windows')
@@ -429,9 +429,31 @@ test('win32 staging fails when only foreign bindings exist', () => {
     })
 
     assert.throws(
-      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32' }),
-      /no win32 prebuilt binding/
+      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64' }),
+      /no win32-x64 prebuilt binding/
     )
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('win32-arm64 staging omits incompatible bindings and keeps the fail-soft JS surface', () => {
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const srcRoot = join(tmp, 'get-windows')
+    const destRoot = join(tmp, 'dest')
+
+    makeFakeGetWindows(srcRoot, {
+      bindings: [
+        { dir: 'napi-9-darwin-unknown-arm64', platform: 'darwin' },
+        { dir: 'napi-9-win32-unknown-x64', platform: 'win32' }
+      ]
+    })
+
+    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'arm64' })
+
+    assert.ok(existsSync(join(destRoot, 'lib', 'windows.js')))
+    assert.ok(!existsSync(join(destRoot, 'lib', 'binding')))
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
   }
@@ -456,7 +478,7 @@ test('win32 staging self-heals through the rebuild hook when the binding is miss
       )
     }
 
-    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', rebuild })
+    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64', rebuild })
 
     assert.equal(calls, 1)
     assert.ok(
@@ -476,7 +498,12 @@ test('win32 staging reports the recovery steps when the rebuild hook produces no
     makeFakeGetWindows(srcRoot, { bindings: [] })
 
     assert.throws(
-      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', rebuild: () => {} }),
+      () =>
+        stageGetWindowsInto(srcRoot, destRoot, {
+          platform: 'win32',
+          arch: 'x64',
+          rebuild: () => {}
+        }),
       /npm rebuild get-windows/
     )
   } finally {


### PR DESCRIPTION
## What does this PR do?

Windows ARM64 desktop packaging currently aborts because get-windows 9.3.0 does not publish a win32-arm64 native binding. This change keeps the package build usable by staging the existing fail-soft JavaScript surface without a native binding only for Windows ARM64, while supported Windows architectures continue to fail closed when their required binding is missing.

### Symptom

A Windows ARM64 desktop build fails during `beforePack` with `get-windows has no win32 prebuilt binding under lib/binding`, so electron-builder never produces the new unpacked desktop application.

### Impact

Hermes Desktop cannot be rebuilt or updated natively on Windows ARM64. Window enumeration is unavailable on that architecture because the upstream native binding does not exist, but the rest of the desktop package does not need to be blocked.

### Bug Cause

**Trigger:** `apps/desktop/scripts/before-pack.mjs:149` called get-windows staging without preserving the electron-builder target architecture.

**Causal chain:**
1. electron-builder starts a Windows ARM64 package and supplies `context.arch`.
2. `beforePack` dropped that architecture, while `stageGetWindowsInto` accepted any win32 binding directory and then threw when no binding was present.
3. get-windows publishes ia32 and x64 Windows bindings but no ARM64 binding, so the desktop build aborted before producing the unpacked application.

**Why it is wrong:** The staging policy treated every missing Windows binding as a broken installation even though the staged JavaScript wrapper already has an intentional unavailable fallback for a missing native addon.

**Working sibling / contrast:** Windows x64 and ia32 have upstream bindings and must continue to stage only their matching architecture. A missing or foreign binding on those supported targets remains a packaging error.

**Ruled out:** This is not an install-script approval failure. Rebuilding get-windows cannot create the unpublished win32-arm64 artifact, while the existing rebuild recovery remains valid for supported Windows architectures.

### Fix

Propagate the target architecture from `beforePack`, filter candidate bindings by both platform and architecture, and allow only the win32-arm64 target to stage the fail-soft JavaScript surface without `lib/binding`. Add regression coverage for the ARM64 degradation path and preserve fail-closed coverage for supported Windows architectures.

## Related Issue

Closes #82314

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/scripts/before-pack.mjs` - pass the electron-builder target architecture into get-windows staging.
- `apps/desktop/scripts/stage-native-deps.mjs` - select only matching Windows bindings and degrade safely when win32-arm64 has no upstream binding.
- `apps/desktop/scripts/stage-native-deps.test.mjs` - cover ARM64 fail-soft staging and supported-architecture fail-closed behavior.

## How to Test

1. Run the Windows staging tests and confirm all 7 selected tests pass.
2. Run the beforePack suite and confirm all 10 tests pass.
3. Run ESLint on the three changed scripts.

```bash
cd apps/desktop
npx vitest run --project electron scripts/stage-native-deps.test.mjs -t 'win32'
npx vitest run --project electron scripts/before-pack.test.mjs
npx eslint scripts/before-pack.mjs scripts/stage-native-deps.mjs scripts/stage-native-deps.test.mjs
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] N/A - No Python files changed; the targeted desktop test and lint commands above pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 x64, with the Windows ARM64 target modeled by the staging fixture

### Documentation & Housekeeping

- [x] N/A - No documentation changes are required for this packaging compatibility fix
- [x] N/A - No config keys changed
- [x] N/A - No architecture or workflow documentation changed
- [x] I've considered cross-platform impact: macOS and Linux staging behavior is unchanged, and supported Windows architectures remain fail closed
- [x] N/A - No model tool descriptions or schemas changed
