### PR TITLE
fix(backup): preserve non-SQLite db assets

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -403,6 +403,26 @@ def is_zeroed_sqlite_file(
 
 _SQLITE_HEADER = b"SQLite format 3\0"
 
+
+def _should_snapshot_as_sqlite(path: Path) -> bool:
+    """Whether a ``.db`` file needs a WAL-safe SQLite snapshot.
+
+    ``.db`` is also used by unrelated applications for opaque data files.
+    Treating every such file as SQLite makes one incidental asset abort an
+    otherwise valid full backup.  A readable file is classified by SQLite's
+    magic header; when the lock-safe probe cannot read it, keep the previous
+    fail-closed behaviour and attempt a SQLite snapshot.
+    """
+    if path.suffix.lower() != ".db":
+        return False
+
+    from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
+
+    head = read_header_bytes_preopen(path, length=len(_SQLITE_HEADER))
+    if head is None:
+        return True
+    return head == _SQLITE_HEADER
+
 # Default ceiling above which ``PRAGMA integrity_check`` is skipped in favour
 # of the (O(1)) header + structural probe. ``integrity_check`` walks every
 # b-tree page in the file, so its cost scales with database size: on a 30 GB
@@ -699,7 +719,7 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
         for i, (abs_path, rel_path) in enumerate(files_to_add, 1):
             try:
                 # Safe copy for SQLite databases (handles WAL mode)
-                if abs_path.suffix == ".db":
+                if _should_snapshot_as_sqlite(abs_path):
                     # Stage the snapshot alongside the output zip so that the
                     # temp file lives on the same filesystem.  The system
                     # default (/tmp) may be a small tmpfs that cannot hold
@@ -1688,7 +1708,7 @@ def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional
         ) as zf:
             for index, (abs_path, rel_path) in enumerate(files_to_add, 1):
                 try:
-                    if abs_path.suffix == ".db":
+                    if _should_snapshot_as_sqlite(abs_path):
                         # Stage the snapshot alongside the output zip so that the
                         # temp file lives on the same filesystem.  The system
                         # default (/tmp) may be a small tmpfs that cannot hold

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -140,6 +140,64 @@ class TestShouldExclude:
 
 class TestBackup:
 
+    def test_non_sqlite_db_asset_is_archived_as_regular_file(self, tmp_path, monkeypatch):
+        """An unrelated ``.db`` asset must not be opened as SQLite."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        asset = hermes_home / "workspaces" / "vendor" / "128B.db"
+        asset.parent.mkdir(parents=True)
+        payload = b"opaque chart data, not sqlite\n"
+        asset.write_bytes(payload)
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        import hermes_cli.backup as backup_mod
+
+        sqlite_sources = []
+        real_safe_copy = backup_mod._safe_copy_db
+
+        def _spy(src, dst):
+            sqlite_sources.append(src)
+            return real_safe_copy(src, dst)
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db", _spy)
+        out_zip = tmp_path / "backup.zip"
+        backup_mod.run_backup(Namespace(output=str(out_zip)))
+
+        assert asset not in sqlite_sources
+        with zipfile.ZipFile(out_zip) as archive:
+            assert archive.read("workspaces/vendor/128B.db") == payload
+
+    def test_automatic_backup_archives_non_sqlite_db_asset(self, tmp_path, monkeypatch):
+        """The pre-update full backup follows the same content-based rule."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        asset = hermes_home / "workspaces" / "vendor" / "128B.db"
+        asset.parent.mkdir(parents=True)
+        payload = b"opaque chart data, not sqlite\n"
+        asset.write_bytes(payload)
+
+        import hermes_cli.backup as backup_mod
+
+        sqlite_sources = []
+        real_safe_copy = backup_mod._safe_copy_db
+
+        def _spy(src, dst):
+            sqlite_sources.append(src)
+            return real_safe_copy(src, dst)
+
+        monkeypatch.setattr(backup_mod, "_safe_copy_db", _spy)
+        out_zip = tmp_path / "automatic.zip"
+        result = backup_mod._write_full_zip_backup(out_zip, hermes_home)
+
+        assert result == out_zip
+        assert asset not in sqlite_sources
+        with zipfile.ZipFile(out_zip) as archive:
+            assert archive.read("workspaces/vendor/128B.db") == payload
+
 
     def test_db_snapshots_staged_beside_output_zip(self, tmp_path, monkeypatch):
         """SQLite staging temp files must be created on the output zip's
@@ -1242,7 +1300,6 @@ class TestMemoryProviderExternalPaths:
         assert (restored.stat().st_mode & 0o777) == 0o600
         # External state did NOT leak into HERMES_HOME.
         assert not (hermes_home / "_external").exists()
-
 
 
 

--- a/tests/hermes_cli/test_backup_stability.py
+++ b/tests/hermes_cli/test_backup_stability.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -94,7 +95,8 @@ def test_quick_snapshot_listing_ignores_partial_directories(tmp_path) -> None:
 def test_failed_automatic_backup_preserves_previous_archive(tmp_path, monkeypatch) -> None:
     home = tmp_path / ".hermes"
     home.mkdir()
-    (home / "state.db").write_bytes(b"not-a-database")
+    with sqlite3.connect(home / "state.db") as conn:
+        conn.execute("CREATE TABLE sample (value TEXT)")
     archive = tmp_path / "automatic.zip"
     archive.write_bytes(b"previous-valid-backup")
 


### PR DESCRIPTION
## Summary

- classify `.db` backup candidates by the SQLite magic header instead of the extension alone
- archive readable non-SQLite `.db` assets as regular files in both manual and automatic full backups
- preserve the existing fail-closed SQLite snapshot behavior when a candidate cannot be probed safely

## Reproduction

A real pre-update backup aborted on a third-party pChart asset at:

`kanban/boards/wdd/workspaces/<task>/manage.go/lib/pChart/examples/data/128B.db`

The file uses the `.db` suffix but is not SQLite. Both full-backup paths previously passed every `.db` file to `sqlite3.backup()`. The automatic path then aborted the whole archive with `SQLITE_NOTADB`.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_backup.py tests/hermes_cli/test_backup_stability.py`
- 48 tests passed
- new behavior tests cover both manual and automatic full backups with a real SQLite database and an opaque `.db` asset
