### PR TITLE
fix(agent): let transform_llm_output split display text from memory-sync text

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -550,11 +550,26 @@ def finalize_turn(
 
     _response_transformed = False
     _pre_transform_response = None
+    # Memory-sync override for this turn. None means "use final_response",
+    # i.e. today's behavior (memory receives whatever was transformed for
+    # display). A plugin can set this to a different string via the dict
+    # return form below, e.g. to keep a display-only addition out of
+    # external memory.
+    _memory_response = None
 
     # Plugin hook: transform_llm_output
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can transform the LLM's output text before it's returned.
-    # First hook to return a string wins; None/empty return leaves text unchanged.
+    # Return either a str (replaces the response text; used for both display
+    # and external-memory sync, matching prior behavior) or a dict shaped
+    # {"display": str, "memory": str} to send a different value to external
+    # memory providers than what's shown to the user -- e.g. a plugin that
+    # appends a display-only footer (a citation, a sponsored message) can
+    # keep that footer out of what the model "remembers" saying. A dict
+    # without a valid "memory" string falls back to "display", i.e. behaves
+    # like a plain string return. First hook to return a non-empty str or a
+    # dict with a non-empty "display" wins; None/empty return leaves text
+    # unchanged.
     if final_response and not interrupted:
         try:
             from hermes_cli.lifecycle import invoke_hook as _invoke_hook
@@ -570,7 +585,19 @@ def finalize_turn(
                     _pre_transform_response = final_response
                     final_response = _hook_result
                     _response_transformed = True
-                    break  # First non-empty string wins
+                    break  # First non-empty result wins
+                if (
+                    isinstance(_hook_result, dict)
+                    and isinstance(_hook_result.get("display"), str)
+                    and _hook_result["display"]
+                ):
+                    _pre_transform_response = final_response
+                    final_response = _hook_result["display"]
+                    _memory_override = _hook_result.get("memory")
+                    if isinstance(_memory_override, str):
+                        _memory_response = _memory_override
+                    _response_transformed = True
+                    break  # First non-empty result wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
 
@@ -738,9 +765,12 @@ def finalize_turn(
         agent._iters_since_skill = 0
 
     # External memory provider: sync the completed turn + queue next prefetch.
+    # Uses _memory_response when a transform_llm_output plugin explicitly set
+    # one (dict return with a "memory" key); otherwise behaves as before and
+    # syncs whatever final_response ended up being.
     agent._sync_external_memory_for_turn(
         original_user_message=original_user_message,
-        final_response=final_response,
+        final_response=_memory_response if _memory_response is not None else final_response,
         interrupted=interrupted,
         messages=messages,
     )

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -57,7 +57,7 @@ behavior-affecting hooks:
 | `pre_llm_call` | May return a string or `{"context": "..."}` to inject ephemeral context into the current user message. |
 | `pre_tool_call` | May return `{"action": "block", "message": "..."}` to block a tool before execution. |
 | `transform_tool_result` | May return a replacement tool result string after `post_tool_call`. |
-| `transform_llm_output` | May return a replacement final assistant text string. |
+| `transform_llm_output` | May return a replacement final assistant text string, or a `{"display": ..., "memory": ...}` dict to split what's shown from what's synced to external memory. |
 
 Telemetry plugins should treat these behavior-affecting returns as optional
 compatibility features, not as observability requirements.

--- a/tests/agent/test_turn_finalizer_memory_sync_pre_transform.py
+++ b/tests/agent/test_turn_finalizer_memory_sync_pre_transform.py
@@ -1,0 +1,354 @@
+"""Verify the display/memory split for `transform_llm_output` (#57282).
+
+A `transform_llm_output` plugin can append display-only content (a citation,
+a sponsored-message footer) to the response. Before this change, that
+appended content also flowed into external memory sync, so a memory
+provider (e.g. Honcho) would store it as if the model had said it. Plugins
+can now optionally return `{"display": str, "memory": str}` instead of a
+plain string to keep the two separate. A plain string return, or a dict
+without a `"memory"` key, behaves exactly as before: memory receives the
+same value as display.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+from agent.turn_finalizer import finalize_turn
+from agent.memory_provider import MemoryProvider
+from agent.memory_manager import MemoryManager
+
+
+class FakeAgent:
+    """Matches the FakeAgent convention in test_turn_finalizer_final_response_persistence.py."""
+
+    def __init__(self):
+        self.max_iterations = 90
+        self.iteration_budget = SimpleNamespace(remaining=10, used=1, max_total=90)
+        self.quiet_mode = True
+        self.model = "test-model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.session_id = "sess-test"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "test"
+        self._tool_guardrail_halt_decision = None
+        self._interrupt_message = None
+        self._response_was_previewed = True
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+        self.persisted_messages: list[dict[str, Any]] | None = None
+        self._persist_user_message_idx: int | None = None
+        self._persist_user_message_override: Any = None
+        self._persist_user_message_timestamp: float | None = None
+        self.sync_calls: list[dict] = []
+
+    def _handle_max_iterations(self, messages, api_call_count):
+        raise AssertionError("not expected")
+
+    def _emit_status(self, *_args, **_kwargs):
+        pass
+
+    def _safe_print(self, *_args, **_kwargs):
+        pass
+
+    def _save_trajectory(self, *_args, **_kwargs):
+        pass
+
+    def _cleanup_task_resources(self, *_args, **_kwargs):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, messages):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        self.persisted_messages = [dict(message) for message in messages]
+
+    def _apply_persist_user_message_override(self, messages):
+        idx = self._persist_user_message_idx
+        override = self._persist_user_message_override
+        if idx is not None and override is not None:
+            messages[idx]["content"] = override
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **kwargs):
+        self.sync_calls.append(kwargs)
+
+
+_BASE_KWARGS = dict(
+    effective_task_id="task-test",
+    turn_id="turn-test",
+    conversation_history=[],
+    _should_review_memory=False,
+    _turn_exit_reason="text_response(final)",
+)
+
+
+def _messages_for(user_message: str) -> list[dict]:
+    return [{"role": "user", "content": user_message}]
+
+
+def test_memory_sync_receives_unchanged_response_when_no_transform(monkeypatch):
+    """No transform fires -> memory sync gets the original response."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+
+    finalize_turn(
+        agent,
+        final_response="Hi there!",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=_messages_for("Hello"),
+        user_message="Hello",
+        original_user_message="Hello",
+        **_BASE_KWARGS,
+    )
+
+    assert len(agent.sync_calls) == 1
+    assert agent.sync_calls[0]["final_response"] == "Hi there!"
+
+
+def test_memory_sync_receives_transformed_response_with_string_return(monkeypatch):
+    """A plain string return is used for both display and memory (prior behavior, unchanged)."""
+    raw = "Here is the answer."
+    appended = "\n\n[Source: example.com]"
+
+    def _fake_invoke_hook(hook_name, **_kwargs):
+        if hook_name == "transform_llm_output":
+            return [raw + appended]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_invoke_hook)
+    agent = FakeAgent()
+
+    result = finalize_turn(
+        agent,
+        final_response=raw,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=_messages_for("What is the answer?"),
+        user_message="What is the answer?",
+        original_user_message="What is the answer?",
+        **_BASE_KWARGS,
+    )
+
+    assert result["final_response"] == raw + appended
+    assert result["response_transformed"] is True
+    assert len(agent.sync_calls) == 1
+    assert agent.sync_calls[0]["final_response"] == raw + appended
+
+
+def test_memory_sync_receives_dict_memory_override(monkeypatch):
+    """A dict return with an explicit "memory" key sends that value to memory sync,
+    while the user still sees the full "display" value."""
+    raw = "Here is the answer."
+    displayed = raw + "\n\n---\nSponsored: Acme Widgets"
+
+    def _fake_invoke_hook(hook_name, **_kwargs):
+        if hook_name == "transform_llm_output":
+            return [{"display": displayed, "memory": raw}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_invoke_hook)
+    agent = FakeAgent()
+
+    result = finalize_turn(
+        agent,
+        final_response=raw,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=_messages_for("What is the answer?"),
+        user_message="What is the answer?",
+        original_user_message="What is the answer?",
+        **_BASE_KWARGS,
+    )
+
+    assert result["final_response"] == displayed
+    assert result["response_transformed"] is True
+    assert len(agent.sync_calls) == 1
+    assert agent.sync_calls[0]["final_response"] == raw
+    assert "Sponsored" not in agent.sync_calls[0]["final_response"]
+
+
+def test_memory_sync_dict_without_memory_key_falls_back_to_display(monkeypatch):
+    """A dict return with only "display" set behaves like a plain string return:
+    memory receives the same (post-transform) value as display."""
+    displayed = "Rewritten response."
+
+    def _fake_invoke_hook(hook_name, **_kwargs):
+        if hook_name == "transform_llm_output":
+            return [{"display": displayed}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_invoke_hook)
+    agent = FakeAgent()
+
+    result = finalize_turn(
+        agent,
+        final_response="Original.",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=_messages_for("Hello"),
+        user_message="Hello",
+        original_user_message="Hello",
+        **_BASE_KWARGS,
+    )
+
+    assert result["final_response"] == displayed
+    assert len(agent.sync_calls) == 1
+    assert agent.sync_calls[0]["final_response"] == displayed
+
+
+def test_memory_sync_dict_with_non_string_memory_falls_back_to_display(monkeypatch):
+    """A "memory" value that isn't a string is ignored, same fallback as a missing key."""
+    displayed = "Rewritten response."
+
+    def _fake_invoke_hook(hook_name, **_kwargs):
+        if hook_name == "transform_llm_output":
+            return [{"display": displayed, "memory": None}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_invoke_hook)
+    agent = FakeAgent()
+
+    finalize_turn(
+        agent,
+        final_response="Original.",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=_messages_for("Hello"),
+        user_message="Hello",
+        original_user_message="Hello",
+        **_BASE_KWARGS,
+    )
+
+    assert agent.sync_calls[0]["final_response"] == displayed
+
+
+def test_memory_sync_passes_interrupted_flag(monkeypatch):
+    """Interrupted turns still pass interrupted=True through (sync itself skips internally)."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+
+    finalize_turn(
+        agent,
+        final_response="Partial...",
+        api_call_count=1,
+        interrupted=True,
+        failed=False,
+        messages=_messages_for("Hello"),
+        user_message="Hello",
+        original_user_message="Hello",
+        **_BASE_KWARGS,
+    )
+
+    assert len(agent.sync_calls) == 1
+    assert agent.sync_calls[0]["interrupted"] is True
+    assert agent.sync_calls[0]["final_response"] == "Partial..."
+
+
+class _RecordingProvider(MemoryProvider):
+    """Minimal provider that just records what it was asked to sync."""
+
+    def __init__(self):
+        self.synced: list[tuple[str, str]] = []
+
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str = "", **kwargs) -> None:
+        pass
+
+    def sync_turn(self, user_content, assistant_content, *, session_id: str = "", messages=None) -> None:
+        self.synced.append((user_content, assistant_content))
+
+    def get_tool_schemas(self):
+        return []
+
+
+class _RealMemorySyncAgent(FakeAgent):
+    """Same as FakeAgent, but `_sync_external_memory_for_turn` mirrors the real
+    implementation in `agent/run_agent.py` closely enough to exercise a real
+    `MemoryManager` + provider end-to-end, instead of just recording the kwargs
+    it was called with."""
+
+    def __init__(self, memory_manager: MemoryManager):
+        super().__init__()
+        self._memory_manager = memory_manager
+
+    def _sync_external_memory_for_turn(self, *, original_user_message, final_response,
+                                        interrupted, messages=None):
+        if interrupted:
+            return
+        if not (self._memory_manager and final_response and original_user_message):
+            return
+        self._memory_manager.sync_all(
+            original_user_message, final_response, session_id=self.session_id or "",
+        )
+
+
+def test_memory_sync_recording_provider_receives_memory_value_end_to_end(monkeypatch):
+    """End-to-end: a real MemoryManager + provider must receive the "memory"
+    value, not the "display" value, when a plugin splits the two."""
+    raw = "Here is the answer."
+    displayed = raw + "\n\n---\nSponsored: Acme Widgets"
+
+    def _fake_invoke_hook(hook_name, **_kwargs):
+        if hook_name == "transform_llm_output":
+            return [{"display": displayed, "memory": raw}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_invoke_hook)
+
+    mgr = MemoryManager()
+    provider = _RecordingProvider()
+    mgr.add_provider(provider)
+    agent = _RealMemorySyncAgent(mgr)
+
+    finalize_turn(
+        agent,
+        final_response=raw,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=_messages_for("What is the answer?"),
+        user_message="What is the answer?",
+        original_user_message="What is the answer?",
+        **_BASE_KWARGS,
+    )
+
+    assert mgr.flush_pending(timeout=10) is True
+    assert len(provider.synced) == 1
+    _user_content, assistant_content = provider.synced[0]
+    assert assistant_content == raw
+    assert "Sponsored" not in assistant_content

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -399,7 +399,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `transform_terminal_output` | Transform | After bounded foreground process capture, before final output limiting; first string replaces output. | `command`, `output`, `returncode`, `task_id`, `env_type` | Command/output may contain credentials. |
 | `pre_llm_call` | Directive/control | Once per turn before the loop; all valid string/`{"context": ...}` returns are joined and injected into the user message. | `session_id`, `task_id`, `turn_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, `platform`, `parent_session_id`, `sender_id` | Full user message and conversation history. |
 | `post_llm_call` | Observer | Successful, non-interrupted turn finalization; return ignored. | `session_id`, `task_id`, `turn_id`, `user_message`, `assistant_response`, `conversation_history`, `model`, `platform` | Full prompt, response, and history. |
-| `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
+| `transform_llm_output` | Transform | Before `post_llm_call` and final delivery; first non-empty string replaces the response, or a `{"display": ..., "memory": ...}` dict replaces it while sending a different value to external memory. | `response_text`, `session_id`, `model`, `platform` | Full final assistant text. |
 | `pre_verify` | Directive/control | At the bounded edited-code verify gate; first valid continue/block-stop directive keeps the turn going. | `session_id`, `platform`, `model`, `coding`, `attempt`, `final_response`, `changed_paths` | Draft response and changed paths. |
 | `pre_api_request` | Observer | Per provider attempt, immediately before the request; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `user_message`, `conversation_history`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `retry_count`, `request_messages`, `message_count`, `tool_count`, `approx_input_tokens`, `request_char_count`, `max_tokens`, `started_at`, `middleware_trace`, `request` | High sensitivity: legacy `user_message`, `conversation_history`, and `request_messages` are intentionally raw; prefer sanitized `request`. |
 | `post_api_request` | Observer | After normalized provider success; return ignored. | `task_id`, `turn_id`, `api_request_id`, `session_id`, `platform`, `model`, `provider`, `base_url`, `api_mode`, `api_call_count`, `api_duration`, `started_at`, `ended_at`, `finish_reason`, `message_count`, `response_model`, `response`, `usage`, `assistant_message`, `assistant_content_chars`, `assistant_tool_call_count` | Sanitized `response` is available, but raw normalized `assistant_message` may contain model/user content; `usage` is accounting data. |
@@ -1267,7 +1267,7 @@ def my_callback(
     model: str,
     platform: str,
     **kwargs,
-) -> str | None:
+) -> str | dict | None:
 ```
 
 | Parameter | Type | Description |
@@ -1277,9 +1277,20 @@ def my_callback(
 | `model` | `str` | Model name that produced the response (e.g. `anthropic/claude-sonnet-4.6`). |
 | `platform` | `str` | Delivery platform (`cli`, `telegram`, `discord`, …; empty when unset). |
 
-**Return value:** Non-empty `str` to replace the response text, `None` or empty string to leave it unchanged. **First non-empty string wins** when multiple plugins register. Unlike the tool and terminal transforms, an empty string is not accepted as a replacement.
+**Return value:** A non-empty `str` replaces the response text, and is used both for what's shown to the user and for what's synced to external memory. A dict `{"display": str, "memory": str}` splits the two: `"display"` replaces the response text exactly like a plain string would; `"memory"` — if present and a string — is what gets synced to external memory providers instead. A dict without a `"memory"` key behaves exactly like a plain string return. `None` or an empty string leaves the response unchanged. **First non-empty result wins** when multiple plugins register. Unlike the tool and terminal transforms, an empty string is not accepted as a replacement.
 
-**Use cases:** Apply a personality/vocabulary transform (pirate-speak, Spongebob), redact user-specific identifiers from the final text, append a project-specific signature footer, enforce a house style guide without burning tokens on SOUL instructions.
+```python
+# Replace the response text (memory sees the same value)
+return "rewritten response"
+
+# Append something the user should see but the model shouldn't "remember" saying
+return {"display": response_text + "\n\n---\nSource: example.com", "memory": response_text}
+
+# No change
+return None
+```
+
+**Use cases:** Apply a personality/vocabulary transform (pirate-speak, Spongebob), redact user-specific identifiers from the final text, append a project-specific signature footer, enforce a house style guide without burning tokens on SOUL instructions, append a display-only citation or sponsored-message footer without polluting external memory.
 
 When CLI streaming is enabled, an append-only transform is printed after the
 streamed body. A transform that replaces the response is printed in full after
@@ -1296,6 +1307,20 @@ def spongebob(response_text, **kwargs):
 
 def register(ctx):
     ctx.register_hook("transform_llm_output", spongebob)
+```
+
+**Example — display-only footer kept out of memory:**
+
+```python
+def add_citation(response_text, **kwargs):
+    footer = "\n\n---\nSource: internal-kb/article-42"
+    return {
+        "display": response_text + footer,
+        "memory": response_text,  # external memory never sees the footer
+    }
+
+def register(ctx):
+    ctx.register_hook("transform_llm_output", add_citation)
 ```
 
 The hook is guarded on a non-empty, non-interrupted response — it will not fire on stop-button interrupts or empty turns. Exceptions are logged as warnings and do not break agent execution.


### PR DESCRIPTION
## What does this PR do?

Lets a `transform_llm_output` plugin send a **different value to external memory** than the one it shows the user, by optionally returning `{"display": str, "memory": str}` instead of a plain string.

Today a plugin's return value is used for both purposes. A plugin that appends **display-only** content — a citation, a disclaimer, a sponsored-message footer — has no way to keep that content out of external memory, so a provider (Honcho, etc.) stores it as if the model had said it, and it can resurface in later turns as part of the assistant's own prior response.

Semantics:

| Return | Display | External memory |
|---|---|---|
| `"text"` (plain string) | `"text"` | `"text"` — **unchanged from today** |
| `{"display": d, "memory": m}` | `d` | `m` |
| `{"display": d}` (no `memory`) | `d` | `d` — same as a plain string |
| `None` / empty | unchanged | unchanged |

Strictly opt-in and backward compatible: plain-string returns behave exactly as before, and a `"memory"` value that isn't a string is ignored rather than erroring.

## Related Issue

Fixes #57282

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_finalizer.py` — the `transform_llm_output` result loop now also accepts a dict with a non-empty `"display"`. When one carries a string `"memory"`, it's captured in a new `_memory_response` local, which is then passed to `_sync_external_memory_for_turn` in place of `final_response`. When it isn't, `_memory_response` stays `None` and the existing `final_response` is used — today's behavior.
- `tests/agent/test_turn_finalizer_memory_sync_pre_transform.py` — new, 7 tests (see below).
- `website/docs/user-guide/features/hooks.md` — summary-table return type, callback signature, return-value prose, and a new display-only-footer example.
- `docs/observability/README.md` — the one-line hook-return description.

### Why this shape, and not the alternatives in the issue

The issue lists three options. This implements **Option 2** (structured return).

- **Option 1** (a `display_only=True` flag at `register_hook` time) makes the choice per *registration* rather than per *turn*. A plugin that sometimes appends and sometimes rewrites can't express both, and the flag sits far away from the code that decides what to return.
- **Option 3** (a new `transform_memory_assistant` hook, mirroring the `transform_persisted_assistant` proposal in #46574) is the more general design and composes well with that hook family, but it costs a second hook invocation per turn and forces plugin authors to keep two callbacks in sync just to say "remember the version without my footer." Worth revisiting if #46574 lands and a broader per-consumer hook family emerges — this change doesn't preclude it.
- **Option 2** keeps the decision at the single point where the plugin already knows the answer, adds no new hook, and there's precedent in this codebase: `pre_llm_call` and `pre_verify` already accept a documented dict-or-string return.

This also addresses the review feedback on #57289 (same issue, different approach — that PR routes the pre-transform response to memory unconditionally, which fixes display-only appends but breaks restoration transforms like PII de-redaction that need the *transformed* value to be canonical). Here the transformed value stays the default and a plugin opts into anything else. I have no stake in which lands; noting the overlap for whoever triages.

### Scope notes

- No change is needed at the hook-dispatch layer — `PluginManager.invoke_hook` already returns callback values untouched; the `str`-only gate was the caller-side loop in `turn_finalizer.py`, which is what this changes.
- `_memory_response` is deliberately a **separate** local from `_pre_transform_response`. The latter was added for the CLI-streaming suffix fix and means "None unless a transform fired"; reusing it here would couple the two features and change that contract for its existing consumers in `cli.py` and `acp_adapter/server.py`.
- The other `_sync_external_memory_for_turn` call site, `agent/codex_runtime.py`, never runs `transform_llm_output`, so it has no leak to fix and is untouched.
- An explicit `{"memory": ""}` is honored rather than treated as absent; it falls through the existing empty-response guard in `_sync_external_memory_for_turn` and simply skips the sync for that turn.
- I did not touch the `zh-Hans` i18n copy of `hooks.md` — flagging it for translators rather than machine-translating it here.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_turn_finalizer_memory_sync_pre_transform.py -v
scripts/run_tests.sh tests/agent/test_turn_finalizer_cleanup_guard.py \
  tests/agent/test_turn_finalizer_final_response_persistence.py \
  tests/agent/test_turn_finalizer_interrupt_alternation.py \
  tests/agent/test_turn_finalizer_iteration_limit_exit.py \
  tests/test_transform_llm_output_hook.py \
  tests/agent/test_memory_async_sync.py tests/agent/test_memory_provider.py -v
```

New tests cover: no transform fires; plain-string return (pins today's behavior — memory gets the same post-transform value as display); dict with distinct `display`/`memory`; dict with only `display` (falls back); dict with a non-string `memory` (same fallback); interrupted turns; and an **end-to-end test through a real `MemoryManager` and a recording `MemoryProvider`**, asserting the provider itself receives the `memory` value — not just that the call site was handed it. That last one is in response to the review note on #57289 asking for provider-level coverage rather than a stub at the `_sync_external_memory_for_turn` seam.

Manual check: register a plugin returning `{"display": response_text + "\n\nFOOTER", "memory": response_text}`, run a turn with an external memory provider configured, and confirm the footer appears in the response but not in what's recalled on the next turn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected test files via `scripts/run_tests.sh` and they pass (86 tests across the files listed above); `ruff check` and `ty check` are clean on the changed files
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've considered cross-platform impact — pure Python logic, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
