### PR TITLE
fix(agent): recognize the retry loop's other synthetic nudges during compaction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4592,12 +4592,33 @@ This compaction should PRIORITISE preserving all information related to the focu
         if cls._is_context_summary_content(content):
             return True
         text = _content_text_for_contains(content).strip()
+        # Sibling recovery nudges from agent.conversation_loop's retry loop:
+        # same "ephemeral scaffolding, not a real human turn" class as the
+        # markers above (see _CODEX_INCOMPLETE_NUDGE's own docstring there),
+        # imported lazily to avoid a module-load-order cycle (conversation_loop
+        # already imports FROM this module at call time for the same reason).
+        from agent.conversation_loop import (
+            _CODEX_ACK_CONTINUATION_NUDGE,
+            _CODEX_INCOMPLETE_NUDGE,
+            _DROPPED_TOOLCALL_NUDGE_CONTENT,
+            _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX,
+            _LENGTH_CONTINUATION_NETWORK_STUB,
+            _LENGTH_CONTINUATION_OUTPUT_LIMIT,
+        )
+
         return text in {
             COMPRESSION_CONTINUATION_USER_CONTENT,
             _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT,
             MAX_ITERATIONS_SUMMARY_REQUEST,
+            _CODEX_INCOMPLETE_NUDGE,
+            _CODEX_ACK_CONTINUATION_NUDGE,
+            _DROPPED_TOOLCALL_NUDGE_CONTENT,
+            _LENGTH_CONTINUATION_NETWORK_STUB,
+            _LENGTH_CONTINUATION_OUTPUT_LIMIT,
         } or text.startswith(
             TODO_INJECTION_HEADER + "\n"
+        ) or text.startswith(
+            _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX
         )
 
     @staticmethod

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4601,6 +4601,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             _CODEX_ACK_CONTINUATION_NUDGE,
             _CODEX_INCOMPLETE_NUDGE,
             _DROPPED_TOOLCALL_NUDGE_CONTENT,
+            _EMPTY_TOOL_RESPONSE_NUDGE,
             _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX,
             _LENGTH_CONTINUATION_NETWORK_STUB,
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
@@ -4613,6 +4614,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             _CODEX_INCOMPLETE_NUDGE,
             _CODEX_ACK_CONTINUATION_NUDGE,
             _DROPPED_TOOLCALL_NUDGE_CONTENT,
+            _EMPTY_TOOL_RESPONSE_NUDGE,
             _LENGTH_CONTINUATION_NETWORK_STUB,
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
         } or text.startswith(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -759,11 +759,34 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     return True
 
 
+# The three _get_continuation_prompt variants below, in named-constant form
+# so agent.context_compressor's _is_synthetic_compression_user_turn can
+# recognize them by content after a crash/interrupt persists one mid-list —
+# these rows carry no durable role beyond driving the retry, and SessionDB
+# projection strips the _length_continuation_nudge metadata tag that marks
+# them in live memory (see agent/context_compressor.py).
+_LENGTH_CONTINUATION_NETWORK_STUB = (
+    "[System: The previous response was cut off by a "
+    "network error mid-stream. Continue exactly where "
+    "you left off. Do not restart or repeat prior text. "
+    "Finish the answer directly.]"
+)
+_LENGTH_CONTINUATION_OUTPUT_LIMIT = (
+    "[System: Your previous response was truncated by the output "
+    "length limit. Continue exactly where you left off. Do not "
+    "restart or repeat prior text. Finish the answer directly.]"
+)
+# The dropped-tools variant interpolates the tool name list right after this
+# prefix, so it can't be exact-matched — this stable prefix is what
+# _is_synthetic_compression_user_turn checks with str.startswith instead.
+_LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX = "[System: Your previous tool call ("
+
+
 def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List[str]] = None) -> str:
     if is_partial_stub and dropped_tools:
         tool_list = ", ".join(dropped_tools[:3])
         return (
-            "[System: Your previous tool call "
+            f"{_LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX}"
             f"({tool_list}) was too large and "
             "the stream timed out before it "
             "could be delivered. Do NOT retry "
@@ -776,18 +799,9 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
             "tokens to avoid stream timeouts.]"
         )
     elif is_partial_stub:
-        return (
-            "[System: The previous response was cut off by a "
-            "network error mid-stream. Continue exactly where "
-            "you left off. Do not restart or repeat prior text. "
-            "Finish the answer directly.]"
-        )
+        return _LENGTH_CONTINUATION_NETWORK_STUB
     else:
-        return (
-            "[System: Your previous response was truncated by the output "
-            "length limit. Continue exactly where you left off. Do not "
-            "restart or repeat prior text. Finish the answer directly.]"
-        )
+        return _LENGTH_CONTINUATION_OUTPUT_LIMIT
 
 
 # Continuation nudge for Codex/Responses turns that came back with only
@@ -802,6 +816,27 @@ _CODEX_INCOMPLETE_NUDGE = (
     "never produced a visible answer or tool call. Do not keep thinking. "
     "Produce your final answer as plain text now (or make the tool call "
     "you were planning).]"
+)
+
+
+# Re-prompt sent after a Codex/Responses turn ends with an acknowledgment-only
+# reply (no tool calls, no final answer) — named so
+# agent.context_compressor's _is_synthetic_compression_user_turn can
+# recognize it by content the same way it recognizes _CODEX_INCOMPLETE_NUDGE.
+_CODEX_ACK_CONTINUATION_NUDGE = (
+    "[System: Continue now. Execute the required tool calls and only "
+    "send your final answer after completing the task.]"
+)
+
+# Re-prompt sent when a provider returns finish_reason="tool_calls" with an
+# empty tool_calls array (dropped-tool-call recovery, see the retry loop
+# below). Named for the same reason as _CODEX_ACK_CONTINUATION_NUDGE — this
+# pair is only stripped from the durable transcript once the turn reaches
+# finalization; an interrupt/crash mid-retry can still persist it.
+_DROPPED_TOOLCALL_NUDGE_CONTENT = (
+    "Your previous turn indicated a tool call but none was "
+    "included. Do not narrate a plan or restate intent — issue "
+    "the actual tool call now to continue the task."
 )
 
 
@@ -7272,10 +7307,7 @@ def run_conversation(
 
                     continue_msg = {
                         "role": "user",
-                        "content": (
-                            "[System: Continue now. Execute the required tool calls and only "
-                            "send your final answer after completing the task.]"
-                        ),
+                        "content": _CODEX_ACK_CONTINUATION_NUDGE,
                     }
                     messages.append(continue_msg)
                     agent._session_messages = messages
@@ -7343,11 +7375,7 @@ def run_conversation(
                     messages.append(final_msg)
                     messages.append({
                         "role": "user",
-                        "content": (
-                            "Your previous turn indicated a tool call but none was "
-                            "included. Do not narrate a plan or restate intent — issue "
-                            "the actual tool call now to continue the task."
-                        ),
+                        "content": _DROPPED_TOOLCALL_NUDGE_CONTENT,
                         "_dropped_toolcall_nudge": True,
                     })
                     agent._session_messages = messages

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -779,7 +779,7 @@ _LENGTH_CONTINUATION_OUTPUT_LIMIT = (
 # The dropped-tools variant interpolates the tool name list right after this
 # prefix, so it can't be exact-matched — this stable prefix is what
 # _is_synthetic_compression_user_turn checks with str.startswith instead.
-_LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX = "[System: Your previous tool call ("
+_LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX = "[System: Your previous tool call "
 
 
 def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List[str]] = None) -> str:
@@ -837,6 +837,15 @@ _DROPPED_TOOLCALL_NUDGE_CONTENT = (
     "Your previous turn indicated a tool call but none was "
     "included. Do not narrate a plan or restate intent — issue "
     "the actual tool call now to continue the task."
+)
+
+# Re-prompt sent when the model returns an empty response after executing tool
+# calls (#9400). Named for the same reason as the nudges above — its
+# _empty_recovery_synthetic metadata flag doesn't survive SessionDB projection.
+_EMPTY_TOOL_RESPONSE_NUDGE = (
+    "You just executed tool calls but returned an "
+    "empty response. Please process the tool "
+    "results above and continue with the task."
 )
 
 
@@ -7070,11 +7079,7 @@ def run_conversation(
                         messages.append(_nudge_msg)
                         messages.append({
                             "role": "user",
-                            "content": (
-                                "You just executed tool calls but returned an "
-                                "empty response. Please process the tool "
-                                "results above and continue with the task."
-                            ),
+                            "content": _EMPTY_TOOL_RESPONSE_NUDGE,
                             "_empty_recovery_synthetic": True,
                         })
                         continue

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -280,6 +280,12 @@ def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
             "the actual tool call now to continue the task.",
             id="dropped_toolcall_nudge",
         ),
+        pytest.param(
+            "You just executed tool calls but returned an "
+            "empty response. Please process the tool "
+            "results above and continue with the task.",
+            id="empty_tool_response_nudge",
+        ),
     ],
 )
 def test_conversation_loop_retry_nudges_are_synthetic(content):

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -237,6 +237,97 @@ def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
     assert messages[idx]["content"] == human["content"]
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(
+            "[System: The previous response was cut off by a "
+            "network error mid-stream. Continue exactly where "
+            "you left off. Do not restart or repeat prior text. "
+            "Finish the answer directly.]",
+            id="length_continuation_network_stub",
+        ),
+        pytest.param(
+            "[System: Your previous response was truncated by the output "
+            "length limit. Continue exactly where you left off. Do not "
+            "restart or repeat prior text. Finish the answer directly.]",
+            id="length_continuation_output_limit",
+        ),
+        pytest.param(
+            "[System: Your previous tool call (write_file) was too large and "
+            "the stream timed out before it could be delivered. Do NOT retry "
+            "the same tool call with the same large content. Instead, break the "
+            "content into multiple smaller tool calls (e.g. use multiple patch "
+            "calls or write smaller files). Each tool call's arguments must be "
+            "under ~8K tokens to avoid stream timeouts.]",
+            id="length_continuation_dropped_tools",
+        ),
+        pytest.param(
+            "[System: Your previous response contained only internal reasoning and "
+            "never produced a visible answer or tool call. Do not keep thinking. "
+            "Produce your final answer as plain text now (or make the tool call "
+            "you were planning).]",
+            id="codex_incomplete_nudge",
+        ),
+        pytest.param(
+            "[System: Continue now. Execute the required tool calls and only "
+            "send your final answer after completing the task.]",
+            id="codex_ack_continuation_nudge",
+        ),
+        pytest.param(
+            "Your previous turn indicated a tool call but none was "
+            "included. Do not narrate a plan or restate intent — issue "
+            "the actual tool call now to continue the task.",
+            id="dropped_toolcall_nudge",
+        ),
+    ],
+)
+def test_conversation_loop_retry_nudges_are_synthetic(content):
+    """These are runtime recovery nudges appended by conversation_loop's retry
+    loop (length-continuation, codex incomplete/ack-continuation,
+    dropped-tool-call) — same "ephemeral scaffolding, not a human turn" class
+    as MAX_ITERATIONS_SUMMARY_REQUEST above. A turn interrupted/crashed mid-
+    retry can persist one of these as a plain role="user" row (their
+    _length_continuation_nudge/_dropped_toolcall_nudge metadata tags do not
+    survive SessionDB projection), so recognition must be content-based."""
+    nudge = {"role": "user", "content": content}
+    assert ContextCompressor._is_synthetic_compression_user_turn(nudge) is True
+
+    human = {"role": "user", "content": "Ship the release notes for v2."}
+    assert ContextCompressor._is_synthetic_compression_user_turn(human) is False
+
+
+def test_real_task_wins_over_trailing_dropped_tools_continuation_nudge(compressor):
+    """The dropped-tools continuation nudge interpolates the tool name list,
+    so it can only be recognized by a stable prefix (unlike the other nudges,
+    which are exact-matched) — this proves that prefix path actually wires
+    into anchor selection, not just the classifier in isolation."""
+    human = {"role": "user", "content": "Refactor the auth module and add tests."}
+    messages = [
+        human,
+        {"role": "assistant", "content": "Working on it.", "tool_calls": [
+            {"id": "c1", "function": {"name": "write_file", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        {
+            "role": "user",
+            "content": (
+                "[System: Your previous tool call (write_file, patch_file) was "
+                "too large and the stream timed out before it could be "
+                "delivered. Do NOT retry the same tool call with the same "
+                "large content. Instead, break the content into multiple "
+                "smaller tool calls (e.g. use multiple patch calls or write "
+                "smaller files). Each tool call's arguments must be under "
+                "~8K tokens to avoid stream timeouts.]"
+            ),
+        },
+    ]
+
+    idx = compressor._find_last_user_message_idx(messages, head_end=0)
+    assert idx == 0, "nudge was selected as the anchor instead of the human task"
+    assert messages[idx]["content"] == human["content"]
+
+
 def test_compress_context_todo_snapshot_stays_synthetic_across_two_boundaries(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Extends `_is_synthetic_compression_user_turn` to recognize 6 more retry-loop nudge strings as synthetic during compaction, preventing them from becoming the compaction anchor when a crash/interrupt persists them mid-retry.

Salvage of #81704 by @pierrenode — cherry-picked with authorship preserved, plus two follow-up fixes.

## What it solves

A crash/interrupt mid-retry can persist nudge messages as plain `role="user"` rows (their underscore-prefixed metadata flags don't survive SessionDB projection), letting them become the compaction anchor / auto-focus topic instead of the real task. The earlier #81608 fix only covered the max-iteration nudge; this PR covers its 6 siblings.

## Changes

- **`agent/conversation_loop.py`**: Promotes 5 inline nudge literals to named module-level constants (`_LENGTH_CONTINUATION_NETWORK_STUB`, `_LENGTH_CONTINUATION_OUTPUT_LIMIT`, `_LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX`, `_CODEX_ACK_CONTINUATION_NUDGE`, `_DROPPED_TOOLCALL_NUDGE_CONTENT`). Adds `_EMPTY_TOOL_RESPONSE_NUDGE` for the empty-response-after-tool-calls nudge.
- **`agent/context_compressor.py`**: Extends `_is_synthetic_compression_user_turn` to recognize all 6 new constants (5 exact-match + 1 prefix-match for the dropped-tools variant).
- **`tests/agent/test_context_compressor_zero_user_provenance.py`**: 8 parametrized test cases (6 from original PR + 1 for empty-response nudge + existing max-iteration case) + anchor-selection test for the prefix-match path.

## Salvage notes

- Cherry-picked @pierrenode's commit `8177258b` with authorship preserved.
- **Fixed double-paren bug**: `_LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX` ended with `(` but `_get_continuation_prompt` still had `f"({tool_list})"`, producing `((write_file)` instead of `(write_file)`. The test didn't catch it because it hardcoded the correct string instead of calling the function. Fixed by removing the `(` from the prefix constant.
- **Widened to sibling site**: Promoted the empty-response nudge ("You just executed tool calls but returned an empty response...") to `_EMPTY_TOOL_RESPONSE_NUDGE` and added it to the classifier — same bug class, same metadata-stripping pattern.
- Filed issue for 2 remaining dynamic nudges (pre-verify `_verify_nudge2`, kanban `_kanban_nudge`) that can't be exact-matched.

## Validation

| | Before | After |
|---|---|---|
| Context compressor tests | 136 passed | 136 passed |
| Zero-user-provenance tests | 12 passed | 13 passed (+1 nudge case) |
| Continuation/finish-reason tests | 26+17 passed | 26+17 passed |
| Ruff | clean | clean |
| E2E (string equivalence, classifier, prefix match) | — | ✓ verified |

Closes #81704
