### PR TITLE
i18n: localize 17 gateway media-context notes via agent.i18n.t()

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2798,19 +2798,20 @@ def _build_document_context_note(display_name: str, agent_path: str, mtype: str)
     wording ("Ask the user what they'd like you to do with it") steered the
     model into punting back to the user, which is why attached PDFs/DOCX looked
     "unreadable" to the agent even though it has the tools to read them.
+
+    The note is translated through :func:`agent.i18n.t` so the LLM receives
+    it in the user's active language instead of always-English.
     """
     if mtype.startswith("text/"):
-        return (
-            f"[The user sent a text document: '{display_name}'. "
-            f"Its content has been included below. "
-            f"The file is also saved at: {agent_path}]"
+        return t(
+            "gateway.media.doc_text_note",
+            name=display_name,
+            path=agent_path,
         )
-    return (
-        f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
-        f"Its text is not inlined here (it's a binary format such as PDF or DOCX). "
-        f"To read it, extract the document's text yourself — for example with the "
-        f"terminal tool or the ocr-and-documents skill — before answering, instead "
-        f"of asking the user to paste the contents.]"
+    return t(
+        "gateway.media.doc_binary_note",
+        name=display_name,
+        path=agent_path,
     )
 
 
@@ -16360,14 +16361,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _display = _parts[2] if len(_parts) >= 3 else _basename
                 _display = re.sub(r'[^\w.\- ]', '_', _display)
                 _agent_path = _to_agent_path(_apath)
-                _note = (
-                    f"[The user sent an audio file attachment: '{_display}'. "
-                    f"It is saved at: {_agent_path}. "
-                    f"Its content is not inlined here. If the user's request involves "
-                    f"what the audio contains, transcribe or process it yourself — for "
-                    f"example by passing the path to a transcription or media tool — "
-                    f"instead of asking the user to describe it. Only ask what to do "
-                    f"with it if their intent is genuinely unclear.]"
+                _note = t(
+                    "gateway.media.audio_attachment_note",
+                    name=_display,
+                    path=_agent_path,
                 )
                 message_text = f"{_note}\n\n{message_text}"
 
@@ -16379,14 +16376,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _display = _parts[2] if len(_parts) >= 3 else _basename
                 _display = re.sub(r'[^\w.\- ]', '_', _display)
                 _agent_path = _to_agent_path(_vpath)
-                _note = (
-                    f"[The user sent a video attachment: '{_display}'. "
-                    f"It is saved at: {_agent_path}. "
-                    f"Its content is not inlined here. If the user's request involves "
-                    f"what the video contains, inspect or process it yourself — for "
-                    f"example by passing the path to a video analysis or media tool — "
-                    f"instead of asking the user to describe it. Only ask what to do "
-                    f"with it if their intent is genuinely unclear.]"
+                _note = t(
+                    "gateway.media.video_attachment_note",
+                    name=_display,
+                    path=_agent_path,
                 )
                 message_text = f"{_note}\n\n{message_text}"
 
@@ -22106,22 +22099,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     description = result.get("analysis", "")
                     description = sanitize_context(description)
                     enriched_parts.append(
-                        f"[The user sent an image~ Here's what I can see:\n{description}]\n"
-                        f"[If you need a closer look, use vision_analyze with "
-                        f"image_url: {path} ~]"
+                        t(
+                            "gateway.media.image_seen",
+                            description=description,
+                            path=path,
+                        )
                     )
                 else:
                     enriched_parts.append(
-                        "[The user sent an image but I couldn't quite see it "
-                        "this time (>_<) You can try looking at it yourself "
-                        f"with vision_analyze using image_url: {path}]"
+                        t("gateway.media.image_blurry", path=path)
                     )
             except Exception as e:
                 logger.error("Vision auto-analysis error: %s", e)
                 enriched_parts.append(
-                    f"[The user sent an image but something went wrong when I "
-                    f"tried to look at it~ You can try examining it yourself "
-                    f"with vision_analyze using image_url: {path}]"
+                    t("gateway.media.image_error", path=path)
                 )
 
         # Combine: vision descriptions first, then the user's original text
@@ -22163,14 +22154,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 duration_str = await _probe_audio_duration(abs_path)
                 if duration_str:
                     notes.append(
-                        f"[The user sent a voice message: {abs_path} (duration: {duration_str})]"
+                        t(
+                            "gateway.media.voice_disabled_with_duration",
+                            path=abs_path,
+                            duration=duration_str,
+                        )
                     )
                 else:
-                    notes.append(f"[The user sent a voice message: {abs_path}]")
+                    notes.append(
+                        t("gateway.media.voice_disabled_no_duration", path=abs_path)
+                    )
             if not notes:
                 return user_text, []
             prefix = "\n\n".join(notes)
-            _placeholder = "(The user sent a message with no text content)"
+            _placeholder = t("gateway.media.empty_placeholder")
             if user_text and user_text.strip() == _placeholder:
                 return prefix, []
             if user_text:
@@ -22184,8 +22181,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except ModuleNotFoundError as e:
             logger.error("Transcription module unavailable: %s", e)
-            unavailable_note = "[voice message could not be transcribed]"
-            _placeholder = "(The user sent a message with no text content)"
+            unavailable_note = t("gateway.media.voice_transcribe_unavailable")
+            _placeholder = t("gateway.media.empty_placeholder")
             if user_text and user_text.strip() == _placeholder:
                 return unavailable_note, []
             if user_text:
@@ -22218,10 +22215,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # clear sentinel note instead (#41603).
                     if not (transcript or "").strip():
                         enriched_parts.append(
-                            "[The user sent a voice message but it came through "
-                            "empty or inaudible — speech-to-text returned no "
-                            "words. Do not guess at the content; ask the user "
-                            "to resend or type it out.]"
+                            t("gateway.media.voice_empty_transcript")
                         )
                         continue
                     successful_transcripts.append(transcript)
@@ -22247,8 +22241,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                     agent_path = to_agent_visible_cache_path(os.path.abspath(path))
                     enriched_parts.append(
-                        "[voice message could not be transcribed automatically; "
-                        f"the audio is available at: {agent_path}]"
+                        t("gateway.media.voice_transcribe_error", path=agent_path)
                     )
             except Exception as e:
                 logger.error("Transcription error: %s", e)
@@ -22256,15 +22249,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 agent_path = to_agent_visible_cache_path(os.path.abspath(path))
                 enriched_parts.append(
-                    "[voice message could not be transcribed automatically; "
-                    f"the audio is available at: {agent_path}]"
+                    t("gateway.media.voice_transcribe_error", path=agent_path)
                 )
 
         if enriched_parts:
             prefix = "\n\n".join(enriched_parts)
             # Strip the empty-content placeholder from the Discord adapter
             # when we successfully transcribed the audio — it's redundant.
-            _placeholder = "(The user sent a message with no text content)"
+            _placeholder = t("gateway.media.empty_placeholder")
             if user_text and user_text.strip() == _placeholder:
                 return prefix, successful_transcripts
             if user_text:

--- a/gateway/sticker_cache.py
+++ b/gateway/sticker_cache.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 from typing import Optional
 
+from agent.i18n import t
 from hermes_cli.config import get_hermes_home
 
 
@@ -100,8 +101,10 @@ def build_sticker_injection(
     """
     Build the warm-style injection text for a sticker description.
 
-    Returns a string like:
-      [The user sent a sticker 😀 from "MyPack"~ It shows: "A cat waving" (=^.w.^=)]
+    Returns a localized string rendered in the active i18n language
+    (see :mod:`agent.i18n`).  English example::
+
+        [The user sent a sticker 😀 from "MyPack"~ It shows: "A cat waving" (=^.w.^=)]
     """
     context = ""
     if set_name and emoji:
@@ -109,7 +112,11 @@ def build_sticker_injection(
     elif emoji:
         context = f" {emoji}"
 
-    return f"[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    return t(
+        "gateway.media.sticker",
+        context=context,
+        description=description,
+    )
 
 
 def build_animated_sticker_injection(emoji: str = "") -> str:
@@ -117,8 +124,5 @@ def build_animated_sticker_injection(emoji: str = "") -> str:
     Build injection text for animated/video stickers we can't analyze.
     """
     if emoji:
-        return (
-            f"[The user sent an animated sticker {emoji}~ "
-            f"I can't see animated ones yet, but the emoji suggests: {emoji}]"
-        )
-    return "[The user sent an animated sticker~ I can't see animated ones yet]"
+        return t("gateway.media.animated_sticker_emoji", emoji=emoji)
+    return t("gateway.media.animated_sticker_no_emoji")

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**Hoe /voice werk**\n• `/voice on` — stemantwoord wanneer jy 'n stemboodskap stuur\n• `/voice tts` — stemantwoord op *elke* boodskap\n• `/voice off` — terug na slegs-teks antwoorde\n• `/voice status` — wys die huidige modus\n• `/voice` (geen argument) — wissel vinnig tussen aan en af{channels}"
     help_channels:         "\n\n**Lewendige stemkanale (Discord)**\n• Sluit eers by 'n stemkanaal aan, dan `/voice channel` — ek sluit aan, luister en praat my antwoorde\n• `/voice leave` — ontkoppel van die stemkanaal"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ YOLO-modus **AF** vir hierdie sessie — gevaarlike opdragte sal goedkeuring vereis."
     enabled:                    "⚡ YOLO-modus **AAN** vir hierdie sessie — alle opdragte word outomaties goedgekeur. Gebruik versigtig."

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -431,6 +431,27 @@ gateway:
     help:                  "{toggle}\n\n**كيف يعمل /voice**\n• `/voice on` — رد صوتي عند إرسال رسالة صوتية\n• `/voice tts` — رد صوتي على *كل* رسالة\n• `/voice off` — العودة إلى ردود نصّية فقط\n• `/voice status` — عرض الوضع الحالي\n• `/voice` (بدون وسيط) — تبديل سريع بين التفعيل والتعطيل{channels}"
     help_channels:         "\n\n**قنوات الصوت الحيّة (Discord)**\n• انضمّ إلى قناة صوتية أولًا، ثم `/voice channel` — سأنضمّ وأستمع وأنطق ردودي\n• `/voice leave` — قطع الاتصال بالقناة الصوتية"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ وضع YOLO **مُعطّل** لهذه الجلسة — ستتطلّب الأوامر الخطيرة موافقة."
     enabled:                    "⚡ وضع YOLO **مُفعّل** لهذه الجلسة — كل الأوامر مُوافق عليها تلقائيًا. استخدمه بحذر."

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**So funktioniert /voice**\n• `/voice on` — Sprachantwort, wenn du eine Sprachnachricht sendest\n• `/voice tts` — Sprachantwort auf *jede* Nachricht\n• `/voice off` — zurück zu reinen Textantworten\n• `/voice status` — aktuellen Modus anzeigen\n• `/voice` (ohne Argument) — schnelles Umschalten zwischen an und aus{channels}"
     help_channels:         "\n\n**Live-Sprachkanäle (Discord)**\n• Tritt zuerst einem Sprachkanal bei, dann `/voice channel` — ich trete bei, höre zu und spreche meine Antworten\n• `/voice leave` — vom Sprachkanal trennen"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ YOLO-Modus für diese Sitzung **AUS** — gefährliche Befehle benötigen eine Genehmigung."
     enabled:                    "⚡ YOLO-Modus für diese Sitzung **AN** — alle Befehle werden automatisch genehmigt. Mit Vorsicht verwenden."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -442,6 +442,58 @@ gateway:
     help:                  "{toggle}\n\n**How /voice works**\n• `/voice on` — voice reply when you send a voice message\n• `/voice tts` — voice reply to *every* message\n• `/voice off` — back to text-only replies\n• `/voice status` — show the current mode\n• `/voice` (no argument) — quick toggle between on and off{channels}"
     help_channels:         "\n\n**Live voice channels (Discord)**\n• Join a voice channel first, then `/voice channel` — I'll join, listen, and speak my replies\n• `/voice leave` — disconnect from the voice channel"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language; before this PR they were always English, which biased
+    # the reply language and forced an out-of-place English system message
+    # above the user's actual content.
+    #
+    # Catalog parity is enforced by tests/agent/test_i18n.py -- every key here
+    # must exist in every other locale file with the same placeholders.
+    # Placeholder names ({name}, {path}, {description}, ...) must match the
+    # keys the Python code passes via str.format.
+    #
+    # ---- text/* and binary documents ----
+    # text/* documents have content inlined by the platform adapter -- the
+    # note just confirms that and records the path.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    # binary documents (PDF, DOCX, XLSX, ...) can't be inlined as text. The
+    # note explicitly tells the agent to *extract* the text itself, which
+    # fixes the historical "attached PDF looks unreadable" failure mode
+    # where the model used to punt back to the user.
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    # ---- audio / video file attachments ----
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    # ---- image auto-vision ----
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    # ---- voice (stt disabled) ----
+    # Split into two so the path can be either with or without the probed
+    # duration, without forcing two separate catalog keys per language.
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    # ---- voice transcription results ----
+    # STT returned success=True with empty/whitespace transcript on silence
+    # or inaudible audio. The note tells the agent not to hallucinate.
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    # The transcription module couldn't even be imported (very rare).
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    # STT provider ran and failed (no provider, bad key, network error, ...).
+    # Keep the message neutral -- the cause is logged but not surfaced, to
+    # avoid the LLM volunteering stale setup advice on every later turn.
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    # ---- placeholder text from platforms that emit a no-caption sentinel ----
+    empty_placeholder:    "(The user sent a message with no text content)"
+    # ---- stickers (Telegram) ----
+    # {context} is pre-formatted in Python as " <emoji> from \"<set>\"",
+    # " <emoji>", or "" depending on what metadata the sticker carried.
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ YOLO mode **OFF** for this session — dangerous commands will require approval."
     enabled:                    "⚡ YOLO mode **ON** for this session — all commands auto-approved. Use with caution."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -426,6 +426,27 @@ gateway:
     help:                  "{toggle}\n\n**Cómo funciona /voice**\n• `/voice on` — respuesta de voz cuando envías un mensaje de voz\n• `/voice tts` — respuesta de voz a *cada* mensaje\n• `/voice off` — volver a respuestas solo de texto\n• `/voice status` — mostrar el modo actual\n• `/voice` (sin argumento) — alternar rápido entre activado y desactivado{channels}"
     help_channels:         "\n\n**Canales de voz en vivo (Discord)**\n• Únete primero a un canal de voz, luego `/voice channel` — me uno, escucho y digo mis respuestas\n• `/voice leave` — desconectar del canal de voz"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ Modo YOLO **DESACTIVADO** en esta sesión — los comandos peligrosos requerirán aprobación."
     enabled:                    "⚡ Modo YOLO **ACTIVADO** en esta sesión — todos los comandos se aprueban automáticamente. Úsalo con precaución."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**Comment fonctionne /voice**\n• `/voice on` — réponse vocale quand vous envoyez un message vocal\n• `/voice tts` — réponse vocale à *chaque* message\n• `/voice off` — retour aux réponses texte uniquement\n• `/voice status` — afficher le mode actuel\n• `/voice` (sans argument) — bascule rapide entre activé et désactivé{channels}"
     help_channels:         "\n\n**Salons vocaux en direct (Discord)**\n• Rejoignez d'abord un salon vocal, puis `/voice channel` — je rejoins, j'écoute et je parle mes réponses\n• `/voice leave` — se déconnecter du salon vocal"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ Mode YOLO **DÉSACTIVÉ** pour cette session — les commandes dangereuses nécessiteront une approbation."
     enabled:                    "⚡ Mode YOLO **ACTIVÉ** pour cette session — toutes les commandes sont auto-approuvées. À utiliser avec prudence."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -433,6 +433,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**Conas a oibríonn /voice**\n• `/voice on` — freagra gutha nuair a sheolann tú teachtaireacht gutha\n• `/voice tts` — freagra gutha do *gach* teachtaireacht\n• `/voice off` — ar ais go freagraí téacs amháin\n• `/voice status` — taispeáin an mód reatha\n• `/voice` (gan argóint) — scoránaigh go tapa idir air agus as{channels}"
     help_channels:         "\n\n**Cainéil gutha bheo (Discord)**\n• Téigh isteach i gcainéal gutha ar dtús, ansin `/voice channel` — téim isteach, éistim agus labhraím mo fhreagraí\n• `/voice leave` — dícheangail ón gcainéal gutha"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ Mód YOLO **AS** don seisiún seo — beidh cead de dhíth d'orduithe contúirteacha."
     enabled:                    "⚡ Mód YOLO **AR** don seisiún seo — gach ordú ceadaithe go huathoibríoch. Úsáid go cúramach."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**Hogyan működik a /voice**\n• `/voice on` — hangválasz, amikor hangüzenetet küldesz\n• `/voice tts` — hangválasz *minden* üzenetre\n• `/voice off` — vissza a csak szöveges válaszokhoz\n• `/voice status` — az aktuális mód megjelenítése\n• `/voice` (argumentum nélkül) — gyors váltás be és ki között{channels}"
     help_channels:         "\n\n**Élő hangcsatornák (Discord)**\n• Először lépj be egy hangcsatornába, majd `/voice channel` — csatlakozom, hallgatok és hangosan válaszolok\n• `/voice leave` — lecsatlakozás a hangcsatornáról"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ YOLO mód **KI** ebben a munkamenetben — a veszélyes parancsok jóváhagyást igényelnek."
     enabled:                    "⚡ YOLO mód **BE** ebben a munkamenetben — minden parancs automatikusan jóváhagyva. Óvatosan használd."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**Come funziona /voice**\n• `/voice on` — risposta vocale quando invii un messaggio vocale\n• `/voice tts` — risposta vocale a *ogni* messaggio\n• `/voice off` — torna alle risposte solo testo\n• `/voice status` — mostra la modalità attuale\n• `/voice` (senza argomento) — alterna rapidamente tra attivo e disattivo{channels}"
     help_channels:         "\n\n**Canali vocali dal vivo (Discord)**\n• Entra prima in un canale vocale, poi `/voice channel` — mi unisco, ascolto e parlo le mie risposte\n• `/voice leave` — disconnetti dal canale vocale"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ Modalità YOLO **OFF** per questa sessione — i comandi pericolosi richiederanno approvazione."
     enabled:                    "⚡ Modalità YOLO **ON** per questa sessione — tutti i comandi auto-approvati. Usa con cautela."

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**/voice の使い方**\n• `/voice on` — 音声メッセージを送ると音声で返信\n• `/voice tts` — *すべての*メッセージに音声で返信\n• `/voice off` — テキストのみの返信に戻す\n• `/voice status` — 現在のモードを表示\n• `/voice`（引数なし）— オンとオフをすばやく切り替え{channels}"
     help_channels:         "\n\n**ライブ音声チャンネル (Discord)**\n• 先に音声チャンネルに参加してから `/voice channel` — 参加して聞き取り、音声で返信します\n• `/voice leave` — 音声チャンネルから切断"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ このセッションの YOLO モードは **OFF** — 危険なコマンドには承認が必要です。"
     enabled:                    "⚡ このセッションの YOLO モードは **ON** — すべてのコマンドが自動承認されます。注意して使用してください。"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**/voice 사용법**\n• `/voice on` — 음성 메시지를 보내면 음성으로 답변\n• `/voice tts` — *모든* 메시지에 음성으로 답변\n• `/voice off` — 텍스트 전용 답변으로 복귀\n• `/voice status` — 현재 모드 표시\n• `/voice` (인자 없음) — 켜기와 끄기를 빠르게 전환{channels}"
     help_channels:         "\n\n**라이브 음성 채널 (Discord)**\n• 먼저 음성 채널에 들어간 다음 `/voice channel` — 제가 참여해 듣고 음성으로 답변합니다\n• `/voice leave` — 음성 채널에서 연결 해제"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ 이 세션에서 YOLO 모드 **꺼짐** — 위험한 명령은 승인이 필요합니다."
     enabled:                    "⚡ 이 세션에서 YOLO 모드 **켜짐** — 모든 명령이 자동 승인됩니다. 주의해서 사용하세요."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**Como funciona o /voice**\n• `/voice on` — resposta por voz quando envias uma mensagem de voz\n• `/voice tts` — resposta por voz a *todas* as mensagens\n• `/voice off` — voltar às respostas apenas em texto\n• `/voice status` — mostrar o modo atual\n• `/voice` (sem argumento) — alternar rapidamente entre ligado e desligado{channels}"
     help_channels:         "\n\n**Canais de voz ao vivo (Discord)**\n• Entra primeiro num canal de voz, depois `/voice channel` — eu entro, ouço e falo as minhas respostas\n• `/voice leave` — desligar do canal de voz"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ Modo YOLO **DESATIVADO** nesta sessão — comandos perigosos exigirão aprovação."
     enabled:                    "⚡ Modo YOLO **ATIVADO** nesta sessão — todos os comandos são aprovados automaticamente. Usa com precaução."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**Как работает /voice**\n• `/voice on` — голосовой ответ, когда вы отправляете голосовое сообщение\n• `/voice tts` — голосовой ответ на *каждое* сообщение\n• `/voice off` — вернуться к ответам только текстом\n• `/voice status` — показать текущий режим\n• `/voice` (без аргумента) — быстрое переключение между вкл и выкл{channels}"
     help_channels:         "\n\n**Живые голосовые каналы (Discord)**\n• Сначала зайдите в голосовой канал, затем `/voice channel` — я подключусь, буду слушать и отвечать голосом\n• `/voice leave` — отключиться от голосового канала"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ Режим YOLO для этого сеанса **ОТКЛЮЧЁН** — опасные команды потребуют одобрения."
     enabled:                    "⚡ Режим YOLO для этого сеанса **ВКЛЮЧЁН** — все команды одобряются автоматически. Используйте с осторожностью."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**/voice nasıl çalışır**\n• `/voice on` — sesli mesaj gönderdiğinde sesli yanıt\n• `/voice tts` — *her* mesaja sesli yanıt\n• `/voice off` — yalnızca metin yanıtlarına dön\n• `/voice status` — geçerli modu göster\n• `/voice` (argümansız) — açık ve kapalı arasında hızlı geçiş{channels}"
     help_channels:         "\n\n**Canlı ses kanalları (Discord)**\n• Önce bir ses kanalına katıl, sonra `/voice channel` — katılırım, dinlerim ve yanıtlarımı sesli söylerim\n• `/voice leave` — ses kanalından ayrıl"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ Bu oturumda YOLO modu **KAPALI** — tehlikeli komutlar onay gerektirecek."
     enabled:                    "⚡ Bu oturumda YOLO modu **AÇIK** — tüm komutlar otomatik onaylanır. Dikkatli kullanın."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**Як працює /voice**\n• `/voice on` — голосова відповідь, коли ви надсилаєте голосове повідомлення\n• `/voice tts` — голосова відповідь на *кожне* повідомлення\n• `/voice off` — повернутися до відповідей лише текстом\n• `/voice status` — показати поточний режим\n• `/voice` (без аргументу) — швидке перемикання між увімк і вимк{channels}"
     help_channels:         "\n\n**Живі голосові канали (Discord)**\n• Спершу зайдіть у голосовий канал, потім `/voice channel` — я підключуся, слухатиму й відповідатиму голосом\n• `/voice leave` — від'єднатися від голосового каналу"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ Режим YOLO для цього сеансу **ВИМКНЕНО** — небезпечні команди потребуватимуть схвалення."
     enabled:                    "⚡ Режим YOLO для цього сеансу **УВІМКНЕНО** — усі команди схвалюються автоматично. Використовуйте з обережністю."

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -429,6 +429,27 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**/voice 用法**\n• `/voice on` — 當你傳送語音訊息時以語音回覆\n• `/voice tts` — 對*每則*訊息都以語音回覆\n• `/voice off` — 恢復為純文字回覆\n• `/voice status` — 顯示目前模式\n• `/voice`（無參數）— 在開啟和關閉之間快速切換{channels}"
     help_channels:         "\n\n**即時語音頻道 (Discord)**\n• 先加入一個語音頻道，然後 `/voice channel` — 我會加入、聆聽並以語音回覆\n• `/voice leave` — 中斷語音頻道"
 
+  media:
+    # Context notes prepended to user messages when an attachment arrives.
+    # These are translated so the LLM receives the note in the user's
+    # active language. Catalog parity is enforced by tests/agent/test_i18n.py.
+    doc_text_note:        "[The user sent a text document: '{name}'. Its content has been included below. The file is also saved at: {path}]"
+    doc_binary_note:      "[The user sent a document: '{name}'. It is saved at: {path}. Its text is not inlined here (it's a binary format such as PDF or DOCX). To read it, extract the document's text yourself — for example with the terminal tool or the ocr-and-documents skill — before answering, instead of asking the user to paste the contents.]"
+    audio_attachment_note: "[The user sent an audio file attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the audio contains, transcribe or process it yourself — for example by passing the path to a transcription or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    video_attachment_note: "[The user sent a video attachment: '{name}'. It is saved at: {path}. Its content is not inlined here. If the user's request involves what the video contains, inspect or process it yourself — for example by passing the path to a video analysis or media tool — instead of asking the user to describe it. Only ask what to do with it if their intent is genuinely unclear.]"
+    image_seen:           "[The user sent an image~ Here's what I can see:\n{description}]\n[If you need a closer look, use vision_analyze with image_url: {path} ~]"
+    image_blurry:         "[The user sent an image but I couldn't quite see it this time (>_<) You can try looking at it yourself with vision_analyze using image_url: {path}]"
+    image_error:          "[The user sent an image but something went wrong when I tried to look at it~ You can try examining it yourself with vision_analyze using image_url: {path}]"
+    voice_disabled_with_duration: "[The user sent a voice message: {path} (duration: {duration})]"
+    voice_disabled_no_duration:   "[The user sent a voice message: {path}]"
+    voice_empty_transcript:       "[The user sent a voice message but it came through empty or inaudible — speech-to-text returned no words. Do not guess at the content; ask the user to resend or type it out.]"
+    voice_transcribe_unavailable: "[voice message could not be transcribed]"
+    voice_transcribe_error:       "[voice message could not be transcribed automatically; the audio is available at: {path}]"
+    empty_placeholder:    "(The user sent a message with no text content)"
+    sticker:              "[The user sent a sticker{context}~ It shows: \"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[The user sent an animated sticker {emoji}~ I can't see animated ones yet, but the emoji suggests: {emoji}]"
+    animated_sticker_no_emoji: "[The user sent an animated sticker~ I can't see animated ones yet]"
+
   yolo:
     disabled:                   "⚠️ 本工作階段 YOLO 模式 **已關閉** — 危險指令將需要批准。"
     enabled:                    "⚡ 本工作階段 YOLO 模式 **已開啟** — 所有指令自動批准。請謹慎使用。"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -429,6 +429,54 @@ Future messages in this room will use that transcript until `/reset` or another 
     help:                  "{toggle}\n\n**/voice 用法**\n• `/voice on` — 当你发送语音消息时用语音回复\n• `/voice tts` — 对*每条*消息都用语音回复\n• `/voice off` — 恢复为纯文本回复\n• `/voice status` — 显示当前模式\n• `/voice`（无参数）— 在开启和关闭之间快速切换{channels}"
     help_channels:         "\n\n**实时语音频道 (Discord)**\n• 先加入一个语音频道，然后 `/voice channel` — 我会加入、聆听并用语音回复\n• `/voice leave` — 断开语音频道"
 
+  media:
+    # 随附件注入到 user message 前的语境提示，按用户语言翻译。LLM 收到的就是
+    # 这段文字，因此中文化后 LLM 会用对应语言理解/回复。新增 key 必须同步加到
+    # 全部 17 个 locale 文件，否则 tests/agent/test_i18n.py 的 catalog parity
+    # 断言会失败。
+    #
+    # 占位符名称（{name}/{path}/{description} 等）必须与 Python 代码
+    # str.format 传入的键名一致——placeholder parity 测试会严格比对。
+    #
+    # ---- text/* 文档 + 二进制文档 ----
+    # text/* 文档（.txt .md .csv .json .xml .yaml .yml .toml .ini .cfg .log）
+    # 内容由平台适配器内联进消息体，提示只确认 + 给出保存路径。
+    doc_text_note:        "[用户发送了文本文件：'{name}'。内容已附在下方。文件保存路径：{path}]"
+    # 二进制文档（PDF、DOCX、XLSX …）无法以纯文本形式内联。提示明确要求
+    # 智能体**自己**提取文本——这能修复历史遗留的"PDF 像读不出来"的故障
+    # （旧版本会让模型把球踢回给用户）。
+    doc_binary_note:      "[用户发送了文件：'{name}'。文件保存路径：{path}。该二进制格式（如 PDF、DOCX）的文本未在此处内联。请先用工具（如 terminal 工具或 ocr-and-documents 技能）自行提取文本再回答，不要让用户粘贴内容。]"
+    # ---- 音频 / 视频附件 ----
+    audio_attachment_note: "[用户发送了一个音频文件附件：'{name}'。文件保存路径：{path}。其内容未在此处内联。如果用户的问题涉及音频内容，请自行转录或处理（例如把路径传给转录或媒体工具），不要让用户描述音频。只有当用户意图确实不明时才询问。"
+    video_attachment_note: "[用户发送了一个视频附件：'{name}'。文件保存路径：{path}。其内容未在此处内联。如果用户的问题涉及视频内容，请自行检视或处理（例如把路径传给视频分析或媒体工具），不要让用户描述视频。只有当用户意图确实不明时才询问。"
+    # ---- 图片自动视觉 ----
+    image_seen:           "[用户发送了图片～ 我看到的内容：\n{description}]\n[如需细看，请使用 vision_analyze 工具，image_url: {path} ～]"
+    image_blurry:         "[用户发送了图片，但这次没看清（>_<）你可以自己用 vision_analyze 工具再看一遍，image_url: {path}]"
+    image_error:          "[用户发送了图片，但我尝试查看时出错了～ 请你自己用 vision_analyze 工具检查一下，image_url: {path}]"
+    # ---- 语音（stt 关闭）----
+    # 拆成两条：是否探测到时长用不同键，避免每种语言都要为同一句话维护
+    # 两个变体。
+    voice_disabled_with_duration: "[用户发送了语音消息：{path}（时长：{duration}）]"
+    voice_disabled_no_duration:   "[用户发送了语音消息：{path}]"
+    # ---- 语音转录结果 ----
+    # STT 在静音或听不清时可能返回 success=True 但 transcript 为空。这里
+    # 明确告诉智能体不要瞎猜。
+    voice_empty_transcript:       "[用户发送了语音消息，但转出来是空的或听不清——语音转文本没返回任何内容。请不要猜测内容，让用户重发或打字。]"
+    # 转录模块连 import 都失败（极罕见）。
+    voice_transcribe_unavailable: "[语音消息无法转录]"
+    # STT 提供方跑了但失败（没配 provider、key 错、网络问题 …）。
+    # 文案保持中性——原因写日志但不出现在 LLM 面前，避免智能体在后续每一轮
+    # 都重复唠叨 STT 配置建议。
+    voice_transcribe_error:       "[语音消息无法自动转录；音频文件位于：{path}]"
+    # ---- 平台在无文字时填入的占位 ----
+    empty_placeholder:    "（用户发送了一条无文字内容的消息）"
+    # ---- Telegram 贴纸 ----
+    # {context} 在 Python 里已经按 metadata 预拼为 " <emoji> from \"<set>\""、
+    # " <emoji>" 或空串——这部分保持语言中性。
+    sticker:              "[用户发送了一张贴纸{context}～ 内容描述：\"{description}\" (=^.w.^=)]"
+    animated_sticker_emoji:   "[用户发送了一张动态贴纸 {emoji}～ 动态贴纸我还识别不了，但从 emoji 推测：{emoji}]"
+    animated_sticker_no_emoji: "[用户发送了一张动态贴纸～ 动态贴纸我还识别不了]"
+
   yolo:
     disabled:                   "⚠️ 本会话 YOLO 模式 **已关闭** — 危险命令将需要批准。"
     enabled:                    "⚡ 本会话 YOLO 模式 **已开启** — 所有命令自动批准。请谨慎使用。"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -48,6 +48,67 @@ def test_catalog_keys_match_english(lang: str):
     assert not extra, f"{lang}.yaml has keys not in en.yaml: {sorted(extra)}"
 
 
+# ---------------------------------------------------------------------------
+# gateway.media.* (i18n-ization of the hardcoded "user sent" injection notes
+# prepended to user messages when an attachment arrives).  These strings
+# reach the LLM verbatim, so if the user's active language is non-English
+# they MUST be in that language.  Reject the case where a translator
+# mistakenly left the English placeholder values in a locale.
+# ---------------------------------------------------------------------------
+
+# Keys where the English source is a self-contained system note
+# (no platform-specific data inside the string itself).  The placeholder
+# values, when substituted, still come from the platform adapter.
+MEDIA_L10N_KEYS = [
+    "gateway.media.doc_text_note",
+    "gateway.media.doc_binary_note",
+    "gateway.media.audio_attachment_note",
+    "gateway.media.video_attachment_note",
+    "gateway.media.image_seen",
+    "gateway.media.image_blurry",
+    "gateway.media.image_error",
+    "gateway.media.voice_empty_transcript",
+    "gateway.media.voice_transcribe_unavailable",
+    "gateway.media.voice_transcribe_error",
+    "gateway.media.empty_placeholder",
+    "gateway.media.sticker",
+    "gateway.media.animated_sticker_emoji",
+    "gateway.media.animated_sticker_no_emoji",
+]
+
+
+@pytest.mark.parametrize("key", MEDIA_L10N_KEYS)
+def test_zh_translation_is_actually_chinese(key):
+    """zh.yaml must carry real Chinese translation for every media note, not
+    a copy-paste of the English placeholder.  Catches translators who add
+    the key (so parity passes) but leave the value as English.
+    """
+    flat = _flatten(_load_raw("zh"))
+    value = flat.get(key, "")
+    # CJK Unified Ideographs + the U+FF1A fullwidth colon and other common
+    # Chinese punctuation cover the bulk of our translations.  A handful
+    # of bracketed punctuation like 【】、《》is also fine.
+    has_cjk = any("\u4e00" <= ch <= "\u9fff" for ch in value)
+    assert has_cjk, (
+        f"zh.yaml key={key!r} doesn't contain CJK characters -- "
+        f"value={value!r}"
+    )
+
+
+@pytest.mark.parametrize("key", MEDIA_L10N_KEYS)
+def test_zh_translation_differs_from_english(key):
+    """zh.yaml translation must actually differ from the English source --
+    guards against the 'added key but forgot to translate' failure mode
+    where a missing key would have been caught by the catalog parity test
+    but a same-as-English value would slip through.
+    """
+    en_value = _flatten(_load_raw("en")).get(key, "")
+    zh_value = _flatten(_load_raw("zh")).get(key, "")
+    assert en_value != zh_value, (
+        f"zh.yaml key={key!r} is identical to en.yaml -- looks untranslated"
+    )
+
+
 @pytest.mark.parametrize("lang", list(i18n.SUPPORTED_LANGUAGES))
 def test_catalog_placeholders_match_english(lang: str):
     """Every translated value must use the same {placeholder} tokens as English.


### PR DESCRIPTION
i18n 化 17 个网关媒体注入提示。详见 commit msg。