### PR TITLE
fix(aux): downgrade json_schema response_format for json_object-only providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1065,6 +1065,29 @@ NOUS_EXTRA_BODY = _nous_extra_body()
 # Set at resolve time — True if the auxiliary client points to Nous Portal
 auxiliary_is_nous: bool = False
 
+# Providers whose Chat Completions endpoint rejects ``response_format`` type
+# ``json_schema`` with HTTP 400 — they only accept ``json_object``. DeepSeek's
+# API docs list only ``json_object``; Moonshot/Kimi likewise. Substring match
+# so both bare names ("deepseek") and branded labels ("kimi-coding-cn") are
+# caught. Callers that pass a schema (title generation) already pin the JSON
+# shape in the prompt and parse locally, so downgrading to ``json_object``
+# keeps those providers working without losing the structured output.
+_JSON_OBJECT_ONLY_PROVIDERS = ("deepseek", "moonshot", "kimi")
+
+
+def _provider_rejects_json_schema(provider: Optional[str]) -> bool:
+    """True for providers documented to reject ``json_schema`` response_format.
+
+    Unknown providers fail open (return False): we only downgrade providers
+    with *known* json_object-only support, so a brand-new provider never
+    loses schema-constrained output because of this list.
+    """
+    if not provider:
+        return False
+    p = str(provider).strip().lower()
+    return any(tok in p for tok in _JSON_OBJECT_ONLY_PROVIDERS)
+
+
 # Default auxiliary models per provider
 _OPENROUTER_MODEL = "google/gemini-3.6-flash"
 _NOUS_MODEL = "google/gemini-3.6-flash"
@@ -8961,6 +8984,19 @@ def _call_llm_impl(
         final_model,
         resolved_api_mode,
     )
+
+    # json_schema response_format is rejected with HTTP 400 by json_object-only
+    # providers (DeepSeek, Moonshot/Kimi — "This response_format_type is
+    # unavailable now"). Downgrade to json_object so schema-constrained tasks
+    # (title generation) keep working: the prompt already pins the expected
+    # JSON shape, and callers parse locally (e.g. _extract_title_text).
+    _response_format = (effective_extra_body or {}).get("response_format")
+    if (
+        isinstance(_response_format, dict)
+        and _response_format.get("type") == "json_schema"
+        and _provider_rejects_json_schema(request_provider)
+    ):
+        effective_extra_body["response_format"] = {"type": "json_object"}
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4546,3 +4546,139 @@ class TestFastModelTier:
             _FAST_MODEL_TASKS
         )
         assert not overlap
+
+
+# ── response_format downgrade for json_object-only providers ──────────────
+
+
+class TestResponseFormatDowngrade:
+    """json_schema response_format must be downgraded to json_object for
+    providers that reject it with HTTP 400 (DeepSeek, Moonshot/Kimi), while
+    every other provider keeps the schema."""
+
+    @pytest.mark.parametrize(
+        "provider,expected",
+        [
+            ("deepseek", True),
+            ("DEEPSEEK", True),
+            ("moonshot", True),
+            ("kimi", True),
+            ("kimi-coding-cn", True),
+            ("openai", False),
+            ("openrouter", False),
+            ("zai", False),
+            ("nous", False),
+            ("custom", False),
+            (None, False),
+            ("", False),
+        ],
+    )
+    def test_provider_rejects_json_schema(self, provider, expected):
+        from agent.auxiliary_client import _provider_rejects_json_schema
+
+        assert _provider_rejects_json_schema(provider) is expected
+
+    @pytest.mark.parametrize(
+        "provider,expected_type",
+        [
+            # json_object-only providers get the downgrade
+            ("deepseek", "json_object"),
+            ("kimi-coding-cn", "json_object"),
+            # schema-capable providers keep json_schema
+            ("openai", "json_schema"),
+            ("openrouter", "json_schema"),
+            ("zai", "json_schema"),
+        ],
+    )
+    def test_call_llm_downgrades_response_format_on_wire(
+        self, provider, expected_type
+    ):
+        """The response_format that actually reaches the provider SDK must be
+        downgraded for json_object-only providers and untouched otherwise."""
+        from agent.auxiliary_client import call_llm
+
+        fake_client = MagicMock()
+        fake_client.base_url = "https://example.invalid/v1"
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = '{"title": "hello"}'
+        fake_client.chat.completions.create.return_value = resp
+
+        schema_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "session_title",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"title": {"type": "string"}},
+                    "required": ["title"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(provider, "test-model", None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(fake_client, "test-model"),
+            ),
+            patch(
+                "agent.auxiliary_client._validate_llm_response",
+                side_effect=lambda resp, _task, **_kw: resp,
+            ),
+        ):
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+                extra_body={"response_format": schema_format},
+            )
+
+        assert result is resp
+        call_kwargs = fake_client.chat.completions.create.call_args.kwargs
+        sent_format = call_kwargs["extra_body"]["response_format"]
+        assert sent_format["type"] == expected_type
+        if expected_type == "json_schema":
+            assert sent_format["json_schema"]["name"] == "session_title"
+
+    def test_call_llm_leaves_other_extra_body_fields_untouched(self):
+        """Downgrading must not clobber unrelated extra_body keys."""
+        from agent.auxiliary_client import call_llm
+
+        fake_client = MagicMock()
+        fake_client.base_url = "https://api.deepseek.com/v1"
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = '{"title": "hello"}'
+        fake_client.chat.completions.create.return_value = resp
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("deepseek", "deepseek-v4-flash", None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(fake_client, "deepseek-v4-flash"),
+            ),
+            patch(
+                "agent.auxiliary_client._validate_llm_response",
+                side_effect=lambda resp, _task, **_kw: resp,
+            ),
+        ):
+            call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+                extra_body={
+                    "response_format": {"type": "json_schema", "json_schema": {}},
+                    "user": "keep-me",
+                },
+            )
+
+        call_kwargs = fake_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["extra_body"]["user"] == "keep-me"
+        assert call_kwargs["extra_body"]["response_format"]["type"] == "json_object"


### PR DESCRIPTION
## Problem

Since commit f726090d4 ("feat(sessions): name a session the moment it starts"), title generation sends a strict `response_format: {type: json_schema, ...}` on every auto-title call. DeepSeek and Moonshot/Kimi Chat Completions endpoints reject `json_schema` with HTTP 400:

```
⚠ Auxiliary title generation failed: HTTP 400: This response_format_type is unavailable now
```

These providers only accept `response_format: {type: json_object}` (DeepSeek API docs list only `json_object`; Moonshot/Kimi the same). The failure is silent-ish: the instant derived title remains, but every session on these providers loses its LLM-refined title and the user sees the ⚠ warning on each new session.

## Fix

In `_call_llm_impl`, after the provider is fully resolved (including auto-detection), downgrade the wire `response_format` from `json_schema` to `json_object` when the resolved provider is documented json_object-only (`deepseek`, `moonshot`, `kimi` — substring match, so labels like `kimi-coding-cn` are caught).

Why this is safe:
- The title prompt already embeds the expected JSON shape (`Reply with JSON only: {"title": "..."}`) and callers parse locally (`_extract_title_text` has JSON + prose fallbacks), so structured output is preserved.
- Unknown providers **fail open** (schema is kept) — only providers with documented json_object-only support are downgraded, so no new provider loses schema-constrained output because of this list.
- `json_object` mode on DeepSeek requires "json" to appear in the prompt, which the title prompt satisfies.

## Verification

- 18 new unit tests: `_provider_rejects_json_schema` param matrix + wire-level assertions that `call_llm` sends `json_object` for deepseek/kimi-coding-cn and keeps `json_schema` for openai/openrouter/zai, plus an extra_body non-clobber check.
- Full `tests/agent/test_auxiliary_client.py` + `tests/agent/test_title_generator.py`: 213 passed.
- Live DeepSeek check: `generate_title("帮我查一下之前提的 PR 状态怎么样")` returns `查询 PR 状态` — no 400.