### PR TITLE
fix(file-ops): an invalid lead byte at the sample cut is binary, not text

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -739,6 +739,22 @@ class TestByteLayerBinaryDetection:
         # Error near the end but the prefix itself is not clean UTF-8.
         assert file_ops._is_likely_binary_bytes(b"\xff\xfe" + b"a" * 10 + b"\xe4") is True
 
+    def test_invalid_lead_byte_at_the_cut_is_binary(self, file_ops):
+        # Clean prefix, error in the last 3 bytes — but 0xFF is not a UTF-8
+        # lead byte in any position, so this is not a cut character and the
+        # file must stay read-only. Deciding "cut" by position alone reads it
+        # as text and lets a round-trip rewrite the byte as U+FFFD.
+        assert file_ops._is_likely_binary_bytes(b"a" * 999 + b"\xff") is True
+
+    def test_stray_continuation_byte_at_the_cut_is_binary(self, file_ops):
+        # 0x80 is a continuation byte with nothing to continue.
+        assert file_ops._is_likely_binary_bytes(b"a" * 999 + b"\x80") is True
+
+    def test_four_byte_sequence_cut_after_one_byte_is_text(self, file_ops):
+        # The over-correction guard: a genuine cut leaving only the lead byte
+        # of a 4-byte sequence is still text.
+        assert file_ops._is_likely_binary_bytes(b"a" * 999 + b"\xf0") is False
+
     # --- transport: _sample_file_bytes ------------------------------------
 
     def test_sample_decodes_base64_transport(self, mock_env):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,6 +27,7 @@ Usage:
 
 import base64
 import binascii
+import codecs
 import os
 import re
 import difflib
@@ -947,19 +948,22 @@ class ShellFileOperations(FileOperations):
             return False
         if b"\x00" in sample:
             return True
+        # An incremental decoder states the contract above directly: with
+        # final=False it buffers a trailing sequence that is incomplete but
+        # well formed, and raises on anything else.
+        #
+        # Deciding it by position instead — the error starts in the last 3
+        # bytes and the prefix is clean, therefore a cut — also accepts a byte
+        # that cannot begin a sequence in any position. b"a" * 999 + b"\xff"
+        # is a cut by position, but \xff is not a UTF-8 lead byte, so the file
+        # is binary; reading it as text is the mojibake round-trip this guard
+        # exists to prevent.
+        decoder = codecs.getincrementaldecoder("utf-8")()
         try:
-            sample.decode("utf-8")
-            return False
-        except UnicodeDecodeError as exc:
-            # UTF-8 sequences are at most 4 bytes: an error starting in the
-            # last 3 bytes with a clean prefix is a boundary cut, not binary.
-            if exc.start >= len(sample) - 3:
-                try:
-                    sample[: exc.start].decode("utf-8")
-                    return False
-                except UnicodeDecodeError:
-                    pass
+            decoder.decode(sample, final=False)
+        except UnicodeDecodeError:
             return True
+        return False
 
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """


### PR DESCRIPTION
## What does this PR do?

Follow-up to #80440, which moved binary detection to the byte layer and fixed the #80308 class. Its boundary rule decides "one incomplete sequence at the end" by **position**: a decode error starting in the last 3 bytes with a clean prefix is treated as a cut character.

That also accepts a byte which cannot begin a UTF-8 sequence *in any position*. On `main` today:

```python
>>> ShellFileOperations._is_likely_binary_bytes(b"a" * 999 + b"\xff")
False   # read as text
```

`0xFF` is never a UTF-8 lead byte, so this is not a cut character — it is a binary file whose first 1000 bytes happen to end on one. Reading it as text is exactly the round-trip the guard exists to prevent: the transport decodes with `errors="replace"`, so the undecodable byte arrives as U+FFFD, and a read → edit → write rewrites the original byte with a replacement character. That is the anti-mojibake guarantee #80440's docstring commits to.

The fix uses an incremental decoder with `final=False`. That *is* the stated contract, expressed directly — it buffers a trailing sequence that is incomplete but well formed, and raises on everything else — so it needs no positional reasoning and is shorter than the test it replaces:

```python
decoder = codecs.getincrementaldecoder("utf-8")()
try:
    decoder.decode(sample, final=False)
except UnicodeDecodeError:
    return True
return False
```

Every CJK/emoji/BOM/latin-1/NUL case from #80440 keeps its current behaviour — the existing suite passes unchanged. Only bytes that are invalid in every position change classification.

## Related Issue

No open issue for this specific gap — it is a residual edge of the rule introduced in #80440 (issue #80308). Happy to file one first if you'd prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py` — `_is_likely_binary_bytes`: replace the positional last-3-bytes test with an incremental decoder (`final=False`); add `import codecs`.
- `tests/tools/test_file_operations.py` — three cases in `TestByteLayerBinaryDetection`:
  - `test_invalid_lead_byte_at_the_cut_is_binary` — `b"a" * 999 + b"\xff"`
  - `test_stray_continuation_byte_at_the_cut_is_binary` — `b"a" * 999 + b"\x80"`
  - `test_four_byte_sequence_cut_after_one_byte_is_text` — over-correction guard, a genuine cut leaving only an `\xf0` lead byte is still text

## How to Test

1. Reproduce on `main`:
   ```python
   from tools.file_operations import ShellFileOperations as S
   assert S._is_likely_binary_bytes(b"a" * 999 + b"\xff") is True  # fails on main
   ```
2. The two regression tests fail without the source change and pass with it. Checked out on this branch:
   ```
   git stash push tools/file_operations.py
   pytest tests/tools/test_file_operations.py -k "at_the_cut or four_byte_sequence_cut" -q
   #   2 failed, 1 passed          <- the guard test passes either way, by design
   git stash pop
   pytest tests/tools/test_file_operations.py -q
   #   65 passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — searched open *and* closed for `_is_likely_binary_bytes` (only #80440), for lead-byte/boundary wording, and the open PRs touching `file_operations`; none address this edge
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not verified locally.** `pytest tests/tools/test_file_operations.py -q` passes (65 passed); the full suite did not finish in my environment (it stalls well outside the files this PR touches, apparently on network-dependent tests). Leaving this to CI rather than checking a box I did not verify.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.9 (Darwin 24.6.0), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: the existing docstring already states this contract ("allowing one incomplete multibyte sequence at the very end"); this change makes the implementation match it.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — `codecs` is stdlib and the change is pure byte handling with no platform-dependent behaviour.
