### PR TITLE
fix(desktop): add a visible HUD drag grip

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -5,6 +5,8 @@ import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, u
 import { useHudComposerDrag } from '@/app/hud/composer-drag'
 import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
 import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
 import { Slot as ContribSlot } from '@/contrib/react/slot'
 import { useI18n } from '@/i18n'
 import { chatMessageText } from '@/lib/chat-messages'
@@ -103,7 +105,12 @@ export function ChatBar({
   onTranscribeAudio
 }: ChatBarProps) {
   const hudMode = useStore($hudMode)
-  const { grabbing: hudGrabbing, onPointerDown: onHudDragPointerDown } = useHudComposerDrag(hudMode)
+
+  const {
+    grabbing: hudGrabbing,
+    onGripKeyDown: onHudDragGripKeyDown,
+    onPointerDown: onHudDragPointerDown
+  } = useHudComposerDrag(hudMode)
 
   // Typed stop phrase during an active voice conversation ends it — same
   // semantics as SAYING "stop" (voice-stop-word.ts) or clicking the pill's
@@ -1257,6 +1264,20 @@ export function ChatBar({
                     )}
                   >
                     <div className="flex translate-y-[3px] items-start gap-(--composer-control-gap) self-start [grid-area:menu]">
+                      {hudMode && (
+                        <Tip label={t.titlebar.dragHud}>
+                          <button
+                            aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight"
+                            aria-label={t.titlebar.dragHud}
+                            className="flex size-6 shrink-0 touch-none cursor-grab appearance-none items-center justify-center rounded-md border-0 bg-transparent p-0 text-(--ui-text-tertiary) opacity-70 hover:bg-(--chrome-action-hover) hover:text-(--ui-text-secondary) hover:opacity-100 active:cursor-grabbing"
+                            data-hud-drag-grip
+                            onKeyDown={onHudDragGripKeyDown}
+                            type="button"
+                          >
+                            <Codicon name="gripper" />
+                          </button>
+                        </Tip>
+                      )}
                       {contextMenu}
                       <ContribSlot area={COMPOSER_AREAS.leading} />
                     </div>

--- a/apps/desktop/src/app/hud/composer-drag.test.tsx
+++ b/apps/desktop/src/app/hud/composer-drag.test.tsx
@@ -1,0 +1,143 @@
+import { act, renderHook } from '@testing-library/react'
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useHudComposerDrag } from './composer-drag'
+
+const { triggerHaptic } = vi.hoisted(() => ({ triggerHaptic: vi.fn() }))
+const moveBy = vi.fn()
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic }))
+
+function pointerEvent(
+  currentTarget: HTMLElement,
+  target: HTMLElement,
+  screenX: number,
+  screenY: number
+): ReactPointerEvent<HTMLElement> {
+  return {
+    button: 0,
+    currentTarget,
+    pointerId: 7,
+    preventDefault: vi.fn(),
+    screenX,
+    screenY,
+    target
+  } as unknown as ReactPointerEvent<HTMLElement>
+}
+
+function keyboardEvent(key: string, shiftKey = false): ReactKeyboardEvent<HTMLElement> {
+  return {
+    key,
+    preventDefault: vi.fn(),
+    shiftKey
+  } as unknown as ReactKeyboardEvent<HTMLElement>
+}
+
+function dispatchPointer(type: 'pointermove' | 'pointerup' | 'pointercancel', screenX: number, screenY: number) {
+  const event = new MouseEvent(type, { bubbles: true })
+
+  Object.defineProperties(event, {
+    pointerId: { value: 7 },
+    screenX: { value: screenX },
+    screenY: { value: screenY }
+  })
+
+  window.dispatchEvent(event)
+}
+
+describe('useHudComposerDrag', () => {
+  let composer: HTMLElement
+  let grip: HTMLElement
+  const setPointerCapture = vi.fn<(pointerId: number) => void>()
+  const releasePointerCapture = vi.fn<(pointerId: number) => void>()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { hud: { moveBy } } })
+
+    composer = globalThis.document.createElement('div')
+    grip = globalThis.document.createElement('span')
+    grip.setAttribute('data-hud-drag-grip', '')
+    composer.append(grip)
+    globalThis.document.body.append(composer)
+
+    composer.setPointerCapture = setPointerCapture
+    composer.releasePointerCapture = releasePointerCapture
+    composer.hasPointerCapture = vi.fn(() => true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.document.body.innerHTML = ''
+  })
+
+  it('moves immediately from the visible grip and suppresses its follow-up click', () => {
+    const { result } = renderHook(() => useHudComposerDrag(true))
+    const click = vi.fn()
+    grip.addEventListener('click', click)
+
+    act(() => result.current.onPointerDown(pointerEvent(composer, grip, 100, 200)))
+    act(() => dispatchPointer('pointermove', 107, 194))
+    act(() => dispatchPointer('pointerup', 107, 194))
+    grip.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(setPointerCapture).toHaveBeenCalledWith(7)
+    expect(moveBy).toHaveBeenCalledWith({ x: 7, y: -6 })
+    expect(click).not.toHaveBeenCalled()
+    expect(releasePointerCapture).toHaveBeenCalledWith(7)
+  })
+
+  it('moves the HUD with arrow keys and accelerates with Shift', () => {
+    const { result } = renderHook(() => useHudComposerDrag(true))
+    const left = keyboardEvent('ArrowLeft')
+    const downFast = keyboardEvent('ArrowDown', true)
+    const enter = keyboardEvent('Enter')
+
+    act(() => result.current.onGripKeyDown(left))
+    act(() => result.current.onGripKeyDown(downFast))
+    act(() => result.current.onGripKeyDown(enter))
+
+    expect(moveBy).toHaveBeenNthCalledWith(1, { x: -12, y: 0 })
+    expect(moveBy).toHaveBeenNthCalledWith(2, { x: 0, y: 48 })
+    expect(moveBy).toHaveBeenCalledTimes(2)
+    expect(left.preventDefault).toHaveBeenCalledOnce()
+    expect(downFast.preventDefault).toHaveBeenCalledOnce()
+    expect(enter.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('keeps the long-press composer fallback', () => {
+    const { result } = renderHook(() => useHudComposerDrag(true))
+
+    act(() => result.current.onPointerDown(pointerEvent(composer, composer, 100, 200)))
+    act(() => vi.advanceTimersByTime(140))
+    act(() => dispatchPointer('pointermove', 96, 211))
+
+    expect(setPointerCapture).toHaveBeenCalledWith(7)
+    expect(moveBy).toHaveBeenCalledWith({ x: -4, y: 11 })
+  })
+
+  it('cancels an unarmed composer press that becomes a normal drag', () => {
+    const { result } = renderHook(() => useHudComposerDrag(true))
+
+    act(() => result.current.onPointerDown(pointerEvent(composer, composer, 100, 200)))
+    act(() => dispatchPointer('pointermove', 109, 200))
+    act(() => vi.advanceTimersByTime(140))
+
+    expect(setPointerCapture).not.toHaveBeenCalled()
+    expect(moveBy).not.toHaveBeenCalled()
+    expect(triggerHaptic).not.toHaveBeenCalled()
+  })
+
+  it('keeps screen-coordinate reverse and diagonal deltas after a grip drag arms', () => {
+    const { result } = renderHook(() => useHudComposerDrag(true))
+
+    act(() => result.current.onPointerDown(pointerEvent(composer, grip, 100, 200)))
+    act(() => dispatchPointer('pointermove', 115, 185))
+    act(() => dispatchPointer('pointermove', 108, 191))
+
+    expect(moveBy).toHaveBeenNthCalledWith(1, { x: 15, y: -15 })
+    expect(moveBy).toHaveBeenNthCalledWith(2, { x: -7, y: 6 })
+  })
+})

--- a/apps/desktop/src/app/hud/composer-drag.ts
+++ b/apps/desktop/src/app/hud/composer-drag.ts
@@ -1,4 +1,11 @@
-import { type PointerEvent as ReactPointerEvent, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 import { triggerHaptic } from '@/lib/haptics'
 
@@ -7,6 +14,7 @@ import { triggerHaptic } from '@/lib/haptics'
 const LONG_PRESS_MS = 140
 /** Slop before the hold is read as a text selection instead of a grab. */
 const MOVE_TOLERANCE = 8
+const KEYBOARD_MOVE_STEP = 12
 
 interface PressState {
   armed: boolean
@@ -18,8 +26,23 @@ interface PressState {
   target: HTMLElement
 }
 
+function arm(state: PressState, setGrabbing: (grabbing: boolean) => void) {
+  state.armed = true
+  setGrabbing(true)
+  triggerHaptic('selection')
+
+  // Capture so the moves keep arriving once the cursor outruns the bar,
+  // and drop the caret so the drag isn't also extending a selection.
+  state.target.setPointerCapture(state.pointerId)
+
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.blur()
+  }
+}
+
 /**
- * HUD-only: press and hold the composer, then drag to move the window.
+ * HUD-only: drag the visible composer grip immediately, or press and hold
+ * anywhere else on the composer before dragging to move the window.
  *
  * The only way to move the HUD. An `-webkit-app-region: drag` handle is the
  * obvious alternative and cannot work here: the window manager takes a drag
@@ -58,6 +81,11 @@ export function useHudComposerDrag(enabled: boolean) {
         return
       }
 
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+
       const target = event.currentTarget
 
       stateRef.current = {
@@ -70,8 +98,16 @@ export function useHudComposerDrag(enabled: boolean) {
         target
       }
 
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current)
+      // The grip is deliberately a normal renderer hit target, rather than an
+      // app-region drag handle: click-through needs these pointer events to
+      // keep the HUD solid under the cursor. Starting there is an explicit move
+      // gesture, so capture immediately instead of making an ordinary drag lose
+      // to the long-press slop.
+      if (event.target instanceof Element && event.target.closest('[data-hud-drag-grip]')) {
+        event.preventDefault()
+        arm(stateRef.current, setGrabbing)
+
+        return
       }
 
       timerRef.current = window.setTimeout(() => {
@@ -81,18 +117,37 @@ export function useHudComposerDrag(enabled: boolean) {
           return
         }
 
-        state.armed = true
-        setGrabbing(true)
-        triggerHaptic('selection')
-
-        // Capture so the moves keep arriving once the cursor outruns the bar,
-        // and drop the caret so the drag isn't also extending a selection.
-        state.target.setPointerCapture(state.pointerId)
-
-        if (document.activeElement instanceof HTMLElement) {
-          document.activeElement.blur()
-        }
+        arm(state, setGrabbing)
       }, LONG_PRESS_MS)
+    },
+    [enabled]
+  )
+
+  const onGripKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLElement>) => {
+      if (!enabled) {
+        return
+      }
+
+      const step = event.shiftKey ? KEYBOARD_MOVE_STEP * 4 : KEYBOARD_MOVE_STEP
+
+      const delta =
+        event.key === 'ArrowLeft'
+          ? { x: -step, y: 0 }
+          : event.key === 'ArrowRight'
+            ? { x: step, y: 0 }
+            : event.key === 'ArrowUp'
+              ? { x: 0, y: -step }
+              : event.key === 'ArrowDown'
+                ? { x: 0, y: step }
+                : null
+
+      if (!delta) {
+        return
+      }
+
+      event.preventDefault()
+      window.hermesDesktop?.hud?.moveBy?.(delta)
     },
     [enabled]
   )
@@ -159,5 +214,5 @@ export function useHudComposerDrag(enabled: boolean) {
 
   useEffect(() => reset, [reset])
 
-  return { grabbing, onPointerDown }
+  return { grabbing, onGripKeyDown, onPointerDown }
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -204,6 +204,7 @@ export const en: Translations = {
     openStarmap: 'Open memory graph',
     enterHud: 'HUD mode',
     exitHud: 'Exit HUD mode',
+    dragHud: 'Drag HUD',
     layoutEditor: 'Layout editor',
     layoutEditorTitle: 'Layout editor — ⌘-click resets the layout'
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -202,7 +202,8 @@ export const ja = defineLocale({
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
     openSettings: '設定を開く',
-    openStarmap: 'メモリグラフを開く'
+    openStarmap: 'メモリグラフを開く',
+    dragHud: 'HUD をドラッグ'
   },
 
   language: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -246,6 +246,7 @@ export interface Translations {
     openStarmap: string
     enterHud: string
     exitHud: string
+    dragHud: string
     layoutEditor: string
     layoutEditorTitle: string
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -196,7 +196,8 @@ export const zhHant = defineLocale({
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
     openSettings: '開啟設定',
-    openStarmap: '開啟記憶圖譜'
+    openStarmap: '開啟記憶圖譜',
+    dragHud: '拖曳 HUD'
   },
 
   language: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -199,6 +199,7 @@ export const zh: Translations = {
     openStarmap: '打开记忆图谱',
     enterHud: 'HUD 模式',
     exitHud: '退出 HUD 模式',
+    dragHud: '拖动 HUD',
     layoutEditor: '布局编辑器',
     layoutEditorTitle: '布局编辑器 — ⌘ 点击重置布局'
   },


### PR DESCRIPTION
## Problem

The HUD can currently be moved only by holding the composer for 140 ms without exceeding an 8 px slop. That gesture is undiscoverable and easy to lose to normal pointer movement.

A native `-webkit-app-region: drag` handle is not suitable here: the HUD click-through implementation needs renderer pointer events to keep the transparent window interactive under the cursor.

## Fix

- add a visible grip inside the existing composer control row
- arm the existing `hud.moveBy` pointer-capture path immediately when dragging the grip
- retain long-press-anywhere as a fallback
- preserve click suppression and screen-coordinate reverse/diagonal movement
- add keyboard movement with Arrow keys (`Shift` for larger steps)
- keep `resizable: true` and the current click-through design unchanged
- add focused regression coverage for immediate grip drag, fallback hold, slop cancellation, reverse/diagonal deltas, click suppression, and keyboard movement

Related to #82321, but this intentionally does not change the separate Windows resize-edge behavior.

## Verification

- focused HUD tests — 11/11 passed after rebasing onto current `main`
- full UI project — 3634/3634 passed
- renderer, Electron, and E2E TypeScript checks
- ESLint and Prettier on all touched files
- `electron-builder --dir` package build on macOS arm64
- packaged live smoke:
  - grip/input overlap: 0 px²
  - semantic element: labeled, focusable `BUTTON`
  - one-step pointer drag: requested 48×24 px, BrowserWindow moved 43×22 px
  - `ArrowRight`: BrowserWindow moved exactly 12×0 px

## Known baseline

The existing packaged first-run suite passes its HUD containment test and 3 other checks, but `boot progress overlay fades out or shows error state` waits at 12% for a first-run setup choice and times out. The same failure reproduces on the build with an unchanged renderer, so it is not introduced by this PR.
