### PR TITLE
fix(mcp): defer hermes-tools startup discovery

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -45,6 +45,7 @@ Spawned by: CodexAppServerSession.ensure_started() when the runtime is
 from __future__ import annotations
 
 import inspect
+import importlib
 import json
 import logging
 import os
@@ -148,6 +149,59 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "kanban_link",
 )
 
+# These modules register every built-in tool that can appear in EXPOSED_TOOLS.
+# Importing them directly populates the registry without importing model_tools,
+# whose module-level discovery loads the entire Hermes tool catalog.
+MCP_TOOL_MODULES: tuple[str, ...] = (
+    "tools.web_tools",
+    "tools.browser_tool",
+    "tools.vision_tools",
+    "tools.image_generation_tool",
+    "tools.skills_tool",
+    "tools.tts_tool",
+    "tools.kanban_tools",
+)
+
+MCP_KANBAN_TOOLS = frozenset(
+    name for name in EXPOSED_TOOLS if name.startswith("kanban_")
+)
+
+
+def _load_mcp_tool_definitions() -> list[dict]:
+    """Load only the registry modules needed to build the MCP schema."""
+    from tools.registry import registry
+
+    for module_name in MCP_TOOL_MODULES:
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:
+            logger.warning("Could not import MCP tool module %s: %s", module_name, exc)
+
+    # Kanban availability is a cheap environment/profile gate. Keep it
+    # accurate, but do not run the cold dependency probes for browser, vision,
+    # image generation, or TTS while Codex is waiting for MCP initialization.
+    tool_names = set(EXPOSED_TOOLS)
+    check_results = {}
+    for name in MCP_KANBAN_TOOLS:
+        entry = registry.get_entry(name)
+        check_fn = entry.check_fn if entry is not None else None
+        if check_fn is None:
+            continue
+        if check_fn not in check_results:
+            try:
+                check_results[check_fn] = bool(check_fn())
+            except Exception as exc:
+                logger.debug("MCP Kanban availability check failed: %s", exc)
+                check_results[check_fn] = False
+        if not check_results[check_fn]:
+            tool_names.discard(name)
+
+    return registry.get_definitions(
+        tool_names,
+        quiet=True,
+        skip_check_fn=True,
+    )
+
 
 def _build_server() -> Any:
     """Create the FastMCP server with Hermes tools attached. Lazy imports
@@ -159,12 +213,6 @@ def _build_server() -> Any:
         raise ImportError(
             f"hermes-tools MCP server requires the 'mcp' package: {exc}"
         ) from exc
-
-    # Discover Hermes tools so dispatch works.
-    from model_tools import (
-        get_tool_definitions,
-        handle_function_call,
-    )
 
     mcp = FastMCP(
         "hermes-tools",
@@ -181,7 +229,7 @@ def _build_server() -> Any:
     # MCP clients see the same parameter docs Hermes gives the model.
     all_defs = {
         td["function"]["name"]: td["function"]
-        for td in (get_tool_definitions(quiet_mode=True) or [])
+        for td in (_load_mcp_tool_definitions() or [])
         if isinstance(td, dict) and td.get("type") == "function"
     }
 
@@ -208,6 +256,11 @@ def _build_server() -> Any:
 
             def _dispatch(**kwargs: Any) -> str:
                 try:
+                    # Keep the full dispatcher off the MCP startup path. It
+                    # imports every Hermes tool and plugin; the first real
+                    # tool call is the correct point to pay that cost.
+                    from model_tools import handle_function_call
+
                     # Filter out None values before dispatch so unset optionals
                     # aren't forwarded to the handler.
                     args = {k: v for k, v in kwargs.items() if v is not None}

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -107,6 +107,104 @@ class TestModuleSurface:
             f"because codex has built-in equivalents: {leaked}"
         )
 
+    def test_build_server_uses_mcp_scoped_tool_loading(self, monkeypatch):
+        """MCP startup must not assemble Hermes' full tool catalog."""
+        import sys
+        import types
+
+        import agent.transports.hermes_tools_mcp_server as m
+
+        calls = []
+
+        def fake_load_mcp_tool_definitions():
+            calls.append(True)
+            return [{
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }]
+
+        monkeypatch.setattr(m, "_load_mcp_tool_definitions", fake_load_mcp_tool_definitions)
+
+        class FakeFastMCP:
+            def __init__(self, *args, **kwargs):
+                self.tools = []
+
+            def add_tool(self, handler, *, name, description):
+                self.tools.append((name, description))
+
+        fake_fastmcp = types.ModuleType("mcp.server.fastmcp")
+        fake_fastmcp.FastMCP = FakeFastMCP
+        fake_server = types.ModuleType("mcp.server")
+        fake_server.fastmcp = fake_fastmcp
+        fake_mcp = types.ModuleType("mcp")
+        fake_mcp.server = fake_server
+        monkeypatch.setitem(sys.modules, "mcp", fake_mcp)
+        monkeypatch.setitem(sys.modules, "mcp.server", fake_server)
+        monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fake_fastmcp)
+
+        server = m._build_server()
+
+        assert calls == [True]
+        assert server.tools == [("web_search", "Search the web.")]
+
+    def test_build_server_defers_model_tools_until_first_call(self, monkeypatch):
+        """MCP build must avoid model_tools and load it only for dispatch."""
+        import sys
+        import types
+
+        import agent.transports.hermes_tools_mcp_server as m
+
+        monkeypatch.setattr(
+            m,
+            "_load_mcp_tool_definitions",
+            lambda: [{
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }],
+            raising=False,
+        )
+
+        fake_model_tools = types.ModuleType("model_tools")
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        class FakeFastMCP:
+            def __init__(self, *args, **kwargs):
+                self.tools = []
+                self.handlers = {}
+
+            def add_tool(self, handler, *, name, description):
+                self.tools.append((name, description))
+                self.handlers[name] = handler
+
+        fake_fastmcp = types.ModuleType("mcp.server.fastmcp")
+        fake_fastmcp.FastMCP = FakeFastMCP
+        fake_server = types.ModuleType("mcp.server")
+        fake_server.fastmcp = fake_fastmcp
+        fake_mcp = types.ModuleType("mcp")
+        fake_mcp.server = fake_server
+        monkeypatch.setitem(sys.modules, "mcp", fake_mcp)
+        monkeypatch.setitem(sys.modules, "mcp.server", fake_server)
+        monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fake_fastmcp)
+
+        server = m._build_server()
+        assert server.tools == [("web_search", "Search the web.")]
+        assert not hasattr(fake_model_tools, "handle_function_call")
+
+        fake_model_tools.handle_function_call = (
+            lambda tool_name, args: f"called:{tool_name}:{args}"
+        )
+        assert server.handlers["web_search"](query="hello") == (
+            "called:web_search:{'query': 'hello'}"
+        )
+
 
 
 

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -136,6 +136,27 @@ class TestGetDefinitions:
         assert len(defs) == 2
         assert calls["count"] == 1
 
+    def test_can_skip_check_fn_probes_for_schema_only_surfaces(self):
+        reg = ToolRegistry()
+        calls = {"count": 0}
+
+        def check_fn():
+            calls["count"] += 1
+            return False
+
+        reg.register(
+            name="cold_tool",
+            toolset="cold",
+            schema=_make_schema("cold_tool"),
+            handler=_dummy_handler,
+            check_fn=check_fn,
+        )
+
+        defs = reg.get_definitions({"cold_tool"}, skip_check_fn=True)
+
+        assert [d["function"]["name"] for d in defs] == ["cold_tool"]
+        assert calls["count"] == 0
+
 
 class TestUnknownToolDispatch:
     def test_returns_error_json(self):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -714,7 +714,12 @@ class ToolRegistry:
     # Schema retrieval
     # ------------------------------------------------------------------
 
-    def get_definitions(self, tool_names: Set[str], quiet: bool = False) -> List[dict]:
+    def get_definitions(
+        self,
+        tool_names: Set[str],
+        quiet: bool = False,
+        skip_check_fn: bool = False,
+    ) -> List[dict]:
         """Return OpenAI-format tool schemas for the requested tool names.
 
         Only tools whose ``check_fn()`` returns True (or have no check_fn)
@@ -724,6 +729,11 @@ class ToolRegistry:
         etc.); TTL chosen so env-var changes (``hermes tools enable foo``)
         still take effect in near-real-time without forcing a full cache
         flush on every call.
+
+        When ``skip_check_fn`` is True, return schemas without running
+        availability probes. This is for schema-only startup surfaces that
+        cannot block on cold optional dependencies; callers must keep normal
+        runtime availability handling on the execution path.
         """
         result = []
         # Per-call cache on top of the 30 s TTL — handles repeat probes of the
@@ -735,7 +745,7 @@ class ToolRegistry:
             entry = entries_by_name.get(name)
             if not entry:
                 continue
-            if entry.check_fn:
+            if entry.check_fn and not skip_check_fn:
                 if entry.check_fn not in check_results:
                     check_results[entry.check_fn] = _check_fn_cached(entry.check_fn)
                 if not check_results[entry.check_fn]:


### PR DESCRIPTION
Fixes #82424

## Summary

- Load only the seven built-in modules that provide the `hermes-tools` bridge surface.
- Avoid cold optional availability probes during MCP schema assembly while retaining the cheap Kanban scope gate.
- Lazy-import `model_tools.handle_function_call` until the first tool call.
- Add MCP and registry regression tests.

## Why

`model_tools` performs full built-in discovery at import time. The Codex `hermes-tools` bridge exposes 17 tools, so importing the full catalog delays MCP initialization and can trigger Codex's pending optional-server warning.

## Verification

- `scripts/run_tests.sh tests/agent/transports/ -q` — 241 passed.
- `scripts/run_tests.sh tests/agent/transports/test_hermes_tools_mcp_server.py tests/tools/test_registry.py -q` — 50 passed.
- `ruff check` on all changed files — passed.
- `git diff --check` — passed.
- Real stdio MCP `initialize` plus `tools/list` — 17 tools.
- Real `skills_list` call — passed.
- Three fresh `codex exec` launches — initialized `hermes-tools` without the pending/startup interruption message.

## Broader test note

The full CI-parity suite was attempted but stopped after unrelated provider-environment failures caused by the local test environment lacking the `anthropic` package and some provider credentials. The changed transport suite passed within that run.

## Platforms

Verified on macOS (Apple Silicon), Python 3.11, Codex CLI 0.147.0.

Related: #55005, #11115, #63626.
