### PR TITLE
fix(computer-use): restore WSL control with non-executable DrvFS drivers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11923,6 +11923,7 @@ def main():
         if action == "status":
             import subprocess
             from tools.computer_use.cua_backend import (
+                cua_driver_argv,
                 cua_driver_update_check,
                 resolve_cua_driver_cmd,
             )
@@ -11934,7 +11935,7 @@ def main():
                 try:
                     from hermes_cli.tools_config import _cua_driver_env
                     version = subprocess.run(
-                        [path, "--version"],
+                        cua_driver_argv(path, "--version"),
                         capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5,
                         env=_cua_driver_env(),
                     ).stdout.strip()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -764,6 +764,12 @@ def _resolved_cua_driver_cmd() -> Optional[str]:
     return resolve_cua_driver_cmd()
 
 
+def _cua_driver_argv(binary: str, *args: str) -> List[str]:
+    from tools.computer_use.cua_backend import cua_driver_argv
+
+    return cua_driver_argv(binary, *args)
+
+
 def _cua_driver_env() -> dict:
     """cua-driver child env with the Hermes telemetry policy applied.
 
@@ -989,7 +995,7 @@ def install_cua_driver(
     if binary and not upgrade:
         try:
             version = subprocess.run(
-                [binary, "--version"],
+                _cua_driver_argv(binary, "--version"),
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5, env=_cua_driver_env(),
                 creationflags=_post_setup_no_window_flags(),
             ).stdout.strip()
@@ -1076,7 +1082,7 @@ def install_cua_driver(
         # Show before/after version when we have a baseline. Best-effort.
         try:
             before = subprocess.run(
-                [binary, "--version"],
+                _cua_driver_argv(binary, "--version"),
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5, env=_cua_driver_env(),
                 creationflags=_post_setup_no_window_flags(),
             ).stdout.strip()
@@ -1094,7 +1100,7 @@ def install_cua_driver(
     if ok and before:
         try:
             after = subprocess.run(
-                [binary, "--version"],
+                _cua_driver_argv(binary, "--version"),
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5, env=_cua_driver_env(),
                 creationflags=_post_setup_no_window_flags(),
             ).stdout.strip()

--- a/tests/computer_use/test_cua_wsl_nonexec_driver.py
+++ b/tests/computer_use/test_cua_wsl_nonexec_driver.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tools.computer_use import cua_backend, doctor, permissions
+
+
+DRIVER = "/mnt/c/Users/test/cua-driver.exe"
+
+
+def _nonexec_wsl_driver():
+    def isfile(path: str) -> bool:
+        return path in {DRIVER, "/init"}
+
+    def access(path: str, mode: int) -> bool:
+        return path == "/init"
+
+    return (
+        patch("hermes_constants.is_wsl", return_value=True),
+        patch.object(cua_backend.os.path, "isfile", side_effect=isfile),
+        patch.object(cua_backend.os, "access", side_effect=access),
+        patch.object(cua_backend.shutil, "which", return_value=None),
+    )
+
+
+def test_resolver_accepts_nonexec_wsl_drvfs_exe_and_prefixes_init():
+    patches = _nonexec_wsl_driver()
+    with patches[0], patches[1], patches[2], patches[3]:
+        assert cua_backend.resolve_cua_driver_cmd(DRIVER) == DRIVER
+        assert cua_backend.cua_driver_argv(DRIVER, "--version") == [
+            "/init",
+            DRIVER,
+            "--version",
+        ]
+
+
+def test_init_prefix_is_not_used_for_direct_or_native_execution():
+    with (
+        patch("hermes_constants.is_wsl", return_value=True),
+        patch.object(cua_backend.shutil, "which", return_value=DRIVER),
+        patch.object(cua_backend.os, "access", return_value=True),
+    ):
+        assert cua_backend.resolve_cua_driver_cmd(DRIVER) == DRIVER
+        assert cua_backend.cua_driver_argv(DRIVER, "mcp") == [DRIVER, "mcp"]
+
+    with patch("hermes_constants.is_wsl", return_value=False):
+        assert cua_backend.cua_driver_argv(DRIVER, "mcp") == [DRIVER, "mcp"]
+
+
+def test_status_uses_shared_init_invocation_for_nonexec_wsl_driver():
+    seen: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        seen.append(argv)
+        if "--version" in argv:
+            return SimpleNamespace(stdout="cua-driver 0.19.2\n", returncode=0)
+        return SimpleNamespace(
+            stdout=json.dumps({"ok": True, "probes": []}),
+            returncode=0,
+        )
+
+    patches = _nonexec_wsl_driver()
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patch.object(permissions.sys, "platform", "linux"),
+        patch.object(permissions.subprocess, "run", side_effect=fake_run),
+    ):
+        status = permissions.computer_use_status(DRIVER)
+
+    assert status["installed"] is True
+    assert status["ready"] is True
+    assert seen
+    assert all(argv[:2] == ["/init", DRIVER] for argv in seen)
+
+
+def test_doctor_and_runtime_use_shared_init_invocation_for_nonexec_wsl_driver():
+    popen = SimpleNamespace()
+    patches = _nonexec_wsl_driver()
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patch.object(doctor.subprocess, "Popen", return_value=popen) as mock_popen,
+    ):
+        assert doctor._open_mcp(DRIVER) is popen
+    assert mock_popen.call_args.args[0] == ["/init", DRIVER, "mcp"]
+
+    completed = SimpleNamespace(returncode=1, stdout="")
+    patches = _nonexec_wsl_driver()
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patch.object(cua_backend.subprocess, "run", return_value=completed) as mock_run,
+    ):
+        assert cua_backend._resolve_mcp_invocation(DRIVER) == (DRIVER, ["mcp"])
+    assert mock_run.call_args.args[0] == ["/init", DRIVER, "manifest"]

--- a/tests/computer_use/test_cua_wsl_nonexec_driver.py
+++ b/tests/computer_use/test_cua_wsl_nonexec_driver.py
@@ -93,12 +93,21 @@ def test_doctor_and_runtime_use_shared_init_invocation_for_nonexec_wsl_driver():
 
     completed = SimpleNamespace(returncode=1, stdout="")
     patches = _nonexec_wsl_driver()
+    cua_backend._cua_driver_supports_no_overlay.cache_clear()
     with (
         patches[0],
         patches[1],
         patches[2],
         patches[3],
+        # Force the Linux/WSL auto no_overlay path so the ``--help`` probe
+        # also runs (CI Linux runners hit this; Windows hosts often do not).
+        patch.object(cua_backend, "_cua_no_overlay", return_value=True),
         patch.object(cua_backend.subprocess, "run", return_value=completed) as mock_run,
     ):
         assert cua_backend._resolve_mcp_invocation(DRIVER) == (DRIVER, ["mcp"])
-    assert mock_run.call_args.args[0] == ["/init", DRIVER, "manifest"]
+    # First hop is always ``manifest``; auto no_overlay then probes ``--help``.
+    # Both must share the /init argv contract.
+    assert [call.args[0] for call in mock_run.call_args_list] == [
+        ["/init", DRIVER, "manifest"],
+        ["/init", DRIVER, "--help"],
+    ]

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -43,6 +43,7 @@ import functools
 import json
 import logging
 import os
+import posixpath
 import re
 import shutil
 import subprocess
@@ -377,7 +378,7 @@ def _wsl_windows_path_to_posix(path: str) -> str:
     drive = (win.drive or "").rstrip(":").lower()
     if not drive:
         return path
-    return os.path.join("/mnt", drive, *(str(part) for part in win.parts[1:]))
+    return posixpath.join("/mnt", drive, *(str(part) for part in win.parts[1:]))
 
 
 class _EmbeddedCuaDaemon:
@@ -439,7 +440,7 @@ class _EmbeddedCuaDaemon:
             raise RuntimeError(cua_driver_install_hint())
         self._command, self._mcp_args = _resolve_mcp_invocation(self._driver_cmd)
         env = _sanitize_subprocess_env(self.child_env())
-        command = [
+        command = cua_driver_argv(
             self._command,
             "serve",
             "--embedded",
@@ -449,7 +450,7 @@ class _EmbeddedCuaDaemon:
             "--permission-mode",
             "unrestricted",
             "--dangerously-bypass-approvals",
-        ]
+        )
         self._process = subprocess.Popen(
             command,
             stdin=subprocess.DEVNULL,
@@ -475,7 +476,7 @@ class _EmbeddedCuaDaemon:
                 )
             try:
                 probe = subprocess.run(
-                    [self._command, "status", "--socket", self.socket_path],
+                    cua_driver_argv(self._command, "status", "--socket", self.socket_path),
                     stdin=subprocess.DEVNULL,
                     capture_output=True,
                     text=True,
@@ -510,7 +511,7 @@ class _EmbeddedCuaDaemon:
 
             try:
                 subprocess.run(
-                    [self._command, "stop", "--socket", self.socket_path],
+                    cua_driver_argv(self._command, "stop", "--socket", self.socket_path),
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -563,7 +564,7 @@ def _resolve_mcp_invocation(
     try:
         from tools.environments.local import _sanitize_subprocess_env
         proc = subprocess.run(
-            [driver_cmd, "manifest"],
+            cua_driver_argv(driver_cmd, "manifest"),
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout,
             stdin=subprocess.DEVNULL,
             creationflags=windows_hide_flags(),
@@ -635,7 +636,7 @@ def _cua_driver_supports_no_overlay(driver_cmd: str) -> bool:
         # and MCP spawn; #53503/#55709/#58889 lineage).
         from tools.environments.local import _sanitize_subprocess_env
         proc = subprocess.run(
-            [driver_cmd, "--help"],
+            cua_driver_argv(driver_cmd, "--help"),
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=3.0,
             stdin=subprocess.DEVNULL,
             creationflags=windows_hide_flags(),
@@ -689,6 +690,33 @@ def _has_path_separator(value: str) -> bool:
     return os.sep in value or (os.altsep is not None and os.altsep in value)
 
 
+def _wsl_init_can_launch(driver_cmd: str) -> bool:
+    """Whether WSL ``/init`` can launch a non-executable DrvFS Windows binary."""
+    if not re.match(r"^/mnt/[A-Za-z](?:/|$)", driver_cmd):
+        return False
+    if not driver_cmd.lower().endswith(".exe"):
+        return False
+    try:
+        from hermes_constants import is_wsl
+
+        if not is_wsl():
+            return False
+    except Exception:
+        return False
+    return (
+        os.path.isfile(driver_cmd)
+        and not os.access(driver_cmd, os.X_OK)
+        and os.path.isfile("/init")
+        and os.access("/init", os.X_OK)
+    )
+
+
+def cua_driver_argv(driver_cmd: str, *args: str) -> List[str]:
+    """Build argv for every cua-driver spawn, including narrow WSL interop."""
+    prefix = ["/init", driver_cmd] if _wsl_init_can_launch(driver_cmd) else [driver_cmd]
+    return [*prefix, *args]
+
+
 def _candidate_cua_driver_commands(override: Optional[str] = None) -> List[str]:
     """Return candidate cua-driver commands in resolution order.
 
@@ -735,7 +763,7 @@ def resolve_cua_driver_cmd(override: Optional[str] = None) -> Optional[str]:
     for candidate in _candidate_cua_driver_commands(override):
         expanded = os.path.expanduser(candidate)
         if _has_path_separator(expanded):
-            if shutil.which(expanded):
+            if shutil.which(expanded) or _wsl_init_can_launch(expanded):
                 return expanded
         else:
             resolved = shutil.which(expanded)
@@ -775,7 +803,7 @@ def cua_driver_update_check(*, timeout: Optional[float] = None) -> Optional[Dict
     try:
         from tools.environments.local import _sanitize_subprocess_env
         proc = subprocess.run(
-            [driver_cmd, "check-update", "--json"],
+            cua_driver_argv(driver_cmd, "check-update", "--json"),
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout,
             # Some older drivers don't have the verb and fall through to a
             # stdin-reading mode rather than erroring — DEVNULL gives them EOF
@@ -1159,9 +1187,10 @@ class _CuaDriverSession:
                 command, args = _resolve_mcp_invocation(driver_cmd)
                 child_env = cua_driver_child_env()
             _t_manifest = _time.monotonic()
+            invocation = cua_driver_argv(command, *args)
             params = StdioServerParameters(
-                command=command,
-                args=args,
+                command=invocation[0],
+                args=invocation[1:],
                 # Apply the telemetry policy first (default: disabled), then
                 # sanitize Hermes-managed secrets out of the child env.
                 env=_sanitize_subprocess_env(child_env),
@@ -1557,13 +1586,13 @@ class _CuaDriverSession:
             driver_command = embedded_daemon.proxy_invocation()[0]
             child_env = embedded_daemon.child_env()
             socket_args = ["--socket", embedded_daemon.socket_path]
-        cmd = [
+        cmd = cua_driver_argv(
             driver_command,
             "call",
             name,
             json.dumps(call_args),
             *socket_args,
-        ]
+        )
         attempts = 4
         backoff = 0.5
         parsed: Any = None

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -86,6 +86,12 @@ def _sanitized_cua_env() -> Dict[str, str]:
         return env
 
 
+def _driver_argv(binary: str, *args: str) -> List[str]:
+    from tools.computer_use.cua_backend import cua_driver_argv
+
+    return cua_driver_argv(binary, *args)
+
+
 def _is_valid_health_report(payload: Any) -> bool:
     """True when *payload* looks like a schema_version=1 health_report."""
     if not isinstance(payload, dict):
@@ -110,7 +116,7 @@ def _read_cli_version(binary: str, *, timeout: float = 5.0) -> Optional[str]:
     """
     try:
         completed = subprocess.run(
-            [binary, "--version"],
+            _driver_argv(binary, "--version"),
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -208,7 +214,7 @@ def _open_mcp(binary: str) -> subprocess.Popen:
     # default Windows install — which raises UnicodeDecodeError on the
     # first non-ASCII byte. Pin the codec.
     return subprocess.Popen(
-        [binary, "mcp"],
+        _driver_argv(binary, "mcp"),
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -312,7 +318,7 @@ def _cli_driver_version(binary: str, timeout: float = 5.0) -> Tuple[str, Optiona
     """Return (status, version_or_message) from ``cua-driver --version``."""
     try:
         completed = subprocess.run(
-            [binary, "--version"],
+            _driver_argv(binary, "--version"),
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -339,7 +345,7 @@ def _cli_doctor_snippet(binary: str, timeout: float = 8.0) -> Optional[str]:
     """Optional one-shot ``cua-driver doctor`` text (best-effort, never fatal)."""
     try:
         completed = subprocess.run(
-            [binary, "doctor"],
+            _driver_argv(binary, "doctor"),
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/tools/computer_use/permissions.py
+++ b/tools/computer_use/permissions.py
@@ -43,6 +43,12 @@ def _resolve_driver_cmd(override: Optional[str]) -> Optional[str]:
     return resolve_cua_driver_cmd(override)
 
 
+def _driver_argv(binary: str, *args: str) -> List[str]:
+    from tools.computer_use.cua_backend import cua_driver_argv
+
+    return cua_driver_argv(binary, *args)
+
+
 def _child_env() -> Dict[str, str]:
     """cua-driver child env: telemetry opt-in policy + secret sanitization.
 
@@ -66,7 +72,7 @@ def _child_env() -> Dict[str, str]:
 
 def _run(binary: str, *args: str, timeout: float) -> subprocess.CompletedProcess:
     return subprocess.run(
-        [binary, *args],
+        _driver_argv(binary, *args),
         capture_output=True,
         text=True, encoding='utf-8', errors='replace',
         timeout=timeout,
@@ -186,7 +192,7 @@ def request_permissions_grant(driver_cmd: Optional[str] = None) -> int:
     try:
         return int(
             subprocess.run(
-                [binary, "permissions", "grant"],
+                _driver_argv(binary, "permissions", "grant"),
                 env=_child_env(),
                 stdin=subprocess.DEVNULL,
             ).returncode


### PR DESCRIPTION
## What does this PR do?

WSL users can now use a Windows `cua-driver.exe` from a restrictive DrvFS mount even when the file has no POSIX execute bit. Without this fix, Hermes reports the verified driver as not installed and Computer Use remains unavailable, although WSL `/init` can launch the same binary successfully.

### Symptom

With `HERMES_CUA_DRIVER_CMD` pointing to an existing Windows `cua-driver.exe` on a DrvFS mount configured with `fmask=111`, `resolve_cua_driver_cmd()` returns no driver. Status, doctor, readiness checks, and runtime Computer Use consequently report the driver as unavailable. Direct execution fails with exit 126, while `/init <driver> ...` succeeds.

### Impact

Computer Use is unusable for WSL users whose DrvFS policy intentionally removes POSIX execute bits from Windows binaries. The failure affects discovery and every driver launch surface, not only one CLI command.

### Bug Cause

**Trigger:** `tools/computer_use/cua_backend.py:756` in `resolve_cua_driver_cmd()` when an explicit WSL DrvFS `.exe` path is not executable according to POSIX `X_OK`.

**Causal chain:**
1. A WSL user configures an existing Windows `cua-driver.exe` on `/mnt/<drive>/...` under a restrictive DrvFS mount.
2. The shared resolver relies on `shutil.which()`, which rejects the path because its POSIX execute bit is absent, even though WSL interop can launch the PE binary through `/init`.
3. Shared status and readiness surfaces report the driver as missing, and subprocess launch paths cannot start the MCP or CLI protocol.

**Why it is wrong:** POSIX executability is not the complete launch contract for a Windows PE binary under WSL. `/init` provides a supported interop launch path for this narrow case.

**Working sibling / contrast:** Native Linux drivers and directly executable WSL paths already launch directly and continue to do so. The new prefix applies only to an existing, non-executable `.exe` under `/mnt/<drive>` while running in WSL and while executable `/init` is present.

**Ruled out:** This is not the Windows named-pipe socket issue because failure occurs before the embedded daemon selects a socket. It is also not manifest path normalization because an already normalized `/mnt/<drive>/...exe` path still fails the `X_OK` resolver gate.

### Fix

Add one shared `cua_driver_argv()` builder that prefixes `/init` only for the verified WSL interop boundary, and let the resolver accept the same path under that contract. Route runtime MCP, CLI fallback, embedded daemon, update/version probes, install checks, status, doctor, and permissions through the shared argv builder so discovery and invocation cannot disagree.

## Related Issue

Fixes #82409

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py` - add narrow WSL `/init` resolution and argv construction, then use it for runtime and update launches.
- `tools/computer_use/doctor.py` and `tools/computer_use/permissions.py` - use the same argv contract for health, readiness, and permission probes.
- `hermes_cli/tools_config.py` and `hermes_cli/main.py` - use the same argv contract for install, update, and status version checks.
- `tests/computer_use/test_cua_wsl_nonexec_driver.py` - cover resolver acceptance, `/init` prefixing, direct/native preservation, and status/doctor/runtime parity.

## How to Test

1. On WSL2, expose the verified Windows `cua-driver.exe` as mode `0644` on a DrvFS mount and set `HERMES_CUA_DRIVER_CMD` to its `/mnt/<drive>/...` path.
2. Confirm direct launch fails with exit 126, while Hermes resolves the driver and launches it through `/init`.
3. Start a real MCP session and call `list_windows`; confirm the Windows UI Automation result is returned.
4. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/computer_use tests/tools/test_computer_use_cua_backend_linux.py tests/tools/test_computer_use_cua_0_9.py tests/tools/test_computer_use_cua_0_10_permissions.py tests/hermes_cli/test_install_cua_driver.py
```

Result: 139 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 host with WSL2 Ubuntu 22.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

A real WSL verification with a mode `0644` DrvFS driver confirmed that Hermes resolved the path through `/init`, reported it installed, completed an MCP session, and enumerated Windows windows.
