### PR TITLE
fix(dingtalk): recover incoming handler after lazy SDK install

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -187,7 +187,7 @@ def ensure_dingtalk_deps() -> bool:
     re-creating the #79812 deadlock for extra-configured setups.
     """
     global DINGTALK_STREAM_AVAILABLE, dingtalk_stream, ChatbotMessage, CallbackMessage, AckMessage
-    global HTTPX_AVAILABLE, httpx
+    global HTTPX_AVAILABLE, httpx, _IncomingHandler
     if DINGTALK_STREAM_AVAILABLE and HTTPX_AVAILABLE:
         return True
     try:
@@ -209,6 +209,22 @@ def ensure_dingtalk_deps() -> bool:
     httpx = _httpx
     DINGTALK_STREAM_AVAILABLE = True
     HTTPX_AVAILABLE = True
+
+    # _IncomingHandler may have been defined while dingtalk-stream was
+    # unavailable, permanently freezing its base class to object. Rebind it
+    # once the lazy install succeeds so SDK dispatch methods such as
+    # raw_process() are available in the same process.
+    if not issubclass(_IncomingHandler, dingtalk_stream.ChatbotHandler):
+        stale_handler_cls = _IncomingHandler
+        _IncomingHandler = type(
+            "_IncomingHandler",
+            (stale_handler_cls, dingtalk_stream.ChatbotHandler),
+            {
+                "__module__": __name__,
+                "__doc__": stale_handler_cls.__doc__,
+            },
+        )
+
     return True
 
 

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -97,7 +97,7 @@ def ensure_dingtalk_deps() -> bool:
     ``create_adapter()``, and have the installer veto on env-var grounds before ever installing —
     re-creating the #79812 deadlock for extra-configured setups.
     """
-    global DINGTALK_STREAM_AVAILABLE, dingtalk_stream, ChatbotMessage, CallbackMessage, AckMessage, HTTPX_AVAILABLE, httpx
+    global DINGTALK_STREAM_AVAILABLE, dingtalk_stream, ChatbotMessage, CallbackMessage, AckMessage, HTTPX_AVAILABLE, httpx, _IncomingHandler
     if DINGTALK_STREAM_AVAILABLE and HTTPX_AVAILABLE:
         return True
     try:
@@ -110,6 +110,16 @@ def ensure_dingtalk_deps() -> bool:
         return False
     dingtalk_stream, ChatbotMessage, CallbackMessage, AckMessage, httpx = _ds, _CM, _CBM, _AM, _httpx
     DINGTALK_STREAM_AVAILABLE = HTTPX_AVAILABLE = True
+    if not issubclass(_IncomingHandler, dingtalk_stream.ChatbotHandler):
+        stale_handler_cls = _IncomingHandler
+        _IncomingHandler = type(
+            "_IncomingHandler",
+            (stale_handler_cls, dingtalk_stream.ChatbotHandler),
+            {
+                "__module__": __name__,
+                "__doc__": stale_handler_cls.__doc__,
+            },
+        )
     return True
 
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -283,6 +283,109 @@ class TestHandlerProcessIsAsync:
         assert asyncio.iscoroutinefunction(_IncomingHandler.process)
 
 
+class TestLazyDependencyRecovery:
+    """Regression coverage for SDKs that become available after module import."""
+
+    @pytest.mark.asyncio
+    async def test_connect_uses_sdk_handler_after_lazy_install(self, monkeypatch):
+        import sys
+        from types import ModuleType
+
+        import plugins.platforms.dingtalk.adapter as dt
+        import tools.lazy_deps
+
+        # Reproduce the import-time failure from #78597: the adapter module
+        # already exists, but its handler was created without the SDK base.
+        class FrozenIncomingHandler:
+            def __init__(self, adapter, loop=None):
+                self._adapter = adapter
+                self._loop = loop
+
+            async def process(self, message):
+                return 200, "OK"
+
+        monkeypatch.setattr(dt, "DINGTALK_STREAM_AVAILABLE", False)
+        monkeypatch.setattr(dt, "dingtalk_stream", None)
+        monkeypatch.setattr(dt, "_IncomingHandler", FrozenIncomingHandler)
+
+        # Fake the SDK that becomes importable after the lazy install.
+        fake_sdk = ModuleType("dingtalk_stream")
+        fake_frames = ModuleType("dingtalk_stream.frames")
+
+        class FakeChatbotHandler:
+            async def raw_process(self, message):
+                return await self.process(message)
+
+        class FakeChatbotMessage:
+            TOPIC = "fake-chatbot-topic"
+
+        class FakeCallbackMessage:
+            pass
+
+        class FakeAckMessage:
+            STATUS_OK = 200
+            STATUS_SYSTEM_EXCEPTION = 500
+
+        class FakeStreamClient:
+            def __init__(self, credential):
+                self.credential = credential
+                self.registered_handler = None
+
+            def register_callback_handler(self, topic, handler):
+                self.registered_handler = handler
+
+        fake_sdk.ChatbotHandler = FakeChatbotHandler
+        fake_sdk.ChatbotMessage = FakeChatbotMessage
+        fake_sdk.Credential = lambda client_id, client_secret: (
+            client_id,
+            client_secret,
+        )
+        fake_sdk.DingTalkStreamClient = FakeStreamClient
+
+        fake_frames.CallbackMessage = FakeCallbackMessage
+        fake_frames.AckMessage = FakeAckMessage
+
+        # Make Python's import system see our newly "installed" SDK.
+        monkeypatch.setitem(sys.modules, "dingtalk_stream", fake_sdk)
+        monkeypatch.setitem(sys.modules, "dingtalk_stream.frames", fake_frames)
+
+        # The real package installation is irrelevant to this regression test.
+        monkeypatch.setattr(
+            tools.lazy_deps,
+            "ensure",
+            lambda *args, **kwargs: True,
+        )
+
+        assert dt.ensure_dingtalk_deps() is True
+        assert dt.DINGTALK_STREAM_AVAILABLE is True
+
+        adapter = dt.DingTalkAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "client_id": "test-client",
+                    "client_secret": "test-secret",
+                },
+            )
+        )
+
+        # Do not start a real WebSocket loop.
+        async def fake_run_stream():
+            return None
+
+        monkeypatch.setattr(adapter, "_run_stream", fake_run_stream)
+
+        connected = await adapter.connect()
+
+        assert connected is True
+
+        handler = adapter._stream_client.registered_handler
+
+        assert handler is not None
+        assert hasattr(handler, "raw_process")
+        assert await handler.raw_process(object()) == (200, "OK")
+
+
 class TestExtractText:
     """_extract_text must handle both legacy and current SDK payload shapes.
 


### PR DESCRIPTION
## Summary

Fixes a DingTalk inbound-message failure that can persist for the lifetime of the gateway process when the adapter is imported before `dingtalk-stream` becomes available.

If the SDK import fails during module initialization, `_IncomingHandler` is created with `object` as its base class. The lazy dependency path can later make `dingtalk_stream` available in the same process, but the already-created handler class keeps its original base and therefore still lacks SDK-provided dispatch behavior such as `raw_process()`.

The result is a partially working adapter: connection/outbound behavior can recover, while inbound messages continue to fail.

Fixes #78597.

## Root cause

The handler base is selected when the class definition executes:

```python
class _IncomingHandler(
    dingtalk_stream.ChatbotHandler
    if DINGTALK_STREAM_AVAILABLE
    else object
):
    ...
```

When the SDK is unavailable at import time, the class is created as an `object`-based handler.

Later dependency recovery can update the module-level SDK state, but it does not retroactively change the inheritance of `_IncomingHandler`.

That leaves two pieces of runtime state out of sync:

```text
dingtalk_stream available again        yes
DINGTALK_STREAM_AVAILABLE              true
_IncomingHandler SDK inheritance       stale
SDK raw_process() dispatch             missing
```

## Fix

After the DingTalk dependency becomes available, the recovery path now verifies that `_IncomingHandler` actually inherits from `dingtalk_stream.ChatbotHandler`.

If the handler is stale, it rebuilds the module-level handler class using:

- the existing stale handler class, preserving Hermes-specific handler logic
- `dingtalk_stream.ChatbotHandler`, restoring the SDK dispatch contract

Conceptually:

```text
Recovered _IncomingHandler
        ↓
stale _IncomingHandler
        ↓
dingtalk_stream.ChatbotHandler
        ↓
object
```

This allows SDK methods such as `raw_process()` to resolve through the SDK base while Hermes' existing `process()` implementation remains available.

The rebuild is guarded with `issubclass(...)`, so the normal startup path is unchanged when the SDK was already available and `_IncomingHandler` already has the correct base.

This avoids mutating `__bases__`, reloading the entire adapter module, or duplicating SDK dispatch logic inside Hermes.

## Regression test

Added a regression test for the actual same-process lifecycle:

```text
adapter already imported
        ↓
SDK initially unavailable
        ↓
handler class is stale / object-based
        ↓
SDK becomes importable later
        ↓
dependency recovery succeeds
        ↓
connect() registers the handler
        ↓
registered handler must expose SDK raw_process()
```

The test uses a fake `dingtalk_stream` module through `sys.modules` so dependency availability can be controlled deterministically without performing a real package installation during the test.

The important distinction from the existing handler tests is that this regression exercises the SDK-facing dispatch boundary rather than only calling Hermes' `process()` implementation directly.

## RED → GREEN

Before adding the regression:

```text
tests/gateway/test_dingtalk.py
31 passed
```

With the regression test added but before the production fix:

```text
31 passed, 1 failed
```

The new test failed at the expected symptom:

```python
assert hasattr(handler, "raw_process")
```

After the fix:

```text
32 passed
```

After rebasing onto the latest upstream `main`, the focused regression test and the full DingTalk test module were run again and remained green.

## Validation

Tested locally on Windows PowerShell with Python 3.11.6.

Focused validation:

```text
python -m pytest tests/gateway/test_dingtalk.py -v
# 32 passed

python -m ruff check plugins/platforms/dingtalk/adapter.py tests/gateway/test_dingtalk.py
# All checks passed!

git diff --check
# clean
```

A broader local run of `tests/gateway` was also performed:

```text
4985 passed
73 failed
37 skipped
1 xfailed
```

The remaining failures were outside the DingTalk change and were associated with unrelated platform/dependency/environment assumptions in the native Windows test environment. They were not included in this PR in order to keep the fix scoped.

## Scope

This PR changes only:

```text
plugins/platforms/dingtalk/adapter.py
tests/gateway/test_dingtalk.py
```

The production change is limited to recovering the stale DingTalk incoming-handler inheritance after same-process lazy SDK availability, with regression coverage for that lifecycle.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`fix(dingtalk): ...`)
- [x] I searched for existing open PRs for #78597 and the relevant DingTalk failure/lazy-install keywords
- [x] My PR contains only changes related to this bug fix
- [x] I reproduced the stale-handler state before changing production code
- [x] I added a regression test that was RED before the fix and GREEN after it
- [x] The focused DingTalk test module passes: 32 tests
- [x] Ruff passes for the changed Python files
- [x] `git diff --check` is clean
- [x] I rebased onto the latest upstream `main` and re-ran the focused tests

### Testing / Environment

- [x] Tested on Windows PowerShell with Python 3.11.6
- [x] Ran the broader `tests/gateway` suite and documented unrelated native-Windows/environment failures above
- [ ] Full repository test suite passes locally
- [ ] Live DingTalk end-to-end testing was performed with a real bot/SDK session
