### PR TITLE
fix(gateway): preserve queued follow-ups across restart

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6108,6 +6108,16 @@ class BasePlatformAdapter(ABC):
             max_ms = 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
+    def _preserve_pending_for_gateway_restart(self) -> bool:
+        """Leave drain-time follow-ups queued for replacement recovery."""
+        runner = getattr(self, "gateway_runner", None)
+        queue_during_drain = getattr(runner, "_queue_during_drain_enabled", None)
+        return bool(
+            getattr(runner, "_draining", False)
+            and callable(queue_during_drain)
+            and queue_during_drain()
+        )
+
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         # Track delivery outcomes for the processing-complete hook
@@ -6646,8 +6656,13 @@ class BasePlatformAdapter(ABC):
             # this task hand off the follow-up.
             await self._flush_text_debounce_now(session_key)
 
-            # Check if there's a pending message that was queued during our processing
-            if session_key in self._pending_messages:
+            # Check if there's a pending message that was queued during our processing.
+            # During a queued restart drain, teardown owns this event and persists it
+            # for the replacement gateway instead of this process starting another turn.
+            if (
+                not self._preserve_pending_for_gateway_restart()
+                and session_key in self._pending_messages
+            ):
                 pending_event = self._pending_messages.pop(session_key)
                 logger.debug("[%s] Processing queued follow-up message", self.name)
                 # Keep the _active_sessions entry live across the turn chain
@@ -6771,7 +6786,9 @@ class BasePlatformAdapter(ABC):
             # busy-handler path.  Without this block, we would delete the
             # active-session entry and the queued message would be silently
             # dropped (user never gets a reply).
-            late_pending = self._pending_messages.pop(session_key, None)
+            late_pending = None
+            if not self._preserve_pending_for_gateway_restart():
+                late_pending = self._pending_messages.pop(session_key, None)
             if late_pending is not None:
                 current_task = asyncio.current_task()
                 existing_task = self._session_tasks.get(session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26199,7 +26199,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Use session_key (not source.chat_id) to match adapter's storage keys.
             pending_event = None
             pending = None
-            if result and adapter and session_key:
+            preserve_pending_for_restart = (
+                self._draining and self._queue_during_drain_enabled()
+            )
+            if result and adapter and session_key and not preserve_pending_for_restart:
                 pending_event = _dequeue_pending_event(adapter, session_key)
                 # /queue overflow: after consuming the adapter's "next-up"
                 # slot, promote the next queued event into it so the

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,6 +1,9 @@
 import asyncio
 import shutil
 import subprocess
+import sys
+import threading
+import types
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -54,6 +57,143 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
     assert "Draining" in expected and "1" in expected
     running_agent.interrupt.assert_not_called()
     runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_drain_preserves_queued_followup_for_shutdown(
+    tmp_path, monkeypatch
+):
+    """A drain-time follow-up must reach replacement recovery intact (#82381)."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", "1")
+    monkeypatch.setattr(
+        "gateway.restart.is_container_restart_context", lambda: False
+    )
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    turn_started = threading.Event()
+    release_turn = threading.Event()
+    agent_calls: list[str] = []
+
+    class BlockingAgent:
+        def __init__(self, **_kwargs):
+            self.tools = []
+
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            agent_calls.append(message)
+            turn_started.set()
+            assert release_turn.wait(timeout=5), "blocked test turn was not released"
+            return {
+                "final_response": "first turn complete",
+                "messages": conversation_history or [],
+                "api_calls": 1,
+            }
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = BlockingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    runner, adapter = make_restart_runner()
+    adapter.gateway_runner = runner
+    runner._busy_input_mode = "queue"
+    runner._restart_after_turn_timeout = 5.0
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._session_run_generation = {}
+    runner.hooks.loaded_hooks = False
+
+    flush_calls: list[tuple[dict, str]] = []
+
+    def capture_shutdown_pending(pending, *, reason="shutdown"):
+        flush_calls.append((dict(pending), reason))
+        return len(pending)
+
+    monkeypatch.setattr(
+        "gateway.shutdown_flush.flush_pending_to_file", capture_shutdown_pending
+    )
+
+    stop_calls = []
+
+    async def replacement_stop(**kwargs):
+        stop_calls.append(kwargs)
+        await adapter.cancel_background_tasks()
+        runner._shutdown_event.set()
+
+    runner.stop = AsyncMock(side_effect=replacement_stop)
+
+    source = make_restart_source()
+    session_key = build_session_key(source)
+    first_event = MessageEvent(
+        text="first turn",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="first",
+    )
+
+    async def dispatch(event):
+        if event is first_event:
+            result = await runner._run_agent(
+                message=event.text,
+                context_prompt="",
+                history=[],
+                source=event.source,
+                session_id="session-82381",
+                session_key=session_key,
+            )
+            return result["final_response"]
+        return await runner._handle_message(event)
+
+    adapter.set_message_handler(dispatch)
+
+    await adapter.handle_message(first_event)
+    assert await asyncio.to_thread(turn_started.wait, 5)
+    for _ in range(100):
+        if session_key in runner._running_agents:
+            break
+        await asyncio.sleep(0.01)
+    assert session_key in runner._running_agents
+
+    restart_event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="restart",
+    )
+    await adapter.handle_message(restart_event)
+    assert runner._draining is True
+    assert any("Draining 1 active agent" in message for message in adapter.sent)
+
+    followup = MessageEvent(
+        text="follow up",
+        message_type=MessageType.PHOTO,
+        source=source,
+        message_id="followup",
+        media_urls=["/tmp/followup.png"],
+        metadata={"opaque": "preserve-me"},
+    )
+    await adapter.handle_message(followup)
+
+    assert adapter._pending_messages[session_key] is followup
+    assert any("queued for the next turn after it comes back" in message for message in adapter.sent)
+
+    release_turn.set()
+    await asyncio.wait_for(runner._restart_task, timeout=5)
+
+    assert agent_calls == ["first turn"]
+    assert flush_calls == [({session_key: followup}, "adapter_shutdown")]
+    assert stop_calls == [
+        {
+            "restart": True,
+            "detached_restart": False,
+            "service_restart": True,
+        }
+    ]
 
 
 def test_load_busy_text_mode_follows_input_mode_and_honors_legacy(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Keeps follow-up `MessageEvent`s in the adapter queue once a queued gateway restart begins. The existing adapter shutdown flush can then persist the full event for replacement-gateway recovery instead of the finishing turn dequeuing and discarding it.

The guard applies both where `GatewayRunner._run_agent()` checks for pending input and where `BasePlatformAdapter` hands off queued follow-ups, while leaving normal queue/steer and FIFO processing unchanged outside restart drain.

## Related Issue

Fixes #82381

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: do not dequeue adapter input during a queued restart drain.
- `gateway/platforms/base.py`: leave drain-time follow-ups for adapter shutdown persistence rather than chaining another turn.
- `tests/gateway/test_restart_drain.py`: add an integration regression covering `/restart`, an in-flight turn, a media follow-up, shutdown flush, and replacement restart.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_restart_drain.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_pending_drain_race.py tests/gateway/test_pending_drain_no_recursion.py -q`.
2. Confirm all 50 tests pass, including `test_restart_drain_preserves_queued_followup_for_shutdown`.
3. Run `.venv/bin/ruff check gateway/run.py gateway/platforms/base.py tests/gateway/test_restart_drain.py` and `git diff --check origin/main...HEAD`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed PRs to make sure this is not a duplicate.
- [x] This PR contains only changes related to this fix.
- [ ] I've run the entire `pytest tests/ -q` suite locally; focused canonical suites pass and CI will run the full matrix.
- [x] I've added regression coverage for the bug.
- [x] I've tested on macOS 26.5.2 with Python 3.11.15.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing contract or configuration changed.
- [x] `cli-config.yaml.example`: N/A; no configuration keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered; the change is platform-independent asyncio/adapter logic.
- [x] Tool descriptions/schemas: N/A; no tool contract changed.

## Screenshots / Logs

Not applicable. Focused validation: 50 tests passed; Ruff, Python compilation, and `git diff --check` passed.