### PR TITLE
feat(discord)!: scope free_response_channels to mention gating only

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1050,7 +1050,8 @@ platform_toolsets:
 #
 # discord:
 #   require_mention: true            # Require @mention in server channels (default: true)
-#   auto_thread: true                # Auto-create thread on @mention (default: true)
+#   auto_thread: true                # Auto-create thread for handled channel messages (default: true)
+#   no_thread_channels: []           # Channel IDs that reply inline instead of threading
 #   free_response_channels: ""       # Channel IDs where no mention is needed
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7756,13 +7756,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
                     return False
         # Auto-thread: when enabled, automatically create a thread for every
-        # @mention in a text channel so each conversation is isolated (like Slack).
-        # Messages already inside threads or DMs are unaffected.
-        # no_thread_channels: channels where bot responds directly without thread.
+        # new text-channel conversation the bot handles so each conversation is
+        # isolated (like Slack). Messages already inside threads or DMs are
+        # unaffected. no_thread_channels is the explicit escape hatch for
+        # channels where the bot should respond directly without a thread.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels = self._get_no_thread_channels()
-            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_keys & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -179,6 +179,27 @@ async def test_no_thread_channel_skips_auto_thread(adapter, monkeypatch):
     assert event.source.chat_type == "group"
 
 
+@pytest.mark.asyncio
+async def test_free_response_channel_still_auto_threads(adapter, monkeypatch):
+    """Free-response channels should bypass mention gating but still auto-thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "900")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    fake_thread = FakeThread(channel_id=999)
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(channel=FakeTextChannel(channel_id=900), content="hello without mention")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
 # ── auto-thread failure must not silently fall back to inline (#20243) ──
 
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -277,18 +277,44 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
 
 
 @pytest.mark.asyncio
-async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypatch):
-    """Free-response channels should reply inline, never spawn a new thread.
+async def test_discord_free_response_channel_does_not_skip_auto_thread(adapter, monkeypatch):
+    """free_response_channels gates mentions only — it must not skip threading.
 
-    Without this, every message in a free-response channel would auto-create
-    a fresh thread (since the channel bypasses the @mention gate, every
-    message looks like a fresh trigger).  That turns a "lightweight chat"
-    channel into a thread-spawning machine — see the docs at
-    website/docs/user-guide/messaging/discord.md which already describe
-    this as the intended behavior.
+    Replaces the inverse assertion added in 93fe4b35, which folded
+    ``is_free_channel`` into ``skip_thread``.  That overloaded one setting with
+    two unrelated policies: when the bot answers, and where the answer goes.
+    Threading is now governed solely by ``auto_thread`` +
+    ``no_thread_channels``; see the companion coverage in
+    test_discord_channel_controls.py for the no-thread escape hatch.
     """
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+
+    fake_thread = FakeThread(channel_id=790)
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="casual chat in free-response channel",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "casual chat in free-response channel"
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_response_with_no_thread_channel_replies_inline(adapter, monkeypatch):
+    """The documented migration path: pair the channel with no_thread_channels."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "789")
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
 
     adapter._auto_create_thread = AsyncMock()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -329,7 +329,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `DISCORD_COMMAND_SYNC_POLICY` | Discord slash-command startup sync policy: `safe` (diff and reconcile), `bulk` (legacy `tree.sync()`), or `off` |
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
-| `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
+| `DISCORD_AUTO_THREAD` | Auto-create a thread for each handled channel message (default: `true`); exempt channels via `DISCORD_NO_THREAD_CHANNELS` |
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | When `true`, accept attachments of any file type (not just the built-in PDF/text/zip/office allowlist). Unknown types are cached and surfaced to the agent as a local path so it can inspect them via `terminal` / `read_file` / `ffprobe`. Default `false`. |
 | `DISCORD_MAX_ATTACHMENT_BYTES` | Maximum bytes per attachment the gateway will cache. Default `33554432` (32 MiB). Set to `0` for no cap (attachments are held in memory while being written). |
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2182,12 +2182,12 @@ Configure Discord-specific behavior for the messaging gateway:
 discord:
   require_mention: true          # Require @mention to respond in server channels
   free_response_channels: ""     # Comma-separated channel IDs where bot responds without @mention
-  auto_thread: true              # Auto-create threads on @mention in channels
+  auto_thread: true              # Auto-create threads for handled channel messages
 ```
 
 - `require_mention` — when `true` (default), the bot only responds in server channels when mentioned with `@BotName`. DMs always work without mention.
 - `free_response_channels` — comma-separated list of channel IDs where the bot responds to every message without requiring a mention.
-- `auto_thread` — when `true` (default), mentions in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading).
+- `auto_thread` — when `true` (default), messages the bot handles in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading). List channels in `no_thread_channels` to keep replies inline there.
 
 ## Security
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -16,13 +16,13 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
-| **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. Messages in these channels are answered inline — auto-threading is skipped so the channel stays a lightweight chat. |
+| **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. This controls *when* Hermes answers, not *where* the answer goes: auto-threading still applies. Add the channel to `DISCORD_NO_THREAD_CHANNELS` if you want inline replies so the channel stays a lightweight chat. |
 | **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
 
 :::tip
-If you want a normal bot-help channel where people can talk to Hermes without tagging it every time, add that channel to `DISCORD_FREE_RESPONSE_CHANNELS`.
+If you want a normal bot-help channel where people can talk to Hermes without tagging it every time, add that channel to `DISCORD_FREE_RESPONSE_CHANNELS`. Add it to `DISCORD_NO_THREAD_CHANNELS` as well if you also want the replies inline instead of in a thread.
 :::
 
 ### Discord Gateway Model
@@ -300,7 +300,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_THREAD_REQUIRE_MENTION` | No | `false` | When `true`, the in-thread mention shortcut is disabled — threads are gated the same as channels, requiring `@mention` even after the bot has already participated. Use this when multiple bots share a thread and you want each to fire only on explicit `@mention`. |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
-| `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
+| `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every text-channel message the bot handles, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. Use `DISCORD_NO_THREAD_CHANNELS` to exempt individual channels. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
@@ -400,15 +400,19 @@ discord:
 
 If a thread's parent channel is in this list, the thread also becomes mention-free.
 
-Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface. If you want threading behavior, don't list the channel as free-response (use normal `@mention` flow instead).
+This setting governs **mention gating only** — it does not change where the bot replies. Free-response channels still auto-thread when [`auto_thread`](#discordauto_thread) is `true` (the default). To keep a channel as a lightweight inline chat surface, add it to [`no_thread_channels`](#discordno_thread_channels), which is the single control for opting out of threading.
+
+:::warning Changed behavior
+Free-response channels previously skipped auto-threading implicitly. They no longer do. If you relied on that, add the same channel IDs to `no_thread_channels` to restore inline replies.
+:::
 
 #### `discord.auto_thread`
 
 **Type:** boolean — **Default:** `true`
 
-When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
+When enabled, every message the bot handles in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating. Set [`thread_require_mention`](#discordthread_require_mention) to `true` to disable this in-thread shortcut for multi-bot setups.
 
-Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in [`no_thread_channels`](#discordno_thread_channels) bypass auto-threading and get inline replies instead — that list is the only way to opt a channel out of threading while leaving `auto_thread` on.
 
 #### `discord.reactions`
 
@@ -446,6 +450,8 @@ If a thread's parent channel is in this list, messages in that thread are also i
 **Type:** string or list — **Default:** `[]`
 
 Channel IDs where the bot responds directly in the channel instead of auto-creating a thread. This only has an effect when `auto_thread` is `true` (the default). In these channels, the bot responds inline like a normal message rather than spawning a new thread.
+
+This is the single escape hatch for threading, and it is independent of mention gating — list a channel here whether or not it is also in [`free_response_channels`](#discordfree_response_channels).
 
 ```yaml
 discord:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -265,7 +265,7 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `DISCORD_COMMAND_SYNC_POLICY` | Discord 斜杠命令启动同步策略：`safe`（差异对比并协调）、`bulk`（旧版 `tree.sync()`）或 `off` |
 | `DISCORD_REQUIRE_MENTION` | 在服务器频道中响应前要求 @mention |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | 不需要 mention 的逗号分隔频道 ID |
-| `DISCORD_AUTO_THREAD` | 支持时自动将长回复转为线程 |
+| `DISCORD_AUTO_THREAD` | 为机器人处理的每条频道消息自动创建线程（默认：`true`）；通过 `DISCORD_NO_THREAD_CHANNELS` 豁免个别频道 |
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | 设为 `true` 时接受任意文件类型的附件（不仅限于内置的 PDF/文本/zip/office 白名单）。未知类型被缓存并以本地路径形式提供给 agent，供其通过 `terminal`/`read_file`/`ffprobe` 检查。默认 `false`。 |
 | `DISCORD_MAX_ATTACHMENT_BYTES` | gateway 缓存的每个附件最大字节数。默认 `33554432`（32 MiB）。设为 `0` 表示无上限（附件在写入时保存在内存中）。 |
 | `DISCORD_REACTIONS` | 处理期间在消息上启用 emoji 反应（默认：`true`） |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1588,12 +1588,12 @@ timezone: "America/New_York"   # IANA 时区（默认："" = 服务器本地时�
 discord:
   require_mention: true          # 在服务器频道中需要 @提及才能响应
   free_response_channels: ""     # 逗号分隔的频道 ID，bot 在这些频道无需 @提及即可响应
-  auto_thread: true              # 在频道中 @提及时自动创建线程
+  auto_thread: true              # 为 bot 处理的频道消息自动创建线程
 ```
 
 - `require_mention` —— 为 `true`（默认）时，bot 仅在服务器频道中被 `@BotName` 提及时响应。DM 始终无需提及即可工作。
 - `free_response_channels` —— 逗号分隔的频道 ID 列表，bot 在这些频道对每条消息响应，无需提及。
-- `auto_thread` —— 为 `true`（默认）时，频道中的提及会自动为对话创建线程，保持频道整洁（类似 Slack 线程）。
+- `auto_thread` —— 为 `true`（默认）时，bot 在频道中处理的消息会自动为对话创建线程，保持频道整洁（类似 Slack 线程）。若要让某些频道直接回复，请将它们列入 `no_thread_channels`。
 
 ## 安全
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/discord.md
@@ -16,13 +16,13 @@ Hermes Agent 以机器人形式与 Discord 集成，让你可以通过私信或�
 |---------|----------|
 | **私信（DM）** | Hermes 响应每条消息，无需 `@提及`。每个私信有独立的会话。 |
 | **服务器频道** | 默认情况下，Hermes 仅在被 `@提及` 时响应。如果你在频道中发帖但未提及它，Hermes 会忽略该消息。 |
-| **自由响应频道** | 你可以通过 `DISCORD_FREE_RESPONSE_CHANNELS` 将特定频道设为无需提及，或通过 `DISCORD_REQUIRE_MENTION=false` 全局禁用提及要求。这些频道中的消息会直接回复——自动创建线程功能会被跳过，使频道保持轻量级聊天状态。 |
+| **自由响应频道** | 你可以通过 `DISCORD_FREE_RESPONSE_CHANNELS` 将特定频道设为无需提及，或通过 `DISCORD_REQUIRE_MENTION=false` 全局禁用提及要求。此设置只控制 Hermes *何时* 回复，而不控制回复*发送到哪里*：自动创建线程仍然生效。如果你希望机器人直接回复、让频道保持轻量级聊天状态，请将该频道加入 `DISCORD_NO_THREAD_CHANNELS`。 |
 | **线程（Thread）** | Hermes 在同一线程中回复。提及规则仍然适用，除非该线程或其父频道被配置为自由响应。线程的会话历史与父频道相互隔离。 |
 | **多用户共享频道** | 默认情况下，Hermes 为安全和清晰起见，在频道内按用户隔离会话历史。在同一频道中交谈的两个人不会共享同一份对话记录，除非你明确禁用该功能。 |
 | **提及其他用户的消息** | 当 `DISCORD_IGNORE_NO_MENTION` 为 `true`（默认值）时，如果消息 @提及了其他用户但**未**提及机器人，Hermes 保持沉默。这可防止机器人介入针对其他人的对话。如果你希望机器人响应所有消息而不管提及了谁，请设置为 `false`。此设置仅适用于服务器频道，不适用于私信。 |
 
 :::tip
-如果你想要一个普通的机器人帮助频道，让用户无需每次都 @标记就能与 Hermes 对话，请将该频道添加到 `DISCORD_FREE_RESPONSE_CHANNELS`。
+如果你想要一个普通的机器人帮助频道，让用户无需每次都 @标记就能与 Hermes 对话，请将该频道添加到 `DISCORD_FREE_RESPONSE_CHANNELS`。如果你还希望回复直接发在频道里而不是线程中，请同时将它加入 `DISCORD_NO_THREAD_CHANNELS`。
 :::
 
 ### Discord Gateway（网关）模型
@@ -297,7 +297,7 @@ Discord 行为通过两个文件控制：**`~/.hermes/.env`** 用于凭据和环
 | `DISCORD_THREAD_REQUIRE_MENTION` | 否 | `false` | 为 `true` 时，禁用线程内的提及快捷方式——线程与频道的门控方式相同，即使机器人已经参与其中，也需要 `@提及`。当多个机器人共享一个线程且你希望每个机器人仅在明确 `@提及` 时触发时使用此设置。 |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | 否 | — | 机器人无需 `@提及` 即可响应的频道 ID，逗号分隔，即使 `DISCORD_REQUIRE_MENTION` 为 `true` 也适用。 |
 | `DISCORD_IGNORE_NO_MENTION` | 否 | `true` | 为 `true` 时，如果消息 `@提及` 了其他用户但**未**提及机器人，机器人保持沉默。防止机器人介入针对其他人的对话。仅适用于服务器频道，不适用于私信。 |
-| `DISCORD_AUTO_THREAD` | 否 | `true` | 为 `true` 时，自动为文本频道中的每次 `@提及` 创建新线程，使每个对话相互隔离（类似 Slack 行为）。已在线程或私信中的消息不受影响。 |
+| `DISCORD_AUTO_THREAD` | 否 | `true` | 为 `true` 时，为机器人处理的每条文本频道消息自动创建新线程，使每个对话相互隔离（类似 Slack 行为）。已在线程或私信中的消息不受影响。使用 `DISCORD_NO_THREAD_CHANNELS` 可豁免个别频道。 |
 | `DISCORD_ALLOW_BOTS` | 否 | `"none"` | 控制机器人如何处理来自其他 Discord 机器人的消息。`"none"` — 忽略所有其他机器人。`"mentions"` — 仅接受 `@提及` Hermes 的机器人消息。`"all"` — 接受所有机器人消息。 |
 | `DISCORD_REACTIONS` | 否 | `true` | 为 `true` 时，机器人在处理过程中为消息添加 emoji 反应（开始时 👀，成功时 ✅，出错时 ❌）。设置为 `false` 可完全禁用反应。 |
 | `DISCORD_IGNORED_CHANNELS` | 否 | — | 机器人**永不**响应的频道 ID，逗号分隔，即使被 `@提及` 也不响应。优先于所有其他频道设置。 |
@@ -326,7 +326,7 @@ discord:
   require_mention: true           # 在服务器频道中需要 @提及
   thread_require_mention: false   # 为 true 时，线程中也需要 @提及（多机器人线程）
   free_response_channels: ""      # 逗号分隔的频道 ID（或 YAML 列表）
-  auto_thread: true               # 在 @提及 时自动创建线程
+  auto_thread: true               # 为机器人处理的频道消息自动创建线程
   reactions: true                 # 处理过程中添加 emoji 反应
   ignored_channels: []            # 机器人永不响应的频道 ID
   no_thread_channels: []          # 机器人不创建线程直接响应的频道 ID
@@ -389,7 +389,11 @@ discord:
 
 如果线程的父频道在此列表中，该线程也变为无需提及。
 
-自由响应频道还会**跳过自动创建线程**——机器人直接回复而不是为每条消息创建新线程。这使频道可用作轻量级聊天界面。如果你想要线程行为，不要将频道列为自由响应（改用普通的 `@提及` 流程）。
+此设置**仅控制提及门控**，不会改变机器人在哪里回复。当 [`auto_thread`](#discordauto_thread) 为 `true`（默认值）时，自由响应频道仍会自动创建线程。若要让某个频道保持轻量级的直接聊天界面，请将它加入 [`no_thread_channels`](#discordno_thread_channels)——这是退出线程行为的唯一控制项。
+
+:::warning 行为变更
+自由响应频道以前会隐式跳过自动创建线程，现在不再如此。如果你依赖该行为，请将相同的频道 ID 加入 `no_thread_channels` 以恢复直接回复。
+:::
 
 #### `discord.auto_thread`
 
@@ -397,7 +401,7 @@ discord:
 
 启用后，普通文本频道中的每次 `@提及` 都会自动为对话创建新线程。这保持主频道整洁，并为每个对话提供独立的会话历史。一旦创建线程，该线程中的后续消息不需要 `@提及`——机器人知道它已经在参与其中。对于多机器人设置，将 [`thread_require_mention`](#discordthread_require_mention) 设置为 `true` 可禁用此线程内快捷方式。
 
-在现有线程或私信中发送的消息不受此设置影响。`discord.free_response_channels` 或 `discord.no_thread_channels` 中列出的频道也会绕过自动创建线程，改为直接回复。
+在现有线程或私信中发送的消息不受此设置影响。[`no_thread_channels`](#discordno_thread_channels) 中列出的频道会绕过自动创建线程，改为直接回复——在保持 `auto_thread` 开启的情况下，该列表是让频道退出线程行为的唯一方式。
 
 #### `discord.reactions`
 
@@ -435,6 +439,8 @@ discord:
 **类型：** 字符串或列表 — **默认值：** `[]`
 
 机器人直接在频道中响应而不自动创建线程的频道 ID。仅在 `auto_thread` 为 `true`（默认值）时有效。在这些频道中，机器人像普通消息一样直接回复，而不是创建新线程。
+
+这是退出线程行为的唯一控制项，且与提及门控相互独立——无论频道是否同时列在 [`free_response_channels`](#discordfree_response_channels) 中，都可以把它加到这里。
 
 ```yaml
 discord:


### PR DESCRIPTION
## What this is

A proposal to change a deliberate design decision, not a bugfix. The branch was originally titled `fix(discord)`, which misrepresented it — apologies for the noise. Retitled and rewritten.

`free_response_channels` currently skips auto-threading. That is intentional: 93fe4b35 folded `is_free_channel` into `skip_thread` on purpose, and #12728 then documented it explicitly, noting the behavior "was intentional but never documented, causing user confusion." This PR argues the intent should change. If you disagree, closing it is a perfectly reasonable outcome and no rework is wasted.

## Why change it

`free_response_channels` decides two unrelated things:

1. May the bot reply without an `@mention`? (mention gating)
2. Where does the reply go — inline or in a thread? (routing)

Consequences of coupling them:

- **An operator cannot express "mention-free chat, but still thread each conversation."** There is no configuration that produces it. The only way to get threading is to give up mention-free replies.
- **The threading rule is non-local.** `auto_thread` and `no_thread_channels` are where a reader looks to answer "does this channel thread?", and both can say yes while a third setting silently overrides them.
- **Two settings now do the same job.** `no_thread_channels` already exists and is documented as *the* threading opt-out.

After this change, threading is governed only by `auto_thread` + `no_thread_channels`, and `no_thread_channels` is the single escape hatch.

To be precise about the scope: this is **not** a new capability for unmentioned messages. With `require_mention: false` and `auto_thread: true`, ordinary channel messages already auto-threaded. `free_response_channels` was the one place that opted out.

Unchanged: voice-linked text channels and reply-type messages still skip threading, and `DISCORD_HISTORY_BACKFILL`'s free-response exemption is untouched — that one is about the mention gap, not routing.

## Breaking change

Channels in `discord.free_response_channels` / `DISCORD_FREE_RESPONSE_CHANNELS` now auto-thread instead of replying inline. Anyone relying on the documented behavior will see a thread per conversation where they previously saw inline replies.

**Migration:** add the same channel IDs to `discord.no_thread_channels` / `DISCORD_NO_THREAD_CHANNELS`.

```yaml
discord:
  free_response_channels: [1234567890]   # no @mention needed (unchanged)
  no_thread_channels: [1234567890]       # add this to keep inline replies
```

The commit is marked `feat(discord)!:` with a `BREAKING CHANGE:` trailer. If you would rather this land behind an opt-in flag than as a default change, say so and I will rework it that way.

## Changes

- `plugins/platforms/discord/adapter.py` — drop `or is_free_channel` from the `skip_thread` gate; update the comment to describe the new rule.
- Docs — the previous revision of this branch shipped code that contradicted its own docs. Now updated in six places across `website/docs/user-guide/messaging/discord.md`, `configuration.md`, `reference/environment-variables.md` and `cli-config.yaml.example`, including a migration note under `discord.free_response_channels`. The zh-Hans translations asserted the same behavior and are updated to match.
- Tests — `test_discord_free_response.py::test_discord_free_response_channel_skips_auto_thread` (added by 93fe4b35) asserted the old behavior and **failed** on the previous revision of this branch. Replaced with the inverse assertion, plus new coverage for the migration path (free-response + `no_thread_channels` → inline).

## Validated

Run on Linux, Python 3.11.15, discord.py 2.7.1, in an isolated venv.

- `scripts/run_tests.sh tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_free_response.py -q` → **2 files, 29 tests passed, 0 failed**
- Full Discord surface, `tests/gateway -k discord`, per-file isolation → **275 passed, 2 skipped**, no failures attributable to this change.
- `ruff check .` (the blocking lint job) → **All checks passed**
- `ascii-guard lint --exclude-code-blocks docs` (docs-site-checks) → **401 files, 0 errors**
- `npm run build:fast` (Docusaurus, en) → **success**; the only broken links reported are the pre-existing `/docs/llms.txt` and `/docs/llms-full.txt`, unrelated to these pages.

Not run: the full suite, Windows/macOS, and a live Discord server. This touches one boolean in a routing gate, so the risk is concentrated in the config semantics rather than the platform, but a maintainer sanity-check against a real server before merging would be sensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
