### PR TITLE
fix: disable verify-on-stop auto mode for cron agents

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7357,7 +7357,9 @@ def run_conversation(
                         verify_on_stop_enabled,
                     )
 
-                    if verify_on_stop_enabled():
+                    if verify_on_stop_enabled(
+                        platform=getattr(agent, "platform", None),
+                    ):
                         _verify_nudge = build_verify_on_stop_nudge(
                             session_id=getattr(agent, "session_id", None),
                             changed_paths=getattr(agent, "_turn_file_mutation_paths", set()),

--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -92,7 +92,11 @@ def _session_is_messaging_surface() -> bool:
         return False
 
 
-def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
+def verify_on_stop_enabled(
+    config: dict[str, Any] | None = None,
+    *,
+    platform: str | None = None,
+) -> bool:
     """Return whether edit -> verify-before-finish behavior is enabled.
 
     Precedence: an explicit ``HERMES_VERIFY_ON_STOP`` env var wins, then an
@@ -101,8 +105,10 @@ def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
     coding surfaces (CLI, TUI, desktop) and programmatic callers, OFF for
     conversational messaging surfaces (Telegram, Discord, etc.) where the
     verification narrative would reach a human as chat noise. An explicit
-    bool forces the behavior in either direction. A missing or unrecognized
-    value falls back to the surface-aware ``"auto"`` default.
+    bool forces the behavior in either direction. In automatic mode, the
+    authoritative agent platform disables this interactive coding guard for
+    unattended cron turns. A missing or unrecognized value falls back to the
+    surface-aware ``"auto"`` default.
     """
     env = os.environ.get("HERMES_VERIFY_ON_STOP")
     if env is not None:
@@ -118,6 +124,10 @@ def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
     cfg_val = agent_cfg.get("verify_on_stop") if isinstance(agent_cfg, dict) else None
     if isinstance(cfg_val, bool):
         return cfg_val
+    auto_enabled = (
+        str(platform or "").strip().lower() != "cron"
+        and not _session_is_messaging_surface()
+    )
     if isinstance(cfg_val, str):
         token = cfg_val.strip().lower()
         if token in {"1", "true", "yes", "on"}:
@@ -125,9 +135,9 @@ def verify_on_stop_enabled(config: dict[str, Any] | None = None) -> bool:
         if token in {"0", "false", "no", "off"}:
             return False
         if token == "auto":
-            return not _session_is_messaging_surface()
+            return auto_enabled
     # Missing or unrecognized value -> surface-aware "auto" default.
-    return not _session_is_messaging_surface()
+    return auto_enabled
 
 
 def _candidate_cwds(paths: Iterable[str]) -> list[Path]:

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -61,6 +61,27 @@ def test_verify_on_stop_env_can_enable(clear_verify_env):
     assert verify_on_stop_enabled({"agent": {}}) is True
 
 
+def test_verify_on_stop_auto_off_for_explicit_cron_platform(clear_verify_env):
+    # Cron is an unattended automation surface. Its job-owned state writes must
+    # not be mistaken for interactive coding edits when ambient context is absent.
+    assert verify_on_stop_enabled(
+        {"agent": {"verify_on_stop": "auto"}}, platform="cron"
+    ) is False
+
+
+def test_verify_on_stop_explicit_enable_wins_on_cron(clear_verify_env):
+    assert verify_on_stop_enabled(
+        {"agent": {"verify_on_stop": True}}, platform="cron"
+    ) is True
+
+
+def test_verify_on_stop_env_enable_wins_on_cron(clear_verify_env):
+    clear_verify_env.setenv("HERMES_VERIFY_ON_STOP", "1")
+    assert verify_on_stop_enabled(
+        {"agent": {"verify_on_stop": False}}, platform="cron"
+    ) is True
+
+
 
 
 

--- a/tests/run_agent/test_verification_continuation_budget.py
+++ b/tests/run_agent/test_verification_continuation_budget.py
@@ -80,6 +80,39 @@ def test_verify_on_stop_preserves_composed_report_at_budget_limit(agent, monkeyp
     assert not result["messages"][1].get("_verification_stop_synthetic")
 
 
+def test_cron_auto_skips_verify_on_stop_when_ambient_context_is_absent(
+    agent, monkeypatch
+):
+    def model_call(_api_kwargs):
+        agent._turn_file_mutation_paths = {"state.json"}
+        return _response("cron alert")
+
+    agent.platform = "cron"
+    agent._interruptible_api_call = model_call
+    monkeypatch.delenv("HERMES_VERIFY_ON_STOP", raising=False)
+
+    with (
+        patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"agent": {"verify_on_stop": "auto"}},
+        ),
+        patch(
+            "agent.verification_stop._session_is_messaging_surface",
+            return_value=False,
+        ),
+        patch(
+            "agent.verification_stop.build_verify_on_stop_nudge",
+            return_value="verify it",
+        ) as build_nudge,
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+    ):
+        result = agent.run_conversation("inspect scheduled work")
+
+    assert result["final_response"] == "cron alert"
+    assert result["completed"] is True
+    build_nudge.assert_not_called()
+
+
 def test_pre_verify_preserves_composed_report_at_budget_limit(agent, monkeypatch):
     def model_call(_api_kwargs):
         agent._turn_file_mutation_paths = {"changed.py"}


### PR DESCRIPTION
## Summary

- disable verify-on-stop auto mode for explicit cron agents when ambient session context is absent
- preserve explicit environment and configuration overrides
- add focused unit and end-to-end regression coverage

## Testing

- focused verification-stop tests: 15 passed
- cron tests: 392 passed
- full agent suite: 6 existing Anthropic SDK-dependent failures, reproduced unchanged on the tested baseline