### PR TITLE
feat: add bounded delegation routes

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7792,6 +7792,7 @@ class AIAgent:
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
+            route=function_args.get("route"),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -27,6 +27,8 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_progress_callback,
     _build_child_system_prompt,
+    _get_child_timeout,
+    _resolve_delegation_route,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -64,6 +66,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("goal", props)
         self.assertIn("tasks", props)
         self.assertIn("context", props)
+        self.assertEqual(props["route"]["type"], "string")
+        self.assertNotIn("route", props["tasks"]["items"]["properties"])
         # toolsets is intentionally NOT exposed to the model — subagents always
         # inherit the parent's toolsets. Letting the model name toolsets was a
         # capability-selection surface the model should not control.
@@ -156,6 +160,43 @@ class TestStripBlockedTools(unittest.TestCase):
         self.assertIn("terminal", result)
         self.assertIn("file", result)
         self.assertIn("web", result)
+
+    def test_narrow_route_omits_unrelated_tool_and_skill_schemas(self):
+        import model_tools
+
+        parent = _make_mock_parent()
+        # A real CLI parent normally exposes one composite toolset. The route
+        # must still be able to select its narrower ``file`` subset.
+        parent.enabled_toolsets = ["hermes-cli", "mcp-unrelated"]
+        parent.disabled_toolsets = []
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Read only",
+                context=None,
+                toolsets=["file"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                delegation_cfg={"enabled_toolsets": ["file"]},
+                strict_toolsets=True,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["enabled_toolsets"], ["file"])
+        definitions = model_tools.get_tool_definitions(
+            enabled_toolsets=kwargs["enabled_toolsets"],
+            disabled_toolsets=kwargs["disabled_toolsets"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        names = {item["function"]["name"] for item in definitions}
+        self.assertIn("read_file", names)
+        self.assertNotIn("web_search", names)
+        self.assertNotIn("skill_view", names)
 
     def test_mixed_composite_is_subtracted_at_child_assembly(self):
         """A mixed platform bundle must not re-expose blocked leaf tools.
@@ -645,6 +686,125 @@ class TestBlockedTools(unittest.TestCase):
         can batch mechanical work instead of burning reasoning iterations
         (Teknium, Jul 2026)."""
         self.assertNotIn("execute_code", DELEGATE_BLOCKED_TOOLS)
+
+
+class TestDelegationRoutes(unittest.TestCase):
+    def test_route_overlays_operator_fields_and_keeps_selection_call_scoped(self):
+        cfg, toolsets = _resolve_delegation_route(
+            {
+                "model": "default-model",
+                "provider": "custom",
+                "base_url": "https://default.example/v1",
+                "child_timeout_seconds": 900,
+                "routes": {
+                    "scout": {
+                        "model": "fast-model",
+                        "provider": "openrouter",
+                        "reasoning_effort": "low",
+                        "enabled_toolsets": ["file", "web"],
+                        "child_timeout_seconds": 75,
+                    }
+                },
+            },
+            "scout",
+        )
+
+        self.assertEqual(cfg["model"], "fast-model")
+        self.assertEqual(cfg["provider"], "openrouter")
+        self.assertNotIn("base_url", cfg)
+        self.assertEqual(toolsets, ["file", "web"])
+        self.assertEqual(_get_child_timeout(cfg), 75.0)
+
+    def test_invalid_route_policy_fails_closed(self):
+        invalid_routes = [
+            {"enabled_toolsets": []},
+            {"enabled_toolsets": ["file", ""]},
+            {"child_timeout_seconds": 0},
+            {"child_timeout_seconds": True},
+            {"unexpected": "field"},
+        ]
+        for route_cfg in invalid_routes:
+            with self.subTest(route_cfg=route_cfg):
+                with self.assertRaises(ValueError):
+                    _resolve_delegation_route(
+                        {"routes": {"scout": route_cfg}}, "scout"
+                    )
+
+    def test_delegate_applies_route_toolsets_and_freezes_timeout(self):
+        parent = _make_mock_parent()
+        parent._credential_pool = None
+        child = MagicMock()
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        config = {
+            "routes": {
+                "scout": {
+                    "enabled_toolsets": ["file"],
+                    "child_timeout_seconds": 60,
+                }
+            }
+        }
+        inherited_creds = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "request_overrides": {},
+            "max_output_tokens": None,
+            "command": None,
+            "args": [],
+        }
+
+        with (
+            patch("tools.delegate_tool._load_config", return_value=config),
+            patch(
+                "tools.delegate_tool._resolve_delegation_credentials",
+                return_value=inherited_creds,
+            ),
+            patch(
+                "tools.delegate_tool._build_child_preserving_parent_tools",
+                return_value=child,
+            ) as build_child,
+        ):
+            result = json.loads(
+                delegate_task(
+                    goal="Read one file",
+                    route="scout",
+                    background=False,
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertEqual(result["results"][0]["status"], "completed")
+        self.assertEqual(build_child.call_args.kwargs["toolsets"], ["file"])
+        self.assertTrue(build_child.call_args.kwargs["strict_toolsets"])
+        self.assertNotIn("model", build_child.call_args.kwargs["delegation_cfg"])
+        self.assertEqual(child._delegate_child_timeout, 60.0)
+
+    def test_unknown_route_fails_before_child_construction(self):
+        parent = _make_mock_parent()
+        with (
+            patch(
+                "tools.delegate_tool._load_config",
+                return_value={"routes": {"scout": {}}},
+            ),
+            patch("tools.delegate_tool._build_child_preserving_parent_tools") as build_child,
+        ):
+            result = json.loads(
+                delegate_task(
+                    goal="Must not start",
+                    route="missing",
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertIn("Unknown delegation route", result["error"])
+        build_child.assert_not_called()
 
 class TestDelegationCredentialResolution(unittest.TestCase):
     """Tests for provider:model credential resolution in delegation config."""
@@ -1240,6 +1400,7 @@ class TestDispatchDelegateTask(unittest.TestCase):
                 parent,
                 {
                     "goal": "test",
+                    "route": "scout",
                     "acp_command": "claude",
                     "acp_args": ["--acp", "--stdio"],
                     "tasks": [
@@ -1255,6 +1416,7 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertNotIn("acp_command", captured)
         self.assertNotIn("acp_args", captured)
         self.assertEqual(captured["goal"], "test")
+        self.assertEqual(captured["route"], "scout")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
 

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -195,6 +195,33 @@ class TestRunSingleChildTimeoutDump:
             parent_agent=parent,
         )
 
+    def test_route_timeout_is_used_without_reloading_global_config(
+        self, hermes_home, monkeypatch
+    ):
+        from tools import delegate_tool
+
+        child = _StubChild(api_call_count=1, hang_seconds=10.0)
+        child._delegate_child_timeout = 0.05
+        monkeypatch.setattr(
+            delegate_tool,
+            "_get_child_timeout",
+            lambda: pytest.fail("route timeout must be frozen at dispatch"),
+        )
+        parent = MagicMock()
+        parent._touch_activity = MagicMock()
+        parent._current_task_id = None
+
+        result = delegate_tool._run_single_child(
+            task_index=0,
+            goal="bounded scout",
+            child=child,
+            parent_agent=parent,
+        )
+
+        assert result["status"] == "timeout"
+        assert result["timeout_seconds"] == 0.05
+        assert result["timed_out_after_seconds"] < 1
+
     def test_zero_api_calls_writes_dump_and_surfaces_path(self, hermes_home, monkeypatch):
         child = _StubChild(api_call_count=0, hang_seconds=10.0)
         result = self._invoke_with_short_timeout(child, monkeypatch)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -655,7 +655,7 @@ def _get_max_async_children() -> int:
     return _get_max_concurrent_children()
 
 
-def _get_child_timeout() -> Optional[float]:
+def _get_child_timeout(cfg: Optional[Dict[str, Any]] = None) -> Optional[float]:
     """Read delegation.child_timeout_seconds from config.
 
     Returns the number of seconds a single child agent is allowed to run
@@ -673,7 +673,7 @@ def _get_child_timeout() -> Optional[float]:
     Set ``delegation.child_timeout_seconds`` to a positive number to opt back
     in to a hard cap (floor 30 s); ``0`` or a negative value means disabled.
     """
-    cfg = _load_config()
+    cfg = _load_config() if cfg is None else cfg
     val = cfg.get("child_timeout_seconds")
     if val is not None:
         try:
@@ -1325,6 +1325,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Effective delegation config after applying a selected named route.
+    delegation_cfg: Optional[Dict[str, Any]] = None,
+    # A route-owned allowlist is exact; do not append inherited MCP toolsets.
+    strict_toolsets: bool = False,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1358,7 +1362,7 @@ def _build_child_agent(
     parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
     tui_depth = max(0, child_depth - 1)  # 0 = first-level child for the UI
 
-    delegation_cfg = _load_config()
+    delegation_cfg = delegation_cfg if delegation_cfg is not None else _load_config()
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
@@ -1385,7 +1389,7 @@ def _build_child_agent(
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
         child_toolsets = [t for t in toolsets if t in expanded_parent]
-        if _get_inherit_mcp_toolsets():
+        if not strict_toolsets and _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )
@@ -2290,8 +2294,14 @@ def _run_single_child(
 
         # Run child with an optional hard timeout (off by default —
         # result(timeout=None) blocks until the child finishes). Stuck-child
-        # protection comes from the heartbeat staleness monitor instead.
-        child_timeout = _get_child_timeout()
+        # protection comes from the heartbeat staleness monitor instead. A
+        # route-selected timeout is frozen on the child at dispatch.
+        child_dict = getattr(child, "__dict__", {})
+        child_timeout = (
+            child_dict["_delegate_child_timeout"]
+            if "_delegate_child_timeout" in child_dict
+            else _get_child_timeout()
+        )
         # Daemon worker (tools.daemon_pool): a timed-out child is abandoned
         # below; a stdlib non-daemon worker would then block interpreter
         # exit at atexit-join time if the child never unwinds.
@@ -3120,6 +3130,100 @@ def _validate_batch_tasks(task_list: List[Dict[str, Any]]) -> Optional[str]:
     return None
 
 
+def _resolve_delegation_route(
+    cfg: Dict[str, Any], route: Optional[str]
+) -> tuple[Dict[str, Any], Optional[List[str]]]:
+    """Overlay one operator-defined call route and return its toolset limit."""
+    selected = route if route is not None else cfg.get("default_route")
+    if selected is None:
+        return cfg, None
+    source = "route" if route is not None else "delegation.default_route"
+    if not isinstance(selected, str) or not selected.strip():
+        raise ValueError(f"{source} must be a non-empty string.")
+    selected = selected.strip()
+
+    routes = cfg.get("routes")
+    if not isinstance(routes, dict):
+        raise ValueError(
+            f"Delegation route '{selected}' cannot be resolved because "
+            "delegation.routes must be an object."
+        )
+    if selected not in routes:
+        raise ValueError(f"Unknown delegation route '{selected}'.")
+    route_cfg = routes[selected]
+    if not isinstance(route_cfg, dict):
+        raise ValueError(f"Delegation route '{selected}' must be an object.")
+
+    allowed_fields = {
+        "model",
+        "provider",
+        "reasoning_effort",
+        "enabled_toolsets",
+        "child_timeout_seconds",
+    }
+    unknown_fields = sorted(str(field) for field in route_cfg if field not in allowed_fields)
+    if unknown_fields:
+        raise ValueError(
+            f"Delegation route '{selected}' contains unsupported field(s): "
+            + ", ".join(unknown_fields)
+            + "."
+        )
+
+    for field in ("model", "provider"):
+        if field in route_cfg and (
+            not isinstance(route_cfg[field], str) or not route_cfg[field].strip()
+        ):
+            raise ValueError(
+                f"delegation.routes.{selected}.{field} must be a non-empty string."
+            )
+
+    if "reasoning_effort" in route_cfg:
+        from hermes_constants import parse_reasoning_effort
+
+        if parse_reasoning_effort(route_cfg["reasoning_effort"]) is None:
+            raise ValueError(
+                f"delegation.routes.{selected}.reasoning_effort is invalid: "
+                f"{route_cfg['reasoning_effort']!r}."
+            )
+
+    route_toolsets = route_cfg.get("enabled_toolsets")
+    if "enabled_toolsets" in route_cfg:
+        if (
+            not isinstance(route_toolsets, list)
+            or not route_toolsets
+            or any(not isinstance(item, str) or not item.strip() for item in route_toolsets)
+        ):
+            raise ValueError(
+                f"delegation.routes.{selected}.enabled_toolsets must be a "
+                "non-empty list of non-empty strings."
+            )
+        route_toolsets = [item.strip() for item in route_toolsets]
+
+    if "child_timeout_seconds" in route_cfg:
+        value = route_cfg["child_timeout_seconds"]
+        if isinstance(value, bool):
+            raise ValueError(
+                f"delegation.routes.{selected}.child_timeout_seconds must be "
+                "a positive number."
+            )
+        try:
+            parsed_timeout = float(value)
+        except (TypeError, ValueError):
+            parsed_timeout = 0
+        if parsed_timeout <= 0:
+            raise ValueError(
+                f"delegation.routes.{selected}.child_timeout_seconds must be "
+                "a positive number."
+            )
+
+    effective = dict(cfg)
+    if "provider" in route_cfg:
+        for field in ("base_url", "api_key", "api_mode"):
+            effective.pop(field, None)
+    effective.update(route_cfg)
+    return effective, route_toolsets
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -3128,6 +3232,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    route: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3181,8 +3286,12 @@ def delegate_task(
             f"multiplies API cost)."
         )
 
-    # Load config
+    # Resolve one call-level operator route before any child is built.
     cfg = _load_config()
+    try:
+        cfg, route_toolsets = _resolve_delegation_route(cfg, route)
+    except ValueError as exc:
+        return tool_error(str(exc))
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     # Model-supplied max_iterations is ignored — the config value is authoritative
     # so users get predictable budgets. The kwarg is retained for internal callers
@@ -3337,9 +3446,9 @@ def delegate_task(
             task_index=i,
             goal=t["goal"],
             context=_child_context,
-            # Subagents always inherit the parent's toolsets; the model
-            # cannot choose or narrow them (no model-facing toolsets arg).
-            toolsets=None,
+            # Route toolsets are operator-owned and can only narrow the
+            # parent's effective capabilities in _build_child_agent.
+            toolsets=route_toolsets,
             model=creds["model"],
             max_iterations=effective_max_iter,
             task_count=n_tasks,
@@ -3353,7 +3462,10 @@ def delegate_task(
             override_acp_command=creds.get("command"),
             override_acp_args=creds.get("args"),
             role=effective_role,
+            delegation_cfg=cfg,
+            strict_toolsets=route_toolsets is not None,
         )
+        child._delegate_child_timeout = _get_child_timeout(cfg)
         # Attach the validated schema for the completion-side validation
         # hook in _run_single_child. Absent (None) on schema-less tasks.
         if _task_schema is not None:
@@ -4217,6 +4329,13 @@ DELEGATE_TASK_SCHEMA = {
                     "specific you are, the better the subagent performs."
                 ),
             },
+            "route": {
+                "type": "string",
+                "description": (
+                    "Optional named route from delegation.routes. The selected "
+                    "route applies to every child in this call, including batches."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -4335,6 +4454,7 @@ registry.register(
         goal=args.get("goal"),
         context=args.get("context"),
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
+        route=args.get("route"),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -140,22 +140,83 @@ process disappears while it is still running is recorded as `unknown`, because
 Hermes cannot prove whether its external side effects happened. Pending and
 delivered records are bounded and profile-local.
 
-## Model Override
+## Model Override and Named Routes
 
-You can configure a different model for subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:
+You can configure a default model and provider for all subagents via `config.yaml`:
 
 ```yaml
 # In ~/.hermes/config.yaml
 delegation:
   model: "google/gemini-flash-2.0"    # Cheaper model for subagents
-  provider: "openrouter"              # Optional: route subagents to a different provider
+  provider: "openrouter"              # Optional: use a different provider
+  reasoning_effort: low                # Optional: override parent reasoning
 ```
 
-If omitted, subagents use the same model as the parent.
+If these values are omitted, subagents inherit them from the parent.
+
+For call-level selection, define user-named routes under `delegation.routes`.
+Each route may set `model`, `provider`, `reasoning_effort`,
+`enabled_toolsets`, and `child_timeout_seconds`:
+
+```yaml
+# In ~/.hermes/config.yaml
+delegation:
+  model: "anthropic/claude-sonnet-4"
+  provider: "openrouter"
+  reasoning_effort: medium
+  default_route: quick
+  routes:
+    quick:
+      model: "google/gemini-flash-2.0"
+      reasoning_effort: low
+      enabled_toolsets: [file, web]
+      child_timeout_seconds: 120
+    deep-review:
+      model: "anthropic/claude-opus-4"
+      reasoning_effort: high
+```
+
+Select a route with the single optional, call-level `route` parameter:
+
+```python
+delegate_task(
+    goal="Review the authentication changes",
+    route="deep-review"
+)
+```
+
+The selected route applies to every child in the call. Do not put `route` in
+individual task objects:
+
+```python
+delegate_task(
+    tasks=[
+        {"goal": "Review the API changes"},
+        {"goal": "Review the database migration"},
+    ],
+    route="deep-review"
+)
+```
+
+A route overrides the top-level delegation values it defines. Missing route
+fields inherit the matching top-level delegation values, then the existing
+parent behavior. Route toolsets can only narrow the parent's effective tools;
+they cannot grant a capability that the parent lacks. A route timeout uses the
+same 30-second floor and timeout result metadata as the global child timeout.
+When `route`
+is omitted, Hermes uses `delegation.default_route` if configured. With neither
+a call route nor a default route, delegation behaves as before. Unknown or
+invalid selected routes fail before any child starts.
 
 ## Inherited Tool Access
 
-`delegate_task` does not accept a model-facing `toolsets` parameter. Each subagent inherits the parent's enabled toolsets so the model cannot grant a child capabilities that the parent does not have. Configure the parent's tools before starting the conversation if delegated work needs additional capabilities.
+`delegate_task` does not accept a model-facing `toolsets` parameter. Each
+subagent inherits the parent's enabled toolsets unless the selected
+operator-defined route narrows them with `enabled_toolsets`. A route cannot
+grant a child capabilities that the parent does not have. A narrow scout route
+also avoids loading unrelated tool schemas and skill guidance. Configure the
+parent's tools before starting the conversation if delegated work needs
+additional capabilities.
 
 Certain tools are blocked for subagents even when the parent has them:
 - `delegate_task` — blocked for leaf subagents (the default). Retained for `role="orchestrator"` children, bounded by `max_spawn_depth` — see [Depth Limit and Nested Orchestration](#depth-limit-and-nested-orchestration) below.
@@ -193,6 +254,9 @@ delegation:
 ```
 
 A positive value enforces a hard wall-clock limit on each child; `0` or a negative value disables it.
+An operator-defined route can set a smaller positive
+`child_timeout_seconds` for bounded scout work without imposing that cap on
+long-running worker routes.
 
 When a configured cap fires, the child's result carries structured timeout
 metadata alongside the error message so parents and hooks can distinguish a


### PR DESCRIPTION
## Summary
- add operator-defined call-level delegation routes with fail-closed validation
- let a route narrow child toolsets exactly, including excluding inherited MCP and skill schemas
- freeze a route-scoped child timeout at dispatch so bounded scouts stop before provider timeouts
- document route configuration and add focused routing, startup, dispatch, and timeout tests

## Evaluation
Validated against `origin/main` at `934546fd5ab8032893f3665ce5f50ac36eeeba99`. Current upstream has no named-route resolver, so this adapts the historical call-level seam without adding per-task route or fork-context behavior.

## Verification
- `uv run --extra dev python -m pytest tests/tools/test_delegate*.py -q` — 134 passed, 5 subtests passed
- `uv run --extra dev ruff check tools/delegate_tool.py run_agent.py tests/tools/test_delegate.py tests/tools/test_delegate_subagent_timeout_diagnostic.py` — passed
- `git diff --check` — passed
- Internal P0/P1 review found one P1 (route allowlists inherited unrelated MCP toolsets); fixed by making route-owned toolsets exact and extending the focused test.

## Known baseline test issue
A broader mixed run also reaches the existing order-dependent `TestDelegationCleanup.test_timed_out_child_keeps_relay_session_until_its_turn_exits` failure. The same 1 failure / 19 passes reproduces on a clean detached `origin/main` worktree at the evaluated SHA, while the test passes in isolation. No test was weakened or skipped in the focused gate above.
