### PR TITLE
fix(cli): honor configured iteration budgets across entry paths

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -602,6 +602,7 @@ class SessionManager:
             return self._agent_factory()
 
         from run_agent import AIAgent
+        from hermes_cli.agent_budget import resolve_agent_max_turns
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -631,6 +632,7 @@ class SessionManager:
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
+            "max_iterations": resolve_agent_max_turns(config),
         }
 
         try:

--- a/cli.py
+++ b/cli.py
@@ -4499,6 +4499,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.api_key = api_key or os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
         else:
             self.api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
+        # Keep the CLI override so per-turn config refreshes cannot replace it.
+        self._max_turns_cli_override = max_turns
         # Max turns priority: CLI arg > config file > env var > default
         if max_turns is not None:  # CLI arg was explicitly set
             self.max_turns = max_turns
@@ -13882,6 +13884,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 pass
 
+    def _refresh_max_turns_from_config(self) -> None:
+        """Refresh the long-lived agent's iteration budget for the next turn."""
+        if getattr(self, "_max_turns_cli_override", None) is not None:
+            return
+
+        from hermes_cli.agent_budget import resolve_agent_max_turns
+
+        self.max_turns = resolve_agent_max_turns(load_cli_config())
+        if self.agent is not None:
+            self.agent.max_iterations = self.max_turns
+
     def chat(self, message, images: list = None, voice_input: bool = False) -> Optional[str]:
         """
         Send a message to the agent and get a response.
@@ -13916,6 +13929,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
             return None
+
+        self._refresh_max_turns_from_config()
 
         turn_route = self._resolve_turn_agent_config(message)
         if turn_route["signature"] != self._active_agent_route_signature:

--- a/hermes_cli/agent_budget.py
+++ b/hermes_cli/agent_budget.py
@@ -1,0 +1,51 @@
+"""Shared agent iteration-budget resolution for all entry points."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+
+DEFAULT_AGENT_MAX_TURNS = 500
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def resolve_agent_max_turns(
+    config: Mapping[str, Any] | None,
+    *,
+    explicit: int | None = None,
+    environ: Mapping[str, str] | None = None,
+    default: int = DEFAULT_AGENT_MAX_TURNS,
+) -> int:
+    """Resolve max turns with CLI-compatible precedence.
+
+    Precedence is explicit override, ``agent.max_turns``, the legacy root
+    ``max_turns`` key, ``HERMES_MAX_ITERATIONS``, then the default.
+    """
+    config = config or {}
+    agent_config = config.get("agent")
+    if not isinstance(agent_config, Mapping):
+        agent_config = {}
+    environment = os.environ if environ is None else environ
+
+    for value in (
+        explicit,
+        agent_config.get("max_turns"),
+        config.get("max_turns"),
+        environment.get("HERMES_MAX_ITERATIONS"),
+        default,
+    ):
+        resolved = _positive_int(value)
+        if resolved is not None:
+            return resolved
+    return DEFAULT_AGENT_MAX_TURNS

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -331,6 +331,7 @@ def _run_agent(
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
+    from hermes_cli.agent_budget import resolve_agent_max_turns
     from hermes_cli.models import detect_provider_for_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
@@ -443,6 +444,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            max_iterations=resolve_agent_max_turns(cfg),
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -93,7 +93,13 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m", "provider": "p"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {
+                "agent": {"max_turns": 200},
+                "model": {"default": "m", "provider": "p"},
+            },
+        ),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -118,6 +124,7 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     assert captured["session_db"] is sentinel_db
     assert captured["platform"] == "acp"
     assert captured["session_id"] == "acp-session"
+    assert captured["max_iterations"] == 200
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_cli_iteration_budget_refresh.py
+++ b/tests/cli/test_cli_iteration_budget_refresh.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import cli as cli_mod
+
+
+def _partial_cli(*, max_turns=90, explicit=None):
+    cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    cli.max_turns = max_turns
+    setattr(cli, "_max_turns_cli_override", explicit)
+    cli.agent = SimpleNamespace(max_iterations=max_turns)
+    return cli
+
+
+def test_refresh_updates_reused_agent_from_current_config(tmp_path, monkeypatch):
+    cli = _partial_cli()
+    (tmp_path / "config.yaml").write_text("agent:\n  max_turns: 200\n")
+    monkeypatch.setattr(cli_mod, "_hermes_home", tmp_path)
+
+    cli._refresh_max_turns_from_config()
+
+    assert cli.max_turns == 200
+    assert cli.agent is not None
+    assert cli.agent.max_iterations == 200
+
+
+def test_refresh_preserves_explicit_cli_override(tmp_path, monkeypatch):
+    cli = _partial_cli(max_turns=25, explicit=25)
+    (tmp_path / "config.yaml").write_text("agent:\n  max_turns: 200\n")
+    monkeypatch.setattr(cli_mod, "_hermes_home", tmp_path)
+
+    cli._refresh_max_turns_from_config()
+
+    assert cli.max_turns == 25
+    assert cli.agent is not None
+    assert cli.agent.max_iterations == 25
+
+
+def test_chat_refreshes_max_turns_before_agent_initialization():
+    cli = _partial_cli()
+    setattr(cli, "_secret_capture_callback", lambda *_args, **_kwargs: {})
+    cli._last_turn_interrupted = False
+    setattr(cli, "_active_agent_route_signature", "route")
+    route = {
+        "signature": "route",
+        "model": None,
+        "runtime": None,
+        "request_overrides": None,
+    }
+
+    with (
+        patch.object(cli, "_ensure_runtime_credentials", return_value=True),
+        patch.object(cli, "_resolve_turn_agent_config", return_value=route),
+        patch.object(cli, "_refresh_max_turns_from_config") as refresh,
+        patch.object(cli, "_init_agent", return_value=False),
+    ):
+        cli.chat("hello")
+
+    refresh.assert_called_once_with()

--- a/tests/hermes_cli/test_agent_budget.py
+++ b/tests/hermes_cli/test_agent_budget.py
@@ -1,0 +1,27 @@
+from hermes_cli.agent_budget import DEFAULT_AGENT_MAX_TURNS, resolve_agent_max_turns
+
+
+def test_nested_agent_max_turns_wins():
+    assert (
+        resolve_agent_max_turns(
+            {"agent": {"max_turns": 200}, "max_turns": 77},
+            environ={"HERMES_MAX_ITERATIONS": "66"},
+        )
+        == 200
+    )
+
+
+def test_legacy_env_and_default_fallbacks():
+    assert resolve_agent_max_turns({"max_turns": 77}, environ={}) == 77
+    assert resolve_agent_max_turns({}, environ={"HERMES_MAX_ITERATIONS": "66"}) == 66
+    assert resolve_agent_max_turns({}, environ={}) == DEFAULT_AGENT_MAX_TURNS
+
+
+def test_invalid_values_fail_closed_to_next_source():
+    assert (
+        resolve_agent_max_turns(
+            {"agent": {"max_turns": 0}, "max_turns": "invalid"},
+            environ={"HERMES_MAX_ITERATIONS": "55"},
+        )
+        == 55
+    )


### PR DESCRIPTION
## Summary
- resolve the configured agent iteration budget consistently for one-shot and ACP sessions
- refresh the long-lived interactive CLI agent between conversation turns
- preserve explicit CLI overrides over configuration values

## Verification
- 13 focused tests passed after the final rebase
- repository-native `scripts/run_tests.sh` passed
- Ruff and `git diff --check` passed
- deterministic privacy/Gitleaks pre-push gate passed
- independent exact-SHA review found no blocking or nonblocking findings