### PR TITLE
fix(mcp): deliver events when a state.db commit lands within one mtime tick

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import re
+import sqlite3
 import sys
 import threading
 import time
@@ -333,6 +334,12 @@ class EventBridge:
         self._pending_approvals: Dict[str, dict] = {}
         # mtime cache — skip expensive work when state.db hasn't changed
         self._state_db_mtime: float = 0.0
+        # PRAGMA data_version watermark, sampled on the long-lived read-only
+        # connection below. Only comparable across samples from that ONE
+        # connection, so it is reset whenever the connection is reopened.
+        self._state_db_version: Optional[int] = None
+        self._state_watch_conn: Optional[sqlite3.Connection] = None
+        self._state_watch_identity: Optional[tuple[int, int]] = None
         self._cached_sessions_index: dict = {}
 
     def start(self):
@@ -357,6 +364,18 @@ class EventBridge:
         self._new_event.set()  # Wake any waiters
         if self._thread:
             self._thread.join(timeout=5)
+        # The polling thread is the only user of the watcher connection once it
+        # is running, so close it only when that thread has actually finished.
+        # A thread that outlived the join may still be inside _poll_once, and
+        # leaking a read-only descriptor until the process exits is cheaper
+        # than closing a connection out from under a live statement.
+        if self._thread is not None and self._thread.is_alive():
+            logger.warning(
+                "EventBridge: poll thread still running after stop(); "
+                "leaving the state.db watcher open"
+            )
+        else:
+            self._close_state_watch_conn()
         logger.debug("EventBridge stopped")
 
     def poll_events(
@@ -466,14 +485,11 @@ class EventBridge:
         except ImportError:
             db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
         try:
-            self._state_db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0
-        except OSError:
-            self._state_db_mtime = 0.0
-        try:
-            self._cached_sessions_index = _load_sessions_index()
+            entries = self._refresh_index_and_watermark(db_file)
         except Exception:
-            self._cached_sessions_index = {}
-        for session_key, entry in self._cached_sessions_index.items():
+            self._cached_sessions_index = entries = {}
+            self._state_db_mtime, self._state_db_version = self._sample_state_watermark(db_file)
+        for session_key, entry in entries.items():
             session_id = entry.get("session_id", "")
             if not session_id:
                 continue
@@ -486,6 +502,116 @@ class EventBridge:
                 latest = max(all_ts)
                 if latest > 0.0:
                     self._last_poll_timestamps[session_key] = latest
+
+    def _refresh_index_and_watermark(self, db_file: Path) -> dict:
+        """Refresh the routing index and record the watermark it has observed.
+
+        The stored watermark is sampled AFTER an index refresh, because that
+        refresh opens SessionDB, whose schema initialisation commits the first
+        time it runs against a database. A watermark taken before it would
+        record the bridge's own write as a peer's change and force a redundant
+        scan on the next tick.
+
+        Only one skew is dangerous: a watermark ahead of the index. A session
+        registered after the index query but before the sample would be absent
+        from the entries below AND already counted in the watermark, so every
+        later poll would take the confirmed-quiet skip and its first message
+        would wait for an unrelated commit — the dropped-new-conversation
+        shape (#8925) this poller exists to avoid. So when anything at all
+        committed while the index was being read, the index is read once more,
+        now that the watermark is fixed: that read sees everything committed
+        through it, and a commit landing afterwards moves the version again
+        and is picked up on the next poll. The opposite skew — index ahead of
+        the watermark — only ever costs one redundant scan.
+        """
+        before = self._sample_state_watermark(db_file)
+        entries = _load_sessions_index()
+        self._state_db_mtime, self._state_db_version = self._sample_state_watermark(db_file)
+        if (self._state_db_mtime, self._state_db_version) != before:
+            entries = _load_sessions_index()
+        self._cached_sessions_index = entries
+        return entries
+
+    def _close_state_watch_conn(self) -> None:
+        """Drop the watcher connection; the next sample reopens it."""
+        conn, self._state_watch_conn = self._state_watch_conn, None
+        self._state_watch_identity = None
+        if conn is None:
+            return
+        try:
+            conn.close()
+        except (sqlite3.Error, OSError) as exc:
+            logger.debug("EventBridge: closing state.db watcher failed: %s", exc)
+
+    def _sample_state_watermark(self, db_file: Path) -> tuple[float, Optional[int]]:
+        """Return the (mtime, data_version) pair state.db shows right now.
+
+        Both halves are taken at the same instant so the gate in _poll_once
+        compares like with like on the next tick; a missing file yields the
+        (0.0, None) "nothing to watch" pair.
+        """
+        try:
+            db_stat = db_file.stat()
+        except OSError:
+            self._close_state_watch_conn()
+            return 0.0, None
+        return db_stat.st_mtime, self._sample_state_db_version(db_file, db_stat)
+
+    def _sample_state_db_version(self, db_file: Path, db_stat) -> Optional[int]:
+        """Return state.db's PRAGMA data_version, or None when it can't be read.
+
+        data_version changes whenever ANOTHER connection commits, including WAL
+        commits that never touch the main file's mtime, so it answers the
+        question mtime cannot: has anything landed since the last sample?
+
+        The counter is per-connection, so samples are only comparable while the
+        same connection stays open. A replaced file (different st_dev/st_ino)
+        therefore closes the old connection and clears the watermark, which
+        makes the caller treat the database as changed.
+
+        None means "unknown" — the file is not a readable SQLite database, the
+        open failed, or the read raced a writer. Callers must scan on None
+        rather than assume the database is quiet.
+        """
+        identity = (db_stat.st_dev, db_stat.st_ino)
+        if self._state_watch_conn is not None and identity != self._state_watch_identity:
+            self._close_state_watch_conn()
+
+        if self._state_watch_conn is None:
+            try:
+                from hermes_cli.sqlite_safe_read import (
+                    UntrackableConnectionError,
+                    connect_tracked,
+                )
+            except ImportError as exc:
+                logger.debug("EventBridge: sqlite_safe_read unavailable: %s", exc)
+                return None
+            try:
+                # Tracked, so the byte-probe guard in sqlite_safe_read still
+                # holds; read-only and isolation_level=None, so watching takes
+                # no lock the gateway's writers could contend with.
+                conn = connect_tracked(
+                    f"file:{db_file}?mode=ro",
+                    tracking_path=db_file,
+                    uri=True,
+                    check_same_thread=False,
+                    isolation_level=None,
+                    timeout=1.0,
+                )
+            except (UntrackableConnectionError, sqlite3.Error, OSError) as exc:
+                logger.debug("EventBridge: state.db watcher open failed: %s", exc)
+                return None
+            self._state_watch_conn = conn
+            self._state_watch_identity = identity
+            self._state_db_version = None
+
+        try:
+            row = self._state_watch_conn.execute("PRAGMA data_version").fetchone()
+        except (sqlite3.Error, OSError) as exc:
+            logger.debug("EventBridge: state.db data_version unreadable: %s", exc)
+            self._close_state_watch_conn()
+            return None
+        return row[0] if row else None
 
     def _poll_loop(self):
         """Background loop: poll SessionDB for new messages."""
@@ -504,13 +630,19 @@ class EventBridge:
     def _poll_once(self, db):
         """Check for new messages across all sessions.
 
-        Uses a single mtime check on state.db to skip work when nothing
-        has changed — makes 200ms polling essentially free.  Since #9006
-        the routing index itself lives in state.db (session rows carry
-        session_key/origin metadata), so a new conversation and its first
-        message land in the SAME file and one mtime check covers both —
-        eliminating the old dual-file (sessions.json + state.db) race that
-        could drop brand-new conversations (#8925).
+        A cheap mtime check on state.db carries the common case — it makes
+        200ms polling essentially free.  Since #9006 the routing index itself
+        lives in state.db (session rows carry session_key/origin metadata), so
+        a new conversation and its first message land in the SAME file and one
+        check covers both — eliminating the old dual-file (sessions.json +
+        state.db) race that could drop brand-new conversations (#8925).
+
+        An unchanged mtime is not proof of an unchanged database: filesystem
+        timestamps tick on the coarse clock, so a commit landing in the same
+        tick as the previous stat leaves the mtime identical, and under WAL a
+        commit does not touch the main file at all until checkpoint. So the
+        database itself is asked, via PRAGMA data_version, before any poll is
+        skipped.
         """
         try:
             from hermes_constants import get_hermes_home
@@ -519,19 +651,32 @@ class EventBridge:
             db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
         try:
-            db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0
+            db_stat = db_file.stat()
         except OSError:
-            db_mtime = 0.0
+            db_stat = None
 
-        if db_mtime == self._state_db_mtime:
-            return  # Nothing changed since last poll — skip entirely
+        db_mtime = db_stat.st_mtime if db_stat is not None else 0.0
 
-        self._state_db_mtime = db_mtime
+        if db_stat is None:
+            # Nothing to watch: drop the connection and the watermark so a
+            # recreated state.db is sampled from scratch.
+            self._close_state_watch_conn()
+            self._state_db_version = None
+            if db_mtime == self._state_db_mtime:
+                return  # Still absent since last poll — skip entirely
+        elif db_mtime == self._state_db_mtime:
+            version = self._sample_state_db_version(db_file, db_stat)
+            # An unreadable version (None) leaves quiescence unconfirmed, so
+            # the scan below runs rather than risk dropping events.
+            if version is not None and version == self._state_db_version:
+                return  # Confirmed quiet since last poll — skip entirely
+
         # Refresh the routing index from state.db on every change tick —
         # it's a single indexed query and it can never lag the messages
-        # table (both live in the same database file).
-        self._cached_sessions_index = _load_sessions_index()
-        entries = self._cached_sessions_index
+        # table (both live in the same database file). The watermark is taken
+        # with it, so the index can never trail what the skip gate treats as
+        # already seen; see _refresh_index_and_watermark.
+        entries = self._refresh_index_and_watermark(db_file)
 
         for session_key, entry in entries.items():
             session_id = entry.get("session_id", "")

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -9,6 +9,7 @@ Three layers of tests:
 """
 
 import asyncio
+import contextlib
 import inspect
 import json
 import os
@@ -1055,6 +1056,111 @@ class TestEdgeCases:
 # 7. EVENT BRIDGE POLL LOOP E2E — real SQLite DB, mtime optimization
 # ---------------------------------------------------------------------------
 
+_POLL_SESSION_KEY = "agent:main:telegram:dm:poll_regression"
+
+
+@contextlib.contextmanager
+def _baselined_bridge(tmp_path, monkeypatch, session_id):
+    """Yield (bridge, db, db_path) for a bridge baselined over a real state.db.
+
+    The database holds one message and the routing index names one session, so
+    the bridge has recorded that session's latest timestamp and state.db's
+    watermark: anything committed afterwards is a genuinely new event.
+
+    Baselining opens the bridge's read-only watcher connection, so the whole
+    test body runs inside this manager and stop() closes it however the test
+    ends.
+    """
+    import mcp_serve
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+    (sessions_dir / "sessions.json").write_text(json.dumps({
+        _POLL_SESSION_KEY: {
+            "session_key": _POLL_SESSION_KEY,
+            "session_id": session_id,
+            "platform": "telegram",
+            "updated_at": "2026-03-29T15:00:01",
+            "origin": {"platform": "telegram", "chat_id": "poll_regression"},
+        }
+    }))
+
+    db_path = tmp_path / "state.db"
+    _create_test_db(db_path, session_id, [
+        {"role": "user", "content": "baselined", "timestamp": "2026-03-29T15:00:01"},
+    ])
+
+    class CountingDB:
+        def __init__(self):
+            self.call_count = 0
+
+        def get_messages(self, sid):
+            self.call_count += 1
+            conn = sqlite3.connect(str(db_path))
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                (sid,),
+            ).fetchall()
+            conn.close()
+            return [dict(r) for r in rows]
+
+    db = CountingDB()
+    monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: db)
+
+    bridge = mcp_serve.EventBridge()
+    bridge._establish_baseline()
+    try:
+        yield bridge, db, db_path
+    finally:
+        bridge.stop()
+
+
+def _commit_reply(db_path, session_id, content, conn=None):
+    """Commit one message through a connection other than the bridge's."""
+    writer = conn if conn is not None else sqlite3.connect(str(db_path))
+    try:
+        writer.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_id, "assistant", content, "2026-03-29T15:00:09"),
+        )
+        writer.commit()
+    finally:
+        if conn is None:
+            writer.close()
+
+
+def _messages_in_main_db_file(db_path, tmp_path, session_id):
+    """Return the message contents readable from state.db's main file alone.
+
+    The file is copied WITHOUT its -wal sidecar, so a commit still parked in
+    the write-ahead log is invisible here while the live database still
+    serves it — which is what makes "not yet checkpointed" an assertion rather
+    than an assumption.
+    """
+    main_only = tmp_path / "state-main-file-only.db"
+    main_only.write_bytes(db_path.read_bytes())
+    conn = sqlite3.connect(str(main_only))
+    try:
+        return [row[0] for row in conn.execute(
+            "SELECT content FROM messages WHERE session_id = ? ORDER BY id",
+            (session_id,),
+        )]
+    finally:
+        conn.close()
+
+
+def _pin_mtime(db_path, stat_result):
+    """Restore db_path's timestamps to stat_result, to the nanosecond.
+
+    Reproduces what a coarse filesystem clock does on its own — leave the mtime
+    byte-identical across a commit — without depending on the granularity of
+    the clock the tests happen to run on.
+    """
+    os.utime(db_path, ns=(stat_result.st_atime_ns, stat_result.st_mtime_ns))
+
+
 class TestEventBridgePollE2E:
     """End-to-end tests for the EventBridge polling loop with real files."""
 
@@ -1380,6 +1486,94 @@ class TestEventBridgePollE2E:
         assert len(events) == 1
         assert events[0]["session_key"] == "agent:main:telegram:dm:fresh"
         assert events[0]["content"] == "hello after baseline"
+
+    def test_poll_delivers_commit_landing_within_one_mtime_tick(self, tmp_path, monkeypatch):
+        """A commit whose mtime is indistinguishable from the previous poll's
+        must still be delivered.
+
+        File timestamps tick on the coarse clock, so a commit landing in the
+        same tick as the last stat leaves state.db's mtime byte-identical. The
+        mtime is restored to the baselined value so that condition holds on any
+        clock granularity instead of by timing luck.
+        """
+        session_id = "20260329_150000_same_tick"
+        with _baselined_bridge(tmp_path, monkeypatch, session_id) as (bridge, db, db_path):
+            baseline_stat = db_path.stat()
+            assert bridge._state_db_mtime == baseline_stat.st_mtime
+
+            _commit_reply(db_path, session_id, "same-tick reply")
+            _pin_mtime(db_path, baseline_stat)
+            assert db_path.stat().st_mtime == bridge._state_db_mtime
+
+            bridge._poll_once(db)
+            events = bridge.poll_events(after_cursor=0)["events"]
+
+        assert [e["content"] for e in events] == ["same-tick reply"]
+
+    def test_poll_delivers_wal_commit_parked_before_checkpoint(self, tmp_path, monkeypatch):
+        """A WAL commit must be delivered before anything checkpoints it.
+
+        In WAL mode the commit lands in state.db-wal and the main file is left
+        alone until checkpoint, so its mtime cannot report the write.
+        Autocheckpointing is off and the writer connection stays open across
+        the poll, and the test proves the commit is still parked rather than
+        assuming it: the row is readable from the live database and absent from
+        the main file on its own.
+        """
+        session_id = "20260329_150000_wal_commit"
+        with _baselined_bridge(tmp_path, monkeypatch, session_id) as (bridge, db, db_path):
+            baseline_stat = db_path.stat()
+
+            writer = sqlite3.connect(str(db_path))
+            try:
+                # Switching journal mode rewrites the main file's header; the
+                # pin below puts its mtime back to the value the bridge
+                # baselined, so only the WAL commit is left for the poll to
+                # notice.
+                assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+                writer.execute("PRAGMA wal_autocheckpoint=0")
+                _commit_reply(db_path, session_id, "wal reply", conn=writer)
+
+                assert "wal reply" in [m["content"] for m in db.get_messages(session_id)]
+                assert "wal reply" not in _messages_in_main_db_file(
+                    db_path, tmp_path, session_id)
+
+                _pin_mtime(db_path, baseline_stat)
+                assert db_path.stat().st_mtime == bridge._state_db_mtime
+
+                bridge._poll_once(db)
+                events = bridge.poll_events(after_cursor=0)["events"]
+            finally:
+                writer.close()
+
+        assert [e["content"] for e in events] == ["wal reply"]
+
+    def test_poll_after_delivery_skips_when_nothing_committed(self, tmp_path, monkeypatch):
+        """Confirming quiescence must stay as cheap as the old mtime check.
+
+        Both polls see the same pinned mtime, so the skip can only come from
+        the database itself reporting no commit — not from a timestamp that
+        happened to move.
+        """
+        session_id = "20260329_150000_quiet_after"
+        with _baselined_bridge(tmp_path, monkeypatch, session_id) as (bridge, db, db_path):
+            baseline_stat = db_path.stat()
+
+            _commit_reply(db_path, session_id, "delivered reply")
+            _pin_mtime(db_path, baseline_stat)
+
+            bridge._poll_once(db)
+            assert bridge.poll_events(after_cursor=0)["events"]
+            delivered_calls = db.call_count
+            assert delivered_calls >= 1
+
+            # Nothing commits between the two polls.
+            _pin_mtime(db_path, baseline_stat)
+            assert db_path.stat().st_mtime == bridge._state_db_mtime
+            bridge._poll_once(db)
+
+        assert db.call_count == delivered_calls, \
+            "A poll over a confirmed-quiet state.db must not read messages"
 
     def test_poll_interval_is_200ms(self):
         """Verify the poll interval constant."""


### PR DESCRIPTION
Fixes #82433.

## What

`EventBridge._poll_once` skips all scanning whenever `state.db`'s `st_mtime` equals the cached value. That gate misses two classes of real commits:

- **Same-tick commits.** Kernel file timestamps come from the coarse clock (granularity = timer tick, typically 1–4 ms), so a commit landing in the same tick as the previously-statted mtime leaves `st_mtime` (and `st_mtime_ns`) byte-identical. The poller skips, and the message is delivered only when a later unrelated write bumps the mtime — never, if the conversation goes quiet.
- **WAL commits.** `SessionDB` defaults to `journal_mode=WAL`, where a commit appends to `state.db-wal` and does not touch the main file until checkpoint.

This is also why `tests/test_mcp_serve.py::TestEventBridgePollE2E::test_startup_baseline_suppresses_historical_replay` and `::test_new_conversation_after_baseline_is_delivered` fail deterministically on fast machines (`write_text` → baseline stat → `os.utime(path, None)` all inside one tick — observed baseline mtime `…465.2518728` == post-utime mtime `…465.2518728` → zero events) while GitHub-hosted runners pass on tick luck. Related flake report: #75955 is the *other* known source of instability in this area; this one is independent of it.

## Why

The mtime check is a one-sided signal: a changed mtime proves change, but an unchanged mtime proves nothing inside the clock tick, and proves nothing about WAL state at any time.

## How

Keep the mtime fast-path. When mtime alone says "unchanged", ask the database itself via `PRAGMA data_version` on a bridge-owned, long-lived, read-only connection (`file:…?mode=ro`, `uri=True`, `check_same_thread=False` — baseline and poll run on different threads — `isolation_level=None`, opened through `connect_tracked` so `sqlite_safe_read`'s byte-probe protection holds). `data_version` moves on this connection whenever *another* connection commits — independent of filesystem timestamps, and it sees WAL commits before checkpoint.

- mtime changed → scan, as before.
- mtime unchanged → `data_version` unchanged → skip. Idle polls stay ~free: one `stat` + one PRAGMA read.
- mtime unchanged → `data_version` moved or unreadable → scan (an unreadable version leaves quiescence unconfirmed; scanning is the safe direction).
- Values are never compared across connections: an `(st_dev, st_ino)` change closes the watcher, reopens, and forces a scan.
- The watermark is sampled around the routing-index refresh with one bounded re-read when a commit races the refresh, so a brand-new session registered mid-refresh cannot be absorbed by the watermark (the #8925 dropped-conversation shape).
- `stop()` closes the watcher only after the poll thread has actually finished.

Why the PRAGMA cannot ride SessionDB's own connection: `data_version` is per-connection; `_load_sessions_index_from_db` opens and closes a fresh `SessionDB` per call; and `_poll_once` is driven in tests by duck-typed fakes exposing only `get_messages`.

One interaction disclosed rather than left for a reviewer to find: the watcher is a live tracked connection, so `sqlite_safe_read`'s same-process byte probes on `state.db` (`is_zeroed_state_db()`, `_backup_db_file()`'s raw copy) refuse while it is open. Startup ordering is unaffected, and a zeroed `state.db` self-heals within one poll (the PRAGMA fails and the watcher closes).

## How to test

`tests/test_mcp_serve.py` gains three deterministic regressions (red on current `main`, green with the fix, stable under a stat-truncating shim that forces whole-second timestamps):

- a peer commit whose `state.db` mtime is pinned byte-identical (`os.utime(..., ns=…)`) to the cached stat is still delivered;
- a WAL commit parked before any checkpoint (`wal_autocheckpoint=0`; asserted absent from the main db file, visible through the live db) is still delivered;
- after a delivering poll, a quiet second poll performs zero `get_messages` calls — through the real `data_version` path on a real SQLite db, not timestamp luck.

Full file: 91 passed. Existing `TestEventBridgePollE2E` tests unchanged and green.

## Platforms tested

Linux (python:3.11 container, `uv sync --locked --extra all --extra dev`); the defect and fix are platform-generic (coarse timestamps exist on every OS; macOS/WSL2 equally exposed).
