### PR TITLE
fix(desktop): convert artifact timestamps from seconds to milliseconds

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -39,6 +39,23 @@ function artifactSessionTitle(session: SessionInfo): string {
   return session.title?.trim() || session.preview?.trim() || 'Untitled session'
 }
 
+/**
+ * Hermes state.db stores message/session times as Unix **seconds**
+ * (``time.time()``). ``Date`` / ``Intl.DateTimeFormat`` expect milliseconds.
+ * Values already in ms (or ``Date.now()``) pass through unchanged.
+ *
+ * Without the conversion, Artifacts timestamps render as Jan 1970
+ * (e.g. 1.7e9 seconds → ~20 days after epoch in ms) (#81016).
+ */
+export function toEpochMs(value: number | null | undefined, fallback = Date.now()): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return fallback
+  }
+  // Unix seconds today are ~1.7e9; ms are ~1.7e12. Threshold 1e12 ≈ 2001-09-09
+  // in ms, safely above any second-based timestamp for the next ~30k years.
+  return value < 1e12 ? value * 1000 : value
+}
+
 function normalizeValue(value: string): string {
   return value.trim().replace(/[),.;]+$/, '')
 }
@@ -283,7 +300,9 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
         label: artifactLabel(value),
         sessionId: session.id,
         sessionTitle: title,
-        timestamp: message.timestamp || session.last_active || session.started_at || Date.now()
+        timestamp: toEpochMs(
+          message.timestamp || session.last_active || session.started_at
+        )
       })
     })
   }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { $connection } from '@/store/session'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
-import { artifactImageSrc, collectArtifactsForSession, loadArtifactsForSessions } from './artifact-utils'
+import {
+  artifactImageSrc,
+  collectArtifactsForSession,
+  loadArtifactsForSessions,
+  toEpochMs
+} from './artifact-utils'
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -44,8 +49,30 @@ describe('collectArtifactsForSession', () => {
     expect(artifacts[0]).toMatchObject({
       href: 'https://example.com/docs/getting-started',
       kind: 'link',
-      value: 'https://example.com/docs/getting-started'
+      value: 'https://example.com/docs/getting-started',
+      // DB seconds → ms for Date formatting (#81016)
+      timestamp: 2_000_000
     })
+  })
+
+  it('converts second-based session timestamps to ms when messages omit them', () => {
+    // 2026-08-07 19:43:00 UTC
+    const sessionTs = Math.floor(Date.UTC(2026, 7, 7, 19, 43, 0) / 1000)
+    const artifacts = collectArtifactsForSession(
+      makeSession({ last_active: sessionTs, started_at: sessionTs }),
+      [
+        {
+          content: 'See https://example.com/report.pdf',
+          role: 'assistant'
+        }
+      ]
+    )
+
+    expect(artifacts).toHaveLength(1)
+    expect(artifacts[0].timestamp).toBe(sessionTs * 1000)
+    // Must not render as 1970 when fed to Date
+    expect(new Date(artifacts[0].timestamp).getUTCFullYear()).toBe(2026)
+    expect(new Date(artifacts[0].timestamp).getUTCMonth()).toBe(7)
   })
 
   it('indexes http links present in tool JSON payloads', () => {
@@ -87,6 +114,13 @@ describe('collectArtifactsForSession', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/fs/read-data-url?path=%2FUsers%2Fme%2F.hermes%2Fskills%2Fwork-esab%2Freferences%2Fimages%2Fmanual-step03.jpeg'
     })
+  })
+})
+
+describe('toEpochMs', () => {
+  it('multiplies second-scale values and leaves millisecond values alone', () => {
+    expect(toEpochMs(1_700_000_000)).toBe(1_700_000_000_000)
+    expect(toEpochMs(1_700_000_000_000)).toBe(1_700_000_000_000)
   })
 })
 


### PR DESCRIPTION
## What does this PR do?

The Desktop Artifacts view passed `state.db` Unix **seconds** (`message.timestamp` / `session.last_active` / `session.started_at`) into `new Date()`, which expects milliseconds. That renders every artifact as Jan 22, 1970 (e.g. ~1.7e9 treated as ~20 days after epoch).

Normalize at collect time with a seconds/ms heuristic (same idea as the sidebar age formatter) so both display and sort order use real session times.

## Related Issue

Fixes #81016

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/artifacts/artifact-utils.ts`: add `toEpochMs()` and use it when building `ArtifactRecord.timestamp`.
- `apps/desktop/src/app/artifacts/index.test.ts`: regression for second-scale session times and ms passthrough.

## How to Test

1. Produce an artifact in a session (file/image/link in an assistant message)
2. Open Artifacts view
3. Before: timestamp column shows Jan 22, 1970. After: real session date/time

Automated:

```bash
cd apps/desktop && npx vitest run src/app/artifacts/index.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted tests above and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (vitest)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — covered by unit tests asserting year 2026 for a known session epoch.