### PR TITLE
fix(mcp): detect session changes in SQLite WAL

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -313,6 +313,22 @@ def _ts_float(ts) -> float:
     return 0.0
 
 
+def _file_signature(path: Path) -> Optional[tuple[int, int]]:
+    """Return metadata that changes on file rewrites and same-mtime appends."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return stat.st_mtime_ns, stat.st_size
+
+
+def _sqlite_state_signature(
+    db_file: Path,
+) -> tuple[Optional[tuple[int, int]], Optional[tuple[int, int]]]:
+    """Return the filesystem state of a SQLite database and its WAL sidecar."""
+    return _file_signature(db_file), _file_signature(Path(f"{db_file}-wal"))
+
+
 class EventBridge:
     """Background poller that watches SessionDB for new messages and
     maintains an in-memory event queue with waiter support.
@@ -331,8 +347,8 @@ class EventBridge:
         self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
         # In-memory approval tracking (populated from events)
         self._pending_approvals: Dict[str, dict] = {}
-        # mtime cache — skip expensive work when state.db hasn't changed
-        self._state_db_mtime: float = 0.0
+        # Filesystem cache — skip work when state.db and its WAL are unchanged.
+        self._state_db_signature = (None, None)
         self._cached_sessions_index: dict = {}
 
     def start(self):
@@ -449,8 +465,8 @@ class EventBridge:
 
     def _establish_baseline(self) -> None:
         """Record the latest per-session message timestamp and the current
-        state.db mtime WITHOUT emitting events, so startup does not replay
-        history (#13414).
+        state.db/WAL signature WITHOUT emitting events, so startup does not
+        replay history (#13414).
 
         Only sessions that already exist at startup are baselined; a session
         that first appears afterwards is absent here and defaults to
@@ -465,10 +481,7 @@ class EventBridge:
             db_file = get_hermes_home() / "state.db"
         except ImportError:
             db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
-        try:
-            self._state_db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0
-        except OSError:
-            self._state_db_mtime = 0.0
+        self._state_db_signature = _sqlite_state_signature(db_file)
         try:
             self._cached_sessions_index = _load_sessions_index()
         except Exception:
@@ -504,13 +517,10 @@ class EventBridge:
     def _poll_once(self, db):
         """Check for new messages across all sessions.
 
-        Uses a single mtime check on state.db to skip work when nothing
-        has changed — makes 200ms polling essentially free.  Since #9006
-        the routing index itself lives in state.db (session rows carry
-        session_key/origin metadata), so a new conversation and its first
-        message land in the SAME file and one mtime check covers both —
-        eliminating the old dual-file (sessions.json + state.db) race that
-        could drop brand-new conversations (#8925).
+        Uses a filesystem signature for state.db and state.db-wal to skip work
+        when neither has changed, keeping 200ms idle polling essentially free.
+        Since #9006 the routing index and messages live in the same SQLite
+        database, including its WAL sidecar while WAL mode is active.
         """
         try:
             from hermes_constants import get_hermes_home
@@ -518,18 +528,14 @@ class EventBridge:
         except ImportError:
             db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
-        try:
-            db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0
-        except OSError:
-            db_mtime = 0.0
-
-        if db_mtime == self._state_db_mtime:
+        db_signature = _sqlite_state_signature(db_file)
+        if db_signature == self._state_db_signature:
             return  # Nothing changed since last poll — skip entirely
 
-        self._state_db_mtime = db_mtime
+        self._state_db_signature = db_signature
         # Refresh the routing index from state.db on every change tick —
         # it's a single indexed query and it can never lag the messages
-        # table (both live in the same database file).
+        # table (both live in the same database).
         self._cached_sessions_index = _load_sessions_index()
         entries = self._cached_sessions_index
 

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1052,7 +1052,7 @@ class TestEdgeCases:
 
 
 # ---------------------------------------------------------------------------
-# 7. EVENT BRIDGE POLL LOOP E2E — real SQLite DB, mtime optimization
+# 7. EVENT BRIDGE POLL LOOP E2E — real SQLite DB, filesystem change gate
 # ---------------------------------------------------------------------------
 
 class TestEventBridgePollE2E:
@@ -1219,7 +1219,7 @@ class TestEventBridgePollE2E:
         )
         conn.commit()
         conn.close()
-        # Touch the DB file to update mtime (WAL mode may not update mtime on small writes)
+        # Make this legacy main-file change path explicit.
         os.utime(db_path, None)
 
         # Update sessions.json updated_at to trigger re-check
@@ -1232,6 +1232,86 @@ class TestEventBridgePollE2E:
         assert len(r2["events"]) == 1
         assert r2["events"][0]["content"] == "New reply!"
 
+    def test_poll_detects_message_committed_only_to_wal(self, tmp_path, monkeypatch):
+        """A WAL-only commit must open the poll gate without touching state.db."""
+        import hermes_state
+        import mcp_serve
+
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: False,
+        )
+        SessionDB = hermes_state.SessionDB
+        db_path = tmp_path / "state.db"
+        wal_path = tmp_path / "state.db-wal"
+        session_id = "20260329_150000_wal_message"
+        session_key = "agent:main:telegram:dm:wal"
+        writer = SessionDB(db_path=db_path)
+        reader = None
+        try:
+            assert writer._conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+            assert writer._conn.execute(
+                "PRAGMA wal_autocheckpoint=0"
+            ).fetchone()[0] == 0
+            writer.create_session(
+                session_id,
+                "telegram",
+                session_key=session_key,
+                chat_id="wal",
+                chat_type="dm",
+            )
+            writer.append_message(
+                session_id, "user", "Before baseline", timestamp=1000.0
+            )
+
+            # Keep the bridge on a separate, real read-only SQLite connection.
+            reader = SessionDB(db_path=db_path, read_only=True)
+
+            def load_index():
+                return {
+                    row["session_key"]: mcp_serve._row_to_index_entry(row)
+                    for row in reader.list_gateway_sessions(active_only=True)
+                }
+
+            monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: reader)
+            monkeypatch.setattr(mcp_serve, "_load_sessions_index", load_index)
+
+            bridge = mcp_serve.EventBridge()
+            bridge._establish_baseline()
+            baseline_signature = bridge._state_db_signature
+            assert baseline_signature == mcp_serve._sqlite_state_signature(db_path)
+            assert baseline_signature[1] is not None
+            baseline_wal_mtime_ns = wal_path.stat().st_mtime_ns
+
+            writer.append_message(
+                session_id, "assistant", "Committed to WAL", timestamp=1001.0
+            )
+
+            # Restore the WAL mtime to prove that append size is also part of
+            # the signature; coarse/same-timestamp filesystems must not miss it.
+            appended_wal = wal_path.stat()
+            assert appended_wal.st_size > baseline_signature[1][1]
+            os.utime(
+                wal_path,
+                ns=(appended_wal.st_atime_ns, baseline_wal_mtime_ns),
+            )
+            changed_signature = mcp_serve._sqlite_state_signature(db_path)
+            assert changed_signature[0] == baseline_signature[0]
+            assert changed_signature[1] != baseline_signature[1]
+            assert changed_signature[1][0] == baseline_signature[1][0]
+
+            bridge._poll_once(reader)
+
+            events = bridge.poll_events(after_cursor=0)["events"]
+            assert len(events) == 1
+            assert events[0]["role"] == "assistant"
+            assert events[0]["content"] == "Committed to WAL"
+        finally:
+            if reader is not None:
+                reader.close()
+            writer.close()
+
     def test_poll_picks_up_new_conversation_on_db_change(
         self, tmp_path, monkeypatch
     ):
@@ -1240,11 +1320,11 @@ class TestEventBridgePollE2E:
 
         Since #9006 the routing index lives IN state.db (session rows carry
         session_key/origin metadata), so a new conversation's registration and
-        its first message land in the same file — a single mtime check covers
-        both and the old dual-file (sessions.json + state.db) race (#8925) is
-        structurally impossible. This test asserts the index is refreshed on a
-        db-mtime bump, so a conversation the bridge has never seen before is
-        emitted on the same tick.
+        its first message land in the same SQLite database. The main/WAL
+        filesystem signature covers both and the old dual-file (sessions.json +
+        state.db) race (#8925) is structurally impossible. This test asserts the
+        index is refreshed on a database-signature change, so a conversation the
+        bridge has never seen before is emitted on the same tick.
         """
         import mcp_serve
 
@@ -1252,7 +1332,7 @@ class TestEventBridgePollE2E:
         sessions_dir.mkdir()
         monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
 
-        # _poll_once reads <HERMES_HOME>/state.db for its mtime gate; the autouse
+        # _poll_once signatures <HERMES_HOME>/state.db and its WAL; the autouse
         # fixture points HERMES_HOME at tmp_path.
         db_path = tmp_path / "state.db"
         db_path.write_text("placeholder")
@@ -1282,10 +1362,9 @@ class TestEventBridgePollE2E:
                 }]
 
         bridge = mcp_serve.EventBridge()
-        # Bridge has never seen this db state (mtime differs) and has an
-        # empty cached index — exactly the state after a new conversation's
-        # first write.
-        bridge._state_db_mtime = 0.0
+        # Bridge has never seen this database signature and has an empty cached
+        # index — exactly the state after a new conversation's first write.
+        bridge._state_db_signature = (None, None)
         assert bridge._cached_sessions_index == {}
 
         bridge._poll_once(DB())
@@ -1335,7 +1414,7 @@ class TestEventBridgePollE2E:
             "id": 2, "role": "assistant", "content": "arrived after start",
             "timestamp": "2026-03-29T15:05:00",
         })
-        os.utime(db_path, None)  # bump mtime so the poll gate opens
+        os.utime(db_path, None)  # change the signature so the poll gate opens
         bridge._poll_once(DB())
         events = bridge.poll_events(after_cursor=0)["events"]
         assert len(events) == 1


### PR DESCRIPTION
## What does this PR do?

Makes the MCP `EventBridge` change gate aware of SQLite WAL state. The cached signature now covers both `state.db` and `state.db-wal` using nanosecond mtime and file size, so a committed message in the WAL opens the poll gate even when the main database file has not changed.

The idle fast path remains filesystem-only, and WAL sidecar appearance, append growth, truncation, or disappearance all change the signature without forcing checkpoints or scanning messages unconditionally.

## Related Issue

Fixes #82377

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `mcp_serve.py`: replace the main-file mtime cache with a main/WAL filesystem signature.
- `tests/test_mcp_serve.py`: add a real two-connection `SessionDB` regression with WAL autocheckpoint disabled and same-mtime WAL growth.
- Update existing EventBridge tests and descriptions to use the new signature terminology.

## How to Test

1. Run `scripts/run_tests.sh tests/test_mcp_serve.py -q`.
2. Confirm all 89 tests pass, including `test_poll_detects_message_committed_only_to_wal`.
3. Run `.venv/bin/ruff check mcp_serve.py tests/test_mcp_serve.py` and `git diff --check origin/main...HEAD`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed PRs to make sure this is not a duplicate.
- [x] This PR contains only changes related to this fix.
- [ ] I've run the entire `pytest tests/ -q` suite locally; the complete MCP test file passes and CI will run the full matrix.
- [x] I've added regression coverage for the bug.
- [x] I've tested on macOS 26.5.2 with Python 3.11.15 and SQLite WAL mode.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing contract changed.
- [x] `cli-config.yaml.example`: N/A; no configuration keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered; the signature uses portable `Path.stat()` metadata and handles absent sidecars.
- [x] Tool descriptions/schemas: N/A; MCP event schemas are unchanged.

## Screenshots / Logs

Not applicable. Focused validation: 89 tests passed; Ruff, Python compilation, and `git diff --check` passed.