### PR TITLE
fix(cron): reset cron-delivery ContextVars to _UNSET after a job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3467,7 +3467,7 @@ def run_job(
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
-    from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
+    from gateway.session_context import set_session_vars, clear_session_vars, reset_cron_delivery_vars, _VAR_MAP
 
     # Cron execution is an internal scheduler context, not a live inbound
     # gateway message. Do not seed HERMES_SESSION_* contextvars from the
@@ -4388,8 +4388,12 @@ def run_job(
             _cron_session_var.reset(_cron_session_token)
         if _non_dispatcher_token is not None:
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
-        for _var_name in _cron_delivery_vars:
-            _VAR_MAP[_var_name].set("")
+        # Restore the cron-delivery vars to their *never set* (_UNSET) state, not
+        # "" — an empty string suppresses the os.environ fallback in
+        # get_session_env, so setting "" here would leak an empty cron-delivery
+        # value into every later caller in this thread/task (cross-run / cross-
+        # test pollution). reset_cron_delivery_vars() returns them to _UNSET.
+        reset_cron_delivery_vars()
         if _session_db:
             # Compression can rotate the live agent onto a continuation while
             # this run is in flight. Finalize that continuation, not the stale

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -360,6 +360,28 @@ def reset_session_vars() -> None:
         pass
 
 
+def reset_cron_delivery_vars() -> None:
+    """Restore the cron auto-delivery ContextVars to their *never set* state.
+
+    Distinct from setting them to ``""``: an empty string is the
+    "explicitly cleared" state that suppresses the ``os.environ`` fallback in
+    ``get_session_env`` (correct WHILE a job runs, so a job's own
+    ``send_message`` can detect a duplicate auto-delivery target). After a job
+    finishes, the vars must be returned to the ``_UNSET`` sentinel so the next
+    caller in the same thread/task falls back to ``os.environ`` again. Without
+    this, a cron run leaks an empty cron-delivery value into every later caller
+    in the process — observed as cross-test pollution where a later
+    ``send_message`` no longer detects the cron duplicate-target case because
+    the ContextVar shadows the env the caller set.
+    """
+    for var in (
+        _CRON_AUTO_DELIVER_PLATFORM,
+        _CRON_AUTO_DELIVER_CHAT_ID,
+        _CRON_AUTO_DELIVER_THREAD_ID,
+    ):
+        var.set(_UNSET)
+
+
 def get_session_env(name: str, default: str = "") -> str:
     """Read a session context variable by its legacy ``HERMES_SESSION_*`` name.
 

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -273,3 +273,59 @@ def test_cron_session_set_clear_and_reset_tristate(monkeypatch):
     reset_session_vars()
     assert get_session_env("HERMES_CRON_SESSION") == "1"
 
+
+# ---------------------------------------------------------------------------
+# reset_cron_delivery_vars: cron auto-delivery vars must return to the *never
+# set* (_UNSET) state after a job, NOT "" — otherwise an empty value leaks
+# into every later same-thread caller and shadows the os.environ fallback.
+# ---------------------------------------------------------------------------
+
+from gateway.session_context import (  # noqa: E402
+    reset_cron_delivery_vars,
+    _CRON_AUTO_DELIVER_PLATFORM,
+    _CRON_AUTO_DELIVER_CHAT_ID,
+    _CRON_AUTO_DELIVER_THREAD_ID,
+)
+
+_CRON_DELIVERY_VARS = (
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+    "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+)
+
+
+def test_reset_cron_delivery_vars_restores_unset_sentinel():
+    """After a cron job, the delivery vars must hold _UNSET, not ""."""
+    # Simulate run_job setting the delivery target during execution.
+    _CRON_AUTO_DELIVER_PLATFORM.set("telegram")
+    _CRON_AUTO_DELIVER_CHAT_ID.set("-1001")
+    _CRON_AUTO_DELIVER_THREAD_ID.set("")
+
+    reset_cron_delivery_vars()
+
+    assert _CRON_AUTO_DELIVER_PLATFORM.get() is _UNSET
+    assert _CRON_AUTO_DELIVER_CHAT_ID.get() is _UNSET
+    assert _CRON_AUTO_DELIVER_THREAD_ID.get() is _UNSET
+
+
+def test_reset_cron_delivery_vars_reenables_environ_fallback(monkeypatch):
+    """The bug: a cron run set the vars to "" (the explicitly-cleared state),
+    which suppresses the os.environ fallback in get_session_env, so a later
+    same-thread caller read "" instead of the env it had set. After the fix,
+    reset_cron_delivery_vars() returns the vars to _UNSET so the fallback works.
+    """
+    # A later caller (e.g. send_message) relies on the env var.
+    monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "999")
+
+    # Reproduce the OLD leak: a finished cron job left the vars at "".
+    _CRON_AUTO_DELIVER_PLATFORM.set("")
+    _CRON_AUTO_DELIVER_CHAT_ID.set("")
+    # With "" set, the contextvar shadows os.environ — fallback suppressed.
+    assert get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") == ""
+    assert get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") == ""
+
+    # The fix restores _UNSET, so get_session_env falls back to os.environ.
+    reset_cron_delivery_vars()
+    assert get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") == "discord"
+    assert get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") == "999"


### PR DESCRIPTION
## What

`run_job()` sets the `HERMES_CRON_AUTO_DELIVER_*` ContextVars while a job runs so the job's own `send_message` can detect a duplicate auto-delivery target. On the way out it "cleared" them by setting `""` — but an empty string is the *explicitly cleared* state that suppresses the `os.environ` fallback in `get_session_env`. Correct WHILE the job runs; wrong after it: the empty value leaks into every later caller in the same thread/task (cross-run / cross-test pollution), so a subsequent consumer that should have fallen back to `os.environ` sees "explicitly no target" instead.

Fix: `reset_cron_delivery_vars()` in `gateway/session_context.py` returns the vars to the `_UNSET` sentinel (never-set state), and `run_job()` calls it in the job-teardown path instead of the `""` loop.

## Why

- The scheduler thread is long-lived: one job's teardown must not change delivery-target resolution for the next job or for non-cron callers on the same thread.
- The distinction between "explicitly cleared" (`""`, suppress fallback) and "never set" (`_UNSET`, allow fallback) is the documented contract of `get_session_env` — teardown was landing on the wrong side of it.

## How to test

```
scripts/run_tests.sh tests/gateway/test_session_env.py -- -q
```

11 tests pass, including the new one: after `reset_cron_delivery_vars()`, `get_session_env` falls back to `os.environ` again (fails against the previous `""` teardown).

Tested on Linux (aarch64).

Supersedes auto-closed #47089 (head fork deleted in a remote swap; GitHub can't reopen a PR whose head repo is gone). Rebased onto current main — upstream's `run_job` teardown gained cwd-lock and non-dispatcher token handling since; this change composes with both.
