### PR TITLE
Drag sidebar sessions and projects by the title

### DIFF
--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -110,4 +110,19 @@ describe('session drop targeting across stacked tabs', () => {
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
     expect(openSessionTile).not.toHaveBeenCalled()
   })
+
+  // Standing side chrome hosts no main tile, so a session has nowhere to land
+  // there. That refusal is load-bearing twice over: the sidebar row runs the
+  // reorder off the SAME press, so the deny is what leaves the list to it,
+  // and ZoneDropOverlay keys off the same test to stay dark over those zones
+  // instead of outlining a drop that would only be refused.
+  it('commits nothing over the sidebar, leaving the region to the reorder', () => {
+    mountStackedTabs()
+    $layoutTree.set(group(['sessions'], { id: 'g1' }))
+
+    dragTo(document.getElementById('row')!, 120, 400)
+
+    expect(requestComposerInsertRefs).not.toHaveBeenCalled()
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -55,7 +55,9 @@ export function SidebarDateDivider({ className, label, ...props }: React.Compone
   )
 }
 
-/** Outer grid — sole owner of row height. */
+/** Outer grid — sole owner of row height. The trailing `actions` slot is
+ *  marked `data-row-actions` so a row-wide drag gesture can exclude it with
+ *  one selector: it holds real controls, never grab surface. */
 export function SidebarRowShell({
   actions,
   children,
@@ -65,7 +67,11 @@ export function SidebarRowShell({
   return (
     <div className={cn(rowMinH, 'grid grid-cols-[minmax(0,1fr)_auto] items-stretch rounded-md', className)} {...props}>
       {children}
-      {actions ? <div className="flex shrink-0 items-center self-center">{actions}</div> : null}
+      {actions ? (
+        <div className="flex shrink-0 items-center self-center" data-row-actions>
+          {actions}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -125,6 +125,18 @@ export function ProjectOverviewRow({
         </>
       }
       className={cn('group/workspace', dragging && 'cursor-grabbing bg-(--ui-sidebar-surface-background)')}
+      // The label is grab surface too, not just the lead's grabber — same
+      // listeners, minus the controls that keep their own gestures. A project
+      // row has no rival drag (its title navigates on CLICK), so the sortable
+      // owns the press outright.
+      {...dragHandleProps}
+      onPointerDown={event => {
+        if ((event.target as HTMLElement).closest('[data-reorder-handle], [data-row-actions]')) {
+          return
+        }
+
+        dragHandleProps?.onPointerDown?.(event)
+      }}
       ref={rowRef}
     >
       <SidebarRowCluster className="min-w-0 flex-1">
@@ -141,6 +153,7 @@ export function ProjectOverviewRow({
             <button
               aria-label={s.projects.toggle(project.label, !open)}
               className="flex flex-1 items-center self-stretch bg-transparent p-0"
+              data-row-actions
               onClick={toggleOpen}
               type="button"
             >

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -140,19 +140,26 @@ function SidebarSessionRowImpl({
           className
         )}
         data-working={liveTurn ? 'true' : undefined}
+        // The row runs BOTH drags off one press, and each declines outside its
+        // own region — so no timing/arbitration rule is needed and neither can
+        // steal the other's gesture. Over the sidebar only the reorder has a
+        // target (the session drop denies: side chrome hosts no main tile);
+        // over the tree only the session drop does (no sortable row there).
+        // Whichever one the release lands on is the one that commits.
+        {...dragHandleProps}
         onPointerDown={event => {
-          // Reorder drags belong to dnd-kit (the grab handle); the ⋯ actions
-          // cluster keeps its own gestures. Everything else on the row —
-          // including the row-body BUTTON, the natural grab surface — is a
-          // session drag source: a POINTER drag on the shared drag session
-          // (never native HTML5 DnD: no macOS snap-back, Esc aborts
-          // instantly). Sub-threshold releases stay ordinary clicks, so
-          // resume / pin / open-in-window are untouched.
+          // The grabber already carries these same listeners, and the ⋯
+          // cluster keeps its own gestures.
           if ((event.target as HTMLElement).closest('[data-reorder-handle], [data-row-actions]')) {
             return
           }
 
+          // A POINTER drag on the shared drag session (never native HTML5 DnD:
+          // no macOS snap-back, Esc aborts instantly). Sub-threshold releases
+          // stay ordinary clicks, so resume / pin / open-in-window are
+          // untouched.
           startSessionDrag({ id: session.id, profile: session.profile || 'default', title }, event)
+          dragHandleProps?.onPointerDown?.(event)
         }}
         // Hovering a row from another profile (the all-profiles view) telegraphs
         // a cross-profile resume — start that backend's spawn now so the click

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -50,6 +50,7 @@ import {
   closeTreeTabsToRight,
   collapseTreePane,
   isCollapsePane,
+  isMainStripPane,
   isSessionStripPane,
   noteActiveTreeGroup,
   reloadTreePane,
@@ -768,10 +769,19 @@ function ZoneDropOverlay({ node }: { node: GroupNode }) {
   }
 
   // A session drag (sidebar row) reuses this exact overlay — over ANY zone
-  // now (stack into its tabs / split its edges); only a CHAT zone's center is
-  // a link-to-chat (the composer overlay owns that visual).
+  // that hosts a MAIN tile (stack into its tabs / split its edges); only a
+  // CHAT zone's center is a link-to-chat (the composer overlay owns that
+  // visual). Standing side chrome — the sidebar, files, terminal — hosts no
+  // main tile, so a session can't land there: those zones stay DARK rather
+  // than painting an idle outline the drop would only refuse. Same test
+  // `tileZoneHost` (session-drag.ts) resolves the drop with, so what lights
+  // up and what commits cannot disagree.
   const sessionDrag = dragging === SESSION_TILE_DRAG
   const chatZone = node.panes.some(isSessionStripPane)
+
+  if (sessionDrag && !chatZone && !node.panes.some(isMainStripPane)) {
+    return null
+  }
 
   const isDragSource = node.panes.includes(dragging)
 


### PR DESCRIPTION
## Summary

Reordering a session or project in the sidebar meant hitting the grabber in the lead column — a 14px target that only appears on hover. The row's title is the obvious thing to grab, so the sortable listeners now live on the row shell.

For a session that puts two drags on one press, since the title already starts the drag into the layout. They arbitrate by region rather than by timing, and each simply declines outside its own: over the sidebar only the reorder has a target (the session drop denies — standing side chrome hosts no main tile), over the tree only the session drop does (no sortable row there). Whichever one the release lands on commits.

That deny was already correct but invisible: a dragged session outlined every zone in the tree, sidebar and terminal included, advertising drops that were always refused. The overlay now gates on the same test `tileZoneHost` resolves the real drop with, so what lights up and what commits can't drift apart.

## Test plan

- [x] Drag a session title into a pane — stacks, splits, and links into a composer as before
- [x] Drag a session title up/down the list — reorders
- [x] Drag a project title — reorders; a plain click still enters the project
- [x] The grabber, the ⋯ menu, and the disclosure caret keep their own gestures
- [x] Sidebar, files, and terminal zones stay dark during a session drag
- [x] `tsc --noEmit` and eslint clean; 606 desktop tests pass, including a new case pinning that a session dropped on the sidebar commits nothing