### PR TITLE
fix(agent): recognize venv-qualified pytest commands

### DIFF
--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -200,6 +200,20 @@ def _strip_command_prefix(tokens: list[str]) -> list[str]:
     return remaining
 
 
+def _normalize_python_test_executable(tokens: list[str]) -> list[str]:
+    """Normalize venv-qualified Python/pytest executables for suite matching."""
+    if not tokens:
+        return tokens
+    executable = _clean_token(tokens[0])
+    basename = executable.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    if basename in {"pytest", "pytest.exe"}:
+        return ["pytest", *tokens[1:]]
+    if re.fullmatch(r"python(?:3(?:\.\d+)?)?(?:\.exe)?", basename):
+        normalized = "python" if basename in {"python", "python.exe"} else "python3"
+        return [normalized, *tokens[1:]]
+    return tokens
+
+
 def _equivalent_needles(needle: list[str]) -> list[list[str]]:
     """Return command spellings equivalent to the detected canonical command."""
     candidates = [needle]
@@ -227,12 +241,17 @@ def _find_canonical_match(command: str, canonical_commands: list[str]) -> Option
     """Return ``(canonical, trailing_args)`` for the first detected command."""
 
     segments = _split_segment_tokens(command)
+    for windows_tokens in _split_segment_tokens(command, posix=False):
+        if windows_tokens not in segments:
+            segments.append(windows_tokens)
     for canonical in canonical_commands:
         needle = _canonical_tokens(canonical)
         if not needle:
             continue
         for tokens in segments:
-            candidate_tokens = _strip_command_prefix(tokens)
+            candidate_tokens = _normalize_python_test_executable(
+                _strip_command_prefix(tokens)
+            )
             for candidate in _equivalent_needles(needle):
                 if candidate_tokens[:len(candidate)] == candidate:
                     return canonical, candidate_tokens[len(candidate):]

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -82,6 +82,34 @@ def test_shell_wrappers_match_but_echo_does_not(tmp_path, monkeypatch):
     assert echoed is None
 
 
+def test_pytest_venv_executables_match_canonical_suite(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _python_project(tmp_path)
+
+    commands = (
+        "uv run pytest",
+        ".venv/bin/python -m pytest",
+        ".venv/bin/pytest",
+        "/opt/project/.venv/bin/python3.11 -m pytest",
+        r".venv\Scripts\pytest.exe",
+        r".venv\Scripts\python.exe -m pytest",
+        ".venv/Scripts/pytest.exe",
+        ".venv/Scripts/python.exe -m pytest",
+    )
+
+    for command in commands:
+        evidence = classify_verification_command(
+            command,
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+        )
+        assert evidence is not None, command
+        assert evidence.canonical_command == "pytest", command
+        assert evidence.kind == "test", command
+        assert evidence.scope == "full", command
+
+
 
 
 def test_temp_script_records_ad_hoc_evidence_without_canonical_suite(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- normalize semantically equivalent pytest launchers for verification evidence
- support POSIX virtualenv paths and Windows `.exe`/drive-qualified paths
- keep similarly named non-pytest commands excluded

## Verification
- 7 focused tests passed after the final rebase
- repository-native `scripts/run_tests.sh` passed
- Ruff and `git diff --check` passed
- deterministic privacy/Gitleaks pre-push gate passed
- independent exact-SHA review found no blocking or nonblocking findings