### PR TITLE
fix(desktop): resolve macOS helper outside app.asar

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -53,6 +53,23 @@ function patchUnixTerminalAsarPaths(destRoot) {
   }
 }
 
+function patchGetWindowsMacOSAsarHelperPath(destRoot) {
+  const filePath = join(destRoot, 'lib', 'macos.js')
+  const source = readFileSync(filePath, 'utf8')
+  const patched = source.replace(
+    "const binary = path.join(__dirname, '../main');",
+    "const binary = path.join(__dirname, '../main').replace(/app\\.asar(?!\\.unpacked)/, 'app.asar.unpacked');"
+  )
+
+  if (patched === source) {
+    throw new Error(
+      '[stage-native-deps] get-windows lib/macos.js helper path did not match the verified 9.3.0 layout'
+    )
+  }
+
+  writeFileSync(filePath, patched)
+}
+
 /**
  * Locate node-pty's package root via real module resolution, so this
  * works whether it's hoisted to a workspace root or local to this app.
@@ -431,15 +448,14 @@ export function stageGetWindowsInto(
   destRoot,
   { platform = process.platform, rebuild } = {}
 ) {
-  // The STAGED_WINDOWS_JS rewrite mirrors this exact version's export surface.
-  // A version bump must fail the build here until the rewrite is re-verified —
-  // otherwise it ships stale and fails soft as a generic "unavailable".
+  // Both the Windows shim and the macOS helper-path patch mirror this exact
+  // version's source. A version bump must fail here until both are re-verified.
   const srcVersion = JSON.parse(readFileSync(join(srcRoot, 'package.json'), 'utf8')).version
   if (srcVersion !== GET_WINDOWS_VERSION) {
     throw new Error(
-      `[stage-native-deps] get-windows is ${srcVersion} but the staged lib/windows.js ` +
-        `rewrite was verified against ${GET_WINDOWS_VERSION}. Re-verify the rewrite ` +
-        `(STAGED_WINDOWS_JS) against the new version, then update GET_WINDOWS_VERSION.`
+      `[stage-native-deps] get-windows is ${srcVersion} but the native staging rewrites ` +
+        `were verified against ${GET_WINDOWS_VERSION}. Re-verify STAGED_WINDOWS_JS and ` +
+        `the lib/macos.js helper-path patch, then update GET_WINDOWS_VERSION.`
     )
   }
 
@@ -457,6 +473,10 @@ export function stageGetWindowsInto(
     if (entry.isFile() && entry.name.endsWith('.js')) {
       cpSync(join(srcRoot, 'lib', entry.name), join(destRoot, 'lib', entry.name))
     }
+  }
+
+  if (platform === 'darwin') {
+    patchGetWindowsMacOSAsarHelperPath(destRoot)
   }
 
   writeFileSync(join(destRoot, 'lib', 'windows.js'), STAGED_WINDOWS_JS)

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -366,6 +366,21 @@ function makeFakeGetWindows(srcRoot, { version = '9.3.0', bindings = [] } = {}) 
   fs.mkdirSync(join(srcRoot, 'lib'), { recursive: true })
   fs.writeFileSync(join(srcRoot, 'package.json'), JSON.stringify({ name: 'get-windows', version, main: 'index.js' }))
   fs.writeFileSync(join(srcRoot, 'index.js'), 'export {};')
+  fs.writeFileSync(
+    join(srcRoot, 'lib', 'macos.js'),
+    [
+      "import path from 'node:path';",
+      "import childProcess from 'node:child_process';",
+      "import {fileURLToPath} from 'node:url';",
+      '',
+      'const __dirname = path.dirname(fileURLToPath(import.meta.url));',
+      "const binary = path.join(__dirname, '../main');",
+      '',
+      'export function activeWindowSync() {',
+      "  return JSON.parse(childProcess.execFileSync(binary, [], {encoding: 'utf8'}));",
+      '}'
+    ].join('\n')
+  )
   fs.writeFileSync(join(srcRoot, 'lib', 'windows.js'), '// upstream pre-gyp loader')
   fs.writeFileSync(join(srcRoot, 'main'), '#!/bin/sh\n')
 
@@ -500,6 +515,64 @@ test('staging refuses a get-windows version the lib/windows.js rewrite was not v
     fs.rmSync(tmp, { recursive: true, force: true })
   }
 })
+
+test.skipIf(process.platform === 'win32')(
+  'darwin staging resolves the macOS wrapper helper from app.asar.unpacked',
+  async () => {
+    const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+    try {
+      const srcRoot = join(tmp, 'get-windows')
+      const asarRoot = join(tmp, 'Hermes.app', 'Contents', 'Resources', 'app.asar')
+      const destRoot = join(asarRoot, 'dist', 'node_modules', 'get-windows')
+      const unpackedRoot = join(
+        tmp,
+        'Hermes.app',
+        'Contents',
+        'Resources',
+        'app.asar.unpacked',
+        'dist',
+        'node_modules',
+        'get-windows'
+      )
+
+      makeFakeGetWindows(srcRoot)
+      fs.writeFileSync(join(srcRoot, 'main'), '#!/bin/sh\nprintf \'{"from":"unpacked"}\'\n')
+
+      stageGetWindowsInto(srcRoot, destRoot, { platform: 'darwin' })
+      fs.cpSync(destRoot, unpackedRoot, { recursive: true })
+      fs.rmSync(join(destRoot, 'main'))
+
+      const stagedMacOSPath = join(destRoot, 'lib', 'macos.js')
+      const stagedMacOSSource = fs.readFileSync(stagedMacOSPath, 'utf8')
+      fs.writeFileSync(
+        stagedMacOSPath,
+        stagedMacOSSource.replace(
+          ".replace(/app\\.asar(?!\\.unpacked)/, 'app.asar.unpacked')",
+          ''
+        )
+      )
+      const oldMacOSUrl = pathToFileURL(stagedMacOSPath)
+      oldMacOSUrl.searchParams.set('t', `${Date.now()}-old`)
+      const oldMacOS = await import(oldMacOSUrl.href)
+      assert.throws(() => oldMacOS.activeWindowSync(), /ENOENT/)
+
+      fs.writeFileSync(stagedMacOSPath, stagedMacOSSource)
+      const stagedMacOSUrl = pathToFileURL(stagedMacOSPath)
+      stagedMacOSUrl.searchParams.set('t', `${Date.now()}-fixed`)
+      const stagedMacOS = await import(stagedMacOSUrl.href)
+
+      assert.deepEqual(stagedMacOS.activeWindowSync(), { from: 'unpacked' })
+
+      stageGetWindowsInto(srcRoot, unpackedRoot, { platform: 'darwin' })
+      const alreadyUnpackedMacOSUrl = pathToFileURL(join(unpackedRoot, 'lib', 'macos.js'))
+      alreadyUnpackedMacOSUrl.searchParams.set('t', `${Date.now()}-already-unpacked`)
+      const alreadyUnpackedMacOS = await import(alreadyUnpackedMacOSUrl.href)
+      assert.deepEqual(alreadyUnpackedMacOS.activeWindowSync(), { from: 'unpacked' })
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  }
+)
 
 test('darwin staging ships the Swift helper executable and the rewritten windows.js', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))


### PR DESCRIPTION
## Problem

On macOS, `get-windows` resolves its Swift helper relative to `lib/macos.js`. In an electron-builder package the wrapper remains inside `app.asar`, while the executable helper is unpacked to `app.asar.unpacked`. Spawning the virtual `app.asar/.../main` path therefore fails (`ENOTDIR` in a real package).

## Fix

- patch the staged macOS wrapper to resolve bare `app.asar` paths through `app.asar.unpacked`
- keep already-unpacked paths unchanged
- fail closed if the verified `get-windows@9.3.0` wrapper layout changes
- add a behavioral regression test that executes the staged wrapper, proves the unpatched path fails, and proves the unpacked helper runs after the patch

The source dependency is not modified; only the staged copy used for Desktop packaging is rewritten.

## Verification

- `vitest run --project electron scripts/stage-native-deps.test.mjs` — 24/24 passed after rebasing onto current `main`
- full Electron project — 1001 passed, 2 skipped
- `node --check` on both touched scripts
- `electron-builder --dir` package build on macOS arm64
- packaged runtime smoke: loaded `lib/macos.js` from `app.asar`, executed the helper from `app.asar.unpacked`, and received a valid 12-window array

## Known baseline

The existing packaged first-run test `boot progress overlay fades out or shows error state` waits at 12% for a first-run setup choice and times out. The same failure reproduces with the unchanged renderer build and is unrelated to this staging fix.
