### PR TITLE
fix(desktop): gate agent external links away from file:

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8787,6 +8787,17 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
 
   installContextMenu(win)
   win.webContents.setWindowOpenHandler(details => {
+    // window.open from the renderer (markdown/terminal) must not use the
+    // artifact file: openPath path — that stays on hermes:openExternal IPC.
+    let parsed: URL
+    try {
+      parsed = new URL(details.url)
+    } catch {
+      return { action: 'deny' }
+    }
+    if (!['http:', 'https:', 'mailto:'].includes(parsed.protocol)) {
+      return { action: 'deny' }
+    }
     openExternalUrl(details.url)
 
     return { action: 'deny' }

--- a/apps/desktop/src/app/right-sidebar/terminal/links.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/links.test.ts
@@ -53,6 +53,15 @@ describe('terminal links', () => {
     expect(openExternal).not.toHaveBeenCalled()
   })
 
+
+  it('does not open non-http(s) URLs through the desktop bridge', () => {
+    terminalLinkHandler.activate(new MouseEvent('click', { metaKey: true }), 'file:///tmp/secret', {
+      end: { x: 10, y: 1 },
+      start: { x: 1, y: 1 }
+    })
+
+    expect(openExternal).not.toHaveBeenCalled()
+  })
   it('routes OSC 8 hyperlinks the same way, instead of xterm\u2019s confirm() dialog', () => {
     terminalLinkHandler.activate(new MouseEvent('click', { metaKey: true }), 'https://example.com/osc8', {
       end: { x: 10, y: 1 },

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -270,18 +270,10 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
 
   const target = href ? normalizeExternalUrl(href) : href
 
+  // Non-http(s) must not become target=_blank — Electron routes that through
+  // openExternalUrl, which intentionally allows file: for the artifacts panel.
   if (!target || !/^https?:\/\//i.test(target)) {
-    return (
-      <a
-        className={cn('ref wrap-anywhere', className)}
-        href={href}
-        rel="noopener noreferrer"
-        target="_blank"
-        {...props}
-      >
-        {children}
-      </a>
-    )
+    return <span className={cn('ref wrap-anywhere', className)}>{children}</span>
   }
 
   const text = childrenToText(children)

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -6,8 +6,10 @@ import {
   ExternalLink,
   fetchLinkTitle,
   hostPathLabel,
+  isSafeExternalUrl,
   isTitleFetchable,
   LinkifiedText,
+  openExternalLink,
   PrettyLink,
   urlSlugTitleLabel
 } from './external-link'
@@ -102,6 +104,22 @@ describe('external link helpers', () => {
     expect(bridge).toHaveBeenCalledTimes(1)
   })
 
+
+  it('rejects non-http(s) URLs before calling the desktop bridge', () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    installDesktopBridge({ openExternal: openExternal as unknown as Window['hermesDesktop']['openExternal'] })
+
+    expect(isSafeExternalUrl('https://example.com')).toBe(true)
+    expect(isSafeExternalUrl('file:///tmp/secret')).toBe(false)
+    expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false)
+
+    openExternalLink('file:///tmp/secret')
+    openExternalLink('javascript:alert(1)')
+    expect(openExternal).not.toHaveBeenCalled()
+
+    openExternalLink('https://example.com/ok')
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/ok')
+  })
   it('opens links via the desktop bridge', () => {
     const openExternal = vi.fn().mockResolvedValue(undefined)
     installDesktopBridge({ openExternal: openExternal as unknown as Window['hermesDesktop']['openExternal'] })

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -195,10 +195,22 @@ export function useLinkTitle(url?: null | string): string {
   return title
 }
 
-export function openExternalLink(href: string): void {
-  if (href) {
-    void window.hermesDesktop?.openExternal?.(href)
+/** http(s) only — agent/terminal/markdown must not reach file: openPath. */
+export function isSafeExternalUrl(value: string): boolean {
+  try {
+    const parsed = new URL(normalizeExternalUrl(value))
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && Boolean(parsed.hostname.trim())
+  } catch {
+    return false
   }
+}
+
+export function openExternalLink(href: string): void {
+  if (!href || !isSafeExternalUrl(href)) {
+    return
+  }
+
+  void window.hermesDesktop?.openExternal?.(normalizeExternalUrl(href))
 }
 
 interface ExternalLinkProps extends Omit<ComponentProps<'a'>, 'href' | 'target'> {


### PR DESCRIPTION
## Why

Desktop `openExternalUrl` intentionally allows `file:` for the artifacts panel (`shell.openPath`). Agent-influenced paths still reached that sink:

1. Terminal OSC8 / web-links → `openExternalLink` → IPC with no scheme gate
2. Markdown non-http(s) fallback rendered `<a target="_blank">`, which Electron routes through `setWindowOpenHandler` → `openExternalUrl`

TUI already rejects non-http(s) in `parseSafeUrl`. Open OAuth PRs (#82350/#82365/#82382) only cover MCP `authorization_url`.

## Fix

- `isSafeExternalUrl` + fail-closed `openExternalLink` (http/https only)
- Markdown non-http(s) renders a `<span>` (no `target=_blank`)
- `setWindowOpenHandler` allows only `http:`/`https:`/`mailto:` (artifact `file:` stays on dedicated IPC)

## Test plan

- [x] `npx vitest run --project ui src/lib/external-link.test.tsx src/app/right-sidebar/terminal/links.test.ts` (26/26)
- [ ] https terminal / markdown links still open externally
- [ ] `file:` / `javascript:` from agent text do not open
- [ ] Artifacts panel local open still works via IPC


Made with [Cursor](https://cursor.com)