### PR TITLE
build: enforce LF for source files via gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,21 @@ web/package-lock.json linguist-generated=true
 Dockerfile  text eol=lf
 *.dockerfile text eol=lf
 docker/entrypoint.sh text eol=lf
+
+# Enforce LF for source files. Without this, Windows checkouts silently
+# produce CRLF, which breaks Linux CI lint (whole-file diff noise on .py
+# and .ts) and byte-sensitive parsers. Text files are normalized to LF on
+# checkout regardless of the platform's core.autocrlf setting.
+*.py     text eol=lf
+*.ts     text eol=lf
+*.tsx    text eol=lf
+*.js     text eol=lf
+*.mjs    text eol=lf
+*.cjs    text eol=lf
+*.md     text eol=lf
+*.json   text eol=lf
+*.yaml   text eol=lf
+*.yml    text eol=lf
+*.toml   text eol=lf
+*.css    text eol=lf
+*.html   text eol=lf


### PR DESCRIPTION
Windows checkouts silently produce CRLF for files without an eol rule — the upstream file only covered `*.sh` and Dockerfiles. New .py/.ts/.md files authored on Windows land as CRLF, breaking Linux CI lint (whole-file diff noise) and byte-sensitive parsers. A recent doc pass had to manually sed 9 AGENTS.md files back to LF, and the repo carries 3580 working-tree files drifted to CRLF.

Add `text eol=lf` for every source extension (`*.py`, `*.ts`, `*.tsx`, `*.js`, `*.mjs`, `*.cjs`, `*.md`, `*.json`, `*.yaml`, `*.yml`, `*.toml`, `*.css`, `*.html`).

Checkouts normalize to LF on every platform regardless of `core.autocrlf`; already-committed blobs are unaffected (they are LF). This makes Windows contributions byte-identical to Linux CI expectations from the start — no more 'fix the line endings' follow-up commits on Windows-authored PRs.