### PR TITLE
fix(session): prevent stale titles from overwriting cross-surface renames

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3272,7 +3272,8 @@ class APIServerAdapter(BasePlatformAdapter):
     def _session_response(session: Dict[str, Any]) -> Dict[str, Any]:
         """Return a stable, client-safe session representation."""
         safe_keys = (
-            "id", "source", "user_id", "model", "title", "started_at", "ended_at",
+            "id", "source", "user_id", "model", "title", "title_changed_at",
+            "started_at", "ended_at",
             "end_reason", "message_count", "tool_call_count", "input_tokens",
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
@@ -3458,8 +3459,9 @@ class APIServerAdapter(BasePlatformAdapter):
                             )
                             return None, f"title:Title already in use by session {conflict['id']}"
                     conn.execute(
-                        "UPDATE sessions SET title = ? WHERE id = ?",
-                        (clean_title, session_id),
+                        "UPDATE sessions SET title = ?, title_changed_at = ? "
+                        "WHERE id = ?",
+                        (clean_title, _time.time(), session_id),
                     )
                 session_row = conn.execute(
                     "SELECT * FROM sessions WHERE id = ?", (session_id,)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6045,6 +6045,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if self._title_rank(current["title_source"]) >= new_rank:
                     return 0
 
+            changed_at = time.time()
             if title:
                 # Check uniqueness (allow the same session to keep its own title)
                 cursor = conn.execute(
@@ -6069,8 +6070,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         conn, ancestor_id=conflict_id, descendant_id=session_id
                     ):
                         conn.execute(
-                            "UPDATE sessions SET title = NULL WHERE id = ?",
-                            (conflict_id,),
+                            "UPDATE sessions SET title = NULL, title_changed_at = ? "
+                            "WHERE id = ?",
+                            (changed_at, conflict_id),
                         )
                     else:
                         raise ValueError(
@@ -6080,11 +6082,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # NULL-safe in SQLite), so a concurrent write between the SELECT
             # and here loses instead of being silently overwritten.
             cursor = conn.execute(
-                "UPDATE sessions SET title = ?, title_source = ? "
+                "UPDATE sessions SET title = ?, title_source = ?, "
+                "title_changed_at = ? "
                 "WHERE id = ? AND title IS ? AND title_source IS ?",
                 (
                     title,
                     source if title else None,
+                    changed_at,
                     session_id,
                     current["title"],
                     current["title_source"],
@@ -6852,7 +6856,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 merged = dict(s)
                 for key in (
                     "id", "ended_at", "end_reason", "message_count",
-                    "tool_call_count", "title", "last_active", "preview",
+                    "tool_call_count", "title", "title_changed_at", "last_active", "preview",
                     "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
                 ):
                     if key in tip_row:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -243,6 +243,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     pricing_version TEXT,
     title TEXT,
     title_source TEXT,
+    title_changed_at REAL,
     last_activity_at REAL,
     last_activity_description TEXT,
     last_activity_provenance TEXT,

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -840,7 +840,19 @@ class A2AAdapter(BasePlatformAdapter):
             return
         try:
             con = sqlite3.connect(db, timeout=5)
-            con.execute("UPDATE sessions SET title = ? WHERE id = ?", (title, session_id))
+            columns = {
+                row[1] for row in con.execute("PRAGMA table_info(sessions)").fetchall()
+            }
+            if "title_changed_at" in columns:
+                con.execute(
+                    "UPDATE sessions SET title = ?, title_changed_at = ? WHERE id = ?",
+                    (title, time.time(), session_id),
+                )
+            else:
+                con.execute(
+                    "UPDATE sessions SET title = ? WHERE id = ?",
+                    (title, session_id),
+                )
             con.commit()
             con.close()
         except Exception:

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -321,9 +321,11 @@ async def test_create_session_respects_browser_source_and_model_lock(adapter, se
 
     assert payload["session"]["source"] == "hermes_browser"
     assert payload["session"]["model"] == "x-ai/grok-4.5"
+    assert payload["session"]["title_changed_at"] is not None
     row = session_db.get_session("browser-lock-session")
     assert row["source"] == "hermes_browser"
     assert row["model"] == "x-ai/grok-4.5"
+    assert row["title_changed_at"] == payload["session"]["title_changed_at"]
     import json as _json
     model_config = row.get("model_config")
     if isinstance(model_config, str):

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1618,3 +1618,37 @@ print('fake reply')
         title = con.execute("SELECT title FROM sessions WHERE id='sess-1'").fetchone()[0]
         con.close()
         assert title == "a2a-dev-ctx-unsafe-value"
+
+    def test_title_forward_session_stamps_title_clock(self, monkeypatch, tmp_path):
+        import sqlite3
+
+        from plugins.platforms.a2a.adapter import A2AAdapter
+        from gateway.config import PlatformConfig
+
+        profile_home = tmp_path / "profile"
+        profile_home.mkdir()
+        db = profile_home / "state.db"
+        with sqlite3.connect(db) as con:
+            con.execute(
+                "CREATE TABLE sessions ("
+                "id TEXT PRIMARY KEY, title TEXT, title_changed_at REAL)"
+            )
+            con.execute(
+                "INSERT INTO sessions (id, title) VALUES (?, ?)",
+                ("sess-1", None),
+            )
+
+        monkeypatch.setattr(
+            "plugins.platforms.a2a.adapter._profile_home",
+            lambda profile: str(profile_home),
+        )
+        adapter = A2AAdapter(PlatformConfig(enabled=True))
+        adapter._title_forward_session("dev", "sess-1", "Forwarded")
+
+        with sqlite3.connect(db) as con:
+            title, title_changed_at = con.execute(
+                "SELECT title, title_changed_at FROM sessions WHERE id = ?",
+                ("sess-1",),
+            ).fetchone()
+        assert title == "Forwarded"
+        assert title_changed_at is not None

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1359,6 +1359,63 @@ class TestSessionTitle:
         session = db.get_session("s1")
         assert session["title"] == "My Session"
 
+    def test_title_mutations_use_a_dedicated_write_clock(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        with mock.patch.object(hermes_state.time, "time", return_value=100.0):
+            assert db.set_session_title("s1", "My Session") is True
+
+        session = db.get_session("s1")
+        assert session["title_changed_at"] == 100.0
+        assert session["last_activity_at"] is None
+
+        db.touch_session_activity("s1", ts=150.0)
+        session = db.get_session("s1")
+        assert session["title_changed_at"] == 100.0
+        assert session["last_activity_at"] == 150.0
+
+        with mock.patch.object(hermes_state.time, "time", return_value=200.0):
+            assert db.set_session_title("s1", "") is True
+
+        session = db.get_session("s1")
+        assert session["title"] is None
+        assert session["title_changed_at"] == 200.0
+
+    def test_auto_title_clocks_only_an_accepted_write(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        with mock.patch.object(hermes_state.time, "time", return_value=100.0):
+            assert db.set_auto_title_if_empty("s1", "Generated") is True
+
+        with mock.patch.object(hermes_state.time, "time", return_value=200.0):
+            assert db.set_auto_title_if_empty("s1", "Ignored") is False
+
+        session = db.get_session("s1")
+        assert session["title"] == "Generated"
+        assert session["title_changed_at"] == 100.0
+
+    def test_legacy_title_clock_is_null_until_the_next_title_write(self, tmp_path):
+        db_path = tmp_path / "legacy-title-clock.db"
+        with sqlite3.connect(db_path) as conn:
+            legacy_schema = SCHEMA_SQL.replace("    title_changed_at REAL,\n", "")
+            assert legacy_schema != SCHEMA_SQL
+            conn.executescript(legacy_schema)
+            conn.execute(
+                "INSERT INTO sessions "
+                "(id, source, started_at, title, title_source) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("legacy", "cli", 1.0, "Legacy title", "user"),
+            )
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened.get_session("legacy")["title_changed_at"] is None
+            with mock.patch.object(hermes_state.time, "time", return_value=300.0):
+                assert reopened.set_session_title("legacy", "Fresh title") is True
+            assert reopened.get_session("legacy")["title_changed_at"] == 300.0
+        finally:
+            reopened.close()
+
 
 
 
@@ -1463,10 +1520,13 @@ class TestSessionTitleLineage:
         db.set_session_title("tip", "fingerprint-scanner #2")
 
         # User renames the visible tip back to the base name — must succeed.
-        assert db.set_session_title("tip", "fingerprint-scanner") is True
+        with mock.patch.object(hermes_state.time, "time", return_value=500.0):
+            assert db.set_session_title("tip", "fingerprint-scanner") is True
         assert db.get_session("tip")["title"] == "fingerprint-scanner"
+        assert db.get_session("tip")["title_changed_at"] == 500.0
         # Title transferred off the hidden ancestor — no duplicate titles.
         assert db.get_session("root")["title"] is None
+        assert db.get_session("root")["title_changed_at"] == 500.0
 
 
     def test_unrelated_session_still_conflicts(self, db):


### PR DESCRIPTION
## What does this PR do?

Session titles now carry a dedicated write clock instead of forcing cross-surface clients to infer title freshness from general session activity. Without this clock, an ordinary message can make a stale `state.db` title appear newer than a title renamed in another surface, allowing the stale value to overwrite the newer rename.

The change adds a nullable `title_changed_at` field, stamps it atomically with every accepted title mutation, exposes it through the session API, and preserves compatibility with legacy databases.

## Related Issue

Fixes #82380

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_common.py` - add the nullable `sessions.title_changed_at` column through the existing declarative schema reconciliation path.
- `hermes_state.py` - stamp manual titles, automatic titles, clears, and compression-lineage transfers in the same transaction as the title write; project the tip clock for compressed sessions.
- `gateway/platforms/api_server.py` - stamp titles created through the session API and expose the clock in client-safe session responses.
- `plugins/platforms/a2a/adapter.py` - stamp forwarded-session title writes while retaining a fallback for legacy schemas that do not yet have the column.
- `tests/` - cover legacy migration, accepted and rejected title writes, clears, ordinary activity isolation, lineage transfer, API exposure, and A2A writes.

## How to Test

1. Open a legacy database whose `sessions` table has title fields but no `title_changed_at`; initialize `SessionDB` and verify that reconciliation adds the nullable column without inventing a timestamp for existing rows.
2. Write, auto-generate, clear, and transfer titles, then verify that accepted mutations advance `title_changed_at` while rejected automatic writes and `touch_session_activity()` do not.
3. Verify API session creation/list responses and A2A direct title writes expose or stamp the dedicated clock.
4. Run the focused regression tests:

```bash
scripts/run_tests.sh tests/test_hermes_state.py -k 'title_mutations_use_a_dedicated_write_clock or auto_title_clocks_only_an_accepted_write or legacy_title_clock_is_null_until_the_next_title_write or rename_continuation_back_to_base_transfers_title or schema_sql_is_source_of_truth'
scripts/run_tests.sh tests/gateway/test_session_api.py -k create_session_respects_browser_source_and_model_lock
scripts/run_tests.sh tests/plugins/test_a2a_plugin.py -k title_forward_session_stamps_title_clock
```

All 7 focused tests pass. Verification against disposable real-environment databases also confirmed schema reconciliation, isolated title clocks, API exposure, compression transfer, and modern/legacy A2A behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all 7 focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; this change exposes self-describing session metadata through the existing API
- [x] `cli-config.yaml.example` is N/A; no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no workflow or architecture policy changed
- [x] I've considered cross-platform impact; the schema and API behavior are platform-independent
- [x] Tool descriptions and schemas are N/A; no model tool behavior changed
