### PR TITLE
fix(agent): keep real tasks as compaction anchors after dynamic retries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -33,6 +33,7 @@ from agent.auxiliary_client import (
 )
 from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.error_classifier import FailoverReason, classify_api_error
+from agent.kanban_stop import KANBAN_STOP_NUDGE_PREFIX
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
@@ -41,6 +42,7 @@ from agent.model_metadata import (
 )
 from agent.redact import redact_sensitive_text
 from agent.turn_context import drop_stale_api_content
+from agent.verify_hooks import PRE_VERIFY_CONTINUE_NUDGE_PREFIX
 from tools.todo_tool import TODO_INJECTION_HEADER
 
 logger = logging.getLogger(__name__)
@@ -4621,6 +4623,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             TODO_INJECTION_HEADER + "\n"
         ) or text.startswith(
             _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX
+        ) or text.startswith(
+            (PRE_VERIFY_CONTINUE_NUDGE_PREFIX, KANBAN_STOP_NUDGE_PREFIX)
         )
 
     @staticmethod

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -21,6 +21,14 @@ _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 
+# Stable content marker for SessionDB-projected stop nudges. The task id makes
+# the full message dynamic, while underscore metadata is not projected back
+# into conversation history.
+KANBAN_STOP_NUDGE_PREFIX = (
+    "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
+    "terminal state for the board.\n\n"
+)
+
 
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
@@ -86,9 +94,7 @@ def build_kanban_stop_nudge(
         return None
 
     tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
-    return (
-        "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
-        "terminal state for the board.\n\n"
+    return KANBAN_STOP_NUDGE_PREFIX + (
         f"Task `{tid}` is still `running`. Ending now without a board tool "
         "causes a protocol violation (clean exit with no "
         "`kanban_complete` / `kanban_block`).\n\n"
@@ -102,6 +108,7 @@ def build_kanban_stop_nudge(
 
 
 __all__ = [
+    "KANBAN_STOP_NUDGE_PREFIX",
     "build_kanban_stop_nudge",
     "kanban_stop_nudge_enabled",
     "session_called_kanban_terminal",

--- a/agent/verify_hooks.py
+++ b/agent/verify_hooks.py
@@ -20,6 +20,14 @@ from utils import is_truthy_value
 
 DEFAULT_MAX_VERIFY_NUDGES = 3
 
+# ``pre_verify`` hooks return user-controlled continuation text, so the nudge
+# has no fixed body that survives SessionDB projection. Prefix every accepted
+# directive with this stable marker so compaction can still distinguish the
+# projected role="user" row from a human-authored turn.
+PRE_VERIFY_CONTINUE_NUDGE_PREFIX = (
+    "[System: A pre-verify hook requested another agent turn.]\n\n"
+)
+
 # Shipped guidance appended to the verification-stop nudge when code lacks fresh
 # verification evidence. Wording mirrors the user-facing "clean your work"
 # workflow, but does not create its own extra model turn.
@@ -64,6 +72,7 @@ def _agent_cfg(config: Optional[dict[str, Any]]) -> dict[str, Any]:
 __all__ = [
     "CODING_VERIFY_GUIDANCE",
     "DEFAULT_MAX_VERIFY_NUDGES",
+    "PRE_VERIFY_CONTINUE_NUDGE_PREFIX",
     "coding_verify_guidance",
     "max_verify_nudges",
 ]

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -48,6 +48,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
 
 from hermes_constants import get_hermes_home
+from agent.verify_hooks import PRE_VERIFY_CONTINUE_NUDGE_PREFIX
 from utils import env_var_enabled, fast_safe_load
 from hermes_cli.config import cfg_get
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
@@ -2588,7 +2589,7 @@ def get_pre_verify_continue_message(
             continue
         message = result.get("message") or result.get("reason")
         if isinstance(message, str) and message.strip():
-            return message.strip()
+            return PRE_VERIFY_CONTINUE_NUDGE_PREFIX + message.strip()
 
     return None
 

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -20,6 +20,8 @@ from agent.conversation_compression import (
     _ensure_compressed_has_user_turn,
     compress_context,
 )
+from agent.kanban_stop import build_kanban_stop_nudge
+from hermes_cli.plugins import get_pre_verify_continue_message
 from hermes_state import SessionDB
 from tools.todo_tool import TODO_INJECTION_HEADER
 
@@ -331,6 +333,51 @@ def test_real_task_wins_over_trailing_dropped_tools_continuation_nudge(compresso
 
     idx = compressor._find_last_user_message_idx(messages, head_end=0)
     assert idx == 0, "nudge was selected as the anchor instead of the human task"
+    assert messages[idx]["content"] == human["content"]
+
+
+def test_dynamic_retry_nudges_are_synthetic_after_projection(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda *_args, **_kwargs: [
+            {"action": "continue", "message": "Run the focused regression tests."}
+        ],
+    )
+    pre_verify_nudge = get_pre_verify_continue_message()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_dynamic")
+    kanban_nudge = build_kanban_stop_nudge(messages=[])
+
+    assert pre_verify_nudge is not None
+    assert kanban_nudge is not None
+    for content in (pre_verify_nudge, kanban_nudge):
+        projected = {"role": "user", "content": content}
+        assert ContextCompressor._is_synthetic_compression_user_turn(projected) is True
+
+
+def test_real_task_wins_over_trailing_dynamic_retry_nudges(compressor, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda *_args, **_kwargs: [
+            {"decision": "block", "reason": "Inspect the generated diff first."}
+        ],
+    )
+    pre_verify_nudge = get_pre_verify_continue_message()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_dynamic")
+    kanban_nudge = build_kanban_stop_nudge(messages=[])
+
+    human = {"role": "user", "content": "Refactor the auth module and add tests."}
+    messages = [
+        human,
+        {"role": "assistant", "content": "I will verify the changes."},
+        {"role": "user", "content": pre_verify_nudge},
+        {"role": "assistant", "content": "I will finish the board handoff."},
+        {"role": "user", "content": kanban_nudge},
+    ]
+
+    idx = compressor._find_last_user_message_idx(messages, head_end=0)
+    assert idx == 0, "dynamic retry nudge was selected instead of the human task"
     assert messages[idx]["content"] == human["content"]
 
 


### PR DESCRIPTION
## What does this PR do?

When a crash or interrupt persists a dynamic pre-verify or kanban stop retry nudge, SessionDB projection drops its underscore-prefixed metadata. Context compaction can then mistake that synthetic `role="user"` row for a human turn and anchor the summary on retry instructions instead of the real task. This change gives both dynamic nudge families stable content prefixes and recognizes those prefixes after projection, preserving the real human task as the compaction anchor.

## Related Issue

Closes #82445

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/verify_hooks.py` - define a stable prefix for dynamically generated pre-verify continuation nudges.
- `hermes_cli/plugins.py` - prepend the stable marker to accepted pre-verify hook directives.
- `agent/kanban_stop.py` - expose and reuse a stable prefix for task-specific stop-loop nudges.
- `agent/context_compressor.py` - classify both projected prefix families as synthetic user turns.
- `tests/agent/test_context_compressor_zero_user_provenance.py` - cover both dynamic producers and prove that the real human task remains the anchor.

## How to Test

1. Generate both dynamic nudge variants with producer-specific content.
2. Strip transient metadata as SessionDB projection does and verify both projected rows remain synthetic.
3. Place both nudges after a real user task and verify compaction selects the real task as its anchor.
4. Run the focused regression file (52 passed):

```bash
scripts/run_tests.sh tests/agent/test_context_compressor_zero_user_provenance.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A
