### PR TITLE
fix(agent): classify Anthropic "extra usage" 400 as billing, not format_error

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -143,6 +143,24 @@ _BILLING_ERROR_CODES = frozenset({
     _XAI_SPENDING_LIMIT_ERROR_CODE,
 })
 
+# Anthropic subscription *entitlement* gate, surfaced as HTTP 400.  When a
+# Claude Pro/Max subscription must enable extra usage to keep serving, native
+# Anthropic returns a 400 whose body reads like "Third-party apps now draw from
+# your extra usage. To continue, enable extra usage in your account settings."
+# This is a billing/entitlement condition, not a malformed request — without
+# this it fell through to the generic ``format_error`` bucket, so the user got
+# an opaque "format error" instead of actionable billing guidance and no
+# credential rotation fired.  Patterns are deliberately specific (an account
+# *action* on extra usage) so they do NOT collide with the 429 rolling-cap /
+# long-context tier gate, which is "extra usage" + "long context" and is
+# classified separately as ``long_context_tier`` on the 429 path.
+_ENTITLEMENT_PATTERNS = [
+    "draw from your extra usage",
+    "enable extra usage",
+    "exceed your extra usage",
+    "extra usage allowance",
+]
+
 # Patterns that indicate rate limiting (transient, will resolve)
 _RATE_LIMIT_PATTERNS = [
     "rate limit",
@@ -1434,6 +1452,17 @@ def _classify_400(
             should_rotate_credential=True,
             should_fallback=True,
         )
+    # Anthropic subscription entitlement gate ("extra usage") arrives as a 400.
+    # Treat as billing (rotate + fall back + surface billing guidance) rather
+    # than the generic format_error. Checked before _BILLING_PATTERNS since the
+    # phrasing is distinct; both converge on FailoverReason.billing.
+    if any(p in error_msg for p in _ENTITLEMENT_PATTERNS):
+        return result_fn(
+            FailoverReason.billing,
+            retryable=False,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
     if any(p in error_msg for p in _BILLING_PATTERNS):
         return result_fn(
             FailoverReason.billing,
@@ -1598,6 +1627,18 @@ def _classify_by_message(
         return result_fn(
             FailoverReason.overloaded,
             retryable=True,
+        )
+
+    # Entitlement gate ("extra usage") when surfaced without a status code.
+    # Must come BEFORE the generic billing check so the specific entitlement
+    # phrasing is classified here. Guard against the long-context tier phrasing
+    # so it isn't swallowed here (that path stays retryable on the 429 branch).
+    if any(p in error_msg for p in _ENTITLEMENT_PATTERNS) and "long context" not in error_msg:
+        return result_fn(
+            FailoverReason.billing,
+            retryable=False,
+            should_rotate_credential=True,
+            should_fallback=True,
         )
 
     # Billing patterns

--- a/tests/agent/test_entitlement_extra_usage_classification.py
+++ b/tests/agent/test_entitlement_extra_usage_classification.py
@@ -1,0 +1,84 @@
+"""Anthropic subscription *entitlement* 400 ("extra usage" / "third-party apps
+now draw from your extra usage") must classify as BILLING, not format_error.
+
+Repro (forensics in this repo's own incident history): when a Claude
+subscription must enable extra usage, native Anthropic returns HTTP 400 with a
+body like "Third-party apps now draw from your extra usage. To continue, enable
+extra usage in your account settings." The generic 400 path classified this as
+``format_error`` — so the user got an opaque "format error" instead of the
+actionable billing/entitlement guidance, and no credential rotation was
+triggered (``should_rotate_credential`` stayed False).
+
+These are behavior-contract tests: the entitlement signal => billing + rotate +
+fallback, while the *rolling-cap* 429 ("extra usage" + "long context") must stay
+``long_context_tier`` (retryable, NOT billing). Guards both the fix and the
+no-collision invariant.
+"""
+
+from agent.error_classifier import FailoverReason, classify_api_error
+
+
+class _FakeResp:
+    def __init__(self, body, status=400):
+        self.status_code = status
+        self._b = body
+
+    def json(self):
+        return self._b
+
+
+class _FakeErr(Exception):
+    def __init__(self, msg, body, status=400):
+        super().__init__(msg)
+        self.status_code = status
+        self.body = body
+        self.response = _FakeResp(body, status)
+
+
+def _classify(msg, status=400):
+    body = {"type": "error", "error": {"type": "invalid_request_error", "message": msg}}
+    return classify_api_error(
+        _FakeErr(msg, body, status),
+        provider="anthropic",
+        model="claude-opus-4-8",
+        approx_tokens=4000,
+        context_length=200000,
+        num_messages=10,
+    )
+
+
+class TestEntitlementExtraUsageIsBilling:
+    def test_third_party_draw_from_extra_usage_is_billing(self):
+        r = _classify(
+            "Third-party apps now draw from your extra usage. To continue, "
+            "enable extra usage in your account settings."
+        )
+        assert r.reason == FailoverReason.billing
+        assert r.should_fallback is True
+        assert r.should_rotate_credential is True
+
+    def test_exceed_extra_usage_allowance_is_billing(self):
+        r = _classify("This request would exceed your extra usage allowance.")
+        assert r.reason == FailoverReason.billing
+        assert r.should_rotate_credential is True
+
+    def test_enable_extra_usage_phrasing_is_billing(self):
+        r = _classify("Please enable extra usage in your account settings to continue.")
+        assert r.reason == FailoverReason.billing
+
+
+class TestNoCollisionWithLongContextTier:
+    """The 429 rolling-cap / long-context tier gate must remain untouched —
+    it is retryable and NOT billing."""
+
+    def test_429_extra_usage_long_context_stays_tier_gate(self):
+        r = _classify(
+            "Request requires extra usage for the long context window.",
+            status=429,
+        )
+        assert r.reason == FailoverReason.long_context_tier
+        assert r.reason != FailoverReason.billing
+
+    def test_real_billing_credit_balance_still_billing(self):
+        r = _classify("Your credit balance is too low to access the Anthropic API.")
+        assert r.reason == FailoverReason.billing


### PR DESCRIPTION
## What

Native Anthropic returns the Claude Pro/Max subscription *entitlement* gate as an HTTP **400** whose body reads like "Third-party apps now draw from your extra usage. To continue, enable extra usage in your account settings." That is a billing/entitlement condition, not a malformed request — but the classifier only knew billing shapes on 402/403/429, so this fell through to the generic `format_error` bucket: the user got an opaque "format error" instead of actionable billing guidance, and credential rotation never fired.

Fix: `_ENTITLEMENT_PATTERNS` ("draw from your extra usage", "enable extra usage", …) classified as billing on the 400 path. Patterns are deliberately specific (an account *action* on extra usage) so they do NOT collide with the 429 rolling-cap / long-context tier gate ("extra usage" + "long context"), which stays classified as `long_context_tier`.

## Why

- A subscription account hitting the extra-usage gate is a recoverable, user-actionable state; surfacing it as `format_error` hides the one thing the user needs to do.
- With multiple credentials pooled, misclassification also blocks rotation to a healthy key.

## How to test

```
scripts/run_tests.sh tests/agent/test_entitlement_extra_usage_classification.py -- -q
```

5 tests: each entitlement phrasing classifies as billing on 400; the long-context 429 shape stays `long_context_tier`; unrelated 400s still classify as `format_error`. Reproduced live against native Anthropic with a subscription account in the extra-usage state before writing the fix.

Tested on Linux (aarch64).

Supersedes auto-closed #49379 (head fork deleted in a remote swap; GitHub can't reopen a PR whose head repo is gone). Rebased onto current main — the classifier gained xAI spending-limit codes in the same region since, and this change composes with them.
