### PR TITLE
fix(desktop): keep the HUD on the session it was opened for

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { _resetLegacyDiscardForTests } from '@/store/session'
+import type * as WindowsStore from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
 
 import { useDesktopIntegrations } from './use-desktop-integrations'
@@ -12,7 +13,7 @@ import { useDesktopIntegrations } from './use-desktop-integrations'
 const { hudWindowMock } = vi.hoisted(() => ({ hudWindowMock: vi.fn(() => false) }))
 
 vi.mock('@/store/windows', async importOriginal => {
-  const actual = await importOriginal<typeof import('@/store/windows')>()
+  const actual = await importOriginal<typeof WindowsStore>()
 
   return {
     ...actual,

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -6,6 +6,20 @@ import type { SessionInfo } from '@/types/hermes'
 
 import { useDesktopIntegrations } from './use-desktop-integrations'
 
+// Mutable HUD-window flag so the restore tests can flip the window kind the
+// hook believes it runs in. Default false keeps the pre-existing restore
+// coverage exercising the real main-window path.
+const { hudWindowMock } = vi.hoisted(() => ({ hudWindowMock: vi.fn(() => false) }))
+
+vi.mock('@/store/windows', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/windows')>()
+
+  return {
+    ...actual,
+    isHudWindow: () => hudWindowMock()
+  }
+})
+
 // Pure-jsdom localStorage (no nanostores persistence module needed — the
 // production functions write directly to window.localStorage through the
 // persistString/storedString helpers in @/lib/storage, which in jsdom resolves
@@ -42,6 +56,8 @@ describe('useDesktopIntegrations', () => {
     window.localStorage.clear()
     _resetLegacyDiscardForTests()
     navigate = vi.fn()
+    // Every test starts as a main window; only the HUD describe flips this.
+    hudWindowMock.mockReturnValue(false)
 
     // Stub the desktop bridge so the hook's useEffect callbacks don't try to
     // reach real Electron IPC. The established desktop-test pattern assigns a
@@ -234,6 +250,43 @@ describe('useDesktopIntegrations', () => {
       })
 
       // No navigation — coder's remembered route doesn't belong to ops.
+      expect(navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('HUD window (win=hud)', () => {
+    beforeEach(() => {
+      hudWindowMock.mockReturnValue(true)
+    })
+
+    it('does NOT restore remembered navigation on a blank new-chat route', () => {
+      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'remembered-session')
+      window.localStorage.setItem('hermes.desktop.lastRoute.profile.default', '/remembered-session')
+
+      render({ profileReady: true, sessions: [session({ id: 'remembered-session', profile: 'default' })] })
+
+      // The HUD is a fresh full renderer booting at the default route, but its
+      // destination was chosen explicitly by hudTargetSessionId() at open time
+      // — remembered-navigation restore must not hijack it to the last session.
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('does NOT write remembered navigation while showing a session', () => {
+      render({
+        profileReady: true,
+        routedSessionId: 'live',
+        sessions: [session({ id: 'live', profile: 'default' })]
+      })
+
+      expect(window.localStorage.getItem('hermes.desktop.lastSessionId.profile.default')).toBeNull()
+      expect(window.localStorage.getItem('hermes.desktop.lastRoute.profile.default')).toBeNull()
+    })
+
+    it('does not restore the remembered session id either', () => {
+      window.localStorage.setItem('hermes.desktop.lastSessionId.profile.default', 'remembered-session')
+
+      render({ profileReady: true, sessions: [session({ id: 'remembered-session', profile: 'default' })] })
+
       expect(navigate).not.toHaveBeenCalled()
     })
   })

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -14,7 +14,7 @@ import {
 } from '@/store/session'
 import { onSessionsChanged } from '@/store/session-sync'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
-import { isSecondaryWindow } from '@/store/windows'
+import { isHudWindow, isSecondaryWindow } from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
@@ -82,7 +82,7 @@ export function useDesktopIntegrations({
   // This ref is a one-time lifecycle latch, not a mirror of reactive atom state.
   // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
-    if (!profileReady) {
+    if (!profileReady || isHudWindow()) {
       return
     }
 


### PR DESCRIPTION
## What does this PR do?

HUD mode (`Ctrl/Cmd+Shift+H`) could land on the **wrong conversation**: opening it on a brand-new blank chat (`#/`) let the main window's cold-start "restore last session" logic run inside the HUD — a full app renderer — so it navigated to the remembered session instead of staying on the new one. A blank draft has no stored session id yet, so the HUD boots at the default route, which is exactly the route the restore logic claims on cold start.

Guard the restore/remember effect with `isHudWindow()`: the HUD's destination is always chosen explicitly at open time (`hudTargetSessionId()`), so remembered-navigation restore must not run inside it. This also stops the HUD from clobbering the main window's remembered navigation while it is up.

## Related

- Fixes the "started a new session, went to HUD, and it reverted to the last session" report.
- **#82310** (HUD profile handoff) is a *different* bug with a *similar* visible symptom — HUD opening against the wrong profile vs. this cold-start restore hijack. No file overlap; both are needed. When opening HUD on a blank new chat with #82310 applied, the restore effect would still jump to the (adopted) profile's last session without this guard.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts` — bail the remembered-navigation restore/remember effect when `isHudWindow()` is true (one-line guard + import)
- `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx` — 3 new tests: HUD does not restore remembered navigation at the blank new-chat route, does not restore the remembered session id, and does not write remembered navigation while showing a session (mutable `isHudWindow` mock, main-window default preserved)

## How to Test

1. Open a session, send a message, then click **+** (or ⌘N) for a blank new chat.
2. Enter HUD mode (`Ctrl/Cmd+Shift+H` or the titlebar toggle).
3. **Before:** HUD jumps to the last session. **After:** HUD stays on the blank new chat.
4. (Regression) Open HUD from an existing session — it opens on that session.

```bash
cd apps/desktop && npx vitest run src/app/contrib/hooks/use-desktop-integrations.test.tsx
```

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — #82310 is related but distinct (no overlap, cross-referenced)
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] Verified on Windows: build clean, 22/22 tests pass, manual HUD repro fixed