### PR TITLE
fix(process-registry): keep CLI workers off controlling tty

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1649,6 +1649,10 @@ class TestSystemdCgroupIsolation:
     ENTIRE gateway cgroup, taking down the messaging control plane.
     """
 
+    @pytest.fixture(autouse=True)
+    def _mark_gateway_process(self, monkeypatch):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
     def _fake_popen_capture(self):
         """Return (fake_popen, captured) where captured["argv"] gets the
         argv passed to subprocess.Popen."""
@@ -1779,6 +1783,63 @@ class TestSystemdCgroupIsolation:
         argv = captured["argv"]
         assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
+
+    def test_inherited_systemd_marker_does_not_scope_interactive_cli(
+        self, registry, monkeypatch
+    ):
+        """A CLI inside a supervised terminal must keep workers off its tty."""
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setenv("INVOCATION_ID", "herdr-service-inherited-marker")
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert captured["argv"] == [
+            "/bin/bash",
+            "-lic",
+            "set +m; echo hello",
+        ]
+        assert captured["start_new_session"] is True
+
+    def test_inherited_systemd_marker_does_not_scope_interactive_cli_pty(
+        self, registry, monkeypatch
+    ):
+        """The same gateway-identity gate applies to PTY-backed workers."""
+        from ptyprocess import PtyProcess
+
+        fake_pty = MagicMock()
+        fake_pty.pid = 4321
+
+        monkeypatch.setenv("INVOCATION_ID", "herdr-service-inherited-marker")
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn, \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+
+        assert pty_spawn.call_args.args[0] == [
+            "/bin/bash",
+            "-lic",
+            "set +m; codex",
+        ]
+        assert session.systemd_unit == ""
 
     def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
         self, registry, monkeypatch

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1652,6 +1652,10 @@ class TestSystemdCgroupIsolation:
     @pytest.fixture(autouse=True)
     def _mark_gateway_process(self, monkeypatch):
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid(),
+        )
 
     def _fake_popen_capture(self):
         """Return (fake_popen, captured) where captured["argv"] gets the
@@ -1689,20 +1693,26 @@ class TestSystemdCgroupIsolation:
         # _build_systemd_scope_argv calls shutil.which — point it at a stub.
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             session = registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
         assert argv[0] == "/usr/bin/systemd-run", argv
         assert "--user" in argv
         assert "--scope" in argv
-        assert "--quiet" in argv, "systemd-run argv must include --quiet (#70716 gap #3)"
+        assert "--quiet" in argv, (
+            "systemd-run argv must include --quiet (#70716 gap #3)"
+        )
         assert "--unit" in argv
         unit_idx = argv.index("--unit")
         assert argv[unit_idx + 1].startswith("hermes-worker-"), argv
-        assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", argv  # _build_systemd_scope_argv uses bare name
+        assert argv[unit_idx + 1] == f"hermes-worker-{session.id}", (
+            argv
+        )  # _build_systemd_scope_argv uses bare name
         properties = [
             argv[index + 1]
             for index, value in enumerate(argv[:-1])
@@ -1730,9 +1740,7 @@ class TestSystemdCgroupIsolation:
         # The session must record the unit name so kill_process can stop it.
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
-    def test_falls_back_when_systemd_run_unavailable(
-        self, registry, monkeypatch
-    ):
+    def test_falls_back_when_systemd_run_unavailable(self, registry, monkeypatch):
         """Under a supervisor but without systemd-run, fall back to the
         legacy ``start_new_session=True`` path (worker shares the gateway
         cgroup)."""
@@ -1748,9 +1756,11 @@ class TestSystemdCgroupIsolation:
             lambda: True,
         )
 
-        with patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
@@ -1758,9 +1768,7 @@ class TestSystemdCgroupIsolation:
         assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
-    def test_falls_back_when_not_under_supervisor(
-        self, registry, monkeypatch
-    ):
+    def test_falls_back_when_not_under_supervisor(self, registry, monkeypatch):
         """CLI mode (no supervisor) must NOT wrap in a systemd scope even if
         systemd-run is available — isolation is a gateway concern."""
         fake_popen, captured = self._fake_popen_capture()
@@ -1775,9 +1783,11 @@ class TestSystemdCgroupIsolation:
             lambda: False,
         )
 
-        with patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             registry.spawn_local("echo hello", cwd="/tmp")
 
         argv = captured["argv"]
@@ -1799,9 +1809,11 @@ class TestSystemdCgroupIsolation:
         )
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with patch("subprocess.Popen", side_effect=fake_popen), \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             registry.spawn_local("echo hello", cwd="/tmp")
 
         assert captured["argv"] == [
@@ -1829,9 +1841,79 @@ class TestSystemdCgroupIsolation:
         )
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn, \
-            patch("threading.Thread", return_value=MagicMock()), \
-            patch.object(registry, "_write_checkpoint"):
+        with (
+            patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+
+        assert pty_spawn.call_args.args[0] == [
+            "/bin/bash",
+            "-lic",
+            "set +m; codex",
+        ]
+        assert session.systemd_unit == ""
+
+    def test_inherited_gateway_tree_markers_do_not_scope_child_cli(
+        self, registry, monkeypatch
+    ):
+        """Gateway descendants are not the gateway process that owns the PID file."""
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setenv("INVOCATION_ID", "inherited-systemd-marker")
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid() + 1,
+        )
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert captured["argv"] == [
+            "/bin/bash",
+            "-lic",
+            "set +m; echo hello",
+        ]
+        assert captured["start_new_session"] is True
+
+    def test_inherited_gateway_tree_markers_do_not_scope_child_cli_pty(
+        self, registry, monkeypatch
+    ):
+        """The PID-bound gateway identity gate also protects PTY-backed children."""
+        from ptyprocess import PtyProcess
+
+        fake_pty = MagicMock(pid=4321)
+
+        monkeypatch.setenv("INVOCATION_ID", "inherited-systemd-marker")
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid() + 1,
+        )
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+
+        with (
+            patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
             session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
 
         assert pty_spawn.call_args.args[0] == [

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1649,8 +1649,9 @@ class TestSystemdCgroupIsolation:
     ENTIRE gateway cgroup, taking down the messaging control plane.
     """
 
-    @pytest.fixture(autouse=True)
-    def _mark_gateway_process(self, monkeypatch):
+    @pytest.fixture()
+    def _gateway_identity(self, monkeypatch):
+        """Opt-in: mark this test as running AS the live gateway process."""
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
@@ -1675,7 +1676,7 @@ class TestSystemdCgroupIsolation:
         return fake_popen, captured
 
     def test_wraps_in_systemd_scope_when_supervisor_and_available(
-        self, registry, monkeypatch
+        self, registry, monkeypatch, _gateway_identity
     ):
         """Under a supervisor with systemd-run available, the spawn argv is
         wrapped in ``systemd-run --user --scope --unit=hermes-worker-<id>``."""
@@ -1740,7 +1741,7 @@ class TestSystemdCgroupIsolation:
         # The session must record the unit name so kill_process can stop it.
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
-    def test_falls_back_when_systemd_run_unavailable(self, registry, monkeypatch):
+    def test_falls_back_when_systemd_run_unavailable(self, registry, monkeypatch, _gateway_identity):
         """Under a supervisor but without systemd-run, fall back to the
         legacy ``start_new_session=True`` path (worker shares the gateway
         cgroup)."""
@@ -1794,12 +1795,15 @@ class TestSystemdCgroupIsolation:
         assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
+    @pytest.mark.parametrize("use_pty", [False, True])
     def test_inherited_systemd_marker_does_not_scope_interactive_cli(
-        self, registry, monkeypatch
+        self, registry, monkeypatch, use_pty
     ):
-        """A CLI inside a supervised terminal must keep workers off its tty."""
-        fake_popen, captured = self._fake_popen_capture()
+        """A CLI inside a supervised terminal must keep workers off its tty.
 
+        INVOCATION_ID is inherited by every descendant, so its presence
+        alone must not activate the gateway-only systemd scope path.
+        """
         monkeypatch.setenv("INVOCATION_ID", "herdr-service-inherited-marker")
         monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
@@ -1809,58 +1813,44 @@ class TestSystemdCgroupIsolation:
         )
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with (
-            patch("subprocess.Popen", side_effect=fake_popen),
-            patch("threading.Thread", return_value=MagicMock()),
-            patch.object(registry, "_write_checkpoint"),
-        ):
-            registry.spawn_local("echo hello", cwd="/tmp")
+        if use_pty:
+            from ptyprocess import PtyProcess
 
-        assert captured["argv"] == [
-            "/bin/bash",
-            "-lic",
-            "set +m; echo hello",
-        ]
-        assert captured["start_new_session"] is True
+            fake_pty = MagicMock(pid=4321)
+            with (
+                patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
+                patch("threading.Thread", return_value=MagicMock()),
+                patch.object(registry, "_write_checkpoint"),
+            ):
+                session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+            assert pty_spawn.call_args.args[0] == [
+                "/bin/bash", "-lic", "set +m; codex",
+            ]
+        else:
+            fake_popen, captured = self._fake_popen_capture()
+            with (
+                patch("subprocess.Popen", side_effect=fake_popen),
+                patch("threading.Thread", return_value=MagicMock()),
+                patch.object(registry, "_write_checkpoint"),
+            ):
+                session = registry.spawn_local("echo hello", cwd="/tmp")
+            assert captured["argv"] == [
+                "/bin/bash", "-lic", "set +m; echo hello",
+            ]
+            assert captured["start_new_session"] is True
 
-    def test_inherited_systemd_marker_does_not_scope_interactive_cli_pty(
-        self, registry, monkeypatch
-    ):
-        """The same gateway-identity gate applies to PTY-backed workers."""
-        from ptyprocess import PtyProcess
-
-        fake_pty = MagicMock()
-        fake_pty.pid = 4321
-
-        monkeypatch.setenv("INVOCATION_ID", "herdr-service-inherited-marker")
-        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
-        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
-        monkeypatch.setattr(
-            "tools.process_registry._systemd_run_user_scope_available",
-            lambda: True,
-        )
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
-
-        with (
-            patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
-            patch("threading.Thread", return_value=MagicMock()),
-            patch.object(registry, "_write_checkpoint"),
-        ):
-            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
-
-        assert pty_spawn.call_args.args[0] == [
-            "/bin/bash",
-            "-lic",
-            "set +m; codex",
-        ]
         assert session.systemd_unit == ""
 
+    @pytest.mark.parametrize("use_pty", [False, True])
     def test_inherited_gateway_tree_markers_do_not_scope_child_cli(
-        self, registry, monkeypatch
+        self, registry, monkeypatch, use_pty
     ):
-        """Gateway descendants are not the gateway process that owns the PID file."""
-        fake_popen, captured = self._fake_popen_capture()
+        """Gateway descendants are not the gateway process that owns the PID file.
 
+        _HERMES_GATEWAY is inherited (and set by importing gateway.run), so
+        both it and INVOCATION_ID may be present in a child process. The
+        PID-ownership gate must still keep the scope path off.
+        """
         monkeypatch.setenv("INVOCATION_ID", "inherited-systemd-marker")
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
         monkeypatch.setattr(
@@ -1874,57 +1864,36 @@ class TestSystemdCgroupIsolation:
         )
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with (
-            patch("subprocess.Popen", side_effect=fake_popen),
-            patch("threading.Thread", return_value=MagicMock()),
-            patch.object(registry, "_write_checkpoint"),
-        ):
-            registry.spawn_local("echo hello", cwd="/tmp")
+        if use_pty:
+            from ptyprocess import PtyProcess
 
-        assert captured["argv"] == [
-            "/bin/bash",
-            "-lic",
-            "set +m; echo hello",
-        ]
-        assert captured["start_new_session"] is True
+            fake_pty = MagicMock(pid=4321)
+            with (
+                patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
+                patch("threading.Thread", return_value=MagicMock()),
+                patch.object(registry, "_write_checkpoint"),
+            ):
+                session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+            assert pty_spawn.call_args.args[0] == [
+                "/bin/bash", "-lic", "set +m; codex",
+            ]
+        else:
+            fake_popen, captured = self._fake_popen_capture()
+            with (
+                patch("subprocess.Popen", side_effect=fake_popen),
+                patch("threading.Thread", return_value=MagicMock()),
+                patch.object(registry, "_write_checkpoint"),
+            ):
+                session = registry.spawn_local("echo hello", cwd="/tmp")
+            assert captured["argv"] == [
+                "/bin/bash", "-lic", "set +m; echo hello",
+            ]
+            assert captured["start_new_session"] is True
 
-    def test_inherited_gateway_tree_markers_do_not_scope_child_cli_pty(
-        self, registry, monkeypatch
-    ):
-        """The PID-bound gateway identity gate also protects PTY-backed children."""
-        from ptyprocess import PtyProcess
-
-        fake_pty = MagicMock(pid=4321)
-
-        monkeypatch.setenv("INVOCATION_ID", "inherited-systemd-marker")
-        monkeypatch.setenv("_HERMES_GATEWAY", "1")
-        monkeypatch.setattr(
-            "gateway.status.get_running_pid",
-            lambda *, cleanup_stale=False: os.getpid() + 1,
-        )
-        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
-        monkeypatch.setattr(
-            "tools.process_registry._systemd_run_user_scope_available",
-            lambda: True,
-        )
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
-
-        with (
-            patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
-            patch("threading.Thread", return_value=MagicMock()),
-            patch.object(registry, "_write_checkpoint"),
-        ):
-            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
-
-        assert pty_spawn.call_args.args[0] == [
-            "/bin/bash",
-            "-lic",
-            "set +m; codex",
-        ]
         assert session.systemd_unit == ""
 
     def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
-        self, registry, monkeypatch
+        self, registry, monkeypatch, _gateway_identity
     ):
         """Cleanup must not killpg: scope teardown is the authoritative path."""
         fake_popen, _captured = self._fake_popen_capture()
@@ -1957,7 +1926,7 @@ class TestSystemdCgroupIsolation:
         assert stop_unit.call_args.args[0].endswith(".scope")
         killpg.assert_not_called()
 
-    def test_pty_spawn_is_wrapped_in_systemd_scope(self, registry, monkeypatch):
+    def test_pty_spawn_is_wrapped_in_systemd_scope(self, registry, monkeypatch, _gateway_identity):
         """Interactive executors receive the same sibling-cgroup isolation."""
         from ptyprocess import PtyProcess
 
@@ -1989,7 +1958,7 @@ class TestSystemdCgroupIsolation:
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
     def test_pty_spawn_failure_reaps_scope_before_distinct_pipe_fallback(
-        self, registry, monkeypatch
+        self, registry, monkeypatch, _gateway_identity
     ):
         """A failed PTY scope must not collide with the pipe fallback scope."""
         from ptyprocess import PtyProcess
@@ -2044,7 +2013,7 @@ class TestSystemdCgroupIsolation:
         )
 
     def test_pty_spawn_failure_does_not_fallback_when_scope_reap_fails(
-        self, registry, monkeypatch
+        self, registry, monkeypatch, _gateway_identity
     ):
         """Do not launch a duplicate command while the failed PTY scope may live."""
         from ptyprocess import PtyProcess

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1095,7 +1095,6 @@ class ProcessRegistry:
         # cgroup (and the messaging control plane with it). This applies to
         # both pipe mode and the PTY path above.
         shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
-        use_systemd_scope = False
         in_supervised_gateway = not _IS_WINDOWS and _is_supervised_gateway_process()
         use_systemd_scope = (
             in_supervised_gateway and _systemd_run_user_scope_available()
@@ -1130,7 +1129,7 @@ class ProcessRegistry:
                 # in the worker can still kill the whole gateway (#70716).
                 logger.debug(
                     "Local background executor not isolated in a systemd scope "
-                    "(supervisor=%s, systemd-run --user available=%s); "
+                    "(in_supervised_gateway=%s, systemd-run --user available=%s); "
                     "worker shares the gateway cgroup.",
                     in_supervised_gateway,
                     _systemd_run_user_scope_available(),

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -248,21 +248,25 @@ def _systemd_run_user_scope_available() -> bool:
 def _is_supervised_gateway_process() -> bool:
     """Return whether this process is in a supervised Hermes gateway runtime.
 
-    Supervisor markers such as systemd's ``INVOCATION_ID`` are inherited by
-    every descendant. An interactive CLI launched from a supervised terminal
-    manager therefore cannot use that marker alone: its login-shell workers
-    would stay in the CLI's session and could take ownership of the controlling
-    tty. ``gateway.run`` adds ``_HERMES_GATEWAY`` to the gateway process tree;
-    unrelated supervised terminal managers do not.
+    Both supervisor markers and ``_HERMES_GATEWAY`` are inherited by every
+    descendant, and importing ``gateway.run`` also sets the latter. Require
+    this process to own the live gateway PID file as well. That keeps transient
+    systemd scopes limited to the gateway itself instead of terminal children
+    or unrelated interactive CLIs in the same supervised process tree.
     """
     if os.environ.get("_HERMES_GATEWAY") != "1":
         return False
 
     try:
         from gateway.restart import is_gateway_supervisor_process
+        from gateway.status import get_running_pid
 
-        return is_gateway_supervisor_process()
-    except Exception:
+        return (
+            is_gateway_supervisor_process()
+            and get_running_pid(cleanup_stale=False) == os.getpid()
+        )
+    except Exception as exc:
+        logger.debug("Could not verify supervised gateway process identity: %s", exc)
         return False
 
 
@@ -1012,30 +1016,26 @@ class ProcessRegistry:
                 # Cgroup isolation for PTY mode (#70716, reviewer gap #1):
                 # Wrap the PTY command in a systemd scope so interactive
                 # executors get their own cgroup, same as pipe mode.
-                pty_under_supervisor = _is_supervised_gateway_process()
+                pty_in_supervised_gateway = (
+                    not _IS_WINDOWS and _is_supervised_gateway_process()
+                )
                 pty_use_systemd_scope = (
-                    not _IS_WINDOWS
-                    and pty_under_supervisor
-                    and _systemd_run_user_scope_available()
+                    pty_in_supervised_gateway and _systemd_run_user_scope_available()
                 )
 
                 if pty_use_systemd_scope:
                     pty_argv = _build_systemd_scope_argv(
-                        pty_argv, unit_suffix=session.id,
+                        pty_argv,
+                        unit_suffix=session.id,
                     )
                     session.systemd_unit = f"hermes-worker-{session.id}.scope"
                     pty_scope_attempted = True
-                elif not _IS_WINDOWS:
-                    try:
-                        from gateway.restart import is_gateway_supervisor_process as _sup
-                        if _sup():
-                            logger.debug(
-                                "PTY background executor not isolated in a "
-                                "systemd scope (systemd-run --user unavailable); "
-                                "worker shares the gateway cgroup."
-                            )
-                    except Exception:
-                        pass
+                elif pty_in_supervised_gateway:
+                    logger.debug(
+                        "PTY background executor not isolated in a "
+                        "systemd scope (systemd-run --user unavailable); "
+                        "worker shares the gateway cgroup."
+                    )
 
                 pty_proc = _PtyProcessCls.spawn(
                     pty_argv,
@@ -1088,29 +1088,26 @@ class ProcessRegistry:
         bg_env["PYTHONUNBUFFERED"] = "1"
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
-        # Cgroup isolation (#70716): when running under a service manager
-        # (systemd gateway), wrap the worker in its own transient systemd
+        # Cgroup isolation (#70716): when running in the live, supervised
+        # systemd gateway, wrap the worker in its own transient systemd
         # scope so it gets a separate cgroup.  An OOM in the worker then
         # kills only the worker instead of taking down the whole gateway
-        # cgroup (and the messaging control plane with it).  We only do this
-        # for both pipe mode and the PTY path above.
+        # cgroup (and the messaging control plane with it). This applies to
+        # both pipe mode and the PTY path above.
         shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
         use_systemd_scope = False
-        under_supervisor = _is_supervised_gateway_process()
+        in_supervised_gateway = not _IS_WINDOWS and _is_supervised_gateway_process()
         use_systemd_scope = (
-            not _IS_WINDOWS
-            and under_supervisor
-            and _systemd_run_user_scope_available()
+            in_supervised_gateway and _systemd_run_user_scope_available()
         )
 
         if use_systemd_scope:
             unit_suffix = (
-                f"{session.id}-pipe-fallback"
-                if pty_scope_attempted
-                else session.id
+                f"{session.id}-pipe-fallback" if pty_scope_attempted else session.id
             )
             spawn_argv = _build_systemd_scope_argv(
-                shell_argv, unit_suffix=unit_suffix,
+                shell_argv,
+                unit_suffix=unit_suffix,
             )
             session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
             # CRITICAL (#70716 regression): systemd-run --scope does NOT give
@@ -1127,7 +1124,7 @@ class ProcessRegistry:
         else:
             spawn_argv = shell_argv
             popen_start_new_session = True
-            if not _IS_WINDOWS and under_supervisor:
+            if in_supervised_gateway:
                 # Running under a supervisor but could not get a private
                 # cgroup — the worker shares the gateway cgroup, so an OOM
                 # in the worker can still kill the whole gateway (#70716).
@@ -1135,7 +1132,7 @@ class ProcessRegistry:
                     "Local background executor not isolated in a systemd scope "
                     "(supervisor=%s, systemd-run --user available=%s); "
                     "worker shares the gateway cgroup.",
-                    under_supervisor,
+                    in_supervised_gateway,
                     _systemd_run_user_scope_available(),
                 )
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -245,6 +245,27 @@ def _systemd_run_user_scope_available() -> bool:
         return available
 
 
+def _is_supervised_gateway_process() -> bool:
+    """Return whether this process is in a supervised Hermes gateway runtime.
+
+    Supervisor markers such as systemd's ``INVOCATION_ID`` are inherited by
+    every descendant. An interactive CLI launched from a supervised terminal
+    manager therefore cannot use that marker alone: its login-shell workers
+    would stay in the CLI's session and could take ownership of the controlling
+    tty. ``gateway.run`` adds ``_HERMES_GATEWAY`` to the gateway process tree;
+    unrelated supervised terminal managers do not.
+    """
+    if os.environ.get("_HERMES_GATEWAY") != "1":
+        return False
+
+    try:
+        from gateway.restart import is_gateway_supervisor_process
+
+        return is_gateway_supervisor_process()
+    except Exception:
+        return False
+
+
 def _build_systemd_scope_argv(
     shell_argv: List[str],
     unit_suffix: str,
@@ -991,18 +1012,12 @@ class ProcessRegistry:
                 # Cgroup isolation for PTY mode (#70716, reviewer gap #1):
                 # Wrap the PTY command in a systemd scope so interactive
                 # executors get their own cgroup, same as pipe mode.
-                pty_use_systemd_scope = False
-                try:
-                    from gateway.restart import is_gateway_supervisor_process
-
-                    pty_under_supervisor = is_gateway_supervisor_process()
-                    pty_use_systemd_scope = (
-                        not _IS_WINDOWS
-                        and pty_under_supervisor
-                        and _systemd_run_user_scope_available()
-                    )
-                except Exception:
-                    pty_use_systemd_scope = False
+                pty_under_supervisor = _is_supervised_gateway_process()
+                pty_use_systemd_scope = (
+                    not _IS_WINDOWS
+                    and pty_under_supervisor
+                    and _systemd_run_user_scope_available()
+                )
 
                 if pty_use_systemd_scope:
                     pty_argv = _build_systemd_scope_argv(
@@ -1081,18 +1096,12 @@ class ProcessRegistry:
         # for both pipe mode and the PTY path above.
         shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
         use_systemd_scope = False
-        under_supervisor = False
-        try:
-            from gateway.restart import is_gateway_supervisor_process
-
-            under_supervisor = is_gateway_supervisor_process()
-            use_systemd_scope = (
-                not _IS_WINDOWS
-                and under_supervisor
-                and _systemd_run_user_scope_available()
-            )
-        except Exception:
-            use_systemd_scope = False
+        under_supervisor = _is_supervised_gateway_process()
+        use_systemd_scope = (
+            not _IS_WINDOWS
+            and under_supervisor
+            and _systemd_run_user_scope_available()
+        )
 
         if use_systemd_scope:
             unit_suffix = (


### PR DESCRIPTION
## Summary

Interactive Hermes CLIs launched from supervised terminal managers no longer mistake inherited service-manager metadata for gateway identity, preventing SIGTTOU stops when background workers seize tty foreground ownership.

## Root cause

The old code gated systemd scope usage on `is_gateway_supervisor_process()` alone, which checks supervisor markers like `INVOCATION_ID`. These markers are inherited by ALL descendant processes — an interactive CLI inside a supervised terminal (e.g. Herdr) would pass the check, causing its background workers to enter `systemd-run --scope` without `start_new_session=True`. The worker then took foreground tty ownership, and prompt-toolkit's next `tcsetattr` stopped Hermes with SIGTTOU.

## Changes

- Add `_is_supervised_gateway_process()` predicate requiring all three: `_HERMES_GATEWAY=1` env var + `is_gateway_supervisor_process()` + `get_running_pid() == os.getpid()` (PID file ownership)
- Replace two inline try/except blocks with the single predicate (deduplication)
- Add 4 regression tests covering inherited-marker and PID-mismatch scenarios for both pipe and PTY modes

## Salvage follow-up (this PR)

Cherry-picked @bgrablin's two commits onto current `main` (147 commits ahead), then applied cleanups:

- Remove dead `use_systemd_scope = False` assignment (leftover from old try/except, immediately overwritten)
- Update stale log label `supervisor=` → `in_supervised_gateway=` to match renamed variable
- Convert autouse `_mark_gateway_process` fixture to opt-in `_gateway_identity` so negative tests start clean instead of undoing the fixture
- Parametrize 4 near-duplicate negative tests (2 scenarios × pipe/PTY) into 2 parametrized tests (net -32 LOC)

## Validation

| | Before | After |
|---|---|---|
| Tests | 76 passed | 76 passed |
| Ruff | clean | clean |
| Net LOC | +212/-63 | +153/-63 (follow-up -59) |

## Credits

@bgrablin authored the core fix and regression tests in #82031. This salvage preserves both commits with original authorship via rebase-merge.

Closes #82031
