### PR TITLE
fix(agent): never re-emit tool_calls: [] after dedup collapses a turn

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3458,7 +3458,19 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    # Deduplication removed every call in this message (all
+                    # ids were already seen earlier in the payload — common
+                    # after dropped-tool-call re-prompts / retries in long
+                    # sessions). Rewriting tool_calls: [] here would
+                    # re-introduce the exact empty-array shape strict
+                    # OpenAI-compatible providers reject with HTTP 400
+                    # (#58755 follow-up: step 2 above only catches arrays
+                    # that were already empty on input). Drop the key
+                    # instead — semantically identical to "no calls".
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -356,6 +356,39 @@ def test_sanitize_drops_empty_tool_calls_array():
     assert assistant["content"] == "answer"
 
 
+def test_sanitize_dedup_does_not_reintroduce_empty_tool_calls():
+    """Dedup removing every call of a later assistant turn must not
+    re-introduce ``tool_calls: []`` (#58755 follow-up).
+
+    After a dropped-tool-call re-prompt / retry in a long session, a later
+    assistant turn can repeat a tool_call_id already seen earlier in the
+    payload. The dedup pass then collapses that turn to zero calls; before
+    this fix it rewrote ``tool_calls: []`` AFTER the empty-array drop pass,
+    so strict OpenAI-compatible providers (opencode-go/zen, DeepSeek,
+    Fireworks) rejected the request with HTTP 400 "Invalid
+    'messages[N].tool_calls': empty array".
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "do it"},
+        {"role": "assistant", "content": "calling", "tool_calls": [
+            {"id": "call_X", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_X", "content": "r1"},
+        {"role": "assistant", "content": "retry", "tool_calls": [
+            {"id": "call_X", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "call_X", "content": "r2"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    for m in out:
+        if m.get("role") == "assistant" and "tool_calls" in m:
+            assert m["tool_calls"], f"empty tool_calls survived: {m!r}"
+
+
 
 
 


### PR DESCRIPTION
## Problem

In long sessions, Hermes occasionally sends a payload to the provider containing an assistant message with an empty `tool_calls: []` array. Strict OpenAI-compatible providers (opencode-go, opencode-zen, DeepSeek, Fireworks, Mistral) reject it with:

```
HTTP 400: [invalid_request_error] Invalid 'messages[N].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.
```

This 400s **every subsequent request** in the session until the poisoned message scrolls out of context.

## Root cause

`sanitize_api_messages` (agent/agent_runtime_helpers.py) already drops `tool_calls: []` on assistant messages in step 2 (#58755). But the **dedup pass (step 3)** runs *after* it and can re-introduce the exact rejected shape:

- When a later assistant turn repeats tool_call_ids already seen earlier in the payload (common after dropped-tool-call re-prompts or retries in long sessions), `kept_tcs` collapses to `[]`.
- The code then rewrites `msg = {**msg, "tool_calls": kept_tcs}`, re-creating `tool_calls: []` after step 2 already cleaned the input.

## Fix

When dedup removes every call of a message, drop the `tool_calls` key instead of rewriting an empty array — semantically identical to "no calls", content preserved.

## Verification

- New regression test `test_sanitize_dedup_does_not_reintroduce_empty_tool_calls` fails on current main with the exact production symptom, passes with the fix.
- All 15 tests in tests/run_agent/test_message_sequence_repair.py pass.
- Verified against a real captured production payload (855 messages, 3 empty-tool_calls stubs): after the fix, zero empty arrays survive sanitization.