### PR TITLE
fix(desktop): wait for managed backend teardown on quit

### DIFF
--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -93,8 +93,6 @@ export async function waitForBackendExit(
       } catch {
         // Already gone.
       }
-
-      resolve()
     }, timeoutMs)
 
     child.once('exit', () => {

--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -43,7 +43,7 @@ export interface KillableChild extends BackendProcessRoot {
 export interface WaitableChild extends KillableChild {
   exitCode?: number | null
   signalCode?: string | null
-  once: (event: 'exit', listener: () => void) => unknown
+  once: (event: 'close' | 'exit', listener: () => void) => unknown
 }
 
 /**
@@ -95,10 +95,13 @@ export async function waitForBackendExit(
       }
     }, timeoutMs)
 
-    child.once('exit', () => {
+    const finish = () => {
       clearTimeout(timer)
       resolve()
-    })
+    }
+
+    child.once('exit', finish)
+    child.once('close', finish)
   })
 }
 

--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -70,6 +70,10 @@ export function stopBackendChild(child: KillableChild | null | undefined, deps: 
   }
 }
 
+export function shouldHoldBackendQuit(done: boolean, processCount: number, teardownPending: boolean): boolean {
+  return !done && (processCount > 0 || teardownPending)
+}
+
 /** Wait for graceful exit, then force-kill a backend that ignored SIGTERM. */
 export async function waitForBackendExit(
   child: WaitableChild | null | undefined,

--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -70,10 +70,6 @@ export function stopBackendChild(child: KillableChild | null | undefined, deps: 
   }
 }
 
-export function shouldHoldBackendQuit(done: boolean, processCount: number, teardownPending: boolean): boolean {
-  return !done && (processCount > 0 || teardownPending)
-}
-
 /** Wait for graceful exit, then force-kill a backend that ignored SIGTERM. */
 export async function waitForBackendExit(
   child: WaitableChild | null | undefined,

--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -40,6 +40,12 @@ export interface KillableChild extends BackendProcessRoot {
   kill: (signal: string) => void
 }
 
+export interface WaitableChild extends KillableChild {
+  exitCode?: number | null
+  signalCode?: string | null
+  once: (event: 'exit', listener: () => void) => unknown
+}
+
 /**
  * Stop a managed child process, choosing the right strategy for the platform.
  * No-ops silently if `child` is falsy, already killed, or the kill attempt
@@ -62,6 +68,40 @@ export function stopBackendChild(child: KillableChild | null | undefined, deps: 
   } catch {
     // Already gone.
   }
+}
+
+/** Wait for graceful exit, then force-kill a backend that ignored SIGTERM. */
+export async function waitForBackendExit(
+  child: WaitableChild | null | undefined,
+  deps: StopBackendChildDeps,
+  timeoutMs = 5000
+): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+
+  await new Promise<void>(resolve => {
+    const timer = setTimeout(() => {
+      try {
+        const isWindows = deps.isWindows ?? process.platform === 'win32'
+
+        if (isWindows && Number.isInteger(child.pid)) {
+          deps.forceKillProcessTree(child.pid as number)
+        } else {
+          child.kill('SIGKILL')
+        }
+      } catch {
+        // Already gone.
+      }
+
+      resolve()
+    }, timeoutMs)
+
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
 }
 
 /**

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,7 +32,11 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
-import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
+import {
+  stopBackendChild as stopBackendChildImpl,
+  stopBackendTreesForUpdate,
+  waitForBackendExit as waitForBackendExitImpl
+} from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -2646,6 +2650,8 @@ let isQuittingForHandoff = false
 // (the app.quit() that follows re-enters before-quit and must pass through).
 let quitPromptOpen = false
 let quitConfirmedWithActiveWork = false
+let backendQuitTeardownPromise: Promise<void> | null = null
+let backendQuitTeardownDone = false
 
 // Resolve the staged updater binary the desktop may hand an update to. On
 // Windows that binary owns ALL repo mutation — running `hermes update` +
@@ -8047,34 +8053,7 @@ function sendConnectionApplied() {
 }
 
 async function waitForBackendExit(child, timeoutMs = 5000) {
-  if (!child) {
-    return
-  }
-
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return
-  }
-
-  await new Promise<void>(resolve => {
-    const timer = setTimeout(() => {
-      try {
-        if (IS_WINDOWS && Number.isInteger(child.pid)) {
-          forceKillProcessTree(child.pid)
-        } else {
-          child.kill('SIGKILL')
-        }
-      } catch {
-        // Already gone.
-      }
-
-      resolve()
-    }, timeoutMs)
-
-    child.once('exit', () => {
-      clearTimeout(timer)
-      resolve()
-    })
-  })
+  await waitForBackendExitImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS }, timeoutMs)
 }
 
 // The profile the primary (window) backend runs as. readActiveDesktopProfile()
@@ -12504,6 +12483,26 @@ app.on('before-quit', event => {
   // exactly as it was.
   if (heldQuitForActiveWork(event)) {
     return
+  }
+
+  const backendProcesses = [
+    backendConnectionState.getProcess(),
+    ...[...backendPool.values()].map(entry => entry.process)
+  ].filter(child => child && child.exitCode === null && child.signalCode === null)
+
+  if (!backendQuitTeardownDone && backendProcesses.length > 0) {
+    event.preventDefault()
+
+    if (!backendQuitTeardownPromise) {
+      for (const child of backendProcesses) {
+        stopBackendChild(child)
+      }
+
+      backendQuitTeardownPromise = Promise.all(backendProcesses.map(child => waitForBackendExit(child))).then(() => {
+        backendQuitTeardownDone = true
+        app.quit()
+      })
+    }
   }
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1081,6 +1081,9 @@ let softRehomeInProgress = false
 // with no named profiles never populates this map, so their experience is
 // byte-for-byte the single-backend behavior.
 const backendPool = new Map() // profile -> { process, port, token, connectionPromise, lastActiveAt }
+// Process entries are deliberately removed before their children have exited in
+// re-home/idle paths; keep that physical teardown inventory until exit/close.
+const pendingBackendExits = new Map<any, Promise<void>>()
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
@@ -7353,6 +7356,7 @@ async function buildRemoteConnection(
 }
 
 const sshConnections = new Map<string, any>()
+const pendingSshTeardowns = new Set<Promise<void>>()
 const desktopInstallationId = loadOrCreateInstallationId(DESKTOP_INSTALLATION_PATH)
 
 const sshBootstrapCoordinator = createBootstrapCoordinator()
@@ -7385,35 +7389,41 @@ async function sshProbeReuseProof(baseUrl, token, spawnNonce) {
   }
 }
 
-async function teardownSshConnection(profile) {
+function teardownSshConnection(profile) {
   const scope = sshScopeKey(profile)
   const state = sshConnections.get(scope)
 
   if (!state) {
-    return
+    return Promise.resolve()
   }
 
   sshConnections.delete(scope)
 
-  for (const [id, info] of [...terminalSessions.entries()]) {
-    if (info.sshScope === scope) {
-      disposeTerminalSession(id)
+  const teardown = (async () => {
+    for (const [id, info] of [...terminalSessions.entries()]) {
+      if (info.sshScope === scope) {
+        disposeTerminalSession(id)
+      }
     }
-  }
 
-  try {
-    if (state.localPort && state.remotePort) {
-      await state.ssh.cancelForward(state.localPort, state.remotePort)
+    try {
+      if (state.localPort && state.remotePort) {
+        await state.ssh.cancelForward(state.localPort, state.remotePort)
+      }
+    } catch {
+      // best effort
     }
-  } catch {
-    // best effort
-  }
 
-  try {
-    await state.ssh.close()
-  } catch {
-    // best effort
-  }
+    try {
+      await state.ssh.close()
+    } catch {
+      // best effort
+    }
+  })()
+
+  pendingSshTeardowns.add(teardown)
+
+  return teardown.finally(() => pendingSshTeardowns.delete(teardown))
 }
 
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
@@ -8012,6 +8022,7 @@ function resetHermesConnection({ soft = false } = {}) {
   remoteLiveness.clear()
   const hermesProcess = backendConnectionState.invalidate()
   stopBackendChild(hermesProcess)
+  void waitForBackendExit(hermesProcess).catch(error => rememberLog(`Backend teardown failed: ${error.message}`))
 
   if (!soft) {
     resetBootProgressForReconnect()
@@ -8055,8 +8066,25 @@ function sendConnectionApplied() {
   webContents.send('hermes:connection:applied')
 }
 
-async function waitForBackendExit(child, timeoutMs = 5000) {
-  await waitForBackendExitImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS }, timeoutMs)
+function waitForBackendExit(child, timeoutMs = 5000) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve()
+  }
+
+  const existing = pendingBackendExits.get(child)
+
+  if (existing) {
+    return existing
+  }
+
+  const waiting = waitForBackendExitImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS }, timeoutMs)
+  pendingBackendExits.set(child, waiting)
+  void waiting.then(
+    () => pendingBackendExits.delete(child),
+    () => pendingBackendExits.delete(child)
+  )
+
+  return waiting
 }
 
 // The profile the primary (window) backend runs as. readActiveDesktopProfile()
@@ -8114,7 +8142,12 @@ async function ensureBackend(profile) {
   }
 
   entry.connectionPromise = spawnPoolBackend(key, entry).catch(error => {
-    backendPool.delete(key)
+    if (backendPool.get(key) === entry) {
+      backendPool.delete(key)
+    }
+
+    stopBackendChild(entry.process)
+    void waitForBackendExit(entry.process).catch(error => rememberLog(`Backend teardown failed: ${error.message}`))
     throw error
   })
   backendPool.set(key, entry)
@@ -8300,12 +8333,19 @@ async function spawnPoolBackend(profile, entry) {
 
   child.once('error', error => {
     rememberLog(`Hermes backend for profile "${profile}" failed to start: ${error.message}`)
-    backendPool.delete(profile)
+
+    if (backendPool.get(profile) === entry) {
+      backendPool.delete(profile)
+    }
+
     rejectStart?.(error)
   })
   child.once('exit', (code, signal) => {
     rememberLog(`Hermes backend for profile "${profile}" exited (${signal || code})`)
-    backendPool.delete(profile)
+
+    if (backendPool.get(profile) === entry) {
+      backendPool.delete(profile)
+    }
 
     if (!ready) {
       rejectStart?.(
@@ -8368,6 +8408,7 @@ function stopPoolBackend(profile) {
 
   backendPool.delete(profile)
   stopBackendChild(entry.process)
+  void waitForBackendExit(entry.process).catch(error => rememberLog(`Backend teardown failed: ${error.message}`))
 }
 
 async function teardownPoolBackendAndWait(profile) {
@@ -12457,7 +12498,13 @@ function configureSpellChecker() {
 // and the confirmation is on screen; "Quit Anyway" re-enters before-quit with
 // the latch set and falls straight through to the teardown below.
 function heldQuitForActiveWork(event: Electron.Event): boolean {
-  if (SKIP_QUIT_CONFIRM || quitConfirmedWithActiveWork || quitPromptOpen) {
+  if (quitPromptOpen) {
+    event.preventDefault()
+
+    return true
+  }
+
+  if (SKIP_QUIT_CONFIRM || quitConfirmedWithActiveWork) {
     return false
   }
 
@@ -12516,11 +12563,16 @@ app.on('before-quit', event => {
 
   const primaryStart = backendConnectionState.getPromise()
   const poolEntries = [...backendPool.values()]
+  const pendingBackendDrains = [...pendingBackendExits.values()]
+  const pendingSshDrains = [...pendingSshTeardowns]
 
   const backendProcesses = [
     backendConnectionState.getProcess(),
-    ...poolEntries.map(entry => entry.process)
-  ].filter(child => child && child.exitCode === null && child.signalCode === null)
+    ...poolEntries.map(entry => entry.process),
+    ...pendingBackendExits.keys()
+  ].filter((child, index, processes) => {
+    return child && child.exitCode === null && child.signalCode === null && processes.indexOf(child) === index
+  })
 
   const backendStarts = [primaryStart, ...poolEntries.map(entry => entry.connectionPromise)].filter(Boolean)
   const sshScopes = [...sshConnections.keys()]
@@ -12528,7 +12580,14 @@ app.on('before-quit', event => {
 
   if (
     !quitTeardown.done &&
-    (backendProcesses.length > 0 || backendStarts.length > 0 || sshScopes.length > 0 || sshBootstraps.length > 0)
+    (
+      backendProcesses.length > 0 ||
+      backendStarts.length > 0 ||
+      pendingBackendDrains.length > 0 ||
+      sshScopes.length > 0 ||
+      sshBootstraps.length > 0 ||
+      pendingSshDrains.length > 0
+    )
   ) {
     event.preventDefault()
     quitConfirmedWithActiveWork = true
@@ -12545,20 +12604,27 @@ app.on('before-quit', event => {
           stopBackendChild(child)
         }
 
+        const backendTeardown = Promise.allSettled([
+          ...backendProcesses.map(child => waitForBackendExit(child)),
+          ...pendingBackendDrains,
+          ...backendStarts
+        ])
+
         const sshTeardown = (async () => {
-          if (sshScopes.length === 0 && sshBootstraps.length === 0) {
+          if (sshScopes.length === 0 && sshBootstraps.length === 0 && pendingSshDrains.length === 0) {
             return
           }
 
           const established = sshScopes.map(scope => teardownSshConnection(scope || null))
-          const pending = Promise.allSettled([...established, ...sshBootstraps])
+          const branches = [...established, ...sshBootstraps, ...pendingSshDrains]
+          const pending = Promise.allSettled(branches)
 
           await Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))])
           await sshBootstrapCoordinator.forceCleanupAll()
-          await Promise.allSettled(established)
+          await Promise.allSettled(branches)
         })()
 
-        await Promise.all([...backendProcesses.map(child => waitForBackendExit(child)), sshTeardown])
+        await Promise.all([backendTeardown, sshTeardown])
       }, () => app.quit())
       .catch(error => rememberLog(`Quit teardown failed: ${error instanceof Error ? error.message : String(error)}`))
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1798,10 +1798,11 @@ function updateGateDeps() {
 // Block until no live update is in progress (or we hit the wait timeout).
 // Emits a boot-progress phase so the renderer shows "Update in progress…"
 // rather than a frozen splash. Returns true if it parked at all.
-async function waitForUpdateToFinish() {
+async function waitForUpdateToFinish(isCancelled = () => false) {
   let announced = false
 
   const outcome = await waitForUpdateClearance(updateGateDeps(), {
+    isCancelled,
     onWaitTick: async reason => {
       if (!announced) {
         announced = true
@@ -1838,6 +1839,10 @@ async function waitForUpdateToFinish() {
     }
   } catch (err) {
     rememberLog(`[updates] could not read hand-off result: ${err.message}`)
+  }
+
+  if (outcome === 'cancelled') {
+    throw new Error('Hermes backend start was cancelled because the Desktop is quitting.')
   }
 
   if (outcome === 'clear') {
@@ -8266,7 +8271,8 @@ async function spawnPoolBackend(profile, entry) {
   {
     let poolAnnounced = false
 
-    await waitForUpdateClearance(updateGateDeps(), {
+    const updateClearance = await waitForUpdateClearance(updateGateDeps(), {
+      isCancelled: () => quitTeardown.started || backendPool.get(profile) !== entry,
       onWaitTick: reason => {
         if (!poolAnnounced) {
           poolAnnounced = true
@@ -8276,6 +8282,10 @@ async function spawnPoolBackend(profile, entry) {
       pollMs: UPDATE_WAIT_POLL_MS,
       timeoutMs: UPDATE_WAIT_TIMEOUT_MS
     })
+
+    if (updateClearance === 'cancelled') {
+      throw new Error('Hermes backend start was cancelled because its profile connection changed or the Desktop is quitting.')
+    }
   }
 
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
@@ -8578,7 +8588,7 @@ async function startHermes() {
       waitForDecision: waitForFirstRunSetupChoice,
       // Mutual exclusion with an in-app update (#50238). Remote connections
       // return before this waiter; local starts park until the updater exits.
-      waitForLocalStart: waitForUpdateToFinish
+      waitForLocalStart: () => waitForUpdateToFinish(() => quitTeardown.started)
     })
 
     if (setup.kind === 'remote') {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -33,7 +33,6 @@ import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
 import {
-  shouldHoldBackendQuit,
   stopBackendChild as stopBackendChildImpl,
   stopBackendTreesForUpdate,
   waitForBackendExit as waitForBackendExitImpl
@@ -167,7 +166,13 @@ import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
-import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import {
+  type ActiveWork,
+  createQuitTeardownBarrier,
+  mergeActiveWork,
+  normalizeActiveWork,
+  quitPromptFor
+} from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   RemoteLivenessTracker,
@@ -2651,8 +2656,7 @@ let isQuittingForHandoff = false
 // (the app.quit() that follows re-enters before-quit and must pass through).
 let quitPromptOpen = false
 let quitConfirmedWithActiveWork = false
-let backendQuitTeardownPromise: Promise<void> | null = null
-let backendQuitTeardownDone = false
+const quitTeardown = createQuitTeardownBarrier()
 
 // Resolve the staged updater binary the desktop may hand an update to. On
 // Windows that binary owns ALL repo mutation — running `hermes update` +
@@ -7353,8 +7357,6 @@ const desktopInstallationId = loadOrCreateInstallationId(DESKTOP_INSTALLATION_PA
 
 const sshBootstrapCoordinator = createBootstrapCoordinator()
 
-let sshQuitTeardownDone = false
-
 function sshScopeKey(profile) {
   return connectionScopeKey(profile) || ''
 }
@@ -8077,6 +8079,10 @@ function profileRouteOptions(profile) {
 // resolveProfileBackendRoute(). An empty / unknown profile resolves to the
 // primary, so legacy callers are unchanged.
 async function ensureBackend(profile) {
+  if (quitTeardown.started) {
+    throw new Error('Hermes Desktop is quitting.')
+  }
+
   const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
   const route = resolveProfileBackendRoute(key, profileRouteOptions(key))
 
@@ -8250,6 +8256,10 @@ async function spawnPoolBackend(profile, entry) {
 
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
+  if (quitTeardown.started || backendPool.get(profile) !== entry) {
+    throw new Error('Hermes backend start was cancelled because the Desktop is quitting.')
+  }
+
   const child = spawn(
     backend.command,
     backend.args,
@@ -8415,6 +8425,10 @@ async function prepareProfileDeleteRequest(request) {
 }
 
 async function startHermes() {
+  if (quitTeardown.started) {
+    throw new Error('Hermes Desktop is quitting.')
+  }
+
   // Latched-failure short-circuit: once bootstrap has failed in this
   // process, every subsequent startHermes() call re-throws the same error
   // without re-running install.ps1. This prevents the renderer's
@@ -8538,6 +8552,10 @@ async function startHermes() {
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)
     rememberLog(`Starting Hermes backend via ${backend.label}`)
 
+    if (quitTeardown.started) {
+      throw new Error('Hermes backend start was cancelled because the Desktop is quitting.')
+    }
+
     const hermesProcess = spawn(
       backend.command,
       backend.args,
@@ -8572,6 +8590,7 @@ async function startHermes() {
 
     if (!processOwner) {
       stopBackendChild(hermesProcess)
+      await waitForBackendExit(hermesProcess)
       throw new Error('Hermes backend start was superseded by a newer connection attempt.')
     }
 
@@ -12480,49 +12499,68 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
 }
 
 app.on('before-quit', event => {
-  // Runs ahead of every teardown below, so "Keep Running" leaves the app
-  // exactly as it was.
+  // A retry from one teardown branch must not bypass another branch whose
+  // registry was already cleared while physical cleanup is still pending.
+  if (quitTeardown.pending) {
+    event.preventDefault()
+
+    return
+  }
+
+  // Runs ahead of the first teardown so "Keep Running" leaves the app exactly
+  // as it was. Once teardown starts, quitConfirmedWithActiveWork is the
+  // authorization latch for the one internal retry.
   if (heldQuitForActiveWork(event)) {
     return
   }
 
+  const primaryStart = backendConnectionState.getPromise()
+  const poolEntries = [...backendPool.values()]
+
   const backendProcesses = [
     backendConnectionState.getProcess(),
-    ...[...backendPool.values()].map(entry => entry.process)
+    ...poolEntries.map(entry => entry.process)
   ].filter(child => child && child.exitCode === null && child.signalCode === null)
 
+  const backendStarts = [primaryStart, ...poolEntries.map(entry => entry.connectionPromise)].filter(Boolean)
+  const sshScopes = [...sshConnections.keys()]
+  const sshBootstraps = sshBootstrapCoordinator.promises()
+
   if (
-    shouldHoldBackendQuit(backendQuitTeardownDone, backendProcesses.length, backendQuitTeardownPromise !== null)
+    !quitTeardown.done &&
+    (backendProcesses.length > 0 || backendStarts.length > 0 || sshScopes.length > 0 || sshBootstraps.length > 0)
   ) {
     event.preventDefault()
+    quitConfirmedWithActiveWork = true
 
-    if (!backendQuitTeardownPromise) {
-      for (const child of backendProcesses) {
-        stopBackendChild(child)
-      }
-
-      backendQuitTeardownPromise = Promise.all(backendProcesses.map(child => waitForBackendExit(child))).then(() => {
-        backendQuitTeardownDone = true
-        app.quit()
-      })
-    }
-  }
-
-  if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
-    event.preventDefault()
+    // Fence starts before the event loop can resume. Pending primary attempts
+    // lose attachProcess(), while pending pool attempts lose their entry check.
+    backendConnectionState.invalidate()
+    backendPool.clear()
     sshBootstrapCoordinator.cancelAll()
-    const scopes = [...sshConnections.keys()]
 
-    const pending = Promise.allSettled([
-      ...scopes.map(scope => teardownSshConnection(scope || null)),
-      ...sshBootstrapCoordinator.promises()
-    ])
+    void quitTeardown
+      .start(async () => {
+        for (const child of backendProcesses) {
+          stopBackendChild(child)
+        }
 
-    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))]).then(async () => {
-      await sshBootstrapCoordinator.forceCleanupAll()
-      sshQuitTeardownDone = true
-      app.quit()
-    })
+        const sshTeardown = (async () => {
+          if (sshScopes.length === 0 && sshBootstraps.length === 0) {
+            return
+          }
+
+          const established = sshScopes.map(scope => teardownSshConnection(scope || null))
+          const pending = Promise.allSettled([...established, ...sshBootstraps])
+
+          await Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))])
+          await sshBootstrapCoordinator.forceCleanupAll()
+          await Promise.allSettled(established)
+        })()
+
+        await Promise.all([...backendProcesses.map(child => waitForBackendExit(child)), sshTeardown])
+      }, () => app.quit())
+      .catch(error => rememberLog(`Quit teardown failed: ${error instanceof Error ? error.message : String(error)}`))
   }
 
   // Clean quit mid-boot should not trip next-launch --no-sandbox (#38216).

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8141,15 +8141,17 @@ async function ensureBackend(profile) {
     remoteBaseUrl: null
   }
 
-  entry.connectionPromise = spawnPoolBackend(key, entry).catch(error => {
-    if (backendPool.get(key) === entry) {
-      backendPool.delete(key)
-    }
+  entry.connectionPromise = quitTeardown.track(
+    spawnPoolBackend(key, entry).catch(error => {
+      if (backendPool.get(key) === entry) {
+        backendPool.delete(key)
+      }
 
-    stopBackendChild(entry.process)
-    void waitForBackendExit(entry.process).catch(error => rememberLog(`Backend teardown failed: ${error.message}`))
-    throw error
-  })
+      stopBackendChild(entry.process)
+      void waitForBackendExit(entry.process).catch(error => rememberLog(`Backend teardown failed: ${error.message}`))
+      throw error
+    })
+  )
   backendPool.set(key, entry)
   startPoolIdleReaper()
 
@@ -8514,7 +8516,7 @@ async function startHermes() {
   // a local failure latches to break install-restart loops.
   let attemptedRemote = primaryBackendIsRemote()
 
-  const connectionPromise = (async () => {
+  const connectionPromise = quitTeardown.track((async () => {
     const connectRemote = async remote => {
       await advanceBootProgress('backend.remote', `Connecting to remote Hermes backend at ${remote.baseUrl}`, 24)
       await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
@@ -8793,6 +8795,7 @@ async function startHermes() {
     )
     throw error
   })
+  );
 
   backendConnectionState.setPromise(connectionAttempt, connectionPromise)
 
@@ -12563,6 +12566,7 @@ app.on('before-quit', event => {
 
   const primaryStart = backendConnectionState.getPromise()
   const poolEntries = [...backendPool.values()]
+  const pendingBackendStarts = quitTeardown.tracked
   const pendingBackendDrains = [...pendingBackendExits.values()]
   const pendingSshDrains = [...pendingSshTeardowns]
 
@@ -12574,7 +12578,10 @@ app.on('before-quit', event => {
     return child && child.exitCode === null && child.signalCode === null && processes.indexOf(child) === index
   })
 
-  const backendStarts = [primaryStart, ...poolEntries.map(entry => entry.connectionPromise)].filter(Boolean)
+  const backendStarts = [primaryStart, ...poolEntries.map(entry => entry.connectionPromise), ...pendingBackendStarts].filter(
+    (start, index, starts) => start && starts.indexOf(start) === index
+  )
+
   const sshScopes = [...sshConnections.keys()]
   const sshBootstraps = sshBootstrapCoordinator.promises()
 
@@ -12606,8 +12613,7 @@ app.on('before-quit', event => {
 
         const backendTeardown = Promise.allSettled([
           ...backendProcesses.map(child => waitForBackendExit(child)),
-          ...pendingBackendDrains,
-          ...backendStarts
+          ...pendingBackendDrains
         ])
 
         const sshTeardown = (async () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -33,6 +33,7 @@ import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
 import {
+  shouldHoldBackendQuit,
   stopBackendChild as stopBackendChildImpl,
   stopBackendTreesForUpdate,
   waitForBackendExit as waitForBackendExitImpl
@@ -12490,7 +12491,9 @@ app.on('before-quit', event => {
     ...[...backendPool.values()].map(entry => entry.process)
   ].filter(child => child && child.exitCode === null && child.signalCode === null)
 
-  if (!backendQuitTeardownDone && backendProcesses.length > 0) {
+  if (
+    shouldHoldBackendQuit(backendQuitTeardownDone, backendProcesses.length, backendQuitTeardownPromise !== null)
+  ) {
     event.preventDefault()
 
     if (!backendQuitTeardownPromise) {

--- a/apps/desktop/electron/quit-guard.test.ts
+++ b/apps/desktop/electron/quit-guard.test.ts
@@ -105,3 +105,30 @@ test('one quit barrier waits for backend and SSH teardown before one retry', asy
   assert.equal(duplicateRuns, 0)
   assert.equal(retries, 1)
 })
+
+test('one quit barrier retains a removed pool start until it settles', async () => {
+  let releaseStart!: () => void
+  let retries = 0
+
+  const start = new Promise<void>(resolve => {
+    releaseStart = resolve
+  })
+
+  const barrier = createQuitTeardownBarrier()
+
+  barrier.track(start)
+
+  const teardown = barrier.start(async () => {
+    // The start was removed from its pool registry before this quit began.
+  }, () => {
+    retries += 1
+  })
+
+  await Promise.resolve()
+  assert.equal(barrier.pending, true)
+  assert.equal(retries, 0)
+
+  releaseStart()
+  await teardown
+  assert.equal(retries, 1)
+})

--- a/apps/desktop/electron/quit-guard.test.ts
+++ b/apps/desktop/electron/quit-guard.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { createQuitTeardownBarrier, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 
 test('normalizeActiveWork drops junk and keeps the count at least the title count', () => {
   assert.deepEqual(normalizeActiveWork(null), { count: 0, titles: [] })
@@ -59,4 +59,49 @@ test('quitPromptFor speaks singular for one chat', () => {
   assert.ok(prompt)
   assert.equal(prompt.message, 'Hermes is still working on 1 chat.')
   assert.ok(prompt.detail.includes('mid-turn'))
+})
+
+test('one quit barrier waits for backend and SSH teardown before one retry', async () => {
+  let releaseBackend!: () => void
+  let releaseSsh!: () => void
+  let retries = 0
+  let duplicateRuns = 0
+
+  const backend = new Promise<void>(resolve => {
+    releaseBackend = resolve
+  })
+
+  const ssh = new Promise<void>(resolve => {
+    releaseSsh = resolve
+  })
+
+  const barrier = createQuitTeardownBarrier()
+
+  const first = barrier.start(async () => {
+    await Promise.all([backend, ssh])
+  }, () => {
+    retries += 1
+  })
+
+  const second = barrier.start(async () => {
+    duplicateRuns += 1
+  }, () => {
+    retries += 1
+  })
+
+  assert.equal(first, second)
+  assert.equal(barrier.started, true)
+  assert.equal(barrier.pending, true)
+
+  releaseBackend()
+  await Promise.resolve()
+  assert.equal(barrier.pending, true)
+  assert.equal(retries, 0)
+
+  releaseSsh()
+  await first
+  assert.equal(barrier.done, true)
+  assert.equal(barrier.pending, false)
+  assert.equal(duplicateRuns, 0)
+  assert.equal(retries, 1)
 })

--- a/apps/desktop/electron/quit-guard.ts
+++ b/apps/desktop/electron/quit-guard.ts
@@ -95,6 +95,7 @@ export function quitPromptFor(work: ActiveWork, quittingForHandoff: boolean): nu
 export function createQuitTeardownBarrier() {
   let teardown: Promise<void> | null = null
   let done = false
+  const tracked = new Set<Promise<unknown>>()
 
   return {
     get done() {
@@ -106,11 +107,24 @@ export function createQuitTeardownBarrier() {
     get started() {
       return teardown !== null
     },
+    get tracked() {
+      return [...tracked]
+    },
+    track<T>(branch: Promise<T>): Promise<T> {
+      tracked.add(branch)
+      void branch.then(
+        () => tracked.delete(branch),
+        () => tracked.delete(branch)
+      )
+
+      return branch
+    },
     start(run: () => Promise<void>, retryQuit: () => void): Promise<void> {
       if (!teardown) {
         teardown = Promise.resolve()
           .then(run)
-          .then(() => {
+          .then(async () => {
+            await Promise.allSettled([...tracked])
             done = true
             retryQuit()
           })

--- a/apps/desktop/electron/quit-guard.ts
+++ b/apps/desktop/electron/quit-guard.ts
@@ -90,3 +90,33 @@ export function quitPromptFor(work: ActiveWork, quittingForHandoff: boolean): nu
     message: work.count === 1 ? 'Hermes is still working on 1 chat.' : `Hermes is still working on ${work.count} chats.`
   }
 }
+
+/** One authorized quit owns every asynchronous teardown branch and one retry. */
+export function createQuitTeardownBarrier() {
+  let teardown: Promise<void> | null = null
+  let done = false
+
+  return {
+    get done() {
+      return done
+    },
+    get pending() {
+      return teardown !== null && !done
+    },
+    get started() {
+      return teardown !== null
+    },
+    start(run: () => Promise<void>, retryQuit: () => void): Promise<void> {
+      if (!teardown) {
+        teardown = Promise.resolve()
+          .then(run)
+          .then(() => {
+            done = true
+            retryQuit()
+          })
+      }
+
+      return teardown
+    }
+  }
+}

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
@@ -129,6 +129,21 @@ test('cancelAll invalidates every pending scope and exposes promises for quit', 
   assert.ok(results.every(result => result.status === 'rejected' && (result.reason as any).kind === 'superseded'))
 })
 
+test('cancelAll fences later bootstraps during app quit', async () => {
+  const coordinator = createBootstrapCoordinator()
+  let ran = false
+
+  coordinator.cancelAll()
+
+  await assert.rejects(
+    coordinator.start('late', 'x', async () => {
+      ran = true
+    }),
+    (error: any) => error.kind === 'cancelled'
+  )
+  assert.equal(ran, false)
+})
+
 test('cancelAndWait drains only the requested scope', async () => {
   const coordinator = createBootstrapCoordinator()
   const firstGate = deferred()

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.ts
@@ -23,8 +23,16 @@ function createBootstrapCoordinator() {
   const pending = new Map<string, any>()
   const generations = new Map<string, number>()
   const drains = new Map<string, Promise<void>>()
+  let cancelled = false
 
   function start(scope, fingerprint, run) {
+    if (cancelled) {
+      const error: any = new Error('SSH bootstrap was cancelled because the Desktop is quitting.')
+      error.kind = 'cancelled'
+
+      return Promise.reject(error)
+    }
+
     const current = pending.get(scope)
 
     if (current?.fingerprint === fingerprint) {
@@ -111,6 +119,8 @@ function createBootstrapCoordinator() {
   }
 
   function cancelAll() {
+    cancelled = true
+
     for (const entry of active) {
       entry.controller.abort()
     }

--- a/apps/desktop/electron/update-gate.test.ts
+++ b/apps/desktop/electron/update-gate.test.ts
@@ -142,3 +142,21 @@ test('returns timeout when the gate never opens', async () => {
 
   assert.equal(outcome, 'timeout')
 })
+
+test('returns cancelled when a parked start is cancelled', async () => {
+  let cancelled = false
+  let clock = 0
+
+  const outcome = await waitForUpdateClearance(deps(true, false), {
+    isCancelled: () => cancelled,
+    now: () => clock,
+    pollMs: 10,
+    sleep: async ms => {
+      clock += ms
+      cancelled = true
+    },
+    timeoutMs: 50
+  })
+
+  assert.equal(outcome, 'cancelled')
+})

--- a/apps/desktop/electron/update-gate.ts
+++ b/apps/desktop/electron/update-gate.ts
@@ -47,11 +47,13 @@ export function updateGateReason(deps: UpdateGateDeps): UpdateGateReason {
   return null
 }
 
-export type UpdateClearanceOutcome = 'clear' | 'finished' | 'timeout'
+export type UpdateClearanceOutcome = 'clear' | 'finished' | 'timeout' | 'cancelled'
 
 export interface WaitForUpdateClearanceOptions {
   timeoutMs: number
   pollMs: number
+  /** Stops a no-longer-owned launch instead of waiting out an update. */
+  isCancelled?: () => boolean
   /** Invoked once per poll while parked (boot progress / logging). */
   onWaitTick?: (reason: Exclude<UpdateGateReason, null>) => void | Promise<void>
   now?: () => number
@@ -73,6 +75,11 @@ export async function waitForUpdateClearance(
 ): Promise<UpdateClearanceOutcome> {
   const now = options.now || Date.now
   const sleep = options.sleep || (ms => new Promise<void>(r => setTimeout(r, ms)))
+  const isCancelled = options.isCancelled || (() => false)
+
+  if (isCancelled()) {
+    return 'cancelled'
+  }
 
   let reason = updateGateReason(deps)
 
@@ -83,11 +90,24 @@ export async function waitForUpdateClearance(
   const deadline = now() + options.timeoutMs
 
   while (reason && now() < deadline) {
+    if (isCancelled()) {
+      return 'cancelled'
+    }
+
     if (options.onWaitTick) {
       await options.onWaitTick(reason)
     }
 
+    if (isCancelled()) {
+      return 'cancelled'
+    }
+
     await sleep(options.pollMs)
+
+    if (isCancelled()) {
+      return 'cancelled'
+    }
+
     reason = updateGateReason(deps)
   }
 

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -179,6 +179,26 @@ test('waitForBackendExit does not resolve until the force-killed backend exits',
   assert.equal(resolved, true)
 })
 
+test('waitForBackendExit resolves on close when spawn failed before exit', async () => {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    kill: () => {},
+    killed: false,
+    pid: undefined,
+    signalCode: null
+  })
+
+  const waiting = waitForBackendExit(child, { forceKillProcessTree: () => {}, isWindows: false }, 0)
+  child.emit('close', -2, null)
+
+  const result = await Promise.race([
+    waiting.then(() => 'closed'),
+    new Promise(resolve => setTimeout(() => resolve('pending'), 20))
+  ])
+
+  assert.equal(result, 'closed')
+})
+
 test('Windows update tree-kills captured roots without pre-signalling the primary backend', () => {
   const primary = makeChild({ pid: 101 })
   const pooled = makeChild({ pid: 202 })

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
 
 import { test } from 'vitest'
 
-import { stopBackendChild, stopBackendTreesForUpdate } from './backend-child'
+import { stopBackendChild, stopBackendTreesForUpdate, waitForBackendExit } from './backend-child'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 test('hiddenWindowsChildOptions adds windowsHide:true on Windows when unset', () => {
@@ -129,6 +130,26 @@ test('stopBackendChild swallows errors thrown by the kill strategy', () => {
       isWindows: false
     })
   })
+})
+
+test('waitForBackendExit force-kills a backend that ignores SIGTERM', async () => {
+  const calls: string[] = []
+
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    kill: (signal: string) => calls.push(signal),
+    killed: true,
+    pid: 4242,
+    signalCode: null
+  })
+
+  await waitForBackendExit(
+    child,
+    { forceKillProcessTree: () => {}, isWindows: false },
+    0
+  )
+
+  assert.deepEqual(calls, ['SIGKILL'])
 })
 
 test('Windows update tree-kills captured roots without pre-signalling the primary backend', () => {

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -143,13 +143,40 @@ test('waitForBackendExit force-kills a backend that ignores SIGTERM', async () =
     signalCode: null
   })
 
-  await waitForBackendExit(
+  const waiting = waitForBackendExit(
     child,
     { forceKillProcessTree: () => {}, isWindows: false },
     0
   )
 
+  await new Promise(resolve => setTimeout(resolve, 10))
   assert.deepEqual(calls, ['SIGKILL'])
+
+  child.emit('exit')
+  await waiting
+})
+
+test('waitForBackendExit does not resolve until the force-killed backend exits', async () => {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    kill: () => {},
+    killed: true,
+    pid: 4242,
+    signalCode: null
+  })
+
+  let resolved = false
+
+  const waiting = waitForBackendExit(child, { forceKillProcessTree: () => {}, isWindows: false }, 0).then(() => {
+    resolved = true
+  })
+
+  await new Promise(resolve => setTimeout(resolve, 10))
+  assert.equal(resolved, false)
+
+  child.emit('exit')
+  await waiting
+  assert.equal(resolved, true)
 })
 
 test('Windows update tree-kills captured roots without pre-signalling the primary backend', () => {

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -3,7 +3,12 @@ import { EventEmitter } from 'node:events'
 
 import { test } from 'vitest'
 
-import { stopBackendChild, stopBackendTreesForUpdate, waitForBackendExit } from './backend-child'
+import {
+  shouldHoldBackendQuit,
+  stopBackendChild,
+  stopBackendTreesForUpdate,
+  waitForBackendExit
+} from './backend-child'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 test('hiddenWindowsChildOptions adds windowsHide:true on Windows when unset', () => {
@@ -36,6 +41,12 @@ test('hiddenWindowsChildOptions defaults isWindows from process.platform when om
   const expectedHide = process.platform === 'win32'
 
   assert.equal(Boolean(result.windowsHide), expectedHide)
+})
+
+test('backend quit stays held while captured teardown is pending after registries clear', () => {
+  assert.equal(shouldHoldBackendQuit(false, 0, true), true)
+  assert.equal(shouldHoldBackendQuit(false, 1, false), true)
+  assert.equal(shouldHoldBackendQuit(true, 1, true), false)
 })
 
 function makeChild(overrides: Partial<{ pid: number | null; killed: boolean }> = {}) {

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -3,12 +3,7 @@ import { EventEmitter } from 'node:events'
 
 import { test } from 'vitest'
 
-import {
-  shouldHoldBackendQuit,
-  stopBackendChild,
-  stopBackendTreesForUpdate,
-  waitForBackendExit
-} from './backend-child'
+import { stopBackendChild, stopBackendTreesForUpdate, waitForBackendExit } from './backend-child'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 test('hiddenWindowsChildOptions adds windowsHide:true on Windows when unset', () => {
@@ -41,12 +36,6 @@ test('hiddenWindowsChildOptions defaults isWindows from process.platform when om
   const expectedHide = process.platform === 'win32'
 
   assert.equal(Boolean(result.windowsHide), expectedHide)
-})
-
-test('backend quit stays held while captured teardown is pending after registries clear', () => {
-  assert.equal(shouldHoldBackendQuit(false, 0, true), true)
-  assert.equal(shouldHoldBackendQuit(false, 1, false), true)
-  assert.equal(shouldHoldBackendQuit(true, 1, true), false)
 })
 
 function makeChild(overrides: Partial<{ pid: number | null; killed: boolean }> = {}) {


### PR DESCRIPTION
## Summary

- hold Electron quit behind one reentrant barrier for managed backend, SSH, and prior re-home/pool drain teardown
- join pending primary/pool startup (including starts removed from the pool during a connection change); cancel update-gated starts once their profile ownership or Desktop quit latch is lost
- permanently fence late SSH bootstrap, wait for observed child exit/terminal close after escalation, and preserve active-work confirmation against reentrant quit

Fixes #76245
Fixes #80898

Related: #76244, #46778

## Validation

- `npm run test:desktop:platforms` — 1007 passed, 2 skipped
- `npx tsc -p tsconfig.electron.json --noEmit`
- ESLint and `git diff --check`
- packaged macOS arm64 app (`e99b2fda32`): two rapid quit requests; backend exited at 3.487s, app at 3.655s (exit 0), no PPID-1 `hermes serve` remained

## Scope

Does not alter Python graceful-shutdown policy or intentionally detached updater/relaunch handoffs. It fixes the Desktop quit ownership boundary for local backends and SSH teardown.
