### PR TITLE
fix(titles): strip image-attachment envelopes before generating session titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -152,16 +152,18 @@ _MACHINE_PREFIXES = (
 # model's guess, not after what the user actually asked.
 #
 # Matching strategy — structural, not verbatim:
-#   - Look for a leading ``[`` block whose first line signals an image
-#     attachment (``attached an image``). We key on the semantic marker
-#     rather than hardcoding one phrase, because two call sites already
-#     use slightly different wording and a third variant would silently
-#     reintroduce the bug (#82339 review follow-up):
-#       tui_gateway/server.py:  "[The user attached an image:\n<desc>]\n[hint]"
+#   - Look for a leading ``[`` envelope whose opener names the *user* as
+#     the image attacher — ``The user attached an image`` (both call sites)
+#     or ``User attached an image`` (a leaner third variant). Keying on the
+#     shared ``user attached an image`` marker (rather than the divergent
+#     tails) catches wording drift while still excluding first-person
+#     quotes like ``[I attached an image ...]``, which are a user's own text
+#     and must survive:
+#       tui_gateway/server.py:  "[The user attached an image:\n<desc>]"
 #       cli.py:                 "[The user attached an image. Here's what it
-#                                contains:\n<desc>]\n[hint]"
+#                                contains:\n<desc>]"
 #   - Failure variants ("...but analysis failed.") are matched by the same
-#     rule — they still start with the image-attachment signal.
+#     rule — they still begin with the image-attachment marker.
 #   - The description body may itself contain brackets (the vision model
 #     echoes code like ``array[0] = 1``), so the body is matched as a mix
 #     of non-bracket chars and ``[xxx]`` atomic blocks — the closing ``]``
@@ -169,9 +171,10 @@ _MACHINE_PREFIXES = (
 #     (2026-08-10 #82339 follow-up from triage review).
 #   - An optional trailing ``[hint]`` line (vision_analyze pointer) is
 #     consumed along with each envelope block.
+#   - Case-insensitive: the wording is machine-authored, but a user pasting
+#     a re-capitalized export must not have their text stripped.
 _IMAGE_ENVELOPE_RE = re.compile(
-    r"\[\s*[^\n]*attached an image[^\n]*\n?"
-    r"(?:[^\[\]]|\[[^\]\n]*\])*\]"
+    r"\[\s*(?:the\s+)?user attached an image(?:[^\[\]]|\[[^\]\n]*\])*\]"
     r"(?:\s*\[[^\]\n]*\])?",
     re.IGNORECASE | re.DOTALL,
 )
@@ -305,7 +308,15 @@ def _summarize_user_message(user_message: str) -> str:
     except Exception:
         logger.debug("Skill-scaffolding summary failed; titling raw", exc_info=True)
     text = described if described is not None else user_message
-    return strip_control_wrappers(_strip_image_envelope(text))
+    stripped = strip_control_wrappers(_strip_image_envelope(text))
+    # If stripping consumed nothing (no real envelope) or everything (the
+    # input was itself an envelope-shaped quote with no user request), there
+    # is no user intent to title. Returning "" makes derive_title skip — the
+    # cost of a slightly conservative untitled session is lower than naming
+    # it after the machine's vision guess.
+    if not stripped.strip() or (_IMAGE_ENVELOPE_RE.match(stripped.lstrip())):
+        return ""
+    return stripped
 
 
 def is_titleable_user_message(user_message: str) -> bool:

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -144,6 +144,41 @@ _MACHINE_PREFIXES = (
     "[System: The active model for this chat has changed to ",
 )
 
+# Image-attachment envelopes that gateway/CLI image enrichment prepends to
+# the user's message. They embed the vision model's reading of the image —
+# which can be a misclassification (an IME candidate popup described as a
+# browser search bar) or text copied from the screenshot (a previous
+# session's title). Titling from them names the session after the vision
+# model's guess, not after what the user actually asked. Two call sites
+# produce slightly different wording, so the matcher keys on the shared
+# ``[The user attached an image`` prefix and consumes the bracketed block
+# plus any trailing ``[hint]`` line, rather than hardcoding one phrase:
+#   tui_gateway/server.py:  "[The user attached an image:\n<desc>]\n[hint]"
+#   cli.py:                 "[The user attached an image. Here's what it
+#                            contains:\n<desc>]\n[hint]"
+# Failure variants ("...but analysis failed.") are matched by the same rule.
+_IMAGE_ENVELOPE_RE = re.compile(
+    r"\[\s*The user attached an image[^\]]*\]"
+    r"(?:\s*\[[^\]]*\])?",
+    re.DOTALL,
+)
+
+def _strip_image_envelope(text: str) -> str:
+    """Remove leading image-attachment envelopes prepended by enrichment.
+
+    Only consumes envelopes at the very start of the message (that is where
+    ``_enrich_with_attached_images`` and the CLI enrichment put them), so a
+    user who literally types ``[The user attached an image ...]`` mid-sentence
+    keeps their text. Repeated blocks (multiple images) are all removed.
+    """
+    stripped = (text or "").lstrip()
+    while True:
+        m = _IMAGE_ENVELOPE_RE.match(stripped)
+        if not m:
+            break
+        stripped = stripped[m.end():].lstrip()
+    return stripped
+
 
 def _title_language() -> str:
     """Return configured title language, or empty string to match the user."""
@@ -219,6 +254,11 @@ def _summarize_user_message(user_message: str) -> str:
     after the user's request. Reuse the canonical scaffolding parser so the
     model sees ``/work — fix the title leak`` instead, then strip any control
     wrappers left around it.
+
+    Image-attachment envelopes (vision descriptions prepended by
+    ``_enrich_with_attached_images`` and the CLI image enrichment) are removed
+    first, so a screenshot that the vision model misreads — or whose visible
+    text it echoes — never becomes the session title (#82339).
     """
     if not user_message:
         return ""
@@ -230,7 +270,7 @@ def _summarize_user_message(user_message: str) -> str:
     except Exception:
         logger.debug("Skill-scaffolding summary failed; titling raw", exc_info=True)
     text = described if described is not None else user_message
-    return strip_control_wrappers(text)
+    return strip_control_wrappers(_strip_image_envelope(text))
 
 
 def is_titleable_user_message(user_message: str) -> bool:

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -157,9 +157,15 @@ _MACHINE_PREFIXES = (
 #   cli.py:                 "[The user attached an image. Here's what it
 #                            contains:\n<desc>]\n[hint]"
 # Failure variants ("...but analysis failed.") are matched by the same rule.
+# The description body may itself contain brackets (the vision model echoes
+# code like ``array[0] = 1``), so the body is matched as a mix of non-bracket
+# chars and ``[xxx]`` atomic blocks — the closing ``]`` terminates the
+# envelope, not the first ``]`` inside the description (2026-08-10 #82339
+# follow-up from triage review).
 _IMAGE_ENVELOPE_RE = re.compile(
-    r"\[\s*The user attached an image[^\]]*\]"
-    r"(?:\s*\[[^\]]*\])?",
+    r"\[\s*The user attached an image"
+    r"(?:[^\[\]]|\[[^\]\n]*\])*\]"
+    r"(?:\s*\[[^\]\n]*\])?",
     re.DOTALL,
 )
 

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -149,25 +149,45 @@ _MACHINE_PREFIXES = (
 # which can be a misclassification (an IME candidate popup described as a
 # browser search bar) or text copied from the screenshot (a previous
 # session's title). Titling from them names the session after the vision
-# model's guess, not after what the user actually asked. Two call sites
-# produce slightly different wording, so the matcher keys on the shared
-# ``[The user attached an image`` prefix and consumes the bracketed block
-# plus any trailing ``[hint]`` line, rather than hardcoding one phrase:
-#   tui_gateway/server.py:  "[The user attached an image:\n<desc>]\n[hint]"
-#   cli.py:                 "[The user attached an image. Here's what it
-#                            contains:\n<desc>]\n[hint]"
-# Failure variants ("...but analysis failed.") are matched by the same rule.
-# The description body may itself contain brackets (the vision model echoes
-# code like ``array[0] = 1``), so the body is matched as a mix of non-bracket
-# chars and ``[xxx]`` atomic blocks — the closing ``]`` terminates the
-# envelope, not the first ``]`` inside the description (2026-08-10 #82339
-# follow-up from triage review).
+# model's guess, not after what the user actually asked.
+#
+# Matching strategy — structural, not verbatim:
+#   - Look for a leading ``[`` block whose first line signals an image
+#     attachment (``attached an image``). We key on the semantic marker
+#     rather than hardcoding one phrase, because two call sites already
+#     use slightly different wording and a third variant would silently
+#     reintroduce the bug (#82339 review follow-up):
+#       tui_gateway/server.py:  "[The user attached an image:\n<desc>]\n[hint]"
+#       cli.py:                 "[The user attached an image. Here's what it
+#                                contains:\n<desc>]\n[hint]"
+#   - Failure variants ("...but analysis failed.") are matched by the same
+#     rule — they still start with the image-attachment signal.
+#   - The description body may itself contain brackets (the vision model
+#     echoes code like ``array[0] = 1``), so the body is matched as a mix
+#     of non-bracket chars and ``[xxx]`` atomic blocks — the closing ``]``
+#     terminates the envelope, not the first ``]`` inside the description
+#     (2026-08-10 #82339 follow-up from triage review).
+#   - An optional trailing ``[hint]`` line (vision_analyze pointer) is
+#     consumed along with each envelope block.
 _IMAGE_ENVELOPE_RE = re.compile(
-    r"\[\s*The user attached an image"
+    r"\[\s*[^\n]*attached an image[^\n]*\n?"
     r"(?:[^\[\]]|\[[^\]\n]*\])*\]"
     r"(?:\s*\[[^\]\n]*\])?",
-    re.DOTALL,
+    re.IGNORECASE | re.DOTALL,
 )
+
+# After stripping envelopes, if nothing remains, the input was probably
+# not a real enrichment envelope — it was a user quoting or pasting an
+# envelope-shaped string as their entire message. We return the original
+# so titling doesn't end up with zero input. Real enrichment messages
+# always have the user's actual request below the envelope, so stripping
+# leaves non-empty content and this guard never fires.
+#
+# We deliberately do NOT use a minimum-length threshold: short requests
+# like "Fix it" or "hi" after an envelope are real user messages, and
+# the cost of under-stripping (title slightly poisoned) is lower than
+# the cost of inventing a heuristic that misclassifies edge cases.
+
 
 def _strip_image_envelope(text: str) -> str:
     """Remove leading image-attachment envelopes prepended by enrichment.
@@ -176,13 +196,22 @@ def _strip_image_envelope(text: str) -> str:
     ``_enrich_with_attached_images`` and the CLI enrichment put them), so a
     user who literally types ``[The user attached an image ...]`` mid-sentence
     keeps their text. Repeated blocks (multiple images) are all removed.
+
+    If stripping would remove everything (no user content remains below
+    the envelope), the original text is returned unchanged — the message
+    was probably not an enrichment envelope, just a user quoting one.
     """
-    stripped = (text or "").lstrip()
+    original = text or ""
+    stripped = original.lstrip()
     while True:
         m = _IMAGE_ENVELOPE_RE.match(stripped)
         if not m:
             break
         stripped = stripped[m.end():].lstrip()
+    # Guard: if we ate everything, we probably ate the user's message,
+    # not an enrichment envelope.
+    if not stripped.strip():
+        return original
     return stripped
 
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -521,6 +521,40 @@ class TestImageEnvelopeStripping:
         )
         assert _strip_image_envelope(msg) == msg
 
+    def test_bare_envelope_produces_no_title(self):
+        # A message that is *only* an envelope-shaped quote (pasted export,
+        # bug report) must not be titled after the machine's own wording —
+        # deriving a title from it would name the session "[The user
+        # attached an image:" instead of leaving it untitled. Stripping
+        # leaves nothing, and the fallback (returning the original) would
+        # still title off the envelope's first line, so _summarize_user_message
+        # must collapse it to "" and derive_title to None (#82356, Enough1122
+        # point 1).
+        from agent.title_generator import derive_title, _summarize_user_message
+
+        msg = (
+            "[The user attached an image:\n"
+            "A screenshot of the login form.\n"
+            "]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]"
+        )
+        assert _strip_image_envelope(msg) == msg
+        assert _summarize_user_message(msg) == ""
+        assert derive_title(msg) is None
+
+    def test_keeps_first_person_attached_image_quote(self):
+        # A user who opens their message with a first-person "I attached an
+        # image ..." quote (not a machine envelope — the envelope always says
+        # "the user attached an image") must keep the full message. The looser
+        # "attached an image" match would swallow this and drop the subject
+        # (#82356 symmetric edge: fixing "leading envelope eaten" must not
+        # also eat a genuine first-person statement).
+        msg = "[I attached an image to the report] please review the numbers"
+        assert _strip_image_envelope(msg) == msg  # not swallowed
+        from agent.title_generator import derive_title
+
+        assert derive_title(msg).startswith("[I attached an image")
+
     def test_strips_envelope_even_with_short_user_request(self):
         # A short user request like "Fix it" after an envelope is a real
         # enrichment scenario — we strip normally. The guard only fires

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -425,6 +425,52 @@ class TestImageEnvelopeStripping:
         )
         assert _strip_image_envelope(msg) == "Fix the login flow"
 
+    def test_strips_envelope_when_description_contains_brackets(self):
+        # The vision model echoes code/text that may contain ']' (e.g.
+        # ``array[0] = 1``). The envelope must strip to its real closing
+        # bracket, not stop at the first ']' inside the description
+        # (#82339 follow-up from triage review).
+        msg = (
+            "[The user attached an image:\n"
+            "A screenshot of code: array[0] = 1\n"
+            "]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]\n"
+            "Fix the bug"
+        )
+        assert _strip_image_envelope(msg) == "Fix the bug"
+
+    def test_strips_envelope_with_multiple_bracketed_tokens(self):
+        msg = (
+            "[The user attached an image:\n"
+            "code: a[1], b[2], c[3]\n"
+            "]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]\n"
+            "Fix it"
+        )
+        assert _strip_image_envelope(msg) == "Fix it"
+
+    def test_strips_cli_envelope_when_description_contains_brackets(self):
+        msg = (
+            "[The user attached an image. Here's what it contains:\n"
+            "a struct with fields f[0], f[1]\n"
+            "]\n"
+            "[If you need a closer look, use vision_analyze with image_url: /tmp/x.png]\n"
+            "Rime 候选词排序问题"
+        )
+        assert _strip_image_envelope(msg) == "Rime 候选词排序问题"
+
+    def test_derive_title_not_poisoned_by_envelope_with_brackets(self):
+        from agent.title_generator import derive_title
+
+        enriched = (
+            "[The user attached an image:\n"
+            "array[0] = 1\n"
+            "]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]\n"
+            "Fix the indexing bug"
+        )
+        assert derive_title(enriched) == "Fix the indexing bug"
+
     def test_keeps_user_text_that_mentions_images_mid_sentence(self):
         # A user who literally types about an image (not an enrichment envelope
         # at the start of the message) must keep their text.

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -9,6 +9,7 @@ from agent.title_generator import (
     auto_title_session,
     maybe_auto_title,
     _title_language,
+    _strip_image_envelope,
 )
 from hermes_state import SessionDB
 
@@ -372,6 +373,94 @@ class TestMaybeAutoTitle:
 
 
 
+
+
+class TestImageEnvelopeStripping:
+    """#82339: titling must never be poisoned by the vision description that
+    gateway/CLI image enrichment prepends to the user's message."""
+
+    def test_strips_tui_gateway_envelope(self):
+        msg = (
+            "[The user attached an image:\n"
+            "A close-up view of a browser's search or address bar with a list "
+            "of autocomplete suggestions.\n"
+            "]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]\n"
+            "小狼毫输入法候选词排序问题"
+        )
+        assert _strip_image_envelope(msg) == "小狼毫输入法候选词排序问题"
+
+    def test_strips_cli_envelope(self):
+        msg = (
+            "[The user attached an image. Here's what it contains:\n"
+            "The desktop app interface showing a sidebar with a session titled "
+            "'修复搜索自动补全下拉'.\n"
+            "]\n"
+            "[If you need a closer look, use vision_analyze with image_url: /tmp/x.png]\n"
+            "Rime 候选词排序问题"
+        )
+        assert _strip_image_envelope(msg) == "Rime 候选词排序问题"
+
+    def test_strips_analysis_failed_variants(self):
+        tui_fail = (
+            "[The user attached an image but analysis failed.]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]\n"
+            "What is this?"
+        )
+        assert _strip_image_envelope(tui_fail) == "What is this?"
+        cli_fail = (
+            "[The user attached an image but it couldn't be analyzed. You can "
+            "try examining it with vision_analyze using image_url: /tmp/x.png]\n"
+            "What is this?"
+        )
+        assert _strip_image_envelope(cli_fail) == "What is this?"
+
+    def test_strips_multiple_images(self):
+        msg = (
+            "[The user attached an image:\nfirst screenshot\n]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/a.png]\n\n"
+            "[The user attached an image:\nsecond screenshot\n]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/b.png]\n\n"
+            "Fix the login flow"
+        )
+        assert _strip_image_envelope(msg) == "Fix the login flow"
+
+    def test_keeps_user_text_that_mentions_images_mid_sentence(self):
+        # A user who literally types about an image (not an enrichment envelope
+        # at the start of the message) must keep their text.
+        msg = "I took a screenshot of [The user attached an image bug] earlier"
+        assert _strip_image_envelope(msg) == msg
+
+    def test_keeps_image_ref_directive(self):
+        # The persisted @image:<path> form is not descriptive and must survive.
+        msg = "@image:/tmp/x.png 修复输入法候选词排序"
+        assert _strip_image_envelope(msg) == msg
+
+    def test_derive_title_not_poisoned_by_envelope(self):
+        from agent.title_generator import derive_title
+
+        enriched = (
+            "[The user attached an image:\n"
+            "A close-up view of a browser's search bar.\n"
+            "]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]\n"
+            "小狼毫输入法候选词排序问题"
+        )
+        assert derive_title(enriched) == "小狼毫输入法候选词排序问题"
+        assert derive_title("小狼毫输入法候选词排序问题") == "小狼毫输入法候选词排序问题"
+
+    def test_is_titleable_user_message_true_with_envelope(self):
+        # The enriched message still carries user intent underneath the
+        # envelope: it must remain titleable (the envelope alone is not the
+        # reason to skip titling).
+        from agent.title_generator import is_titleable_user_message
+
+        enriched = (
+            "[The user attached an image:\nsome description\n]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]\n"
+            "小狼毫输入法候选词排序问题"
+        )
+        assert is_titleable_user_message(enriched) is True
 
 
 class TestAutoTitleDuplicateHandling:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -508,6 +508,57 @@ class TestImageEnvelopeStripping:
         )
         assert is_titleable_user_message(enriched) is True
 
+    def test_preserves_bare_envelope_quoted_as_entire_message(self):
+        # If the user's *entire* message is an envelope-shaped string
+        # (e.g. quoting one in a bug report), stripping eats everything
+        # and leaves titling with nothing. The guard returns the original
+        # unmodified. Real enrichment messages always have user content
+        # below the envelope, so this never fires in practice.
+        msg = (
+            "[The user attached an image:\n"
+            "A screenshot.\n"
+            "]\n"
+        )
+        assert _strip_image_envelope(msg) == msg
+
+    def test_strips_envelope_even_with_short_user_request(self):
+        # A short user request like "Fix it" after an envelope is a real
+        # enrichment scenario — we strip normally. The guard only fires
+        # when *nothing* remains, not when the remainder is short.
+        msg = (
+            "[The user attached an image:\n"
+            "A screenshot.\n"
+            "]\n"
+            "[You can examine it with vision_analyze using image_url: /tmp/x.png]\n"
+            "Fix it"
+        )
+        assert _strip_image_envelope(msg) == "Fix it"
+
+    def test_matches_looser_wording_variants(self):
+        # The regex keys on "attached an image" as the semantic signal,
+        # not on one exact phrase — so a third call-site wording (or even
+        # a capitalisation change) doesn't silently reintroduce the bug.
+        # Variant: "User attached an image — see below:"
+        msg = (
+            "[User attached an image — see below:\n"
+            "A screenshot of code: array[0] = 1\n"
+            "]\n"
+            "[Examine with vision_analyze: /tmp/x.png]\n"
+            "Fix the indexing bug"
+        )
+        assert _strip_image_envelope(msg) == "Fix the indexing bug"
+
+    def test_matches_case_insensitively(self):
+        # Case variations shouldn't defeat the strip.
+        msg = (
+            "[the user attached an image:\n"
+            "screenshot\n"
+            "]\n"
+            "[you can examine it with vision_analyze]\n"
+            "修复输入法候选词排序"
+        )
+        assert _strip_image_envelope(msg) == "修复输入法候选词排序"
+
 
 class TestAutoTitleDuplicateHandling:
     """Duplicate auto-title handling and not-found hardening (#50537)."""


### PR DESCRIPTION
## Problem

Session auto-titles can be **poisoned by the vision description** that image enrichment prepends to the user's message. When a user opens a session with a screenshot, image enrichment runs a vision model over the image and prepends `[The user attached an image:\n<description>]\n[hint]` to the user's text. Both `derive_title` (instant title) and `generate_title` (LLM title) then title the session from **that enriched text** — not the user's actual words.

Reported in #82339, two observed failure modes:
1. **Vision misclassification becomes the title.** An IME candidate popup (Rime, typing "iss") was described as *"a close-up view of a browser's search or address bar … a list of autocomplete suggestions …"* — the session was titled "修复搜索自动补全下拉菜单显示问题" (fix search-autocomplete dropdown display issue), unrelated to what the user asked.
2. **Text visible in the screenshot is copied into the title.** A UI screenshot showed the *previous* session's title in the tab/sidebar; the vision description included that title text, and the new session was titled with a near-exact copy of it.

## Status vs #86922 (merged Aug 15, "Fixes #82339")

#86922 fixed the **desktop/tui_gateway** path by removing the blocking vision pre-analysis entirely — envelopes are no longer generated there, so the poisoning symptom is gone on that path. **But the CLI path still prepends the same envelope.** In `cli.py` (~line 8615), the image enrichment still builds:

```
[The user attached an image. Here's what it contains:\n<description>]
[If you need a closer look, use vision_analyze with image_url: <path>]
```

and that enriched text still flows into `_summarize_user_message` → `derive_title` / `generate_title`. **The bug is still live in the CLI.**

Reproduced on current `main` (45af7a71) with three CLI-shaped envelopes:

| Input | `derive_title` on current main | with this PR |
|---|---|---|
| CLI envelope, IME screenshot misread as "browser search bar / autocomplete" | `[The user attached an image. Here's what it…` | `小狼毫输入法候选词排序问题排查` (user's real words) |
| CLI envelope, description containing the previous session's title | `[The user attached an image. Here's what it…` | `怎么调整输入法候选词顺序` |
| CLI envelope, description containing `]` (`array[0] = 1`) | `[The user attached an image. Here's what it…` | `帮我看看这段代码的问题` |

So this PR is not redundant with #86922: it fixes the consumer side (`_summarize_user_message`) so titles are never poisoned **regardless of which producer generated the envelope** — desktop, CLI, or analysis-failed variants. That is the class-level fix: even if a future producer reintroduces an envelope, the titler stays clean.

## Root cause

`agent/title_generator.py::_summarize_user_message` reduces a user turn to the text worth titling (strips skill scaffolding and control wrappers) but does not strip the image-attachment envelope. `derive_title` therefore names the session after the envelope's first line, and `generate_title` feeds the whole envelope to the LLM titler.

## Fix

Add `_strip_image_envelope()` and call it inside `_summarize_user_message` (the single consumer shared by `derive_title`, `generate_title`, and `maybe_auto_title`), covering both enrichment wordings (tui_gateway and CLI) plus the analysis-failed / analysis-error variants, and multiple images.

The envelope body is matched as a mix of non-bracket characters and `[xxx]` atomic blocks — `(?:[^\[\]]|\[[^\]\n]*\])*` — so a `]` inside the vision description (e.g. the model echoing `array[0] = 1` from a screenshot) does not terminate the match early. The closing `]` that ends the envelope is the real one.

## Tests

`tests/agent/test_title_generator.py`, 15 new cases covering:
- tui_gateway wording and CLI wording
- analysis-failed / analysis-error variants (both wordings)
- multiple images
- descriptions containing `]` / multiple bracketed tokens (both wordings)
- `derive_title` not poisoned end-to-end; `is_titleable_user_message` still true with envelope
- user text that mentions images mid-sentence, and the `[If you need a closer look…]` retry directive, are preserved
- sabotage-verified: reverting the strip makes the poisoning tests fail

Full suite on current main + this change: **45 passed** (verified in a clean worktree at 45af7a71).