### PR TITLE
fix(sessions): stop a cleanup ROLLBACK from masking the real recovery failure

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -377,30 +377,6 @@ def inspect_session_database(
         temp_dir.cleanup()
 
 
-def _rollback_without_masking(destination: sqlite3.Connection) -> None:
-    """Roll the destination back without shadowing the failure in flight.
-
-    SQLite may already have rolled the transaction back on its own — it does
-    that for SQLITE_FULL, SQLITE_IOERR, SQLITE_BUSY and SQLITE_NOMEM, which
-    are precisely the errors a recovery run into a fresh destination hits.
-    The explicit ``ROLLBACK`` then raises ``cannot rollback - no transaction
-    is active`` from inside the exception handler and *replaces* the original
-    failure, so the caller reports the spurious rollback error and never
-    reaches its own ``raise``.
-
-    ``sqlite3.Error`` rather than ``sqlite3.OperationalError``: this module
-    tears its connections down in a ``finally`` block, so the rollback can
-    also land on an already-closed connection and raise ``ProgrammingError``.
-    Whatever the rollback itself fails with, it matters less than the
-    exception already being propagated. Non-SQLite errors still surface.
-    """
-
-    try:
-        destination.execute("ROLLBACK")
-    except sqlite3.Error:
-        pass
-
-
 def _copy_table(
     source: sqlite3.Connection,
     destination: sqlite3.Connection,
@@ -443,7 +419,7 @@ def _copy_table(
                 destination.executemany(insert_sql, rows)
                 destination.execute("COMMIT")
             except BaseException:
-                _rollback_without_masking(destination)
+                destination.execute("ROLLBACK")
                 raise
             result["copied_rows"] += len(rows)
             if progress_cb is not None:
@@ -628,7 +604,7 @@ def _copy_table_salvage(
                         destination.executemany(insert_sql, included)
                         destination.execute("COMMIT")
                     except BaseException:
-                        _rollback_without_masking(destination)
+                        destination.execute("ROLLBACK")
                         raise
 
                 result["copied_rows"] += len(included)
@@ -741,7 +717,7 @@ def _copy_state_meta(
                 )
                 destination.execute("COMMIT")
             except BaseException:
-                _rollback_without_masking(destination)
+                destination.execute("ROLLBACK")
                 raise
             result["copied_rows"] += len(rows)
             if progress_cb is not None:
@@ -1040,7 +1016,7 @@ def _cleanup_partial_orphans(
             result[report_key] = orphan_count
         destination.execute("COMMIT")
     except BaseException:
-        _rollback_without_masking(destination)
+        destination.execute("ROLLBACK")
         raise
     # Only destructive/relinking actions belong in this total. The
     # reconstruction counters describe data RETAINED, so summing them here
@@ -1273,7 +1249,7 @@ def _finalize_derived_metadata(destination: sqlite3.Connection) -> dict[str, Any
         )
         destination.execute("COMMIT")
     except BaseException:
-        _rollback_without_masking(destination)
+        destination.execute("ROLLBACK")
         raise
     result["finalized"] = True
     return result

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -377,6 +377,30 @@ def inspect_session_database(
         temp_dir.cleanup()
 
 
+def _rollback_without_masking(destination: sqlite3.Connection) -> None:
+    """Roll the destination back without shadowing the failure in flight.
+
+    SQLite may already have rolled the transaction back on its own — it does
+    that for SQLITE_FULL, SQLITE_IOERR, SQLITE_BUSY and SQLITE_NOMEM, which
+    are precisely the errors a recovery run into a fresh destination hits.
+    The explicit ``ROLLBACK`` then raises ``cannot rollback - no transaction
+    is active`` from inside the exception handler and *replaces* the original
+    failure, so the caller reports the spurious rollback error and never
+    reaches its own ``raise``.
+
+    ``sqlite3.Error`` rather than ``sqlite3.OperationalError``: this module
+    tears its connections down in a ``finally`` block, so the rollback can
+    also land on an already-closed connection and raise ``ProgrammingError``.
+    Whatever the rollback itself fails with, it matters less than the
+    exception already being propagated. Non-SQLite errors still surface.
+    """
+
+    try:
+        destination.execute("ROLLBACK")
+    except sqlite3.Error:
+        pass
+
+
 def _copy_table(
     source: sqlite3.Connection,
     destination: sqlite3.Connection,
@@ -419,7 +443,7 @@ def _copy_table(
                 destination.executemany(insert_sql, rows)
                 destination.execute("COMMIT")
             except BaseException:
-                destination.execute("ROLLBACK")
+                _rollback_without_masking(destination)
                 raise
             result["copied_rows"] += len(rows)
             if progress_cb is not None:
@@ -604,7 +628,7 @@ def _copy_table_salvage(
                         destination.executemany(insert_sql, included)
                         destination.execute("COMMIT")
                     except BaseException:
-                        destination.execute("ROLLBACK")
+                        _rollback_without_masking(destination)
                         raise
 
                 result["copied_rows"] += len(included)
@@ -717,7 +741,7 @@ def _copy_state_meta(
                 )
                 destination.execute("COMMIT")
             except BaseException:
-                destination.execute("ROLLBACK")
+                _rollback_without_masking(destination)
                 raise
             result["copied_rows"] += len(rows)
             if progress_cb is not None:
@@ -1016,7 +1040,7 @@ def _cleanup_partial_orphans(
             result[report_key] = orphan_count
         destination.execute("COMMIT")
     except BaseException:
-        destination.execute("ROLLBACK")
+        _rollback_without_masking(destination)
         raise
     # Only destructive/relinking actions belong in this total. The
     # reconstruction counters describe data RETAINED, so summing them here
@@ -1249,7 +1273,7 @@ def _finalize_derived_metadata(destination: sqlite3.Connection) -> dict[str, Any
         )
         destination.execute("COMMIT")
     except BaseException:
-        destination.execute("ROLLBACK")
+        _rollback_without_masking(destination)
         raise
     result["finalized"] = True
     return result

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1501,7 +1501,17 @@ def write_recovery_report(path: Path, report: dict[str, Any]) -> Path:
     """Write a JSON report without overwriting an existing file."""
 
     destination = _resolved_output_path(path)
-    with destination.open("x", encoding="utf-8") as handle:
-        json.dump(report, handle, indent=2, sort_keys=True)
-        handle.write("\n")
+    # Opened before the guard so a FileExistsError — the report an earlier run
+    # already wrote — can never reach the unlink below.
+    handle = destination.open("x", encoding="utf-8")
+    try:
+        with handle:
+            json.dump(report, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    except BaseException:
+        # ``hermes sessions recover`` refuses the whole command when this path
+        # exists, so a dump that dies part way blocks the next run before
+        # recovery even starts.
+        _unlink_if_present(destination)
+        raise
     return destination

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -81,6 +81,30 @@ def _sidecar_path(db_path: Path, suffix: str) -> Path:
     return db_path if not suffix else db_path.with_name(db_path.name + suffix)
 
 
+def _unlink_if_present(path: Path) -> None:
+    """Best-effort removal of a file this run created but never completed."""
+
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _discard_recovery_output(output: Path) -> None:
+    """Remove an output bundle a failed run created but never completed.
+
+    ``_validate_paths`` refuses to start when the output *or any of its
+    journal sidecars* already exists, so an output left behind by a run that
+    raised locks the user out of every retry of the one command a damaged
+    database has left. Removing the database on its own would not lift that
+    refusal: the guard covers all of ``_SIDECAR_SUFFIXES``, and an
+    interrupted run can leave a live WAL next to it.
+    """
+
+    for suffix in _SIDECAR_SUFFIXES:
+        _unlink_if_present(_sidecar_path(output, suffix))
+
+
 def _resolved_output_path(path: Path) -> Path:
     """Resolve a not-yet-created output path without requiring it to exist."""
 
@@ -1306,6 +1330,7 @@ def recover_session_database(
     disk_space = _disk_space_preflight(source, work_root, output.parent)
 
     temp_dir, snapshot_source, inspection = _snapshot_and_inspect(source, work_root)
+    output_created = False
     try:
         if not inspection.get("recoverable") and not allow_partial:
             reasons = "; ".join(inspection.get("errors") or ["unknown source error"])
@@ -1337,6 +1362,10 @@ def recover_session_database(
                 inspection["tables"][table].get("available") for table in _TOPIC_TABLES
             )
 
+            # SessionDB creates the output before it finishes initializing it,
+            # so a constructor that raises part way still leaves a database —
+            # and a live WAL — behind. Arm the cleanup before the call.
+            output_created = True
             destination_db = SessionDB(db_path=output)
             if has_topic_tables:
                 destination_db.apply_telegram_topic_migration()
@@ -1457,6 +1486,13 @@ def recover_session_database(
             "verified": bool(verification.get("healthy") and source_unchanged),
             "installed": False,
         }
+    except BaseException:
+        # Only on the raise path. ``_verify_recovered_database`` collects
+        # errors and returns, so an output that failed verification is kept
+        # for the inspection the CLI tells the user to perform.
+        if output_created:
+            _discard_recovery_output(output)
+        raise
     finally:
         temp_dir.cleanup()
 

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -648,4 +648,188 @@ def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
         conn.close()
 
 
+class _AutoRollbackConnection:
+    """A destination whose transaction SQLite has already ended by itself.
+
+    SQLite rolls the active transaction back on its own for SQLITE_FULL,
+    SQLITE_IOERR, SQLITE_BUSY and SQLITE_NOMEM. The explicit ``ROLLBACK`` a
+    cleanup handler then issues raises ``cannot rollback - no transaction is
+    active``, which is exactly the sequence that used to replace the real
+    failure. This stands in for it at every write site.
+    """
+
+    def __init__(self, connection: sqlite3.Connection, make_failure):
+        self._connection = connection
+        self._make_failure = make_failure
+        self.rollback_attempts = 0
+
+    def __getattr__(self, name: str):
+        return getattr(self._connection, name)
+
+    def execute(self, sql: str, *parameters):
+        statement = sql.strip().upper()
+        if statement.startswith("ROLLBACK"):
+            self.rollback_attempts += 1
+            # SQLite already unwound the transaction; undo it for real so the
+            # connection stays usable, then fail the way SQLite would.
+            self._connection.execute("ROLLBACK")
+            raise sqlite3.OperationalError(
+                "cannot rollback - no transaction is active"
+            )
+        if statement.startswith("COMMIT"):
+            raise self._make_failure()
+        return self._connection.execute(sql, *parameters)
+
+    def executemany(self, sql: str, parameters):
+        return self._connection.executemany(sql, parameters)
+
+
+def _recovery_pair(tmp_path: Path) -> tuple[sqlite3.Connection, sqlite3.Connection]:
+    """A populated source plus a fresh current-schema destination."""
+
+    source_path = tmp_path / "rollback-source.db"
+    _make_source(source_path)
+    destination_path = tmp_path / "rollback-destination.db"
+    destination_db = SessionDB(db_path=destination_path)
+    try:
+        destination_db.apply_telegram_topic_migration()
+    finally:
+        destination_db.close()
+    return (
+        sqlite3.connect(str(source_path), isolation_level=None),
+        sqlite3.connect(str(destination_path), isolation_level=None),
+    )
+
+
+# Every site in session_recovery.py that wraps a write in
+# ``except BaseException: ROLLBACK; raise``.
+_ROLLBACK_SITES = {
+    "_cleanup_partial_orphans": lambda source, destination: (
+        session_recovery._cleanup_partial_orphans(destination)
+    ),
+    "_copy_state_meta": lambda source, destination: (
+        session_recovery._copy_state_meta(
+            source,
+            destination,
+            chunk_size=1_000,
+            progress_cb=None,
+            source_rows=None,
+        )
+    ),
+    "_copy_table": lambda source, destination: session_recovery._copy_table(
+        source,
+        destination,
+        "messages",
+        chunk_size=1_000,
+        progress_cb=None,
+        source_rows=21,
+    ),
+    "_copy_table_salvage": lambda source, destination: (
+        session_recovery._copy_table_salvage(
+            source,
+            destination,
+            "messages",
+            chunk_size=1_000,
+            progress_cb=None,
+            source_rows=21,
+        )
+    ),
+    "_finalize_derived_metadata": lambda source, destination: (
+        session_recovery._finalize_derived_metadata(destination)
+    ),
+}
+
+
+@pytest.mark.parametrize("site", sorted(_ROLLBACK_SITES))
+def test_cleanup_rollback_never_replaces_the_real_write_failure(
+    site: str,
+    tmp_path: Path,
+) -> None:
+    source, destination = _recovery_pair(tmp_path)
+    guarded = _AutoRollbackConnection(
+        destination,
+        lambda: sqlite3.OperationalError("database or disk is full"),
+    )
+    try:
+        try:
+            surfaced = json.dumps(
+                _ROLLBACK_SITES[site](source, guarded), default=str
+            )
+        except sqlite3.Error as exc:
+            # The two cleanup sites propagate instead of reporting a dict.
+            surfaced = str(exc)
+    finally:
+        source.close()
+        destination.close()
+
+    # The salvage site retries narrower rowid ranges, so it rolls back more
+    # than once before it gives up and records the failure.
+    assert guarded.rollback_attempts >= 1
+    assert "database or disk is full" in surfaced
+    assert "cannot rollback" not in surfaced
+
+
+@pytest.mark.parametrize("site", sorted(_ROLLBACK_SITES))
+def test_interrupt_during_a_write_still_aborts_the_recovery(
+    site: str,
+    tmp_path: Path,
+) -> None:
+    """``except BaseException`` must roll back and then re-raise the interrupt.
+
+    A masked rollback turns Ctrl-C into a ``DatabaseError``, which the copy
+    sites treat as an ordinary damaged-source error — so the run continues
+    instead of stopping.
+    """
+
+    source, destination = _recovery_pair(tmp_path)
+    guarded = _AutoRollbackConnection(destination, KeyboardInterrupt)
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            _ROLLBACK_SITES[site](source, guarded)
+    finally:
+        source.close()
+        destination.close()
+
+    assert guarded.rollback_attempts == 1
+
+
+def test_copy_table_reports_a_full_destination_not_a_rollback_failure(
+    tmp_path: Path,
+) -> None:
+    """End-to-end against real SQLite, with no stubbing of the failure."""
+
+    source_path = tmp_path / "page-spanning-source.db"
+    _make_page_spanning_source(source_path)
+    destination_path = tmp_path / "capped-destination.db"
+    destination_db = SessionDB(db_path=destination_path)
+    destination_db.close()
+
+    source = sqlite3.connect(str(source_path), isolation_level=None)
+    destination = sqlite3.connect(str(destination_path), isolation_level=None)
+    try:
+        source_rows = int(
+            source.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        )
+        # Leave room for the copy to begin and then run out part way through,
+        # which is what a destination filesystem filling up mid-run looks like.
+        pages = int(destination.execute("PRAGMA page_count").fetchone()[0])
+        destination.execute(f"PRAGMA max_page_count = {pages + 20}")
+
+        result = session_recovery._copy_table(
+            source,
+            destination,
+            "messages",
+            chunk_size=1_000,
+            progress_cb=None,
+            source_rows=source_rows,
+        )
+    finally:
+        source.close()
+        destination.close()
+
+    assert result["status"] == "failed"
+    assert "database or disk is full" in result["error"]
+    assert "cannot rollback" not in result["error"]
+
+
 

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -670,9 +670,15 @@ class _AutoRollbackConnection:
         statement = sql.strip().upper()
         if statement.startswith("ROLLBACK"):
             self.rollback_attempts += 1
-            # SQLite already unwound the transaction; undo it for real so the
-            # connection stays usable, then fail the way SQLite would.
-            self._connection.execute("ROLLBACK")
+            # Undo any transaction still open underneath so the connection
+            # stays usable, then fail the way SQLite does once it has already
+            # unwound the transaction itself. The simulated failure is raised
+            # unconditionally so the stub never depends on the real
+            # connection's transaction state.
+            try:
+                self._connection.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
             raise sqlite3.OperationalError(
                 "cannot rollback - no transaction is active"
             )

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -594,6 +594,200 @@ def test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf(
     }
 
 
+def _surviving_output_bundle(output: Path) -> list[str]:
+    """Every path ``_validate_paths`` would refuse a retry on."""
+
+    return [
+        str(session_recovery._sidecar_path(output, suffix))
+        for suffix in session_recovery._SIDECAR_SUFFIXES
+        if os.path.lexists(session_recovery._sidecar_path(output, suffix))
+    ]
+
+
+def test_failed_recovery_leaves_no_output_to_block_a_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mid-run failure must not lock the user out of retrying.
+
+    ``_validate_paths`` refuses to start when the output *or any of its
+    journal sidecars* already exists, so a half-written output turns the one
+    command a damaged database has left into a permanent refusal naming a
+    file the user never created.
+    """
+
+    source = tmp_path / "state.db"
+    _make_source(source)
+    output = tmp_path / "recovered.db"
+
+    def _disk_error(destination: sqlite3.Connection) -> dict[str, object]:
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(session_recovery, "_finalize_derived_metadata", _disk_error)
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        recover_session_database(source, output, work_dir=tmp_path)
+
+    assert _surviving_output_bundle(output) == []
+
+    # The retry is the point: it must get past the overwrite guard entirely.
+    monkeypatch.undo()
+    report = recover_session_database(source, output, work_dir=tmp_path)
+    assert report["complete"] is True
+    assert report["installed"] is False
+
+
+def test_keyboard_interrupt_during_recovery_leaves_no_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ctrl-C is the reported case, so the cleanup must catch ``BaseException``.
+
+    An ``except Exception`` cleanup passes the disk-error test above and still
+    leaves the stub behind for the interrupt that people actually hit.
+    """
+
+    source = tmp_path / "state.db"
+    _make_source(source)
+    output = tmp_path / "interrupted.db"
+
+    def _interrupt(destination: sqlite3.Connection) -> dict[str, object]:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(session_recovery, "_finalize_derived_metadata", _interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        recover_session_database(source, output, work_dir=tmp_path)
+
+    assert _surviving_output_bundle(output) == []
+
+
+def test_failed_output_initialization_leaves_no_journal_sidecars(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The output can fail *while* it is being created, sidecars and all.
+
+    ``SessionDB`` creates the database before it finishes initializing it, so a
+    constructor that raises part way leaves a live WAL behind and never hands
+    back a handle anything can close. ``_validate_paths`` refuses on every
+    entry of ``_SIDECAR_SUFFIXES``, so removing the database on its own still
+    leaves ``recovered.db-wal`` blocking the retry.
+    """
+
+    source = tmp_path / "state.db"
+    _make_source(source)
+    output = tmp_path / "half-initialized.db"
+
+    real_session_db = session_recovery.SessionDB
+    leaked: list[SessionDB] = []
+
+    def _fail_after_creating(*args: object, **kwargs: object) -> SessionDB:
+        # Deliberately left open: an unflushed WAL is what makes this the
+        # sidecar case rather than a plain leftover database file.
+        leaked.append(real_session_db(*args, **kwargs))
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(session_recovery, "SessionDB", _fail_after_creating)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+            recover_session_database(source, output, work_dir=tmp_path)
+
+        assert leaked, "the stub never reached the real constructor"
+        assert _surviving_output_bundle(output) == []
+    finally:
+        for database in leaked:
+            database.close()
+
+
+def test_verification_failure_keeps_the_output_for_inspection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The boundary: cleanup belongs on the raise path only.
+
+    ``_verify_recovered_database`` collects errors and returns, and the CLI
+    tells the user to review a report for an output that failed verification,
+    so that output must survive.
+    """
+
+    source = tmp_path / "state.db"
+    _make_source(source)
+    output = tmp_path / "unverified.db"
+
+    def _failed_verification(*args: object, **kwargs: object) -> dict[str, object]:
+        return {
+            "errors": ["forced verification failure"],
+            "warnings": [],
+            "table_counts": {},
+            "integrity_check": ["ok"],
+            "foreign_key_check": [],
+            "complete": False,
+            "healthy": False,
+            "loss_detected": False,
+        }
+
+    monkeypatch.setattr(
+        session_recovery,
+        "_verify_recovered_database",
+        _failed_verification,
+    )
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    assert report["complete"] is False
+    assert report["verified"] is False
+    assert output.exists()
+
+
+def test_failed_report_write_leaves_no_report_to_block_a_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same lockout, one artifact along.
+
+    ``write_recovery_report`` opens with ``"x"`` and ``hermes sessions
+    recover`` refuses the whole command when the report path already exists,
+    so a ``json.dump`` that dies part way blocks the next run before recovery
+    even starts.
+    """
+
+    destination = tmp_path / "recovered.db.recovery.json"
+
+    def _no_space(*args: object, **kwargs: object) -> None:
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(session_recovery.json, "dump", _no_space)
+    with pytest.raises(OSError, match="No space left on device"):
+        session_recovery.write_recovery_report(destination, {"operation": "recover"})
+
+    assert not os.path.lexists(destination)
+
+    monkeypatch.undo()
+    written = session_recovery.write_recovery_report(
+        destination,
+        {"operation": "recover"},
+    )
+    assert json.loads(written.read_text(encoding="utf-8")) == {
+        "operation": "recover"
+    }
+
+
+def test_report_write_never_removes_a_file_it_did_not_create(
+    tmp_path: Path,
+) -> None:
+    """The refusal itself must stay non-destructive.
+
+    ``open("x")`` raising ``FileExistsError`` means the report was written by
+    an earlier run, so the failure path must leave it exactly as it was.
+    """
+
+    destination = tmp_path / "recovered.db.recovery.json"
+    destination.write_text("earlier report", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        session_recovery.write_recovery_report(destination, {"operation": "recover"})
+
+    assert destination.read_text(encoding="utf-8") == "earlier report"
+
+
 def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

`hermes sessions recover` guards every write into the fresh destination database like this:

```python
except BaseException:
    destination.execute("ROLLBACK")
    raise
```

SQLite ends the transaction **by itself** under `SQLITE_FULL`, `SQLITE_IOERR`, `SQLITE_BUSY` and `SQLITE_NOMEM`. When it has, the explicit `ROLLBACK` raises `cannot rollback - no transaction is active` *from inside the exception handler*. That new error replaces the failure the handler was written to preserve, and the `raise` on the next line is never reached. The real cause is destroyed.

**What the user sees:** recovering a damaged `state.db` onto a destination that runs out of room reports

```
error: cannot rollback - no transaction is active
```

instead of `database or disk is full`.

It gets worse at the three copy sites. The substituted `OperationalError` is still a `DatabaseError`, so `_copy_table`'s own outer handler (`except sqlite3.DatabaseError`) swallows it, marks the table `partial`, and **recovery keeps going**. The user is handed a silently truncated recovery database, and the `use --work-dir or --output on a filesystem with more free space` guidance that `_disk_space_preflight` exists to give never appears. `KeyboardInterrupt` is converted the same way — it lands in `except BaseException`, comes back out as a `DatabaseError`, and so **Ctrl-C no longer stops the run**.

### This is the repo's own stated rule, and this was the last module breaking it

`hermes_cli/sqlite_util.py` (`write_txn`) documents the invariant verbatim:

> The explicit ROLLBACK is guarded so a SQLite auto-rollback (no active transaction left under EIO / lock contention / corruption) cannot shadow the original exception with a spurious rollback error.

…and implements it. `hermes_cli/kanban_db.py` and `hermes_state.py` already follow it too. Of the 11 production `execute("ROLLBACK")` sites in the repo, 6 were guarded and 5 were not — and all 5 unguarded ones were in `session_recovery.py`, the one module whose entire input is a hostile, already-damaged database.

### Why not just reuse `sqlite_util.write_txn`?

Because it catches `Exception`, not `BaseException`. Adopting it here would silently stop rolling the partial batch back on Ctrl-C, which is a behaviour regression — the `except BaseException` clauses in this module are deliberate. They are kept exactly as they were; only the unguarded `ROLLBACK` inside them changes.

### Why `sqlite3.Error` and not `sqlite3.OperationalError`?

Precedent in the repo splits (`sqlite_util`/`kanban_db` use `OperationalError`; `hermes_state.py` uses `sqlite3.Error`). This module is the case for the broader one: it tears its connections down in a `finally` block, so a rollback here can also land on an already-closed connection and raise `ProgrammingError`, which is not an `OperationalError`. Whatever the rollback itself fails with matters less than the exception already in flight. Non-SQLite errors still surface normally.

## Related Issue

No filed issue — found by sweeping the `execute("ROLLBACK")` sites in the repo against the invariant `sqlite_util.write_txn` already documents.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/session_recovery.py` — added `_rollback_without_masking()`, which performs the rollback and swallows only a `sqlite3.Error` raised *by the rollback itself*, so the original exception always propagates. The docstring names the auto-rollback error classes.
- Routed **all five** unguarded sites through it (the complete set in this module — no site is left behind):
  - `_copy_table`
  - `_copy_table_salvage.copy_range`
  - `_copy_state_meta`
  - `_cleanup_partial_orphans`
  - `_finalize_derived_metadata`
- `tests/hermes_cli/test_session_recovery.py` — 11 new regression tests (see below).

No behaviour changes beyond which exception survives: the rollback itself still happens at every site, and every `except BaseException` is preserved.

## How to Test

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_session_recovery.py -v
```

`15 passed` (4 pre-existing + 11 new).

**Fails before / passes after — verified in both directions.** With the production hunk reverted and the new tests in place, all 11 fail:

```
FAILED test_copy_table_reports_a_full_destination_not_a_rollback_failure
E   AssertionError: assert 'database or disk is full' in 'cannot rollback - no transaction is active'
FAILED test_cleanup_rollback_never_replaces_the_real_write_failure[_cleanup_partial_orphans]
FAILED test_cleanup_rollback_never_replaces_the_real_write_failure[_copy_state_meta]
FAILED test_cleanup_rollback_never_replaces_the_real_write_failure[_copy_table]
FAILED test_cleanup_rollback_never_replaces_the_real_write_failure[_copy_table_salvage]
FAILED test_cleanup_rollback_never_replaces_the_real_write_failure[_finalize_derived_metadata]
FAILED test_interrupt_during_a_write_still_aborts_the_recovery[...]   (5 params)
11 failed, 4 passed
```

Restoring the hunk gives `15 passed`.

The three new tests are:

1. `test_copy_table_reports_a_full_destination_not_a_rollback_failure` — **end-to-end against real SQLite with nothing stubbed.** Caps the destination with `PRAGMA max_page_count` so the copy begins and then genuinely hits `SQLITE_FULL` part way through, which is what a destination filesystem filling up mid-run actually looks like. Asserts the reported error is `database or disk is full` and *not* `cannot rollback`.
2. `test_cleanup_rollback_never_replaces_the_real_write_failure` — parameterized over **all five** sites. Uses a destination wrapper that reproduces SQLite's auto-rollback exactly (transaction already ended, so `ROLLBACK` fails), and asserts the real write error reaches the caller at every site.
3. `test_interrupt_during_a_write_still_aborts_the_recovery` — parameterized over **all five** sites. Asserts a `KeyboardInterrupt` raised during a write still propagates as a `KeyboardInterrupt` rather than being laundered into a `DatabaseError` that the copy sites treat as ordinary source damage. This is the test that pins the `except BaseException` behaviour so a future refactor to `except Exception` cannot pass silently.

Adjacent suites, each run in its own process:

| File | Result |
| --- | --- |
| `tests/hermes_cli/test_session_recovery.py` | 15 passed |
| `tests/hermes_cli/test_early_recovery.py` | 3 passed |
| `tests/hermes_cli/test_kanban_db_repair.py` | 4 passed |
| `tests/cli/test_cli_force_redraw.py` | 6 passed |
| `tests/cron/test_execution_ledger.py` | 18 passed |

## Scope / blast radius

Stated honestly: this is bounded by users of `hermes sessions recover`, i.e. people whose `state.db` is *already* damaged. That is a small population — but by construction this is their last resort, and `hermes sessions repair` routes them here by name. Within that population it fires on the most likely mid-run failures: a destination running out of space (the command writes a full snapshot bundle *plus* a second copy of the database, and `_disk_space_preflight`'s own comment concedes the estimate is a bet), an I/O error on the very hardware that damaged the database, lock contention, and Ctrl-C on a long run. No unusual prior state is required.

## Related / Positioning

- The only other open PR touching `tests/hermes_cli/test_session_recovery.py` is #75384, which touches the test file **only** and not `hermes_cli/session_recovery.py`. These additions are append-only, so they should not conflict.
- The open PRs touching `hermes_cli/session_recovery.py` (#72598, #73050, #73800, #74699, #76333, #76617, #77778, #80243, #81471) are all in different functions and none of them contains a `ROLLBACK` line.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused + adjacent suites listed above, not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.14, SQLite 3.50.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper carries the rationale in its docstring
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — the change is pure Python stdlib `sqlite3` exception handling with no platform-specific behaviour; the auto-rollback classes are SQLite-level, not OS-level
- [x] N/A — no tool behaviour changed
