### PR TITLE
fix(tui): fix unreadable session-title chip contrast in the status bar

### DIFF
--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -116,7 +116,15 @@ describe('StatusRule session title', () => {
 
     expect(rendered).toContain('weekly-digest')
     expect(rendered).not.toContain('~/repo')
-    expect(title?.props.backgroundColor).toBe(DEFAULT_THEME.color.accent)
+    // Regression for issue #82465: a raw, full-saturation accent-hue
+    // background (e.g. #FFBF00 on DARK_SEEDS) paired with statusFg (a
+    // near-white tone never designed to sit on it) rendered at roughly a
+    // 1.5-2:1 contrast ratio -- unreadable. No background fill at all;
+    // the accent color goes on the text instead, matching the theme's
+    // own convention that a raw accent hue is never used as a solid
+    // fill elsewhere (fills are always softened, e.g. activeRow).
+    expect(title?.props.backgroundColor).toBeUndefined()
+    expect(title?.props.color).toBe(DEFAULT_THEME.color.accent)
   })
 })
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -751,9 +751,8 @@ export function StatusRule({
           <Text color={t.color.border}>{separatorWidth >= 3 ? ' ─ ' : ' '}</Text>
           <Box flexShrink={0} width={rightWidth}>
             <Text
-              backgroundColor={sessionTitle ? t.color.accent : undefined}
               bold={!!sessionTitle}
-              color={sessionTitle ? t.color.statusFg : t.color.label}
+              color={sessionTitle ? t.color.accent : t.color.label}
               wrap="truncate-end"
             >
               {rightLabel}


### PR DESCRIPTION
Fixes #82465.

## Problem

The session-name chip at the right end of the TUI status bar rendered white/near-white text (`t.color.statusFg`) on a raw, full-saturation accent-hue background (`t.color.accent`, `#FFBF00` -- bright yellow -- in `DARK_SEEDS`). Two token problems stacked: `accent` is the accent identity hue, never used elsewhere as a solid fill; and `statusFg` is a light-gray-lifted-toward-near-white tone never designed to sit on a saturated fill. Contrast landed around 1.5-2:1, unreadable on the default dark theme.

## Fix

Applied the issue's recommended first option: drop the background fill entirely and render the title as accent-colored text on the normal status bar background. Same highlight intent, readable contrast on both dark and light seeds.

## Verification

Updated the existing test that had encoded the buggy expectation, and added an explicit contrast-regression assertion. Verified as a genuine regression by reverting the fix and confirming the test fails with the exact reported `#FFBF00` background color.

54/54 pass across the three appChrome-related test files (no regression).