### PR TITLE
fix(agent): preserve phone numbers in final replies

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1676,7 +1676,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # when disabled. (#19798)
     if isinstance(_san_content, str) and _san_content:
         from agent.redact import redact_sensitive_text
-        _san_content = redact_sensitive_text(_san_content)
+        _san_content = redact_sensitive_text(_san_content, redact_phone_numbers=False)
 
     # NOTE (empty-content class fix): textless assistant turns are NOT padded
     # here.  The single owner for "never send a turn strict wire validation

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -776,6 +776,7 @@ def redact_sensitive_text(
     code_file: bool = False,
     file_read: bool = False,
     redact_url_credentials: bool = False,
+    redact_phone_numbers: bool = True,
 ) -> str:
     """Apply all redaction patterns to a block of text.
 
@@ -788,6 +789,11 @@ def redact_sensitive_text(
     additionally redact credential-named query parameters and ``user:pass@``
     URL userinfo. The default remains False because actionable OAuth callback,
     magic-link, and pre-signed URLs must survive ordinary tool flows unchanged.
+
+    Set redact_phone_numbers=False at final assistant-response boundaries where
+    public or user-requested E.164 phone numbers and ``tel:`` links must remain
+    callable. The default remains True for logs, tool output, internal platform
+    identifiers, and other diagnostic surfaces.
 
     Set code_file=True to skip the ENV-assignment and JSON-field regex
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
@@ -996,7 +1002,7 @@ def redact_sensitive_text(
         text = _redact_form_body(text)
 
     # E.164 phone numbers (Signal, WhatsApp)
-    if "+" in text:
+    if redact_phone_numbers and "+" in text:
         def _redact_phone(m):
             phone = m.group(1)
             if len(phone) <= 8:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -570,7 +570,11 @@ def _gateway_loop_exception_handler(
     loop.default_exception_handler(context)
 
 
-def _redact_gateway_user_facing_secrets(text: str) -> str:
+def _redact_gateway_user_facing_secrets(
+    text: str,
+    *,
+    redact_phone_numbers: bool = True,
+) -> str:
     """Secret redaction before text can leave the gateway.
 
     Delegates to the authoritative ``agent.redact.redact_sensitive_text`` — the
@@ -589,7 +593,11 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
     try:
         from agent.redact import redact_sensitive_text
 
-        redacted = redact_sensitive_text(redacted, force=True)
+        redacted = redact_sensitive_text(
+            redacted,
+            force=True,
+            redact_phone_numbers=redact_phone_numbers,
+        )
     except Exception:
         # Fail-soft: fall back to the local pattern pass below rather than
         # letting a redactor import/error leak the raw text to chat.
@@ -735,7 +743,7 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     if str(text).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
         return ""
 
-    redacted = _redact_gateway_user_facing_secrets(str(text))
+    redacted = _redact_gateway_user_facing_secrets(str(text), redact_phone_numbers=False)
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -602,6 +602,29 @@ class TestFormBodyRedaction:
         assert "first=1" in redact_sensitive_text(text)
 
 
+class TestPhoneNumberRedaction:
+    def test_e164_numbers_redact_by_default(self):
+        text = "Call +15551234567 now"
+        result = redact_sensitive_text(text, force=True)
+
+        assert "+15551234567" not in result
+        assert "+155****4567" in result
+
+    def test_e164_numbers_can_be_preserved_for_user_visible_replies(self):
+        text = "Call +15551234567 or use [Call +15551234567](tel:+15551234567)."
+        result = redact_sensitive_text(text, force=True, redact_phone_numbers=False)
+
+        assert result == text
+
+    def test_disabling_phone_redaction_does_not_disable_secret_redaction(self):
+        token = "sk-ABCDEF0123456789abcdef0123"
+        text = f"Call +15551234567 with token {token}"
+        result = redact_sensitive_text(text, force=True, redact_phone_numbers=False)
+
+        assert "+15551234567" in result
+        assert token not in result
+
+
 class TestLowercaseDottedConfigKeys:
     """Issue #16413 — config-file passwords in lowercase/dotted/colon keys
     must be redacted. The uppercase _ENV_ASSIGN_RE missed these, leaking

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -307,6 +307,18 @@ def test_telegram_final_response_keeps_normal_answers():
     assert _sanitize_gateway_final_response(Platform.TELEGRAM, answer) == answer
 
 
+def test_telegram_final_response_preserves_phone_links_but_redacts_secrets():
+    """Final assistant replies may intentionally contain callable phone links."""
+    token = "sk-ABCDEF0123456789abcdef0123"
+    answer = f"Call [support +15551234567](tel:+15551234567), not {token}."
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, answer)
+
+    assert "+15551234567" in sanitized
+    assert "tel:+15551234567" in sanitized
+    assert token not in sanitized
+
+
 # Synthetic credential shapes from #23810. Bodies are placeholder gibberish —
 # never real tokens — but they match the canonical redaction patterns. The
 # outbound gateway redactor previously used a narrow local pattern subset that

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1425,6 +1425,16 @@ class TestBuildAssistantMessage:
         assert result["content"] == "Hello!"
         assert result["finish_reason"] == "stop"
 
+    def test_assistant_message_preserves_phone_numbers_but_redacts_secrets(self, agent):
+        token = "sk-ABCDEF0123456789abcdef0123"
+        msg = _mock_assistant_msg(
+            content=f"Call +15551234567 with [tel](tel:+15551234567), not {token}."
+        )
+        result = agent._build_assistant_message(msg, "stop")
+
+        assert "+15551234567" in result["content"]
+        assert "tel:+15551234567" in result["content"]
+        assert token not in result["content"]
 
 
 


### PR DESCRIPTION
## Summary
- add a `redact_phone_numbers` switch to the central redactor while keeping phone redaction enabled by default
- preserve E.164 numbers and `tel:` links at assistant-content and gateway final-reply boundaries
- keep API/token redaction active on those user-visible paths

Fixes #82405.

## Tests
- `.venv/bin/python -m pytest tests/agent/test_redact.py::TestPhoneNumberRedaction -q`
- `.venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestBuildAssistantMessage::test_assistant_message_preserves_phone_numbers_but_redacts_secrets -q`
- `.venv/bin/python -m pytest tests/gateway/test_telegram_noise_filter.py::test_telegram_final_response_preserves_phone_links_but_redacts_secrets -q`
- `.venv/bin/python -m pytest tests/gateway/test_signal.py::TestSignalPhoneRedaction::test_us_number -q`
- `.venv/bin/python -m pytest tests/agent/test_redact.py -q`
- `.venv/bin/python -m pytest tests/gateway/test_telegram_noise_filter.py::test_chat_gateways_redact_secret_in_non_error_body tests/gateway/test_telegram_noise_filter.py::test_telegram_final_response_redacts_auth_secrets tests/gateway/test_telegram_noise_filter.py::test_telegram_final_response_keeps_normal_answers -q`
- `.venv/bin/python -m ruff check agent/redact.py agent/chat_completion_helpers.py gateway/run.py tests/agent/test_redact.py tests/run_agent/test_run_agent.py tests/gateway/test_telegram_noise_filter.py`
- `git diff --check -- agent/redact.py agent/chat_completion_helpers.py gateway/run.py tests/agent/test_redact.py tests/run_agent/test_run_agent.py tests/gateway/test_telegram_noise_filter.py`