### PR TITLE
fix(dashboard): point WhatsApp setup guide at Baileys docs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7753,7 +7753,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     "whatsapp": {
         "name": "WhatsApp",
         "description": "Use Hermes through the bundled WhatsApp bridge with QR-based auth.",
-        "docs_url": "https://github.com/tulir/whatsmeow",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/whatsapp",
         "env_vars": (
             "WHATSAPP_ENABLED",
             "WHATSAPP_MODE",


### PR DESCRIPTION
## Summary
- Fix stale WhatsApp Channels UI `docs_url` that opened tulir/whatsmeow
- Point **Open setup guide** at the Hermes Baileys WhatsApp docs

## Why
The bundled bridge is Baileys (`scripts/whatsapp-bridge`, `@whiskeysockets/baileys`). Desktop Messaging was sending users to the wrong library.

## Test plan
- [ ] Open Hermes Desktop → Messaging → WhatsApp → Open setup guide
- [ ] Confirm it opens https://hermes-agent.nousresearch.com/docs/user-guide/messaging/whatsapp
- [ ] Confirm `scripts/whatsapp-bridge/package.json` still depends on `@whiskeysockets/baileys`

Fixes #82387