### PR TITLE
fix(chat-completions): preserve bridged tool response name

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -239,6 +239,11 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - A tool-result ``name`` that differs from the matching assistant
+          tool call. Deferred tools use the outer ``tool_call`` bridge on the
+          wire while Hermes records the resolved inner tool name for display
+          and search. Gemini rejects that mismatch with ``INVALID_ARGUMENT``,
+          so the wire copy must use the name associated with ``tool_call_id``.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -253,10 +258,39 @@ class ChatCompletionsTransport(ProviderTransport):
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
         )
+        tool_call_names: dict[str, str] = {}
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            tool_calls = msg.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                continue
+            for tc in tool_calls:
+                if not isinstance(tc, dict):
+                    continue
+                call_id = tc.get("id")
+                function = tc.get("function")
+                function_name = (
+                    function.get("name") if isinstance(function, dict) else None
+                )
+                if (
+                    isinstance(call_id, str)
+                    and call_id
+                    and isinstance(function_name, str)
+                    and function_name
+                ):
+                    tool_call_names[call_id] = function_name
+
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
+            tool_call_id = msg.get("tool_call_id")
+            expected_tool_name = (
+                tool_call_names.get(tool_call_id)
+                if isinstance(tool_call_id, str)
+                else None
+            )
             if (
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
@@ -264,6 +298,10 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or (
+                    expected_tool_name is not None
+                    and msg.get("name") != expected_tool_name
+                )
             ):
                 needs_sanitize = True
                 break
@@ -299,6 +337,15 @@ class ChatCompletionsTransport(ProviderTransport):
                     copied_msg = dict(msg)
                     sanitized[msg_idx] = copied_msg
                 return copied_msg
+
+            tool_call_id = msg.get("tool_call_id")
+            expected_tool_name = (
+                tool_call_names.get(tool_call_id)
+                if isinstance(tool_call_id, str)
+                else None
+            )
+            if expected_tool_name is not None and msg.get("name") != expected_tool_name:
+                mutable_msg()["name"] = expected_tool_name
 
             if (
                 "codex_reasoning_items" in msg

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -84,6 +84,56 @@ class TestChatCompletionsBasic:
         msgs = [{"role": "user", "content": "hi"}]
         assert transport.convert_messages(msgs) is msgs
 
+    @pytest.mark.parametrize("include_tool_name", [False, True])
+    def test_convert_messages_matches_deferred_tool_result_name(
+        self, transport, include_tool_name
+    ):
+        """Gemini requires a tool result to name the function actually called.
+
+        Hermes keeps the resolved MCP name for its own display/search metadata,
+        but a deferred call is represented to the model by the ``tool_call``
+        bridge. The wire copy must therefore use that outer name without
+        mutating the canonical conversation history.
+        """
+        tool_result = {
+            "role": "tool",
+            "name": "mcp__server__status",
+            "tool_call_id": "call_1",
+            "content": '{"ok":true}',
+        }
+        if include_tool_name:
+            tool_result["tool_name"] = "mcp__server__status"
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "tool_call",
+                            "arguments": '{"name":"mcp__server__status"}',
+                        },
+                    }
+                ],
+            },
+            tool_result,
+        ]
+
+        result = transport.convert_messages(msgs, model="google/gemini-3.6-flash")
+
+        assert result[1]["name"] == result[0]["tool_calls"][0]["function"]["name"]
+        assert result[1]["name"] == "tool_call"
+        assert "tool_name" not in result[1]
+        assert result[0] is msgs[0]
+        assert result[1] is not msgs[1]
+        assert msgs[1]["name"] == "mcp__server__status"
+        assert msgs[1].get("tool_name") == (
+            "mcp__server__status" if include_tool_name else None
+        )
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 


### PR DESCRIPTION
## Summary

- Track each assistant tool call's original function name by tool call ID.
- Rewrite only the outbound tool-result copy when its name differs from the matching assistant call.
- Preserve Hermes' canonical inner tool name for display, search, and persistence.
- Add regression coverage for deferred Tool Search results with and without internal `tool_name` metadata.

## Root cause

Deferred Tool Search exposes the outer `tool_call` bridge to the model, while Hermes executes and records the unwrapped MCP/plugin tool name. For example, the assistant call uses `tool_call`, but the result message uses `mcp__server__status` for the same `tool_call_id`.

Gemini requires the function call and response associated with one tool call ID to use the same name. When Gemini 3.6 Flash is routed through OpenRouter's Chat Completions API, the mismatch causes the next request to fail with `INVALID_ARGUMENT`. Since the underlying tool may already have executed, retrying can duplicate side effects.

This mirrors the native Gemini fix from #72090 / commit `01cb38e8ecfe4b7fe338fc9e7c17d022963b74bd`, while covering the OpenRouter Chat Completions transport used by `google/gemini-3.6-flash`.

## Validation

- Regression test reproduced the mismatch before the fix.
- `scripts/run_tests.sh tests/agent/transports/test_chat_completions.py tests/agent/test_gemini_native_adapter.py -q` — 56 passed.
- `.venv/bin/ruff check agent/transports/chat_completions.py tests/agent/transports/test_chat_completions.py`
- `git diff --check`

Fixes #72089