### PR TITLE
fix(tui): exclude cron and subagent from session auto-resume

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12641,12 +12641,14 @@ def test_session_activate_can_omit_duplicate_desktop_transcript(monkeypatch):
 
 
 def test_session_most_recent_returns_first_non_denied(monkeypatch):
-    """Drops `tool` rows like session.list does, returns the first hit."""
+    """Drops non-interactive rows like session.list does, returns the first hit."""
 
     class _DB:
         def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
             return [
-                {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
+                {"id": "cron-1", "source": "cron", "title": "job", "started_at": 102},
+                {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 101},
+                {"id": "sub-1", "source": "subagent", "title": "child", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
             ]
 
@@ -12661,10 +12663,33 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     assert resp["result"]["source"] == "tui"
 
 
+def test_session_most_recent_skips_cron_before_human_session(monkeypatch):
+    """#82300: a more-recent cron job must not win auto-resume."""
+
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+            return [
+                {"id": "cron-1", "source": "cron", "title": "nightly", "started_at": 200},
+                {"id": "cli-1", "source": "cli", "title": "user", "started_at": 100},
+            ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+
+    assert resp["result"]["session_id"] == "cli-1"
+    assert resp["result"]["source"] == "cli"
+
+
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
         def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
-            return [{"id": "tool-1", "source": "tool", "started_at": 1}]
+            return [
+                {"id": "tool-1", "source": "tool", "started_at": 2},
+                {"id": "cron-1", "source": "cron", "started_at": 1},
+            ]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -170,11 +170,13 @@ def _(rid, params: dict) -> dict:
             # ones not enumerated here), ACP adapter clients, webhook sessions,
             # custom `HERMES_SESSION_SOURCE` values, and older installs with
             # different source labels. We deny-list only the noisy internal
-            # sources (``tool`` sub-agent runs and ``kanban`` dispatcher
-            # workers) rather than allow-listing a fixed set of platform names
-            # that goes stale whenever a new platform is added or a user names
-            # their own source.
-            deny = frozenset({"kanban", "tool"})
+            # sources (``tool``/``subagent`` runs, ``kanban`` dispatcher workers,
+            # and ``cron`` scheduled jobs) rather than allow-listing a fixed set
+            # of platform names that goes stale whenever a new platform is added
+            # or a user names their own source. Cron must be denied so
+            # tui_auto_resume_recent cannot land on a scheduled-job session after
+            # the user's last interactive turn (#82300).
+            deny = frozenset({"kanban", "tool", "cron", "subagent"})
 
             limit = int(params.get("limit", 200) or 200)
             # Over-fetch modestly so per-source filtering doesn't leave us
@@ -215,11 +217,11 @@ def _(rid, params: dict) -> dict:
 def _(rid, params: dict) -> dict:
     """Return the most recent human-facing session id, or ``None``.
 
-    Mirrors ``session.list``'s deny-list behaviour (drops ``tool``
-    sub-agent rows and ``kanban`` worker rows).  Used by TUI auto-resume when
-    ``display.tui_auto_resume_recent`` is on; the field is also handy
-    for any CLI tooling that wants "latest session" without paginating
-    the full list.
+    Mirrors ``session.list``'s deny-list behaviour (drops ``tool`` /
+    ``subagent`` rows, ``kanban`` workers, and ``cron`` scheduled jobs).
+    Used by TUI auto-resume when ``display.tui_auto_resume_recent`` is on;
+    the field is also handy for any CLI tooling that wants "latest session"
+    without paginating the full list.
 
     Contract: a ``{"session_id": null}`` result means "no eligible
     session found right now".  Errors are also folded into that
@@ -233,10 +235,10 @@ def _(rid, params: dict) -> dict:
         if db is None:
             return _ok(rid, {"session_id": None})
         try:
-            deny = frozenset({"kanban", "tool"})
-            # Over-fetch by a generous bounded amount so heavy sub-agent
-            # users (lots of recent ``tool`` rows) don't get a false
-            # "no eligible session" answer.  ``session.list`` uses a
+            deny = frozenset({"kanban", "tool", "cron", "subagent"})
+            # Over-fetch by a generous bounded amount so heavy sub-agent /
+            # cron users (lots of recent non-interactive rows) don't get a
+            # false "no eligible session" answer.  ``session.list`` uses a
             # similar over-fetch strategy.
             rows = db.list_sessions_rich(
                 source=None, limit=200, order_by_last_active=True, compact_rows=True


### PR DESCRIPTION
## What does this PR do?

When `display.tui_auto_resume_recent` is on, `session.most_recent` (and `session.list`) only denied `kanban`/`tool` rows. A cron job that ran after the user's last interactive turn became the "most recent" session, so the TUI resumed into automated cron context instead of the user's conversation.

Adds `cron` and `subagent` to the same deny-list both RPCs already share, matching Desktop's non-human sidebar sources.

## Related Issue

Fixes #82300

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/methods_session.py`: extend deny frozenset to `{"kanban", "tool", "cron", "subagent"}` in `session.list` and `session.most_recent`; update docs.
- `tests/test_tui_gateway_server.py`: cover cron-ahead-of-cli auto-resume skip.

## How to Test

1. Enable `display.tui_auto_resume_recent: true`
2. Use a TUI/CLI session, then let a cron job run (or insert a more-recent `source=cron` row)
3. Restart the TUI
4. Before: resumes the cron session. After: resumes the last human-facing session

Automated:

```bash
pytest tests/test_tui_gateway_server.py -q -k 'session_most_recent'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted tests above and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit-tested RPC path.

Note: older open PR #22203 targeted `tui_gateway/server.py` before this logic moved to `methods_session.py`; the deny list on main still lacked `cron`.