### PR TITLE
fix(mcp): neutralise min-release-age for npx/npm MCP spawns

### DIFF
--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -33,6 +33,29 @@ def test_resolve_stdio_command_falls_back_to_hermes_node_bin(tmp_path):
     assert env["PATH"].split(os.pathsep)[0] == str(node_bin)
 
 
+def test_resolve_stdio_command_neutralises_min_release_age_for_npx():
+    """Docker/runtime MCP installs via npx must not inherit the checkout's
+    min-release-age gate (#82410)."""
+    command, env = _resolve_stdio_command("npx", {"PATH": "/usr/bin"})
+    assert command.endswith("npx") or command == "npx"
+    assert env["npm_config_min_release_age"] == "0"
+
+    command, env = _resolve_stdio_command(
+        os.path.join(os.sep, "usr", "local", "bin", "npm"),
+        {"PATH": "/usr/bin"},
+    )
+    assert command.endswith("npm")
+    assert env["npm_config_min_release_age"] == "0"
+
+
+def test_resolve_stdio_command_respects_user_min_release_age_override():
+    command, env = _resolve_stdio_command(
+        "npx",
+        {"PATH": "/usr/bin", "npm_config_min_release_age": "14"},
+    )
+    assert env["npm_config_min_release_age"] == "14"
+
+
 def test_resolve_stdio_command_falls_back_to_usr_local_bin():
     """When ``npx`` isn't on the filtered PATH and isn't under ``$HERMES_HOME/node/bin``
     or ``~/.local/bin``, the resolver should still locate it at ``/usr/local/bin/npx``.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -743,6 +743,15 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     if command_dir:
         resolved_env = _prepend_path(resolved_env, command_dir)
 
+    # Hermes checkouts ship a `.npmrc` with `min-release-age=14` (supply-chain
+    # gate for the monorepo build). Docker images bake that file at
+    # /opt/hermes/.npmrc, so stdio MCP servers launched via `npx`/`npm` inherit
+    # the age gate and fail ETARGET on freshly published user packages (#82410).
+    # Neutralise the gate for MCP installs only — same pattern as
+    # hermes_cli/npm_engine._upgrade_env().
+    if os.path.basename(resolved_command).lower() in {"npx", "npm"}:
+        resolved_env.setdefault("npm_config_min_release_age", "0")
+
     return resolved_command, resolved_env
 
 


### PR DESCRIPTION
## What does this PR do?

Hermes Docker images bake the checkout `.npmrc` (including `min-release-age=14`) at `/opt/hermes`. When users add stdio MCP servers that launch via `npx` or `npm`, npm inherits that supply-chain age gate and fails with `ETARGET` on freshly published packages — e.g. `No matching version found for @chris235/paperless-mcp@1.1.0 with a date before …`.

This sets `npm_config_min_release_age=0` when resolving `npx`/`npm` MCP commands, matching the existing pattern in `hermes_cli/npm_engine._upgrade_env()`. User overrides via MCP `env:` are preserved via `setdefault`.

## Related Issue

Fixes #82410

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` — neutralise `min-release-age` for `npx`/`npm` stdio MCP spawns in `_resolve_stdio_command`
- `tests/tools/test_mcp_tool_issue_948.py` — regression tests for the env override and user override preservation

## How to Test

1. From a Hermes checkout with `.npmrc` `min-release-age=14`, use npm 11+ (Docker image Node 26 ships npm 11).
2. Run `npx -y @chris235/paperless-mcp@1.1.0 --help` from the checkout cwd — reproduces `ETARGET`.
3. Run `_resolve_stdio_command("npx", {"PATH": "/usr/bin"})` — returned env includes `npm_config_min_release_age=0`.
4. `scripts/run_tests.sh tests/tools/test_mcp_tool_issue_948.py -q` — all tests pass.

## Checklist

### Code

- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I ran `scripts/run_tests.sh tests/tools/test_mcp_tool_issue_948.py -q` and all tests pass
- [x] I added tests for my changes
- [x] I tested on my platform: Ubuntu (Cloud Agent VM), npm 11.17.0

### Documentation & Housekeeping

- [x] Documentation update — N/A (behavioral fix; Docker docs already describe `npx` MCP usage)
- [x] Cross-platform impact — N/A (env var override; no platform-specific code)