### PR TITLE
fix(desktop): reject split renderer packages

### DIFF
--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -1,8 +1,9 @@
 /**
  * after-pack.mjs — electron-builder afterPack hook.
  *
- * Stamps the Hermes icon + identity onto the packed Windows Hermes.exe via
- * rcedit (delegated to set-exe-identity.mjs). This runs for EVERY packed build
+ * Verifies that the ASAR index and unpacked renderer payload are one coherent
+ * artifact, then stamps the Hermes icon + identity onto the packed Windows
+ * Hermes.exe via rcedit. This runs for EVERY packed build
  * — first install, `hermes desktop`, the installer's --update rebuild, and a
  * dev's manual `npm run pack` — so the branded exe can never silently revert
  * to the stock "Electron" icon/name (the bug when the stamp lived only in
@@ -21,9 +22,21 @@
 
 import path from 'node:path'
 
+import { assertPackagedRendererIntegrity, packagedResourcesDir } from './packaged-renderer-integrity.mjs'
 import { stampExeIdentity } from './set-exe-identity.mjs'
 
 export default async function afterPack(context) {
+  const resourcesDir = packagedResourcesDir(
+    context.appOutDir,
+    context.electronPlatformName,
+    context.packager?.appInfo?.productFilename
+  )
+  try {
+    assertPackagedRendererIntegrity(resourcesDir)
+  } catch (err) {
+    throw new Error(`[after-pack] packaged renderer integrity check failed: ${err.message}`)
+  }
+
   if (context.electronPlatformName !== 'win32') {
     return
   }

--- a/apps/desktop/scripts/packaged-renderer-integrity.mjs
+++ b/apps/desktop/scripts/packaged-renderer-integrity.mjs
@@ -1,0 +1,156 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { listPackage, statFile } from '@electron/asar'
+
+const RENDERER_PREFIX = 'dist/'
+const POST_PACK_MUTABLE_PREFIX = 'dist/node_modules/'
+
+function normalizeAsarPath(value) {
+  return value.replace(/\\/g, '/').replace(/^\/+/, '')
+}
+
+function isRendererFile(value) {
+  return value.startsWith(RENDERER_PREFIX)
+}
+
+function isPostPackMutable(value) {
+  // macOS code signing rewrites native node-pty/get-windows payloads after
+  // electron-builder creates the ASAR metadata. Their paths must still match,
+  // but their post-sign sizes and hashes legitimately differ from the index.
+  return value.startsWith(POST_PACK_MUTABLE_PREFIX)
+}
+
+function collectDiskFiles(root, relative = '') {
+  const files = []
+  for (const entry of fs.readdirSync(path.join(root, relative), { withFileTypes: true })) {
+    const child = relative ? path.join(relative, entry.name) : entry.name
+    if (entry.isDirectory()) {
+      files.push(...collectDiskFiles(root, child))
+    } else if (entry.isFile()) {
+      files.push(normalizeAsarPath(path.posix.join('dist', child)))
+    }
+  }
+  return files.sort()
+}
+
+function sha256File(filePath) {
+  const hash = createHash('sha256')
+  hash.update(fs.readFileSync(filePath))
+  return hash.digest('hex')
+}
+
+function diskPathFor(unpackedDist, archivePath) {
+  return path.join(unpackedDist, ...archivePath.slice('dist/'.length).split('/'))
+}
+
+export function packagedResourcesDir(appOutDir, platform, productFilename = 'Hermes') {
+  return platform === 'darwin'
+    ? path.join(appOutDir, `${productFilename}.app`, 'Contents', 'Resources')
+    : path.join(appOutDir, 'resources')
+}
+
+export function verifyPackagedRenderer(resourcesDir) {
+  const asarPath = path.join(resourcesDir, 'app.asar')
+  const unpackedDist = path.join(resourcesDir, 'app.asar.unpacked', 'dist')
+  const errors = []
+
+  if (!fs.existsSync(asarPath)) {
+    return { ok: false, errors: [`missing ASAR archive: ${asarPath}`] }
+  }
+  if (!fs.existsSync(path.join(unpackedDist, 'index.html'))) {
+    return {
+      ok: false,
+      errors: [`missing unpacked renderer entry point: ${path.join(unpackedDist, 'index.html')}`]
+    }
+  }
+
+  let archiveEntries
+  try {
+    archiveEntries = listPackage(asarPath)
+  } catch (err) {
+    return { ok: false, errors: [`cannot read ASAR index: ${err.message}`] }
+  }
+
+  const indexedFiles = new Map()
+  for (const rawEntry of archiveEntries) {
+    const entry = normalizeAsarPath(rawEntry)
+    if (!isRendererFile(entry)) continue
+    try {
+      const metadata = statFile(asarPath, entry)
+      if (!('files' in metadata)) indexedFiles.set(entry, metadata)
+    } catch (err) {
+      errors.push(`cannot read ASAR metadata for ${entry}: ${err.message}`)
+    }
+  }
+
+  const diskFiles = new Set(collectDiskFiles(unpackedDist).filter(isRendererFile))
+
+  for (const entry of diskFiles) {
+    if (!indexedFiles.has(entry)) {
+      errors.push(`unpacked renderer file is absent from ASAR index: ${entry}`)
+    }
+  }
+  for (const [entry, metadata] of indexedFiles) {
+    const filePath = diskPathFor(unpackedDist, entry)
+    if (!diskFiles.has(entry)) {
+      errors.push(`ASAR index points to a missing unpacked renderer file: ${entry}`)
+      continue
+    }
+    if (metadata.unpacked !== true) {
+      errors.push(`renderer file is not marked unpacked in ASAR index: ${entry}`)
+      continue
+    }
+    if (isPostPackMutable(entry)) continue
+    const diskSize = fs.statSync(filePath).size
+    if (typeof metadata.size === 'number' && metadata.size !== diskSize) {
+      errors.push(`renderer size mismatch for ${entry}: ASAR=${metadata.size}, disk=${diskSize}`)
+      continue
+    }
+    const expectedHash = metadata.integrity?.hash?.toLowerCase()
+    if (!expectedHash) {
+      errors.push(`renderer file has no ASAR integrity hash: ${entry}`)
+    } else if (sha256File(filePath) !== expectedHash) {
+      errors.push(`renderer hash mismatch between ASAR index and disk: ${entry}`)
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    indexedFileCount: indexedFiles.size,
+    unpackedFileCount: diskFiles.size
+  }
+}
+
+export function formatPackagedRendererErrors(errors, limit = 8) {
+  const visible = errors.slice(0, limit)
+  const omitted = errors.length - visible.length
+  return [...visible, ...(omitted > 0 ? [`... and ${omitted} more renderer integrity error(s)`] : [])].join('\n')
+}
+
+export function assertPackagedRendererIntegrity(resourcesDir) {
+  const result = verifyPackagedRenderer(resourcesDir)
+  if (!result.ok) {
+    throw new Error(formatPackagedRendererErrors(result.errors))
+  }
+  return result
+}
+
+const invokedDirectly = process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url
+
+if (invokedDirectly) {
+  const resourcesDir = process.argv[2]
+  if (!resourcesDir) {
+    console.error('usage: node packaged-renderer-integrity.mjs <resources-dir>')
+    process.exitCode = 2
+  } else {
+    const result = verifyPackagedRenderer(path.resolve(resourcesDir))
+    if (!result.ok) {
+      console.error(formatPackagedRendererErrors(result.errors))
+      process.exitCode = 1
+    }
+  }
+}

--- a/apps/desktop/scripts/packaged-renderer-integrity.test.mjs
+++ b/apps/desktop/scripts/packaged-renderer-integrity.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { createPackageWithOptions } from '@electron/asar'
+import { test } from 'vitest'
+
+import afterPack from './after-pack.mjs'
+import {
+  assertPackagedRendererIntegrity,
+  packagedResourcesDir,
+  verifyPackagedRenderer
+} from './packaged-renderer-integrity.mjs'
+
+test('resolves Electron Builder resource directories on every platform', () => {
+  assert.equal(
+    packagedResourcesDir('/release/mac-arm64', 'darwin', 'Hermes'),
+    path.join('/release/mac-arm64', 'Hermes.app', 'Contents', 'Resources')
+  )
+  assert.equal(
+    packagedResourcesDir('/release/win-unpacked', 'win32', 'Hermes'),
+    path.join('/release/win-unpacked', 'resources')
+  )
+})
+
+async function makePackage(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-renderer-integrity-'))
+  const source = path.join(root, 'source')
+  const resources = path.join(root, 'app', 'resources')
+  fs.mkdirSync(source, { recursive: true })
+  fs.mkdirSync(resources, { recursive: true })
+  for (const [relative, content] of Object.entries(files)) {
+    const target = path.join(source, relative)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(target, content)
+  }
+  await createPackageWithOptions(source, path.join(resources, 'app.asar'), {
+    unpackDir: 'dist'
+  })
+  return { root, appOutDir: path.join(root, 'app'), resources }
+}
+
+test('accepts a packaged renderer whose ASAR index matches unpacked files', async () => {
+  const fixture = await makePackage({
+    'dist/index.html': '<script type="module" src="./assets/index-new.js"></script>',
+    'dist/assets/index-new.js': 'console.log("new")',
+    'dist/assets/feature-new.js': 'export const feature = true'
+  })
+  try {
+    const result = verifyPackagedRenderer(fixture.resources)
+
+    assert.equal(result.ok, true)
+    assert.equal(result.indexedFileCount, 3)
+    assert.equal(result.unpackedFileCount, 3)
+    await assert.doesNotReject(afterPack({ electronPlatformName: 'linux', appOutDir: fixture.appOutDir }))
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('rejects stale ASAR names paired with a newer unpacked renderer', async () => {
+  const fixture = await makePackage({
+    'dist/index.html': '<script type="module" src="./assets/index-old.js"></script>',
+    'dist/assets/index-old.js': 'console.log("old")'
+  })
+  try {
+    const assets = path.join(fixture.resources, 'app.asar.unpacked', 'dist', 'assets')
+    fs.rmSync(path.join(assets, 'index-old.js'))
+    fs.writeFileSync(path.join(assets, 'index-new.js'), 'console.log("new")')
+
+    const result = verifyPackagedRenderer(fixture.resources)
+
+    assert.equal(result.ok, false)
+    assert.ok(result.errors.some(error => error.includes('absent from ASAR index: dist/assets/index-new.js')))
+    assert.ok(result.errors.some(error => error.includes('missing unpacked renderer file: dist/assets/index-old.js')))
+    await assert.rejects(
+      afterPack({ electronPlatformName: 'linux', appOutDir: fixture.appOutDir }),
+      /packaged renderer integrity check failed/
+    )
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('rejects content drift even when the renderer filename is unchanged', async () => {
+  const fixture = await makePackage({
+    'dist/index.html': '<script type="module" src="./assets/index.js"></script>',
+    'dist/assets/index.js': 'original bytes'
+  })
+  try {
+    const asset = path.join(fixture.resources, 'app.asar.unpacked', 'dist', 'assets', 'index.js')
+    fs.writeFileSync(asset, 'different data')
+
+    assert.throws(
+      () => assertPackagedRendererIntegrity(fixture.resources),
+      /hash mismatch between ASAR index and disk: dist\/assets\/index.js/
+    )
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})
+
+test('allows native dependency bytes to change during post-pack signing', async () => {
+  const fixture = await makePackage({
+    'dist/index.html': '<main id="root"></main>',
+    'dist/node_modules/get-windows/main': 'unsigned native helper'
+  })
+  try {
+    fs.writeFileSync(
+      path.join(fixture.resources, 'app.asar.unpacked', 'dist', 'node_modules', 'get-windows', 'main'),
+      'signed native helper with a larger code signature'
+    )
+
+    assert.equal(verifyPackagedRenderer(fixture.resources).ok, true)
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -3,9 +3,9 @@ import os from 'node:os'
 import path from 'node:path'
 import { spawn, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
-import { listPackage } from '@electron/asar'
 
 import PACKAGE_JSON from '../package.json' with { type: 'json' }
+import { assertPackagedRendererIntegrity } from './packaged-renderer-integrity.mjs'
 
 const MODE = process.argv[2] || 'help'
 const ARCH = process.arch === 'arm64' ? 'arm64' : 'x64'
@@ -23,9 +23,7 @@ const APP = (() => {
     return {
       appPath,
       binary: path.join(appPath, 'Contents', 'MacOS', 'Hermes'),
-      resourcesPath: path.join(appPath, 'Contents', 'Resources'),
-      asarPath: path.join(appPath, 'Contents', 'Resources', 'app.asar'),
-      unpackedDistIndex: path.join(appPath, 'Contents', 'Resources', 'app.asar.unpacked', 'dist', 'index.html')
+      resourcesPath: path.join(appPath, 'Contents', 'Resources')
     }
   }
   if (PLATFORM === 'win32') {
@@ -33,9 +31,7 @@ const APP = (() => {
     return {
       appPath: unpacked,
       binary: path.join(unpacked, 'Hermes.exe'),
-      resourcesPath: path.join(unpacked, 'resources'),
-      asarPath: path.join(unpacked, 'resources', 'app.asar'),
-      unpackedDistIndex: path.join(unpacked, 'resources', 'app.asar.unpacked', 'dist', 'index.html')
+      resourcesPath: path.join(unpacked, 'resources')
     }
   }
   // linux unpacked layout matches windows but with different binary name
@@ -43,9 +39,7 @@ const APP = (() => {
   return {
     appPath: unpacked,
     binary: path.join(unpacked, 'Hermes'),
-    resourcesPath: path.join(unpacked, 'resources'),
-    asarPath: path.join(unpacked, 'resources', 'app.asar'),
-    unpackedDistIndex: path.join(unpacked, 'resources', 'app.asar.unpacked', 'dist', 'index.html')
+    resourcesPath: path.join(unpacked, 'resources')
   }
 })()
 
@@ -288,8 +282,7 @@ function launchFresh() {
 //   - node-pty IS shipped inside app.asar.unpacked/dist/node_modules/node-pty
 //     with package.json + lib/ + at least one .node binary (the renderer's
 //     integrated terminal needs this; see Phase 1F.6).
-//   - The renderer's dist/index.html is reachable (either unpacked or
-//     inside app.asar).
+//   - The ASAR renderer index exactly matches the unpacked dist payload.
 function validateBundle() {
   if (!exists(APP.binary)) {
     die(`Missing packaged app binary: ${APP.binary}`)
@@ -358,20 +351,10 @@ function validateBundle() {
     }
   }
 
-  // Renderer payload check (either unpacked or in the asar)
-  if (exists(APP.unpackedDistIndex)) {
-    return { stamp, nodeBinaries }
-  }
-  if (!exists(APP.asarPath)) {
-    die(`Missing renderer payload: neither ${APP.unpackedDistIndex} nor ${APP.asarPath} exists`)
-  }
-  const files = listPackage(APP.asarPath)
-  // Normalize separators because @electron/asar's listPackage returns
-  // backslash-prefixed entries on Windows ('\\dist\\index.html') and
-  // forward-slash on Unix.
-  const normalized = files.map(f => f.replace(/\\/g, '/').replace(/^\/+/, ''))
-  if (!normalized.includes('dist/index.html')) {
-    die(`Missing renderer payload file in app.asar: ${APP.asarPath} (expected dist/index.html)`)
+  try {
+    assertPackagedRendererIntegrity(APP.resourcesPath)
+  } catch (err) {
+    die(`Packaged renderer integrity check failed: ${err.message}`)
   }
   return { stamp, nodeBinaries }
 }

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5936,11 +5936,13 @@ def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode:
     ``hermes update`` that pulled new source but hasn't built yet).
     """
     # If there's no build output at all, we definitely need to build
+    packaged_executable = None
     if source_mode:
         if not _desktop_dist_exists(desktop_dir):
             return True
     else:
-        if _desktop_packaged_executable(desktop_dir) is None:
+        packaged_executable = _desktop_packaged_executable(desktop_dir)
+        if packaged_executable is None:
             return True
 
     stamp_file = _desktop_stamp_path()
@@ -5961,7 +5963,22 @@ def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode:
         return True
 
     current_hash = _compute_desktop_content_hash(project_root)
-    return current_hash != saved_hash
+    if current_hash != saved_hash:
+        return True
+
+    if packaged_executable is not None:
+        integrity_error = _desktop_packaged_renderer_integrity_error(
+            project_root, packaged_executable
+        )
+        if integrity_error is not None:
+            logger.warning(
+                "Desktop content stamp matched, but the packaged renderer is "
+                "inconsistent; forcing rebuild: %s",
+                integrity_error,
+            )
+            return True
+
+    return False
 
 
 def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None:
@@ -6016,6 +6033,56 @@ def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
         if matching:
             existing = matching
     return max(existing, key=lambda p: p.stat().st_mtime)
+
+
+def _desktop_packaged_resources_dir(packaged_executable: Path) -> Path:
+    """Return the Electron resources directory beside ``packaged_executable``."""
+    if (
+        packaged_executable.parent.name == "MacOS"
+        and packaged_executable.parent.parent.name == "Contents"
+    ):
+        return packaged_executable.parent.parent / "Resources"
+    return packaged_executable.parent / "resources"
+
+
+def _desktop_packaged_renderer_integrity_error(
+    project_root: Path, packaged_executable: Path
+) -> Optional[str]:
+    """Return renderer package skew detected by the Node ASAR verifier."""
+    from hermes_constants import find_node_executable, with_hermes_node_path
+
+    verifier = (
+        project_root
+        / "apps"
+        / "desktop"
+        / "scripts"
+        / "packaged-renderer-integrity.mjs"
+    )
+    if not verifier.is_file():
+        return f"renderer verifier is missing: {verifier}"
+
+    node = find_node_executable("node")
+    if not node:
+        return "Node.js is unavailable, so the packaged renderer cannot be verified"
+
+    resources_dir = _desktop_packaged_resources_dir(packaged_executable)
+    try:
+        result = subprocess.run(
+            [node, str(verifier), str(resources_dir)],
+            cwd=project_root,
+            env=with_hermes_node_path(),
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"renderer verifier could not run: {exc}"
+    if result.returncode == 0:
+        return None
+
+    detail = (result.stderr or result.stdout or "unknown verifier failure").strip()
+    return detail[:2000]
 
 
 # ─── Desktop exe integrity gate (#69179) ────────────────────────────────────
@@ -6292,6 +6359,8 @@ def _rollback_desktop_from_backup(packaged_executable: Path) -> Optional[Path]:
         return None
     if _desktop_exe_integrity_error(backup_exe) is not None:
         return None
+    if _desktop_packaged_renderer_integrity_error(PROJECT_ROOT, backup_exe) is not None:
+        return None
     corrupt_dir = unpacked.parent / (unpacked.name + ".corrupt")
     try:
         shutil.rmtree(corrupt_dir, ignore_errors=True)
@@ -6325,17 +6394,24 @@ def _ensure_desktop_exe_launchable(
     if packaged_executable is None or sys.platform != "win32":
         return packaged_executable, False
 
-    error = _desktop_exe_integrity_error(packaged_executable)
+    exe_error = _desktop_exe_integrity_error(packaged_executable)
+    renderer_error = None
+    if exe_error is None:
+        renderer_error = _desktop_packaged_renderer_integrity_error(
+            PROJECT_ROOT, packaged_executable
+        )
+    error = exe_error or renderer_error
     if error is None:
         return packaged_executable, False
 
-    print(f"✗ The built Hermes.exe failed its integrity check: {error}")
+    print(f"✗ The built desktop package failed its integrity check: {error}")
     print(f"    at: {packaged_executable}")
 
     # Self-heal setup for the retry: drop the (likely corrupt) cached Electron
     # zip and the content stamp so the next rebuild is a genuine re-download +
     # re-stage rather than a replay of the same broken extraction.
-    _purge_electron_build_cache(desktop_dir)
+    if exe_error is not None:
+        _purge_electron_build_cache(desktop_dir)
     try:
         _desktop_stamp_path().unlink()
     except OSError:
@@ -7117,6 +7193,16 @@ def cmd_gui(args: argparse.Namespace):
             print("  Or drop --skip-build to package automatically.")
             sys.exit(1)
         else:
+            integrity_error = _desktop_packaged_renderer_integrity_error(
+                PROJECT_ROOT, packaged_executable
+            )
+            if integrity_error is not None:
+                print(
+                    "✗ --skip-build cannot use the packaged desktop app because "
+                    f"its renderer is inconsistent: {integrity_error}"
+                )
+                print("  Drop --skip-build to rebuild the package automatically.")
+                sys.exit(1)
             print(f"→ Skipping desktop package build (--skip-build); using {packaged_executable}")
     else:
         # Check the content-hash stamp before doing any build work.
@@ -7214,6 +7300,16 @@ def cmd_gui(args: argparse.Namespace):
                 _stop_desktop_processes_locking_build(desktop_dir)
                 build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
             if build_result.returncode != 0:
+                if not source_mode and sys.platform == "win32":
+                    failed_executable = _desktop_packaged_executable(desktop_dir)
+                    if failed_executable is not None:
+                        restored = _rollback_desktop_from_backup(failed_executable)
+                        if restored is not None:
+                            packaged_executable = restored
+                            print(
+                                "  ↩ Desktop build failed — restored the previous "
+                                "verified package from backup."
+                            )
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")
                 if sys.platform == "win32":

--- a/tests/hermes_cli/test_desktop_exe_integrity.py
+++ b/tests/hermes_cli/test_desktop_exe_integrity.py
@@ -204,7 +204,8 @@ def test_rollback_restores_backup_and_keeps_corrupt_copy(tmp_path):
     backup_exe = desktop_dir / "release" / "win-unpacked.bak" / "Hermes.exe"
     make_pe(backup_exe, PE_AMD64)  # valid old build
 
-    with patch("hermes_cli.main._windows_native_machine", return_value="AMD64"):
+    with patch("hermes_cli.main._windows_native_machine", return_value="AMD64"), \
+         patch("hermes_cli.main._desktop_packaged_renderer_integrity_error", return_value=None):
         restored = cli_main._rollback_desktop_from_backup(exe)
 
     assert restored == exe
@@ -233,6 +234,7 @@ def test_gate_fails_clearly_without_backup(tmp_path, monkeypatch, capsys):
     fake.write_bytes(b"<html>proxy error</html>" + b" " * 600)
 
     with patch("hermes_cli.main._purge_electron_build_cache", return_value=[]), \
+         patch("hermes_cli.main._desktop_packaged_renderer_integrity_error", return_value=None), \
          patch("hermes_cli.main._desktop_stamp_path", return_value=tmp_path / "stamp.json"):
         verified, rolled_back = cli_main._ensure_desktop_exe_launchable(desktop_dir, exe)
 
@@ -285,6 +287,7 @@ def test_build_only_fails_when_pack_produces_corrupt_exe(tmp_path, monkeypatch, 
          patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \
          patch("hermes_cli.main._purge_electron_build_cache", return_value=[]), \
          patch("hermes_cli.main._desktop_stamp_path", return_value=tmp_path / "stamp.json"), \
+         patch("hermes_cli.main._desktop_packaged_renderer_integrity_error", return_value=None), \
          patch("hermes_cli.main._write_desktop_build_stamp") as mock_stamp, \
          patch("hermes_cli.main._windows_native_machine", return_value="AMD64"), \
          patch("hermes_cli.main.subprocess.run", return_value=pack_ok), \
@@ -298,5 +301,4 @@ def test_build_only_fails_when_pack_produces_corrupt_exe(tmp_path, monkeypatch, 
     mock_stamp.assert_not_called()
     out = capsys.readouterr().out
     assert "integrity check" in out
-
 

--- a/tests/hermes_cli/test_desktop_renderer_integrity.py
+++ b/tests/hermes_cli/test_desktop_renderer_integrity.py
@@ -1,0 +1,219 @@
+"""Regression coverage for packaged renderer ASAR/disk skew (#81028)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+
+def _packaged_linux_tree(tmp_path: Path) -> tuple[Path, Path]:
+    desktop_dir = tmp_path / "apps" / "desktop"
+    executable = desktop_dir / "release" / "linux-unpacked" / "hermes"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"executable")
+    return desktop_dir, executable
+
+
+def _matching_stamp(tmp_path: Path) -> Path:
+    stamp = tmp_path / "desktop-build-stamp.json"
+    stamp.write_text(
+        json.dumps({"contentHash": "same", "sourceMode": False}),
+        encoding="utf-8",
+    )
+    return stamp
+
+
+def test_matching_content_stamp_cannot_hide_renderer_skew(tmp_path, monkeypatch):
+    desktop_dir, executable = _packaged_linux_tree(tmp_path)
+    stamp = _matching_stamp(tmp_path)
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+
+    with (
+        patch("hermes_cli.main._desktop_stamp_path", return_value=stamp),
+        patch("hermes_cli.main._compute_desktop_content_hash", return_value="same"),
+        patch(
+            "hermes_cli.main._desktop_packaged_renderer_integrity_error",
+            return_value="unpacked renderer file is absent from ASAR index",
+        ) as verify,
+    ):
+        assert cli_main._desktop_build_needed(desktop_dir, tmp_path, source_mode=False)
+
+    verify.assert_called_once_with(tmp_path, executable)
+
+
+def test_matching_content_stamp_skips_coherent_package(tmp_path, monkeypatch):
+    desktop_dir, executable = _packaged_linux_tree(tmp_path)
+    stamp = _matching_stamp(tmp_path)
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+
+    with (
+        patch("hermes_cli.main._desktop_stamp_path", return_value=stamp),
+        patch("hermes_cli.main._compute_desktop_content_hash", return_value="same"),
+        patch(
+            "hermes_cli.main._desktop_packaged_renderer_integrity_error",
+            return_value=None,
+        ) as verify,
+    ):
+        assert not cli_main._desktop_build_needed(
+            desktop_dir, tmp_path, source_mode=False
+        )
+
+    verify.assert_called_once_with(tmp_path, executable)
+
+
+def test_rollback_refuses_backup_with_stale_renderer(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+    unpacked = tmp_path / "release" / "win-unpacked"
+    current_exe = unpacked / "Hermes.exe"
+    backup_exe = tmp_path / "release" / "win-unpacked.bak" / "Hermes.exe"
+    current_exe.parent.mkdir(parents=True)
+    backup_exe.parent.mkdir(parents=True)
+    current_exe.write_bytes(b"new")
+    backup_exe.write_bytes(b"old")
+
+    with (
+        patch("hermes_cli.main._desktop_exe_integrity_error", return_value=None),
+        patch(
+            "hermes_cli.main._desktop_packaged_renderer_integrity_error",
+            return_value="stale ASAR index",
+        ),
+    ):
+        assert cli_main._rollback_desktop_from_backup(current_exe) is None
+
+    assert current_exe.read_bytes() == b"new"
+    assert backup_exe.read_bytes() == b"old"
+
+
+def test_windows_gate_restores_only_verified_renderer_backup(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+    unpacked = tmp_path / "release" / "win-unpacked"
+    current_exe = unpacked / "Hermes.exe"
+    backup_exe = tmp_path / "release" / "win-unpacked.bak" / "Hermes.exe"
+    current_exe.parent.mkdir(parents=True)
+    backup_exe.parent.mkdir(parents=True)
+    current_exe.write_bytes(b"new")
+    backup_exe.write_bytes(b"old")
+
+    def renderer_error(_root, executable):
+        return "stale ASAR index" if executable == current_exe else None
+
+    with (
+        patch("hermes_cli.main.PROJECT_ROOT", tmp_path),
+        patch("hermes_cli.main._desktop_exe_integrity_error", return_value=None),
+        patch(
+            "hermes_cli.main._desktop_packaged_renderer_integrity_error",
+            side_effect=renderer_error,
+        ),
+        patch("hermes_cli.main._desktop_stamp_path", return_value=tmp_path / "stamp"),
+    ):
+        verified, rolled_back = cli_main._ensure_desktop_exe_launchable(
+            tmp_path, current_exe
+        )
+
+    assert verified == current_exe
+    assert rolled_back is True
+    assert current_exe.read_bytes() == b"old"
+    assert "stale ASAR index" in capsys.readouterr().out
+
+
+def test_failed_windows_pack_restores_verified_renderer_backup(
+    tmp_path, monkeypatch, capsys
+):
+    root = tmp_path / "hermes-agent"
+    desktop_dir = root / "apps" / "desktop"
+    (desktop_dir / "package.json").parent.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+    current_exe = desktop_dir / "release" / "win-unpacked" / "Hermes.exe"
+    backup_exe = desktop_dir / "release" / "win-unpacked.bak" / "Hermes.exe"
+    current_exe.parent.mkdir(parents=True)
+    backup_exe.parent.mkdir(parents=True)
+    current_exe.write_bytes(b"new-skewed-package")
+    backup_exe.write_bytes(b"previous-good-package")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+
+    args = argparse.Namespace(
+        skip_build=False,
+        build_only=True,
+        force_build=False,
+        source=False,
+        fake_boot=False,
+        ignore_existing=False,
+        hermes_root=None,
+        cwd=None,
+    )
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    pack_failed = subprocess.CompletedProcess(["npm", "run", "pack"], 1)
+
+    with (
+        patch("hermes_cli.main._resolve_node_runtime_npm", return_value="npm"),
+        patch(
+            "hermes_cli.main._run_npm_install_deterministic",
+            return_value=install_ok,
+        ),
+        patch("hermes_cli.main._desktop_build_needed", return_value=True),
+        patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]),
+        patch("hermes_cli.main._desktop_exe_integrity_error", return_value=None),
+        patch(
+            "hermes_cli.main._desktop_packaged_renderer_integrity_error",
+            side_effect=lambda _root, exe: (
+                "stale ASAR index" if exe == current_exe else None
+            ),
+        ),
+        patch("hermes_cli.main.subprocess.run", return_value=pack_failed),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli_main.cmd_gui(args)
+
+    assert exc.value.code == 1
+    assert current_exe.read_bytes() == b"previous-good-package"
+    output = capsys.readouterr().out
+    assert "restored the previous verified package" in output
+    assert "Desktop GUI build failed" in output
+
+
+def test_skip_build_refuses_inconsistent_renderer_package(
+    tmp_path, monkeypatch, capsys
+):
+    root = tmp_path / "hermes-agent"
+    desktop_dir = root / "apps" / "desktop"
+    (desktop_dir / "package.json").parent.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+    executable = desktop_dir / "release" / "linux-unpacked" / "hermes"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"executable")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+
+    args = argparse.Namespace(
+        skip_build=True,
+        build_only=False,
+        force_build=False,
+        source=False,
+        fake_boot=False,
+        ignore_existing=False,
+        hermes_root=None,
+        cwd=None,
+    )
+    with (
+        patch(
+            "hermes_cli.main._desktop_packaged_renderer_integrity_error",
+            return_value="ASAR index points to a missing renderer asset",
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli_main.cmd_gui(args)
+
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert "--skip-build cannot use" in output
+    assert "Drop --skip-build to rebuild" in output


### PR DESCRIPTION
## Summary

- add a packaged-renderer verifier that compares every `dist/**` path in `app.asar` with `app.asar.unpacked/dist`, requires each entry to be marked unpacked, and checks size plus SHA-256 for non-native files
- run the verifier from Electron Builder's `afterPack` hook and the existing packaged-app test harness, so a split artifact fails before it can be stamped or shipped
- make the CLI reject a matching content stamp when the installed package is inconsistent, refuse an inconsistent `--skip-build` launch, and only restore a Windows rollback backup after both executable and renderer verification

## Root Cause

The desktop content stamp describes the source tree, not the relationship between the packaged ASAR index and its separately unpacked `dist` files. A partially refreshed package can therefore keep a matching stamp while the ASAR names old hashed chunks and the unpacked tree contains new ones. The existing bundle validation returned as soon as unpacked `index.html` existed, so this split package looked healthy and launched into a white renderer.

The new verifier treats the ASAR index and unpacked tree as one artifact. It compares path membership for all unpacked `dist/**` files and byte integrity for renderer/main/preload/data files. Native dependencies retain path/unpacked checks but skip byte checks because macOS code signing legitimately rewrites those binaries after ASAR metadata is created.

## Recovery Behavior

- normal launch/update: inconsistent package invalidates the matching stamp and forces a rebuild
- explicit `--skip-build`: fails clearly instead of opening a known-broken package
- Windows build failure: restores the prior `.bak` tree only when its PE and renderer package both verify
- production packaging: `afterPack` aborts before success when ASAR/unpacked parity is broken

## Related Work

This is distinct from #53776 (source/build commit warning), #71523 (empty/minimal package payload), #46661 (renderer path preference), #76809 (ignore updater artifacts), and #59942 (install rebuilt app placement). None validate one-to-one ASAR index membership and content against the unpacked renderer tree.

## Verification

- `npm --prefix apps/desktop run test:desktop:platforms` - 988 passed, 2 skipped
- focused CLI/update suites - 63 passed
- `npm --prefix apps/desktop run build` - passed
- `npm --prefix apps/desktop run lint` - 0 errors (repository baseline warnings only)
- Ruff and `git diff --check` - passed
- real signed macOS arm64 `npm run pack` - passed; verifier matched all 381 indexed/unpacked `dist` files
- copied real package with one unpacked asset removed - verifier failed with the exact missing ASAR-index target

Windows recovery and path behavior are covered with synthetic Windows package trees; no live Windows host was available locally.

Fixes #81028
