### PR TITLE
fix(kanban): preserve create-time blocked tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3123,13 +3123,27 @@ def create_task(
     # insert, at which point both rows exist but the next lookup stabilises.
     if idempotency_key:
         row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "SELECT id, status FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
             "ORDER BY created_at DESC LIMIT 1",
             (idempotency_key,),
         ).fetchone()
         if row:
-            return row["id"]
+            existing_id = row["id"]
+            if (
+                initial_status == "blocked"
+                and row["status"] == "blocked"
+                and not _has_sticky_block(conn, existing_id)
+            ):
+                with write_txn(conn):
+                    if not _has_sticky_block(conn, existing_id):
+                        _append_event(
+                            conn,
+                            existing_id,
+                            "blocked",
+                            {"reason": "initial_status=blocked", "kind": "needs_input"},
+                        )
+            return existing_id
 
     now = int(time.time())
 
@@ -3270,6 +3284,13 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked", "kind": "needs_input"},
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -29,6 +29,7 @@ landed via #28754 / #28781 ahead of this fix.
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 
@@ -40,12 +41,31 @@ from hermes_cli import kanban_db as kb
 @pytest.fixture
 def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Isolated HERMES_HOME with an empty kanban DB."""
+    inherited_db = os.environ.get("HERMES_KANBAN_DB")
     home = tmp_path / ".hermes"
     home.mkdir()
+    disposable_db = tmp_path / "disposable-kanban.db"
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(disposable_db))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_WORKSPACES_ROOT", raising=False)
+    if inherited_db:
+        assert Path(inherited_db).expanduser() != disposable_db
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert kb.kanban_db_path() == disposable_db
     kb.init_db()
     return home
+
+
+def _event_kinds(conn, task_id: str) -> list[str]:
+    return [
+        row["kind"]
+        for row in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id ASC",
+            (task_id,),
+        ).fetchall()
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +94,91 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             promoted = kb.recompute_ready(conn)
             assert promoted == 0, "worker-blocked task must not auto-promote"
             assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_create_time_blocked_parent_free_task_is_sticky(kanban_home: Path) -> None:
+    """``initial_status='blocked'`` is an explicit human-ops block.
+
+    Even with no parents, dispatcher recomputation must not silently
+    promote it to ready/claimable. The sticky marker must be durable and
+    ordered after the ``created`` event so notification cursors can inherit
+    both creation facts before they are caught up.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="parked for ops", initial_status="blocked")
+
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert _event_kinds(conn, tid) == ["created", "blocked"]
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, tid) is None
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_create_time_blocked_child_with_done_parent_is_sticky(kanban_home: Path) -> None:
+    """A blocked child must not become claimable when its parents are done."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="already reviewed parent")
+        assert kb.complete_task(conn, parent, summary="done")
+        child = kb.create_task(
+            conn,
+            title="child parked for ops",
+            parents=[parent],
+            initial_status="blocked",
+        )
+
+        assert kb.get_task(conn, child).status == "blocked"
+        assert _event_kinds(conn, child)[:2] == ["created", "blocked"]
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.claim_task(conn, child) is None
+        assert kb.get_task(conn, child).status == "blocked"
+
+
+def test_reused_still_blocked_idempotent_task_gets_sticky_marker_only_on_explicit_block_request(
+    kanban_home: Path,
+) -> None:
+    """Legacy idempotent rows may already be blocked without a marker.
+
+    Backfill the marker only when the retried creator again explicitly asks
+    for ``initial_status='blocked'``. Default idempotent reuse keeps the old
+    non-sticky auto-recover behavior.
+    """
+    with kb.connect() as conn:
+        non_explicit = kb.create_task(
+            conn, title="legacy default reuse", idempotency_key="default-reuse"
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (non_explicit,))
+        conn.commit()
+
+        assert (
+            kb.create_task(
+                conn, title="legacy default reuse", idempotency_key="default-reuse"
+            )
+            == non_explicit
+        )
+        assert _event_kinds(conn, non_explicit) == ["created"]
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, non_explicit).status == "ready"
+
+        explicit = kb.create_task(
+            conn, title="legacy blocked reuse", idempotency_key="blocked-reuse"
+        )
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (explicit,))
+        conn.commit()
+
+        assert (
+            kb.create_task(
+                conn,
+                title="legacy blocked reuse",
+                idempotency_key="blocked-reuse",
+                initial_status="blocked",
+            )
+            == explicit
+        )
+        assert _event_kinds(conn, explicit) == ["created", "blocked"]
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, explicit).status == "blocked"
 
 
 


### PR DESCRIPTION
## Summary
- Refreshes the already-reviewed sticky-block source correction from PR #82404 onto exact current `origin/main` (`3f832978d30e0e14437edbf7a3f63315f08bad36` at execution time).
- Emits a durable `blocked` event immediately after `created` for `create_task(initial_status="blocked")`, before notification subscription cursor inheritance.
- Backfills the sticky marker for idempotent reuse only when the existing row is still blocked and the retried caller explicitly requests `initial_status="blocked"`; default legacy idempotent reuse remains auto-recoverable.

Supersedes source candidate: #82404. Does not close/mutate #82008 or #82404.

## Verification
- `git fetch origin main pull/82404/head:refs/remotes/origin/pr/82404 --no-tags`
- `git merge-base origin/main refs/remotes/origin/pr/82404` -> `085a9d332f60e5547d3f38415868220d1b27b43f`
- `git diff --name-only <merge-base>..refs/remotes/origin/pr/82404` -> exactly `hermes_cli/kanban_db.py`, `tests/hermes_cli/test_kanban_blocked_sticky.py`
- `git diff --name-only <merge-base>..origin/main -- hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py` -> no output
- RED manual disposable DB check on `origin/main` + test-only patch failed as expected: create-time blocked task had only `created`, recomputed to ready, and became claimable.
- `python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py`
- Disposable-DB manual sticky-block checks passed with `PYTHONPATH=$PWD` and explicit temporary `HERMES_HOME`/`HERMES_KANBAN_DB`.
- Canonical board scenario-title zero-delta: before=0 after=0 delta=0.
- `git diff --check`

## Local limitations
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -v --tb=short` could not run: no local virtualenv with pytest; wrapper reported `.venv`, `venv`, and shared `/Users/sopitz/.hermes/hermes-agent/venv` lack pytest.
- Combined `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py -v --tb=short` had the same pytest-unavailable blocker.
- `ruff` unavailable locally (`ruff` and `python -m ruff` not installed).