### PR TITLE
fix(vision): materialize inline images where the sandbox can read them

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -409,6 +409,29 @@ class _StreamErrorEvent(Exception):
         }
 
 
+def _sandbox_reachable_image_dir() -> Path:
+    """Directory for materialized images the agent can actually open.
+
+    Under a non-local terminal backend the agent reads files inside the
+    sandbox, where the host ``$TMPDIR`` is not mounted. The Hermes image cache
+    is auto-mounted and is translated by ``to_agent_visible_cache_path``, so
+    images destined for a vision backend belong there.
+
+    Falls back to deriving the same path when the gateway package is not
+    importable (bare CLI runs).
+    """
+    try:
+        from gateway.platforms.base import get_image_cache_dir
+
+        return get_image_cache_dir()
+    except Exception:
+        from hermes_constants import get_hermes_dir
+
+        fallback = Path(get_hermes_dir()) / "cache" / "images"
+        fallback.mkdir(parents=True, exist_ok=True)
+        return fallback
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -6630,19 +6653,25 @@ class AIAgent:
             "image/jpeg": ".jpg",
             "image/jpg": ".jpg",
         }.get(mime, ".jpg")
-        tmp = tempfile.NamedTemporaryFile(prefix="anthropic_image_", suffix=suffix, delete=False)
+        # Write into the Hermes image cache, NOT the host $TMPDIR. Under a
+        # non-local terminal backend (docker/ssh/modal/...) the vision resolver
+        # reads files *inside* the sandbox, where $TMPDIR is not mounted, so a
+        # temp file here makes every analysis fail with SourceNotFound. The
+        # image cache is auto-mounted and is exactly what
+        # ``to_agent_visible_cache_path`` already knows how to translate.
+        target_dir = _sandbox_reachable_image_dir()
+        target_dir.mkdir(parents=True, exist_ok=True)
+        path = target_dir / f"inline_image_{uuid.uuid4().hex[:12]}{suffix}"
         try:
-            with tmp:
-                tmp.write(base64.b64decode(data))
+            path.write_bytes(base64.b64decode(data))
         except Exception:
-            # delete=False means a corrupt/unsupported data URL would otherwise
-            # leak a zero-byte temp file on every failed materialization.
+            # A corrupt/unsupported data URL would otherwise leave a zero-byte
+            # file behind on every failed materialization.
             try:
-                os.unlink(tmp.name)
+                path.unlink()
             except OSError:
                 pass
             raise
-        path = Path(tmp.name)
         return str(path), path
 
     def _describe_image_for_anthropic_fallback(self, image_url: str, role: str) -> str:

--- a/tests/agent/test_image_materialization_reachable.py
+++ b/tests/agent/test_image_materialization_reachable.py
@@ -1,0 +1,132 @@
+"""Data-URL materialization must land somewhere the sandbox can read.
+
+Observed failure (gateway.log, 2026-08-08), with ``terminal.backend: docker``::
+
+    tools.image_source.SourceNotFound: '/var/folders/.../T/anthropic_image_x.jpg'
+    is not reachable inside the sandbox and no active sandbox session is
+    available to read it
+
+``_materialize_data_url_for_vision`` wrote the decoded image to the host
+``$TMPDIR``. Under a non-local terminal backend, ``vision_analyze`` resolves
+paths *inside the container*, and ``$TMPDIR`` is not mounted there — so every
+such analysis failed, the model got no description and no usable path, and it
+fell back to asking the user for a URL or base64 blob.
+
+The Hermes cache directory *is* auto-mounted and is translated by
+``to_agent_visible_cache_path``, so materialization belongs there.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from run_agent import AIAgent
+
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _data_url(payload: bytes = PNG) -> str:
+    return f"data:image/png;base64,{base64.b64encode(payload).decode('ascii')}"
+
+
+class TestMaterializationLocation:
+    def test_host_tempfile_api_is_not_used(self, monkeypatch, tmp_path):
+        """The whole bug: $TMPDIR is invisible to the sandbox.
+
+        Asserted by forbidding the temp-file API rather than by comparing path
+        prefixes — pytest's own ``tmp_path`` lives under ``$TMPDIR``, so a
+        prefix check cannot distinguish the two.
+        """
+        import run_agent as ra
+
+        cache = tmp_path / "cache-images"
+        monkeypatch.setattr(ra, "_sandbox_reachable_image_dir", lambda: cache)
+
+        def _forbidden(*_args, **_kwargs):
+            raise AssertionError("materialization must not use the host temp dir")
+
+        monkeypatch.setattr(tempfile, "NamedTemporaryFile", _forbidden)
+        monkeypatch.setattr(tempfile, "mkstemp", _forbidden)
+
+        path_str, path_obj = AIAgent._materialize_data_url_for_vision(_data_url())
+        assert path_obj is not None
+        try:
+            assert Path(path_str).parent == cache
+        finally:
+            path_obj.unlink(missing_ok=True)
+
+    def test_file_lands_in_the_reachable_image_dir(self, monkeypatch, tmp_path):
+        import run_agent as ra
+
+        cache = tmp_path / "cache-images"
+        monkeypatch.setattr(ra, "_sandbox_reachable_image_dir", lambda: cache)
+
+        path_str, path_obj = AIAgent._materialize_data_url_for_vision(_data_url())
+        assert path_obj is not None
+        try:
+            assert path_obj.parent == cache
+            assert path_obj.read_bytes() == PNG
+            assert path_str == str(path_obj)
+        finally:
+            path_obj.unlink(missing_ok=True)
+
+    def test_directory_is_created_when_absent(self, monkeypatch, tmp_path):
+        import run_agent as ra
+
+        cache = tmp_path / "not-yet" / "images"
+        monkeypatch.setattr(ra, "_sandbox_reachable_image_dir", lambda: cache)
+
+        _path_str, path_obj = AIAgent._materialize_data_url_for_vision(_data_url())
+        assert path_obj is not None
+        try:
+            assert path_obj.exists()
+        finally:
+            path_obj.unlink(missing_ok=True)
+
+
+class TestPreservedInvariants:
+    def test_no_leak_on_decode_failure(self, monkeypatch, tmp_path):
+        """A corrupt data URL must not leave a zero-byte file behind."""
+        import run_agent as ra
+
+        cache = tmp_path / "cache-images"
+        monkeypatch.setattr(ra, "_sandbox_reachable_image_dir", lambda: cache)
+
+        with pytest.raises(Exception):
+            AIAgent._materialize_data_url_for_vision(
+                "data:image/png;base64,!!!not-valid-base64!!!"
+            )
+
+        leftovers = list(cache.iterdir()) if cache.exists() else []
+        assert leftovers == [], f"leaked files after decode failure: {leftovers}"
+
+    def test_oversized_payload_is_refused(self, monkeypatch, tmp_path):
+        import run_agent as ra
+
+        cache = tmp_path / "cache-images"
+        monkeypatch.setattr(ra, "_sandbox_reachable_image_dir", lambda: cache)
+
+        oversized = "data:image/png;base64," + ("A" * (AIAgent._MAX_DATA_URL_BASE64_BYTES + 1))
+        assert AIAgent._materialize_data_url_for_vision(oversized) == ("", None)
+
+
+class TestSandboxReachableImageDir:
+    def test_returns_a_path(self):
+        from run_agent import _sandbox_reachable_image_dir as sandbox_reachable_image_dir
+
+        assert isinstance(sandbox_reachable_image_dir(), Path)
+
+    def test_result_translates_for_the_container(self, monkeypatch):
+        """The chosen directory must be one the path translator recognises."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        from run_agent import _sandbox_reachable_image_dir as sandbox_reachable_image_dir
+        from tools.credential_files import to_agent_visible_cache_path
+
+        sample = str(sandbox_reachable_image_dir() / "img_demo.jpg")
+        assert to_agent_visible_cache_path(sample).startswith("/root/.hermes/")

--- a/tests/run_agent/test_materialize_data_url_cleanup.py
+++ b/tests/run_agent/test_materialize_data_url_cleanup.py
@@ -1,16 +1,19 @@
-"""Regression test: temp file cleanup when materializing data URLs for vision.
+"""Regression test: file cleanup when materializing data URLs for vision.
 
-`_materialize_data_url_for_vision` creates a `NamedTemporaryFile(delete=False)`
-so the path can be handed to vision backends.  If `base64.b64decode` raises on
-a corrupt/unsupported data URL the temp file would otherwise persist forever
-on disk, leaking once per failed call.
+`_materialize_data_url_for_vision` writes the decoded image to a path that can
+be handed to vision backends.  If `base64.b64decode` raises on a corrupt or
+unsupported data URL, that file would otherwise persist forever on disk,
+leaking once per failed call.
+
+The destination is the sandbox-reachable image cache, not the host `$TMPDIR` —
+see tests/agent/test_image_materialization_reachable.py for why.  These tests
+patch that directory so the leak invariant is still checked where files
+actually land; patching `tempfile.tempdir` would silently assert nothing.
 """
 
 from __future__ import annotations
 
 import base64
-import os
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -18,26 +21,33 @@ import pytest
 from run_agent import AIAgent
 
 
-def _list_anthropic_tmpfiles(tmpdir: str) -> list[str]:
-    return [
-        name for name in os.listdir(tmpdir)
-        if name.startswith("anthropic_image_")
-    ]
+def _patch_image_dir(monkeypatch, target: Path) -> None:
+    import run_agent as ra
+
+    monkeypatch.setattr(ra, "_sandbox_reachable_image_dir", lambda: target)
 
 
-def test_b64decode_failure_does_not_leak_tempfile(monkeypatch, tmp_path):
-    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+def _list_materialized(directory: Path) -> list[str]:
+    if not directory.exists():
+        return []
+    return [p.name for p in directory.iterdir()]
+
+
+def test_b64decode_failure_does_not_leak_file(monkeypatch, tmp_path):
+    image_dir = tmp_path / "cache-images"
+    _patch_image_dir(monkeypatch, image_dir)
 
     bad_url = "data:image/png;base64,!!!not-valid-base64!!!"
     with pytest.raises(Exception):
         AIAgent._materialize_data_url_for_vision(bad_url)
 
-    leftovers = _list_anthropic_tmpfiles(str(tmp_path))
-    assert leftovers == [], f"leaked temp files after decode failure: {leftovers}"
+    leftovers = _list_materialized(image_dir)
+    assert leftovers == [], f"leaked files after decode failure: {leftovers}"
 
 
 def test_successful_decode_returns_path_to_existing_file(monkeypatch, tmp_path):
-    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    image_dir = tmp_path / "cache-images"
+    _patch_image_dir(monkeypatch, image_dir)
 
     payload = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16  # a few bytes is enough
     encoded = base64.b64encode(payload).decode("ascii")
@@ -47,6 +57,7 @@ def test_successful_decode_returns_path_to_existing_file(monkeypatch, tmp_path):
 
     assert isinstance(path_obj, Path)
     assert path_obj.exists()
+    assert path_obj.parent == image_dir
     assert path_obj.read_bytes() == payload
     assert path_str == str(path_obj)
     # Caller is responsible for cleanup; mimic that here so the test leaves


### PR DESCRIPTION
## What does this PR do?

`AIAgent._materialize_data_url_for_vision` decodes an inline `data:` image and hands the resulting path to `vision_analyze_tool`. It wrote that file to the host `$TMPDIR` via `tempfile.NamedTemporaryFile`.

Under a non-local `terminal.backend` (docker/ssh/modal/...), `resolve_image_source` reads the path **inside the sandbox**. `$TMPDIR` is not mounted there, so the read fails closed:

```
tools.image_source.SourceNotFound: '/var/folders/.../T/anthropic_image_vpu3ru__.jpg'
is not reachable inside the sandbox and no active sandbox session is available to read it
```

Every inline-image analysis fails this way on a sandboxed backend. The caller catches it and produces `"Image analysis failed: ..."`, so the model receives neither a description nor an openable path — and typically responds by asking the user to resend the image as a URL or base64 blob.

The fix writes into the Hermes image cache instead. That directory is auto-mounted and is exactly what `tools.credential_files.to_agent_visible_cache_path` already translates:

| written to | resolves inside container as |
|---|---|
| `~/.hermes/cache/images/…` | `/root/.hermes/cache/images/…` ✅ |
| `$TMPDIR/anthropic_image_*.jpg` | unchanged host path ❌ |

Chosen over the alternatives because it reuses the existing, already-mounted cache and its established translation helper, rather than adding a new mount or teaching the resolver about `$TMPDIR`.

## Related Issue

Related to the vision-path family (#51283, #33872, #51513) but distinct — those concern capability routing and path formats, not the sandbox-reachability of the materialization destination.

Fixes #82431

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: new module-level `_sandbox_reachable_image_dir()` returning the mounted image cache, with a derived fallback when the `gateway` package is not importable (bare CLI runs).
- `run_agent.py`: `_materialize_data_url_for_vision` writes to that directory using a `uuid4`-suffixed name instead of `tempfile.NamedTemporaryFile`. The no-leak-on-decode-failure path is preserved (unlink + re-raise).
- `tests/agent/test_image_materialization_reachable.py`: new. Covers destination, directory creation, the preserved leak invariant, the oversized-payload refusal, and that the chosen directory actually translates for a container.
- `tests/run_agent/test_materialize_data_url_cleanup.py`: retargeted at the new location. It patched `tempfile.tempdir`, which the code no longer consults — left as-is it would have passed while asserting nothing.

## How to Test

1. `python -m pytest tests/agent/test_image_materialization_reachable.py tests/run_agent/test_materialize_data_url_cleanup.py -q` → **9 passed**
2. Regression scope: `python -m pytest tests/run_agent/ tests/tools/test_image_source.py -q --continue-on-collection-errors` → **217 failures with and without this change, identical sets** (pre-existing in my environment: missing `pytest-asyncio` and sandbox deps). Verified by stashing the change and diffing the failure lists rather than comparing totals.
3. End-to-end, with `terminal.backend: docker`: send an image to a model that routes inline images through the vision fallback. Before, `~/.hermes/logs/agent.log` shows `SourceNotFound` for a `/var/folders/...` path on every attempt; after, the analysis completes.

## Checklist

- [x] Tests added for the fixed behavior
- [x] No new test failures introduced (verified by before/after failure-set diff)
- [x] Existing regression test updated rather than silently invalidated
