### PR TITLE
fix(sessions): settle empty FTS migrations

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -287,6 +287,9 @@ class SessionSearchMixin:
         if high_water_raw is None:
             return False
         high_water = int(high_water_raw)
+        if high_water <= 0:
+            self._fts_rebuild_finish()
+            return False
         include_trigram = self._trigram_available
         chunk = self._FTS_REBUILD_CHUNK_ROWS
 
@@ -367,6 +370,9 @@ class SessionSearchMixin:
         if high_water_raw is None:
             return False
         high_water = int(high_water_raw)
+        if high_water <= 0:
+            self._fts_cjk_rebuild_finish()
+            return False
         chunk = self._FTS_REBUILD_CHUNK_ROWS
 
         def _do(conn):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2686,6 +2686,46 @@ class TestFTSExternalContentMigration:
         finally:
             db.close()
 
+    def test_optimize_empty_legacy_db_clears_zero_row_rebuild(self, tmp_path):
+        """A zero-row legacy migration must settle instead of staying pending."""
+        db_path = tmp_path / "v22-empty.db"
+        self._build_v22_db(db_path)
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute("DELETE FROM messages")
+            conn.execute("DELETE FROM sessions")
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db.fts_optimize_available() is True
+
+            result = db.optimize_fts_storage(vacuum=False)
+
+            assert result["ok"] is True
+            assert db.get_meta("fts_rebuild_high_water") is None
+            assert db.get_meta("fts_rebuild_progress") is None
+            assert db.get_meta("fts_storage_version") == str(
+                hermes_state.FTS_STORAGE_VERSION
+            )
+            assert db.fts_optimize_available() is False
+        finally:
+            db.close()
+
+    def test_zero_row_cjk_rebuild_claim_is_cleared(self, tmp_path):
+        """The sibling CJK worker must also finish an empty rebuild claim."""
+        db = SessionDB(db_path=tmp_path / "empty-cjk.db")
+        try:
+            if not db._fts_cjk_loaded:
+                pytest.skip("CJK tokenizer is unavailable")
+            db.set_meta("fts_cjk_rebuild_high_water", "0")
+            db.set_meta("fts_cjk_rebuild_progress", "0")
+
+            assert db.fts_cjk_rebuild_step() is False
+
+            assert db.get_meta("fts_cjk_rebuild_high_water") is None
+            assert db.get_meta("fts_cjk_rebuild_progress") is None
+        finally:
+            db.close()
+
 
 
 


### PR DESCRIPTION
## Summary

- finish base FTS rebuild markers immediately when a legacy database has zero messages
- apply the same zero-row completion rule to the sibling CJK rebuild worker
- allow `sessions optimize-storage` to settle and stamp an empty legacy database successfully

## Reproduction

On Hermes v0.20.0, an inactive profile with 0 sessions and 0 messages reports:

```text
Rebuilding index: 100% (0/0)
Reclaiming old index…
Could not optimize: backfill_incomplete
```

The command also exits 0. The zero high-water marker made the worker return without clearing its completed markers, so the final settle guard correctly refused to stamp the migration.

## Verification

- `scripts/run_tests.sh tests/test_hermes_state.py`
- 219 tests passed
- behavior coverage includes an empty v22-shaped database and the sibling zero-row CJK claim
