### PR TITLE
fix(desktop): keep the HUD exit chip clickable when the composer has no focus

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2811,14 +2811,18 @@ button[data-slot='aui_msg-reactions'] svg {
   background: transparent !important;
   border: 0;
   color: var(--ui-text-primary) !important;
-  /* Focus only. A turn landing brings the transcript up but doesn't mean you
-     are reaching for the window controls, and at rest this is a lone chip
-     hovering over whatever you're actually working in. */
-  opacity: 0;
+  /* Always clickable, dim at rest. Gating the CLICKS on composer `:focus` made
+     the only visible way out of HUD mode depend on the thing most likely to be
+     broken when someone wants out: if focus never lands (#81893) you can't type
+     AND the chip silently swallows clicks, leaving a transparent always-on-top
+     rectangle over the desktop with no in-app way to dismiss it.
+
+     Dim rather than invisible keeps the original intent — this shouldn't be a
+     loud chip floating over whatever you're actually working in — without
+     making the escape hatch conditional on the failure it exists for. */
+  opacity: 0.45;
   transition: opacity var(--hud-fade) var(--hud-ease-exit);
-  /* Clicks on exactly the same terms as the paint — a faded-out control that
-     still takes them is an invisible button floating over the app behind. */
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 /* Flipped, "above the composer" is the reserved strip at the top of the
@@ -2828,9 +2832,12 @@ button[data-slot='aui_msg-reactions'] svg {
   top: 0;
 }
 
-[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-exit] {
-  opacity: 0.75;
-  pointer-events: auto;
+/* Hover and focus-visible brighten it too, so pointing at the chip confirms it
+   is a control before you commit the click. */
+[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-exit],
+[data-hud-shell] [data-hud-exit]:hover,
+[data-hud-shell] [data-hud-exit]:focus-visible {
+  opacity: 0.9;
   transition-duration: var(--hud-reveal);
   transition-delay: 0s;
 }


### PR DESCRIPTION
## Summary

The HUD's exit chip is now always clickable instead of only while the composer holds focus.

Salvage of #82317 by @Ne0teric (authorship preserved). That PR's other half — re-centering the composer dock — is dropped: #82233 already fixed the dock offset, and #82317's `translate: none` is the exact literal Lightning CSS folds into `transform`, which is the bug #82233 fixed.

## The problem

`[data-hud-exit]` was `pointer-events: none` until `[data-slot='composer-rich-input']` had `:focus`. That makes the only visible way out of HUD mode conditional on the thing most likely to be broken when someone wants out.

When focus never lands — #81893 on macOS — you can't type *and* clicks on the exit chip are silently ignored. What's left is a transparent always-on-top rectangle over the desktop with no in-app way to dismiss it.

## The fix

Always clickable, dim (`0.45`) at rest, brightening to `0.9` on hover, `:focus-visible`, or composer focus, and to `1` on hover while focused. The original intent holds — this shouldn't be a loud chip floating over whatever you're actually working in — without gating the escape hatch on the failure it exists for.

Adding `:hover` and `:focus-visible` as reveal triggers also makes the chip reachable by keyboard, which the focus-only gate never allowed.

## Validation

| Check | Result |
|---|---|
| Lightning CSS 1.32.0, minified | all three rules survive verbatim — `pointer-events:auto`, the opacity ladder, and the `:has()` selector |
| Diff | `apps/desktop/src/styles.css` only, HUD-scoped selectors |

Does not attempt the focus race in #81893 itself; this is the other half of that trap, seen from the exit side.
