### PR TITLE
fix(desktop): prevent Windows installs from using stale system Node

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -4,6 +4,7 @@ Import-safe module with no dependencies — can be imported from anywhere
 without risk of circular imports.
 """
 
+import ntpath
 import os
 import shutil
 import stat
@@ -666,16 +667,25 @@ def find_node_executable(command: str) -> str | None:
     return find_node_executable_on_path(command)
 
 
+def _node_path_comparison_key(path: str) -> str:
+    """Normalize a PATH entry using the active platform's path semantics."""
+    path_module = ntpath if sys.platform == "win32" else os.path
+    return path_module.normcase(path_module.normpath(path))
+
+
 def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:
     """Return *env* with Hermes-managed Node directories prepended to PATH."""
     merged = dict(os.environ if env is None else env)
     existing = merged.get("PATH", "")
     parts = [p for p in existing.split(os.pathsep) if p]
     managed = [str(path) for path in iter_hermes_node_dirs() if path.is_dir()]
-    for entry in reversed(managed):
-        if entry not in parts:
-            parts.insert(0, entry)
-    merged["PATH"] = os.pathsep.join(parts)
+    managed_keys = {_node_path_comparison_key(entry) for entry in managed}
+    remaining = [
+        entry
+        for entry in parts
+        if _node_path_comparison_key(entry) not in managed_keys
+    ]
+    merged["PATH"] = os.pathsep.join([*managed, *remaining])
     return merged
 
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -83,11 +83,18 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
-def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "managed_already_present",
+    [False, True],
+    ids=["missing", "after-system-node"],
+)
+def test_gui_install_env_prepends_managed_node(
+    tmp_path, monkeypatch, managed_already_present
+):
     """Regression: npm's child scripts (electron-winstaller's select-7z-arch.js)
     shell out to bare ``node``. When Desktop is launched from the updater chain
-    the parent PATH is stripped, so the install env MUST carry the Hermes-managed
-    Node ahead of that bare PATH or the install dies with ``node: not found``.
+    the parent PATH can be stripped or put system Node first, so the install env
+    MUST carry Hermes-managed Node first or lifecycle scripts use the wrong Node.
     """
     import os
 
@@ -101,8 +108,10 @@ def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatc
     home = tmp_path / "hermes-home"
     (home / "node" / "bin").mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(home))
-    # Simulate the stripped PATH the desktop updater chain hands us.
-    monkeypatch.setenv("PATH", os.pathsep.join(["/usr/bin", "/bin"]))
+    inherited_path = ["/usr/bin", "/bin"]
+    if managed_already_present:
+        inherited_path.extend([str(home / "node"), str(home / "node" / "bin")])
+    monkeypatch.setenv("PATH", os.pathsep.join(inherited_path))
 
     install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
     launch_ok = subprocess.CompletedProcess(["hermes"], 0)

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -121,6 +121,41 @@ class TestHermesManagedNode:
 
         assert find_hermes_node_executable("npm") == str(npm_cmd)
 
+    def test_managed_node_dirs_move_ahead_of_system_path(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes"
+        node_dir = home / "node"
+        bin_dir = node_dir / "bin"
+        bin_dir.mkdir(parents=True)
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        env = with_hermes_node_path(
+            {"PATH": os.pathsep.join(["system-node", str(node_dir), "tools"])}
+        )
+
+        assert env["PATH"].split(os.pathsep) == [
+            str(node_dir),
+            str(bin_dir),
+            "system-node",
+            "tools",
+        ]
+
+    def test_windows_managed_node_path_collapses_normalized_duplicates(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "Hermes"
+        node_dir = home / "node"
+        node_dir.mkdir(parents=True)
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        duplicate = f"{str(node_dir).upper()}{os.sep}"
+
+        env = with_hermes_node_path(
+            {"PATH": os.pathsep.join(["system-node", duplicate, str(node_dir)])}
+        )
+
+        assert env["PATH"].split(os.pathsep) == [str(node_dir), "system-node"]
+
 
 
     def test_windows_skips_broken_managed_npm_without_path_fallback(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

On Windows, Desktop dependency installation can run npm with Hermes-managed Node while npm lifecycle children resolve an older system Node from PATH. Electron postinstall then fails with `ERR_REQUIRE_ESM`, blocking Desktop builds and updates even though Hermes has already installed a compatible Node runtime.

This change makes the dependency-install environment move all Hermes-managed Node directories to the front of PATH. It removes normalized duplicate entries first, including Windows case and trailing-separator variants, while preserving the order of unrelated PATH entries.

## Related Issue

Closes #82309

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `hermes_constants.py` - normalize PATH entries with platform path semantics, remove managed-directory duplicates, and prepend canonical managed Node directories.
- `tests/test_hermes_constants.py` - cover managed Node reordering and Windows duplicate normalization.
- `tests/hermes_cli/test_gui_command.py` - cover Desktop install environments when managed Node is missing from PATH or appears after system Node.

## How to Test

1. On Windows, place a system Node directory first in PATH and existing Hermes-managed Node directories later.
2. Build the Desktop dependency environment and confirm the managed directories lead PATH, duplicate variants are removed, and bare `node` resolves to the managed runtime.
3. Run the focused regression tests:

```bash
scripts/run_tests.sh tests/test_hermes_constants.py -k 'managed_node_dirs_move_ahead or windows_managed_node_path_collapses'
scripts/run_tests.sh tests/hermes_cli/test_gui_command.py
```

Observed results: 2 focused PATH tests passed and all 13 Desktop GUI command tests passed. In the Windows real environment, bare `node` resolved to managed Node v22.23.1 after the change instead of the older system Node.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for this bug fix
- [x] I've tested on my platform: Windows 10/11

### Documentation & Housekeeping

- [x] Documentation update is not required for this internal PATH correction
- [x] Config example update is not applicable because no config keys changed
- [x] Contributor guide update is not applicable because no architecture or workflow changed
- [x] I've considered cross-platform impact; POSIX comparison remains case-sensitive and uses POSIX path normalization
- [x] Tool description and schema updates are not applicable

## Screenshots / Logs

```text
Focused managed Node PATH tests: 2 passed
Desktop GUI command tests: 13 passed
Ruff: all checks passed
Windows real-environment verification: managed Node v22.23.1 selected before system Node
```
