### PR TITLE
perf(gateway): 10x faster cold project grouping (3.3s → 0.3s)

### DIFF
--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -146,6 +146,38 @@ def test_warm_roots_probes_in_parallel_and_fills_the_cache(monkeypatch):
     assert live["calls"] == before
 
 
+def test_missing_directory_costs_no_subprocess(monkeypatch):
+    # Deleted worktrees dominate a long session history's cwds, and `git -C` on
+    # one can only fail — so it must never reach the fork.
+    from tui_gateway import git_probe
+
+    def boom(*_a, **_kw):
+        raise AssertionError("spawned git for a directory that does not exist")
+
+    monkeypatch.setattr(git_probe, "bounded_git_probe", boom)
+
+    assert git_probe.run_git("/gone/worktree", "rev-parse", "--show-toplevel") == ""
+
+
+def test_non_repo_cwd_is_not_probed_for_a_common_dir(monkeypatch, tmp_path):
+    # `warm_roots` only reaches `common_repo_root` for cwds that ARE repos, so a
+    # common-dir probe here is one the warm can't absorb: it runs serially on
+    # the discovery pass, once per non-repo cwd.
+    from tui_gateway import git_probe
+
+    git_probe.invalidate()
+    asked = []
+
+    def probe(cwd, *args):
+        asked.append(args[-1])
+        return ""  # not a repo, whatever we ask
+
+    monkeypatch.setattr(git_probe, "run_git", probe)
+
+    assert git_probe.common_repo_root(str(tmp_path)) == ""
+    assert asked == ["--show-toplevel"]
+
+
 def test_create_list_roundtrip(tmp_path):
     created = _call("projects.create", {"name": "Demo", "folders": [str(tmp_path)], "use": True})
     assert created["project"]["slug"] == "demo"

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -178,6 +178,33 @@ def test_non_repo_cwd_is_not_probed_for_a_common_dir(monkeypatch, tmp_path):
     assert asked == ["--show-toplevel"]
 
 
+def test_tree_build_warms_every_path_it_will_resolve(monkeypatch, tmp_path):
+    # build_tree resolves declared project folders and discovered repo roots as
+    # well as session cwds. Anything left out of the warm is probed one
+    # directory at a time while the sidebar shows a skeleton.
+    from tui_gateway import git_probe
+
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    _call("projects.create", {"name": "Repo", "folders": [str(repo)]})
+
+    warmed: list[str] = []
+    real_warm = git_probe.warm_roots
+
+    def recording_warm(cwds, **kw):
+        paths = list(cwds)
+        warmed.extend(paths)
+        return real_warm(paths, **kw)
+
+    monkeypatch.setattr(git_probe, "warm_roots", recording_warm)
+
+    server._build_project_tree(
+        server._get_db(), preview_limit=3, hydrate=False, session_limit=5, include_discovered=True
+    )
+
+    assert str(repo) in warmed
+
+
 def test_create_list_roundtrip(tmp_path):
     created = _call("projects.create", {"name": "Demo", "folders": [str(tmp_path)], "use": True})
     assert created["project"]["slug"] == "demo"

--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -50,7 +50,11 @@ def run_git(cwd: str, *args: str) -> str:
     session readiness when a killed git left a suspended descendant holding the
     pipe handles (issue #68609).
     """
-    if not cwd:
+    if not cwd or not os.path.isdir(cwd):
+        # `git -C` on a directory that no longer exists can only fail, and it
+        # fails at the price of a fork. Deleted worktrees dominate the cwds a
+        # long-lived session history hands us, so the stat pays for itself many
+        # times over on every project-tree build.
         return ""
     return bounded_git_probe(["git", "-C", cwd, *args], timeout=_GIT_TIMEOUT)
 
@@ -151,6 +155,13 @@ def common_repo_root(cwd: str) -> str:
     rendered it twice (a dir-labeled lane plus a branch-labeled ``main`` lane).
     """
     if not cwd:
+        return ""
+
+    # No work tree, nothing to fold. Reading the (warmed, negative-cached)
+    # toplevel first spares every non-repo cwd a second `git` spawn — one the
+    # parallel warm can never absorb, since `resolve()` only reaches here for
+    # cwds that ARE repos.
+    if not repo_root(cwd):
         return ""
 
     def _probe() -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11842,6 +11842,13 @@ def _build_project_tree(
     sessions, projects, discovered, active_id = _project_tree_inputs(
         db, session_limit, include_discovered=include_discovered
     )
+    # build_tree resolves every declared project folder and every discovered
+    # repo root too, and those paths are not session cwds — without this they
+    # are the one part of the build still probing git one directory at a time.
+    git_probe.warm_roots(
+        [str(f.get("path") or "") for p in projects for f in (p.get("folders") or [])]
+        + [str(r.get("root") or "") for r in discovered]
+    )
     tree = project_tree.build_tree(
         projects,
         sessions,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11772,6 +11772,10 @@ def _project_tree_inputs(
         include_children=False,
         exclude_sources=_PROJECT_TREE_EXCLUDED_SOURCES,
         include_archived=False,
+        # `_project_tree_row` keeps ~18 fields and drops the rest, so selecting
+        # the system-prompt blob only to discard it costs tens of MB of B-tree
+        # reads per build on a long-lived database.
+        compact_rows=True,
     )
     sessions = [_project_tree_row(r) for r in rows]
     # Parallel-warm the git cache so build_tree's resolver reads it instead of


### PR DESCRIPTION
Grouping the desktop sidebar by project sat behind a skeleton for seconds on
every cold open. Profiling `projects.tree` against a real session history (886
sessions, 134 distinct cwds) found the build spending almost all of its time on
work whose answer was already known: 219 of its 376 `git` subprocesses ran one
at a time on the main thread, and the query behind it read 37MB of system-prompt
blobs that the very next function drops.

Measured on that history, median of 5 interleaved runs:

| | before | after |
|---|---|---|
| cold build (empty git cache) | 3292 ms | 306 ms |
| warm build | 203 ms | 78 ms |
| serial main-thread `git` runs | 219 (2077 ms) | 16 (0 ms) |

The payload is unchanged — same 272 nodes, structurally identical dumps before
and after, with only live session counters moving between runs.

### Three findings

**Directories that no longer exist.** 118 of the 134 session cwds were deleted
worktrees. `git -C` on one can only fail, and it fails at the cost of a fork;
stat'ing all 134 takes 0.5 ms versus the ~290 ms of forks it replaces.

**Non-repo cwds probed twice.** `resolve()` only calls `common_repo_root` for
cwds that already resolved, so the parallel warm never covered that probe — and
the discovery pass then asked for a common dir on every cwd, one spawn at a
time, including the ones just proven not to be repos. Reading the warmed
toplevel first answers those from cache.

**Paths the warm never saw.** `build_tree` resolves each declared project folder
and each discovered repo root as well as session cwds, and those were left to
probe serially. They now go through the same parallel warm.

### Test plan

- [x] `scripts/run_tests.sh tests/tui_gateway/ tests/test_hermes_state.py tests/hermes_cli/test_git_probe_tree_kill.py` — 633 passed
- [x] Tree payload diffed against `main` on a real database: same node set, no structural change
- [x] Three regression tests, each asserting a probe that must not happen (one of them caught a bug in this PR, where the folder warm read the wrong key and did nothing)