### PR TITLE
fix(env): strip CONDA_SHLVL with CONDA_PREFIX from subprocess env

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -301,27 +301,70 @@ class TestActiveVenvMarkerStripping:
         })
         assert "CONDA_PREFIX" not in result_env
 
+    def test_conda_shlvl_marker_stripped_end_to_end(self):
+        """#82255: half-stripped conda (SHLVL without PREFIX) crashes shell init."""
+        result_env = _run_with_env(extra_os_env={
+            "CONDA_PREFIX": "/opt/conda/envs/hermes",
+            "CONDA_SHLVL": "1",
+            "CONDA_PROMPT_MODIFIER": "(hermes) ",
+        })
+        assert "CONDA_PREFIX" not in result_env
+        assert "CONDA_SHLVL" not in result_env
+        assert "CONDA_PROMPT_MODIFIER" not in result_env
+
     def test_make_run_env_strips_markers(self):
         from tools.environments.local import _make_run_env
-        poison = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "PATH": "/usr/bin"}
+        poison = {
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_SHLVL": "1",
+            "CONDA_PROMPT_MODIFIER": "(base) ",
+            "PATH": "/usr/bin",
+        }
         with patch.dict(os.environ, poison, clear=True):
             result = _make_run_env({})
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
+        assert "CONDA_SHLVL" not in result
+        assert "CONDA_PROMPT_MODIFIER" not in result
 
     def test_sanitize_subprocess_env_strips_markers(self):
         from tools.environments.local import _sanitize_subprocess_env
-        base = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "HOME": "/home/user"}
+        base = {
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_SHLVL": "1",
+            "CONDA_PROMPT_MODIFIER": "(base) ",
+            "HOME": "/home/user",
+        }
         # Even an explicitly-passed extra marker is stripped.
         result = _sanitize_subprocess_env(base, {"VIRTUAL_ENV": "/also/venv"})
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
+        assert "CONDA_SHLVL" not in result
+        assert "CONDA_PROMPT_MODIFIER" not in result
         assert result.get("HOME") == "/home/user"
 
     def test_markers_constant_contents(self):
         from tools.environments.local import _ACTIVE_VENV_MARKER_VARS
         assert "VIRTUAL_ENV" in _ACTIVE_VENV_MARKER_VARS
         assert "CONDA_PREFIX" in _ACTIVE_VENV_MARKER_VARS
+        assert "CONDA_SHLVL" in _ACTIVE_VENV_MARKER_VARS
+        assert "CONDA_PROMPT_MODIFIER" in _ACTIVE_VENV_MARKER_VARS
+
+    def test_stripped_conda_state_is_self_consistent(self):
+        """No CONDA_SHLVL may survive without CONDA_PREFIX (#82255 invariant)."""
+        from tools.environments.local import _sanitize_subprocess_env
+        half = {
+            "CONDA_SHLVL": "1",
+            "CONDA_PROMPT_MODIFIER": "(base) ",
+            "PATH": "/usr/bin",
+            "HOME": "/home/user",
+        }
+        result = _sanitize_subprocess_env(half, {})
+        assert "CONDA_SHLVL" not in result
+        assert "CONDA_PREFIX" not in result
+        assert "CONDA_PROMPT_MODIFIER" not in result
 
 
 def _make_directory_link(link: Path, target: Path) -> None:

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -290,27 +290,70 @@ class TestActiveVenvMarkerStripping:
         })
         assert "CONDA_PREFIX" not in result_env
 
+    def test_conda_shlvl_marker_stripped_end_to_end(self):
+        """#82255: half-stripped conda (SHLVL without PREFIX) crashes shell init."""
+        result_env = _run_with_env(extra_os_env={
+            "CONDA_PREFIX": "/opt/conda/envs/hermes",
+            "CONDA_SHLVL": "1",
+            "CONDA_PROMPT_MODIFIER": "(hermes) ",
+        })
+        assert "CONDA_PREFIX" not in result_env
+        assert "CONDA_SHLVL" not in result_env
+        assert "CONDA_PROMPT_MODIFIER" not in result_env
+
     def test_make_run_env_strips_markers(self):
         from tools.environments.local import _make_run_env
-        poison = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "PATH": "/usr/bin"}
+        poison = {
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_SHLVL": "1",
+            "CONDA_PROMPT_MODIFIER": "(base) ",
+            "PATH": "/usr/bin",
+        }
         with patch.dict(os.environ, poison, clear=True):
             result = _make_run_env({})
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
+        assert "CONDA_SHLVL" not in result
+        assert "CONDA_PROMPT_MODIFIER" not in result
 
     def test_sanitize_subprocess_env_strips_markers(self):
         from tools.environments.local import _sanitize_subprocess_env
-        base = {"VIRTUAL_ENV": "/venv", "CONDA_PREFIX": "/conda", "HOME": "/home/user"}
+        base = {
+            "VIRTUAL_ENV": "/venv",
+            "CONDA_PREFIX": "/conda",
+            "CONDA_SHLVL": "1",
+            "CONDA_PROMPT_MODIFIER": "(base) ",
+            "HOME": "/home/user",
+        }
         # Even an explicitly-passed extra marker is stripped.
         result = _sanitize_subprocess_env(base, {"VIRTUAL_ENV": "/also/venv"})
         assert "VIRTUAL_ENV" not in result
         assert "CONDA_PREFIX" not in result
+        assert "CONDA_SHLVL" not in result
+        assert "CONDA_PROMPT_MODIFIER" not in result
         assert result.get("HOME") == "/home/user"
 
     def test_markers_constant_contents(self):
         from tools.environments.local import _ACTIVE_VENV_MARKER_VARS
         assert "VIRTUAL_ENV" in _ACTIVE_VENV_MARKER_VARS
         assert "CONDA_PREFIX" in _ACTIVE_VENV_MARKER_VARS
+        assert "CONDA_SHLVL" in _ACTIVE_VENV_MARKER_VARS
+        assert "CONDA_PROMPT_MODIFIER" in _ACTIVE_VENV_MARKER_VARS
+
+    def test_stripped_conda_state_is_self_consistent(self):
+        """No CONDA_SHLVL may survive without CONDA_PREFIX (#82255 invariant)."""
+        from tools.environments.local import _sanitize_subprocess_env
+        half = {
+            "CONDA_SHLVL": "1",
+            "CONDA_PROMPT_MODIFIER": "(base) ",
+            "PATH": "/usr/bin",
+            "HOME": "/home/user",
+        }
+        result = _sanitize_subprocess_env(half, {})
+        assert "CONDA_SHLVL" not in result
+        assert "CONDA_PREFIX" not in result
+        assert "CONDA_PROMPT_MODIFIER" not in result
 
 
 class TestProfileScopedPassthrough:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -360,7 +360,13 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # PYTHONPATH is NOT included here — it's handled by
 # _strip_hermes_owned_pythonpath() which removes only Hermes-owned entries,
 # preserving user-set paths.
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "PYTHONHOME")
+_ACTIVE_VENV_MARKER_VARS = (
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+    "CONDA_SHLVL",
+    "CONDA_PROMPT_MODIFIER",
+    "PYTHONHOME",
+)
 
 
 def _is_hermes_internal_secret(key: str) -> bool:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -346,7 +346,19 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # to a different Python version overwrites it and breaks the gateway). The
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+#
+# Conda activation is an atomic set. Stripping only CONDA_PREFIX while leaving
+# CONDA_SHLVL set produces a depth counter with no prefix: conda's shell init
+# then crashes in ``_get_deactivate_scripts`` with
+# ``TypeError: expected str, bytes or os.PathLike object, not NoneType`` (#82255).
+# CONDA_PROMPT_MODIFIER is part of the same set and is stripped for the same
+# reason. CONDA_DEFAULT_ENV bleed-through is tracked separately (#58382).
+_ACTIVE_VENV_MARKER_VARS = (
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+    "CONDA_SHLVL",
+    "CONDA_PROMPT_MODIFIER",
+)
 
 
 def _is_hermes_internal_secret(key: str) -> bool:


### PR DESCRIPTION
## What does this PR do?

Terminal subprocess env sanitization already strips `VIRTUAL_ENV` and `CONDA_PREFIX` so the gateway venv does not clobber project envs. Conda activation is an atomic set: leaving `CONDA_SHLVL` set while `CONDA_PREFIX` is gone makes conda shell init crash in `_get_deactivate_scripts` with `TypeError: expected str, bytes or os.PathLike object, not NoneType`.

Strip `CONDA_SHLVL` and `CONDA_PROMPT_MODIFIER` with `CONDA_PREFIX` so children see a self-consistent empty activation state and re-activate cleanly.

Related but distinct from #58382 / PR #58383 (`CONDA_DEFAULT_ENV` bleed-through). That fix alone does not stop this crash.

## Related Issue

Fixes #82255

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/local.py`: extend `_ACTIVE_VENV_MARKER_VARS` with `CONDA_SHLVL` and `CONDA_PROMPT_MODIFIER`.
- `tests/tools/test_local_env_blocklist.py`: membership + self-consistent stripped state coverage.

## How to Test

1. Start Hermes from a conda-activated shell (`CONDA_PREFIX` + `CONDA_SHLVL` set)
2. Run a terminal command that launches an interactive shell with conda init
3. Before: shell init aborts with TypeError in activate.py. After: clean shell (no half-active conda markers)

Automated:

```bash
pytest tests/tools/test_local_env_blocklist.py -q -k 'ActiveVenv or markers or conda'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted tests above and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (unit tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit-tested env sanitizer.