### PR TITLE
fix(cron): classify script timeouts separately

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -122,6 +122,15 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             "Full details saved in cron output."
         )
 
+    # Script execution happens outside the LLM/provider path.  Check its
+    # explicit error contract before generic timeout matching so a script-only
+    # watchdog timeout never claims a provider fallback was attempted.
+    if lower.startswith("script timed out"):
+        return (
+            f"⚠️ Cron '{job_name}' failed: script timed out. "
+            "No model was invoked. Full details saved in cron output."
+        )
+
     if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -103,6 +104,80 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert error is None
     assert "RAM 92% on host" in final_response
     assert "RAM 92% on host" in doc
+
+
+def test_timed_out_no_agent_script_delivery_is_not_mislabeled_as_provider_failure(
+    hermes_env, monkeypatch,
+):
+    """A watchdog timeout happens before any LLM/provider call.
+
+    The delivery summary must preserve that process-level failure taxonomy and
+    must not claim a provider fallback was attempted or exhausted.
+    """
+    from cron.jobs import create_job
+    import cron.scheduler as scheduler
+
+    (hermes_env / "scripts" / "slow.py").write_text("import time; time.sleep(999)\n")
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="slow.py",
+        no_agent=True,
+        deliver="telegram",
+        name="slow watchdog",
+    )
+    delivered = []
+
+    def _timeout(*_args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="slow.py", timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(scheduler.subprocess, "run", _timeout)
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda _job, content, **_kwargs: delivered.append(content),
+    )
+
+    assert scheduler.run_one_job(job) is True
+    assert len(delivered) == 1
+    assert "script timed out" in delivered[0].lower()
+    assert "provider" not in delivered[0].lower()
+    assert "fallback" not in delivered[0].lower()
+
+
+def test_agent_provider_timeout_delivery_keeps_fallback_guidance(hermes_env, monkeypatch):
+    """Provider timeout classification remains available to agent-backed jobs."""
+    from cron.jobs import create_job
+    import cron.scheduler as scheduler
+
+    job = create_job(
+        prompt="Summarize the overnight logs.",
+        schedule="every 5m",
+        deliver="telegram",
+        name="provider-backed report",
+    )
+    delivered = []
+
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (
+            False,
+            "# Cron Job: provider-backed report\n\nprovider request timed out\n",
+            "",
+            "ReadTimeout: provider request timed out after fallback attempts",
+        ),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda _job, content, **_kwargs: delivered.append(content),
+    )
+
+    assert scheduler.run_one_job(job) is True
+    assert len(delivered) == 1
+    assert "provider timeout" in delivered[0].lower()
+    assert "fallback chain was exhausted or unavailable" in delivered[0].lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- classify the explicit cron script timeout contract before generic provider timeout heuristics
- report that no model was invoked for timed-out `no_agent` jobs
- preserve provider timeout/fallback delivery for agent-backed jobs

## Tests
- `scripts/run_tests.sh tests/cron/ -q` (517 passed)
- `ruff check cron/scheduler.py tests/cron/test_cron_no_agent.py`

Fixes the misleading provider-fallback failure alert emitted when a script-only cron job times out.