### PR TITLE
fix(credential-pool): honor fuzzy throttle windows, stop cooldown bypass, wait for transient recovery

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -923,6 +923,93 @@ def sync_credential_pool_entry_id(agent) -> None:
         agent._credential_pool_entry_id = None
 
 
+# Upper bound for the recoverable-exhaustion wait. Provider throttle windows
+# ("try again in a few minutes") recover in minutes; anything longer than
+# this must surface to the user/fallback chain instead of holding the turn.
+_POOL_RECOVERY_WAIT_MAX_SECONDS = 600.0
+
+
+def _wait_for_pool_recovery(agent, pool) -> bool:
+    """Bounded, interruptible wait for an all-exhausted pool to recover.
+
+    The observed failure class (custom OpenAI-compatible pools, e.g.
+    hyper.charm.land): a transient 429 benches the funded key for its cooldown
+    window, rotation walks into genuinely-depleted siblings, the pool reaches
+    "no available entries", and the turn aborts as "Billing or credits
+    exhausted" — even though the funded key recovers in minutes. This helper
+    closes that gap: when the earliest benched entry is TRANSIENT (not
+    billing-exhausted) and recovers within the bound, wait for it and report
+    success so the caller retries; the recovered entry is served first by the
+    next ``select()`` and billing-benched siblings stay benched.
+
+    Returns True when the wait completed (caller should retry); False when
+    recovery is impossible within the bound, the earliest entry is
+    billing-exhausted (waiting would just defer a guaranteed 402 — the
+    #31273 money-burn protection), or the wait was interrupted.
+    """
+    # Lightweight pool adapters (plugins/tests) may not implement
+    # recoverable_wait_seconds — treat "no assessment" as "no wait".
+    assessment_fn = getattr(pool, "recoverable_wait_seconds", None)
+    if not callable(assessment_fn):
+        return False
+    try:
+        assessment = assessment_fn(max_wait=_POOL_RECOVERY_WAIT_MAX_SECONDS)
+    except Exception:
+        _ra().logger.debug(
+            "credential pool: recoverable_wait_seconds probe failed",
+            exc_info=True,
+        )
+        return False
+    if not isinstance(assessment, tuple) or len(assessment) != 2:
+        return False
+    wait_seconds, transient = assessment
+    if not isinstance(wait_seconds, (int, float)) or wait_seconds <= 0:
+        return False
+    if not transient:
+        return False
+    _ra().logger.info(
+        "credential pool: all entries exhausted but a transiently-benched "
+        "credential recovers in %.0fs — waiting instead of aborting",
+        wait_seconds,
+    )
+    try:
+        vprint = getattr(agent, "_vprint", None)
+        if callable(vprint):
+            vprint(
+                f"{getattr(agent, 'log_prefix', '')}⏳ All pool credentials "
+                f"throttled — waiting {int(wait_seconds)}s for recovery...",
+                force=True,
+            )
+    except Exception:
+        pass
+    sleep_end = time.time() + wait_seconds
+    touch_counter = 0
+    while time.time() < sleep_end:
+        if getattr(agent, "_interrupt_requested", False):
+            # The interrupt flag is left SET for the outer retry loop to
+            # consume — unlike the backoff loop's
+            # clear_interrupt(preserve_redirect=True) handling, a redirect
+            # landing mid-wait is replayed on the next API attempt after the
+            # caller unwinds this recovery.
+            _ra().logger.info(
+                "credential pool: recovery wait interrupted — aborting wait"
+            )
+            return False
+        time.sleep(0.2)
+        touch_counter += 1
+        # Mirror the retry-backoff loop: keep the gateway inactivity monitor
+        # alive during the wait (conversation_loop.py retry-wait pattern).
+        if touch_counter % 150 == 0:  # 150 × 0.2s = 30s
+            try:
+                agent._touch_activity(
+                    f"credential pool recovery wait, "
+                    f"{int(sleep_end - time.time())}s remaining"
+                )
+            except Exception:
+                pass
+    return True
+
+
 def recover_with_credential_pool(
     agent,
     *,
@@ -1081,6 +1168,17 @@ def recover_with_credential_pool(
             )
             agent._swap_credential(next_entry)
             return True, False
+        # Rotation found nothing: the pool is fully benched. When the
+        # earliest benched entry is a TRANSIENT throttle recovering within
+        # the bound, wait for it instead of aborting the turn as billing-
+        # exhausted (hyper.charm.land class: 429 on the funded key, rotation
+        # into dead siblings, "no available entries"). Pure-billing
+        # exhaustion returns False immediately — the #31273 guard.
+        if _wait_for_pool_recovery(agent, pool):
+            recovered_entry = pool.select()
+            if recovered_entry is not None:
+                agent._swap_credential(recovered_entry)
+                return True, False
         return False, has_retried_429
 
     if effective_reason == FailoverReason.rate_limit:
@@ -1119,6 +1217,11 @@ def recover_with_credential_pool(
                 )
                 agent._swap_credential(next_entry)
                 return True, False
+            if _wait_for_pool_recovery(agent, pool):
+                recovered_entry = pool.select()
+                if recovered_entry is not None:
+                    agent._swap_credential(recovered_entry)
+                    return True, False
             return False, True
 
         usage_limit_reached = False
@@ -1143,6 +1246,14 @@ def recover_with_credential_pool(
             )
             agent._swap_credential(next_entry)
             return True, False
+        # Pool fully benched after rotation. If a transiently-benched entry
+        # recovers within the bound, wait and retry it instead of letting the
+        # loop fall through to "no available entries" abort.
+        if _wait_for_pool_recovery(agent, pool):
+            recovered_entry = pool.select()
+            if recovered_entry is not None:
+                agent._swap_credential(recovered_entry)
+                return True, False
         return False, True
 
     if effective_reason == FailoverReason.auth:
@@ -3910,6 +4021,7 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                 value = float(delay_match.group(1))
                 seconds = value / 1000.0 if delay_match.group(2).lower() == "ms" else value
                 context["reset_at"] = time.time() + seconds
+                context["reset_at_source"] = "message_parsed"
             else:
                 resets_in_match = re.search(
                     r"resets?\s+in\s+"
@@ -3924,6 +4036,7 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                     minutes = float(resets_in_match.group(2) or 0)
                     seconds = float(resets_in_match.group(3) or 0)
                     context["reset_at"] = time.time() + (hours * 3600) + (minutes * 60) + seconds
+                    context["reset_at_source"] = "message_parsed"
                 else:
                     sec_match = re.search(
                         r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
@@ -3932,6 +4045,30 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                     )
                     if sec_match:
                         context["reset_at"] = time.time() + float(sec_match.group(1))
+                        context["reset_at_source"] = "message_parsed"
+
+    if "reset_at" not in context:
+        # Fuzzy transient guidance ("Please try again in a few minutes.",
+        # hyper.charm.land-style throttles). Shares the pool's parser so both
+        # consumers agree on the window. Tagged message-derived so the pool's
+        # billing guard drops it for billing-classified failures (a depleted
+        # account must not inherit a fuzzy re-entry window — #31273).
+        # Function-level import: credential_pool is heavy and this module
+        # already imports it lazily at other call sites.
+        _message = context.get("message") or ""
+        if isinstance(_message, str) and _message.strip():
+            try:
+                from agent.credential_pool import (
+                    MESSAGE_DERIVED_RESET_TAG,
+                    _extract_retry_delay_seconds,
+                )
+                _fuzzy_delay = _extract_retry_delay_seconds(_message)
+            except Exception:
+                MESSAGE_DERIVED_RESET_TAG = "message_parsed"
+                _fuzzy_delay = None
+            if _fuzzy_delay is not None:
+                context["reset_at"] = time.time() + _fuzzy_delay
+                context["reset_at_source"] = MESSAGE_DERIVED_RESET_TAG
 
     return context
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4381,6 +4381,13 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     request.  Passing it lets mark_exhausted_and_rotate identify the correct
     pool entry even when another process has already rotated the pool (which
     would leave current() as None, causing the wrong entry to be marked).
+
+    Deliberately NOT given the recoverable-exhaustion wait
+    (``_wait_for_pool_recovery``): auxiliary calls (vision/title/compression)
+    run in the background and must fail fast rather than block up to the wait
+    bound — the main conversation loop owns that recovery. Its
+    ``_pool_error_context`` builds raw-message contexts, so the pool's fuzzy
+    parse + billing guard apply on this path unchanged.
     """
     normalized = _normalize_aux_provider(provider)
     try:
@@ -4412,10 +4419,20 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
 
     if _is_payment_error(exc) or _is_rate_limit_error(exc):
         fallback_status = 402 if _is_payment_error(exc) else 429
+        # Classify the failure semantics for the pool: a payment error is
+        # billing, a rate-limit error is transient. Without this the pool's
+        # billing guard in _normalize_error_context can't fire (failure_reason
+        # is None), and a message-derived fuzzy window leaks through for a
+        # billing 402 — giving it a short bench instead of the full TTL
+        # (#31273 money-burn class).
+        aux_failure_reason = (
+            "billing" if _is_payment_error(exc) else None
+        )
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else fallback_status,
             error_context=error_context,
             api_key_hint=hint,
+            failure_reason=aux_failure_reason,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -18,6 +18,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
 from agent.secret_scope import get_secret as _get_secret
 from agent.credential_persistence import (
+    _fingerprint_value,
     is_borrowed_credential_source,
     sanitize_borrowed_credential_payload,
 )
@@ -130,6 +131,25 @@ EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 # seconds, so a sole credential cools down briefly instead — same rationale as
 # the short 401 cooldown above. Provider-supplied reset_at still overrides.
 EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS = 60   # 1 minute
+
+# Fuzzy "try again in a few minutes"-style provider guidance. Providers
+# routinely throttle with a message instead of a structured reset time
+# (hyper.charm.land: "Please try again in a few minutes."); without a parse
+# for that family the benched key got the 1-hour default even though the
+# provider promised minutes. Derived delays are bounded so a misparse can
+# never bench a key LONGER than the default it replaces.
+FUZZY_RETRY_DELAY_SECONDS = 180          # "try again in a few minutes"
+FUZZY_RETRY_DELAY_SHORT_SECONDS = 60     # "try again in a minute/moment/shortly"
+FUZZY_RETRY_DELAY_CAP_SECONDS = 600      # parsed guidance never exceeds 10 min
+
+# Provenance tag carried on error_context dicts: ``reset_at_source ==
+# MESSAGE_DERIVED_RESET_TAG`` means ``reset_at`` was parsed out of the error
+# MESSAGE text (fuzzy "try again in a few minutes", quotaResetDelay,
+# "resets in ..." heuristics), not supplied by the provider as a structured
+# field/header. Billing-classified failures must not inherit message-derived
+# windows — a depleted account does not reopen on a timer, and a fuzzy bench
+# would just hand the dead key back to re-fail (the #31273 money-burn class).
+MESSAGE_DERIVED_RESET_TAG = "message_parsed"
 
 # ``FailoverReason.billing`` as a bare string. The pool stores classified
 # failure semantics as plain text (it persists to JSON and must not import
@@ -389,13 +409,51 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     hr_only_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\b", message, re.IGNORECASE)
     if hr_only_match:
         return int(hr_only_match.group(1)) * 3600
-    min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min\b", message, re.IGNORECASE)
+    min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min", message, re.IGNORECASE)
     if min_only_match:
         return int(min_only_match.group(1)) * 60
+    # Explicit numeric retry windows phrased as "(try again|retry) in N
+    # minutes/seconds/hours" — e.g. hyper.charm.land's "Please try again in 5
+    # minutes." Capped at FUZZY_RETRY_DELAY_CAP_SECONDS so a misparse can
+    # never bench a key longer than the default TTL it replaces.
+    retry_num_match = re.search(
+        r"(?:try\s+again|retry)\s+in\s+(?:about\s+)?(\d+(?:\.\d+)?)\s*(hour|hr|minute|min|second|sec)s?\b",
+        message,
+        re.IGNORECASE,
+    )
+    if retry_num_match:
+        value = float(retry_num_match.group(1))
+        unit = retry_num_match.group(2).lower()
+        if unit.startswith("hour") or unit == "hr":
+            seconds = value * 3600
+        elif unit.startswith("min"):
+            seconds = value * 60
+        else:
+            seconds = value
+        return min(seconds, FUZZY_RETRY_DELAY_CAP_SECONDS)
+    # Fuzzy transient phrasings with no parseable number. "A few minutes" is
+    # the canonical shape; "in a minute/moment" and "shortly" are the short
+    # variants. These override nothing structured — only reached when no
+    # numeric window matched above.
+    if re.search(
+        r"(?:try\s+again|retry)\s+(?:in\s+)?(?:a\s+)?(?:few\s+|couple\s+of\s+|several\s+)?min(?:ute)?s?\b",
+        message,
+        re.IGNORECASE,
+    ):
+        return float(FUZZY_RETRY_DELAY_SECONDS)
+    if re.search(
+        r"(?:try\s+again|retry)\s+(?:in\s+)?(?:a\s+)?(?:minute|moment|short\s+while|bit)\b|try\s+again\s+shortly",
+        message,
+        re.IGNORECASE,
+    ):
+        return float(FUZZY_RETRY_DELAY_SHORT_SECONDS)
     return None
 
 
-def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _normalize_error_context(
+    error_context: Optional[Dict[str, Any]],
+    failure_reason: Optional[str] = None,
+) -> Dict[str, Any]:
     if not isinstance(error_context, dict):
         return {}
     normalized: Dict[str, Any] = {}
@@ -411,10 +469,33 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
         or error_context.get("retry_until")
     )
     parsed_reset_at = _parse_absolute_timestamp(reset_at)
+    # Provenance: a reset_at already parsed from the message by an upstream
+    # extractor (extract_api_error_context tags it) is message-derived even
+    # though the field is populated — without this the billing guard below
+    # would see a non-empty reset_at and let a fuzzy window through for a
+    # genuinely-depleted account.
+    message_derived = (
+        error_context.get("reset_at_source") == MESSAGE_DERIVED_RESET_TAG
+    )
     if parsed_reset_at is None and isinstance(message, str):
         retry_delay_seconds = _extract_retry_delay_seconds(message)
         if retry_delay_seconds is not None:
             parsed_reset_at = time.time() + retry_delay_seconds
+            message_derived = True
+    # Message-derived reset times are fuzzy provider guidance ("try again in
+    # a few minutes") and are only trustworthy for TRANSIENT failures. A
+    # billing classification means genuine credit depletion — a window parsed
+    # from the billing message body would bench the key for minutes and then
+    # hand it straight back to re-fail (and, worse, it would let the
+    # recoverable-exhaustion wait block on a window that can never reopen).
+    # Structured provider-supplied reset_at values still apply unconditionally:
+    # they are the provider's own contract, not our guesswork.
+    if (
+        parsed_reset_at is not None
+        and failure_reason == FAILURE_REASON_BILLING
+        and message_derived
+    ):
+        parsed_reset_at = None
     if parsed_reset_at is not None:
         normalized["reset_at"] = parsed_reset_at
     return normalized
@@ -674,6 +755,72 @@ class CredentialPool:
             available, _pending = self._available_entries()
             return bool(available)
 
+    def _sole_credential_unlocked(self) -> bool:
+        """True when at most one non-DEAD entry exists (nothing to rotate to).
+
+        Callers MUST hold ``self._lock``. Mirrors the computation in
+        ``_available_entries`` so cooldown sizing is consistent everywhere.
+        """
+        return sum(
+            1 for e in self._entries if e.last_status != STATUS_DEAD
+        ) <= 1
+
+    @staticmethod
+    def _entry_is_billing_benched(entry: PooledCredential) -> bool:
+        """True when an entry's exhaustion is billing/quota, not a transient
+        throttle: HTTP 402, or a classified ``failure_reason=billing``.
+
+        A 402 that the error classifier explicitly resolved to ``rate_limit``
+        (transient usage-limit with a "try again" signal) is NOT billing —
+        ``_classify_402`` disambiguates these, and treating them as billing
+        would give a transient quota a full TTL bench and refuse to wait for
+        its recovery. Check ``failure_reason`` first: an explicit non-billing
+        verdict overrides the raw 402 status.
+        """
+        fr = entry.failure_reason
+        if fr is not None and fr != FAILURE_REASON_BILLING:
+            return False
+        return (
+            entry.last_error_code == 402
+            or fr == FAILURE_REASON_BILLING
+        )
+
+    def _exhausted_candidate_unlocked(
+        self,
+    ) -> List[Tuple[float, PooledCredential, bool]]:
+        """Exhausted entries with unexpired cooldowns, earliest-recovery first.
+
+        Returns ``(until_epoch, entry, billing)`` tuples for every
+        ``STATUS_EXHAUSTED`` entry whose cooldown has not yet elapsed. The
+        ``billing`` flag is :meth:`_entry_is_billing_benched` pre-computed so
+        callers (next_available_at, recoverable_wait_seconds,
+        benched_runtime_keys) share a single pass over the pool.
+
+        Callers MUST hold ``self._lock``. Sole-credential sizing is computed
+        once here and fed to ``_exhausted_until``, so the shorter cooldown a
+        sole-credential throttle receives is reflected in every consumer —
+        ``next_available_at`` reports the seconds-level window instead of the
+        full TTL, and ``recoverable_wait_seconds`` waits for it.
+        """
+        sole_credential = self._sole_credential_unlocked()
+        candidates: List[Tuple[float, PooledCredential, bool]] = []
+        for entry in self._entries:
+            if entry.last_status != STATUS_EXHAUSTED:
+                continue
+            until = _exhausted_until(entry, sole_credential=sole_credential)
+            if until is None:
+                continue
+            candidates.append(
+                (until, entry, self._entry_is_billing_benched(entry))
+            )
+        # Sort by recovery time first, then by billing flag (False < True)
+        # so a transient entry wins a tie at the same epoch. This matters
+        # because recoverable_wait_seconds examines only candidates[0]: if a
+        # billing entry and a transient entry share the same reset_at, the
+        # transient one must come first so the wait is offered.
+        candidates.sort(key=lambda c: (c[0], c[2]))
+        return candidates
+
     def next_available_at(self) -> Optional[float]:
         """Earliest epoch time (seconds) any entry re-enters rotation.
 
@@ -693,21 +840,74 @@ class CredentialPool:
             available, _pending = self._available_entries()
             if available:
                 return None
-            # Mirror _available_entries: if the pool has no other credential
-            # to rotate to, the sole entry's transient throttle cools down in
-            # seconds — next_available_at must report that shorter window too,
-            # or the fallback restore gate waits an hour for a 60s cooldown.
-            sole_credential = sum(
-                1 for e in self._entries if e.last_status != STATUS_DEAD
-            ) <= 1
-            candidates: List[float] = []
-            for entry in self._entries:
-                if entry.last_status != STATUS_EXHAUSTED:
+            candidates = self._exhausted_candidate_unlocked()
+            return candidates[0][0] if candidates else None
+
+    def recoverable_wait_seconds(
+        self, *, max_wait: float = 600.0,
+    ) -> Optional[Tuple[float, bool]]:
+        """Bounded wait assessment for an all-exhausted pool.
+
+        Returns ``(wait_seconds, transient)`` when every non-DEAD entry is
+        exhausted and the earliest cooldown expires within *max_wait*:
+          - ``transient`` is True when the EARLIEST-recovering benched entry
+            is not billing-exhausted (status 402 or classified
+            ``failure_reason=billing``). Waiting for that specific key has a
+            real chance of recovery even when sibling entries are benched for
+            billing — the recovered key is served first and the billing keys
+            stay benched, so no paid request is burned on them.
+          - False when the earliest entry itself is billing-exhausted: the
+            caller must NOT wait — a depleted account does not reopen on a
+            timer, and waiting would just defer the same 402 (the #31273
+            money-burn class).
+        Returns None when some entry is available now, no exhausted entry
+        carries a usable recovery time (DEAD-only pools), or the earliest
+        recovery lies beyond *max_wait*.
+
+        Only the EARLIEST-recovering candidate is examined, not later ones.
+        This is deliberate: if the earliest entry is billing and a later
+        entry is transient, waiting would let the billing entry's cooldown
+        expire mid-wait — ``select()`` would then serve it and re-fail,
+        burning a paid request. Refusing to wait when the earliest entry is
+        billing is the safe choice.
+        """
+        with self._lock:
+            available, _pending = self._available_entries()
+            if available:
+                return None
+            candidates = self._exhausted_candidate_unlocked()
+            if not candidates:
+                return None
+            earliest_until, _, earliest_billing = candidates[0]
+            wait = earliest_until - time.time()
+            if wait < 0 or wait > max_wait:
+                return None
+            return (wait, not earliest_billing)
+
+    def benched_runtime_keys(self) -> Dict[str, Dict[str, Any]]:
+        """Runtime API keys currently benched in an unexpired cooldown.
+
+        Maps ``runtime_api_key`` -> ``{"billing": bool, "reset_at": epoch|None}``.
+        Only ``STATUS_EXHAUSTED`` entries whose cooldown has not yet elapsed
+        are included; DEAD entries (terminal auth) and OK entries are not.
+        Used by the runtime-resolution layer so it never hands out a key the
+        pool has benched for billing — the silent fallthrough that served a
+        depleted key for an hour after the pool benched it.
+        """
+        now = time.time()
+        result: Dict[str, Dict[str, Any]] = {}
+        with self._lock:
+            for until, entry, billing in self._exhausted_candidate_unlocked():
+                if now >= until:
                     continue
-                until = _exhausted_until(entry, sole_credential=sole_credential)
-                if until is not None:
-                    candidates.append(until)
-            return min(candidates) if candidates else None
+                key = entry.runtime_api_key
+                if not key:
+                    continue
+                result[key] = {
+                    "billing": billing,
+                    "reset_at": until,
+                }
+        return result
 
     def entries(self) -> List[PooledCredential]:
         with self._lock:
@@ -799,7 +999,7 @@ class CredentialPool:
         persist: bool = True,
         failure_reason: Optional[str] = None,
     ) -> PooledCredential:
-        normalized_error = _normalize_error_context(error_context)
+        normalized_error = _normalize_error_context(error_context, failure_reason)
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
         # transition to STATUS_DEAD instead of STATUS_EXHAUSTED.  Without this,
         # a revoked credential gets a 1-hour TTL cooldown and then re-enters
@@ -1828,9 +2028,7 @@ class CredentialPool:
         # DEAD entries never re-enter rotation, so if at most one non-DEAD entry
         # exists there is nothing to rotate to: an exhausted sole credential
         # should cool down briefly rather than bench the only key for an hour.
-        sole_credential = sum(
-            1 for e in self._entries if e.last_status != STATUS_DEAD
-        ) <= 1
+        sole_credential = self._sole_credential_unlocked()
         for entry in self._entries:
             # Borrowed credentials persist as metadata-only references and are
             # hydrated from their live source on load.  A stale duplicate row
@@ -2410,11 +2608,60 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
     field_updates = {}
     extra_updates = {}
     _field_names = {f.name for f in fields(existing)}
-    token_changed = (
-        "access_token" in payload
-        and payload["access_token"] is not None
-        and payload["access_token"] != existing.access_token
+    # "Token changed" must mean the SECRET changed (a real key rotation —
+    # old exhaustion state is stale for the new key), NOT a re-hydration of
+    # the same secret. Borrowed entries (custom_providers config keys, env
+    # keys) persist without the secret and re-hydrate from their live source
+    # on every load_pool(); the literal string comparison treated that
+    # re-hydration as a rotation and wiped the persisted bench on each load —
+    # so a billing-benched config key was served again after every reload,
+    # defeating the cooldown filter for exactly the config-seeded pools the
+    # runtime bench filter exists to protect. Compare fingerprints instead:
+    # same secret => keep exhaustion state; genuinely new secret => clear it.
+    incoming_token = payload.get("access_token")
+    incoming_fp = (
+        _fingerprint_value(incoming_token)
+        if incoming_token is not None
+        else None
     )
+    # Existing fingerprint: prefer the live in-memory token, fall back to the
+    # persisted fingerprint (the in-memory token is absent after a borrowed
+    # entry was reloaded from its disk-safe payload).
+    existing_fp = _fingerprint_value(existing.access_token) or (
+        existing.extra.get("secret_fingerprint") if existing.extra else None
+    )
+    # Legacy auth.json written before the fingerprint field existed leaves a
+    # borrowed entry with no in-memory token AND no persisted fingerprint.
+    # The raw-string differ would treat that as a rotation and wipe the
+    # bench on the first load — exactly the defect this predicate exists to
+    # prevent. For borrowed entries with an unknown fingerprint, assume
+    # rehydration (keep the bench, carry the fingerprint forward) rather than
+    # rotation. Owned (manual) entries always persist their raw token, so this
+    # relaxation never masks a genuine rotation.
+    is_borrowed = is_borrowed_credential_source(existing.source, provider)
+    token_changed = bool(
+        "access_token" in payload
+        and incoming_token is not None
+        and incoming_token != existing.access_token
+        and not (
+            incoming_fp is not None
+            and existing_fp is not None
+            and incoming_fp == existing_fp
+        )
+        # No existing fingerprint to compare against: a borrowed entry on its
+        # first load after upgrade cannot prove rotation, so don't assume it.
+        and not (is_borrowed and existing_fp is None)
+    )
+    # Carry the incoming fingerprint onto borrowed entries so same-process
+    # re-seeds can compare even before a persist/reload round-trip stores it.
+    # Owned (manual) entries persist the raw token and compare by value.
+    if (
+        incoming_fp is not None
+        and not token_changed
+        and is_borrowed
+        and (existing.extra or {}).get("secret_fingerprint") != incoming_fp
+    ):
+        extra_updates["secret_fingerprint"] = incoming_fp
     for key, value in payload.items():
         if key in {"id", "priority"} or value is None:
             continue

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -937,6 +937,11 @@ def format_auth_error(error: Exception) -> str:
     if error.code == "insufficient_credits":
         if error.provider == "nous":
             return _format_nous_entitlement_auth_error(error)
+        if error.provider == "custom":
+            # Custom-endpoint credential pools: keep the pool-specific detail
+            # (which pool, the `hermes auth add` remedy) instead of the
+            # generic subscription wording.
+            return str(error)
         return "Subscription credits are exhausted. Top up/renew credits, then retry."
 
     if error.code in {"subscription_expired", "no_usable_credits", "account_missing", "member_spend_cap_exceeded"}:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1725,7 +1725,14 @@ def switch_model(
                 api_key = runtime.get("api_key", "") or _ukey
                 base_url = runtime.get("base_url", "") or _user_pdef.base_url
                 api_mode = runtime.get("api_mode", "")
-            except Exception:
+            except Exception as e:
+                from hermes_cli.auth import AuthError
+                if isinstance(e, AuthError):
+                    # AuthError (e.g. insufficient_credits from a billing-
+                    # benched pool) must propagate — falling back to the raw
+                    # config key would serve a key the pool has benched,
+                    # defeating the cooldown filter (#40960 / #31273).
+                    raise
                 api_key = _ukey
                 base_url = _user_pdef.base_url
                 api_mode = ""
@@ -1766,7 +1773,10 @@ def switch_model(
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
             api_mode = runtime.get("api_mode", "")
-        except Exception:
+        except Exception as e:
+            from hermes_cli.auth import AuthError
+            if isinstance(e, AuthError):
+                raise
             pass
 
     # --- Direct alias override: use exact base_url from the alias if set ---

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 from urllib.parse import urlparse
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -613,8 +614,19 @@ def _try_resolve_from_custom_pool(
     provider_label: str,
     api_mode_override: Optional[str] = None,
     provider_name: Optional[str] = None,
+    exhaustion_info: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
+    """Check if a credential pool exists for a custom endpoint and return a runtime dict if so.
+
+    When the pool exists but every credential is benched (``select()`` returns
+    None), the caller falls through to config/env keys. Historically that
+    fallthrough served the SAME key the pool had just benched for billing —
+    burning requests against a depleted account for the whole bench window
+    with no rotation and no error ("random 402"). When *exhaustion_info* is a
+    dict, it is populated with ``pool_key``, ``benched`` (runtime key ->
+    {"billing": bool, "reset_at": epoch}) and ``next_available_at`` so the
+    caller can refuse billing-benched keys.
+    """
     pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
     if not pool_key:
         return None
@@ -624,6 +636,16 @@ def _try_resolve_from_custom_pool(
             return None
         entry = pool.select()
         if entry is None:
+            if isinstance(exhaustion_info, dict):
+                try:
+                    exhaustion_info["pool_key"] = pool_key
+                    exhaustion_info["benched"] = pool.benched_runtime_keys()
+                    exhaustion_info["next_available_at"] = pool.next_available_at()
+                except Exception:
+                    logger.debug(
+                        "custom pool exhaustion probe failed for %s", pool_key,
+                        exc_info=True,
+                    )
             return None
         pool_api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         if not pool_api_key:
@@ -638,6 +660,77 @@ def _try_resolve_from_custom_pool(
         }
     except Exception:
         return None
+
+
+def _fmt_bench_remaining(reset_at: Any) -> str:
+    """Human-readable remaining time for a benched credential's cooldown."""
+    try:
+        remaining = float(reset_at) - time.time()
+    except (TypeError, ValueError):
+        return "unknown"
+    if remaining <= 0:
+        return "0s"
+    if remaining < 90:
+        return f"{int(remaining)}s"
+    return f"{int(remaining // 60)}m"
+
+
+def _pick_custom_api_key(
+    candidates: List[Any],
+    exhaustion_info: Optional[Dict[str, Any]],
+    *,
+    context: str,
+) -> str:
+    """Pick the first usable candidate key, honoring credential-pool benches.
+
+    When the pool for this endpoint reported exhaustion (*exhaustion_info*),
+    candidates that the pool has benched for BILLING are skipped — serving
+    them burns paid requests against a depleted account for the full bench
+    window, with no rotation and a misleading "out of credits" on every
+    attempt. Transiently-benched keys are still served (they are the only
+    recovery vehicle when the pool has no alternative), but the bypass is
+    logged so it is visible instead of silent.
+
+    Raises :class:`AuthError` with ``code="insufficient_credits"`` when every
+    usable candidate is billing-benched — the gateway's resolution layer turns
+    that into the fallback chain / a clean billing-exhaustion message instead
+    of hitting the endpoint with a depleted key.
+    """
+    benched = (exhaustion_info or {}).get("benched") or {}
+    usable_seen = False
+    for candidate in candidates:
+        key = str(candidate or "").strip()
+        if not has_usable_secret(key):
+            continue
+        usable_seen = True
+        bench = benched.get(key)
+        if bench is None:
+            # Not tracked by the pool (e.g. env-only key never seeded):
+            # nothing the pool knows can disqualify it.
+            return key
+        if bench.get("billing"):
+            logger.info(
+                "credential pool: skipping billing-benched %s key "
+                "(cooldown %s remaining) instead of serving it",
+                context, _fmt_bench_remaining(bench.get("reset_at")),
+            )
+            continue
+        logger.warning(
+            "credential pool bypass: serving transiently-benched %s key "
+            "(%s cooldown remaining) — pool has no other credential",
+            context, _fmt_bench_remaining(bench.get("reset_at")),
+        )
+        return key
+    if usable_seen and benched:
+        pool_key = (exhaustion_info or {}).get("pool_key") or "custom pool"
+        raise AuthError(
+            f"All credentials for {pool_key} are exhausted (billing). "
+            "Add credits with the provider or add another key "
+            "(`hermes auth add`); retrying the depleted keys cannot succeed.",
+            provider="custom",
+            code="insufficient_credits",
+        )
+    return ""
 
 
 def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
@@ -1074,7 +1167,10 @@ def _resolve_named_custom_runtime(
         # Check credential pool first — mirrors the named-custom-provider path
         # so bare `provider: custom` with a configured custom_providers entry
         # also gets its api_key from the pool instead of env var fallbacks.
-        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+        _da_pool_exhaustion: Dict[str, Any] = {}
+        pool_result = _try_resolve_from_custom_pool(
+            base_url, "custom", None, exhaustion_info=_da_pool_exhaustion,
+        )
         if pool_result:
             pool_result["source"] = "direct-alias"
             return pool_result
@@ -1090,9 +1186,12 @@ def _resolve_named_custom_runtime(
             # intuitive match without configuring `custom_providers` first.
             _host_derived_api_key(base_url),
         ]
-        api_key = next(
-            (c for c in api_key_candidates if has_usable_secret(c)),
-            "",
+        # Never hand out a key the pool has benched for billing; raise a
+        # structured exhaustion error when every candidate is benched.
+        api_key = _pick_custom_api_key(
+            api_key_candidates,
+            _da_pool_exhaustion,
+            context="bare-custom",
         ) or "no-key-required"
         return {
             "provider": "custom",
@@ -1115,7 +1214,12 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    _cp_pool_exhaustion: Dict[str, Any] = {}
+    pool_result = _try_resolve_from_custom_pool(
+        base_url, "custom", custom_provider.get("api_mode"),
+        provider_name=custom_provider.get("name"),
+        exhaustion_info=_cp_pool_exhaustion,
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -1151,7 +1255,13 @@ def _resolve_named_custom_runtime(
         # fallback when key_env wasn't set explicitly.
         _host_derived_api_key(base_url),
     ]
-    api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
+    # Never hand out a key the pool has benched for billing; raise a
+    # structured exhaustion error when every candidate is benched.
+    api_key = _pick_custom_api_key(
+        api_key_candidates,
+        _cp_pool_exhaustion,
+        context=f"custom_provider:{custom_provider.get('name', requested_provider)}",
+    )
 
     result = {
         "provider": "custom",
@@ -1297,12 +1407,23 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and base_url:
         # Pass requested_provider so pool lookup prefers name match over base_url,
         # fixing credential mix-ups when multiple custom providers share a base_url.
+        _mc_pool_exhaustion: Dict[str, Any] = {}
         pool_result = _try_resolve_from_custom_pool(
             base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
             provider_name=requested_provider if requested_norm != "custom" else None,
+            exhaustion_info=_mc_pool_exhaustion,
         )
         if pool_result:
             return pool_result
+        if _mc_pool_exhaustion.get("benched"):
+            # Pool exists but every credential is benched. The api_key picked
+            # above may be the very key the pool benched for billing — re-pick
+            # through the bench filter so resolution never serves a depleted
+            # key (raises a structured exhaustion error when all candidates
+            # are billing-benched).
+            api_key = _pick_custom_api_key(
+                api_key_candidates, _mc_pool_exhaustion, context="model-config",
+            )
 
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"

--- a/tests/agent/test_credential_pool_402_flapping.py
+++ b/tests/agent/test_credential_pool_402_flapping.py
@@ -1,0 +1,911 @@
+"""Regression tests for the hyper.charm.land random-402 fix class.
+
+Real-world failure (2026-08-08, custom provider hyper.charm.land, 3-key pool):
+
+1. The funded key hit a transient 429 "Please try again in a few minutes."
+   The pool benched it for the full 1-hour default TTL because the fuzzy
+   retry guidance in the message was not parsed — ``_extract_retry_delay_seconds``
+   only understood structured formats (Fix 1).
+2. Rotation walked into two genuinely-depleted keys (402 billing), the pool
+   reached "no available entries", and the turn aborted as "Billing or
+   credits exhausted" even though the funded key would recover in minutes
+   (Fix 3).
+3. While the pool was fully benched, runtime resolution silently fell
+   through to the config singleton key — serving keys the pool had benched,
+   burning requests against depleted accounts with no rotation and no error
+   (Fix 2).
+
+These tests pin all three behaviors, including the #31273 money-burn guard
+(pure-billing exhaustion must NOT get fuzzy cooldowns or recovery waits).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — fuzzy retry-delay parsing + billing guard (agent/credential_pool.py)
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzyRetryDelayParsing:
+    """Provider throttle messages without structured reset times must yield a
+    bounded cooldown instead of falling through to the 1-hour default."""
+
+    def test_a_few_minutes_parses_to_180s(self):
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        assert (
+            _extract_retry_delay_seconds("Please try again in a few minutes.")
+            == 180.0
+        )
+
+    def test_explicit_numeric_minutes(self):
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        assert _extract_retry_delay_seconds("Please try again in 5 minutes.") == 300.0
+
+    def test_numeric_hours_capped_at_10_minutes(self):
+        """Fuzzy-derived guidance can never bench longer than the cap."""
+        from agent.credential_pool import (
+            FUZZY_RETRY_DELAY_CAP_SECONDS,
+            _extract_retry_delay_seconds,
+        )
+
+        assert (
+            _extract_retry_delay_seconds("try again in about 2 hours")
+            == FUZZY_RETRY_DELAY_CAP_SECONDS
+        )
+
+    def test_short_fuzzy_variants(self):
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        assert _extract_retry_delay_seconds("try again in a moment") == 60.0
+        assert _extract_retry_delay_seconds("please try again shortly") == 60.0
+
+    def test_unrelated_messages_still_return_none(self):
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        assert _extract_retry_delay_seconds("You're out of credits.") is None
+        assert _extract_retry_delay_seconds("") is None
+
+    def test_structured_formats_unaffected(self):
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        assert _extract_retry_delay_seconds("quotaResetDelay: 45s") == 45.0
+        assert _extract_retry_delay_seconds("retry after 30 seconds") == 30.0
+
+
+class TestFuzzyCooldownEndToEnd:
+    """Marking a credential exhausted with a fuzzy throttle message stores the
+    parsed window as reset_at, survives persistence, and unlocks the entry."""
+
+    def _pool(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "auth.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "credential_pool": {
+                        "openrouter": [
+                            {
+                                "id": "cred-1",
+                                "label": "cred-1",
+                                "auth_type": "api_key",
+                                "priority": 0,
+                                "source": "manual",
+                                "access_token": "sk-test-1",
+                                "base_url": "https://openrouter.ai/api/v1",
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from agent.credential_pool import load_pool
+
+        return load_pool("openrouter"), hermes_home
+
+    def test_fuzzy_429_stores_parsed_reset_and_recovers(self, tmp_path, monkeypatch):
+        pool, hermes_home = self._pool(tmp_path, monkeypatch)
+        before = time.time()
+        pool.mark_exhausted_and_rotate(
+            status_code=429,
+            error_context={
+                "reason": "rate_limit",
+                "message": "Please try again in a few minutes.",
+            },
+            api_key_hint="sk-test-1",
+            failure_reason="rate_limit",
+        )
+        entry = pool.entries()[0]
+        assert entry.last_status == "exhausted"
+        assert entry.last_error_reset_at is not None
+        # ~180s window, not the 1-hour default
+        assert 170 <= (entry.last_error_reset_at - before) <= 200
+
+        # Simulate the window elapsing: rewind the persisted timestamps and
+        # reload from disk (also proves the parsed window survives restart).
+        store = json.loads((hermes_home / "auth.json").read_text())
+        for e in store["credential_pool"]["openrouter"]:
+            if e.get("last_status") == "exhausted":
+                e["last_status_at"] = time.time() - 300
+                e["last_error_reset_at"] = time.time() - 60
+        (hermes_home / "auth.json").write_text(json.dumps(store))
+
+        from agent.credential_pool import load_pool
+
+        pool2 = load_pool("openrouter")
+        recovered = pool2.select()
+        assert recovered is not None
+        assert recovered.id == "cred-1"
+        assert recovered.last_status == "ok"
+
+    def test_billing_failure_drops_fuzzy_window(self, tmp_path, monkeypatch):
+        """The #31273 guard: a billing-classified failure must NOT inherit a
+        fuzzy window parsed from its message — the entry keeps the full bench."""
+        pool, _ = self._pool(tmp_path, monkeypatch)
+        pool.mark_exhausted_and_rotate(
+            status_code=402,
+            error_context={
+                "reason": "billing_error",
+                "message": "You're out of credits. Try again in 5 minutes.",
+            },
+            api_key_hint="sk-test-1",
+            failure_reason="billing",
+        )
+        entry = pool.entries()[0]
+        assert entry.last_error_reset_at is None
+        assert pool.has_available() is False
+
+    def test_billing_failure_keeps_structured_reset(self, tmp_path, monkeypatch):
+        """Provider-supplied structured reset_at is the provider's contract —
+        the billing guard only drops message-PARSED windows."""
+        pool, _ = self._pool(tmp_path, monkeypatch)
+        reset = time.time() + 7200
+        pool.mark_exhausted_and_rotate(
+            status_code=402,
+            error_context={
+                "reason": "billing_error",
+                "message": "You're out of credits.",
+                "reset_at": reset,
+            },
+            api_key_hint="sk-test-1",
+            failure_reason="billing",
+        )
+        entry = pool.entries()[0]
+        assert entry.last_error_reset_at == pytest.approx(reset, abs=5)
+
+
+class TestExtractApiErrorContextFuzzy:
+    """The conversation-loop error-context extractor must populate reset_at
+    from fuzzy throttle messages so the pool bench uses the provider window."""
+
+    def _fake_error(self, message: str, error_type: str = "rate_limit_error"):
+        err = Exception(f"Error code: 429 - {message}")
+        err.body = {"error": {"message": message, "type": error_type, "code": None}}
+        return err
+
+    def test_fuzzy_message_populates_reset_at(self):
+        from agent.agent_runtime_helpers import extract_api_error_context
+
+        before = time.time()
+        ctx = extract_api_error_context(
+            self._fake_error("Please try again in a few minutes.")
+        )
+        assert ctx.get("message") == "Please try again in a few minutes."
+        assert ctx.get("reset_at") is not None
+        assert 170 <= (ctx["reset_at"] - before) <= 200
+
+    def test_explicit_numeric_window(self):
+        from agent.agent_runtime_helpers import extract_api_error_context
+
+        before = time.time()
+        ctx = extract_api_error_context(self._fake_error("Please try again in 5 minutes."))
+        assert ctx.get("reset_at") == pytest.approx(before + 300, abs=5)
+
+    def test_structured_field_wins_over_fuzzy(self):
+        from agent.agent_runtime_helpers import extract_api_error_context
+
+        reset = time.time() + 999
+        err = self._fake_error("Please try again in a few minutes.")
+        err.body["error"]["resets_at"] = reset
+        ctx = extract_api_error_context(err)
+        assert ctx.get("reset_at") == reset
+        # Structured provider values are NOT tagged message-derived — the
+        # billing guard must keep them.
+        assert ctx.get("reset_at_source") is None
+
+    def test_message_parsed_windows_are_tagged(self):
+        from agent.agent_runtime_helpers import extract_api_error_context
+
+        for message in (
+            "Please try again in a few minutes.",
+            "quotaResetDelay: 45s",
+            "resets in 5 minutes",
+            "retry after 30 seconds",
+        ):
+            ctx = extract_api_error_context(self._fake_error(message))
+            assert ctx.get("reset_at_source") == "message_parsed", message
+
+
+class TestBillingGuardIntegration:
+    """End-to-end seam: extract_api_error_context -> mark_exhausted_and_rotate.
+
+    The billing guard must drop message-derived windows on the RUNTIME path —
+    not just when a hand-built dict reaches the pool directly (which is what
+    let the seam ship green: the extractor pre-parses messages into reset_at,
+    so the pool sees a populated field, not an empty one).
+    """
+
+    def _pool(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "auth.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "credential_pool": {
+                        "openrouter": [
+                            {
+                                "id": "cred-1",
+                                "label": "cred-1",
+                                "auth_type": "api_key",
+                                "priority": 0,
+                                "source": "manual",
+                                "access_token": "sk-test-1",
+                                "base_url": "https://openrouter.ai/api/v1",
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from agent.credential_pool import load_pool
+
+        return load_pool("openrouter")
+
+    def _billing_error(self, message: str):
+        err = Exception(f"Error code: 402 - {message}")
+        err.body = {"error": {"message": message, "type": "billing_error", "code": None}}
+        return err
+
+    def test_fuzzy_billing_body_gets_full_bench_not_fuzzy_window(
+        self, tmp_path, monkeypatch
+    ):
+        """A genuinely-depleted account whose 402 body contains fuzzy retry
+        phrasing must NOT re-enter rotation after the fuzzy window — that is
+        one burned paid request per window, indefinitely (#31273 class)."""
+        from agent.agent_runtime_helpers import extract_api_error_context
+
+        pool = self._pool(tmp_path, monkeypatch)
+        ctx = extract_api_error_context(
+            self._billing_error("You're out of credits. Try again in 5 minutes.")
+        )
+        # The extractor tags the parsed window; the pool must drop it for
+        # billing failures.
+        assert ctx.get("reset_at_source") == "message_parsed"
+        pool.mark_exhausted_and_rotate(
+            status_code=402,
+            error_context=ctx,
+            api_key_hint="sk-test-1",
+            failure_reason="billing",
+        )
+        entry = pool.entries()[0]
+        assert entry.last_error_reset_at is None
+        assert pool.has_available() is False
+
+    def test_structured_billing_reset_survives_runtime_path(self, tmp_path, monkeypatch):
+        """Provider-supplied structured resets_at is the provider's contract —
+        it must survive the billing guard even through the extractor."""
+        from agent.agent_runtime_helpers import extract_api_error_context
+
+        pool = self._pool(tmp_path, monkeypatch)
+        reset = time.time() + 7200
+        err = self._billing_error("You're out of credits.")
+        err.body["error"]["resets_at"] = reset
+        ctx = extract_api_error_context(err)
+        pool.mark_exhausted_and_rotate(
+            status_code=402,
+            error_context=ctx,
+            api_key_hint="sk-test-1",
+            failure_reason="billing",
+        )
+        entry = pool.entries()[0]
+        assert entry.last_error_reset_at == pytest.approx(reset, abs=5)
+
+    def test_fuzzy_transient_body_keeps_window_runtime_path(self, tmp_path, monkeypatch):
+        """The guard is billing-only: a transient 429 with the same fuzzy
+        message keeps its parsed window through the runtime path."""
+        from agent.agent_runtime_helpers import extract_api_error_context
+
+        pool = self._pool(tmp_path, monkeypatch)
+        before = time.time()
+        err = Exception("Error code: 429 - rate_limit_error")
+        err.body = {
+            "error": {
+                "message": "Please try again in a few minutes.",
+                "type": "rate_limit_error",
+                "code": None,
+            }
+        }
+        ctx = extract_api_error_context(err)
+        pool.mark_exhausted_and_rotate(
+            status_code=429,
+            error_context=ctx,
+            api_key_hint="sk-test-1",
+            failure_reason="rate_limit",
+        )
+        entry = pool.entries()[0]
+        assert entry.last_error_reset_at is not None
+        assert 170 <= (entry.last_error_reset_at - before) <= 200
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — runtime resolution must never serve a billing-benched key
+#         (hermes_cli/runtime_provider.py)
+# ---------------------------------------------------------------------------
+
+
+class TestPickCustomApiKeyBenchFilter:
+    def _exhaustion(self, benched, pool_key="custom:hyper.test"):
+        return {"pool_key": pool_key, "benched": benched, "next_available_at": None}
+
+    def test_billing_benched_key_skipped(self):
+        from hermes_cli.runtime_provider import _pick_custom_api_key
+
+        key = _pick_custom_api_key(
+            ["sk-benched", "sk-healthy"],
+            self._exhaustion({"sk-benched": {"billing": True, "reset_at": time.time() + 3000}}),
+            context="test",
+        )
+        assert key == "sk-healthy"
+
+    def test_all_benched_raises_structured_exhaustion(self):
+        from hermes_cli.auth import AuthError
+        from hermes_cli.runtime_provider import _pick_custom_api_key
+
+        with pytest.raises(AuthError) as ei:
+            _pick_custom_api_key(
+                ["sk-benched"],
+                self._exhaustion({"sk-benched": {"billing": True, "reset_at": time.time() + 3000}}),
+                context="test",
+            )
+        assert ei.value.code == "insufficient_credits"
+
+    def test_transient_bench_is_served_with_warning(self):
+        """A transiently-benched key is the only recovery vehicle when the
+        pool has no alternative — it must still be served (the wait-and-retry
+        path handles recovery)."""
+        from hermes_cli.runtime_provider import _pick_custom_api_key
+
+        key = _pick_custom_api_key(
+            ["sk-throttled"],
+            self._exhaustion({"sk-throttled": {"billing": False, "reset_at": time.time() + 120}}),
+            context="test",
+        )
+        assert key == "sk-throttled"
+
+    def test_no_pool_state_is_legacy_behavior(self):
+        from hermes_cli.runtime_provider import _pick_custom_api_key
+
+        assert _pick_custom_api_key(["sk-any"], None, context="test") == "sk-any"
+        assert _pick_custom_api_key(["sk-any"], {}, context="test") == "sk-any"
+
+    def test_untracked_key_served(self):
+        """Keys the pool never saw (env-only, never seeded) are unaffected."""
+        from hermes_cli.runtime_provider import _pick_custom_api_key
+
+        key = _pick_custom_api_key(
+            ["sk-env-only"],
+            self._exhaustion({"sk-other": {"billing": True, "reset_at": time.time() + 60}}),
+            context="test",
+        )
+        assert key == "sk-env-only"
+
+
+class TestCustomPoolExhaustionInfo:
+    """_try_resolve_from_custom_pool must report pool exhaustion so callers
+    can refuse billing-benched fallthrough keys (the silent-bypass defect)."""
+
+    def _setup_hermes_home(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            "custom_providers:\n"
+            "  - name: HyperTest\n"
+            "    base_url: https://hyper.test/v1\n"
+        )
+        (hermes_home / "auth.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "credential_pool": {
+                        "custom:hypertest": [
+                            {
+                                "id": "cred-1",
+                                "label": "manual-1",
+                                "auth_type": "api_key",
+                                "priority": 0,
+                                "source": "manual",
+                                "access_token": "sk-bench-1",
+                                "base_url": "https://hyper.test/v1",
+                                "last_status": "exhausted",
+                                "last_status_at": time.time(),
+                                "last_error_code": 402,
+                                "failure_reason": "billing",
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        for var in ("OPENAI_API_KEY", "OPENROUTER_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_exhausted_pool_reports_benched_keys(self, tmp_path, monkeypatch):
+        self._setup_hermes_home(tmp_path, monkeypatch)
+        from hermes_cli.auth import AuthError
+        from hermes_cli.runtime_provider import (
+            _pick_custom_api_key,
+            _try_resolve_from_custom_pool,
+        )
+
+        info: dict = {}
+        result = _try_resolve_from_custom_pool(
+            "https://hyper.test/v1", "custom", exhaustion_info=info
+        )
+        assert result is None
+        assert info.get("pool_key") == "custom:hypertest"
+        benched = info.get("benched", {})
+        assert "sk-bench-1" in benched
+        assert benched["sk-bench-1"]["billing"] is True
+        # reset_at must be a concrete future epoch, not a self-reference.
+        reset_at = benched["sk-bench-1"]["reset_at"]
+        assert isinstance(reset_at, float)
+        assert reset_at > time.time()
+        # The fallthrough config key is exactly the benched key → refuse it.
+        with pytest.raises(AuthError) as ei:
+            _pick_custom_api_key(["sk-bench-1"], info, context="custom_provider:HyperTest")
+        assert ei.value.code == "insufficient_credits"
+
+    def test_healthy_pool_unaffected(self, tmp_path, monkeypatch):
+        self._setup_hermes_home(tmp_path, monkeypatch)
+        hermes_home = tmp_path / "hermes"
+        store = json.loads((hermes_home / "auth.json").read_text())
+        entry = store["credential_pool"]["custom:hypertest"][0]
+        for k in ("last_status", "last_status_at", "last_error_code", "failure_reason"):
+            entry.pop(k, None)
+        (hermes_home / "auth.json").write_text(json.dumps(store))
+
+        from hermes_cli.runtime_provider import _try_resolve_from_custom_pool
+
+        info: dict = {}
+        result = _try_resolve_from_custom_pool(
+            "https://hyper.test/v1", "custom", exhaustion_info=info
+        )
+        assert result is not None
+        assert result["api_key"] == "sk-bench-1"
+        assert info == {}  # never populated when the pool can serve
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — recoverable-exhaustion wait (pool assessment + recovery helper)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSeededBenchSurvivesReload:
+    """Borrowed (config-seeded) entries persist without their secret and are
+    re-hydrated from custom_providers.api_key on every load_pool(). The
+    upsert must treat re-hydration as SAME secret (bench survives), not as a
+    rotation (bench wiped) — otherwise a billing-benched config key is served
+    again after every reload, defeating the cooldown filter for exactly the
+    config-seeded pools it exists to protect. A genuinely changed api_key in
+    config.yaml is a real rotation and MUST still clear the bench.
+    """
+
+    def _setup(self, tmp_path, monkeypatch, api_key: str, *, benched: bool):
+        from agent.credential_persistence import _fingerprint_value
+
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            "custom_providers:\n"
+            "  - name: BenchTest\n"
+            "    base_url: https://bench.test/v1\n"
+            f"    api_key: {api_key}\n"
+        )
+        entry = {
+            "id": "cfg-1",
+            "label": "BenchTest",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "config:BenchTest",
+            # Borrowed entries persist WITHOUT the secret.
+            "base_url": "https://bench.test/v1",
+        }
+        if benched:
+            entry.update(
+                {
+                    "last_status": "exhausted",
+                    "last_status_at": time.time(),
+                    "last_error_code": 402,
+                    "failure_reason": "billing",
+                    "last_error_message": "You're out of credits.",
+                    "secret_fingerprint": _fingerprint_value(api_key),
+                }
+            )
+        (hermes_home / "auth.json").write_text(
+            json.dumps(
+                {"version": 1, "credential_pool": {"custom:benchtest": [entry]}}
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        for var in ("OPENAI_API_KEY", "OPENROUTER_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        return hermes_home
+
+    def test_bench_survives_rehydration(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch, "sk-cfg-1", benched=True)
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("custom:benchtest")
+        entries = pool.entries()
+        assert len(entries) == 1
+        # Re-hydrated from config, still benched — NOT treated as rotation.
+        assert entries[0].runtime_api_key == "sk-cfg-1"
+        assert entries[0].last_status == "exhausted"
+        assert pool.has_available() is False
+        assert pool.select() is None
+
+    def test_real_key_rotation_clears_bench(self, tmp_path, monkeypatch):
+        """Persisted bench + fingerprint for sk-cfg-1, but config now carries
+        sk-cfg-2: the secret genuinely changed, so the stale bench clears."""
+        hermes_home = self._setup(tmp_path, monkeypatch, "sk-cfg-1", benched=True)
+        (hermes_home / "config.yaml").write_text(
+            "custom_providers:\n"
+            "  - name: BenchTest\n"
+            "    base_url: https://bench.test/v1\n"
+            "    api_key: sk-cfg-2\n"
+        )
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("custom:benchtest")
+        entries = pool.entries()
+        assert len(entries) == 1
+        assert entries[0].runtime_api_key == "sk-cfg-2"
+        assert entries[0].last_status is None
+        assert pool.select() is not None
+
+    def test_runtime_bench_filter_honors_surviving_bench(self, tmp_path, monkeypatch):
+        """End-to-end with the resolution layer: exhausted pool + config
+        fallthrough key is the benched key -> AuthError, even after a fresh
+        load_pool() re-hydrated the borrowed entry."""
+        self._setup(tmp_path, monkeypatch, "sk-cfg-1", benched=True)
+        from hermes_cli.auth import AuthError
+        from hermes_cli.runtime_provider import (
+            _pick_custom_api_key,
+            _try_resolve_from_custom_pool,
+        )
+
+        info: dict = {}
+        result = _try_resolve_from_custom_pool(
+            "https://bench.test/v1", "custom", exhaustion_info=info
+        )
+        assert result is None
+        assert info.get("benched", {}).get("sk-cfg-1", {}).get("billing") is True
+        with pytest.raises(AuthError) as ei:
+            _pick_custom_api_key(["sk-cfg-1"], info, context="custom_provider:BenchTest")
+        assert ei.value.code == "insufficient_credits"
+
+
+class TestLegacyFingerprintUpgrade:
+    """auth.json written before the fingerprint field existed has borrowed
+    entries with no in-memory secret AND no persisted secret_fingerprint.
+    The first load_pool() must NOT treat that as a rotation and wipe the
+    bench — the legacy-upgrade path must keep the bench and carry the
+    fingerprint forward so subsequent loads compare correctly."""
+
+    def test_bench_survives_first_load_without_fingerprint(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            "custom_providers:\n"
+            "  - name: BenchTest\n"
+            "    base_url: https://bench.test/v1\n"
+            "    api_key: sk-legacy-1\n"
+        )
+        # Legacy entry: benched, but NO secret_fingerprint field.
+        entry = {
+            "id": "cfg-1",
+            "label": "BenchTest",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "config:BenchTest",
+            "base_url": "https://bench.test/v1",
+            "last_status": "exhausted",
+            "last_status_at": time.time(),
+            "last_error_code": 402,
+            "failure_reason": "billing",
+            "last_error_message": "You're out of credits.",
+        }
+        (hermes_home / "auth.json").write_text(
+            json.dumps(
+                {"version": 1, "credential_pool": {"custom:benchtest": [entry]}}
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        for var in ("OPENAI_API_KEY", "OPENROUTER_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("custom:benchtest")
+        entries = pool.entries()
+        assert len(entries) == 1
+        # Legacy upgrade: bench survives even without a persisted fingerprint.
+        assert entries[0].last_status == "exhausted"
+        assert pool.has_available() is False
+        # Fingerprint is carried forward onto the entry so the next load
+        # compares correctly.
+        from agent.credential_persistence import _fingerprint_value
+
+        assert entries[0].extra.get("secret_fingerprint") == _fingerprint_value("sk-legacy-1")
+
+
+class TestRecoverableWaitSeconds:
+    def _entry(self, error_code, *, age_seconds, failure_reason=None, reset_at=None):
+        entry = {
+            "id": f"cred-{error_code}-{age_seconds}",
+            "label": f"cred-{error_code}",
+            "auth_type": "api_key",
+            "priority": 0,
+            "source": "manual",
+            "access_token": f"sk-{error_code}-{int(age_seconds)}",
+            "base_url": "https://openrouter.ai/api/v1",
+            "last_status": "exhausted",
+            "last_status_at": time.time() - age_seconds,
+            "last_error_code": error_code,
+        }
+        if failure_reason is not None:
+            entry["failure_reason"] = failure_reason
+        if reset_at is not None:
+            entry["last_error_reset_at"] = reset_at
+        return entry
+
+    def _pool(self, tmp_path, monkeypatch, entries):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "auth.json").write_text(
+            json.dumps({"version": 1, "credential_pool": {"openrouter": entries}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from agent.credential_pool import load_pool
+
+        return load_pool("openrouter")
+
+    def test_fuzzy_throttle_recovers_within_bound(self, tmp_path, monkeypatch):
+        """hyper.charm.land class: a 429 benched with a parsed 180s window
+        yields a bounded, TRANSIENT wait assessment."""
+        pool = self._pool(
+            tmp_path, monkeypatch,
+            [self._entry(429, age_seconds=30, reset_at=time.time() + 120)],
+        )
+        assessment = pool.recoverable_wait_seconds(max_wait=600)
+        assert assessment is not None
+        wait, transient = assessment
+        assert 100 <= wait <= 130
+        assert transient is True
+
+    def test_hour_long_bench_exceeds_bound(self, tmp_path, monkeypatch):
+        """Default-TTL benches (no provider window) stay beyond the wait bound —
+        recovery must not hold a turn for an hour. Two entries so the
+        sole-credential 60s cap does not apply."""
+        pool = self._pool(
+            tmp_path,
+            monkeypatch,
+            [
+                self._entry(429, age_seconds=30),
+                {**self._entry(429, age_seconds=30), "id": "cred-x",
+                 "access_token": "sk-x"},
+            ],
+        )
+        assert pool.recoverable_wait_seconds(max_wait=600) is None
+
+    def test_billing_earliest_entry_not_transient(self, tmp_path, monkeypatch):
+        """The #31273 guard: waiting on a billing-exhausted account is refused."""
+        pool = self._pool(
+            tmp_path, monkeypatch,
+            [self._entry(402, age_seconds=30, failure_reason="billing",
+                         reset_at=time.time() + 120)],
+        )
+        assessment = pool.recoverable_wait_seconds(max_wait=600)
+        assert assessment is not None
+        _wait, transient = assessment
+        assert transient is False
+
+    def test_transient_earliest_wins_over_billing_sibling(self, tmp_path, monkeypatch):
+        """Mixed pool: the transient key recovers first and is served first,
+        so waiting is justified even while a billing sibling stays benched."""
+        pool = self._pool(
+            tmp_path,
+            monkeypatch,
+            [
+                self._entry(429, age_seconds=30, reset_at=time.time() + 100),
+                self._entry(402, age_seconds=30, failure_reason="billing",
+                            reset_at=time.time() + 300),
+            ],
+        )
+        assessment = pool.recoverable_wait_seconds(max_wait=600)
+        assert assessment is not None
+        wait, transient = assessment
+        assert 80 <= wait <= 110
+        assert transient is True
+
+    def test_available_pool_returns_none(self, tmp_path, monkeypatch):
+        pool = self._pool(tmp_path, monkeypatch, [])
+        assert pool.recoverable_wait_seconds(max_wait=600) is None
+
+    def test_same_reset_at_transient_wins_tiebreak(self, tmp_path, monkeypatch):
+        """Two entries with identical reset_at: a transient 429 and a billing
+        402. The transient entry must win the tiebreak (candidates[0]) so the
+        wait is offered. If the billing entry won, recoverable_wait_seconds
+        would see billing=True for the earliest candidate and refuse to wait —
+        stranding a recoverable transient key behind a depleted one at the
+        same epoch.
+        """
+        reset = time.time() + 120
+        pool = self._pool(
+            tmp_path,
+            monkeypatch,
+            [
+                self._entry(402, age_seconds=30, failure_reason="billing",
+                            reset_at=reset),
+                self._entry(429, age_seconds=30, reset_at=reset),
+            ],
+        )
+        assessment = pool.recoverable_wait_seconds(max_wait=600)
+        assert assessment is not None
+        _wait, transient = assessment
+        assert transient is True
+
+    def test_402_classified_rate_limit_is_not_billing(self, tmp_path, monkeypatch):
+        """A 402 that the error classifier resolved to ``rate_limit`` (transient
+        usage-limit, e.g. "usage limit, try again in 5 minutes") must NOT be
+        treated as billing. The _classify_402 disambiguation exists precisely
+        for this case; _entry_is_billing_benched must honor the classifier
+        override so the entry gets a transient bench and can trigger a wait.
+        """
+        reset = time.time() + 120
+        pool = self._pool(
+            tmp_path,
+            monkeypatch,
+            [
+                self._entry(402, age_seconds=30, failure_reason="rate_limit",
+                            reset_at=reset),
+            ],
+        )
+        assessment = pool.recoverable_wait_seconds(max_wait=600)
+        assert assessment is not None
+        _wait, transient = assessment
+        assert transient is True
+
+
+class TestWaitForPoolRecovery:
+    def _agent(self):
+        agent = MagicMock()
+        agent._interrupt_requested = False
+        agent.log_prefix = ""
+        return agent
+
+    def _pool_with_assessment(self, assessment):
+        class _Pool:
+            def recoverable_wait_seconds(self, *, max_wait=600.0):
+                return assessment
+
+        return _Pool()
+
+    def test_transient_wait_completes_and_reports_true(self):
+        from agent.agent_runtime_helpers import _wait_for_pool_recovery
+
+        start = time.time()
+        assert _wait_for_pool_recovery(self._agent(), self._pool_with_assessment((0.3, True))) is True
+        assert time.time() - start >= 0.3
+
+    def test_billing_assessment_refused_immediately(self, monkeypatch):
+        from agent.agent_runtime_helpers import _wait_for_pool_recovery
+
+        sleep_calls = []
+        import time as time_mod
+
+        monkeypatch.setattr(time_mod, "sleep", lambda s: sleep_calls.append(s))
+        assert _wait_for_pool_recovery(self._agent(), self._pool_with_assessment((0.3, False))) is False
+        # Event-based: the billing refusal must not enter the sleep loop at
+        # all (wall-clock bounds here would be flake-prone on slow runners).
+        assert sleep_calls == []
+
+    def test_none_assessment_refused(self):
+        from agent.agent_runtime_helpers import _wait_for_pool_recovery
+
+        assert _wait_for_pool_recovery(self._agent(), self._pool_with_assessment(None)) is False
+
+    def test_interrupted_wait_returns_false(self):
+        from agent.agent_runtime_helpers import _wait_for_pool_recovery
+
+        agent = self._agent()
+        agent._interrupt_requested = True
+        assert _wait_for_pool_recovery(agent, self._pool_with_assessment((60.0, True))) is False
+
+    def test_lightweight_pool_adapter_without_assessment_api(self):
+        """Pool adapters lacking recoverable_wait_seconds degrade to no-wait
+        instead of raising (compat contract from credential_pool docstring)."""
+        from agent.agent_runtime_helpers import _wait_for_pool_recovery
+
+        class _LegacyPool:
+            def select(self):
+                return None
+
+        assert _wait_for_pool_recovery(self._agent(), _LegacyPool()) is False
+
+
+class TestModelSwitchAuthErrorPropagation:
+    """model_switch.py must propagate AuthError from resolve_runtime_provider
+    instead of swallowing it via a broad except-Exception that falls back to
+    the raw config key — which would serve a key the pool has benched for
+    billing (#40960 / #31273)."""
+
+    def test_autherror_not_swallowed_by_model_switch(self, tmp_path, monkeypatch):
+        """When resolve_runtime_provider raises AuthError (e.g. all keys
+        billing-benched), switch_model must NOT swallow it and silently fall
+        back to the raw config key — it must propagate the error so the
+        caller can route to the fallback chain / billing UX."""
+        from hermes_cli.auth import AuthError
+        from hermes_cli import runtime_provider as rp
+        from hermes_cli.providers import ProviderDef
+        import pytest as _pytest
+
+        def _raise_auth_error(**kwargs):
+            raise AuthError(
+                "All credentials exhausted (billing).",
+                provider="custom",
+                code="insufficient_credits",
+            )
+
+        # Patch at the source module — model_switch imports it locally.
+        monkeypatch.setattr(rp, "resolve_runtime_provider", _raise_auth_error)
+        # Provide a valid ProviderDef so switch_model reaches the resolution
+        # path that calls resolve_runtime_provider.
+        monkeypatch.setattr(
+            "hermes_cli.model_switch.resolve_provider_full",
+            lambda *a, **k: ProviderDef(
+                id="mycustom", name="mycustom", transport="openai_chat",
+                api_key_env_vars=("MY_API_KEY",), base_url="https://test.example/v1",
+                is_aggregator=False, auth_type="api_key", source="user-config",
+            ),
+        )
+
+        from hermes_cli.model_switch import switch_model
+        # AuthError must propagate — NOT be swallowed into a raw-key fallback.
+        with _pytest.raises(AuthError) as ei:
+            switch_model(
+                raw_input="test-model",
+                current_provider="mycustom",
+                current_model="old-model",
+                current_base_url="https://test.example/v1",
+                current_api_key="sk-current",
+                explicit_provider="mycustom",
+                user_providers={"mycustom": {"api": "https://test.example/v1", "api_key": "sk-test"}},
+            )
+        assert ei.value.code == "insufficient_credits"


### PR DESCRIPTION
## What this fixes

Real-world failure class observed against a 3-key custom-provider pool
(hyper.charm.land):

1. A transient upstream 429 with body *"Please try again in a few minutes."*
   benched the funded key for the full 1-hour default TTL — the fuzzy retry
   guidance was never parsed.
2. Rotation then walked into two genuinely-depleted 402 keys, the pool hit
   "no available entries", and the turn aborted as billing-exhausted — while
   the funded key recovered in minutes.
3. While the pool had keys benched, runtime resolution silently fell through
   to the config singleton key (`custom_providers.api_key`), serving keys the
   pool had benched for billing and burning requests on depleted accounts —
   the source of the "random" 402s.
4. Benches on config-seeded (borrowed) entries were additionally wiped on
   every `load_pool()`, because `_upsert_entry` treated secret re-hydration
   as a key rotation — so billing benches on the config key did not survive
   process restarts.

## Changes

1. **Cooldown sizing** (`agent/credential_pool.py`):
   `_extract_retry_delay_seconds` now parses fuzzy retry guidance
   ("try again in a few minutes" → 180 s, "in N minutes" → N×60 capped at
   600 s, "in a moment/shortly" → 60 s). The parsed window rides
   `error_context → reset_at → _exhausted_until`, so the bench matches the
   provider's own guidance. Message-derived windows carry provenance
   (`MESSAGE_DERIVED_RESET_TAG`) and are dropped for billing-classified
   failures (preserving the #31273 money-burn protection) while
   provider-supplied structured `reset_at` fields/headers are kept.
2. **Cooldown bypass** (`hermes_cli/runtime_provider.py`):
   `_try_resolve_from_custom_pool` now reports pool exhaustion state and all
   three fallthrough call sites filter candidates through
   `_pick_custom_api_key` — billing-benched keys are never served. An
   all-benched pool raises `AuthError(code="insufficient_credits")`, which
   the gateway already routes to the fallback chain / billing-exhaustion UX.
3. **Recoverable-exhaustion wait** (`agent/agent_runtime_helpers.py`): when
   rotation reaches "no available entries" and the earliest benched entry is
   transient (not billing) and recovers within 600 s, the recovery path waits
   (interruptible, with activity heartbeat) and retries instead of aborting.
   Pure-billing exhaustion still aborts immediately. Auxiliary background
   calls are intentionally exempt (documented at `_recover_provider_pool`).
4. **Fingerprint-aware rotation detection**
   (`agent/credential_pool.py::_upsert_entry`): re-hydrating the same secret
   no longer clears persisted benches; a genuinely new key in config still
   does.

## Relationship to existing work

- Fuzzy retry phrasing extends the gap documented in #51450 / fixed for
  numeric phrasings in #51461 — non-numeric guidance ("a few minutes") is the
  delta here.
- The `runtime_provider.py` fallthrough site is the same bug class as #40960
  / #57137 (auth.py path), #79840 (fallback chain), and #43277 (codex
  resolver): an exhaustion verdict ignored on a fallthrough path. This PR
  closes the custom-provider runtime-resolution site.
- The recovery wait complements rather than replaces the TTL-shortening
  approach in #74946, and is adjacent to #81209/#81517 and #49769/#49785.
- The #31273 within-turn billing abort (money-burn protection) is preserved:
  billing-classified exhaustion never waits and still aborts;
  `tests/run_agent/test_31273_402_not_retried.py` passes.

## Tests

- New: `tests/agent/test_credential_pool_402_flapping.py` — 36 cases covering
  fuzzy parsing, billing guards (incl. the full extractor → pool runtime
  seam), bench persistence across reload from disk, the resolution bench
  filter, wait-assessment semantics (incl. mixed transient/billing pools),
  and single-key/no-pool legacy behavior.
- Regression: 182 passed across the credential-pool and runtime-resolution
  suites. One pre-existing unrelated failure
  (`test_qwen_oauth_auto_fallthrough_on_auth_failure`) fails identically on
  the parent commit — qwen-oauth auto-resolution fallthrough, untouched by
  this diff.
- Perf: hot path unchanged (`select()` ≈ baseline); the exhaustion probe adds
  cost only in the all-benched state; config cache intact.
- Robustness: suite ×2 flake-free; 8-thread rotation storm ×3 (12,000 ops,
  zero torn writes); scripted flapping simulation 16/16; auth.json integrity
  39/39.

## Scope note

The borrowed-entry persistence model is unchanged: `_seed_custom_pool` still
creates the `config:<name>` entry from `custom_providers.api_key`, and
borrowed entries persist without secrets by design (fail-closed disk
boundary). The fingerprint fix makes that boundary cooldown-correct; changing
the persistence model itself is a separate (security-sensitive) change.
