### PR TITLE
fix(cron): avoid SessionDB leaks on skipped agent runs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3347,12 +3347,62 @@ def run_job(
                 f"{_monitor_context}\n\n{extra_prompt}" if extra_prompt else _monitor_context
             )
 
-    # ---------------------------------------------------------------
-    # Default (LLM) path — import and construct the agent machinery now
-    # that we know we actually need it. Doing these imports here instead of
-    # at module top keeps no_agent ticks from paying for AIAgent / SessionDB
-    # construction costs.
-    # ---------------------------------------------------------------
+    # Wake-gate: if this job has a pre-check script, run it BEFORE building
+    # the prompt or opening SessionDB so a ``{"wakeAgent": false}`` response
+    # can short-circuit without acquiring agent-only resources. We pass the
+    # result into _build_job_prompt so the script is only executed once.
+    prerun_script = None
+    script_path = job.get("script")
+    if script_path:
+        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
+        _ran_ok, _script_output = prerun_script
+        if _ran_ok and not _parse_wake_gate(_script_output):
+            logger.info(
+                "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
+                job_name, job_id,
+            )
+            silent_doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+                "Script gate returned `wakeAgent=false` — agent skipped.\n"
+            )
+            return True, silent_doc, SILENT_MARKER, None
+
+    try:
+        prompt = _build_job_prompt(
+            job, prerun_script=prerun_script, extra_prompt=extra_prompt
+        )
+    except CronPromptInjectionBlocked as block_exc:
+        # Assembled prompt (user prompt + loaded skill content) tripped the
+        # injection scanner. Refuse to run the agent this tick and surface
+        # a clear failure to the operator so they see WHY the scheduled job
+        # didn't run and can audit the offending skill.
+        logger.warning(
+            "Job '%s' (ID: %s): blocked by prompt-injection scanner — %s",
+            job_name, job_id, block_exc,
+        )
+        blocked_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"**Status:** BLOCKED\n\n"
+            "The assembled prompt (user prompt + loaded skill content) tripped "
+            "the cron injection scanner and the agent was NOT run.\n\n"
+            f"**Scanner result:** {block_exc}\n\n"
+            "Audit the skill(s) attached to this job for prompt-injection "
+            "payloads or invisible-unicode markers. If the skill is legitimate "
+            "and the match is a false positive, rephrase the content to avoid "
+            "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
+        )
+        return False, blocked_doc, "", str(block_exc)
+    if prompt is None:
+        logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
+        return True, "", SILENT_MARKER, None
+
+    # Import and construct agent-only machinery only after every wake/prompt
+    # gate has committed this tick to an LLM run. Idle minute-scheduled jobs
+    # must not open a SessionDB connection that an early return could leak.
     from run_agent import AIAgent
 
     # Initialize SQLite session store so cron job messages are persisted
@@ -3422,58 +3472,6 @@ def run_job(
     except Exception as e:
         logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
-    # Wake-gate: if this job has a pre-check script, run it BEFORE building
-    # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
-    # the whole agent run. We pass the result into _build_job_prompt so
-    # the script is only executed once.
-    prerun_script = None
-    script_path = job.get("script")
-    if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
-        _ran_ok, _script_output = prerun_script
-        if _ran_ok and not _parse_wake_gate(_script_output):
-            logger.info(
-                "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
-                job_name, job_id,
-            )
-            silent_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-                "Script gate returned `wakeAgent=false` — agent skipped.\n"
-            )
-            return True, silent_doc, SILENT_MARKER, None
-
-    try:
-        prompt = _build_job_prompt(
-            job, prerun_script=prerun_script, extra_prompt=extra_prompt
-        )
-    except CronPromptInjectionBlocked as block_exc:
-        # Assembled prompt (user prompt + loaded skill content) tripped the
-        # injection scanner. Refuse to run the agent this tick and surface
-        # a clear failure to the operator so they see WHY the scheduled job
-        # didn't run and can audit the offending skill.
-        logger.warning(
-            "Job '%s' (ID: %s): blocked by prompt-injection scanner — %s",
-            job_name, job_id, block_exc,
-        )
-        blocked_doc = (
-            f"# Cron Job: {job_name}\n\n"
-            f"**Job ID:** {job_id}\n"
-            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
-            f"**Status:** BLOCKED\n\n"
-            "The assembled prompt (user prompt + loaded skill content) tripped "
-            "the cron injection scanner and the agent was NOT run.\n\n"
-            f"**Scanner result:** {block_exc}\n\n"
-            "Audit the skill(s) attached to this job for prompt-injection "
-            "payloads or invisible-unicode markers. If the skill is legitimate "
-            "and the match is a false positive, rephrase the content to avoid "
-            "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
-        )
-        return False, blocked_doc, "", str(block_exc)
-    if prompt is None:
-        logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
-        return True, "", SILENT_MARKER, None
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1107,6 +1107,7 @@ class TestRunJobWakeGate:
 
         with patch.object(scheduler, "_run_job_script",
                           return_value=(True, '{"wakeAgent": false}')), \
+             patch("hermes_state.SessionDB") as session_db_cls, \
              patch("run_agent.AIAgent") as agent_cls:
             success, doc, final, err = scheduler.run_job(self._make_job())
 
@@ -1114,7 +1115,41 @@ class TestRunJobWakeGate:
         assert err is None
         assert final == SILENT_MARKER
         assert "Script gate returned `wakeAgent=false`" in doc
+        session_db_cls.assert_not_called()
         agent_cls.assert_not_called()
+
+    def test_prompt_injection_block_does_not_open_session_db(self):
+        """A blocked prompt exits before acquiring agent-only resources."""
+        import cron.scheduler as scheduler
+
+        with patch.object(scheduler, "_run_job_script",
+                          return_value=(True, '{"wakeAgent": true}')), \
+             patch.object(
+                 scheduler,
+                 "_build_job_prompt",
+                 side_effect=scheduler.CronPromptInjectionBlocked("blocked"),
+             ), \
+             patch("hermes_state.SessionDB") as session_db_cls:
+            success, _doc, _final, err = scheduler.run_job(self._make_job())
+
+        assert success is False
+        assert err == "blocked"
+        session_db_cls.assert_not_called()
+
+    def test_empty_prompt_does_not_open_session_db(self):
+        """A prompt-less script tick exits before opening the session store."""
+        import cron.scheduler as scheduler
+
+        with patch.object(scheduler, "_run_job_script",
+                          return_value=(True, '{"wakeAgent": true}')), \
+             patch.object(scheduler, "_build_job_prompt", return_value=None), \
+             patch("hermes_state.SessionDB") as session_db_cls:
+            success, _doc, final, err = scheduler.run_job(self._make_job())
+
+        assert success is True
+        assert final == SILENT_MARKER
+        assert err is None
+        session_db_cls.assert_not_called()
 
     def test_wake_true_runs_agent_with_injected_output(self):
         """When the script returns {wakeAgent: true, data: ...}, the agent is
@@ -1123,15 +1158,19 @@ class TestRunJobWakeGate:
 
         script_output = '{"wakeAgent": true, "data": {"new": 3}}'
         agent = MagicMock()
+        fake_db = MagicMock()
         agent.run_conversation = MagicMock(return_value={
             "final_response": "ok", "messages": []
         })
         with patch.object(scheduler, "_run_job_script",
                           return_value=(True, script_output)), \
+             patch("hermes_state.SessionDB", return_value=fake_db) as session_db_cls, \
              patch("run_agent.AIAgent", return_value=agent) as agent_cls:
             success, doc, final, err = scheduler.run_job(self._make_job())
 
         agent_cls.assert_called_once()
+        session_db_cls.assert_called_once_with()
+        fake_db.close.assert_called_once_with()
         # The script output should be visible in the prompt passed to
         # run_conversation.
         call_kwargs = agent.run_conversation.call_args
@@ -1974,5 +2013,4 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
 


### PR DESCRIPTION
## What does this PR do?

Cron scheduler ticks currently create SessionDB before evaluating the wake script and prompt gates. When a tick is disabled, prompt injection is blocked, or no prompt is available, run_job returns early without closing that database connection. In a long-lived gateway this steadily leaks SQLite file descriptors until unrelated cron work fails with too many open files.

This change defers the AIAgent import and SessionDB construction until after all non-running gates have passed. Real agent executions retain the existing finally-based close path.

## Related issue

N/A — reproduced from a production incident on current main after searching existing issues and pull requests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Tests

## Changes made

- Move wake-script and prompt eligibility checks before SessionDB acquisition in cron/scheduler.py.
- Add regression assertions proving skipped ticks never create SessionDB.
- Preserve the normal execution assertion that SessionDB is created once and closed once.

## How was this tested?

Canonical hermetic test runner:

    HERMES_PYTHON=/Users/waterloodigital/waterloo-digital/.venv/bin/python scripts/run_tests.sh tests/cron/test_scheduler.py tests/cron/test_sessiondb_init_hang.py -q

Result: 74 passed, 0 failed.

Also passed Ruff, py_compile, and git diff --check.

## Checklist

- [x] I have read CONTRIBUTING.md.
- [x] My commit uses the conventional commit format.
- [x] I searched for duplicate issues and pull requests.
- [x] My changes are limited to the reported defect.
- [x] I added regression tests.
- [x] I ran the focused canonical scheduler suite on macOS.
- [ ] I ran the full repository test suite.
- [x] No documentation, configuration, or schema changes are required.
- [x] Cross-platform behavior is unchanged; the fix only changes resource acquisition timing.