### PR TITLE
fix(gateway): block background work while draining

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6303,8 +6303,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # capture / STT pipeline, which otherwise produces a second delayed reply.
         self._recent_voice_transcripts: Dict[tuple[int, int], List[tuple[float, str]]] = {}
 
-        # Track background tasks to prevent garbage collection mid-execution
+        # Track background tasks to prevent garbage collection mid-execution.
+        # /background agent tasks are also tracked separately so drain accounting
+        # can exclude long-lived gateway watcher tasks.
         self._background_tasks: set = set()
+        self._background_agent_tasks: set[asyncio.Task] = set()
 
         # Event-loop liveness heartbeat (#66892): rewritten every 30s while
         # the loop is dispatching. External supervisors use the file mtime /
@@ -7523,9 +7526,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """All agent work the gateway must expose and drain as one total."""
         return (
             self._running_agent_count()
+            + self._active_background_agent_task_count()
             + self._active_cron_job_count()
             + self._active_api_run_count()
         )
+
+    def _active_background_agent_task_count(self) -> int:
+        """Count live agents started by the gateway /background command."""
+        tasks = getattr(self, "_background_agent_tasks", ()) or ()
+        return sum(not task.done() for task in tasks)
 
     def _active_cron_job_count(self) -> int:
         """Count of cron jobs currently executing, from the cron scheduler's
@@ -9344,36 +9353,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
         last_active_count = self._running_agent_count()
+        last_background_count = self._active_background_agent_task_count()
         last_cron_count = self._active_cron_job_count()
         last_api_count = self._active_api_run_count()
         last_status_at = 0.0
 
         def _maybe_update_status(force: bool = False) -> None:
-            nonlocal last_active_count, last_cron_count, last_api_count, last_status_at
+            nonlocal last_active_count, last_background_count, last_cron_count, last_api_count, last_status_at
             now = asyncio.get_running_loop().time()
             active_count = self._running_agent_count()
+            background_count = self._active_background_agent_task_count()
             cron_count = self._active_cron_job_count()
             api_count = self._active_api_run_count()
             if (
                 force
                 or active_count != last_active_count
+                or background_count != last_background_count
                 or cron_count != last_cron_count
                 or api_count != last_api_count
                 or (now - last_status_at) >= 1.0
             ):
                 self._update_runtime_status("draining")
                 last_active_count = active_count
+                last_background_count = background_count
                 last_cron_count = cron_count
                 last_api_count = api_count
                 last_status_at = now
 
-        # Cron jobs run on the scheduler's own thread pool, outside
-        # ``self._running_agents`` — fold their in-flight count into the
-        # same wait/timeout this method already applies to chat sessions,
-        # or a cron job's tool work gets killed with zero warning the
-        # instant it's the only active thing running (#60432).
+        # Cron jobs and /background agents run outside ``self._running_agents``;
+        # fold their in-flight counts into the same wait/timeout this method
+        # already applies to chat sessions, or their tool work can be killed as
+        # soon as it is the only active work (#60432).
         # API-server / desk sessions have the same structural gap (#63529).
-        if not self._running_agents and last_cron_count == 0 and last_api_count == 0:
+        if self._active_work_count() == 0:
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -9383,20 +9395,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         deadline = asyncio.get_running_loop().time() + timeout
         while (
-            (
-                len(self._running_agents)
-                or self._active_cron_job_count()
-                or self._active_api_run_count()
-            )
+            self._active_work_count()
             and asyncio.get_running_loop().time() < deadline
         ):
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = (
-            bool(len(self._running_agents))
-            or bool(self._active_cron_job_count())
-            or bool(self._active_api_run_count())
-        )
+        timed_out = bool(self._active_work_count())
         _maybe_update_status(force=True)
         return snapshot, timed_out
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3318,6 +3318,15 @@ class GatewaySlashCommandsMixin:
         When it completes, sends the result back to the same chat without
         modifying the active session's conversation history.
         """
+        if self._draining:
+            return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+        if self._external_drain_active:
+            return (
+                "⏳ This agent is draining for a maintenance action and isn't "
+                "accepting new turns right now. It'll be back in a moment — "
+                "please resend shortly."
+            )
+
         prompt = event.get_command_args().strip()
         if not prompt:
             return t("gateway.background.usage")
@@ -3344,6 +3353,11 @@ class GatewaySlashCommandsMixin:
         )
         self._background_tasks.add(_task)
         _task.add_done_callback(self._background_tasks.discard)
+        background_agent_tasks = getattr(self, "_background_agent_tasks", None)
+        if background_agent_tasks is None:
+            background_agent_tasks = self._background_agent_tasks = set()
+        background_agent_tasks.add(_task)
+        _task.add_done_callback(background_agent_tasks.discard)
 
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
         return t("gateway.background.started", preview=preview, task_id=task_id)

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -67,6 +67,7 @@ def make_restart_runner(
     runner._pending_approvals = {}
     runner._pending_model_notes = {}
     runner._background_tasks = set()
+    runner._background_agent_tasks = set()
     runner._draining = False
     runner._restart_requested = False
     runner._signal_initiated_shutdown = False

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -12,6 +12,7 @@ import pytest
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource
+from tests.gateway.restart_test_helpers import make_restart_runner
 
 
 def _make_event(text="/background", platform=Platform.TELEGRAM,
@@ -38,6 +39,7 @@ def _make_runner():
     runner._fallback_model = None
     runner._running_agents = {}
     runner._background_tasks = set()
+    runner._background_agent_tasks = set()
 
     mock_store = MagicMock()
     runner.session_store = mock_store
@@ -80,6 +82,42 @@ class TestHandleBackgroundCommand:
         event = _make_event(text="/background   ")
         result = await runner._handle_background_command(event)
         assert "Usage:" in result
+
+    @pytest.mark.asyncio
+    async def test_shutdown_drain_rejects_before_creating_task(self):
+        runner, _adapter = make_restart_runner()
+        runner._draining = True
+        runner._run_background_task = AsyncMock()
+
+        result = await runner._handle_message(
+            _make_event(text="/background summarize the incident")
+        )
+
+        assert result == (
+            "⏳ Gateway is shutting down and is not accepting new work right now."
+        )
+        runner._run_background_task.assert_not_called()
+        assert runner._background_tasks == set()
+        assert runner._background_agent_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_external_drain_rejects_before_creating_task(self):
+        runner, _adapter = make_restart_runner()
+        runner._external_drain_active = True
+        runner._run_background_task = AsyncMock()
+
+        result = await runner._handle_message(
+            _make_event(text="/background summarize the incident")
+        )
+
+        assert result == (
+            "⏳ This agent is draining for a maintenance action and isn't "
+            "accepting new turns right now. It'll be back in a moment — "
+            "please resend shortly."
+        )
+        runner._run_background_task.assert_not_called()
+        assert runner._background_tasks == set()
+        assert runner._background_agent_tasks == set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -144,6 +144,44 @@ async def test_request_restart_defers_stop_until_active_turn_finishes():
 
 
 @pytest.mark.asyncio
+async def test_background_command_task_blocks_active_work_drain_until_done():
+    runner, _adapter = make_restart_runner()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def background_agent(*_args, **_kwargs):
+        started.set()
+        await release.wait()
+
+    runner._run_background_task = AsyncMock(side_effect=background_agent)
+    event = MessageEvent(
+        text="/background summarize the incident",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="bg1",
+    )
+
+    await runner._handle_background_command(event)
+    await started.wait()
+    task = next(iter(runner._background_agent_tasks))
+
+    assert task in runner._background_tasks
+    assert runner._running_agent_count() == 0
+    assert runner._active_work_count() == 1
+
+    drain_task = asyncio.create_task(runner._drain_active_agents(2.0))
+    await asyncio.sleep(0)
+    assert not drain_task.done()
+
+    release.set()
+    _snapshot, timed_out = await drain_task
+    await task
+
+    assert timed_out is False
+    assert runner._active_work_count() == 0
+
+
+@pytest.mark.asyncio
 async def test_request_restart_after_turn_timeout_zero_enters_stop_immediately():
     """restart_after_turn_timeout=0 preserves legacy immediate drain."""
     runner, _adapter = make_restart_runner()


### PR DESCRIPTION
## What does this PR do?

Rejects `/background` before task creation when either shutdown drain or reversible external drain is active. It also tracks agents started by `/background` separately from long-lived gateway housekeeping tasks and includes only those agent tasks in the shared active-work count.

As a result, the gateway no longer admits new background agent work after declaring a drain, and work admitted before the drain must finish or reach the existing drain timeout before shutdown proceeds.

## Related Issue

Fixes #82379

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`: reject `/background` under both drain modes before creating an asyncio task; track admitted background agent tasks.
- `gateway/run.py`: include live background agent tasks in active-work status, wait, and timeout accounting.
- `tests/gateway/test_background_command.py`: cover both shutdown and external-drain rejection paths.
- `tests/gateway/test_restart_drain.py`: prove a pre-existing background task keeps the drain active until completion.
- `tests/gateway/restart_test_helpers.py`: initialize the dedicated background-agent task set in test runners.

## How to Test

1. Run `uv sync --extra dev --extra messaging`.
2. Run `scripts/run_tests.sh tests/gateway/test_background_command.py tests/gateway/test_restart_drain.py tests/gateway/test_external_drain_control.py tests/gateway/test_api_server_active_work_drain.py -q`.
3. Confirm all 52 tests pass, including both drain rejection regressions and the active-work drain regression.
4. Run `.venv/bin/ruff check gateway/run.py gateway/slash_commands.py tests/gateway/restart_test_helpers.py tests/gateway/test_background_command.py tests/gateway/test_restart_drain.py` and `git diff --check origin/main...HEAD`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed PRs to make sure this is not a duplicate.
- [x] This PR contains only changes related to this fix.
- [ ] I've run the entire `pytest tests/ -q` suite locally; focused canonical suites pass and CI will run the full matrix.
- [x] I've added regression coverage for the bug.
- [x] I've tested on macOS 26.5.2 with Python 3.11.15.

### Documentation & Housekeeping

- [x] Documentation update: N/A; user-facing command syntax is unchanged.
- [x] `cli-config.yaml.example`: N/A; no configuration keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered; this is platform-independent asyncio drain accounting.
- [x] Tool descriptions/schemas: N/A; no tool contract changed.

## Screenshots / Logs

Not applicable. Focused validation: 52 tests passed; Ruff, Python compilation, and `git diff --check` passed.