### PR TITLE
fix(desktop): route target="_blank" out of the Preview webview (#81660)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -390,6 +390,7 @@ import {
 } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
+import { installWebviewWindowOpenPolicy } from './webview-window-open'
 import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
 import { registrySshScopeForWindowRoute, WindowConnectionRouteRegistry } from './window-connection-route'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
@@ -12738,6 +12739,12 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     event.preventDefault()
     openExternalUrl(url)
   })
+  // The handler above only covers the window's OWN webContents. A `<webview>`
+  // guest (the Preview pane) is a separate webContents with its own window-open
+  // gate, so `target="_blank"` inside a preview never reached any of this and
+  // died silently (#81660). Guests get their own policy, installed at attach
+  // time — see webview-window-open.ts for why the renderer can't do this.
+  installWebviewWindowOpenPolicy(win.webContents, { log: rememberLog, openExternal: openExternalUrl })
 }
 
 // Every window we open starts with `show: false` so the renderer's first themed

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -213,6 +213,7 @@ import {
 import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
+import { installWebviewWindowOpenPolicy } from './webview-window-open'
 import { readWindowBelow } from './window-below'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -8799,6 +8800,12 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     event.preventDefault()
     openExternalUrl(url)
   })
+  // The handler above only covers the window's OWN webContents. A `<webview>`
+  // guest (the Preview pane) is a separate webContents with its own window-open
+  // gate, so `target="_blank"` inside a preview never reached any of this and
+  // died silently (#81660). Guests get their own policy, installed at attach
+  // time — see webview-window-open.ts for why the renderer can't do this.
+  installWebviewWindowOpenPolicy(win.webContents, { log: rememberLog, openExternal: openExternalUrl })
 }
 
 // Every window we open starts with `show: false` so the renderer's first themed

--- a/apps/desktop/electron/webview-window-open.test.ts
+++ b/apps/desktop/electron/webview-window-open.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for the `<webview>` window-open policy.
+ *
+ * The behaviour these lock down was verified against the pinned Electron
+ * (40.10.2) with a live `<webview>`: without `allowpopups` the guest's
+ * `setWindowOpenHandler` is never called, and with it the handler receives the
+ * `target="_blank"` URL and an in-handler `loadURL` navigates the guest while
+ * `deny` keeps any real window from being created.
+ */
+
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { describe, test } from 'vitest'
+
+import { decideWebviewWindowOpen, installWebviewWindowOpenPolicy } from './webview-window-open'
+
+type Handler = (details: { url: string }) => { action: 'deny' }
+
+function makeGuest({ loadRejects = false }: { loadRejects?: boolean } = {}) {
+  const loaded: string[] = []
+  let destroyed = false
+  let handler: Handler | null = null
+
+  return {
+    loaded,
+    destroy() {
+      destroyed = true
+    },
+    /** Fire the installed handler the way Electron would. */
+    requestWindow(url: string) {
+      assert.ok(handler, 'no window-open handler installed on the guest')
+
+      return handler({ url })
+    },
+    isDestroyed: () => destroyed,
+    loadURL(url: string) {
+      loaded.push(url)
+
+      return loadRejects ? Promise.reject(new Error('ERR_ABORTED')) : Promise.resolve()
+    },
+    setWindowOpenHandler(next: Handler) {
+      handler = next
+    }
+  }
+}
+
+function makeEmbedder() {
+  const emitter = new EventEmitter()
+
+  return {
+    attach(guest: unknown) {
+      emitter.emit('did-attach-webview', {}, guest)
+    },
+    listenerCount: () => emitter.listenerCount('did-attach-webview'),
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter)
+  }
+}
+
+function install(embedder: ReturnType<typeof makeEmbedder>) {
+  const external: string[] = []
+  const logs: string[] = []
+
+  const uninstall = installWebviewWindowOpenPolicy(embedder as never, {
+    log: message => logs.push(message),
+    openExternal: url => external.push(url)
+  })
+
+  return { external, logs, uninstall }
+}
+
+describe('decideWebviewWindowOpen', () => {
+  test('web URLs navigate the requesting guest in place', () => {
+    assert.deepEqual(decideWebviewWindowOpen('https://uzum.uz/ru/product/1'), {
+      action: 'navigate',
+      url: 'https://uzum.uz/ru/product/1'
+    })
+    assert.equal(decideWebviewWindowOpen('http://localhost:5173/page').action, 'navigate')
+  })
+
+  test('mailto goes to the OS handler', () => {
+    assert.deepEqual(decideWebviewWindowOpen('mailto:a@b.co'), { action: 'external', url: 'mailto:a@b.co' })
+  })
+
+  test('file URLs are dropped, never forwarded to the OS', () => {
+    // openExternalUrl() would hand a file: URL to shell.openPath; a previewed
+    // remote page must not be able to reach the local filesystem that way.
+    assert.deepEqual(decideWebviewWindowOpen('file:///etc/passwd'), { action: 'block' })
+  })
+
+  test('non-web schemes, about:blank and junk are dropped', () => {
+    for (const url of ['about:blank', 'javascript:alert(1)', 'data:text/html,<b>x', 'chrome://settings', 'not a url', '', null, undefined]) {
+      assert.equal(decideWebviewWindowOpen(url).action, 'block', `expected ${String(url)} to be blocked`)
+    }
+  })
+})
+
+describe('installWebviewWindowOpenPolicy', () => {
+  test('a target=_blank click navigates the guest and denies the popup', () => {
+    const embedder = makeEmbedder()
+
+    install(embedder)
+
+    const guest = makeGuest()
+
+    embedder.attach(guest)
+
+    assert.deepEqual(guest.requestWindow('https://example.com/target-page'), { action: 'deny' })
+    assert.deepEqual(guest.loaded, ['https://example.com/target-page'])
+  })
+
+  test('mailto is handed to openExternal and never loaded in the pane', () => {
+    const embedder = makeEmbedder()
+    const { external } = install(embedder)
+    const guest = makeGuest()
+
+    embedder.attach(guest)
+    guest.requestWindow('mailto:sales@example.com')
+
+    assert.deepEqual(external, ['mailto:sales@example.com'])
+    assert.deepEqual(guest.loaded, [])
+  })
+
+  test('blocked schemes touch neither the pane nor the OS', () => {
+    const embedder = makeEmbedder()
+    const { external } = install(embedder)
+    const guest = makeGuest()
+
+    embedder.attach(guest)
+
+    assert.deepEqual(guest.requestWindow('file:///C:/Windows/System32/calc.exe'), { action: 'deny' })
+    assert.deepEqual(guest.loaded, [])
+    assert.deepEqual(external, [])
+  })
+
+  test('a destroyed guest is not navigated', () => {
+    const embedder = makeEmbedder()
+
+    install(embedder)
+
+    const guest = makeGuest()
+
+    embedder.attach(guest)
+    guest.destroy()
+
+    assert.deepEqual(guest.requestWindow('https://example.com/'), { action: 'deny' })
+    assert.deepEqual(guest.loaded, [])
+  })
+
+  test('a rejected navigation is logged, not thrown', async () => {
+    const embedder = makeEmbedder()
+    const { logs } = install(embedder)
+    const guest = makeGuest({ loadRejects: true })
+
+    embedder.attach(guest)
+    guest.requestWindow('https://example.com/')
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    assert.equal(logs.length, 1)
+    assert.match(logs[0], /ERR_ABORTED/)
+  })
+
+  test('every attached guest gets the policy, and uninstall stops that', () => {
+    const embedder = makeEmbedder()
+    const { uninstall } = install(embedder)
+
+    const first = makeGuest()
+    const second = makeGuest()
+
+    embedder.attach(first)
+    embedder.attach(second)
+    first.requestWindow('https://example.com/one')
+    second.requestWindow('https://example.com/two')
+
+    assert.deepEqual(first.loaded, ['https://example.com/one'])
+    assert.deepEqual(second.loaded, ['https://example.com/two'])
+
+    uninstall()
+
+    assert.equal(embedder.listenerCount(), 0)
+  })
+
+  test('a missing embedder is a no-op', () => {
+    assert.doesNotThrow(() => installWebviewWindowOpenPolicy(null, { openExternal: () => {} })())
+  })
+})

--- a/apps/desktop/electron/webview-window-open.ts
+++ b/apps/desktop/electron/webview-window-open.ts
@@ -1,0 +1,142 @@
+/**
+ * Window-open policy for the `<webview>` guests the Preview pane embeds.
+ *
+ * A previewed page can ask for a new window two ways: `window.open()` and an
+ * `<a target="_blank">` click. Both land in Chromium's "create new window"
+ * path, and for a `<webview>` that path is gated twice:
+ *
+ *  1. `CanCreateWindow` returns false outright when the guest's `disablePopups`
+ *     preference is set — which is exactly what Electron derives from a MISSING
+ *     `allowpopups` attribute on the `<webview>` element. The request dies
+ *     there, before any JS handler is consulted.
+ *  2. Only if popups are allowed does the guest's `setWindowOpenHandler` run
+ *     and get to decide.
+ *
+ * That is why the Preview pane silently ate `target="_blank"` clicks (#81660):
+ * gate 1 rejected them, so there was nothing left for the app to route. The
+ * renderer can't fix it on its own either — the `<webview>` `new-window` DOM
+ * event was removed in Electron 22, and the desktop ships Electron 40.
+ *
+ * So the pane now sets `allowpopups` to get the request past gate 1, and this
+ * module supplies gate 2: a handler installed from the main process (via the
+ * embedder's `did-attach-webview`) that ALWAYS denies the popup itself and
+ * instead routes the URL — http/https navigate the Preview pane in place,
+ * `mailto:` goes to the OS handler, everything else is dropped.
+ *
+ * Denying every popup is what keeps `allowpopups` from widening the attack
+ * surface: no guest can conjure an OS window, and the schemes that reach the
+ * host are limited to the two a link in a web page may legitimately use. In
+ * particular `file:` is NOT forwarded — `openExternalUrl` would hand it to
+ * `shell.openPath`, and a previewed page must never be able to open local
+ * files through the OS.
+ *
+ * Navigating in place (rather than opening the OS browser) is the behaviour the
+ * issue asks for: the Preview pane is the surface the user is looking at, and
+ * its URL header already follows the guest via `did-navigate`.
+ */
+
+/** What to do with a new-window request coming out of a `<webview>` guest. */
+export type WebviewWindowOpenDecision =
+  /** Load the URL in the requesting guest itself (in-pane navigation). */
+  | { action: 'navigate'; url: string }
+  /** Hand the URL to the OS (`shell.openExternal`). */
+  | { action: 'external'; url: string }
+  /** Drop the request. */
+  | { action: 'block' }
+
+/**
+ * Classify a new-window request by its URL. Pure — the routing table lives
+ * here so the policy can be unit-tested without booting Electron.
+ *
+ * `about:blank` (a bare `window.open()`) and any unparseable or non-web scheme
+ * are blocked: there is no page for the pane to show and nothing safe to hand
+ * the OS.
+ */
+export function decideWebviewWindowOpen(rawUrl: string | null | undefined): WebviewWindowOpenDecision {
+  const raw = String(rawUrl ?? '').trim()
+
+  if (!raw) {
+    return { action: 'block' }
+  }
+
+  let parsed: URL
+
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return { action: 'block' }
+  }
+
+  if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+    return { action: 'navigate', url: parsed.toString() }
+  }
+
+  if (parsed.protocol === 'mailto:') {
+    return { action: 'external', url: parsed.toString() }
+  }
+
+  return { action: 'block' }
+}
+
+/** The slice of `Electron.WebContents` this module drives on a guest. */
+interface WebviewGuest {
+  isDestroyed: () => boolean
+  loadURL: (url: string) => Promise<void>
+  setWindowOpenHandler: (handler: (details: { url: string }) => { action: 'deny' }) => void
+}
+
+/** The slice of `Electron.WebContents` this module listens on for an embedder. */
+interface WebviewEmbedder {
+  on: (event: 'did-attach-webview', listener: (event: unknown, guest: WebviewGuest) => void) => unknown
+  off: (event: 'did-attach-webview', listener: (event: unknown, guest: WebviewGuest) => void) => unknown
+}
+
+interface WebviewWindowOpenPolicyOptions {
+  /** Opens a URL with the OS handler. Same contract as main.ts's `openExternalUrl`. */
+  openExternal: (url: string) => unknown
+  /** Diagnostic sink for a rejected in-pane navigation. */
+  log?: (message: string) => void
+}
+
+/**
+ * Install {@link decideWebviewWindowOpen} on every `<webview>` that attaches to
+ * `embedder`, and return an uninstall function.
+ *
+ * `did-attach-webview` is the supported main-process replacement for the
+ * removed renderer-side `new-window` event, and it fires at attach time — before
+ * the guest has loaded anything — so no click can outrun the handler.
+ *
+ * The handler always returns `deny`; the routing happens as a side effect.
+ */
+export function installWebviewWindowOpenPolicy(
+  embedder: WebviewEmbedder | null | undefined,
+  { openExternal, log = () => {} }: WebviewWindowOpenPolicyOptions
+): () => void {
+  if (!embedder) {
+    return () => {}
+  }
+
+  const onAttach = (_event: unknown, guest: WebviewGuest) => {
+    guest.setWindowOpenHandler(details => {
+      const decision = decideWebviewWindowOpen(details?.url)
+
+      if (decision.action === 'navigate') {
+        if (!guest.isDestroyed()) {
+          void Promise.resolve(guest.loadURL(decision.url)).catch(error =>
+            log(`[preview] webview navigation failed: ${error instanceof Error ? error.message : String(error)}`)
+          )
+        }
+      } else if (decision.action === 'external') {
+        openExternal(decision.url)
+      }
+
+      return { action: 'deny' }
+    })
+  }
+
+  embedder.on('did-attach-webview', onAttach)
+
+  return () => {
+    embedder.off('did-attach-webview', onAttach)
+  }
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -332,6 +332,32 @@ describe('PreviewPane console state', () => {
     expect(rendered.queryByRole('textbox', { name: 'Address' })).not.toBeNull()
   })
 
+  // `allowpopups` is load-bearing, not a loosening: Chromium kills a guest's
+  // new-window request before ANY handler runs when the attribute is absent, so
+  // without it `<a target="_blank">` inside a preview silently does nothing
+  // (#81660). The popup itself is still denied — main.ts installs a window-open
+  // handler on every attached guest (electron/webview-window-open.ts) that
+  // navigates this pane in place instead of opening a window.
+  it('marks the preview webview as popup-capable so target=_blank is routable', async () => {
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'https://example.com',
+            url: 'https://example.com'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview')
+
+    expect(webview?.hasAttribute('allowpopups')).toBe(true)
+  })
+
   it('renders authenticated remote HTML safely and honors source mode', async () => {
     const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -110,6 +110,32 @@ describe('PreviewPane console state', () => {
     forgetPreviewStripTools(tabId)
   })
 
+  // `allowpopups` is load-bearing, not a loosening: Chromium kills a guest's
+  // new-window request before ANY handler runs when the attribute is absent, so
+  // without it `<a target="_blank">` inside a preview silently does nothing
+  // (#81660). The popup itself is still denied — main.ts installs a window-open
+  // handler on every attached guest (electron/webview-window-open.ts) that
+  // navigates this pane in place instead of opening a window.
+  it('marks the preview webview as popup-capable so target=_blank is routable', async () => {
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'https://example.com',
+            url: 'https://example.com'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview')
+
+    expect(webview?.hasAttribute('allowpopups')).toBe(true)
+  })
+
   it('renders authenticated remote HTML safely and honors source mode', async () => {
     const dataUrl = `data:text/html;base64,${btoa('<h1>remote</h1>')}`
 

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -765,6 +765,12 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     webview.setAttribute('partition', 'persist:hermes-preview')
     webview.setAttribute('src', target.url)
     webview.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes')
+    // Without `allowpopups`, Chromium rejects every new-window request from the
+    // guest before any handler runs, so an `<a target="_blank">` click inside a
+    // preview did nothing at all (#81660). This does NOT let previews spawn OS
+    // windows: main.ts installs a window-open handler on every attached guest
+    // that always denies the popup and instead navigates this pane in place.
+    webview.setAttribute('allowpopups', '')
 
     const onConsole = (event: Event) => {
       const detail = event as Event & {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -555,6 +555,12 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     webview.setAttribute('partition', 'persist:hermes-preview')
     webview.setAttribute('src', target.url)
     webview.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes')
+    // Without `allowpopups`, Chromium rejects every new-window request from the
+    // guest before any handler runs, so an `<a target="_blank">` click inside a
+    // preview did nothing at all (#81660). This does NOT let previews spawn OS
+    // windows: main.ts installs a window-open handler on every attached guest
+    // that always denies the popup and instead navigates this pane in place.
+    webview.setAttribute('allowpopups', '')
 
     const onConsole = (event: Event) => {
       const detail = event as Event & {


### PR DESCRIPTION
Fixes #81660.

Clicking an `<a target="_blank">` inside the Preview pane does nothing — no navigation, no popup, no console error. The link in the report is a plain storefront product card:

```html
<a href="/ru/product/…" class="product-card product-card--clickable" target="_blank" rel="noopener noreferrer">
```

## Why nothing happened

A `<webview>` guest's new-window request is gated twice, and it never survived gate 1:

1. `CanCreateWindow` returns false immediately when the guest's `disablePopups` preference is set — which is exactly what Electron derives from a **missing `allowpopups` attribute** on the `<webview>` element (`electron_browser_client.cc`: *"`<webview>` without allowpopups attribute should return null from window.open calls"*).
2. Only if popups are allowed does the guest's `setWindowOpenHandler` run and get to decide.

`preview-pane.tsx` created the guest without `allowpopups`, so every `target="_blank"` click and `window.open()` died at gate 1 — before any application code could route it. And as the issue notes, the renderer can't patch around it: the `<webview>` `new-window` DOM event was removed in Electron 22 and Desktop ships Electron 40.

## Verified on the pinned Electron (40.10.2)

Real `<webview>`, real `target="_blank"` click, main-process handler installed via `did-attach-webview`. Only the `allowpopups` attribute differs between the two runs:

```
$ electron . # today's shape — no allowpopups
[wvtest] did-attach-webview fired
[wvtest] guest did-navigate file:///…/guest.html
[wvtest] done                            <- click swallowed, handler never called

$ electron . --allowpopups # this PR's shape
[wvtest] did-attach-webview fired
[wvtest] guest did-navigate file:///…/guest.html
[wvtest] GUEST-HANDLER url=https://example.com/target-page
[wvtest] guest did-navigate https://example.com/target-page
[wvtest] done
```

No `browser-window-created` in either run: the handler returns `deny`, so nothing ever becomes an OS window.

## The fix

- **`preview-pane.tsx`** sets `allowpopups` so the request reaches gate 2.
- **`electron/webview-window-open.ts`** (new) supplies gate 2: a policy installed from the main process on every guest that attaches to a window, wired into `wireCommonWindowHandlers` so the primary and every secondary session window get it identically. `did-attach-webview` fires at attach time, before the guest loads anything, so no click can outrun it.

The handler **always denies the popup** and routes the URL as a side effect:

| Scheme | Action |
|---|---|
| `http:` / `https:` | Navigate the requesting pane in place |
| `mailto:` | `openExternalUrl` (OS handler) |
| everything else (`file:`, `about:blank`, `data:`, `javascript:`, junk) | Dropped |

Navigating in place is the behaviour the issue prefers, and it's free: the pane's URL header already tracks the guest via `did-navigate`.

`allowpopups` doesn't widen the attack surface, because the popup itself is never granted — and `file:` is deliberately **not** forwarded: `openExternalUrl()` hands `file:` URLs to `shell.openPath`, and a previewed remote page must not be able to open local files through the OS.

## Tests

- `electron/webview-window-open.test.ts` (new, 11 cases): the routing table, deny-on-every-decision, destroyed-guest and rejected-`loadURL` safety, per-guest installation, uninstall.
- `preview-pane.test.tsx`: asserts the pane still marks the webview popup-capable — `allowpopups` is load-bearing here, and a well-meaning "security cleanup" that strips it silently reintroduces this bug.

```
$ npx vitest run electron/webview-window-open.test.ts src/app/chat/right-rail/preview-pane.test.tsx
Test Files  2 passed (2)
     Tests  21 passed (21)
$ npm run typecheck && npx eslint <changed files>   # clean
```

Ran `vitest run electron/ src/app/chat/` before and after: the same 9 files fail on unmodified `main` on this machine (pre-existing Windows/env failures — `desktop-installation`, `ssh-*`, `git-worktree-ops`, `preview-reader`, …); this branch adds 12 passing tests and changes nothing else.

**Platforms:** developed and tested on Windows 11 (the reporter's platform). The change is platform-independent — one DOM attribute and a main-process `webContents` listener, no path or process handling.

<sub>Investigated and drafted with Hermes/Claude assistance; the Electron behaviour above was verified by hand against the pinned runtime.</sub>
