### PR TITLE
fix(state): isolate background reads from writer connection

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -45,7 +45,7 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, TypeVar, cast
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -3648,7 +3648,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return self._get_read_conn()
 
     @contextmanager
-    def _read_ctx(self):
+    def _read_ctx(self) -> Iterator[sqlite3.Connection]:
         """Yield a connection for read-only statements.
 
         WAL: a read-only connection borrowed from a bounded pool with NO
@@ -3691,7 +3691,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._close_read_conn(conn)
             return
         with self._lock:
-            yield self._conn
+            yield cast(sqlite3.Connection, self._conn)
 
     # ── Core write helper ──
 
@@ -6627,11 +6627,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not session_id:
             return None
         now = time.time()
-        row = self._conn.execute(
-            "SELECT holder FROM compression_locks "
-            "WHERE session_id = ? AND expires_at >= ?",
-            (session_id, now),
-        ).fetchone()
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT holder FROM compression_locks "
+                "WHERE session_id = ? AND expires_at >= ?",
+                (session_id, now),
+            ).fetchone()
         if row is None:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
@@ -6705,11 +6706,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # No-op fast path: skip the transaction when there is nothing to
         # clear. Read-only, no write lock.
         try:
-            row = self._conn.execute(
-                "SELECT last_activity_description, last_activity_provenance "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT last_activity_description, last_activity_provenance "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
         except sqlite3.Error:
             row = None
         if row is not None:
@@ -12829,12 +12831,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         no handoff record.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT handoff_state, handoff_platform, handoff_error "
-                "FROM sessions WHERE id = ?",
-                (session_id,),
-            )
-            row = cur.fetchone()
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT handoff_state, handoff_platform, handoff_error "
+                    "FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
             if not row:
                 return None
             return {
@@ -12851,15 +12853,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Used by the gateway's handoff watcher.
         """
         try:
-            cur = self._conn.execute(
-                "SELECT s.*, "
-                "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
-                "FROM sessions s "
-                "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
-                "WHERE s.handoff_state = 'pending' "
-                "ORDER BY s.started_at ASC"
-            )
-            return [self._session_row_dict(r) for r in cur.fetchall()]
+            with self._read_ctx() as conn:
+                rows = conn.execute(
+                    "SELECT s.*, "
+                    "COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
+                    "FROM sessions s "
+                    "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
+                    "WHERE s.handoff_state = 'pending' "
+                    "ORDER BY s.started_at ASC"
+                ).fetchall()
+            return [self._session_row_dict(r) for r in rows]
         except Exception:
             return []
 

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -81,6 +81,34 @@ def test_reads_do_not_take_writer_lock(db):
 
 
 
+@pytest.mark.requires_wal
+def test_background_state_reads_never_touch_shared_writer(db):
+    """Background pollers must not race transcript writes on ``_conn``."""
+    db.try_acquire_compression_lock("s1", "holder", ttl_seconds=60)
+    assert db.request_handoff("s1", "telegram") is True
+    # Open this thread's read connection before poisoning the shared writer.
+    assert db._get_read_conn() is not None
+
+    writer = db._conn
+
+    class PoisonWriter:
+        def execute(self, *_args, **_kwargs):
+            raise AssertionError("read touched shared writer connection")
+
+    db._conn = PoisonWriter()
+    try:
+        assert db.get_compression_lock_holder("s1") == "holder"
+        db.clear_session_activity_labels("s1")
+        assert db.get_handoff_state("s1") == {
+            "state": "pending",
+            "platform": "telegram",
+            "error": None,
+        }
+        assert [row["id"] for row in db.list_pending_handoffs()] == ["s1"]
+    finally:
+        db._conn = writer
+
+
 def test_read_your_writes(db):
     """A fresh committed write must be visible to the read connection."""
     db.append_message("s1", role="user", content="zanzibar checkpoint")


### PR DESCRIPTION
## Summary

- Route four read-only `SessionDB` paths through `_read_ctx()` instead of directly using the shared writer connection.
- Preserve per-thread WAL readers and the existing locked fallback for non-WAL/read-connection failures.
- Add a regression that poisons `_conn` and proves background state reads never touch it.

## Problem

`SessionDB._conn` is opened with `check_same_thread=False` and is shared by gateway worker threads. Most access is serialized by `self._lock`, but four production reads bypassed both `_read_ctx()` and the lock:

- `get_compression_lock_holder()`
- `clear_session_activity_labels()` fast path
- `get_handoff_state()`
- `list_pending_handoffs()`

The always-running handoff watcher calls `list_pending_handoffs()` through `AsyncSessionDB` every two seconds, while transcript appends prepare statements on the same writer connection.

CPython 3.11 releases the GIL around `sqlite3_prepare_v2()`. If one prepare fails while another thread successfully uses the same connection, the successful call can replace SQLite's connection-global error state before `_pysqlite_seterror()` reads it. CPython then returns NULL without a Python exception and surfaces:

```text
<hermes_cli.sqlite_safe_read.TrackedConnection object ...>
returned NULL without setting an exception
```

Hermes treats that as a session persistence failure and rolls back the turn. This was reproduced on Python 3.11.15 / SQLite 3.53.1 by concurrently preparing successful and failing statements on one `check_same_thread=False` connection.

This addresses the underlying shared-connection race rather than broadly retrying every `SystemError` as proposed in #77045.

## Fix

All four reads now use `_read_ctx()`:

- WAL: per-thread read-only connection, no writer contention.
- DELETE mode or read-connection failure: shared writer under `self._lock`.

An AST audit found no remaining production `self._conn` access outside initialization or methods holding `self._lock`; the private FTS probe is called only under its public maintenance methods' lock.

## Verification

- RED: new regression failed on current `main` with `AssertionError: read touched shared writer connection`.
- GREEN: regression passes after the fix.
- `295 passed` across state, FTS, write-lock, compression-lock, handoff, activity, and read-path suites.
- Stress check: 1,000 transcript writes with four concurrent background-reader threads; `0` errors.
- Ruff passed.
- Python compilation passed.
- `git diff --check` passed.
- Independent review found no security concerns or logic errors.

## Risk

Low. SQL, return shapes, and exception handling are unchanged. The only behavioral change is selecting the existing supported read path instead of unsafely sharing `_conn` across worker threads.
