### PR TITLE
fix(agent): cap bp/ark-code-latest output tokens at 32768

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -137,6 +137,8 @@ _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 # max_tokens as a mandatory field.  Previously we hardcoded 16384, which
 # starves thinking-enabled models (thinking tokens count toward the limit).
 _ANTHROPIC_OUTPUT_LIMITS = {
+    # ByteDance models
+    "bp/ark-code-latest": 32_768,
     # Mythos-class named models (claude-fable-5, …) — 1M context, reasoning
     "claude-fable":      128_000,
     # Claude Sonnet 5

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1077,6 +1077,15 @@ class TestGetAnthropicMaxOutput:
         from agent.anthropic_adapter import _get_anthropic_max_output
         assert _get_anthropic_max_output("claude-opus-4-6") == 128_000
 
+    def test_bp_ark_code_latest(self):
+        from agent.anthropic_adapter import (
+            _ANTHROPIC_DEFAULT_OUTPUT_LIMIT,
+            _get_anthropic_max_output,
+        )
+        assert _get_anthropic_max_output("bp/ark-code-latest") == 32_768
+        # Must not silently fall back to the default ceiling
+        assert _get_anthropic_max_output("bp/ark-code-latest") != _ANTHROPIC_DEFAULT_OUTPUT_LIMIT
+
 
 
 


### PR DESCRIPTION
## Summary

Fixes #82281: cron jobs using the `bp/ark-code-latest` model fail with "Context length exceeded" because Hermes requests more output tokens than the model supports.

## Root Cause

`_ANTHROPIC_OUTPUT_LIMITS` in `agent/anthropic_adapter.py` did not list `bp/ark-code-latest`. As a result, `_get_anthropic_max_output()` fell back to `_ANTHROPIC_DEFAULT_OUTPUT_LIMIT` (128,000 tokens), while `bp/ark-code-latest` only supports a maximum of **32,768** output tokens. Anthropic's API rejects `max_tokens` above the model's ceiling, surfacing as a "Context length exceeded" failure in cron jobs.

## Change

- `agent/anthropic_adapter.py`: added `"bp/ark-code-latest": 32_768` to `_ANTHROPIC_OUTPUT_LIMITS` under a `# ByteDance models` comment, matching the dict's existing style. No other behavior changed.
- `tests/agent/test_anthropic_adapter.py`: added `TestGetAnthropicMaxOutput.test_bp_ark_code_latest` asserting `_get_anthropic_max_output("bp/ark-code-latest") == 32_768` and that it does **not** fall back to `_ANTHROPIC_DEFAULT_OUTPUT_LIMIT`.

## Verification

- `python -m pytest tests/agent/test_anthropic_adapter.py -q` → **95 passed** (includes the new test).
- Targeted run: `python -m pytest tests/agent/test_anthropic_adapter.py -q -k bp_ark` → **1 passed**.

Closes #82281
