### PR TITLE
Sidebar filter menu

### DIFF
--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -584,6 +584,111 @@ async function reviewShipInfo(repoPath, ghBin) {
   }
 }
 
+// GraphQL asks per branch, so the answer can't be crowded out the way a
+// `gh pr list` page can. Aliases let one request carry many branches; 50 keeps
+// the document well inside GitHub's node budget.
+const PR_QUERY_BRANCH_CHUNK = 50
+const PR_QUERY_BRANCH_CAP = 300
+
+const PR_NODE_FIELDS = 'number state isDraft isCrossRepository title url headRefName'
+
+function prQueryFor(owner, name, branches, numbers) {
+  const fields = [
+    ...branches.map(
+      (branch, i) =>
+        `b${i}: pullRequests(headRefName: ${JSON.stringify(branch)}, first: 5, ` +
+        `orderBy: {field: CREATED_AT, direction: DESC}) ` +
+        `{ nodes { ${PR_NODE_FIELDS} } }`
+    ),
+    // A PR recovered from a transcript is known by number, and asking for it
+    // directly also tells us its branch — so it lands in the same by-branch map
+    // as everything else.
+    ...numbers.map((number, i) => `n${i}: pullRequest(number: ${number}) { ${PR_NODE_FIELDS} }`)
+  ].join('\n')
+
+  return `query { repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) {\n${fields}\n} }`
+}
+
+const prPayload = pr => ({
+  branch: String(pr.headRefName),
+  draft: Boolean(pr.isDraft),
+  number: Number(pr.number) || 0,
+  state: String(pr.state || '').toLowerCase(),
+  title: String(pr.title || ''),
+  url: String(pr.url || '')
+})
+
+// The PR for each of the given branches, keyed by branch. Asks GitHub about the
+// branches we actually have sessions on rather than listing the repo's newest
+// PRs and hoping ours are in the page — on a busy repo they are not. One
+// GraphQL request per 50 branches; reads only.
+async function reviewPrList(repoPath, ghBin, branches, numbers) {
+  let cwd
+
+  try {
+    cwd = resolveRequestedPathForIpc(repoPath, { purpose: 'Review PR list' })
+  } catch {
+    return { ghReady: false, prs: [] }
+  }
+
+  const wanted = [...new Set((branches || []).filter(Boolean).map(String))].slice(0, PR_QUERY_BRANCH_CAP)
+  const byNumber = [...new Set((numbers || []).map(Number).filter(Boolean))].slice(0, PR_QUERY_BRANCH_CAP)
+
+  if (wanted.length === 0 && byNumber.length === 0) {
+    return { ghReady: false, prs: [] }
+  }
+
+  const repo = await runGh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], cwd, ghBin)
+  const [owner, name] = repo.stdout.trim().split('/')
+
+  if (!repo.ok || !owner || !name) {
+    // gh missing, unauthenticated, or no GitHub remote — all "nothing to badge".
+    return { ghReady: false, prs: [] }
+  }
+
+  const prs = []
+  const chunks = []
+
+  for (let start = 0; start < wanted.length; start += PR_QUERY_BRANCH_CHUNK) {
+    chunks.push([wanted.slice(start, start + PR_QUERY_BRANCH_CHUNK), []])
+  }
+
+  for (let start = 0; start < byNumber.length; start += PR_QUERY_BRANCH_CHUNK) {
+    chunks.push([[], byNumber.slice(start, start + PR_QUERY_BRANCH_CHUNK)])
+  }
+
+  for (const [branchChunk, numberChunk] of chunks) {
+    const query = prQueryFor(owner, name, branchChunk, numberChunk)
+    const res = await runGh(['api', 'graphql', '-f', `query=${query}`], cwd, ghBin)
+
+    if (!res.ok) {
+      continue
+    }
+
+    try {
+      const repository = JSON.parse(res.stdout)?.data?.repository ?? {}
+
+      for (const key of Object.keys(repository)) {
+        // Asked for by number, so it's ours by construction — a fork PR can't
+        // be recovered from our own transcript. Asked for by branch, it has to
+        // prove it: fork PRs share our branch namespace, and a contributor's
+        // `main` is how a session on trunk ends up badged with a stranger's PR.
+        const pr = key.startsWith('n')
+          ? repository[key]
+          : (repository[key]?.nodes ?? []).find(node => node && !node.isCrossRepository)
+
+        if (pr?.headRefName) {
+          prs.push(prPayload(pr))
+        }
+      }
+    } catch {
+      // A malformed chunk drops its branches; the rest still resolve.
+    }
+  }
+
+  return { ghReady: true, prs }
+}
+
 // Create a PR for the current branch (pushing first so gh has a remote ref),
 // letting gh fill title/body from the commits. Returns the new PR url.
 async function reviewCreatePr(repoPath, gitBin, ghBin) {
@@ -716,6 +821,7 @@ export {
   reviewCreatePr,
   reviewDiff,
   reviewList,
+  reviewPrList,
   reviewPush,
   reviewRevert,
   reviewRevParse,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -105,6 +105,7 @@ import {
   reviewCreatePr,
   reviewDiff,
   reviewList,
+  reviewPrList,
   reviewPush,
   reviewRevert,
   reviewRevParse,
@@ -11817,6 +11818,9 @@ ipcMain.handle('hermes:git:review:commitContext', async (_event, repoPath) =>
 )
 ipcMain.handle('hermes:git:review:push', async (_event, repoPath) => reviewPush(repoPath, resolveGitBinary()))
 ipcMain.handle('hermes:git:review:shipInfo', async (_event, repoPath) => reviewShipInfo(repoPath, resolveGhBinary()))
+ipcMain.handle('hermes:git:review:prList', async (_event, repoPath, branches, numbers) =>
+  reviewPrList(repoPath, resolveGhBinary(), branches, numbers)
+)
 ipcMain.handle('hermes:git:review:createPr', async (_event, repoPath) =>
   reviewCreatePr(repoPath, resolveGitBinary(), resolveGhBinary())
 )

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -229,6 +229,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       commitContext: repoPath => ipcRenderer.invoke('hermes:git:review:commitContext', repoPath),
       push: repoPath => ipcRenderer.invoke('hermes:git:review:push', repoPath),
       shipInfo: repoPath => ipcRenderer.invoke('hermes:git:review:shipInfo', repoPath),
+      prList: (repoPath, branches, numbers) =>
+        ipcRenderer.invoke('hermes:git:review:prList', repoPath, branches, numbers),
       createPr: repoPath => ipcRenderer.invoke('hermes:git:review:createPr', repoPath)
     }
   },

--- a/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@nanostores/react'
 import { memo, useEffect } from 'react'
 
+import { PrTag } from '@/app/chat/pr-tag'
 import { StatusRow } from '@/components/chat/status-row'
 import {
   type ActionItemSpec,
@@ -18,6 +19,7 @@ import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
 import { openWorktreeDialog, registerRepoStatusCwd, repoStatusForCwd, repoWorktreesForCwd } from '@/store/coding-status'
 import { notifyError } from '@/store/notifications'
+import { $pullRequestsByBranch, branchPrKey, refreshPullRequests } from '@/store/pull-requests'
 
 // Tiny uppercase section header, matching the composer "+" menu's labels.
 const MENU_SECTION = 'text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-tertiary)'
@@ -76,6 +78,21 @@ export const CodingStatusRow = memo(function CodingStatusRow({
   // turn-settle / tool-complete / focus edges re-probe it too (tiles otherwise
   // only refreshed when the MAIN cwd probe happened to cover them).
   useEffect(() => registerRepoStatusCwd(resolvedRepoPath), [resolvedRepoPath])
+
+  // The branch's PR, so the rail links to it instead of leaving you to go find
+  // it. One `gh` lookup for this one branch, TTL-cached in the store and shared
+  // with the sidebar's badges.
+  const prBranch = status?.detached ? null : status?.branch || null
+
+  useEffect(() => {
+    if (resolvedRepoPath && prBranch) {
+      void refreshPullRequests({ [resolvedRepoPath]: [prBranch] })
+    }
+  }, [resolvedRepoPath, prBranch])
+
+  const pr = useStore($pullRequestsByBranch)[
+    resolvedRepoPath && prBranch ? branchPrKey(resolvedRepoPath, prBranch) : ''
+  ]
 
   const switchToBranch = async (branch: string) => {
     if (!onSwitchBranch) {
@@ -212,6 +229,8 @@ export const CodingStatusRow = memo(function CodingStatusRow({
                 {branchLabel}
               </span>
             </button>
+
+            {pr && <PrTag pr={pr} />}
 
             {/* Worktree path + copy — plain muted text, not a chip. Always in the
                 flex so hover doesn't reflow the row; opacity alone reveals the

--- a/apps/desktop/src/app/chat/pr-tag.tsx
+++ b/apps/desktop/src/app/chat/pr-tag.tsx
@@ -1,0 +1,55 @@
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+import type { HermesBranchPullRequest } from '@/global'
+import { cn } from '@/lib/utils'
+import { pullRequestBucket } from '@/store/pull-requests'
+
+// GitHub's own colour language, mapped onto our tokens: open is the "go" green,
+// merged the purple everyone reads as landed, draft and closed muted since
+// neither is waiting on you.
+const PR_STYLE: Record<string, { className: string; icon: string }> = {
+  closed: { className: 'text-(--ui-red)', icon: 'git-pull-request-closed' },
+  draft: { className: 'text-(--ui-text-quaternary)', icon: 'git-pull-request-draft' },
+  merged: { className: 'text-(--ui-purple)', icon: 'git-merge' },
+  open: { className: 'text-(--ui-green)', icon: 'git-pull-request' }
+}
+
+export function openPullRequest(pr: HermesBranchPullRequest): void {
+  if (pr.url) {
+    void window.hermesDesktop?.openExternal?.(pr.url)
+  }
+}
+
+/** The branch's PR as a row chip: state glyph plus number, tooltipped with the
+ *  title, and a link to the PR on click. Identity like {@link ProfileTag} —
+ *  never a status dot. */
+export function PrTag({ className, pr }: { className?: string; pr: HermesBranchPullRequest }) {
+  const style = PR_STYLE[pullRequestBucket(pr)] ?? PR_STYLE.open
+
+  return (
+    <Tip label={`#${pr.number} ${pr.title}`}>
+      <button
+        aria-label={`Open pull request #${pr.number}`}
+        // A flex box doesn't pass text-decoration down to its items, so the
+        // underline goes on the number itself rather than the chip.
+        className={cn(
+          'group/pr flex shrink-0 items-center gap-0.5 text-[0.625rem] leading-none tabular-nums',
+          style.className,
+          className
+        )}
+        onClick={event => {
+          // The row underneath opens the session on click and pins on
+          // shift-click; the chip is its own target and keeps the press.
+          event.preventDefault()
+          event.stopPropagation()
+          openPullRequest(pr)
+        }}
+        onPointerDown={event => event.stopPropagation()}
+        type="button"
+      >
+        <Codicon name={style.icon} size="0.75rem" />
+        <span className="underline-offset-1 group-hover/pr:underline">{pr.number}</span>
+      </button>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/app/chat/profile-tag.test.tsx
+++ b/apps/desktop/src/app/chat/profile-tag.test.tsx
@@ -28,12 +28,14 @@ describe('ProfileTag', () => {
     expect(tag.textContent).toBe('x')
   })
 
-  it('normalizes an empty profile to default and stays neutral', () => {
+  it('normalizes an empty profile to default, which shows the home glyph', () => {
     render(<ProfileTag profile="" />)
 
     const tag = screen.getByRole('img', { name: 'Profile: default' })
-    expect(tag.textContent).toBe('d')
-    // Default/root profile carries no identity color.
+    // The default profile has no initial and no identity color — it is the
+    // home icon, same as the profiles panel and the rail.
+    expect(tag.textContent).toBe('')
+    expect(tag.querySelector('.codicon-home')).not.toBeNull()
     expect(tag.style.color).toBe('')
   })
 

--- a/apps/desktop/src/app/chat/profile-tag.tsx
+++ b/apps/desktop/src/app/chat/profile-tag.tsx
@@ -1,36 +1,30 @@
 import { useStore } from '@nanostores/react'
 
+import { ProfileGlyph } from '@/components/ui/profile-glyph'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
-import { profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
-import { cn } from '@/lib/utils'
+import { resolveProfileColor } from '@/lib/profile-color'
 import { $profileColors, normalizeProfileKey } from '@/store/profile'
 
-/** Owning-profile chip: soft profile-tint square with the initial, tooltip +
- *  accessible label carrying the full name. Same visual language as the
- *  profile rail; the default profile stays neutral. Identity, not status —
+/** Owning-profile chip: the shared {@link ProfileGlyph}, resolved against the
+ *  live profile colors and labelled with the full name. Identity, not status —
  *  session state dots keep their own semantics (#66003). */
 export function ProfileTag({ className, profile }: { className?: string; profile: null | string | undefined }) {
   const { t } = useI18n()
   const colors = useStore($profileColors)
   const key = normalizeProfileKey(profile)
-  const color = resolveProfileColor(key, colors)
-  const hue = color ?? 'var(--ui-text-quaternary)'
   const label = t.sidebar.row.ownedByProfile(key)
 
   return (
     <Tip label={label}>
-      <span
+      <ProfileGlyph
         aria-label={label}
-        className={cn(
-          'grid size-4 shrink-0 place-items-center rounded-[3px] text-[0.5rem] font-semibold uppercase leading-none',
-          className
-        )}
+        className={className}
+        color={resolveProfileColor(key, colors)}
+        isDefault={key === 'default'}
+        name={key}
         role="img"
-        style={{ backgroundColor: profileColorSoft(hue, 22), color: color ?? undefined }}
-      >
-        {key.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'}
-      </span>
+      />
     </Tip>
   )
 }

--- a/apps/desktop/src/app/chat/session-status-dot.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.tsx
@@ -83,6 +83,11 @@ const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
   }
 }
 
+/** The dot a state paints, for surfaces that describe a status rather than
+ *  render a session — the sidebar's status filter, say. Idle carries no color
+ *  of its own (it inherits the project's), so callers supply one. */
+export const sessionDotClassName = (state: SessionDotState): string => DOT_VARIANTS[state].className
+
 export interface SessionStatusDotProps {
   /** The STORED session id — the key every live-state atom (working /
    *  attention / stalled / unread / background) is keyed by, on BOTH surfaces:

--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -36,7 +36,7 @@ export function SidebarRowStack({ className, ...props }: React.ComponentProps<'d
 
 /** Nested rows (session previews, worktree bodies). */
 export function SidebarRowNest({ className, ...props }: React.ComponentProps<'div'>) {
-  return <SidebarRowStack className={cn('pb-1 pl-4', className)} {...props} />
+  return <SidebarRowStack className={cn('pb-1 pl-2', className)} {...props} />
 }
 
 /**
@@ -44,13 +44,21 @@ export function SidebarRowNest({ className, ...props }: React.ComponentProps<'di
  * the session list. One flat row — a small caption plus a hairline rule — so it
  * groups sessions by recency without adding a level of indentation.
  */
-export function SidebarDateDivider({ className, label, ...props }: React.ComponentProps<'div'> & { label: string }) {
+export function SidebarDateDivider({
+  action,
+  className,
+  label,
+  ...props
+}: React.ComponentProps<'div'> & { action?: React.ReactNode; label: string }) {
   return (
-    <div className={cn('flex select-none items-center gap-2 px-2 pb-0.5 pt-2', className)} {...props}>
+    // group/workspace: a divider heads a group the same way a repo header does,
+    // so it borrows the header's hover-revealed "+" verbatim.
+    <div className={cn('group/workspace flex select-none items-center gap-2 px-2 pb-0.5 pt-2', className)} {...props}>
       <span className="shrink-0 text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
         {label}
       </span>
       <span aria-hidden="true" className="h-px flex-1 bg-(--ui-stroke-tertiary)" />
+      {action}
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -1,0 +1,346 @@
+import { useStore } from '@nanostores/react'
+
+import { sessionDotClassName } from '@/app/chat/session-status-dot'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { useI18n } from '@/i18n'
+import { desktopGit } from '@/lib/desktop-git'
+import { cn } from '@/lib/utils'
+import {
+  $sidebarFiltersActive,
+  $sidebarGrouping,
+  $sidebarOrdering,
+  $sidebarPrFilter,
+  $sidebarProjectFilter,
+  $sidebarRowMeta,
+  $sidebarShowArchived,
+  $sidebarStatusFilter,
+  $sidebarViewCustomized,
+  $sidebarWorkspaceNodeOpen,
+  resetSidebarView,
+  setSidebarGrouping,
+  setSidebarOrdering,
+  setSidebarShowArchived,
+  setWorkspaceNodesOpen,
+  type SidebarGrouping,
+  type SidebarOrdering,
+  type SidebarRowMeta,
+  toggleSidebarPrFilter,
+  toggleSidebarProjectFilter,
+  toggleSidebarRowMeta,
+  toggleSidebarStatusFilter
+} from '@/store/layout'
+import { $projectTree } from '@/store/projects'
+import type { PullRequestBucket } from '@/store/pull-requests'
+import { $unreadFinishedSessionIds, markAllSessionsRead } from '@/store/session'
+import type { SessionStatusBucket } from '@/store/session-dot-state'
+import { $sessionsHaveCost } from '@/store/sidebar-archive'
+
+interface Option<T extends string = string> {
+  /** A status dot's full className, from the row's own vocabulary. */
+  dot?: string
+  icon?: string
+  id: T
+  label: string
+}
+
+const GROUPINGS: Option<SidebarGrouping>[] = [
+  { icon: 'clock', id: 'date', label: 'Updated' },
+  { icon: 'root-folder', id: 'project', label: 'Project' },
+  { icon: 'pulse', id: 'status', label: 'Status' }
+]
+
+const ORDERINGS: Option<SidebarOrdering>[] = [
+  { icon: 'clock', id: 'updated', label: 'Updated' },
+  { icon: 'add', id: 'created', label: 'Created' },
+  { icon: 'pulse', id: 'status', label: 'Status' },
+  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
+  { icon: 'credit-card', id: 'cost', label: 'Cost' },
+  { icon: 'list-ordered', id: 'manual', label: 'Manual' }
+]
+
+const ROW_META: Option<SidebarRowMeta>[] = [
+  { icon: 'clock', id: 'updated', label: 'Updated' },
+  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
+  { icon: 'credit-card', id: 'cost', label: 'Cost' },
+  { icon: 'git-pull-request', id: 'pr', label: 'PR' },
+  { icon: 'account', id: 'profile', label: 'Profile' }
+]
+
+const PR_FILTERS: Option<PullRequestBucket>[] = [
+  { icon: 'git-pull-request', id: 'open', label: 'Open' },
+  { icon: 'git-pull-request-draft', id: 'draft', label: 'Draft' },
+  { icon: 'git-merge', id: 'merged', label: 'Merged' },
+  { icon: 'git-pull-request-closed', id: 'closed', label: 'Closed' },
+  { icon: 'circle-slash', id: 'none', label: 'No PR' }
+]
+
+const STATUS_FILTERS: Option<SessionStatusBucket>[] = [
+  { dot: sessionDotClassName('needs-input'), id: 'needs-input', label: 'Needs input' },
+  { dot: sessionDotClassName('working'), id: 'working', label: 'Working' },
+  { dot: sessionDotClassName('unread'), id: 'unread', label: 'Unread' },
+  { dot: sessionDotClassName('draft'), id: 'draft', label: 'Draft' },
+  { dot: cn(sessionDotClassName('idle'), 'bg-(--ui-text-quaternary)'), id: 'idle', label: 'Idle' }
+]
+
+function OptionGlyph({ option }: { option: Option }) {
+  if (option.dot) {
+    return <span aria-hidden="true" className={cn('shrink-0', option.dot)} />
+  }
+
+  return option.icon ? <Codicon className="text-(--ui-text-tertiary)" name={option.icon} size="0.8125rem" /> : null
+}
+
+/** Every option row — single or multi select — leaves the menu open, so a whole
+ *  view can be set up in one pass. Only the actions at the bottom dismiss it. */
+const keepOpen = (event: Event) => event.preventDefault()
+
+function OptionCheckbox({ checked, onCheck, option }: { checked: boolean; onCheck: () => void; option: Option }) {
+  return (
+    <DropdownMenuCheckboxItem
+      checked={checked}
+      onSelect={event => {
+        keepOpen(event)
+        onCheck()
+      }}
+    >
+      <OptionGlyph option={option} />
+      {option.label}
+    </DropdownMenuCheckboxItem>
+  )
+}
+
+function OptionRadio({ option }: { option: Option }) {
+  return (
+    <DropdownMenuRadioItem onSelect={keepOpen} value={option.id}>
+      <OptionGlyph option={option} />
+      {option.label}
+    </DropdownMenuRadioItem>
+  )
+}
+
+export function SidebarFilterMenu({ className }: { className?: string }) {
+  const { t } = useI18n()
+  const grouping = useStore($sidebarGrouping)
+  const ordering = useStore($sidebarOrdering)
+  const rowMeta = useStore($sidebarRowMeta)
+  const statusFilter = useStore($sidebarStatusFilter)
+  const projectFilter = useStore($sidebarProjectFilter)
+  const prFilter = useStore($sidebarPrFilter)
+  const showArchived = useStore($sidebarShowArchived)
+  const filtersActive = useStore($sidebarFiltersActive)
+  const viewCustomized = useStore($sidebarViewCustomized)
+  const nodeOpen = useStore($sidebarWorkspaceNodeOpen)
+  const projects = useStore($projectTree)
+  const hasCost = useStore($sessionsHaveCost)
+  const unreadIds = useStore($unreadFinishedSessionIds)
+  // PR state comes from `gh` on whichever machine holds the checkout — Electron
+  // locally, the gateway's REST mirror remotely. Resolved per render, not once
+  // at module load: switching to a remote profile swaps the bridge underneath.
+  const prAvailable = Boolean(desktopGit()?.review?.prList)
+  // Project rows default open, so "all collapsed" means every one of them has
+  // been explicitly shut.
+  const projectsCollapsed = projects.length > 0 && projects.every(project => nodeOpen[project.id] === false)
+
+  const groupingLabel = GROUPINGS.find(option => option.id === grouping)?.label
+
+  // Two options are conditional: dragging a row is what picks manual, so it
+  // only appears as a way back out once there's a hand-picked order to leave;
+  // and cost is hidden until some session actually reports spend.
+  const orderings = ORDERINGS.filter(option => {
+    if (option.id === 'manual') {
+      return ordering === 'manual'
+    }
+
+    return option.id !== 'cost' || hasCost || ordering === 'cost'
+  })
+
+  const rowMetaOptions = ROW_META.filter(option => {
+    if (option.id === 'cost') {
+      return hasCost || rowMeta.includes('cost')
+    }
+
+    return option.id !== 'pr' || prAvailable
+  })
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label="Filters"
+          className={cn(
+            className,
+            'data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground data-[state=open]:opacity-100',
+            // Active filters read as "this control is engaged", the same way the
+            // open menu does — never as an accent, which the sidebar reserves
+            // for a session that is actually doing something.
+            filtersActive && 'bg-(--ui-control-active-background) text-foreground opacity-100'
+          )}
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="list-filter" size="0.75rem" />
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" className="min-w-52">
+        <DropdownMenuGroup>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger hideChevron>
+              Grouping
+              <span className="ml-auto flex items-center gap-1 pl-4 text-(--ui-text-tertiary)">
+                {groupingLabel}
+                <Codicon name="chevron-right" size="1rem" />
+              </span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuRadioGroup
+                onValueChange={value => setSidebarGrouping(value as SidebarGrouping)}
+                value={grouping}
+              >
+                {GROUPINGS.map(option => (
+                  <OptionRadio key={option.id} option={option} />
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Ordering</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuRadioGroup
+                onValueChange={value => setSidebarOrdering(value as SidebarOrdering)}
+                value={ordering}
+              >
+                {orderings.map(option => (
+                  <OptionRadio key={option.id} option={option} />
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Show</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {rowMetaOptions.map(option => (
+                <OptionCheckbox
+                  checked={rowMeta.includes(option.id)}
+                  key={option.id}
+                  onCheck={() => toggleSidebarRowMeta(option.id)}
+                  option={option}
+                />
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuGroup>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Filters</DropdownMenuLabel>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Status</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {STATUS_FILTERS.map(option => (
+                <OptionCheckbox
+                  checked={statusFilter.includes(option.id)}
+                  key={option.id}
+                  onCheck={() => toggleSidebarStatusFilter(option.id)}
+                  option={option}
+                />
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          {/* `gh` only exists where the checkout does, so on a remote backend
+              this submenu never appears rather than filtering everything out. */}
+          {prAvailable && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Pull request</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {PR_FILTERS.map(option => (
+                  <OptionCheckbox
+                    checked={prFilter.includes(option.id)}
+                    key={option.id}
+                    onCheck={() => toggleSidebarPrFilter(option.id)}
+                    option={option}
+                  />
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
+
+          {projects.length > 1 && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Project</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="max-h-80 overflow-y-auto">
+                {projects.map(project => (
+                  <OptionCheckbox
+                    checked={projectFilter.includes(project.id)}
+                    key={project.id}
+                    onCheck={() => toggleSidebarProjectFilter(project.id)}
+                    option={{
+                      icon: project.isNoProject ? 'home' : 'root-folder',
+                      id: project.id,
+                      // Home is synthetic, so its label is ours to translate.
+                      label: project.isNoProject ? t.sidebar.projects.home : project.label
+                    }}
+                  />
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
+
+          <OptionCheckbox
+            checked={showArchived}
+            onCheck={() => setSidebarShowArchived(!showArchived)}
+            option={{ id: 'archived', label: 'Archived' }}
+          />
+
+          {/* One way back rather than two near-identical ones: this drops the
+              grouping and sort too, which "clear filters" left behind. */}
+          {viewCustomized && <DropdownMenuItem onSelect={resetSidebarView}>Reset to defaults</DropdownMenuItem>}
+        </DropdownMenuGroup>
+
+        <DropdownMenuSeparator />
+
+        {/* Only the project rows fold, and only when they're what you're
+            looking at — sweeping Pinned and Cron shut alongside them is not
+            what "collapse all" means here. Their lanes underneath keep their
+            own state, so re-opening a project shows it as you left it. */}
+        {grouping === 'project' && projects.length > 0 && (
+          <DropdownMenuItem
+            onSelect={() =>
+              setWorkspaceNodesOpen(
+                projects.map(project => project.id),
+                projectsCollapsed
+              )
+            }
+          >
+            {projectsCollapsed ? 'Expand all' : 'Collapse all'}
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem disabled={unreadIds.length === 0} onSelect={markAllSessionsRead}>
+          Mark all as read
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -36,21 +36,27 @@ import {
   $dismissedAutoProjectIds,
   $panesFlipped,
   $pinnedSessionIds,
-  $sidebarAgentsGrouped,
   $sidebarCronOpen,
+  $sidebarFiltersActive,
+  $sidebarGrouping,
   $sidebarMessagingOpenIds,
+  $sidebarOrdering,
   $sidebarPinsOpen,
+  $sidebarPrDataWanted,
+  $sidebarPrFilter,
+  $sidebarProjectFilter,
   $sidebarProjectOrderIds,
   $sidebarRecentsOpen,
   $sidebarSessionOrderIds,
   $sidebarSessionOrderManual,
+  $sidebarShowArchived,
+  $sidebarStatusFilter,
   $sidebarWorkspaceOrderIds,
   $sidebarWorkspaceParentOrderIds,
   filterVisibleProjects,
   pinSession,
   SESSION_SEARCH_FOCUS_EVENT,
   setPinnedSessionOrder,
-  setSidebarAgentsGrouped,
   setSidebarCronOpen,
   setSidebarPinsOpen,
   setSidebarProjectOrderIds,
@@ -82,6 +88,14 @@ import {
   refreshWorktrees,
   scanAndRecordRepos
 } from '@/store/projects'
+import {
+  $prBranchBySession,
+  $pullRequestsByBranch,
+  pullRequestBucket,
+  recoverSessionPullRequests,
+  refreshPullRequests,
+  sessionPrKey
+} from '@/store/pull-requests'
 import { openRouteTile } from '@/store/route-tiles'
 import {
   $cronSessions,
@@ -96,7 +110,9 @@ import {
   sessionPinId,
   setCurrentCwd
 } from '@/store/session'
+import { $sessionDotStateById, sessionStatusBucket, sessionStatusRank } from '@/store/session-dot-state'
 import { $focusedStoredSessionId, $workingSessionIds, type SplitDir } from '@/store/session-states'
+import { $archivedSessions, loadArchivedSessions, sessionCostUsd } from '@/store/sidebar-archive'
 
 import {
   type AppView,
@@ -109,12 +125,14 @@ import {
 import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
+import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
   excludeProjectSessions,
+  liveSessionProjectId,
   orderProjectsByIds,
   overlayLiveLanes,
   overlayLivePreviews,
@@ -141,6 +159,11 @@ import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 // dominating the sidebar before the user asks to see it.
 const NON_SESSION_INITIAL_ROWS = 3
 const NON_SESSION_LOAD_STEP = 10
+
+// How long after connecting to warm the project tree for someone who isn't in
+// the grouped view. Long enough that the flat list — the thing actually on
+// screen — has the connection to itself first.
+const PROJECT_TREE_WARM_MS = 2_000
 
 const SIDEBAR_NAV: SidebarNavItem[] = [
   {
@@ -182,6 +205,11 @@ const COMPACT_FLAT = 'compact:max-h-none compact:overflow-visible'
 
 // Vertical scroll only — never a horizontal bar from glow bleed, long titles, etc.
 const SCROLL_Y = 'overflow-y-auto overflow-x-hidden overscroll-contain'
+
+// The outer list reserves its bar's width whether or not one is showing, so
+// filtering or collapsing a section doesn't reflow every row sideways. Only the
+// outer one: nested scrollers would each reserve their own and stack the inset.
+const SCROLL_GUTTER = '[scrollbar-gutter:stable]'
 
 // A non-session group's scroll body: own scroller when tall, flattened when compact.
 const GROUP_BODY = cn(SCROLL_Y, COMPACT_FLAT)
@@ -287,7 +315,19 @@ export function ChatSidebar({
   )
 
   const panesFlipped = useStore($panesFlipped)
-  const agentsGrouped = useStore($sidebarAgentsGrouped)
+  const grouping = useStore($sidebarGrouping)
+  const ordering = useStore($sidebarOrdering)
+  const statusFilter = useStore($sidebarStatusFilter)
+  const projectFilter = useStore($sidebarProjectFilter)
+  const prFilter = useStore($sidebarPrFilter)
+  const prDataWanted = useStore($sidebarPrDataWanted)
+  const prBranchOverrides = useStore($prBranchBySession)
+  const pullRequests = useStore($pullRequestsByBranch)
+  const filtersActive = useStore($sidebarFiltersActive)
+  const showArchived = useStore($sidebarShowArchived)
+  const archivedSessions = useStore($archivedSessions)
+  const dotStates = useStore($sessionDotStateById)
+  const agentsGrouped = grouping === 'project'
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const pinsOpen = useStore($sidebarPinsOpen)
   const agentsOpen = useStore($sidebarRecentsOpen)
@@ -381,13 +421,51 @@ export function ChatSidebar({
   // that profile's sessions (clean rows, no per-row tags); ALL fans every
   // profile in, grouped by profile below. Single-profile users land here with
   // scope === their only profile, so nothing is filtered out.
+  // Archived rows are excluded from the sessions query, so Archived is a view of
+  // its own set rather than a filter over this one — a flat list of archived
+  // rows, no project tree, no date or status dividers.
+  const scopedSessions = useMemo(() => {
+    const pool = showArchived ? archivedSessions : sessions
+
+    return showAllProfiles ? pool : pool.filter(s => normalizeProfileKey(s.profile) === profileScope)
+  }, [sessions, archivedSessions, showArchived, showAllProfiles, profileScope])
+
+  // One predicate for the status/project filters, so the flat list and the
+  // project lanes narrow by the same rule. A project lane holds rows the loaded
+  // page may not, so it has to be answerable per session rather than by
+  // membership in the filtered set.
+  const sessionMatchesFilters = useCallback(
+    (session: SessionInfo) => {
+      if (statusFilter.length && !statusFilter.includes(sessionStatusBucket(dotStates[session.id]))) {
+        return false
+      }
+
+      if (prFilter.length) {
+        const key = sessionPrKey(session)
+
+        if (!prFilter.includes(pullRequestBucket(key ? pullRequests[key] : undefined))) {
+          return false
+        }
+      }
+
+      // Same membership the sidebar groups and colors by, so a filtered row
+      // lands in the lane the user picked it from.
+      return !projectFilter.length || projectFilter.includes(liveSessionProjectId(session, projects) ?? '')
+    },
+    [statusFilter, projectFilter, prFilter, pullRequests, projects, dotStates]
+  )
+
+  const filtersNarrow = statusFilter.length > 0 || projectFilter.length > 0 || prFilter.length > 0
+
   const visibleSessions = useMemo(
-    () => (showAllProfiles ? sessions : sessions.filter(s => normalizeProfileKey(s.profile) === profileScope)),
-    [sessions, showAllProfiles, profileScope]
+    () => (filtersNarrow ? scopedSessions.filter(sessionMatchesFilters) : scopedSessions),
+    [scopedSessions, filtersNarrow, sessionMatchesFilters]
   )
 
   // Recents by activity (last_active || started_at). User send stamps
-  // last_active immediately; manual drag order still wins below.
+  // last_active immediately. Ordering by status doesn't sort here — it re-slots
+  // rows *inside* whatever dividers are on, via sortOrderIds below — so the
+  // date buckets stay chronological either way.
   const sortedSessions = useMemo(
     () => [...visibleSessions].sort((a, b) => sessionTime(b) - sessionTime(a)),
     [visibleSessions]
@@ -445,6 +523,14 @@ export function ChatSidebar({
       pinnedIdentitySet.has(session.id) ||
       (session._lineage_root_id != null && pinnedIdentitySet.has(session._lineage_root_id)),
     [pinnedIdentitySet]
+  )
+
+  // What the project tree drops: pins (they live in their own section) plus
+  // anything the active filters exclude, so filtering works the same whether
+  // you're looking at the flat list or the lanes.
+  const isHiddenFromProjects = useCallback(
+    (session: SessionInfo) => isPinnedSession(session) || (filtersNarrow && !sessionMatchesFilters(session)),
+    [isPinnedSession, filtersNarrow, sessionMatchesFilters]
   )
 
   // Full-text search across *all* sessions (not just the loaded page) so 699
@@ -548,7 +634,7 @@ export function ChatSidebar({
   // Workspace grouping is a `project -> repo -> lane -> sessions` tree computed
   // authoritatively on the backend (projects.tree). Parents reorder via
   // workspaceParentOrderIds; worktrees within a parent via workspaceOrderIds.
-  const worktreeGroupingActive = agentsGrouped && !showAllProfiles
+  const worktreeGroupingActive = agentsGrouped && !showAllProfiles && !showArchived
   const gatewayReady = gatewayState === 'open'
 
   // The backend project tree is a structural snapshot, NOT a per-message feed.
@@ -559,15 +645,106 @@ export function ChatSidebar({
   // completing does NOT re-run the heavy list_sessions_rich scan. Project
   // mutations refresh the tree from their own store actions.
   useEffect(() => {
-    if (worktreeGroupingActive && gatewayReady) {
+    if (!gatewayReady) {
+      return
+    }
+
+    if (worktreeGroupingActive) {
       void refreshProjects()
       // Paint the list from the fast tree fetch (explicit projects + repos from
       // existing sessions / the backend cache) FIRST, then kick off the heavy
       // home-dir git crawl so newly-discovered repos fold in afterward — instead
       // of the crawl blocking the first render.
       void refreshProjectTree().finally(() => void scanAndRecordRepos())
+
+      return
     }
+
+    // Flat view: warm the tree in the background anyway. Fetching it only on
+    // the switch meant the first switch of every run paid for the whole round
+    // trip behind a skeleton, and the menu's Project filter had nothing to
+    // list until you'd visited the grouped view at least once.
+    const warm = window.setTimeout(() => void refreshProjectTree(), PROJECT_TREE_WARM_MS)
+
+    return () => window.clearTimeout(warm)
   }, [worktreeGroupingActive, profileScope, gatewayReady])
+
+  // Sessions the branch join can't answer for get one look at their own
+  // transcript — a `gh pr create` in there names the PR outright. Backfills
+  // whatever is loaded, whether or not the badge is on: gating it on the badge
+  // meant switching PR on showed a half-empty list until a second pass caught
+  // up. One request per batch of never-scanned rows, and the scanned set makes
+  // that batch empty from the second pass on, so this settles to nothing.
+  useEffect(() => {
+    if (!gatewayReady) {
+      return
+    }
+
+    const warm = window.setTimeout(() => void recoverSessionPullRequests(scopedSessions), PROJECT_TREE_WARM_MS)
+
+    return () => window.clearTimeout(warm)
+  }, [gatewayReady, scopedSessions])
+
+  // PR state is only fetched for someone who asked to see it — the badge or the
+  // filter — and it asks about the branches on screen, so the answer can't be
+  // crowded out by a busy repo's newer PRs.
+  const prLookupsByRepo = useMemo(() => {
+    if (!prDataWanted) {
+      return {}
+    }
+
+    const byRepo: Record<string, string[]> = {}
+
+    for (const session of scopedSessions) {
+      // The row's own key, so a session bound to a branch (or a PR number) it
+      // was stamped with asks about THAT, not the branch it started on.
+      const [root, lookup] = sessionPrKey(session)?.split('\n') ?? []
+
+      if (root && lookup && !byRepo[root]?.includes(lookup)) {
+        byRepo[root] = [...(byRepo[root] ?? []), lookup]
+      }
+    }
+
+    return byRepo
+    // prBranchOverrides is what `sessionPrKey` reads through — a recovered PR
+    // has to re-ask with the key it just learned.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prDataWanted, scopedSessions, prBranchOverrides])
+
+  // A stable identity for "the same question as last time", so a re-render that
+  // rebuilds the map doesn't re-ask GitHub.
+  const prQueryKey = JSON.stringify(
+    Object.entries(prLookupsByRepo)
+      .map(([root, lookups]) => [root, [...lookups].sort()] as const)
+      .sort(([a], [b]) => a.localeCompare(b))
+  )
+
+  useEffect(() => {
+    if (prQueryKey === '[]') {
+      return
+    }
+
+    const byRepo = Object.fromEntries(JSON.parse(prQueryKey) as [string, string[]][])
+
+    void refreshPullRequests(byRepo)
+
+    // A PR opens, merges or gets closed on github.com, not in here — so like
+    // the project tree, re-pull when the window comes back. The store's own
+    // staleness window keeps a flurry of focus events to one call per repo.
+    const onActive = () => {
+      if (document.visibilityState !== 'hidden') {
+        void refreshPullRequests(byRepo)
+      }
+    }
+
+    window.addEventListener('focus', onActive)
+    document.addEventListener('visibilitychange', onActive)
+
+    return () => {
+      window.removeEventListener('focus', onActive)
+      document.removeEventListener('visibilitychange', onActive)
+    }
+  }, [prQueryKey])
 
   // Out-of-band repo changes (a `git init` / `rm -rf` in another terminal) emit
   // no git events, so — like every git GUI — re-pull on window focus / tab
@@ -629,18 +806,22 @@ export function ChatSidebar({
     }
 
     const sorted = sortProjectsForOverview(
-      filterVisibleProjects(projectTree, dismissedAutoProjects).map(project =>
-        excludeProjectSessions(
-          {
-            ...project,
-            // Home is synthetic, so its name is ours to translate — every other
-            // label is a repo basename or a name the user typed.
-            label: project.isNoProject ? s.projects.home : project.label,
-            repos: orderRepos(project.repos)
-          },
-          isPinnedSession
-        )
-      ),
+      filterVisibleProjects(projectTree, dismissedAutoProjects)
+        // A filtered-out project drops its whole lane, header included — hiding
+        // only its rows would leave a row of empty folders behind.
+        .filter(project => !projectFilter.length || projectFilter.includes(project.id))
+        .map(project =>
+          excludeProjectSessions(
+            {
+              ...project,
+              // Home is synthetic, so its name is ours to translate — every
+              // other label is a repo basename or a name the user typed.
+              label: project.isNoProject ? s.projects.home : project.label,
+              repos: orderRepos(project.repos)
+            },
+            isHiddenFromProjects
+          )
+        ),
       activeProjectId
     )
 
@@ -654,8 +835,9 @@ export function ChatSidebar({
     dismissedAutoProjects,
     orderRepos,
     activeProjectId,
+    projectFilter,
     projectOrderIds,
-    isPinnedSession,
+    isHiddenFromProjects,
     s
   ])
 
@@ -725,9 +907,9 @@ export function ChatSidebar({
     // presentation copy (Home is translated there), not the raw payload's.
     return excludeProjectSessions(
       { ...hydrated, label: overviewEnteredProject.label, repos: orderRepos(hydrated.repos) },
-      isPinnedSession
+      isHiddenFromProjects
     )
-  }, [overviewEnteredProject, enteredProjectTree, orderRepos, isPinnedSession])
+  }, [overviewEnteredProject, enteredProjectTree, orderRepos, isHiddenFromProjects])
 
   // Overlay live `$sessions` onto the entered project so a just-created session
   // (which the backend snapshot hasn't folded in yet) counts as content and
@@ -1019,11 +1201,15 @@ export function ChatSidebar({
   // flag — otherwise a huge default profile keeps "Load more" stuck on while
   // you browse a small one. The backend reports whether its page was capped
   // rather than an exact count, so no COUNT(*) runs per refresh.
-  const loadedSessionCount = showAllProfiles ? sessions.length : visibleSessions.length
+  const loadedSessionCount = showAllProfiles ? sessions.length : scopedSessions.length
 
-  const hasMoreSessions = showAllProfiles
-    ? Object.values(sessionProfilesTruncated).some(Boolean)
-    : Boolean(sessionProfilesTruncated[profileScope])
+  // The archived view is its own (single, capped) query — paging the live
+  // sessions list from under it would just fold un-archived rows back in.
+  const hasMoreSessions =
+    !showArchived &&
+    (showAllProfiles
+      ? Object.values(sessionProfilesTruncated).some(Boolean)
+      : Boolean(sessionProfilesTruncated[profileScope]))
 
   const displayRecentsCountRef = useRef(0)
   const loadedRecentsCountRef = useRef(0)
@@ -1067,6 +1253,44 @@ export function ChatSidebar({
       setRecentsLoadMorePending(false)
     }
   }, [onLoadMoreSessions, recentsLoadMorePending])
+
+  // Archived rows are excluded from the sessions query, so the view has to
+  // fetch its own set.
+  useEffect(() => {
+    if (showArchived) {
+      void loadArchivedSessions()
+    }
+  }, [showArchived])
+
+  // Ranking by size is a question about the whole list ("what did I burn money
+  // on"), so it drops the calendar dividers and ranks globally — "Today" above
+  // the priciest session you have ever had would be a lie. Time- and
+  // state-based keys stay bucketed, where they read correctly per day.
+  const rankedGlobally = ordering === 'cost' || ordering === 'tokens'
+
+  // Every sort key but `updated` is expressed as an id order applied within
+  // whatever dividers are on — so a bucketed key ranks rows inside each day,
+  // and a globally-ranked one (which has no dividers left) ranks the lot.
+  // `updated` is the natural order the list already arrives in, so it needs no
+  // ids at all.
+  const sortOrderIds = useMemo(() => {
+    const rank: null | ((session: SessionInfo) => number) =
+      ordering === 'status'
+        ? session => sessionStatusRank(dotStates[session.id])
+        : ordering === 'created'
+          ? session => -session.started_at
+          : ordering === 'tokens'
+            ? session => -(session.input_tokens + session.output_tokens)
+            : ordering === 'cost'
+              ? session => -sessionCostUsd(session)
+              : null
+
+    if (!rank) {
+      return undefined
+    }
+
+    return [...agentSessions].sort((a, b) => rank(a) - rank(b)).map(session => session.id)
+  }, [ordering, agentSessions, dotStates])
 
   const displayAgentGroups = showAllProfiles ? profileGroups : undefined
 
@@ -1113,9 +1337,15 @@ export function ChatSidebar({
     }
   }, [activeRepoTrees, workspaceParentOrderIds, workspaceOrderIds])
 
-  const showSessionSkeletons = sessionsLoading && sortedSessions.length === 0
+  // Skeletons mean "still loading", so they key off the UNFILTERED set. Keyed
+  // off the filtered one, a filter that matches nothing showed skeletons on
+  // every background refresh instead of the empty state.
+  const showSessionSkeletons = sessionsLoading && scopedSessions.length === 0
 
-  const showSessionSections = showSessionSkeletons || sortedSessions.length > 0 || projectModel.length > 0
+  // Filtered down to nothing still renders the section: the empty state is what
+  // tells you the filter — not an empty account — is why the list is bare.
+  const showSessionSections =
+    showSessionSkeletons || filtersActive || sortedSessions.length > 0 || projectModel.length > 0
 
   // Each reorderable list reports its OWN new id order; persisting is a direct,
   // typed write — no id-prefix sniffing to figure out which level moved.
@@ -1262,7 +1492,7 @@ export function ChatSidebar({
         )}
 
         {showSessionSections && (
-          <div className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y)}>
+          <div className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y, SCROLL_GUTTER)}>
             {trimmedQuery && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}
@@ -1329,14 +1559,19 @@ export function ChatSidebar({
                   // virtualized long list, which must keep its own scroller.
                   !recentsVirtualizes && COMPACT_FLAT
                 )}
-                dateGrouped
                 dndSensors={dndSensors}
                 emptyState={
                   showSessionSkeletons ? (
                     <SidebarSessionSkeletons />
                   ) : (
                     <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
-                      {inProject ? s.projectEmpty : pinnedSessions.length > 0 ? s.allPinned : s.noSessions}
+                      {inProject
+                        ? s.projectEmpty
+                        : filtersActive
+                          ? s.noFilterMatches
+                          : pinnedSessions.length > 0
+                            ? s.allPinned
+                            : s.noSessions}
                     </div>
                   )
                 }
@@ -1356,6 +1591,11 @@ export function ChatSidebar({
                   ) : null
                 }
                 forceEmptyState={showSessionSkeletons}
+                // Archived is a plain list, and so is a magnitude-ranked one.
+                // Otherwise project lanes stay chronological whatever the flat
+                // list does — only the flat list can swap its dividers for
+                // WORKING / DONE.
+                grouping={showArchived || rankedGlobally ? 'none' : grouping === 'status' ? 'status' : 'date'}
                 groups={displayAgentGroups}
                 headerAction={
                   inProject && enteredProject ? (
@@ -1411,26 +1651,7 @@ export function ChatSidebar({
                         </Tip>
                       ) : null}
                       <div className="grid size-6 place-items-center">
-                        {!showAllProfiles && agentSessions.length > 0 ? (
-                          <Tip label={agentsGrouped ? s.showSessions : s.showProjects}>
-                            <Button
-                              aria-label={agentsGrouped ? s.showSessions : s.showProjects}
-                              className={cn(
-                                HEADER_NAV_BTN,
-                                agentsGrouped && 'bg-(--ui-control-active-background) text-foreground opacity-100'
-                              )}
-                              onClick={event => {
-                                event.stopPropagation()
-                                setSidebarRecentsOpen(true)
-                                setSidebarAgentsGrouped(!agentsGrouped)
-                              }}
-                              size="icon-xs"
-                              variant="ghost"
-                            >
-                              <Codicon name={agentsGrouped ? 'list-unordered' : 'root-folder'} size="0.75rem" />
-                            </Button>
-                          </Tip>
-                        ) : null}
+                        {!showAllProfiles ? <SidebarFilterMenu className={HEADER_NAV_BTN} /> : null}
                       </div>
                     </div>
                   )
@@ -1444,7 +1665,7 @@ export function ChatSidebar({
                   ) : undefined
                 }
                 liveSessions={inProject ? agentSessions : undefined}
-                manualOrderIds={agentOrderManual ? agentOrderIds : undefined}
+                manualOrderIds={agentOrderManual ? agentOrderIds : sortOrderIds}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}
                 onDeleteSession={onDeleteSession}

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -29,6 +29,7 @@ import { ColorSwatches } from '@/components/ui/color-swatches'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { ProfileGlyph } from '@/components/ui/profile-glyph'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { getProfileSoul, updateProfileSoul } from '@/hermes'
@@ -496,19 +497,12 @@ function ProfileDropdown({
 // One dropdown row per profile — its own component so each row can own a
 // hover-intent prewarm timer (see useProfilePrewarm).
 function ProfileDropdownItem({ color, name }: { color: null | string; name: string }) {
-  const hue = color ?? 'var(--ui-text-quaternary)'
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(name)
 
   return (
     <SelectItem onPointerEnter={startPrewarm} onPointerLeave={cancelPrewarm} value={name}>
       <span className="flex min-w-0 items-center gap-1.5">
-        <span
-          aria-hidden="true"
-          className="grid size-4 shrink-0 place-items-center rounded-[3px] text-[0.5rem] font-semibold uppercase leading-none"
-          style={{ backgroundColor: profileColorSoft(hue, 22), color: color ?? undefined }}
-        >
-          {name.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'}
-        </span>
+        <ProfileGlyph aria-hidden="true" color={color} isDefault={false} name={name} />
         <span className="truncate">{name}</span>
       </span>
     </SelectItem>

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -12,6 +12,7 @@ export { ProjectMenu } from './project-menu'
 export { SidebarWorkspaceGroup } from './workspace-group'
 export {
   excludeProjectSessions,
+  liveSessionProjectId,
   overlayLiveLanes,
   overlayLivePreviews,
   sessionRecency,

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -1,6 +1,8 @@
+import { useStore } from '@nanostores/react'
 import { memo } from 'react'
 import type * as React from 'react'
 
+import { PrTag } from '@/app/chat/pr-tag'
 import { ProfileTag } from '@/app/chat/profile-tag'
 import { startSessionDrag } from '@/app/chat/session-drag'
 import { PlatformAvatar } from '@/app/messaging/platform-icon'
@@ -11,17 +13,29 @@ import { Tip } from '@/components/ui/tooltip'
 import type { SessionInfo } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
+import { compactNumber } from '@/lib/format'
 import { triggerHaptic } from '@/lib/haptics'
 import { middleClickHandlers } from '@/lib/middle-click'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
+import { $sidebarRowMeta } from '@/store/layout'
+import { normalizeProfileKey } from '@/store/profile'
+import { $pullRequestsByBranch, sessionPrKey } from '@/store/pull-requests'
 import { $sessionDotStateById, hasLiveTurn, showsRunningArc } from '@/store/session-dot-state'
+import { sessionCostUsd } from '@/store/sidebar-archive'
 
 import { SessionStatusDot } from '../session-status-dot'
 
-import { SidebarRowBody, SidebarRowGrab, SidebarRowLabel, SidebarRowLead, SidebarRowShell } from './chrome'
+import {
+  SidebarRowBody,
+  SidebarRowGrab,
+  SidebarRowLabel,
+  SidebarRowLead,
+  SidebarRowLeadGlyph,
+  SidebarRowShell
+} from './chrome'
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 import { useProfilePrewarm } from './use-profile-prewarm'
 
@@ -79,6 +93,48 @@ function SidebarSessionRowImpl({
   const title = sessionTitle(session)
   const age = formatAge(session.last_active || session.started_at, r)
   const handleLabel = `Reorder ${title}`
+  // Opt-in row metadata from the sidebar's filter menu. Read from the store
+  // rather than threaded as props: the subscription re-renders past the memo
+  // below, and a toggle should repaint every row at once anyway.
+  const rowMeta = useStore($sidebarRowMeta)
+  // Pinned metadata occupies the actions slot and swaps out for the kebab on
+  // hover, so the row reserves the same width either way and never reflows.
+  const pinnedAge = rowMeta.includes('updated')
+  // The default profile has no mark worth spending a row slot on — a chip on
+  // every row that says "the normal one" is noise. Named profiles only.
+  const hasProfileTag = normalizeProfileKey(session.profile) !== 'default'
+  const pinnedProfile = hasProfileTag && rowMeta.includes('profile')
+  // The branch's PR, if the row was asked to show one. A selector, not a plain
+  // useStore: a repo's PRs land as a single map write, and only the rows on
+  // those branches should repaint.
+  const prKey = sessionPrKey(session)
+  const pr = useStoreSelector($pullRequestsByBranch, prs => (rowMeta.includes('pr') && prKey ? prs[prKey] : undefined))
+  const totalTokens = session.input_tokens + session.output_tokens
+  const cost = sessionCostUsd(session)
+
+  // Tokens, cost and age share the one trailing slot rather than each claiming
+  // their own column: several switched on read as one figure, not as a
+  // widening gutter.
+  const pinnedFacts = [
+    rowMeta.includes('tokens') && totalTokens > 0 ? compactNumber(totalTokens) : null,
+    // Sub-cent spend rounds to "$0.00", which reads as a bug rather than as a
+    // cheap session — below a cent the row says nothing at all.
+    rowMeta.includes('cost') && cost >= 0.01 ? `$${cost.toFixed(2)}` : null,
+    pinnedAge ? age : null
+  ].filter(Boolean) as string[]
+
+  // The kebab covers the END of the slot, so only the last fact steps aside for
+  // it. With tokens and age both on, hovering costs you the age and keeps the
+  // number you switched on to read.
+  const pinnedTail = pinnedFacts.at(-1) ?? ''
+  const pinnedHead = pinnedFacts.slice(0, -1).join(' · ')
+  const pinnedLabel = pinnedFacts.join(' · ')
+  // Chips that ride in the BODY, beside the title. The kebab lifts out of the
+  // actions slot, so it only ever covers what's in there — a body chip has no
+  // reason to step aside, and the hover-age (which does overlay the body) is
+  // dropped rather than made to fight them.
+  const bodyChip = Boolean(pr) || pinnedProfile || (showProfile && hasProfileTag)
+  const pinnedMeta = Boolean(pinnedLabel) || bodyChip
   // A handed-off session's live source is local, but it originated on a
   // messaging platform — surface that origin as a small badge so e.g. a
   // Telegram thread continued here still reads as Telegram.
@@ -89,6 +145,14 @@ function SidebarSessionRowImpl({
   // whenever any session's status changes, but a row only repaints on its own.
   const dotState = useStoreSelector($sessionDotStateById, states => states[session.id] ?? 'idle')
   const liveTurn = hasLiveTurn(dotState)
+
+  // An archived session has no live status to paint, so the archive glyph takes
+  // the lead slot the dot would occupy instead of adding a column of its own.
+  const lead = session.archived ? (
+    <SidebarRowLeadGlyph className="text-(--ui-text-quaternary)">
+      <Codicon name="archive" size="0.75rem" />
+    </SidebarRowLeadGlyph>
+  ) : null
 
   return (
     <SessionContextMenu
@@ -103,10 +167,36 @@ function SidebarSessionRowImpl({
     >
       <SidebarRowShell
         actions={
-          <div className="relative z-2 grid w-[1.375rem] place-items-center" data-row-actions>
-            {!liveTurn && (
-              <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
-                {age}
+          // Pinned metadata sits in normal flow and the kebab lifts out of it,
+          // so this slot's intrinsic width IS the metadata's — the row's
+          // `auto` actions column measures it and the title truncates against
+          // whatever is switched on, with no width to hand-maintain.
+          <div className="relative z-2 flex items-center justify-end" data-row-actions>
+            {/* Pinned metadata stays put through a turn — it was switched on to
+                be read. Only the tail hands its slot to the kebab; anything
+                ahead of it stays legible while you hover. The hover-only age is
+                an overlay instead, so it needs the row to open up 48px of right
+                padding — which beside a body chip reads as a hole. A row that
+                already shows a chip skips it. */}
+            {(pinnedLabel || (!liveTurn && !bodyChip)) && (
+              <span
+                className={cn(
+                  'pointer-events-none whitespace-nowrap text-right text-[0.625rem] leading-none text-(--ui-text-tertiary)',
+                  !pinnedLabel && 'absolute right-6 opacity-0 transition-opacity group-hover:opacity-100'
+                )}
+              >
+                {pinnedLabel ? (
+                  <>
+                    {pinnedHead}
+                    {/* Never narrower than the kebab that has to cover it. */}
+                    <span className="inline-block min-w-5 transition-opacity group-hover:opacity-0">
+                      {pinnedHead && ' · '}
+                      {pinnedTail}
+                    </span>
+                  </>
+                ) : (
+                  age
+                )}
               </span>
             )}
             <SessionActionsMenu
@@ -121,7 +211,10 @@ function SidebarSessionRowImpl({
             >
               <Button
                 aria-label={r.sessionActions}
-                className="size-5 rounded-[4px] bg-transparent text-transparent transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:bg-(--ui-control-active-background) focus-visible:text-foreground focus-visible:ring-0 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground group-hover:text-(--ui-text-tertiary) [&_svg]:size-3.5!"
+                className={cn(
+                  'size-5 rounded-[4px] bg-transparent text-transparent transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:bg-(--ui-control-active-background) focus-visible:text-foreground focus-visible:ring-0 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground group-hover:text-(--ui-text-tertiary) [&_svg]:size-3.5!',
+                  pinnedLabel && 'absolute right-0'
+                )}
                 size="icon"
                 variant="ghost"
               >
@@ -173,7 +266,10 @@ function SidebarSessionRowImpl({
       >
         {showsRunningArc(dotState) && <span aria-hidden="true" className="arc-border arc-row" />}
         <SidebarRowBody
-          className={cn('z-0 group-hover:pr-12', branchStem && 'pl-3.5')}
+          // Pinned metadata already sits in the actions slot, so the title only
+          // needs a gap from it — and the same gap on hover, or the row would
+          // jump every time the kebab took over.
+          className={cn('z-0', pinnedMeta ? 'pr-2' : 'group-hover:pr-12', branchStem && 'pl-3.5')}
           // Middle-click = open in a new tab (browser muscle memory).
           {...middleClickHandlers(() => {
             triggerHaptic('selection')
@@ -217,16 +313,18 @@ function SidebarSessionRowImpl({
         >
           {reorderable ? (
             <SidebarRowGrab ariaLabel={handleLabel} dragging={dragging} dragHandleProps={dragHandleProps}>
-              <SessionStatusDot
-                branchStem={branchStem}
-                className="transition-opacity group-hover/handle:opacity-0 group-focus-within/handle:opacity-0"
-                session={session}
-                storedSessionId={session.id}
-              />
+              {lead ?? (
+                <SessionStatusDot
+                  branchStem={branchStem}
+                  className="transition-opacity group-hover/handle:opacity-0 group-focus-within/handle:opacity-0"
+                  session={session}
+                  storedSessionId={session.id}
+                />
+              )}
             </SidebarRowGrab>
           ) : (
             <SidebarRowLead className="overflow-hidden">
-              <SessionStatusDot branchStem={branchStem} session={session} storedSessionId={session.id} />
+              {lead ?? <SessionStatusDot branchStem={branchStem} session={session} storedSessionId={session.id} />}
             </SidebarRowLead>
           )}
           {handoffSource && handoffLabel ? (
@@ -241,7 +339,10 @@ function SidebarSessionRowImpl({
           <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
             {title}
           </SidebarRowLabel>
-          {showProfile && <ProfileTag profile={session.profile} />}
+          {/* Stays put on hover, unlike the other chips: it's a link, and the
+              kebab lives in its own column rather than over this one. */}
+          {pr && <PrTag pr={pr} />}
+          {(showProfile || pinnedProfile) && hasProfileTag && <ProfileTag profile={session.profile} />}
         </SidebarRowBody>
       </SidebarRowShell>
     </SessionContextMenu>

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -109,7 +109,7 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
     expect(nextRowsRef).toBe(initialRowsRef)
   })
 
-  it('re-computes flatRows reference when dateGrouped or sessions change', () => {
+  it('re-computes flatRows reference when grouping or sessions change', () => {
     mockVirtualListPropsHistory.length = 0
 
     const initialSessions = generateSessions(VIRTUALIZE_THRESHOLD + 2)
@@ -117,8 +117,8 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
     const { rerender } = render(
       <SidebarSessionsSection
         activeSessionId={null}
-        dateGrouped={false}
         emptyState={<div>Empty</div>}
+        grouping="none"
         label="Sessions"
         onArchiveSession={noop}
         onDeleteSession={noop}
@@ -133,12 +133,12 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
 
     const firstRowsRef = mockVirtualListPropsHistory[0].rows
 
-    // Change dateGrouped to true
+    // Switch on date dividers
     rerender(
       <SidebarSessionsSection
         activeSessionId={null}
-        dateGrouped={true}
         emptyState={<div>Empty</div>}
+        grouping="date"
         label="Sessions"
         onArchiveSession={noop}
         onDeleteSession={noop}
@@ -159,8 +159,8 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
     rerender(
       <SidebarSessionsSection
         activeSessionId={null}
-        dateGrouped={true}
         emptyState={<div>Empty</div>}
+        grouping="date"
         label="Sessions"
         onArchiveSession={noop}
         onDeleteSession={noop}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -1,4 +1,5 @@
 import type { useSensors } from '@dnd-kit/core'
+import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { useCallback, useMemo } from 'react'
 
@@ -9,10 +10,16 @@ import type { HermesGitWorktree } from '@/global'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
-import { groupEntriesByRecency, type SidebarListRow, toSessionRows } from '@/lib/session-date-groups'
+import {
+  groupEntriesByRecency,
+  groupEntriesByStatus,
+  type SidebarListRow,
+  toSessionRows
+} from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
+import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
 import { orderRowsWithinGroups, reorderableRowIds } from './order'
@@ -24,6 +31,7 @@ import {
   SidebarWorkspaceGroup,
   type SidebarWorkspaceTree
 } from './projects'
+import { WorkspaceAddButton } from './projects/workspace-header'
 import { ReorderableList, useSortableBindings } from './reorderable-list'
 import { SidebarSessionSkeletons } from './section-states'
 import { SidebarSessionRow } from './session-row'
@@ -149,11 +157,12 @@ interface SidebarSessionsSectionProps {
   // lists (Pinned / search results) in the All-profiles view, where no group
   // header communicates ownership (#66003).
   showProfileTags?: boolean
-  // Insert "Yesterday" / "Last week" date dividers into the chronological
-  // session list (flat recents + entered-project lanes). Off for hand-ordered
-  // lists, pinned, messaging groups, and the project overview, where the order
-  // isn't strictly by recency so a date bucket would be misleading.
-  dateGrouped?: boolean
+  // Which dividers to fold into the flat list: `date` gives the chronological
+  // "Yesterday" / "Last week" separators (flat recents + entered-project lanes),
+  // `status` splits into WORKING / DONE under the same separators. `none` for
+  // pinned, messaging groups, and the project overview, where the order isn't
+  // strictly by recency so a bucket would be misleading.
+  grouping?: 'date' | 'none' | 'status'
 }
 
 export function SidebarSessionsSection({
@@ -195,10 +204,12 @@ export function SidebarSessionsSection({
   projectBackRow,
   dndSensors,
   showProfileTags = false,
-  dateGrouped = false
+  grouping = 'none'
 }: SidebarSessionsSectionProps) {
   const { t } = useI18n()
   const dividerLabels = t.sidebar.dateDivider
+  const statusDividerLabels = t.sidebar.statusDivider
+  const dotStates = useStore($sessionDotStateById)
   const sectionOpen = collapsible ? open : true
   const hasGroupedSessions = Boolean(groups?.some(group => group.sessions.length > 0))
   // A defined project list is itself content (even an empty project should
@@ -262,14 +273,29 @@ export function SidebarSessionsSection({
     ]
   )
 
-  // A single flat/virtual/lane list row — either a date divider or a session.
+  // Date dividers head a group the same way a repo header does, so they carry
+  // the same hover-revealed "+". Only for dates: "new session in WORKING" is
+  // not a thing.
+  const dividerAction =
+    grouping === 'date' && onNewSessionInWorkspace ? (
+      <WorkspaceAddButton label={t.sidebar.nav['new-session']} onClick={() => onNewSessionInWorkspace(null)} />
+    ) : null
+
+  // A single flat/virtual/lane list row — either a divider or a session.
   const renderListRow = useCallback(
-    (row: SidebarListRow, draggable: boolean) =>
-      row.kind === 'divider' ? (
-        <SidebarDateDivider key={row.key} label={sessionBucketLabel(row.bucket, dividerLabels)} />
-      ) : (
-        renderRow(row.entry.session, draggable, row.entry.branchStem)
-      ),
+    (row: SidebarListRow, draggable: boolean, action?: React.ReactNode) => {
+      if (row.kind === 'session') {
+        return renderRow(row.entry.session, draggable, row.entry.branchStem)
+      }
+
+      return (
+        <SidebarDateDivider
+          action={action}
+          key={row.key}
+          label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
+        />
+      )
+    },
     [dividerLabels, renderRow]
   )
 
@@ -287,11 +313,11 @@ export function SidebarSessionsSection({
     (items: SessionInfo[]) => {
       const entries = flattenSessionsWithBranches(items)
 
-      return (dateGrouped ? groupEntriesByRecency(entries) : toSessionRows(entries)).map(row =>
+      return (grouping === 'date' ? groupEntriesByRecency(entries) : toSessionRows(entries)).map(row =>
         renderListRow(row, false)
       )
     },
-    [dateGrouped, renderListRow]
+    [grouping, renderListRow]
   )
 
   // Flat recents as list rows: grouped by recency when enabled, plain otherwise.
@@ -299,10 +325,19 @@ export function SidebarSessionsSection({
   // row ranks it among its own day's chats instead of freezing the whole list
   // into an undated manual mode.
   const flatRows: SidebarListRow[] = useMemo(() => {
-    const rows = dateGrouped ? groupEntriesByRecency(displayEntries) : toSessionRows(displayEntries)
+    const rows =
+      grouping === 'date'
+        ? groupEntriesByRecency(displayEntries)
+        : grouping === 'status'
+          ? groupEntriesByStatus(
+              displayEntries,
+              entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'),
+              statusDividerLabels
+            )
+          : toSessionRows(displayEntries)
 
     return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
-  }, [dateGrouped, displayEntries, manualOrderIds])
+  }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels])
 
   // dnd-kit must see exactly the ids it renders, in render order: the sortable
   // set is derived from the rows, not from `sessions`. Feeding it the unrendered
@@ -410,6 +445,7 @@ export function SidebarSessionsSection({
       <VirtualSessionList
         activeSessionId={activeSessionId}
         className={contentClassName}
+        dividerAction={dividerAction}
         onArchiveSession={onArchiveSession}
         onBranchSession={onBranchSession}
         onDeleteSession={onDeleteSession}
@@ -433,11 +469,11 @@ export function SidebarSessionsSection({
   } else if (sessionsDraggable && onReorderSessions) {
     inner = (
       <ReorderableList ids={sortableRowIds} onReorder={onReorderSessions} sensors={dndSensors}>
-        {flatRows.map(row => renderListRow(row, true))}
+        {flatRows.map(row => renderListRow(row, true, dividerAction))}
       </ReorderableList>
     )
   } else {
-    inner = flatRows.map(row => renderListRow(row, false))
+    inner = flatRows.map(row => renderListRow(row, false, dividerAction))
   }
 
   // The virtualizer owns its own scroller, so suppress the wrapper's overflow

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -1,6 +1,7 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useVirtualizer } from '@tanstack/react-virtual'
+import type * as React from 'react'
 import { type FC, useCallback, useRef } from 'react'
 
 import type { SessionInfo } from '@/hermes'
@@ -29,6 +30,8 @@ interface SessionRowCommonProps {
 export interface VirtualSessionListProps {
   activeSessionId: null | string
   className?: string
+  /** Hover-revealed control for date dividers (the group-level "+"). */
+  dividerAction?: React.ReactNode
   rows: SidebarListRow[]
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
@@ -46,6 +49,7 @@ const OVERSCAN_ROWS = 12
 export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   activeSessionId,
   className,
+  dividerAction,
   rows: listRows,
   onArchiveSession,
   onBranchSession,
@@ -90,9 +94,10 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     if (row.kind === 'divider') {
       return (
         <SidebarDateDivider
+          action={dividerAction}
           data-index={virtualItem.index}
           key={row.key}
-          label={sessionBucketLabel(row.bucket, dividerLabels)}
+          label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
           ref={virtualizer.measureElement}
         />
       )

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -5,12 +5,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CodeEditor } from '@/components/chat/code-editor'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
-import { Codicon } from '@/components/ui/codicon'
+import { ProfileGlyph } from '@/components/ui/profile-glyph'
 import { getProfileSoul, type ProfileInfo, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
 import { AlertTriangle, Save } from '@/lib/icons'
-import { profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
+import { resolveProfileColor } from '@/lib/profile-color'
 import { normalize } from '@/lib/text'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileColors, refreshProfiles } from '@/store/profile'
@@ -205,6 +205,7 @@ function ProfileRow({
       active={active}
       lead={
         <ProfileGlyph
+          aria-hidden="true"
           color={resolveProfileColor(profile.name, colors)}
           isDefault={profile.is_default}
           name={profile.name}
@@ -216,33 +217,6 @@ function ProfileRow({
       rowKey={profile.name}
       title={profile.name}
     />
-  )
-}
-
-// Leading glyph for a profile row, mirroring the sidebar rail: the default
-// profile gets the `home` icon; named profiles get a soft color-tinted square
-// with their initial in the profile's color.
-function ProfileGlyph({ color, isDefault, name }: { color: null | string; isDefault: boolean; name: string }) {
-  if (isDefault) {
-    return <Codicon className="shrink-0 text-muted-foreground/70" name="home" size="0.9rem" />
-  }
-
-  const hue = color ?? 'var(--ui-text-quaternary)'
-
-  const initial =
-    name
-      .replace(/[^a-z0-9]/gi, '')
-      .charAt(0)
-      .toUpperCase() || '?'
-
-  return (
-    <span
-      aria-hidden="true"
-      className="grid size-4 shrink-0 place-items-center rounded-[3px] text-[0.5rem] font-semibold uppercase leading-none"
-      style={{ backgroundColor: profileColorSoft(hue, 22), color: color ?? undefined }}
-    >
-      {initial}
-    </span>
   )
 }
 

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { getCronJobs, listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
 import { sameCronSignature } from '@/lib/session-signatures'
@@ -9,7 +9,15 @@ import {
   normalizeSessionSource
 } from '@/lib/session-source'
 import { setCronJobs } from '@/store/cron'
-import { $pinnedSessionIds, $sessionsLimit, bumpSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
+import {
+  $pinnedSessionIds,
+  $sessionsLimit,
+  $sidebarFiltersActive,
+  bumpSessionsLimit,
+  raiseSessionsLimit,
+  SIDEBAR_FILTERED_PAGE_SIZE,
+  SIDEBAR_SESSIONS_PAGE_SIZE
+} from '@/store/layout'
 import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import { $removedSessionIds } from '@/store/projects'
 import {
@@ -243,6 +251,36 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     bumpSessionsLimit()
     await refreshSessions()
   }, [refreshSessions])
+
+  // A filter searches the loaded page, so switching one on has to deepen the
+  // page — otherwise "merged PRs" answers for the last 50 rows and reads as
+  // "you only have 6 merged PRs". Clearing the filters hands the window back:
+  // the list refreshes on every settled turn, and paying for 300 rows a turn
+  // once the view is unfiltered again buys nothing. Whatever the user had
+  // paged to by hand is what it returns to.
+  const unfilteredLimit = useRef<null | number>(null)
+
+  useEffect(
+    () =>
+      $sidebarFiltersActive.subscribe(active => {
+        if (active) {
+          unfilteredLimit.current ??= $sessionsLimit.get()
+
+          if (raiseSessionsLimit(SIDEBAR_FILTERED_PAGE_SIZE)) {
+            void refreshSessions()
+          }
+        } else if (unfilteredLimit.current !== null) {
+          const restored = unfilteredLimit.current
+          unfilteredLimit.current = null
+
+          if ($sessionsLimit.get() > restored) {
+            $sessionsLimit.set(restored)
+            void refreshSessions()
+          }
+        }
+      }),
+    [refreshSessions]
+  )
 
   // ALL-profiles view pages one profile at a time: fetch that profile's next
   // page and merge it in place, leaving every other profile's rows untouched.

--- a/apps/desktop/src/components/ui/profile-glyph.tsx
+++ b/apps/desktop/src/components/ui/profile-glyph.tsx
@@ -1,0 +1,43 @@
+import { profileColorSoft } from '@/lib/profile-color'
+import { cn } from '@/lib/utils'
+
+import { Codicon } from './codicon'
+
+/** A profile's mark, in one place: the default profile is the `home` icon (it
+ *  has no color of its own and an initial would read as just another named
+ *  profile); every other profile is a soft tint of its color carrying its
+ *  initial. Presentational — callers resolve the color from `$profileColors`. */
+export function ProfileGlyph({
+  className,
+  color,
+  isDefault,
+  name,
+  ...props
+}: Omit<React.ComponentProps<'span'>, 'color'> & {
+  color: null | string
+  isDefault: boolean
+  name: string
+}) {
+  if (isDefault) {
+    return (
+      <span className={cn('grid size-4 shrink-0 place-items-center', className)} {...props}>
+        <Codicon className="text-(--ui-text-quaternary)" name="home" size="0.75rem" />
+      </span>
+    )
+  }
+
+  const initial = name.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'
+
+  return (
+    <span
+      className={cn(
+        'grid size-4 shrink-0 place-items-center rounded-[3px] text-[0.5rem] font-semibold uppercase leading-none',
+        className
+      )}
+      style={{ backgroundColor: profileColorSoft(color ?? 'var(--ui-text-quaternary)', 22), color: color ?? undefined }}
+      {...props}
+    >
+      {initial}
+    </span>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -260,6 +260,10 @@ declare global {
           commitContext: (repoPath: string) => Promise<{ diff: string; recent: string }>
           push: (repoPath: string) => Promise<{ ok: boolean }>
           shipInfo: (repoPath: string) => Promise<HermesReviewShipInfo>
+          // The PR on each of the given branches — plus any known only by
+          // number — for badging a list of sessions in one request instead of
+          // one `pr view` per checkout.
+          prList: (repoPath: string, branches: string[], numbers?: number[]) => Promise<HermesRepoPullRequests>
           createPr: (repoPath: string) => Promise<{ url: string }>
         }
         // Repo-first discovery: scan bounded roots for git repos (depth-capped).
@@ -933,6 +937,23 @@ export interface HermesReviewPr {
   url: string
   state: string
   number: number
+}
+
+// One repo's PRs as reported by `gh pr list`, each tied to the branch it was
+// opened from — how a session row finds its own PR.
+export interface HermesBranchPullRequest {
+  branch: string
+  draft: boolean
+  number: number
+  /** `open` | `closed` | `merged`, lowercased from gh. */
+  state: string
+  title: string
+  url: string
+}
+
+export interface HermesRepoPullRequests {
+  ghReady: boolean
+  prs: HermesBranchPullRequest[]
 }
 
 // gh availability/auth + the current branch's PR — drives the review pane's PR

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -561,6 +561,23 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
   }
 }
 
+/** The PR each of these sessions opened, recovered from its own transcript —
+ *  for sessions whose recorded branch can't answer (they started on trunk and
+ *  did the work in a worktree). Also returns every id it looked at, so the
+ *  caller can remember a miss and never ask again. */
+export function scanSessionPullRequests(
+  ids: string[]
+): Promise<{ pull_requests: Record<string, { number: number; url: string }>; scanned: string[] }> {
+  return window.hermesDesktop.api<{
+    pull_requests: Record<string, { number: number; url: string }>
+    scanned: string[]
+  }>({
+    path: '/api/profiles/sessions/pull-requests',
+    method: 'POST',
+    body: { ids }
+  })
+}
+
 export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<SidebarSessionsResponse> {
   if (sidebarBatchEndpointMissing) {
     return listSidebarSessionsLegacy(req)

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1560,6 +1560,7 @@ export const ar = defineLocale({
     noWorkspace: 'بدون مساحة عمل',
     projectEmpty: 'لا توجد جلسات بعد',
     noSessions: 'لا توجد جلسات بعد',
+    noFilterMatches: 'لا توجد جلسات تطابق عوامل التصفية هذه',
     projects: {
       sectionLabel: 'المشاريع',
       home: 'الرئيسية',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1869,6 +1869,7 @@ export const en: Translations = {
     noWorkspace: 'No workspace',
     projectEmpty: 'No sessions yet',
     noSessions: 'No sessions yet',
+    noFilterMatches: 'No sessions match these filters',
     projects: {
       sectionLabel: 'Projects',
       home: 'Home',
@@ -1986,6 +1987,10 @@ export const en: Translations = {
       thisWeek: 'Earlier this week',
       lastWeek: 'Last week',
       thisMonth: 'Earlier this month'
+    },
+    statusDivider: {
+      working: 'Working',
+      done: 'Done'
     }
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1696,6 +1696,7 @@ export const ja = defineLocale({
     noWorkspace: 'ワークスペースなし',
     projectEmpty: 'セッションはまだありません',
     noSessions: 'セッションはまだありません',
+    noFilterMatches: 'このフィルターに一致するセッションはありません',
     projects: {
       sectionLabel: 'プロジェクト',
       home: 'ホーム',
@@ -1804,6 +1805,10 @@ export const ja = defineLocale({
       thisWeek: '今週',
       lastWeek: '先週',
       thisMonth: '今月'
+    },
+    statusDivider: {
+      working: '実行中',
+      done: '完了'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1564,6 +1564,7 @@ export interface Translations {
     noWorkspace: string
     projectEmpty: string
     noSessions: string
+    noFilterMatches: string
     projects: {
       sectionLabel: string
       home: string
@@ -1678,6 +1679,10 @@ export interface Translations {
       thisWeek: string
       lastWeek: string
       thisMonth: string
+    }
+    statusDivider: {
+      working: string
+      done: string
     }
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1641,6 +1641,7 @@ export const zhHant = defineLocale({
     noWorkspace: '無工作區',
     projectEmpty: '尚無工作階段',
     noSessions: '尚無工作階段',
+    noFilterMatches: '沒有工作階段符合這些篩選條件',
     projects: {
       sectionLabel: '專案',
       home: '主頁',
@@ -1746,6 +1747,10 @@ export const zhHant = defineLocale({
       thisWeek: '本週',
       lastWeek: '上週',
       thisMonth: '本月'
+    },
+    statusDivider: {
+      working: '進行中',
+      done: '已完成'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2062,6 +2062,7 @@ export const zh: Translations = {
     noWorkspace: '无工作区',
     projectEmpty: '暂无会话',
     noSessions: '暂无会话',
+    noFilterMatches: '没有会话符合这些筛选条件',
     projects: {
       sectionLabel: '项目',
       home: '主页',
@@ -2178,6 +2179,10 @@ export const zh: Translations = {
       thisWeek: '本周',
       lastWeek: '上周',
       thisMonth: '本月'
+    },
+    statusDivider: {
+      working: '进行中',
+      done: '已完成'
     }
   },
 

--- a/apps/desktop/src/lib/desktop-git.ts
+++ b/apps/desktop/src/lib/desktop-git.ts
@@ -2,6 +2,7 @@ import type {
   HermesGitBaseBranch,
   HermesGitBranch,
   HermesGitWorktree,
+  HermesRepoPullRequests,
   HermesRepoStatus,
   HermesReviewList,
   HermesReviewShipInfo
@@ -91,6 +92,9 @@ const remoteGit: GitBridge = {
     push: repoPath => gitPost('review/push', { path: repoPath }),
 
     shipInfo: repoPath => gitGet<HermesReviewShipInfo>('review/ship-info', { path: repoPath }),
+
+    prList: (repoPath, branches, numbers) =>
+      gitPost<HermesRepoPullRequests>('review/pr-list', { branches, numbers: numbers ?? [], path: repoPath }),
 
     createPr: repoPath => gitPost('review/create-pr', { path: repoPath })
   },

--- a/apps/desktop/src/lib/session-date-groups.ts
+++ b/apps/desktop/src/lib/session-date-groups.ts
@@ -1,11 +1,14 @@
 import { type SidebarSessionEntry } from '@/lib/session-branch-tree'
 import { calendarBucket, HOUR, localeWeekStartDay, MINUTE, SECOND, type SessionBucket } from '@/lib/time'
 
-// A flat list row is either a chronological date-bucket divider or a session
-// entry. Interleaving these lets the flat list (and the virtualizer) render
-// date separators inline without a second layer of nesting.
+// A flat list row is either a divider or a session entry. Interleaving these
+// lets the flat list (and the virtualizer) render separators inline without a
+// second layer of nesting. A divider either names a calendar bucket (resolved
+// against the locale's labels at render time) or carries its own label.
 export type SidebarListRow =
-  { bucket: SessionBucket; key: string; kind: 'divider' } | { entry: SidebarSessionEntry; kind: 'session' }
+  | { bucket: SessionBucket; key: string; kind: 'divider' }
+  | { entry: SidebarSessionEntry; kind: 'session' }
+  | { key: string; kind: 'divider'; label: string }
 
 // The row's own age label reads from `last_active || started_at`; bucket off the
 // same value so a divider lines up with what the row actually shows.
@@ -141,6 +144,34 @@ export function groupEntriesByRecency(
   }
 
   return rows
+}
+
+// Split into two runs — still busy, and everything else — under the same
+// dividers the date grouping uses. Branch children ride with their parent, as
+// they do there. Entries arrive already ordered, so each run is contiguous.
+export function groupEntriesByStatus(
+  entries: readonly SidebarSessionEntry[],
+  isWorking: (entry: SidebarSessionEntry) => boolean,
+  labels: { done: string; working: string }
+): SidebarListRow[] {
+  const working: SidebarSessionEntry[] = []
+  const done: SidebarSessionEntry[] = []
+  let cluster = done
+
+  for (const entry of entries) {
+    if (!entry.branchStem) {
+      cluster = isWorking(entry) ? working : done
+    }
+
+    cluster.push(entry)
+  }
+
+  return [
+    ...(working.length ? [{ key: 'status:working', kind: 'divider' as const, label: labels.working }] : []),
+    ...toSessionRows(working),
+    ...(done.length ? [{ key: 'status:done', kind: 'divider' as const, label: labels.done }] : []),
+    ...toSessionRows(done)
+  ]
 }
 
 // Wrap entries as plain session rows (no dividers) so the ungrouped path shares

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -4,10 +4,12 @@ import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
 import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
 import { matchesQuery } from '@/hooks/use-media-query'
-import { Codecs, persistentAtom } from '@/lib/persisted'
+import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
 import { arraysEqual, insertUniqueId, readKey } from '@/lib/storage'
 
 import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride, togglePane } from './panes'
+import type { PullRequestBucket } from './pull-requests'
+import type { SessionStatusBucket } from './session-dot-state'
 
 export const SIDEBAR_DEFAULT_WIDTH = 237
 export const SIDEBAR_MAX_WIDTH = 360
@@ -19,6 +21,10 @@ export const FILE_BROWSER_MIN_WIDTH = '10rem'
 export const FILE_BROWSER_MAX_WIDTH = '20rem'
 
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
+// How deep the list reaches once a filter is on. A filter that only searches
+// the loaded page answers the wrong question — "6 merged PRs" really meant "6
+// among the last 50 rows" — so narrowing the view widens the window it reads.
+export const SIDEBAR_FILTERED_PAGE_SIZE = 300
 
 const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
 const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
@@ -26,6 +32,13 @@ const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
 const SIDEBAR_SESSION_ORDER_STORAGE_KEY = 'hermes.desktop.sessionOrder'
 const SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY = 'hermes.desktop.sessionOrder.manual'
+const SIDEBAR_GROUPING_STORAGE_KEY = 'hermes.desktop.sidebarGrouping'
+const SIDEBAR_SORT_KEY_STORAGE_KEY = 'hermes.desktop.sidebarSortKey'
+const SIDEBAR_ROW_META_STORAGE_KEY = 'hermes.desktop.sidebarRowMeta'
+const SIDEBAR_STATUS_FILTER_STORAGE_KEY = 'hermes.desktop.sidebarStatusFilter'
+const SIDEBAR_SHOW_ARCHIVED_STORAGE_KEY = 'hermes.desktop.sidebarShowArchived'
+const SIDEBAR_PROJECT_FILTER_STORAGE_KEY = 'hermes.desktop.sidebarProjectFilter'
+const SIDEBAR_PR_FILTER_STORAGE_KEY = 'hermes.desktop.sidebarPrFilter'
 const SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY = 'hermes.desktop.workspaceOrder'
 const SIDEBAR_WORKSPACE_PARENT_ORDER_STORAGE_KEY = 'hermes.desktop.workspaceParentOrder'
 const SIDEBAR_PROJECT_ORDER_STORAGE_KEY = 'hermes.desktop.projectOrder'
@@ -186,6 +199,107 @@ export const $sidebarMessagingOpenIds = persistentAtom(
   Codecs.stringArray
 )
 export const $sidebarAgentsGrouped = persistentAtom(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false, Codecs.bool)
+
+/** How the recents list is divided. `date` is the sidebar's long-standing
+ *  default (Today / Yesterday / Last week dividers). */
+export type SidebarGrouping = 'date' | 'project' | 'status'
+/** What ranks rows within whatever grouping is active. */
+export type SidebarOrdering = 'cost' | 'created' | 'manual' | 'status' | 'tokens' | 'updated'
+/** The sort keys the menu offers; `manual` is entered by dragging, not picked. */
+export type SidebarSortKey = Exclude<SidebarOrdering, 'manual'>
+/** Optional per-row metadata the user can switch on. */
+export type SidebarRowMeta = 'cost' | 'pr' | 'profile' | 'tokens' | 'updated'
+
+function oneOf<T extends string>(values: readonly T[], fallback: T): Codec<T> {
+  return {
+    decode: raw => (values.includes(raw as T) ? (raw as T) : fallback),
+    encode: value => value
+  }
+}
+
+function listOf<T extends string>(values: readonly T[]): Codec<T[]> {
+  return {
+    decode: raw => Codecs.stringArray.decode(raw).filter((item): item is T => values.includes(item as T)),
+    encode: value => Codecs.stringArray.encode(value)
+  }
+}
+
+const ROW_META: readonly SidebarRowMeta[] = ['cost', 'pr', 'profile', 'tokens', 'updated']
+const STATUS_FILTERS: readonly SessionStatusBucket[] = ['needs-input', 'working', 'unread', 'draft', 'idle']
+const PR_FILTERS: readonly PullRequestBucket[] = ['open', 'draft', 'merged', 'closed', 'none']
+export const SIDEBAR_SORT_KEYS: readonly SidebarSortKey[] = ['updated', 'created', 'status', 'tokens', 'cost']
+
+// `project` deliberately does NOT live here. Entering a project from ⌘K, the
+// projects store, or a repo scan flips $sidebarAgentsGrouped directly, so that
+// atom stays the single authority for the project view and this one only holds
+// the grouping to fall back to when the user leaves it.
+const $sidebarFlatGrouping = persistentAtom<SidebarGrouping>(
+  SIDEBAR_GROUPING_STORAGE_KEY,
+  'date',
+  oneOf(['date', 'status'], 'date')
+)
+
+const $sidebarSortKey = persistentAtom<SidebarSortKey>(
+  SIDEBAR_SORT_KEY_STORAGE_KEY,
+  'updated',
+  oneOf(SIDEBAR_SORT_KEYS, 'updated')
+)
+
+export const $sidebarRowMeta = persistentAtom<SidebarRowMeta[]>(SIDEBAR_ROW_META_STORAGE_KEY, [], listOf(ROW_META))
+
+// Archived sessions are a separate backend query (`archived: 'only'`), so this
+// flag both filters the list and drives the fetch.
+export const $sidebarShowArchived = persistentAtom(SIDEBAR_SHOW_ARCHIVED_STORAGE_KEY, false, Codecs.bool)
+
+export const $sidebarStatusFilter = persistentAtom<SessionStatusBucket[]>(
+  SIDEBAR_STATUS_FILTER_STORAGE_KEY,
+  [],
+  listOf(STATUS_FILTERS)
+)
+
+// Project ids as `liveSessionProjectId` reports them: an explicit project's id,
+// or a repo root path for an auto-promoted one.
+export const $sidebarProjectFilter = persistentAtom(
+  SIDEBAR_PROJECT_FILTER_STORAGE_KEY,
+  [] as string[],
+  Codecs.stringArray
+)
+
+// Whether a session's branch has a PR, and in what state. Fetched per repo via
+// `gh` (see store/pull-requests), so this is empty on backends without a local
+// checkout — the menu hides the submenu rather than offering a dead filter.
+export const $sidebarPrFilter = persistentAtom<PullRequestBucket[]>(
+  SIDEBAR_PR_FILTER_STORAGE_KEY,
+  [],
+  listOf(PR_FILTERS)
+)
+
+export const $sidebarGrouping: ReadableAtom<SidebarGrouping> = computed(
+  [$sidebarAgentsGrouped, $sidebarFlatGrouping],
+  (grouped, grouping) => (grouped ? 'project' : grouping)
+)
+
+// A hand-dragged order outranks any sort key — dragging IS how you pick manual,
+// so the menu reflects that rather than offering a fourth way to say it.
+export const $sidebarOrdering: ReadableAtom<SidebarOrdering> = computed(
+  [$sidebarSessionOrderManual, $sidebarSortKey],
+  (manual, key) => (manual ? 'manual' : key)
+)
+
+export const $sidebarFiltersActive: ReadableAtom<boolean> = computed(
+  [$sidebarStatusFilter, $sidebarProjectFilter, $sidebarPrFilter, $sidebarShowArchived],
+  (statuses, projects, prs, archived) => statuses.length > 0 || projects.length > 0 || prs.length > 0 || archived
+)
+
+/** Anything at all moved off the shipped view — what makes a reset worth
+ *  offering. Broader than `$sidebarFiltersActive`, which only knows about what
+ *  hides rows, not about how they're grouped, sorted or labelled. */
+export const $sidebarViewCustomized: ReadableAtom<boolean> = computed(
+  [$sidebarGrouping, $sidebarOrdering, $sidebarRowMeta, $sidebarFiltersActive],
+  (grouping, ordering, rowMeta, filtersActive) =>
+    grouping !== 'date' || ordering !== 'updated' || rowMeta.length > 0 || filtersActive
+)
+
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
 export const $panesFlipped = persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Codecs.bool)
@@ -212,6 +326,16 @@ export function setWorkspaceNodeOpen(id: string, open: boolean): void {
 // Toggle a repo/worktree/file-tree node relative to its current resolved state.
 export function toggleWorkspaceNodeCollapsed(id: string, defaultOpen = true): void {
   setWorkspaceNodeOpen(id, !workspaceNodeOpen(id, defaultOpen))
+}
+
+// Fold a whole level shut (or open) in one write — the sidebar's "Collapse all"
+// over the project rows. Their lanes keep their own state underneath, so
+// re-opening a project shows it as the user left it.
+export function setWorkspaceNodesOpen(ids: readonly string[], open: boolean): void {
+  $sidebarWorkspaceNodeOpen.set({
+    ...$sidebarWorkspaceNodeOpen.get(),
+    ...Object.fromEntries(ids.map(id => [id, open]))
+  })
 }
 
 // Dismiss ("delete") an auto-derived project from the overview.
@@ -367,6 +491,79 @@ export function setSidebarAgentsGrouped(grouped: boolean) {
   $sidebarAgentsGrouped.set(grouped)
 }
 
+export function setSidebarGrouping(grouping: SidebarGrouping) {
+  setSidebarAgentsGrouped(grouping === 'project')
+
+  if (grouping !== 'project') {
+    $sidebarFlatGrouping.set(grouping)
+  }
+}
+
+export function setSidebarOrdering(ordering: SidebarOrdering) {
+  if (ordering === 'manual') {
+    setSidebarSessionOrderManual(true)
+
+    return
+  }
+
+  // Picking a sort key is the only way back out of a hand-dragged order, so it
+  // has to drop the saved sequence as well as the flag.
+  setSidebarSessionOrderManual(false)
+  setSidebarSessionOrderIds([])
+  $sidebarSortKey.set(ordering)
+}
+
+export function setSidebarShowArchived(show: boolean) {
+  $sidebarShowArchived.set(show)
+}
+
+function toggleIn<T extends string>($atom: WritableAtom<T[]>, value: T) {
+  const current = $atom.get()
+
+  $atom.set(current.includes(value) ? current.filter(item => item !== value) : [...current, value])
+}
+
+export function toggleSidebarRowMeta(meta: SidebarRowMeta) {
+  toggleIn($sidebarRowMeta, meta)
+}
+
+export function toggleSidebarStatusFilter(status: SessionStatusBucket) {
+  toggleIn($sidebarStatusFilter, status)
+}
+
+export function toggleSidebarProjectFilter(projectId: string) {
+  toggleIn($sidebarProjectFilter, projectId)
+}
+
+export function toggleSidebarPrFilter(bucket: PullRequestBucket) {
+  toggleIn($sidebarPrFilter, bucket)
+}
+
+function clearSidebarFilters() {
+  $sidebarStatusFilter.set([])
+  $sidebarProjectFilter.set([])
+  $sidebarPrFilter.set([])
+  $sidebarShowArchived.set(false)
+}
+
+/** Every knob the filter menu owns, back to the sidebar as it ships: date
+ *  groups, newest first, no extra row metadata, no filters. Ordering goes
+ *  through its setter so a hand-dragged sequence is dropped along with it. */
+export function resetSidebarView() {
+  setSidebarGrouping('date')
+  setSidebarOrdering('updated')
+  $sidebarRowMeta.set([])
+  clearSidebarFilters()
+}
+
+/** Whether anything on screen needs PR data — the gate on shelling out to
+ *  `gh`. Nobody pays for a network call per repo to render a view that would
+ *  not show a PR anywhere. */
+export const $sidebarPrDataWanted: ReadableAtom<boolean> = computed(
+  [$sidebarRowMeta, $sidebarPrFilter],
+  (rowMeta, prFilter) => rowMeta.includes('pr') || prFilter.length > 0
+)
+
 // Write an order list only when it actually changed, so an identical drag
 // result keeps the same array reference and subscribers don't churn.
 function setOrderIds($atom: WritableAtom<string[]>, ids: string[]) {
@@ -445,6 +642,18 @@ export function setPinnedSessionOrder(ids: string[]) {
 export function bumpSessionsLimit(step: number = SIDEBAR_SESSIONS_PAGE_SIZE) {
   const safeStep = Math.max(1, Math.floor(step))
   $sessionsLimit.set($sessionsLimit.get() + safeStep)
+}
+
+/** Raise the window to at least `floor`, never shrinking it. Returns true when
+ *  it moved, so the caller knows a refetch is worth it. */
+export function raiseSessionsLimit(floor: number): boolean {
+  if ($sessionsLimit.get() >= floor) {
+    return false
+  }
+
+  $sessionsLimit.set(floor)
+
+  return true
 }
 
 export function resetSessionsLimit() {

--- a/apps/desktop/src/store/pull-requests.ts
+++ b/apps/desktop/src/store/pull-requests.ts
@@ -1,0 +1,193 @@
+import { atom } from 'nanostores'
+
+import type { HermesBranchPullRequest } from '@/global'
+import { scanSessionPullRequests, type SessionInfo } from '@/hermes'
+import { desktopGit } from '@/lib/desktop-git'
+import { Codecs, persistentAtom } from '@/lib/persisted'
+
+/** How a row's PR reads at a glance — and what the sidebar filters on. A
+ *  session with no branch, no PR, or an unreachable `gh` is `none`. */
+export type PullRequestBucket = 'closed' | 'draft' | 'merged' | 'none' | 'open'
+
+// `gh pr list` is a network call per repo. The sidebar asks on mount, on
+// window focus, and whenever the set of repos on screen changes — this keeps
+// those from stacking into a burst of identical requests.
+const PR_STALE_MS = 60_000
+
+/** Every known PR keyed by `${repoRoot}\n${branch}` — the join a session row
+ *  makes with its own `git_repo_root` + `git_branch`. */
+export const $pullRequestsByBranch = atom<Record<string, HermesBranchPullRequest>>({})
+
+/** Sessions whose PR isn't on the branch they recorded at start — the checkout
+ *  moved mid-conversation, or the work went off to a worktree. Written when the
+ *  desktop creates a PR and when one is recovered from a transcript. Holds the
+ *  lookup key, not the PR, so state stays live through the same refresh as
+ *  everything else. */
+export const $prBranchBySession = persistentAtom<Record<string, string>>(
+  'hermes.desktop.prBranchBySession',
+  {},
+  Codecs.stringRecord
+)
+
+/** Sessions already scanned for a PR url. A transcript doesn't grow a new PR,
+ *  so a miss is permanent and a hit is already in {@link $prBranchBySession} —
+ *  either way the session is never scanned again. */
+const $prScannedSessions = persistentAtom<string[]>('hermes.desktop.prScannedSessions', [], Codecs.stringArray)
+
+const fetchedAt = new Map<string, number>()
+const inFlight = new Set<string>()
+let scanUnavailable = false
+let scanInFlight = false
+
+// A session sitting on the trunk has no PR of its own, and asking GitHub about
+// "main" is how a stranger's fork branch — forks share our branch namespace —
+// ends up badged onto it. Never ask.
+const TRUNK_BRANCHES = new Set(['dev', 'develop', 'main', 'master', 'trunk'])
+
+export const branchPrKey = (repoRoot: string, branch: string): string => `${repoRoot}\n${branch}`
+/** A PR known only by number (recovered from a transcript), keyed so it can
+ *  share the one map. GitHub answers by number just as happily as by branch. */
+export const numberPrKey = (repoRoot: string, number: number): string => `${repoRoot}\n#${number}`
+
+export function sessionPrKey(session: SessionInfo): null | string {
+  const stamped = $prBranchBySession.get()[session.id]
+
+  if (stamped) {
+    return stamped
+  }
+
+  const root = session.git_repo_root
+  const branch = session.git_branch
+
+  return root && branch && !TRUNK_BRANCHES.has(branch.toLowerCase()) ? branchPrKey(root, branch) : null
+}
+
+/** Bind a session to the branch it just opened a PR from. */
+export function stampSessionPrBranch(sessionId: string, repoRoot: string, branch: string): void {
+  if (!sessionId || !repoRoot || !branch) {
+    return
+  }
+
+  $prBranchBySession.set({ ...$prBranchBySession.get(), [sessionId]: branchPrKey(repoRoot, branch) })
+}
+
+/** Recover PRs the branch join can't see, from the sessions' own transcripts.
+ *  A session that ran in the main checkout and worked in a worktree recorded
+ *  `main` (or nothing) as its branch, but it ran `gh pr create` — whose output
+ *  is a bare PR url, the one shape that's a claim rather than a mention. Scans
+ *  each session at most once, ever. */
+export async function recoverSessionPullRequests(sessions: SessionInfo[]): Promise<void> {
+  const scanned = new Set($prScannedSessions.get())
+  const roots = new Map<string, string>()
+
+  for (const session of sessions) {
+    if (session.git_repo_root && !scanned.has(session.id) && !sessionPrKey(session)) {
+      roots.set(session.id, session.git_repo_root)
+    }
+  }
+
+  if (roots.size === 0 || scanUnavailable || scanInFlight) {
+    return
+  }
+
+  scanInFlight = true
+
+  try {
+    const { pull_requests: found, scanned: asked } = await scanSessionPullRequests([...roots.keys()])
+    const stamps = { ...$prBranchBySession.get() }
+
+    for (const [id, pr] of Object.entries(found)) {
+      const root = roots.get(id)
+
+      if (root) {
+        stamps[id] = numberPrKey(root, pr.number)
+      }
+    }
+
+    $prBranchBySession.set(stamps)
+    $prScannedSessions.set([...new Set([...scanned, ...asked])])
+  } catch {
+    // An older backend has no such route. Stop asking rather than retrying on
+    // every list refresh; the branch join still covers the common case.
+    scanUnavailable = true
+  } finally {
+    scanInFlight = false
+  }
+}
+
+export function pullRequestBucket(pr: HermesBranchPullRequest | undefined): PullRequestBucket {
+  if (!pr) {
+    return 'none'
+  }
+
+  if (pr.state === 'merged') {
+    return 'merged'
+  }
+
+  if (pr.state === 'closed') {
+    return 'closed'
+  }
+
+  return pr.draft ? 'draft' : 'open'
+}
+
+/** Pull PRs for the given lookups, grouped by the repo they live in. Each entry
+ *  is a branch name, or `#<number>` for a PR recovered from a transcript. Skips
+ *  repos fetched recently or still in flight. Goes through the remote-aware git
+ *  facade, so a desktop pointed at a remote gateway asks the BACKEND's `gh`
+ *  about the backend's checkout. */
+export async function refreshPullRequests(lookupsByRepo: Record<string, string[]>, force = false): Promise<void> {
+  const review = desktopGit()?.review
+
+  if (!review?.prList) {
+    return
+  }
+
+  const now = Date.now()
+
+  const stale = Object.keys(lookupsByRepo).filter(
+    root => !inFlight.has(root) && (force || now - (fetchedAt.get(root) ?? 0) > PR_STALE_MS)
+  )
+
+  await Promise.all(
+    stale.map(async root => {
+      inFlight.add(root)
+
+      const lookups = lookupsByRepo[root]
+      const numbers = lookups.filter(l => l.startsWith('#')).map(l => Number(l.slice(1)))
+
+      try {
+        const { prs } = await review.prList(
+          root,
+          lookups.filter(l => !l.startsWith('#')),
+          numbers
+        )
+
+        fetchedAt.set(root, Date.now())
+
+        // Replace this repo's slice wholesale: a PR that closed since the last
+        // pull has to disappear, not linger as a stale merge of old and new.
+        const next = Object.fromEntries(
+          Object.entries($pullRequestsByBranch.get()).filter(([key]) => !key.startsWith(`${root}\n`))
+        )
+
+        for (const pr of prs) {
+          next[branchPrKey(root, pr.branch)] = pr
+
+          // The session that recovered it looks it up by number, and its branch
+          // may well be someone else's by now (or deleted).
+          if (numbers.includes(pr.number)) {
+            next[numberPrKey(root, pr.number)] = pr
+          }
+        }
+
+        $pullRequestsByBranch.set(next)
+      } catch {
+        // gh missing, unauthenticated, or off-repo — leave what we had.
+        fetchedAt.set(root, Date.now())
+      } finally {
+        inFlight.delete(root)
+      }
+    })
+  )
+}

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -44,8 +44,10 @@ import { $currentCwd } from './session'
 const requestOneShot = vi.fn(async (_args: unknown) => 'generated message')
 vi.mock('@/lib/oneshot', () => ({ requestOneShot: (args: unknown) => requestOneShot(args) }))
 // refreshRepoStatus is a fire-and-forget side effect of mutations; stub it so it
-// doesn't try to hit the (absent) probe and log.
-vi.mock('./coding-status', () => ({ refreshRepoStatus: vi.fn() }))
+// doesn't try to hit the (absent) probe and log. repoStatusForCwd is read when a
+// new PR binds its session to the branch it came from — no probe here, so no
+// branch either.
+vi.mock('./coding-status', () => ({ refreshRepoStatus: vi.fn(), repoStatusForCwd: () => ({ get: () => null }) }))
 
 function file(path: string, over: Partial<HermesReviewFile> = {}): HermesReviewFile {
   return { path, status: 'modified', staged: false, added: 1, removed: 0, ...over } as HermesReviewFile

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -10,8 +10,9 @@ import { isExcludedPath } from '@/lib/excluded-paths'
 import { requestOneShot } from '@/lib/oneshot'
 import { Codecs, persistentAtom } from '@/lib/persisted'
 
-import { refreshRepoStatus } from './coding-status'
-import { $busy, $currentCwd } from './session'
+import { refreshRepoStatus, repoStatusForCwd } from './coding-status'
+import { stampSessionPrBranch } from './pull-requests'
+import { $busy, $currentCwd, $selectedStoredSessionId, $sessions } from './session'
 import { $workspaceChangeTick } from './workspace-events'
 
 // State for the review pane: the working-tree changed-file list, the selected
@@ -525,6 +526,17 @@ export async function createOrOpenPr(): Promise<void> {
 
     if (url) {
       void window.hermesDesktop?.openExternal?.(url)
+    }
+
+    // The session recorded its branch when it started; the checkout may have
+    // moved since, so bind the conversation to the branch the PR actually came
+    // from — otherwise a session that began on trunk badges whatever else lives
+    // on trunk, or nothing.
+    const session = $sessions.get().find(s => s.id === $selectedStoredSessionId.get())
+    const branch = repoStatusForCwd(ctx.cwd).get()?.branch
+
+    if (session?.git_repo_root && branch) {
+      stampSessionPrBranch(session.id, session.git_repo_root, branch)
     }
 
     void refreshShipInfo()

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -37,6 +37,24 @@ export const showsRunningArc = (state: SessionDotState): boolean => state === 's
  *  answer has not ended. */
 export const hasLiveTurn = (state: SessionDotState): boolean => showsRunningArc(state) || state === 'needs-input'
 
+/** The buckets the sidebar's status filter and ordering work in. `stalled` and
+ *  `background` fold into the state a user would name them. */
+export type SessionStatusBucket = 'draft' | 'idle' | 'needs-input' | 'unread' | 'working'
+
+export const sessionStatusBucket = (state: SessionDotState = 'idle'): SessionStatusBucket =>
+  state === 'stalled' || state === 'background' ? 'working' : state
+
+const STATUS_RANK: Record<SessionStatusBucket, number> = {
+  'needs-input': 0,
+  working: 1,
+  unread: 2,
+  draft: 3,
+  idle: 4
+}
+
+/** Loudest first — what ordering by status sorts on. */
+export const sessionStatusRank = (state?: SessionDotState): number => STATUS_RANK[sessionStatusBucket(state)]
+
 let dotStates: Readonly<Record<string, SessionDotState>> = {}
 
 export const $sessionDotStateById = computed(

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -603,6 +603,12 @@ export const setActiveSessionStoredIdRotation = (next: Updater<ActiveSessionStor
 // Written by session-states.ts (handleTransition), cleared here on session open.
 export const $unreadFinishedSessionIds = atom<string[]>([])
 
+export const markAllSessionsRead = () => {
+  if ($unreadFinishedSessionIds.get().length) {
+    $unreadFinishedSessionIds.set([])
+  }
+}
+
 export const setSelectedStoredSessionId = (next: Updater<string | null>) => {
   updateAtom($selectedStoredSessionId, next)
   // Opening a session clears its unread state — the user is now looking at it.

--- a/apps/desktop/src/store/sidebar-archive.ts
+++ b/apps/desktop/src/store/sidebar-archive.ts
@@ -1,0 +1,40 @@
+import { atom, computed } from 'nanostores'
+
+import { listAllProfileSessions, type SessionInfo } from '@/hermes'
+
+import { $sessions } from './session'
+
+// Archived rows are excluded from the sessions query, so the Archived view has
+// to fetch its own set. Capped: it's a lookup surface, not a feed.
+const ARCHIVED_FETCH_LIMIT = 200
+
+export const $archivedSessions = atom<SessionInfo[]>([])
+export const $archivedSessionsLoading = atom(false)
+
+export async function loadArchivedSessions(): Promise<void> {
+  if ($archivedSessionsLoading.get()) {
+    return
+  }
+
+  $archivedSessionsLoading.set(true)
+
+  try {
+    const result = await listAllProfileSessions(ARCHIVED_FETCH_LIMIT, 0, 'only')
+
+    $archivedSessions.set(result.sessions)
+  } catch {
+    $archivedSessions.set([])
+  } finally {
+    $archivedSessionsLoading.set(false)
+  }
+}
+
+/** Spend on a session — provider-reported price when we have one, our own
+ *  estimate otherwise. */
+export const sessionCostUsd = (session: SessionInfo): number =>
+  session.actual_cost_usd || session.estimated_cost_usd || 0
+
+/** Whether ANY loaded session reports spend. Subscription auth never quotes a
+ *  price, so for those users a cost sort would rank a list of zeroes — the
+ *  menu hides the option instead of offering a dead one. */
+export const $sessionsHaveCost = computed($sessions, sessions => sessions.some(session => sessionCostUsd(session) > 0))

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -481,6 +481,12 @@ export interface SessionInfo {
    *  pins so a pinned conversation survives auto-compression. */
   _lineage_root_id?: null | string
   input_tokens: number
+  /** Spend for the session, straight off the `sessions` row. `actual` is set
+   *  when the provider reported a price; `estimated` is our own pricing-table
+   *  math. Both are 0 on subscription auth that never quotes a price, which is
+   *  why the sidebar only offers a cost sort when some session has spend. */
+  actual_cost_usd?: null | number
+  estimated_cost_usd?: null | number
   is_active: boolean
   last_active: number
   message_count: number

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -463,6 +463,96 @@ def review_ship_info(cwd: str) -> dict:
     return {"ghReady": True, "pr": None}
 
 
+# GraphQL asks per branch, so the answer can't be crowded out the way a
+# `gh pr list` page can. Aliases let one request carry many branches; 50 keeps
+# the document well inside GitHub's node budget.
+_PR_QUERY_BRANCH_CHUNK = 50
+_PR_QUERY_BRANCH_CAP = 300
+
+
+_PR_NODE_FIELDS = "number state isDraft isCrossRepository title url headRefName"
+
+
+def _pr_query(owner: str, name: str, branches: list[str], numbers: list[int]) -> str:
+    fields = [
+        f"b{i}: pullRequests(headRefName: {json.dumps(branch)}, first: 5, "
+        f"orderBy: {{field: CREATED_AT, direction: DESC}}) "
+        f"{{ nodes {{ {_PR_NODE_FIELDS} }} }}"
+        for i, branch in enumerate(branches)
+    ]
+    # A PR recovered from a transcript is known by number, and asking for it
+    # directly also tells us its branch — so it lands in the same by-branch map
+    # as everything else.
+    fields += [f"n{i}: pullRequest(number: {n}) {{ {_PR_NODE_FIELDS} }}" for i, n in enumerate(numbers)]
+    return (
+        f"query {{ repository(owner: {json.dumps(owner)}, name: {json.dumps(name)}) {{\n"
+        + "\n".join(fields)
+        + "\n} }"
+    )
+
+
+def _pr_payload(pr: dict) -> dict:
+    return {
+        "branch": str(pr.get("headRefName")),
+        "draft": bool(pr.get("isDraft")),
+        "number": int(pr.get("number") or 0),
+        "state": str(pr.get("state") or "").lower(),
+        "title": str(pr.get("title") or ""),
+        "url": str(pr.get("url") or ""),
+    }
+
+
+def review_pr_list(cwd: str, branches: list[str], numbers: list[int] = None) -> dict:
+    """The PRs on the given branches (plus any asked for by number). Asks GitHub
+    about the branches we actually have sessions on rather than listing the
+    repo's newest PRs and hoping ours are in the page."""
+    if not _is_dir(cwd):
+        return {"ghReady": False, "prs": []}
+    wanted = list(dict.fromkeys(str(b) for b in (branches or []) if b))[:_PR_QUERY_BRANCH_CAP]
+    by_number = list(dict.fromkeys(int(n) for n in (numbers or []) if n))[:_PR_QUERY_BRANCH_CAP]
+    if not wanted and not by_number:
+        return {"ghReady": False, "prs": []}
+    repo_ok, repo_out = _gh(cwd, ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    owner, _, name = repo_out.strip().partition("/")
+    if not repo_ok or not owner or not name:
+        # gh missing, unauthenticated, or no GitHub remote — all "nothing to badge".
+        return {"ghReady": False, "prs": []}
+
+    prs: list[dict] = []
+    chunks = [
+        (wanted[i : i + _PR_QUERY_BRANCH_CHUNK], [])
+        for i in range(0, len(wanted), _PR_QUERY_BRANCH_CHUNK)
+    ] + [
+        ([], by_number[i : i + _PR_QUERY_BRANCH_CHUNK])
+        for i in range(0, len(by_number), _PR_QUERY_BRANCH_CHUNK)
+    ]
+    for branch_chunk, number_chunk in chunks:
+        ok, out = _gh(cwd, ["api", "graphql", "-f", f"query={_pr_query(owner, name, branch_chunk, number_chunk)}"])
+        if not ok:
+            continue
+        try:
+            repository = (json.loads(out).get("data") or {}).get("repository") or {}
+        except json.JSONDecodeError:
+            continue  # A malformed chunk drops its branches; the rest still resolve.
+        for key, field in repository.items():
+            if not field:
+                continue
+            if key.startswith("n"):
+                # Asked for by number, so it's ours by construction — a fork PR
+                # can't be recovered from our own transcript.
+                if field.get("headRefName"):
+                    prs.append(_pr_payload(field))
+                continue
+            # Fork PRs share our branch namespace: a contributor's `main` is how
+            # a session sitting on trunk ends up badged with a stranger's closed
+            # PR. Only this repo's own branches describe our sessions.
+            nodes = field.get("nodes") or []
+            pr = next((n for n in nodes if n and not n.get("isCrossRepository")), None)
+            if pr and pr.get("headRefName"):
+                prs.append(_pr_payload(pr))
+    return {"ghReady": True, "prs": prs}
+
+
 def review_create_pr(cwd: str) -> dict:
     """Create a PR for the current branch (push first), letting gh fill title/body."""
     try:

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -233,6 +233,18 @@ class GitFileBody(BaseModel):
     file: Optional[str] = None
 
 
+class GitPrListBody(BaseModel):
+    path: str
+    branches: List[str] = []
+    # PRs a session recovered from its transcript, which we know by number
+    # rather than by the branch it came from.
+    numbers: List[int] = []
+
+
+class SessionPrScanBody(BaseModel):
+    ids: List[str] = []
+
+
 class GitCommitBody(BaseModel):
     path: str
     message: str

--- a/hermes_cli/web_routers/git.py
+++ b/hermes_cli/web_routers/git.py
@@ -16,6 +16,7 @@ from hermes_cli.web_models import (
     GitPathBody,
     GitFileBody,
     GitCommitBody,
+    GitPrListBody,
     GitWorktreeAddBody,
     GitWorktreeRemoveBody,
     GitBranchSwitchBody,
@@ -79,6 +80,11 @@ async def git_rev_parse_route(path: str, ref: Optional[str] = None):
 @router.get("/api/git/review/ship-info")
 async def git_ship_info_route(path: str):
     return await _git_op(_web_git.review_ship_info, _git_path(path))
+
+
+@router.post("/api/git/review/pr-list")
+async def git_pr_list_route(body: GitPrListBody):
+    return await _git_op(_web_git.review_pr_list, _git_path(body.path), body.branches, body.numbers)
 
 
 @router.post("/api/git/review/stage")

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -13,7 +13,9 @@ late-binding seam in :mod:`hermes_cli.web_deps` so tests that
 """
 
 import asyncio  # noqa: F401 — used by handlers
+import json
 import logging
+import re
 import subprocess  # noqa: F401
 import sys  # noqa: F401
 import time  # noqa: F401
@@ -33,6 +35,7 @@ from hermes_cli.web_models import (
     ProfileDescriptionUpdate,
     ProfileModelUpdate,
     ProfileDescribeAuto,
+    SessionPrScanBody,
 )
 
 # Same logger the handlers used before extraction (identical logger object).
@@ -368,6 +371,83 @@ def get_profiles_sessions_sidebar(
         },
         "errors": errors,
     }
+
+
+# `gh pr create` prints the PR url and nothing else, so a tool result whose
+# whole output IS a PR url means this session opened that PR. Anything looser —
+# a url inside prose, a `gh pr view` payload, an issue link — is a session
+# TALKING about a PR, which is not the same claim.
+_PR_URL_RE = re.compile(r"^https://github\.com/[\w.-]+/[\w.-]+/pull/(\d+)/?$")
+
+
+def _pr_url_from_tool_output(content: str) -> Optional[Tuple[int, str]]:
+    """The (number, url) a tool result announces, or None."""
+    try:
+        output = (json.loads(content) or {}).get("output")
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return None
+    if not isinstance(output, str):
+        return None
+    match = _PR_URL_RE.match(output.strip())
+    return (int(match.group(1)), match.group(0)) if match else None
+
+
+@sessions_router.post("/api/profiles/sessions/pull-requests")
+def post_profiles_sessions_pull_requests(body: SessionPrScanBody):
+    """The PR each of these sessions opened, recovered from its own transcript.
+
+    A session records the branch it started on, so the sidebar can join a row to
+    its PR — but a session that starts in the main checkout and does its work in
+    a worktree has no branch of its own, and its PR is invisible to that join.
+    The evidence is in the conversation: ``gh pr create`` ran, and its output is
+    a bare PR url. Scanning for exactly that shape recovers the link with no
+    inference (see ``_pr_url_from_tool_output``).
+
+    Read-only across every profile, and the caller is expected to ask once per
+    session and remember the answer — a session's transcript does not grow a
+    second PR.
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    wanted = list(dict.fromkeys(s for s in (body.ids or []) if s))[:2000]
+    if not wanted:
+        return {"pull_requests": {}, "scanned": []}
+
+    try:
+        targets = [(info.name, info.path) for info in profiles_mod.list_profiles()]
+    except Exception:
+        _log.exception("POST /api/profiles/sessions/pull-requests: list_profiles failed")
+        targets = []
+    if not targets:
+        targets.append(("default", profiles_mod.get_profile_dir("default")))
+
+    found: Dict[str, Dict[str, Any]] = {}
+    for name, home in targets:
+        db_path = Path(home) / "state.db"
+        if not db_path.exists():
+            continue
+        try:
+            db = _open_session_db_at_path(db_path, read_only=True)
+        except Exception as exc:
+            _warn_profile_read_error(name, exc)
+            continue
+        try:
+            for pr in db.find_pr_url_messages(wanted):
+                parsed = _pr_url_from_tool_output(pr["content"])
+                if parsed:
+                    number, url = parsed
+                    # Ordered oldest-first, so a later `gh pr create` in the
+                    # same conversation wins — a reopened/replacement PR is the
+                    # one the session ended on.
+                    found[pr["session_id"]] = {"number": number, "url": url}
+        except Exception as exc:
+            _warn_profile_read_error(name, exc)
+        finally:
+            db.close()
+
+    # Every id we looked at, so the caller can remember "asked, nothing there"
+    # and never scan this session again.
+    return {"pull_requests": found, "scanned": wanted}
 
 
 @router.get("/api/profiles")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7827,6 +7827,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             result.append(msg)
         return result
 
+    def find_pr_url_messages(self, session_ids: List[str]) -> List[Dict[str, Any]]:
+        """Tool results in these sessions that mention a GitHub PR url.
+
+        A candidate scan, deliberately loose: it hands back every tool result
+        containing ``/pull/`` and leaves the caller to decide which ones make a
+        claim (see the desktop's PR recovery, which only accepts an output that
+        is a bare PR url — the signature of ``gh pr create``). Ordered
+        oldest-first per session so the caller can take the last match.
+        """
+        found: List[Dict[str, Any]] = []
+        ids = [s for s in session_ids if s]
+        for start in range(0, len(ids), 900):  # SQLite's bound-variable ceiling.
+            chunk = ids[start : start + 900]
+            placeholders = ",".join("?" * len(chunk))
+            with self._read_ctx() as conn:
+                rows = conn.execute(
+                    f"""SELECT session_id, content FROM messages
+                        WHERE session_id IN ({placeholders})
+                          AND role = 'tool' AND content LIKE '%/pull/%'
+                        ORDER BY id ASC""",
+                    chunk,
+                ).fetchall()
+            found.extend({"session_id": row[0], "content": row[1]} for row in rows)
+        return found
+
     def get_messages_around(
         self,
         session_id: str,


### PR DESCRIPTION
The sessions sidebar header had a single toggle: project view, or list view. That one binary was standing in for a whole view configuration, so anything else you wanted — see what's still running, find the expensive sessions, look at one project, check what's merged — had no way to be asked for.

It becomes a menu. Group by date, project or status. Order by updated, created, status, tokens or cost. Show tokens, cost, PR, profile or a pinned timestamp on each row. Filter by status, pull request, project, or archived. All of it persists, and one reset puts it back.

## Pull requests on session rows

The most useful thing the sidebar didn't know was whether a session's work had shipped. A row can now carry its PR — state glyph, number, link — and you can filter on it.

The join is the session's own repo and branch, asked of GitHub in one batched GraphQL request per repo. Branch aliases rather than a `gh pr list` page, because in a busy repo our branches fall off the end of that page. It goes through the remote-aware git facade, so a desktop pointed at a remote gateway asks that backend's `gh` about that backend's checkout.

Two ways a session's branch can't answer for it, both covered:

- **It ran on trunk.** Fork PRs share our branch namespace, so asking GitHub about `main` is how a contributor's closed PR gets badged onto your session. Trunk is never asked about, and cross-repository PRs are dropped server-side regardless.
- **It worked in a worktree,** so the branch it recorded at start isn't where the PR came from. Creating a PR from the review pane now binds the session to the branch it actually used. For the sessions that predate that, the PR is recovered from the transcript: `gh pr create` prints a bare PR URL and nothing else, so a tool result whose entire output is one is a claim rather than a mention. Scanned read-only across profiles, once per session, ever.

## Details that make it read right

- Status grouping reuses the existing date dividers instead of inventing a second kind of separator. A magnitude sort (tokens, cost) drops the calendar entirely — "Today" sitting above the priciest session you have ever had is a lie.
- Row metadata shares the trailing slot the kebab covers on hover, so only the last fact steps aside and the number you switched on stays readable.
- Switching on a filter deepens the loaded page to 300 rows and hands the window back when you clear it. Otherwise "merged PRs" quietly answers for the last 50 rows.
- Archived is a view of its own set, not a filter over the live one. Dragging is still what picks a manual order; the menu only offers a way back out of one.
- Collapse all appears only in the project view and folds only the project rows.
- One shared `ProfileGlyph` now backs the rail, the profiles page and the row chip, which previously each drew their own tinted square.

## Test plan

- [ ] Each grouping, ordering and Show toggle, and that they survive a restart
- [ ] PR badges appear on branch-backed sessions, and on worktree sessions whose PR came from the transcript
- [ ] A session on `main` shows no PR
- [ ] Filtering to a state with no matches shows the empty state, not a skeleton
- [ ] Archived view, reset to defaults, collapse all in project view