### PR TITLE
perf(cache): split skill turns at a builder-declared stable/volatile boundary

### DIFF
--- a/agent/prompt_cache_boundary.py
+++ b/agent/prompt_cache_boundary.py
@@ -1,0 +1,73 @@
+"""Builder-declared stable prefixes for Anthropic prompt caching (#81867).
+
+Skill, webhook, and cron builders concatenate a large static scaffold
+(activation note + expanded skill body) with a small volatile invocation
+tail (ticket payload, timestamps, run context) into one user-message
+string. Only the builder knows the exact byte where the volatile tail
+begins, so it registers the stable prefix here at construction time; the
+cache planner consults the registry to place a cache breakpoint at that
+boundary instead of caching the whole message as one atomic block.
+
+This deliberately avoids re-parsing scaffold marker strings out of the
+message at request time: markers can legitimately appear inside skill
+bodies or inside event payloads (e.g. a helpdesk ticket quoting an agent
+transcript), and any delimiter-search heuristic then either shrinks the
+cached prefix or — worse — silently absorbs volatile bytes into it,
+reintroducing the per-invocation cache miss this exists to fix.
+
+The registry is process-local by design. A freshly fired webhook/cron
+invocation is always built and sent by the same process, which is the
+only window where the split pays off. Any miss (restart, eviction,
+historic message) falls back to the pre-existing whole-message policy.
+"""
+
+import threading
+from collections import OrderedDict
+from typing import Optional
+
+# A couple dozen distinct active scaffolds (webhook routes x skills x cron
+# jobs) is generous for one gateway process; beyond that, oldest entries
+# fall back to whole-message caching rather than growing unboundedly.
+_MAX_ENTRIES = 32
+
+_lock = threading.Lock()
+_prefixes: "OrderedDict[str, None]" = OrderedDict()
+
+
+def register_stable_prefix(prefix: str) -> None:
+    """Record ``prefix`` as the stable scaffold of a just-built message."""
+    if not prefix:
+        return
+    with _lock:
+        _prefixes[prefix] = None
+        _prefixes.move_to_end(prefix)
+        while len(_prefixes) > _MAX_ENTRIES:
+            _prefixes.popitem(last=False)
+
+
+def find_stable_prefix(content: str) -> Optional[str]:
+    """Longest registered prefix that is a *proper* prefix of ``content``.
+
+    Proper (``len(content) > len(prefix)``) so the split never produces an
+    empty volatile text block, which Anthropic rejects on the wire.
+    """
+    with _lock:
+        candidates = list(_prefixes)
+    best: Optional[str] = None
+    for prefix in candidates:
+        if len(content) > len(prefix) and content.startswith(prefix):
+            if best is None or len(prefix) > len(best):
+                best = prefix
+    return best
+
+
+def is_registered_stable_prefix(text: str) -> bool:
+    """Exact-match check used when flattening a decorated split back."""
+    with _lock:
+        return text in _prefixes
+
+
+def clear_stable_prefixes() -> None:
+    """Test isolation helper."""
+    with _lock:
+        _prefixes.clear()

--- a/agent/prompt_cache_boundary.py
+++ b/agent/prompt_cache_boundary.py
@@ -19,6 +19,16 @@ The registry is process-local by design. A freshly fired webhook/cron
 invocation is always built and sent by the same process, which is the
 only window where the split pays off. Any miss (restart, eviction,
 historic message) falls back to the pre-existing whole-message policy.
+
+Split-shape lifetime: the split is applied only while the skill message is
+one of the plan's marked endpoints (the last few cacheable messages). Once
+later turns rotate it out of that window it ships as a single string block
+again, which changes the block boundary once and re-ingests the prefix from
+that message onward exactly one time in a long-lived session. Webhook/cron
+invocations — the workload this exists for — send the skill turn as the
+newest message every time, so they always hit the split shape; the one-time
+re-ingest only affects long interactive sessions and nets out far below the
+per-invocation full rewrite this removes.
 """
 
 import threading
@@ -32,10 +42,12 @@ _MAX_ENTRIES = 32
 
 # Entries hold whole expanded skill bodies, so an entry count alone does not
 # bound memory — a handful of large skills can retain tens of MB in a
-# long-lived gateway process. Evict by total retained bytes too, always
-# keeping the newest entry so a single oversized scaffold still gets a
-# boundary instead of silently disabling the split.
-_MAX_BYTES = 4 * 1024 * 1024
+# long-lived gateway process. Evict by total retained characters too (a
+# conservative proxy for bytes: actual memory is 1–4x depending on the
+# string's widest code point), always keeping the newest entry so a single
+# oversized scaffold still gets a boundary instead of silently disabling
+# the split.
+_MAX_CHARS = 4 * 1024 * 1024
 
 _lock = threading.Lock()
 _prefixes: "OrderedDict[str, None]" = OrderedDict()
@@ -50,7 +62,7 @@ def register_stable_prefix(prefix: str) -> None:
         _prefixes.move_to_end(prefix)
         while len(_prefixes) > _MAX_ENTRIES:
             _prefixes.popitem(last=False)
-        while len(_prefixes) > 1 and sum(map(len, _prefixes)) > _MAX_BYTES:
+        while len(_prefixes) > 1 and sum(map(len, _prefixes)) > _MAX_CHARS:
             _prefixes.popitem(last=False)
 
 
@@ -65,17 +77,15 @@ def find_stable_prefix(content: str) -> Optional[str]:
     which would silently drop it back to whole-message caching.
     """
     with _lock:
-        candidates = list(_prefixes)
-    best: Optional[str] = None
-    for prefix in candidates:
-        if len(content) > len(prefix) and content.startswith(prefix):
-            if best is None or len(prefix) > len(best):
-                best = prefix
-    if best is not None:
-        with _lock:
-            if best in _prefixes:
-                _prefixes.move_to_end(best)
-    return best
+        best: Optional[str] = None
+        for prefix in _prefixes:
+            if len(content) > len(prefix) and content.startswith(prefix):
+                if best is None or len(prefix) > len(best):
+                    best = prefix
+        if best is not None:
+            # After the scan so the OrderedDict is never mutated mid-iteration.
+            _prefixes.move_to_end(best)
+        return best
 
 
 def clear_stable_prefixes() -> None:

--- a/agent/prompt_cache_boundary.py
+++ b/agent/prompt_cache_boundary.py
@@ -30,6 +30,13 @@ from typing import Optional
 # fall back to whole-message caching rather than growing unboundedly.
 _MAX_ENTRIES = 32
 
+# Entries hold whole expanded skill bodies, so an entry count alone does not
+# bound memory — a handful of large skills can retain tens of MB in a
+# long-lived gateway process. Evict by total retained bytes too, always
+# keeping the newest entry so a single oversized scaffold still gets a
+# boundary instead of silently disabling the split.
+_MAX_BYTES = 4 * 1024 * 1024
+
 _lock = threading.Lock()
 _prefixes: "OrderedDict[str, None]" = OrderedDict()
 
@@ -43,6 +50,8 @@ def register_stable_prefix(prefix: str) -> None:
         _prefixes.move_to_end(prefix)
         while len(_prefixes) > _MAX_ENTRIES:
             _prefixes.popitem(last=False)
+        while len(_prefixes) > 1 and sum(map(len, _prefixes)) > _MAX_BYTES:
+            _prefixes.popitem(last=False)
 
 
 def find_stable_prefix(content: str) -> Optional[str]:
@@ -50,6 +59,10 @@ def find_stable_prefix(content: str) -> Optional[str]:
 
     Proper (``len(content) > len(prefix)``) so the split never produces an
     empty volatile text block, which Anthropic rejects on the wire.
+
+    A hit refreshes the entry's LRU position: a scaffold fired every minute
+    by cron must not be evicted by a burst of one-off skill invocations,
+    which would silently drop it back to whole-message caching.
     """
     with _lock:
         candidates = list(_prefixes)
@@ -58,13 +71,11 @@ def find_stable_prefix(content: str) -> Optional[str]:
         if len(content) > len(prefix) and content.startswith(prefix):
             if best is None or len(prefix) > len(best):
                 best = prefix
+    if best is not None:
+        with _lock:
+            if best in _prefixes:
+                _prefixes.move_to_end(best)
     return best
-
-
-def is_registered_stable_prefix(text: str) -> bool:
-    """Exact-match check used when flattening a decorated split back."""
-    with _lock:
-        return text in _prefixes
 
 
 def clear_stable_prefixes() -> None:

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -14,7 +14,7 @@ import copy
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from agent.prompt_cache_boundary import find_stable_prefix, is_registered_stable_prefix
+from agent.prompt_cache_boundary import find_stable_prefix
 
 
 @dataclass(frozen=True)
@@ -193,8 +193,11 @@ def strip_anthropic_cache_control(
 
     Flattening back to a plain string is restricted to the exact shapes
     :func:`apply_anthropic_cache_control` produces from string content —
-    a single ``{"type": "text"}`` part, or the two-part ``[static, volatile]``
-    system split — so the ``""``-join is provably byte-exact. Organic
+    a single ``{"type": "text"}`` part, the two-part ``[static, volatile]``
+    system split, or the two-part builder-declared skill split (recognised
+    by its marker-on-the-first-part shape, so flattening never depends on
+    the prefix registry still holding the entry) — so the ``""``-join is
+    provably byte-exact. Organic
     multi-part text (merged user turns, imported transcripts) and parts
     carrying extra keys (``citations`` etc.) keep their structure; only
     per-part markers are removed. Marker removal is copy-on-write on the
@@ -213,6 +216,21 @@ def strip_anthropic_cache_control(
         content = msg.get("content")
         if not isinstance(content, list):
             continue
+        # Two-part skill-invocation split (#81867). The builder-declared
+        # boundary is the only decoration that marks the *first* part of a
+        # user message: list content otherwise receives its marker on the
+        # last part, and the two-part [static, volatile] split is role-gated
+        # to system. So the shape alone identifies it, and flattening stays
+        # correct even when the prefix registry has since evicted the entry
+        # (failover re-decorates a request built many messages ago, #72626).
+        skill_split_shape = (
+            msg.get("role") == "user"
+            and len(content) == 2
+            and isinstance(content[0], dict)
+            and isinstance(content[1], dict)
+            and "cache_control" in content[0]
+            and "cache_control" not in content[1]
+        )
         if any(isinstance(part, dict) and "cache_control" in part for part in content):
             content = [
                 {k: v for k, v in part.items() if k != "cache_control"}
@@ -230,14 +248,7 @@ def strip_anthropic_cache_control(
         ) and (
             len(content) == 1
             or (msg.get("role") == "system" and len(content) == 2)
-            or (
-                # Two-part skill-invocation split: the first part is byte-for-
-                # byte a builder-registered scaffold, so the ""-join provably
-                # reconstructs the original string.
-                msg.get("role") == "user"
-                and len(content) == 2
-                and is_registered_stable_prefix(content[0]["text"])
-            )
+            or skill_split_shape
         )
         if decoration_shape:
             msg["content"] = "".join(part["text"] for part in content)

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -14,6 +14,8 @@ import copy
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
+from agent.prompt_cache_boundary import find_stable_prefix, is_registered_stable_prefix
+
 
 @dataclass(frozen=True)
 class PromptCachePlan:
@@ -58,6 +60,23 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
         return
 
     if isinstance(content, str):
+        if role == "user":
+            stable_prefix = find_stable_prefix(content)
+            if stable_prefix is not None:
+                # Builder-declared boundary (#81867): the scaffold carries the
+                # breakpoint, the volatile invocation tail rides unmarked so a
+                # changed ticket ID or timestamp no longer invalidates the
+                # whole skill body. Request-local only — the canonical session
+                # message stays a plain string.
+                msg["content"] = [
+                    {
+                        "type": "text",
+                        "text": stable_prefix,
+                        "cache_control": cache_marker,
+                    },
+                    {"type": "text", "text": content[len(stable_prefix):]},
+                ]
+                return
         msg["content"] = [
             {"type": "text", "text": content, "cache_control": cache_marker}
         ]
@@ -211,6 +230,14 @@ def strip_anthropic_cache_control(
         ) and (
             len(content) == 1
             or (msg.get("role") == "system" and len(content) == 2)
+            or (
+                # Two-part skill-invocation split: the first part is byte-for-
+                # byte a builder-registered scaffold, so the ""-join provably
+                # reconstructs the original string.
+                msg.get("role") == "user"
+                and len(content) == 2
+                and is_registered_stable_prefix(content[0]["text"])
+            )
         )
         if decoration_shape:
             msg["content"] = "".join(part["text"] for part in content)

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from hermes_constants import display_hermes_home
+from agent.prompt_cache_boundary import register_stable_prefix
 from agent.skill_preprocessing import (
     expand_inline_shell as _expand_inline_shell,
     load_skills_config as _load_skills_config,
@@ -360,15 +361,26 @@ def _build_skill_message(
             f"(e.g. `node {skill_dir}/scripts/foo.js`)."
         )
 
+    stable_prefix = None
     if user_instruction:
         parts.append("")
-        parts.append(f"The user has provided the following instruction alongside the skill invocation: {user_instruction}")
+        # Everything before the caller-supplied instruction is a stable
+        # scaffold; declare the exact boundary so the Anthropic cache planner
+        # can put a breakpoint on it instead of caching the whole message as
+        # one atomic block (#81867). The static instruction prose stays on
+        # the stable side; the volatile instruction (webhook payload, ticket
+        # IDs, timestamps) and any runtime note ride in the tail.
+        stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
+        parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{user_instruction}")
 
     if runtime_note:
         parts.append("")
         parts.append(f"[Runtime note: {runtime_note}]")
 
-    return "\n".join(parts)
+    message = "\n".join(parts)
+    if stable_prefix is not None and len(message) > len(stable_prefix):
+        register_stable_prefix(stable_prefix)
+    return message
 
 
 def scan_skill_commands() -> Dict[str, Dict[str, Any]]:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -71,6 +71,23 @@ SKILL_SCAFFOLD_SQL_LIKE = _SKILL_INVOCATION_PREFIX + "%"
 SKILL_EXCERPT_JOINT = "\x1e"
 
 
+def append_user_instruction(parts: list, instruction: str) -> str:
+    """Append the instruction line to ``parts``; return the stable prefix.
+
+    Shared by every builder that ends a static skill scaffold with the
+    caller-supplied volatile instruction (single-skill invocations, cron job
+    prompts). The returned prefix ends exactly at the instruction marker, so
+    registering it with ``agent.prompt_cache_boundary`` lets the Anthropic
+    cache planner put a breakpoint on the scaffold instead of caching the
+    whole message as one atomic block (#81867). Keeping construction in one
+    place guarantees the registered prefix stays a byte-prefix of the built
+    message — the invariant the request-time split depends on.
+    """
+    stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
+    parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{instruction}")
+    return stable_prefix
+
+
 def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
     """Recover the user's instruction from a slash-skill-expanded turn.
 
@@ -370,15 +387,14 @@ def _build_skill_message(
         # one atomic block (#81867). The static instruction prose stays on
         # the stable side; the volatile instruction (webhook payload, ticket
         # IDs, timestamps) and any runtime note ride in the tail.
-        stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
-        parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{user_instruction}")
+        stable_prefix = append_user_instruction(parts, user_instruction)
 
     if runtime_note:
         parts.append("")
         parts.append(f"[Runtime note: {runtime_note}]")
 
     message = "\n".join(parts)
-    if stable_prefix is not None and len(message) > len(stable_prefix):
+    if stable_prefix is not None and message.startswith(stable_prefix) and len(message) > len(stable_prefix):
         register_stable_prefix(stable_prefix)
     return message
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2815,15 +2815,14 @@ def _build_job_prompt(
 
     stable_prefix = None
     if prompt:
-        from agent.skill_commands import _SINGLE_SKILL_INSTRUCTION
+        from agent.skill_commands import append_user_instruction
 
         parts.append("")
         # The skill blocks (and any skipped-skill notice) above are stable per
         # job config; the appended instruction carries the volatile per-run
         # data (cron hint + prompt + script output + run context). Declare
         # that boundary for the Anthropic cache planner (#81867).
-        stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
-        parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{prompt}")
+        stable_prefix = append_user_instruction(parts, prompt)
     assembled = _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
     if stable_prefix and len(assembled) > len(stable_prefix) and assembled.startswith(stable_prefix):
         # Guarded because the injection scanner may sanitize (mutate) the

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2813,9 +2813,26 @@ def _build_job_prompt(
         )
         parts.insert(0, notice)
 
+    stable_prefix = None
     if prompt:
-        parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
-    return _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
+        from agent.skill_commands import _SINGLE_SKILL_INSTRUCTION
+
+        parts.append("")
+        # The skill blocks (and any skipped-skill notice) above are stable per
+        # job config; the appended instruction carries the volatile per-run
+        # data (cron hint + prompt + script output + run context). Declare
+        # that boundary for the Anthropic cache planner (#81867).
+        stable_prefix = "\n".join(parts) + "\n" + _SINGLE_SKILL_INSTRUCTION
+        parts.append(f"{_SINGLE_SKILL_INSTRUCTION}{prompt}")
+    assembled = _scan_assembled_cron_prompt("\n".join(parts), job, has_skills=True)
+    if stable_prefix and len(assembled) > len(stable_prefix) and assembled.startswith(stable_prefix):
+        # Guarded because the injection scanner may sanitize (mutate) the
+        # assembled bytes; a mismatch simply falls back to whole-message
+        # caching.
+        from agent.prompt_cache_boundary import register_stable_prefix
+
+        register_stable_prefix(stable_prefix)
+    return assembled
 
 
 def _scan_assembled_cron_prompt(

--- a/tests/agent/test_prompt_cache_boundary.py
+++ b/tests/agent/test_prompt_cache_boundary.py
@@ -64,6 +64,19 @@ def skills(tmp_path, monkeypatch):
 
 
 class TestRegistry:
+    def test_append_user_instruction_prefix_invariant(self):
+        """The shared builder helper must return a byte-prefix of the final
+        joined message — the invariant every registration site depends on."""
+        from agent.skill_commands import append_user_instruction
+
+        parts = ["scaffold line one", "", "skill body", ""]
+        instruction = "ticket=42 time=10:00"
+        stable_prefix = append_user_instruction(parts, instruction)
+        message = "\n".join(parts)
+
+        assert message.startswith(stable_prefix)
+        assert message[len(stable_prefix):] == instruction
+
     def test_requires_proper_prefix(self):
         register_stable_prefix("scaffold")
         assert find_stable_prefix("scaffold volatile") == "scaffold"
@@ -105,12 +118,12 @@ class TestRegistry:
         assert find_stable_prefix("hot-scaffold volatile") == "hot-scaffold "
         assert find_stable_prefix("cold-0 volatile") is None
 
-    def test_total_byte_cap_evicts_oldest_and_keeps_newest(self, monkeypatch):
+    def test_total_char_cap_evicts_oldest_and_keeps_newest(self, monkeypatch):
         """Entries retain whole skill bodies, so the entry count alone does
         not bound memory."""
         from agent import prompt_cache_boundary
 
-        monkeypatch.setattr(prompt_cache_boundary, "_MAX_BYTES", 100)
+        monkeypatch.setattr(prompt_cache_boundary, "_MAX_CHARS", 100)
 
         register_stable_prefix("a" * 80)
         register_stable_prefix("b" * 80)
@@ -121,7 +134,7 @@ class TestRegistry:
     def test_single_oversized_prefix_still_registers(self, monkeypatch):
         from agent import prompt_cache_boundary
 
-        monkeypatch.setattr(prompt_cache_boundary, "_MAX_BYTES", 10)
+        monkeypatch.setattr(prompt_cache_boundary, "_MAX_CHARS", 10)
         oversized = "x" * 500
 
         register_stable_prefix(oversized)

--- a/tests/agent/test_prompt_cache_boundary.py
+++ b/tests/agent/test_prompt_cache_boundary.py
@@ -1,0 +1,309 @@
+"""Builder-declared stable-prefix cache boundaries (#81867).
+
+Webhook/cron skill invocations concatenate a large static scaffold with a
+small volatile tail into one user string; without a declared boundary the
+whole message is cached as one atomic block and a changed ticket ID or
+timestamp forces a full cache rewrite. These tests cover the registry, the
+request-local split, the failover round-trip, and — via the real builders —
+that the boundary comes from construction, not from re-parsing marker
+strings (so payloads that quote the marker cannot poison the stable prefix).
+"""
+
+import copy
+
+import pytest
+from unittest.mock import patch
+
+import agent.skill_bundles as skill_bundles
+import agent.skill_commands as skill_commands
+import tools.skills_tool as skills_tool
+from agent.prompt_cache_boundary import (
+    clear_stable_prefixes,
+    find_stable_prefix,
+    is_registered_stable_prefix,
+    register_stable_prefix,
+)
+from agent.prompt_caching import (
+    apply_anthropic_cache_control,
+    build_prompt_cache_plan,
+    strip_anthropic_cache_control,
+)
+from agent.skill_commands import _SINGLE_SKILL_INSTRUCTION
+
+MARKER = {"type": "ephemeral"}
+
+SKILL_BODY = "Inspect the report carefully and preserve the stable instructions."
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    clear_stable_prefixes()
+    yield
+    clear_stable_prefixes()
+
+
+def _write_skill(skills_dir, name, body=SKILL_BODY):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Description for {name}\n---\n\n# {name}\n\n{body}\n"
+    )
+    return skill_dir
+
+
+@pytest.fixture()
+def skills(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "triage")
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_commands, "_skill_commands", {})
+    monkeypatch.setattr(skill_commands, "_skill_commands_platform", None)
+    monkeypatch.setattr(skill_bundles, "_bundles_cache", {})
+    monkeypatch.setattr(skill_bundles, "_bundles_cache_mtime", None)
+    skill_commands.scan_skill_commands()
+    return skills_dir
+
+
+class TestRegistry:
+    def test_requires_proper_prefix(self):
+        register_stable_prefix("scaffold")
+        assert find_stable_prefix("scaffold volatile") == "scaffold"
+        # Exact match would leave an empty volatile block — never split.
+        assert find_stable_prefix("scaffold") is None
+        assert find_stable_prefix("other") is None
+
+    def test_longest_registered_prefix_wins(self):
+        register_stable_prefix("scaffold")
+        register_stable_prefix("scaffold extended")
+        assert find_stable_prefix("scaffold extended tail") == "scaffold extended"
+
+    def test_lru_eviction_falls_back_safely(self):
+        from agent import prompt_cache_boundary
+
+        for index in range(prompt_cache_boundary._MAX_ENTRIES + 1):
+            register_stable_prefix(f"scaffold-{index} ")
+        assert find_stable_prefix("scaffold-0 volatile") is None
+        assert find_stable_prefix("scaffold-1 volatile") == "scaffold-1 "
+
+    def test_empty_prefix_never_registered(self):
+        register_stable_prefix("")
+        assert not is_registered_stable_prefix("")
+
+
+class TestRequestLocalSplit:
+    def test_volatile_tail_does_not_change_marked_prefix(self):
+        scaffold = "stable skill scaffold\n\n" + _SINGLE_SKILL_INSTRUCTION
+        register_stable_prefix(scaffold)
+
+        first = apply_anthropic_cache_control(
+            [{"role": "user", "content": scaffold + "ticket=one time=10:00"}]
+        )[0]["content"]
+        second = apply_anthropic_cache_control(
+            [{"role": "user", "content": scaffold + "ticket=two time=10:01"}]
+        )[0]["content"]
+
+        assert len(first) == len(second) == 2
+        assert first[0] == second[0]
+        assert first[0] == {"type": "text", "text": scaffold, "cache_control": MARKER}
+        assert "cache_control" not in first[1]
+        assert first[1]["text"] == "ticket=one time=10:00"
+        assert second[1]["text"] == "ticket=two time=10:01"
+
+    def test_unregistered_message_keeps_whole_block_layout(self):
+        content = "stable-looking scaffold\n\n" + _SINGLE_SKILL_INSTRUCTION + "tail"
+        marked = apply_anthropic_cache_control([{"role": "user", "content": content}])
+        assert marked[0]["content"] == [
+            {"type": "text", "text": content, "cache_control": MARKER}
+        ]
+
+    def test_assistant_string_matching_a_prefix_is_not_split(self):
+        register_stable_prefix("scaffold ")
+        marked = apply_anthropic_cache_control(
+            [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "scaffold reply"},
+            ]
+        )
+        assert marked[1]["content"] == [
+            {"type": "text", "text": "scaffold reply", "cache_control": MARKER}
+        ]
+
+    def test_canonical_message_stays_a_string_in_plan(self):
+        scaffold = "stable scaffold "
+        register_stable_prefix(scaffold)
+        original = scaffold + "volatile"
+        messages = [{"role": "user", "content": original}]
+
+        plan = build_prompt_cache_plan(messages, [], native_anthropic=True)
+
+        assert messages == [{"role": "user", "content": original}]
+        assert isinstance(plan.messages[0]["content"], list)
+        assert plan.messages[0]["content"][0]["cache_control"] == MARKER
+        assert "cache_control" not in plan.messages[0]["content"][1]
+
+    def test_strip_reconstructs_exact_string_and_redecorates_identically(self):
+        scaffold = "stable scaffold\n\n" + _SINGLE_SKILL_INSTRUCTION
+        register_stable_prefix(scaffold)
+        original = [{"role": "user", "content": scaffold + "ticket=one"}]
+
+        marked = apply_anthropic_cache_control(copy.deepcopy(original))
+        first_wire = copy.deepcopy(marked)
+        stripped = strip_anthropic_cache_control(marked)
+
+        assert stripped == original
+        assert apply_anthropic_cache_control(copy.deepcopy(stripped)) == first_wire
+
+    def test_strip_leaves_organic_two_part_user_content_structured(self):
+        organic = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "part one"},
+                    {"type": "text", "text": "part two"},
+                ],
+            }
+        ]
+        stripped = strip_anthropic_cache_control(copy.deepcopy(organic))
+        assert stripped == organic
+
+
+class TestRealBuilders:
+    def test_two_invocations_share_the_marked_scaffold(self, skills):
+        first = skill_commands.build_skill_invocation_message(
+            "/triage", user_instruction="ticket=one time=10:00"
+        )
+        second = skill_commands.build_skill_invocation_message(
+            "/triage", user_instruction="ticket=two time=10:01"
+        )
+
+        first_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}], native_anthropic=True
+        )[0]["content"]
+        second_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}], native_anthropic=True
+        )[0]["content"]
+
+        assert len(first_blocks) == len(second_blocks) == 2
+        assert first_blocks[0] == second_blocks[0]
+        assert first_blocks[0]["cache_control"] == MARKER
+        assert SKILL_BODY in first_blocks[0]["text"]
+        assert "ticket=one" not in first_blocks[0]["text"]
+        assert "cache_control" not in first_blocks[1]
+        assert first_blocks[1]["text"] == "ticket=one time=10:00"
+
+    def test_payload_quoting_the_marker_cannot_poison_the_stable_prefix(self, skills):
+        """The differentiator vs marker-search heuristics: a ticket that quotes
+        the instruction marker (e.g. a pasted agent transcript) must stay
+        entirely in the volatile tail, or two invocations stop sharing the
+        cached prefix."""
+        hostile = (
+            "ticket=one\n\n" + _SINGLE_SKILL_INSTRUCTION + "quoted transcript line"
+        )
+        benign = "ticket=two"
+
+        hostile_blocks = apply_anthropic_cache_control(
+            [
+                {
+                    "role": "user",
+                    "content": skill_commands.build_skill_invocation_message(
+                        "/triage", user_instruction=hostile
+                    ),
+                }
+            ]
+        )[0]["content"]
+        benign_blocks = apply_anthropic_cache_control(
+            [
+                {
+                    "role": "user",
+                    "content": skill_commands.build_skill_invocation_message(
+                        "/triage", user_instruction=benign
+                    ),
+                }
+            ]
+        )[0]["content"]
+
+        assert hostile_blocks[0] == benign_blocks[0]
+        assert hostile_blocks[1]["text"] == hostile
+        assert benign_blocks[1]["text"] == benign
+
+    def test_bare_invocation_keeps_whole_block_layout(self, skills):
+        message = skill_commands.build_skill_invocation_message("/triage")
+        blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": message}]
+        )[0]["content"]
+        assert blocks == [{"type": "text", "text": message, "cache_control": MARKER}]
+
+    def test_builder_round_trip_survives_failover_strip(self, skills):
+        original = [
+            {
+                "role": "user",
+                "content": skill_commands.build_skill_invocation_message(
+                    "/triage", user_instruction="ticket=one"
+                ),
+            }
+        ]
+        marked = apply_anthropic_cache_control(copy.deepcopy(original))
+        assert strip_anthropic_cache_control(marked) == original
+
+
+class TestCronBuilder:
+    def _prompts(self, jobs):
+        from cron.scheduler import _build_job_prompt
+
+        with patch(
+            "agent.skill_bundles.resolve_bundle_command_key", return_value=None
+        ), patch(
+            "tools.skills_tool.skill_view", side_effect=self._skill_view
+        ), patch(
+            "tools.skill_usage.bump_use"
+        ):
+            return [_build_job_prompt(job) for job in jobs]
+
+    @staticmethod
+    def _skill_view(name: str) -> str:
+        import json
+
+        if name == "missing":
+            return json.dumps({"success": False, "error": "missing"})
+        return json.dumps({"success": True, "content": f"Stable content for {name}."})
+
+    def test_cron_runs_share_the_marked_scaffold(self):
+        common = {"id": "job-cache", "name": "cache boundary", "skills": ["alpha", "beta"]}
+        first, second = self._prompts(
+            [
+                {**common, "prompt": "ticket=one time=10:00"},
+                {**common, "prompt": "ticket=two time=10:01"},
+            ]
+        )
+
+        first_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}]
+        )[0]["content"]
+        second_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}]
+        )[0]["content"]
+
+        assert isinstance(first, str) and isinstance(second, str)
+        assert len(first_blocks) == len(second_blocks) == 2
+        assert first_blocks[0] == second_blocks[0]
+        assert first_blocks[0]["cache_control"] == MARKER
+        assert "Stable content for alpha." in first_blocks[0]["text"]
+        assert "ticket=one" not in first_blocks[0]["text"]
+        assert first_blocks[1]["text"].endswith("ticket=one time=10:00")
+
+    def test_missing_skill_notice_stays_in_the_stable_prefix(self):
+        common = {"id": "job-skip", "name": "skip notice", "skills": ["missing", "alpha"]}
+        first, second = self._prompts(
+            [{**common, "prompt": "ticket=one"}, {**common, "prompt": "ticket=two"}]
+        )
+
+        first_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": first}]
+        )[0]["content"]
+        second_blocks = apply_anthropic_cache_control(
+            [{"role": "user", "content": second}]
+        )[0]["content"]
+
+        assert first_blocks[0] == second_blocks[0]
+        assert "could not be found" in first_blocks[0]["text"]
+        assert first_blocks[1]["text"].endswith("ticket=one")

--- a/tests/agent/test_prompt_cache_boundary.py
+++ b/tests/agent/test_prompt_cache_boundary.py
@@ -20,7 +20,6 @@ import tools.skills_tool as skills_tool
 from agent.prompt_cache_boundary import (
     clear_stable_prefixes,
     find_stable_prefix,
-    is_registered_stable_prefix,
     register_stable_prefix,
 )
 from agent.prompt_caching import (
@@ -87,7 +86,47 @@ class TestRegistry:
 
     def test_empty_prefix_never_registered(self):
         register_stable_prefix("")
-        assert not is_registered_stable_prefix("")
+        assert find_stable_prefix("anything") is None
+
+    def test_lookup_refreshes_the_entry_lru_position(self):
+        """A cron scaffold fired every minute must survive a burst of one-off
+        invocations; without the refresh it silently drops back to
+        whole-message caching while still being the hottest prefix."""
+        from agent import prompt_cache_boundary
+
+        register_stable_prefix("hot-scaffold ")
+        for index in range(prompt_cache_boundary._MAX_ENTRIES - 1):
+            register_stable_prefix(f"cold-{index} ")
+
+        assert find_stable_prefix("hot-scaffold volatile") == "hot-scaffold "
+
+        register_stable_prefix("newcomer ")
+
+        assert find_stable_prefix("hot-scaffold volatile") == "hot-scaffold "
+        assert find_stable_prefix("cold-0 volatile") is None
+
+    def test_total_byte_cap_evicts_oldest_and_keeps_newest(self, monkeypatch):
+        """Entries retain whole skill bodies, so the entry count alone does
+        not bound memory."""
+        from agent import prompt_cache_boundary
+
+        monkeypatch.setattr(prompt_cache_boundary, "_MAX_BYTES", 100)
+
+        register_stable_prefix("a" * 80)
+        register_stable_prefix("b" * 80)
+
+        assert find_stable_prefix("a" * 80 + "tail") is None
+        assert find_stable_prefix("b" * 80 + "tail") == "b" * 80
+
+    def test_single_oversized_prefix_still_registers(self, monkeypatch):
+        from agent import prompt_cache_boundary
+
+        monkeypatch.setattr(prompt_cache_boundary, "_MAX_BYTES", 10)
+        oversized = "x" * 500
+
+        register_stable_prefix(oversized)
+
+        assert find_stable_prefix(oversized + "tail") == oversized
 
 
 class TestRequestLocalSplit:
@@ -152,6 +191,25 @@ class TestRequestLocalSplit:
 
         assert stripped == original
         assert apply_anthropic_cache_control(copy.deepcopy(stripped)) == first_wire
+
+    def test_strip_flattens_even_after_the_prefix_was_evicted(self):
+        """Mid-turn failover re-decorates a request built many messages ago
+        (#72626). If flattening depended on the registry still holding the
+        entry, a busy gateway that registered _MAX_ENTRIES newer scaffolds in
+        between would ship the split shape to the next provider instead of
+        the canonical string."""
+        from agent import prompt_cache_boundary
+
+        scaffold = "stable scaffold\n\n" + _SINGLE_SKILL_INSTRUCTION
+        register_stable_prefix(scaffold)
+        original = [{"role": "user", "content": scaffold + "ticket=one"}]
+        marked = apply_anthropic_cache_control(copy.deepcopy(original))
+
+        for index in range(prompt_cache_boundary._MAX_ENTRIES + 1):
+            register_stable_prefix(f"unrelated-scaffold-{index} ")
+        assert find_stable_prefix(scaffold + "ticket=one") is None
+
+        assert strip_anthropic_cache_control(marked) == original
 
     def test_strip_leaves_organic_two_part_user_content_structured(self):
         organic = [


### PR DESCRIPTION
## Summary

Webhook/cron skill invocations no longer pay a full Anthropic cache write on every trigger: the message builders now declare the exact stable/volatile boundary at construction time, and the cache planner splits the user message request-locally into [marked stable scaffold, unmarked volatile tail].

Salvage of #82049 by @JoaoMarcos44 — both commits cherry-picked with authorship preserved, plus one review follow-up commit.

Closes #82049. Fixes #81867.

## Real-world impact

A production webhook route invoking a ~21K-char skill per helpdesk ticket (~683 invocations/24h, gaps well under the 5-min cache TTL) measured **identical cache_write_tokens on back-to-back calls 25s apart** — every invocation rewrote the whole block because a few volatile tail bytes (ticket ID, timestamp) invalidated the entire prefix. ~58% of that account's spend was cache writes. With the boundary declared, the scaffold block is byte-identical across invocations and cache reads take over.

## Why this approach (vs #81928 / #81929)

Both sibling PRs re-derive the boundary from the final string with `rfind(<instruction marker>)`. Reproduced empirically during review: when the volatile payload itself quotes the marker (a ticket pasting an agent transcript — exactly the issue's production scenario), `rfind` splits inside the payload and volatile bytes leak into the "stable" prefix — the cache miss silently returns. #81928 also misses cron skip-notice-led prompts (reproduced). #81929 is correct but rides a `str` subclass + sidecar key inside canonical conversation history; this PR keeps history bytes untouched — the registry is process-local, and any miss (restart, eviction, sanitizer mutation) falls back to today's whole-message policy.

## Changes

- `agent/prompt_cache_boundary.py` (new): thread-safe process-local LRU registry (32 entries / 4M chars) of builder-declared stable prefixes
- `agent/skill_commands.py`: `_build_skill_message` registers the scaffold boundary; new shared `append_user_instruction()` helper (review follow-up) so the boundary construction cannot drift between builders
- `cron/scheduler.py`: `_build_job_prompt` declares the boundary via the shared helper, registration guarded against injection-scanner mutations
- `agent/prompt_caching.py`: `_apply_cache_marker` splits registered user strings request-locally; `strip_anthropic_cache_control` flattens the split shape-based (registry-independent) and byte-exactly for mid-turn failover (#72626)
- `tests/agent/test_prompt_cache_boundary.py` (new, 21 tests): registry semantics, request-local split, failover round-trip incl. post-eviction, marker-quoting payload cannot poison the prefix, cron multi-skill/skip-notice shapes, helper byte-prefix contract

Review follow-up commit (on top of the cherry-picks): shared `append_user_instruction()` helper + stronger `startswith` registration guard at both sites, `_MAX_BYTES` → `_MAX_CHARS` rename (it counts characters), single-critical-section `find_stable_prefix`, split-shape-lifetime doc note, helper contract test (mutation-checked).

## Validation

| Check | Result |
|---|---|
| Targeted suites (16 files) on final stack | 315 passed, 0 failed |
| E2E (real builder → split → failover strip → hostile marker-quoting payload) | byte-exact, prefix shared, no poisoning |
| Mutation checks (helper marker drop; LRU-refresh removal) | guard tests fail as expected, restore green |
| ruff on touched files, `git diff --check` | clean |
| Perf probes | lookup 2–4µs full registry, 264ns empty; registration 10–11µs — noise |

Known scope limits (documented in module docstring): direct non-cron bundle invocations put the instruction before the skill blocks, so no stable prefix exists there (same for all three sibling PRs); in long interactive sessions the split shape flips once when the message rotates out of the marked-endpoint window — one-time re-ingest, doesn't affect the webhook/cron workload this fixes.

## Credit

Based on #82049 by @JoaoMarcos44 — commits cherry-picked with authorship preserved. #81928 (@embwl0x) and #81929 (@fangliquanflq) independently attacked the same issue and informed the comparison; closing those with credit.
