### PR TITLE
fix(video_analyze): reject ambiguous cross-provider model overrides

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -993,3 +993,218 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+# ---------------------------------------------------------------------------
+# video_analyze model override provider validation (#82419)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveVideoModelOverride:
+    """Provider-safe resolution of the video_analyze model override.
+
+    A per-call ``model=`` must never silently attach a model from provider B
+    to a client selected for provider A. Provider-qualified models and
+    configured aliases resolve to an explicit provider/model pair; ambiguous
+    bare overrides that do not belong to the routed provider are rejected.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_real_aliases_or_config(self):
+        with (
+            patch("hermes_cli.model_switch._ensure_direct_aliases", return_value=None),
+            patch("hermes_cli.model_switch.DIRECT_ALIASES", {}),
+            patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}),
+        ):
+            yield
+
+    def test_provider_qualified_model_splits_provider_and_model(self):
+        from tools.vision_tools import _resolve_video_model_override
+
+        provider, model, base_url = _resolve_video_model_override(
+            "minimax-cn/MiniMax-M3"
+        )
+        assert provider == "minimax-cn"
+        assert model == "MiniMax-M3"
+        assert base_url is None
+
+    def test_configured_alias_resolves_to_provider_model_pair(self):
+        from hermes_cli.model_switch import DirectAlias
+        from tools.vision_tools import _resolve_video_model_override
+
+        with patch(
+            "hermes_cli.model_switch.DIRECT_ALIASES",
+            {"m3": DirectAlias(model="MiniMax-M3", provider="minimax-cn", base_url="")},
+        ):
+            provider, model, base_url = _resolve_video_model_override("m3")
+        assert provider == "minimax-cn"
+        assert model == "MiniMax-M3"
+        assert base_url is None
+
+    def test_alias_with_custom_base_url_propagates_endpoint(self):
+        from hermes_cli.model_switch import DirectAlias
+        from tools.vision_tools import _resolve_video_model_override
+
+        with patch(
+            "hermes_cli.model_switch.DIRECT_ALIASES",
+            {"local": DirectAlias(
+                model="local-video",
+                provider="custom",
+                base_url="http://localhost:8000/v1",
+            )},
+        ):
+            provider, model, base_url = _resolve_video_model_override("local")
+        assert provider == "custom"
+        assert model == "local-video"
+        assert base_url == "http://localhost:8000/v1"
+
+    def test_bare_model_matching_main_model_is_allowed(self):
+        from tools.vision_tools import _resolve_video_model_override
+
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="openai-codex"),
+            patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.6-sol"),
+        ):
+            provider, model, base_url = _resolve_video_model_override("gpt-5.6-sol")
+        assert provider is None
+        assert model == "gpt-5.6-sol"
+        assert base_url is None
+
+    def test_bare_model_matching_provider_vision_default_is_allowed(self):
+        from tools.vision_tools import _resolve_video_model_override
+
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="xiaomi"),
+            patch("agent.auxiliary_client._read_main_model", return_value="some-chat-model"),
+        ):
+            provider, model, _ = _resolve_video_model_override("mimo-v2.5")
+        assert provider is None
+        assert model == "mimo-v2.5"
+
+    def test_bare_model_matching_configured_vision_model_is_allowed(self):
+        from tools.vision_tools import _resolve_video_model_override
+
+        with (
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"provider": "minimax-cn", "model": "MiniMax-M3"},
+            ),
+            patch("agent.auxiliary_client._read_main_provider", return_value="openai-codex"),
+            patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.6-sol"),
+        ):
+            provider, model, _ = _resolve_video_model_override("MiniMax-M3")
+        assert provider is None
+        assert model == "MiniMax-M3"
+
+    def test_cross_provider_bare_model_is_rejected(self):
+        from tools.vision_tools import _resolve_video_model_override
+
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="openai-codex"),
+            patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.6-sol"),
+            pytest.raises(ValueError, match="does not belong to the provider"),
+        ):
+            _resolve_video_model_override("MiniMax-M3")
+
+    def test_unknown_provider_keeps_prior_behavior(self):
+        from tools.vision_tools import _resolve_video_model_override
+
+        with patch("agent.auxiliary_client._read_main_provider", return_value=""):
+            provider, model, base_url = _resolve_video_model_override("MiniMax-M3")
+        assert provider is None
+        assert model == "MiniMax-M3"
+        assert base_url is None
+
+
+class TestVideoAnalyzeToolModelOverride:
+    """video_analyze_tool must never build an invalid provider/model pair."""
+
+    @staticmethod
+    def _mock_response(text="video analysis result"):
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = text
+        mock_response.choices = [mock_choice]
+        return mock_response
+
+    @staticmethod
+    def _patched_env(tmp_path, mock_llm):
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"\x00" * 64)
+        return (
+            video,
+            [
+                patch("tools.interrupt.is_interrupted", return_value=False),
+                patch("agent.file_safety.raise_if_read_blocked", return_value=None),
+                patch("tools.vision_tools._detect_video_mime_type", return_value="video/mp4"),
+                patch(
+                    "tools.vision_tools._video_to_base64_data_url",
+                    return_value="data:video/mp4;base64,AAAA",
+                ),
+                patch("hermes_cli.config.load_config", return_value={}),
+                patch("tools.vision_tools._load_auxiliary_client", return_value=None),
+                patch("tools.vision_tools.async_call_llm", mock_llm),
+                patch(
+                    "tools.vision_tools.extract_content_or_reasoning",
+                    return_value="red then blue",
+                ),
+                patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}),
+                patch("agent.auxiliary_client._read_main_provider", return_value="openai-codex"),
+                patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.6-sol"),
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_cross_provider_override_fails_clearly_without_llm_call(self, tmp_path):
+        from tools.vision_tools import video_analyze_tool
+
+        mock_llm = AsyncMock(return_value=self._mock_response())
+        video, patchers = self._patched_env(tmp_path, mock_llm)
+        with ExitStack() as stack:
+            for p in patchers:
+                stack.enter_context(p)
+            result = json.loads(
+                await video_analyze_tool(str(video), "what colors?", "MiniMax-M3")
+            )
+
+        assert result["success"] is False
+        assert "does not belong to the provider" in result["error"]
+        mock_llm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provider_qualified_override_routes_to_that_provider(self, tmp_path):
+        from tools.vision_tools import video_analyze_tool
+
+        mock_llm = AsyncMock(return_value=self._mock_response("red then blue"))
+        video, patchers = self._patched_env(tmp_path, mock_llm)
+        with ExitStack() as stack:
+            for p in patchers:
+                stack.enter_context(p)
+            result = json.loads(
+                await video_analyze_tool(
+                    str(video), "what colors?", "minimax-cn/MiniMax-M3"
+                )
+            )
+
+        assert result["success"] is True
+        kwargs = mock_llm.await_args.kwargs
+        assert kwargs["provider"] == "minimax-cn"
+        assert kwargs["model"] == "MiniMax-M3"
+
+    @pytest.mark.asyncio
+    async def test_same_provider_override_still_works(self, tmp_path):
+        from tools.vision_tools import video_analyze_tool
+
+        mock_llm = AsyncMock(return_value=self._mock_response("red then blue"))
+        video, patchers = self._patched_env(tmp_path, mock_llm)
+        with ExitStack() as stack:
+            for p in patchers:
+                stack.enter_context(p)
+            result = json.loads(
+                await video_analyze_tool(str(video), "describe", "gpt-5.6-sol")
+            )
+
+        assert result["success"] is True
+        kwargs = mock_llm.await_args.kwargs
+        assert "provider" not in kwargs
+        assert kwargs["model"] == "gpt-5.6-sol"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -37,7 +37,7 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Awaitable, Dict, Optional
+from typing import Any, Awaitable, Dict, Optional, Tuple
 from urllib.parse import urlparse
 import httpx
 
@@ -1860,6 +1860,105 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
     raise last_error
 
 
+def _validate_video_model_override(model: str) -> None:
+    """Raise when a bare ``video_analyze`` model override is ambiguous.
+
+    The vision auto-router resolves the provider from ``auxiliary.vision.
+    provider`` or the active main runtime. A bare model override that belongs
+    to a *different* provider would be attached to that provider's client,
+    producing an invalid provider/model pair that can fail silently and still
+    report ``success: true`` (#82419). Only models that demonstrably belong to
+    the provider the router will use are accepted; anything else is rejected
+    with a clear error before any LLM call is made.
+    """
+    from agent.auxiliary_client import (
+        _PROVIDER_VISION_MODELS,
+        _get_auxiliary_task_config,
+        _read_main_model,
+        _read_main_provider,
+    )
+
+    vision_cfg = _get_auxiliary_task_config("vision") or {}
+    provider = str(vision_cfg.get("provider") or "").strip().lower()
+    if not provider or provider == "auto":
+        provider = _read_main_provider().strip().lower()
+    if not provider or provider in ("auto", "moa"):
+        # Provider cannot be determined (auto-detect / aggregator chain): there
+        # is no fixed provider to contradict, so keep the prior behavior.
+        return
+
+    normalized_model = model.strip().lower()
+    vision_cfg_model = str(vision_cfg.get("model") or "").strip()
+    if vision_cfg_model and vision_cfg_model.lower() == normalized_model:
+        # Matches the explicitly configured auxiliary.vision.model.
+        return
+    main_model = (_read_main_model() or "").strip()
+    main_model_candidates = [main_model]
+    if "/" in main_model:
+        main_model_candidates.append(main_model.rsplit("/", 1)[1])
+    if any(m and m.lower() == normalized_model for m in main_model_candidates):
+        # Override of the active main model on the same provider.
+        return
+    vision_default = _PROVIDER_VISION_MODELS.get(provider)
+    if vision_default and vision_default.lower() == normalized_model:
+        # The provider's dedicated vision model.
+        return
+    raise ValueError(
+        f"video_analyze: model override {model!r} does not belong to the "
+        f"provider ({provider}) that the vision router uses for this call, so "
+        "it cannot be applied without also switching the provider. Use a "
+        f"provider-qualified model (e.g. '{provider}/{model}') or a configured "
+        "model alias (model.aliases) that maps to a provider/model pair, or "
+        "configure auxiliary.vision.provider for the desired provider."
+    )
+
+
+def _resolve_video_model_override(
+    model: str,
+) -> Tuple[Optional[str], str, Optional[str]]:
+    """Resolve a ``video_analyze`` model override to a safe provider/model pair.
+
+    A per-call ``model=`` override must not silently swap the model while
+    keeping the provider chosen by the vision auto-router: that can build an
+    invalid provider/model pair and, depending on the adapter, return a false
+    success (#82419).
+
+    Resolution order:
+      1. Configured model aliases (``model.aliases`` / ``model_aliases``) that
+         map the override to an explicit provider/model/base_url (e.g. ``m3``
+         -> ``minimax-cn/MiniMax-M3``).
+      2. Provider-qualified strings (``provider/model``) — the provider prefix
+         becomes an explicit override (e.g. ``minimax-cn/MiniMax-M3``).
+      3. Bare model names — accepted only when they demonstrably belong to the
+         provider the vision auto-router will use; otherwise rejected with a
+         clear error (see :func:`_validate_video_model_override`).
+
+    Returns ``(provider_override, model, base_url_override)``. The overrides
+    are ``None`` when the auto-router's provider selection may be kept.
+    """
+    # 1. Configured model alias (config model.aliases / model_aliases).
+    try:
+        from hermes_cli import model_switch as _model_switch
+        _model_switch._ensure_direct_aliases()
+        _direct = _model_switch.DIRECT_ALIASES.get(str(model).strip().lower())
+    except Exception:
+        _direct = None
+    if _direct is not None and _direct.provider:
+        return (
+            _direct.provider,
+            _direct.model or model,
+            _direct.base_url or None,
+        )
+    # 2. Provider-qualified string: provider/model.
+    if "/" in model:
+        provider_part, _, bare_model = model.partition("/")
+        if provider_part.strip() and bare_model.strip():
+            return provider_part.strip(), bare_model.strip(), None
+    # 3. Bare model name — reject ambiguous cross-provider overrides.
+    _validate_video_model_override(model)
+    return None, model, None
+
+
 async def video_analyze_tool(
     video_url: str,
     user_prompt: str,
@@ -1989,7 +2088,14 @@ async def video_analyze_tool(
             "timeout": vision_timeout,
         }
         if model:
-            call_kwargs["model"] = model
+            provider_override, model_override, base_url_override = (
+                _resolve_video_model_override(model)
+            )
+            if provider_override:
+                call_kwargs["provider"] = provider_override
+            if base_url_override:
+                call_kwargs["base_url"] = base_url_override
+            call_kwargs["model"] = model_override
 
         _load_auxiliary_client()
         response = await async_call_llm(**call_kwargs)


### PR DESCRIPTION
## Summary

Fixes #82419. `video_analyze(video_url=..., model=...)` applied the `model=` override without validating or switching the provider selected by the vision auto-router. With an active provider A (e.g. `openai-codex`) and a `model=` belonging to provider B (e.g. `MiniMax-M3`), Hermes built an invalid provider/model pair that could fail silently and still report `success: true` — the caller cannot distinguish real video understanding from a text-only response.

## Root Cause

In `tools/vision_tools.py`, `video_analyze_tool` routed video as `task="vision"` and applied only the model override:

```python
call_kwargs = {
    "task": "vision",
    "messages": messages,
    "temperature": vision_temperature,
    "max_tokens": 4000,
    "timeout": vision_timeout,
}
if model:
    call_kwargs["model"] = model
```

No provider argument is passed. The vision auto-router in `agent/auxiliary_client.py` selects the active main provider first, and `_finalize()` later applies `resolved_model or default_model` — so a model override from provider B is attached to a client selected for provider A (live route probe: `provider = openai-codex`, `model = MiniMax-M3`, `client = AsyncCodexAuxiliaryClient`).

## Change

`video_analyze_tool` now resolves the override before building `call_kwargs` (no changes to `agent/auxiliary_client.py`):

1. **Configured model aliases** (`model.aliases` / `model_aliases`, e.g. `m3: minimax-cn/MiniMax-M3`) resolve to an explicit provider/model/base_url pair, passed through as `provider=`/`base_url=` — matching the documented working route `async_call_llm(task="vision", provider="minimax-cn", model="MiniMax-M3")`.
2. **Provider-qualified strings** (`provider/model`, e.g. `minimax-cn/MiniMax-M3`) split into an explicit `provider=` override plus the bare model.
3. **Bare model names** are accepted only when they demonstrably belong to the provider the vision router will use (`auxiliary.vision.provider` or the active main provider — matched against the configured vision model, the active main model, or the provider's dedicated vision model). Otherwise the ambiguous override is **rejected with a clear error before any LLM call**, suggesting a provider-qualified model/alias or `auxiliary.vision.provider` configuration.

The existing error handler surfaces this as `success: false` with the explanatory message, so the false-success shape is eliminated.

## Verification

- Added unit tests for `_resolve_video_model_override` (alias → provider/model pair, provider-qualified split, same-provider bare override allowed, provider vision default allowed, configured vision model allowed, cross-provider bare override rejected, unknown provider keeps prior behavior).
- Added end-to-end tests proving `video_analyze_tool` never builds an invalid pair: cross-provider bare override returns `success: false` and `async_call_llm` is never invoked; provider-qualified override routes with `provider="minimax-cn", model="MiniMax-M3"` and succeeds; same-provider override keeps working.
- `pytest tests/tools/test_vision_tools.py tests/tools/test_video_analyze.py` — **61 passed**.

## Closes

Closes #82419