### PR TITLE
fix(web): reject non-http(s) MCP OAuth authorization_url before navigate

### DIFF
--- a/web/src/lib/mcp-dashboard-oauth.test.ts
+++ b/web/src/lib/mcp-dashboard-oauth.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
-import { completeMcpDashboardOAuth } from "./mcp-dashboard-oauth";
+import {
+  completeMcpDashboardOAuth,
+  isValidAuthorizationUrl,
+} from "./mcp-dashboard-oauth";
+
+describe("isValidAuthorizationUrl", () => {
+  it("accepts http(s) URLs with a host", () => {
+    expect(isValidAuthorizationUrl("https://idp.example/authorize")).toBe(true);
+    expect(isValidAuthorizationUrl("http://127.0.0.1:8080/oauth")).toBe(true);
+  });
+
+  it("rejects non-http schemes", () => {
+    expect(isValidAuthorizationUrl("javascript:alert(1)")).toBe(false);
+    expect(isValidAuthorizationUrl("file:///etc/passwd")).toBe(false);
+    expect(isValidAuthorizationUrl("not a url")).toBe(false);
+  });
+});
 
 describe("completeMcpDashboardOAuth", () => {
   it("opens the authorization URL in the dashboard browser and polls to approval", async () => {
@@ -67,6 +83,28 @@ describe("completeMcpDashboardOAuth", () => {
       }),
     ).rejects.toThrow("registration denied");
     expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects non-http(s) authorization URLs before navigating", async () => {
+    const close = vi.fn();
+    const authWindow = { location: { href: "" }, close } as unknown as Window;
+    await expect(
+      completeMcpDashboardOAuth({
+        serverName: "reports",
+        start: async () => ({
+          flow_id: "flow-bad-scheme",
+          server_name: "reports",
+          status: "authorization_required",
+          authorization_url: "javascript:alert(1)",
+          error: null,
+        }),
+        status: vi.fn(),
+        open: vi.fn().mockReturnValue(authWindow),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/http\(s\) URL/);
+    expect(close).toHaveBeenCalledOnce();
+    expect(authWindow.location.href).toBe("");
   });
 
   it("fails before starting when the browser blocks the popup", async () => {

--- a/web/src/lib/mcp-dashboard-oauth.ts
+++ b/web/src/lib/mcp-dashboard-oauth.ts
@@ -12,6 +12,16 @@ type CompleteOptions = {
 const defaultSleep = (milliseconds: number) =>
   new Promise<void>((resolve) => window.setTimeout(resolve, milliseconds));
 
+/** http(s) authorization URLs only — reject javascript:/file: before navigate. */
+export function isValidAuthorizationUrl(authorizationUrl: string): boolean {
+  try {
+    const parsed = new URL(authorizationUrl);
+    return (parsed.protocol === "http:" || parsed.protocol === "https:") && Boolean(parsed.host);
+  } catch {
+    return false;
+  }
+}
+
 export async function completeMcpDashboardOAuth({
   serverName,
   start,
@@ -35,6 +45,11 @@ export async function completeMcpDashboardOAuth({
     }
     if (!started.authorization_url) {
       throw new Error("OAuth server did not provide an authorization URL");
+    }
+    if (!isValidAuthorizationUrl(started.authorization_url)) {
+      throw new Error(
+        "OAuth authorization_url must be an http(s) URL with a host",
+      );
     }
     authWindow.location.href = started.authorization_url;
   } catch (error) {


### PR DESCRIPTION
## Summary

Sibling of #82350 (Python `webbrowser.open` / publish path). Dashboard `completeMcpDashboardOAuth` sets `authWindow.location.href = started.authorization_url` with no scheme allowlist, so a hostile `javascript:` / `file:` URL could navigate the popup.

This adds `isValidAuthorizationUrl` (http/https + host) before navigate and closes the popup on failure. Framed as `SECURITY.md` §3.2 hardening.

## Test plan

- [x] `npm test -- src/lib/mcp-dashboard-oauth.test.ts` (8 passed)
- [ ] Manual: normal HTTPS IdP authorization still opens in the dashboard popup


Made with [Cursor](https://cursor.com)