### PR TITLE
feat(memory): add structured pre-compression context

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -73,6 +73,7 @@ from agent.context_engine import (
 )
 from agent.model_metadata import estimate_request_tokens_rough
 from agent.session_activity import ActivityProvenance, normalize_activity_provenance
+from agent.memory_provider import CompressionContext
 
 logger = logging.getLogger(__name__)
 
@@ -2771,8 +2772,31 @@ def compress_context(
         if agent._memory_manager:
             try:
                 _maybe_ctx = agent._memory_manager.on_pre_compress(messages)
-                if isinstance(_maybe_ctx, str):
+
+                if isinstance(_maybe_ctx, CompressionContext):
+                    _context_parts = []
+
+                    if _maybe_ctx.text and _maybe_ctx.text.strip():
+                        _context_parts.append(_maybe_ctx.text)
+
+                    _key_facts = [
+                        fact.strip()
+                        for fact in _maybe_ctx.key_facts
+                        if isinstance(fact, str) and fact.strip()
+                    ]
+                    if _key_facts:
+                        _context_parts.append(
+                            "MEMORY PROVIDER KEY FACTS:\n"
+                            + "\n".join(f"- {fact}" for fact in _key_facts)
+                        )
+
+                    memory_context = sanitize_memory_context(
+                        "\n\n".join(_context_parts)
+                    )
+
+                elif isinstance(_maybe_ctx, str):
                     memory_context = sanitize_memory_context(_maybe_ctx)
+
             except Exception:
                 pass
 

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -33,7 +33,7 @@ import threading
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import Any, Callable, Dict, List, Optional
 
-from agent.memory_provider import MemoryProvider
+from agent.memory_provider import CompressionContext, MemoryProvider
 from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.registry import tool_error
 
@@ -971,24 +971,41 @@ class MemoryManager:
                     provider.name, e,
                 )
 
-    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> CompressionContext:
         """Notify all providers before context compression.
 
-        Returns combined text from providers to include in the compression
-        summary prompt. Empty string if no provider contributes.
+        Legacy string results are preserved as text. Structured provider
+        results additionally contribute key facts for compression.
         """
-        parts = []
+        text_parts: List[str] = []
+        key_facts: List[str] = []
+
         for provider in self._providers:
             try:
                 result = provider.on_pre_compress(messages)
-                if result and result.strip():
-                    parts.append(result)
+
+                if isinstance(result, CompressionContext):
+                    if result.text and result.text.strip():
+                        text_parts.append(result.text)
+                    key_facts.extend(
+                        fact
+                        for fact in result.key_facts
+                        if isinstance(fact, str) and fact.strip()
+                    )
+                elif isinstance(result, str) and result.strip():
+                    text_parts.append(result)
+
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' on_pre_compress failed: %s",
-                    provider.name, e,
+                    provider.name,
+                    e,
                 )
-        return "\n\n".join(parts)
+
+        return CompressionContext(
+            text="\n\n".join(text_parts),
+            key_facts=key_facts,
+        )
 
     @staticmethod
     def _provider_memory_write_metadata_mode(provider: MemoryProvider) -> str:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -25,7 +25,7 @@ Optional hooks (override to opt in):
   on_turn_start(turn, message, **kwargs) — per-turn tick with runtime context
   on_session_end(messages)               — end-of-session extraction
   on_session_switch(new_session_id, **kwargs) — mid-process session_id rotation
-  on_pre_compress(messages) -> str       — extract before context compression
+  on_pre_compress(messages) -> str | CompressionContext — extract before context compression
   on_memory_write(action, target, content, metadata=None) — mirror built-in memory writes
   on_delegation(task, result, **kwargs)  — parent-side observation of subagent work
   backup_paths() -> list[str]            — extra on-disk paths to include in `hermes backup`
@@ -36,6 +36,7 @@ from __future__ import annotations
 import logging
 import re
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,14 @@ def is_trivial_prompt(text: Optional[str]) -> bool:
     if stripped.startswith("/"):
         return True
     return bool(TRIVIAL_PROMPT_RE.match(stripped))
+
+
+@dataclass
+class CompressionContext:
+    """Structured context supplied by memory providers before compression."""
+
+    text: str = ""
+    key_facts: List[str] = field(default_factory=list)
 
 
 class MemoryProvider(ABC):
@@ -255,15 +264,16 @@ class MemoryProvider(ABC):
         Default is no-op for backward compatibility.
         """
 
-    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str | CompressionContext:
         """Called before context compression discards old messages.
 
         Use to extract insights from messages about to be compressed.
         messages is the list that will be summarized/discarded.
 
-        Return text to include in the compression summary prompt so the
-        compressor preserves provider-extracted insights. Return empty
-        string for no contribution (backwards-compatible default).
+        Return either legacy freeform text or a CompressionContext with
+        structured key facts to preserve during compression. Returning a
+        string remains supported for backward compatibility. Return an
+        empty string for no contribution.
         """
         return ""
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -7,7 +7,7 @@ import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from agent.memory_provider import MemoryProvider
+from agent.memory_provider import CompressionContext, MemoryProvider
 from agent.memory_manager import MemoryManager, inject_memory_provider_tools
 
 # ---------------------------------------------------------------------------
@@ -138,6 +138,18 @@ class TestMemoryProviderABC:
         p.sync_turn("user", "assistant")
         p.shutdown()
 
+    def test_compression_context_has_safe_defaults(self):
+        """Structured compression context has isolated mutable defaults."""
+        first = CompressionContext()
+        second = CompressionContext()
+
+        assert first.text == ""
+        assert first.key_facts == []
+
+        first.key_facts.append("important fact")
+
+        assert second.key_facts == []
+
 
 # ---------------------------------------------------------------------------
 # MemoryManager tests
@@ -159,6 +171,48 @@ class TestMemoryManager:
         mgr.add_provider(p)
         assert len(mgr.providers) == 1
         assert [p.name for p in mgr.providers] == ["test1"]
+
+
+    def test_pre_compress_merges_legacy_and_structured_context(self):
+        """Legacy strings and structured provider context are aggregated."""
+        mgr = MemoryManager()
+
+        legacy = FakeMemoryProvider("builtin")
+        legacy.on_pre_compress = MagicMock(
+            return_value="Legacy provider context"
+        )
+
+        structured = FakeMemoryProvider("external")
+        structured.on_pre_compress = MagicMock(
+            return_value=CompressionContext(
+                text="Structured provider context",
+                key_facts=[
+                    "Python version: 3.11",
+                    "Do not modify database schema",
+                ],
+            )
+        )
+
+        mgr.add_provider(legacy)
+        mgr.add_provider(structured)
+
+        messages = [{"role": "user", "content": "Continue the task"}]
+
+        result = mgr.on_pre_compress(messages)
+
+        assert isinstance(result, CompressionContext)
+        assert result.text == (
+            "Legacy provider context\n\n"
+            "Structured provider context"
+        )
+        assert result.key_facts == [
+            "Python version: 3.11",
+            "Do not modify database schema",
+        ]
+
+        legacy.on_pre_compress.assert_called_once_with(messages)
+        structured.on_pre_compress.assert_called_once_with(messages)
+
 
     def test_get_provider_by_name(self):
         mgr = MemoryManager()

--- a/tests/run_agent/test_pre_compress_memory_context.py
+++ b/tests/run_agent/test_pre_compress_memory_context.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from agent.memory_provider import CompressionContext
 
 def _make_agent(memory_manager, compressor):
     from run_agent import AIAgent
@@ -84,6 +85,92 @@ def test_on_pre_compress_result_reaches_compressor_with_existing_options():
         "force": True,
         "memory_context": "Checkpoint id: ctx-orchestrator",
     }
+
+
+def test_structured_pre_compress_context_reaches_compressor():
+    """Structured memory context is rendered into the existing string boundary."""
+    manager = MagicMock()
+    manager.on_pre_compress.return_value = CompressionContext(
+        text="Project state: Hermes",
+        key_facts=[
+            "Python version: 3.11",
+            "Do not modify database schema",
+        ],
+    )
+
+    received = {}
+    compressor = MagicMock()
+
+    def capture_compress(
+        incoming,
+        current_tokens=None,
+        focus_topic=None,
+        force=False,
+        memory_context="",
+    ):
+        received["memory_context"] = memory_context
+        return [incoming[0], incoming[-1]]
+
+    compressor.compress.side_effect = capture_compress
+    _configure_engine_state(compressor)
+    agent = _make_agent(manager, compressor)
+
+    agent._compress_context(
+        _messages(),
+        "sys",
+        approx_tokens=100_000,
+    )
+
+    assert received["memory_context"] == (
+        "Project state: Hermes\n\n"
+        "MEMORY PROVIDER KEY FACTS:\n"
+        "- Python version: 3.11\n"
+        "- Do not modify database schema"
+    )
+
+
+def test_structured_key_facts_are_sanitized_before_compressor():
+    """Structured key facts cannot bypass the memory-context egress sanitizer."""
+    secret = "sk-" + "a" * 30
+
+    manager = MagicMock()
+    manager.on_pre_compress.return_value = CompressionContext(
+        text="Project state: Hermes",
+        key_facts=[
+            f"api key: {secret}",
+            "Python version: 3.11",
+        ],
+    )
+
+    received = []
+    compressor = MagicMock()
+
+    def capture_compress(
+        messages,
+        current_tokens=None,
+        memory_context="",
+        **_kwargs,
+    ):
+        received.append(memory_context)
+        return [messages[0], messages[-1]]
+
+    compressor.compress.side_effect = capture_compress
+    _configure_engine_state(compressor)
+    agent = _make_agent(manager, compressor)
+
+    agent._compress_context(
+        _messages(),
+        "sys",
+        approx_tokens=100_000,
+    )
+
+    assert len(received) == 1
+
+    context = received[0]
+
+    assert secret not in context
+    assert "Python version: 3.11" in context
+    assert "MEMORY PROVIDER KEY FACTS:" in context
 
 
 def test_legacy_engine_receives_only_supported_compression_arguments():

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -83,6 +83,27 @@ class MyMemoryProvider(MemoryProvider):
 | `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
 | `shutdown()` | Process exit | Clean up connections |
 
+## Structured Pre-Compression Context
+
+`on_pre_compress(messages)` may return either a plain string or a `CompressionContext`. Returning a string remains fully supported for backward compatibility.
+
+Use `CompressionContext` when the provider needs to distinguish ordinary context from facts that are especially important to preserve during compression:
+
+```python
+from agent.memory_provider import CompressionContext
+
+def on_pre_compress(self, messages):
+    return CompressionContext(
+        text="Relevant project state",
+        key_facts=[
+            "Python version: 3.11",
+            "Do not modify database schema",
+        ],
+    )
+```
+
+`text` is treated like the legacy string return value. `key_facts` are marked explicitly as important facts before being passed through the existing sanitized compression-context boundary.
+
 ## Config Schema
 
 `get_config_schema()` returns a list of field descriptors used by `hermes memory setup`:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/memory-provider-plugin.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/memory-provider-plugin.md
@@ -83,6 +83,27 @@ class MyMemoryProvider(MemoryProvider):
 | `on_memory_write(action, target, content)` | 内置 memory 写入时 | 同步到你的后端 |
 | `shutdown()` | 进程退出时 | 清理连接 |
 
+## 结构化的压缩前上下文
+
+`on_pre_compress(messages)` 可以返回普通字符串，也可以返回 `CompressionContext`。为保持向后兼容，原有的字符串返回方式仍然完全受支持。
+
+当 provider 需要区分普通上下文与压缩过程中尤其需要保留的关键事实时，可以使用 `CompressionContext`：
+
+```python
+from agent.memory_provider import CompressionContext
+
+def on_pre_compress(self, messages):
+    return CompressionContext(
+        text="相关的项目状态",
+        key_facts=[
+            "Python version: 3.11",
+            "不要修改数据库 schema",
+        ],
+    )
+```
+
+`text` 的处理方式与旧的字符串返回值相同。`key_facts` 会被明确标记为重要事实，然后通过现有的、经过安全处理的压缩上下文边界传递。
+
 ## 配置 Schema
 
 `get_config_schema()` 返回一个字段描述符列表，供 `hermes memory setup` 使用：


### PR DESCRIPTION
## Summary

Adds structured pre-compression context support for memory providers.

Memory providers can now return a `CompressionContext` from `on_pre_compress()` with:

- `text` for normal provider context
- `key_facts` for facts that should be explicitly marked as important during context compression

Legacy string return values remain fully supported.

Closes #23367.

## Implementation

Introduces:

```python
@dataclass
class CompressionContext:
    text: str = ""
    key_facts: List[str] = field(default_factory=list)
```

`MemoryManager.on_pre_compress()` now normalizes contributions from both legacy and structured providers into a single `CompressionContext`.

Before entering the existing context-engine/compressor boundary, structured context is rendered back into the existing `memory_context: str` format:

```text
<normal provider context>

MEMORY PROVIDER KEY FACTS:
- <fact>
- <fact>
```

The resulting string is passed through the existing `sanitize_memory_context()` path before being sent to the compressor.

This keeps the structured representation inside the memory layer and avoids changing the existing context-engine/plugin API.

## Backward compatibility

Existing providers returning `str` from `on_pre_compress()` continue to work unchanged.

No changes are required for existing context-engine implementations or plugins.

## Safety

Structured `key_facts` use the same sanitized memory-context boundary as legacy provider context.

Tests verify that sensitive values supplied through `key_facts` cannot bypass the existing redaction/sanitization path.

## Tests

Added coverage for:

- safe `CompressionContext` defaults
- aggregation of legacy strings and structured provider results
- structured key facts reaching the existing compressor boundary
- sanitization of structured key facts

Focused validation:

```text
97 passed
ruff: all checks passed
git diff --check: clean
```

The broader `tests/agent` suite was also exercised locally on Windows. It contains environment/pre-existing failures involving Windows path handling, default GBK decoding, optional dependencies, provider/global state, and Windows file locking. The focused memory/compression test set passes consistently in a clean UTF-8 test process.

`python scripts/check-windows-footguns.py --diff HEAD^` reports one pre-existing `Path.write_text()` call without an explicit encoding in `tests/agent/test_memory_provider.py`. `git blame HEAD^` shows that the flagged line predates this change (`28e1e210ee`), and this PR does not modify that call.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant focused test suites for this change (97 passed)
- [x] I've added tests for my changes
- [x] I've verified linting with Ruff and `git diff --check`
- [x] I've run `scripts/check-windows-footguns.py --diff HEAD^`

### Documentation & Housekeeping

- [x] I've updated the relevant developer documentation in English and Simplified Chinese
- [x] N/A — no config keys added or changed
- [x] No public ContextEngine or compressor plugin API changes were introduced
- [x] I've considered cross-platform impact and validated the change on Windows
- [x] Structured `key_facts` continue through the existing `sanitize_memory_context()` safety boundary
- [x] N/A — no unrelated tool behavior changed
