### PR TITLE
fix(desktop): allowlist http(s) for MCP OAuth authorization_url

### DIFF
--- a/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { completeMcpDesktopOAuth } from './mcp-dashboard-oauth'
+import { completeMcpDesktopOAuth, isValidAuthorizationUrl } from './mcp-dashboard-oauth'
+
+describe('isValidAuthorizationUrl', () => {
+  it('accepts http(s) URLs with a host', () => {
+    expect(isValidAuthorizationUrl('https://idp.example/authorize')).toBe(true)
+    expect(isValidAuthorizationUrl('http://127.0.0.1:8080/oauth')).toBe(true)
+  })
+
+  it('rejects non-http schemes', () => {
+    expect(isValidAuthorizationUrl('javascript:alert(1)')).toBe(false)
+    expect(isValidAuthorizationUrl('file:///etc/passwd')).toBe(false)
+    expect(isValidAuthorizationUrl('not a url')).toBe(false)
+  })
+})
 
 describe('completeMcpDesktopOAuth', () => {
   it('opens the returned authorization URL and polls through approval', async () => {
@@ -40,6 +53,28 @@ describe('completeMcpDesktopOAuth', () => {
 
     expect(openExternal).toHaveBeenCalledWith('https://idp.example/authorize')
     expect(result.status).toBe('approved')
+  })
+
+  it('rejects non-http(s) authorization URLs before openExternal', async () => {
+    const openExternal = vi.fn()
+
+    await expect(
+      completeMcpDesktopOAuth({
+        serverName: 'reports',
+        start: async () => ({
+          flow_id: 'flow-bad-scheme',
+          server_name: 'reports',
+          status: 'authorization_required',
+          authorization_url: 'file:///etc/passwd',
+          error: null
+        }),
+        status: vi.fn(),
+        openExternal,
+        sleep: async () => {}
+      })
+    ).rejects.toThrow(/http\(s\) URL/)
+
+    expect(openExternal).not.toHaveBeenCalled()
   })
 
   it('retries a transient status failure', async () => {

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.ts
@@ -18,6 +18,16 @@ interface CompleteOptions {
 
 const defaultSleep = (milliseconds: number) => new Promise<void>(resolve => window.setTimeout(resolve, milliseconds))
 
+/** http(s) authorization URLs only — reject javascript:/file: before openExternal. */
+export function isValidAuthorizationUrl(authorizationUrl: string): boolean {
+  try {
+    const parsed = new URL(authorizationUrl)
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && Boolean(parsed.host)
+  } catch {
+    return false
+  }
+}
+
 export async function completeMcpDesktopOAuth({
   serverName,
   start,
@@ -34,6 +44,10 @@ export async function completeMcpDesktopOAuth({
 
   if (!started.authorization_url) {
     throw new Error('OAuth server did not provide an authorization URL')
+  }
+
+  if (!isValidAuthorizationUrl(started.authorization_url)) {
+    throw new Error('OAuth authorization_url must be an http(s) URL with a host')
   }
 
   await openExternal(started.authorization_url)


### PR DESCRIPTION
## Why

`completeMcpDesktopOAuth` passes MCP `authorization_url` to `openExternal` with no scheme check. Desktop IPC `openExternalUrl` intentionally allows `file:` for the artifacts panel, so a hostile or confused OAuth start response can open a local path (same trust model as `javascript:` / non-http schemes on the web path).

Sibling of Python #82350 and web dashboard #82365; this PR covers the desktop Electron path only.

## Fix

`isValidAuthorizationUrl` (http/https + host) before `openExternal`; throw and do not open on reject.

## Test plan

- [x] `npx vitest run --project ui src/lib/mcp-dashboard-oauth.test.ts` (5/5)
- [ ] Normal https IdP URL still opens externally
- [ ] `file:` / `javascript:` fail closed before `openExternal`


Made with [Cursor](https://cursor.com)