### PR TITLE
feat(providers): expose credential owner API

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -206,6 +206,11 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+    # Non-secret provider settings that belong on the provider credential
+    # surface (for example an AWS profile or a service-account path). These
+    # are explicit owner metadata; callers must never infer them from an env
+    # variable prefix or suffix.
+    setting_env_vars: tuple = ()
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -484,6 +489,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
         api_key_env_vars=(),
         base_url_env_var="BEDROCK_BASE_URL",
+        setting_env_vars=("AWS_REGION", "AWS_PROFILE"),
     ),
     "vertex": ProviderConfig(
         id="vertex",
@@ -495,6 +501,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="",
         api_key_env_vars=(),  # OAuth2 (service-account JSON / ADC), not a key
         base_url_env_var="",
+        setting_env_vars=("VERTEX_CREDENTIALS_PATH",),
     ),
     "azure-foundry": ProviderConfig(
         id="azure-foundry",

--- a/hermes_cli/provider_catalog.py
+++ b/hermes_cli/provider_catalog.py
@@ -64,6 +64,7 @@ class ProviderDescriptor:
     tab: str                       # "keys" | "accounts"
     api_key_env_vars: tuple[str, ...]  # credential env vars (may be empty)
     base_url_env_var: str          # base-URL override env var (may be "")
+    setting_env_vars: tuple[str, ...]  # explicit non-secret provider settings
     signup_url: str                # signup / console URL (may be "")
     order: int                     # CANONICAL_PROVIDERS index — mirrors `hermes model`
 
@@ -137,13 +138,16 @@ def provider_catalog() -> list[ProviderDescriptor]:
 
         # Credential env vars: registry first (it already normalizes these),
         # else derive from the profile's env_vars tuple.
-        if cfg and getattr(cfg, "api_key_env_vars", ()):
-            api_key_vars = tuple(cfg.api_key_env_vars)
+        if cfg:
+            api_key_vars = tuple(getattr(cfg, "api_key_env_vars", ()) or ())
             base_url_var = getattr(cfg, "base_url_env_var", "") or ""
+            setting_env_vars = tuple(getattr(cfg, "setting_env_vars", ()) or ())
         elif prof and getattr(prof, "env_vars", ()):
             api_key_vars, base_url_var = _split_env_vars(tuple(prof.env_vars))
+            setting_env_vars = ()
         else:
             api_key_vars, base_url_var = (), ""
+            setting_env_vars = ()
 
         label = (
             (getattr(prof, "display_name", "") if prof else "")
@@ -169,6 +173,7 @@ def provider_catalog() -> list[ProviderDescriptor]:
                 tab=tab_for_auth_type(auth_type),
                 api_key_env_vars=api_key_vars,
                 base_url_env_var=base_url_var,
+                setting_env_vars=setting_env_vars,
                 signup_url=signup_url,
                 order=order,
             )

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -42,6 +42,11 @@ class EnvVarReveal(BaseModel):
     profile: Optional[str] = None
 
 
+class ProviderCredentialUpdate(BaseModel):
+    value: str
+    profile: Optional[str] = None
+
+
 class MemoryProviderConfigUpdate(BaseModel):
     values: Dict[str, Any] = {}
 
@@ -722,4 +727,3 @@ class _PluginProvidersPutBody(BaseModel):
 
 class _PluginVisibilityBody(BaseModel):
     hidden: bool
-

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1319,6 +1319,7 @@ from hermes_cli.web_models import (  # noqa: F401
     EnvVarUpdate,
     EnvVarDelete,
     EnvVarReveal,
+    ProviderCredentialUpdate,
     MemoryProviderConfigUpdate,
     MemoryProviderSetupRequest,
     CustomEndpointUpdate,
@@ -6348,12 +6349,32 @@ async def get_model_options(
             # sync picker build (config load, pricing, refresh probes) runs
             # off the event loop under the requested profile.
             with _profile_scope(profile):
-                return build_model_options_payload(
+                payload = build_model_options_payload(
                     load_picker_context(),
                     explicit_only=bool(explicit_only),
                     include_unconfigured=bool(include_unconfigured),
                     refresh=bool(refresh),
                 )
+                from hermes_cli.provider_catalog import provider_catalog_by_slug
+
+                catalog = provider_catalog_by_slug()
+                for row in payload.get("providers", []):
+                    slug = str(row.get("slug") or "")
+                    descriptor = catalog.get(slug)
+                    if slug == "custom":
+                        setup_kind = "custom_endpoint"
+                    elif descriptor is None:
+                        setup_kind = "none"
+                    elif descriptor.tab == "accounts":
+                        setup_kind = "account"
+                    elif descriptor.tab == "keys":
+                        setup_kind = "credential"
+                    else:
+                        setup_kind = "none"
+                    row["setup_kind"] = setup_kind
+                    if descriptor is not None:
+                        row["auth_type"] = descriptor.auth_type
+                return payload
 
         return await run_in_threadpool(_build_payload_scoped)
     except HTTPException:
@@ -7022,7 +7043,7 @@ def _catalog_provider_env_metadata() -> dict:
             continue
         # API-key vars: the first is the primary (password) field; any aliases
         # are kept as additional password fields so users can clear them too.
-        for env_var in d.api_key_env_vars:
+        for field_order, env_var in enumerate(d.api_key_env_vars):
             if env_var in _non_provider_keys:
                 continue  # don't hijack a shared tool/messaging credential
             meta.setdefault(
@@ -7035,6 +7056,11 @@ def _catalog_provider_env_metadata() -> dict:
                     "is_password": True,
                     "advanced": False,
                     "category": "provider",
+                    "provider_order": d.order,
+                    "provider_description": d.description,
+                    "provider_auth_type": d.auth_type,
+                    "field_role": "primary_secret" if field_order == 0 else "secret_alias",
+                    "field_order": field_order,
                 },
             )
         # Base-URL override is an advanced, non-secret field for the same card.
@@ -7049,45 +7075,33 @@ def _catalog_provider_env_metadata() -> dict:
                     "is_password": False,
                     "advanced": True,
                     "category": "provider",
+                    "provider_order": d.order,
+                    "provider_description": d.description,
+                    "provider_auth_type": d.auth_type,
+                    "field_role": "endpoint",
+                    "field_order": len(d.api_key_env_vars),
                 },
             )
 
-        # AWS-SDK providers (Bedrock) authenticate via the AWS credential chain
-        # rather than a pasted API key, so they have no api_key_env_vars. Tag
-        # their AWS_* settings to the provider card so they still appear on the
-        # Keys tab (otherwise Bedrock — a `hermes model` provider — would be
-        # invisible in the desktop app).
-        if d.auth_type == "aws_sdk":
-            for aws_var in ("AWS_REGION", "AWS_PROFILE"):
-                existing = meta.get(aws_var, {})
-                meta[aws_var] = {
+        for setting_order, env_var in enumerate(d.setting_env_vars):
+            info = _OPT.get(env_var) or {}
+            meta.setdefault(
+                env_var,
+                {
                     "provider": d.slug,
                     "provider_label": d.label,
-                    "description": existing.get("description") or f"{d.label} ({aws_var})",
-                    "url": existing.get("url"),
-                    "is_password": False,
-                    "advanced": existing.get("advanced", True),
+                    "description": info.get("description") or f"{d.label} setting",
+                    "url": info.get("url"),
+                    "is_password": bool(info.get("password", False)),
+                    "advanced": bool(info.get("advanced", True)),
                     "category": "provider",
-                }
-
-        # Vertex AI authenticates via OAuth2 (service-account JSON or ADC), not a
-        # pasted API key, so it also has no api_key_env_vars. Tag its credential
-        # env var to the provider card so it appears on the Keys tab (otherwise
-        # Vertex — a `hermes model` provider — would be invisible in the desktop
-        # app). The value is a filesystem path, not a secret string, so it is
-        # not a password field.
-        if d.auth_type == "vertex":
-            existing = meta.get("VERTEX_CREDENTIALS_PATH", {})
-            meta["VERTEX_CREDENTIALS_PATH"] = {
-                "provider": d.slug,
-                "provider_label": d.label,
-                "description": existing.get("description")
-                or f"{d.label} — service account JSON path (or use ADC)",
-                "url": existing.get("url"),
-                "is_password": False,
-                "advanced": existing.get("advanced", True),
-                "category": "provider",
-            }
+                    "provider_order": d.order,
+                    "provider_description": d.description,
+                    "provider_auth_type": d.auth_type,
+                    "field_role": "setting",
+                    "field_order": len(d.api_key_env_vars) + (1 if d.base_url_env_var else 0) + setting_order,
+                },
+            )
     return meta
 
 
@@ -7127,6 +7141,12 @@ def _get_env_vars_sync(profile: Optional[str] = None):
             # CLI `hermes model` picker uses (not desktop-only prefix guesses).
             "provider": cat_meta.get("provider", ""),
             "provider_label": cat_meta.get("provider_label", ""),
+            "provider_order": cat_meta.get("provider_order"),
+            "provider_description": cat_meta.get("provider_description", ""),
+            "provider_auth_type": cat_meta.get("provider_auth_type", ""),
+            "field_role": cat_meta.get("field_role"),
+            "field_order": cat_meta.get("field_order"),
+            "field_label": info.get("prompt") or var_name,
             # True when this key exists in the user's .env but is NOT in any
             # catalog (OPTIONAL_ENV_VARS or the provider catalog) — an
             # arbitrary/custom env var the user added directly. Surfaced so the
@@ -7158,6 +7178,101 @@ def _get_env_vars_sync(profile: Optional[str] = None):
         row["is_password"] = True
         result[var_name] = row
     return result
+
+
+def _provider_credential_catalog(env_on_disk: Dict[str, str]) -> Dict[str, Any]:
+    """Return the exact provider credential surface owned by Hermes.
+
+    The response deliberately excludes unrelated environment variables and
+    carries explicit provider/field identity, role, and order. Product clients
+    therefore never need prefix matching, `advanced` guesses, or a copied
+    provider registry.
+    """
+    from hermes_cli.provider_catalog import provider_catalog
+
+    metadata = _catalog_provider_env_metadata()
+    providers: List[Dict[str, Any]] = []
+    for descriptor in provider_catalog():
+        if descriptor.tab != "keys":
+            continue
+        fields: List[Dict[str, Any]] = []
+        ordered_keys = (
+            *descriptor.api_key_env_vars,
+            *((descriptor.base_url_env_var,) if descriptor.base_url_env_var else ()),
+            *descriptor.setting_env_vars,
+        )
+        for env_var in ordered_keys:
+            info = metadata.get(env_var)
+            if not info or info.get("provider") != descriptor.slug:
+                continue
+            configured = env_on_disk.get(env_var)
+            optional = OPTIONAL_ENV_VARS.get(env_var) or {}
+            fields.append({
+                "key": env_var,
+                "label": optional.get("prompt") or env_var,
+                "description": optional.get("description") or info.get("description") or "",
+                "role": info["field_role"],
+                "order": info["field_order"],
+                "secret": bool(info.get("is_password", False)),
+                "is_set": bool(configured),
+                "redacted_value": redact_key(configured) if configured else None,
+                "docs_url": optional.get("url") or info.get("url"),
+            })
+        if fields:
+            providers.append({
+                "id": descriptor.slug,
+                "label": descriptor.label,
+                "description": descriptor.description,
+                "auth_type": descriptor.auth_type,
+                "order": descriptor.order,
+                "fields": sorted(fields, key=lambda field: (field["order"], field["key"])),
+            })
+    return {"providers": providers}
+
+
+def _require_provider_credential_field(provider_id: str, field_key: str) -> Dict[str, Any]:
+    metadata = _catalog_provider_env_metadata().get(field_key)
+    if not metadata or metadata.get("provider") != provider_id:
+        raise HTTPException(status_code=404, detail="Unknown provider credential field")
+    return metadata
+
+
+@app.get("/api/providers/credentials")
+async def list_provider_credentials(profile: Optional[str] = None):
+    with _profile_scope(profile):
+        return _provider_credential_catalog(load_env())
+
+
+@app.put("/api/providers/credentials/{provider_id}/{field_key}")
+async def set_provider_credential(
+    provider_id: str,
+    field_key: str,
+    body: ProviderCredentialUpdate,
+    profile: Optional[str] = None,
+):
+    _require_provider_credential_field(provider_id, field_key)
+    try:
+        with _profile_scope(body.profile or profile):
+            from hermes_cli.credential_lifecycle import save_provider_env_credential
+
+            save_provider_env_credential(field_key, body.value)
+        return {"ok": True}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.delete("/api/providers/credentials/{provider_id}/{field_key}")
+async def delete_provider_credential(
+    provider_id: str,
+    field_key: str,
+    profile: Optional[str] = None,
+):
+    _require_provider_credential_field(provider_id, field_key)
+    with _profile_scope(profile):
+        from hermes_cli.credential_lifecycle import remove_provider_env_credential
+
+        remove_provider_env_credential(field_key)
+    return {"ok": True}
 
 
 @app.put("/api/env")
@@ -7627,6 +7742,42 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
         # 429 = key is valid but rate-limited; success = valid.
         return {"ok": True, "reachable": True, "message": ""}
     return {"ok": False, "reachable": True, "message": f"Provider returned HTTP {resp.status_code} for this key."}
+
+
+@app.post("/api/providers/credentials/{provider_id}/{field_key}/validate")
+async def validate_owned_provider_credential(
+    provider_id: str,
+    field_key: str,
+    body: ProviderCredentialUpdate,
+    request: Request,
+):
+    """Validate one exact owner-declared provider credential field.
+
+    Unsupported and temporarily unavailable probes are explicit states. They
+    are never reported as successful validation, so a client can require a
+    separate user-confirmed save instead of silently degrading.
+    """
+    metadata = _require_provider_credential_field(provider_id, field_key)
+    role = metadata.get("field_role")
+    if role not in {"primary_secret", "secret_alias", "endpoint"}:
+        return {
+            "status": "unsupported",
+            "message": "Hermes does not provide live validation for this provider setting.",
+        }
+    if field_key not in _CREDENTIAL_PROBES and field_key != "OPENAI_BASE_URL":
+        return {
+            "status": "unsupported",
+            "message": "Hermes does not provide a live validation probe for this credential.",
+        }
+    result = await validate_provider_credential(
+        EnvVarUpdate(key=field_key, value=body.value),
+        request,
+    )
+    if result.get("ok") and result.get("reachable"):
+        return {"status": "valid", "message": result.get("message") or ""}
+    if result.get("reachable"):
+        return {"status": "invalid", "message": result.get("message") or "The provider rejected this value."}
+    return {"status": "unavailable", "message": result.get("message") or "The provider validation endpoint is unavailable."}
 
 
 @app.delete("/api/env")
@@ -10041,6 +10192,14 @@ async def list_oauth_providers(profile: Optional[str] = None):
             providers = []
             for p in _build_oauth_catalog():
                 status = _resolve_provider_status(p["id"], p.get("status_fn"))
+                status = {
+                    **status,
+                    # Safe Product display contract: raw source_label may contain
+                    # an auth-store path. Keep it for Hermes diagnostics, but give
+                    # embedded products an owner-provided label that never exposes
+                    # local filesystem identity.
+                    "display_label": p["name"] if status.get("logged_in") else None,
+                }
                 disconnect_hint = _oauth_provider_disconnect_hint(p, status)
                 providers.append({
                     "id": p["id"],

--- a/tests/hermes_cli/test_provider_credentials_api.py
+++ b/tests/hermes_cli/test_provider_credentials_api.py
@@ -1,0 +1,113 @@
+from fastapi.testclient import TestClient
+
+from hermes_cli.web_server import _SESSION_TOKEN, app
+
+
+client = TestClient(app)
+HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}
+
+
+def _provider(provider_id: str) -> dict:
+    response = client.get("/api/providers/credentials", headers=HEADERS)
+    assert response.status_code == 200
+    return next(row for row in response.json()["providers"] if row["id"] == provider_id)
+
+
+def test_provider_credentials_expose_owner_roles_and_order():
+    gemini = _provider("gemini")
+    fields = {field["key"]: field for field in gemini["fields"]}
+
+    assert fields["GOOGLE_API_KEY"]["role"] == "primary_secret"
+    assert fields["GEMINI_API_KEY"]["role"] == "secret_alias"
+    assert fields["GEMINI_BASE_URL"]["role"] == "endpoint"
+    assert [field["order"] for field in gemini["fields"]] == sorted(
+        field["order"] for field in gemini["fields"]
+    )
+
+    bedrock = _provider("bedrock")
+    bedrock_fields = {field["key"]: field for field in bedrock["fields"]}
+    assert bedrock_fields["AWS_REGION"]["role"] == "setting"
+    assert bedrock_fields["AWS_PROFILE"]["role"] == "setting"
+
+
+def test_provider_credential_mutation_is_bound_to_provider_identity():
+    wrong = client.put(
+        "/api/providers/credentials/xai/GOOGLE_API_KEY",
+        json={"value": "secret"},
+        headers=HEADERS,
+    )
+    assert wrong.status_code == 404
+
+    saved = client.put(
+        "/api/providers/credentials/gemini/GOOGLE_API_KEY",
+        json={"value": "secret"},
+        headers=HEADERS,
+    )
+    assert saved.status_code == 200
+    assert next(
+        field for field in _provider("gemini")["fields"] if field["key"] == "GOOGLE_API_KEY"
+    )["is_set"] is True
+
+    deleted = client.delete(
+        "/api/providers/credentials/gemini/GOOGLE_API_KEY",
+        headers=HEADERS,
+    )
+    assert deleted.status_code == 200
+    assert next(
+        field for field in _provider("gemini")["fields"] if field["key"] == "GOOGLE_API_KEY"
+    )["is_set"] is False
+
+
+def test_unavailable_validation_capability_is_explicit():
+    response = client.post(
+        "/api/providers/credentials/bedrock/AWS_PROFILE/validate",
+        json={"value": "research"},
+        headers=HEADERS,
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "unsupported"
+
+
+def test_account_status_has_safe_owner_display_label(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    monkeypatch.setattr(
+        web_server,
+        "_resolve_provider_status",
+        lambda _provider_id, _status_fn: {
+            "logged_in": True,
+            "source": "auth_store",
+            "source_label": "/home/private/.credentials.json",
+        },
+    )
+    response = client.get("/api/providers/oauth", headers=HEADERS)
+    assert response.status_code == 200
+    for provider in response.json()["providers"]:
+        assert provider["status"]["display_label"] == provider["name"]
+        assert "/home/private" not in provider["status"]["display_label"]
+
+
+def test_model_options_expose_owner_setup_surface(monkeypatch):
+    import hermes_cli.inventory as inventory
+
+    monkeypatch.setattr(inventory, "load_picker_context", lambda: object())
+    monkeypatch.setattr(
+        inventory,
+        "build_model_options_payload",
+        lambda *_args, **_kwargs: {
+            "providers": [
+                {"slug": "gemini", "name": "Gemini", "models": []},
+                {"slug": "nous", "name": "Nous", "models": []},
+                {"slug": "custom", "name": "Custom", "models": []},
+            ]
+        },
+    )
+    response = client.get(
+        "/api/model/options?include_unconfigured=true&explicit_only=true",
+        headers=HEADERS,
+    )
+    assert response.status_code == 200
+    providers = {row["slug"]: row for row in response.json()["providers"]}
+    assert providers["gemini"]["setup_kind"] == "credential"
+    assert providers["nous"]["setup_kind"] == "account"
+    assert providers["custom"]["setup_kind"] == "custom_endpoint"


### PR DESCRIPTION
## Summary

- expose provider-scoped credential metadata and set/clear endpoints derived from the unified provider catalog
- return explicit valid, invalid, unavailable, and unsupported validation states
- annotate model options with the owner-declared setup surface
- provide a safe display label for connected account status

This keeps provider identity, credential fields, storage, and validation semantics in Hermes while giving non-dashboard clients a narrow API that never needs arbitrary environment-variable discovery or secret reveal.

## Testing

- scripts/run_tests.sh tests/hermes_cli/test_provider_credentials_api.py tests/hermes_cli/test_provider_catalog.py tests/hermes_cli/test_web_server.py -q (150 passed)
- git diff origin/main --check