### PR TITLE
fix(compression): prevent no-op compression with legacy SessionDB

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -404,15 +404,16 @@ def _capture_authoritative_cooldown_under_lease(
         values = vars(compressor)
         session_db = values.get("_session_db")
         session_id = values.get("_session_id")
-        raw_reader = (
-            getattr(
-                type(session_db), "get_compression_failure_cooldown_row", None
-            )
-            if session_db is not None
-            else None
-        )
         if session_db is None or not session_id:
             # Unbound compressors have no durable row to mutate or restore.
+            return None, None
+        missing = object()
+        raw_reader = getattr(
+            type(session_db),
+            "get_compression_failure_cooldown_row",
+            missing,
+        )
+        if raw_reader is missing:
             return None, None
         if not callable(raw_reader):
             return False, None

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -1091,6 +1091,97 @@ class SessionDB:
     return namespace["SessionDB"]
 
 
+def test_legacy_session_db_without_raw_cooldown_api_preserves_compression_compatibility(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale pre-cooldown SessionDB must not turn compression into a no-op."""
+    import hermes_state
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "LEGACY_COOLDOWN_COMPATIBILITY"
+    db.create_session(session_id, source="test")
+    agent = _build_agent_with_db(db, session_id, stub_compressor=False)
+
+    legacy_session_db_class = _make_legacy_session_db_class()
+    legacy_db = legacy_session_db_class(db)
+    monkeypatch.setattr(hermes_state, "SessionDB", legacy_session_db_class)
+    agent._session_db = legacy_db
+    agent.context_compressor._session_db = legacy_db
+    agent.context_compressor._session_id = session_id
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._cached_system_prompt = "sys"
+
+    expected = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compress_spy = MagicMock(return_value=copy.deepcopy(expected))
+    agent.context_compressor.compress = compress_spy
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    compressed, _prompt = agent._compress_context(
+        messages,
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    assert compressed == expected
+    compress_spy.assert_called_once()
+    assert db.get_compression_lock_holder(session_id) is None
+    assert _count_children(db, session_id) == 0
+
+
+def _raise_raw_cooldown_error(_db, _session_id):
+    raise RuntimeError("simulated raw cooldown read failure")
+
+
+@pytest.mark.parametrize(
+    "raw_reader",
+    [None, _raise_raw_cooldown_error],
+    ids=["noncallable", "read-error"],
+)
+def test_malformed_raw_cooldown_api_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_reader,
+) -> None:
+    """A present but malformed cooldown API is not legacy version skew."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "NONCALLABLE_COOLDOWN_API"
+    db.create_session(session_id, source="test")
+    agent = _build_agent_with_db(db, session_id, stub_compressor=False)
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._cached_system_prompt = "sys"
+
+    monkeypatch.setattr(
+        SessionDB,
+        "get_compression_failure_cooldown_row",
+        raw_reader,
+    )
+    compress_spy = MagicMock(
+        return_value=[
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail"},
+        ]
+    )
+    agent.context_compressor.compress = compress_spy
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    compressed, _prompt = agent._compress_context(
+        messages,
+        "sys",
+        approx_tokens=120_000,
+    )
+
+    assert compressed is messages
+    compress_spy.assert_not_called()
+    assert db.get_compression_lock_holder(session_id) is None
+    assert _count_children(db, session_id) == 0
+
+
 class _NominalSessionDBImpostor:
     """A proxy that spoofs names but lacks the real SessionDB source contract."""
 


### PR DESCRIPTION
## What does this PR do?

Fix context compression becoming a no-op during hot-update version skew, where
compression appears to start but never invokes the compressor.

The affected path pairs the newer compression module with a legacy `SessionDB`
that is still loaded in the running process. That legacy class does not provide
`get_compression_failure_cooldown_row`, but the previous implementation treated
this missing API as a durable cooldown read failure.

The caller then failed closed and returned the original messages before calling
the compressor. As a result, compression appeared to start while neither the
messages nor the token usage actually decreased.

This change uses an explicit sentinel to distinguish these cases:

- The legacy API is genuinely absent: preserve the compatibility path and
  continue context compression.
- The API is present but non-callable: fail closed.
- The durable reader raises an exception: fail closed.
- The durable state is read successfully: preserve the existing authoritative
  rollback flow.

The change only corrects the missing-legacy-API case. It does not relax genuine
durable-state read failures or change lock acquisition, summary generation,
commit fencing, or cooldown rollback behavior.

## Related Issue / PR

I did not find an Issue or PR covering the same legacy `SessionDB` version-skew
path.

This regression is technically related to merged PR #76647, which introduced
the authoritative cooldown rollback API. This PR adds the compatibility path
needed when the newer compression module is paired with a legacy `SessionDB`
that does not yet provide that API.

Other no-op compression, anti-thrashing, session rotation, and protected-tail
reports cover failures after the compressor runs or cases where no content can
be compressed. They do not cover this pre-compressor early return.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)

## Changes Made

- Update `agent/conversation_compression.py`:
  - Use an explicit sentinel to detect whether the raw cooldown API is truly
    absent.
  - Return the non-authoritative compatibility result when a legacy
    `SessionDB` does not provide the API, allowing context compression to
    continue.
  - Preserve fail-closed behavior when the API is present but non-callable.
  - Preserve fail-closed behavior when the durable reader raises.

- Update `tests/agent/test_compression_concurrent_fork.py`:
  - Add an end-to-end compression-entry regression test for version skew.
  - Verify that the compressor is invoked when the legacy API is absent.
  - Verify that the result contains the compressor-produced summary rather
    than the original messages.
  - Verify that a present but non-callable API fails closed.
  - Verify that a durable-reader exception fails closed.
  - Verify that the compression lock is released.
  - Verify that the compatibility path does not create a child-session fork.

## How to Reproduce

Before this fix, invoke compression with a legacy `SessionDB` that does not
provide `get_compression_failure_cooldown_row`:

```python
agent._compress_context(
    messages,
    "sys",
    approx_tokens=120_000,
)
```

The affected behavior is:

- The context-compression entry point is reached.
- The compressor is not invoked.
- The original messages are returned unchanged.
- The context size does not decrease.

Externally, compression appears to start but makes no progress.

## How to Test

### 1. Run the compression concurrency and rollback tests

```bash
scripts/run_tests.sh tests/agent/test_compression_concurrent_fork.py -q
```

Observed result:

```text
45 passed
```

### 2. Run the adjacent cooldown and interrupt-protection tests

```bash
scripts/run_tests.sh \
  tests/agent/test_compression_anti_thrash_persistence.py \
  tests/agent/test_compression_interrupt_protection.py -q
```

Observed result:

```text
15 passed
```

### 3. Run static and cross-platform checks

```bash
python -m ruff check \
  agent/conversation_compression.py \
  tests/agent/test_compression_concurrent_fork.py

python -m py_compile \
  agent/conversation_compression.py \
  tests/agent/test_compression_concurrent_fork.py

python scripts/check-windows-footguns.py \
  agent/conversation_compression.py \
  tests/agent/test_compression_concurrent_fork.py

git diff --check HEAD^..HEAD
```

Observed results:

- Ruff: passed.
- Python bytecode compilation: passed.
- Windows footgun scan: passed.
- Git whitespace check: passed.

### Full-suite note

The full local test suite was also attempted, but it was not fully green.
Failures were outside this PR's changed files. The reproducible failing subset
also failed in a clean upstream worktree, so those failures were not attributed
to this PR.

Accordingly, the full-suite checklist item below remains unchecked. The 60
tests directly related to this context-compression change passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this bug fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added regression tests for my changes
- [x] I've tested on WSL2/Linux with Python 3.11

### Documentation & Housekeeping

- [x] Relevant documentation (README, `docs/`, docstrings): N/A; no user-facing configuration or public interface changed
- [x] `cli-config.yaml.example`: N/A; no configuration keys were added or changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A; no architecture or development workflow changed
- [x] Cross-platform impact considered per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] Tool descriptions/schemas: N/A; no tool contract changed

## Screenshots / Logs

N/A. This is an internal context-compression compatibility fix covered by
entry-point regression tests.
