### PR TITLE
fix(gateway): expand env refs in configured model (#82399)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3313,7 +3313,7 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     back to the hardcoded default which fails when the active provider is
     openai-codex.
     """
-    cfg = config if config is not None else _load_gateway_config()
+    cfg = config if config is not None else _load_gateway_runtime_config()
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
         return model_cfg

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -115,6 +115,14 @@ class TestResolveGatewayModel:
         from gateway.run import _resolve_gateway_model
         assert _resolve_gateway_model({"model": {"default": "gpt-5.4"}}) == "gpt-5.4"
 
+    def test_expands_env_reference_when_loading_gateway_config(self, monkeypatch):
+        from gateway import run as gateway_run
+
+        monkeypatch.setenv("MODEL_NAME", "provider/model-from-env")
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"model": {"default": "$" + "{env:MODEL_NAME}"}})
+
+        assert gateway_run._resolve_gateway_model() == "provider/model-from-env"
+
     def test_returns_model_key_fallback(self):
         from gateway.run import _resolve_gateway_model
         assert _resolve_gateway_model({"model": {"model": "gpt-5.4"}}) == "gpt-5.4"


### PR DESCRIPTION
## Summary

Fixes #82399.

The gateway model resolver used the raw YAML loader when no config was passed, bypassing the runtime environment-reference expansion already used by the TUI. This left `${env:MODEL_NAME}` as a literal model name.

The resolver now uses the gateway runtime config loader, with a regression test covering the `${env:VAR}` form.

## Tests

- `python3 -m pytest -q tests/test_empty_model_fallback.py --disable-warnings --maxfail=1` (11 passed)
- `python3 -m py_compile gateway/run.py`
- `git diff --check`
