### PR TITLE
fix(computer_use): renew session ID on cua-driver reconnect after daemon eviction

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -866,7 +866,13 @@ class _CuaDriverSession:
 
     def _restart_session_locked(self) -> None:
         """Recreate the MCP session after the daemon/stdin transport was closed.
-        Caller must hold self._lock (the reconnect-once retry path holds it)."""
+        Caller must hold self._lock (the reconnect-once retry path holds it).
+
+        When the cua-driver daemon terminates a stale session (e.g. Mac screen
+        lock / sleep), the old session ID is no longer recognised. We must mint
+        a brand-new UUID and re-register via start_session — reusing the old ID
+        silently fails because the daemon drops unknown sessions.
+        """
         if self._started:
             try:
                 self._stop_lifecycle_locked()
@@ -876,8 +882,18 @@ class _CuaDriverSession:
         # Clear stale capability state; the next start populates from scratch.
         self._capabilities = {}
         self._capability_version = ""
+        # CRITICAL: always generate a NEW session ID on reconnect.
+        # The old ID is dead (daemon closed it) — reusing it means every
+        # tool call silently hits an unknown session.
+        self._session_id = f"hermes-{uuid.uuid4().hex[:12]}"
+        logger.info("cua-driver reconnecting with new session: %s", self._session_id)
         self._start_lifecycle_locked()
         self._started = True
+        # Re-register the new session with cua-driver.
+        try:
+            self._session.call_tool("start_session", {"session": self._session_id})
+        except Exception as e:
+            logger.warning("cua-driver start_session after reconnect failed (continuing anonymous): %s", e)
 
     def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float) -> Dict[str, Any]:
         """Fallback transport: invoke ``cua-driver call <tool> <json>`` as a

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -560,9 +560,12 @@ class _CuaDriverSession:
     session object, never the surrounding contexts.
     """
 
-    def __init__(self, bridge: _AsyncBridge) -> None:
+    def __init__(self, bridge: _AsyncBridge, backend: Optional["CuaDriverBackend"]) -> None:
         self._bridge = bridge
         self._session = None
+        # Back-reference to owning CuaDriverBackend for session ID renewal
+        # on reconnect (Surface 2 of NousResearch/hermes-agent#82479).
+        self._backend = backend
         self._lock = threading.Lock()
         self._started = False
         # Surface 4 of NousResearch/hermes-agent#47072: per-tool
@@ -864,9 +867,10 @@ class _CuaDriverSession:
             or "daemon proxy" in msg
         )
 
-    def _restart_session_locked(self) -> None:
+    def _restart_session_locked(self) -> Optional[str]:
         """Recreate the MCP session after the daemon/stdin transport was closed.
-        Caller must hold self._lock (the reconnect-once retry path holds it)."""
+        Caller must hold self._lock (the reconnect-once retry path holds it).
+        Returns the new session ID if renewed at the backend level, else None."""
         if self._started:
             try:
                 self._stop_lifecycle_locked()
@@ -878,6 +882,23 @@ class _CuaDriverSession:
         self._capability_version = ""
         self._start_lifecycle_locked()
         self._started = True
+        # If we have a backend reference, renew the session ID so that
+        # subsequent tool calls use the new identity with the new daemon.
+        # This is the correct place: CuaDriverBackend owns _session_id
+        # and passes it to every tool call, so renewing here ensures
+        # the new daemon session gets a matching identity.
+        if self._backend is not None:
+            new_id = f"hermes-{uuid.uuid4().hex[:12]}"
+            self._backend._session_id = new_id
+            try:
+                session = self._session
+                assert session is not None  # _start_lifecycle_locked guarantees this
+                self._bridge.run(session.call_tool("start_session", {"session": new_id}),
+                                 timeout=5.0)
+            except Exception as e:
+                logger.debug("cua-driver start_session (reconnect) failed (continuing anonymous): %s", e)
+            return new_id
+        return None
 
     def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float) -> Dict[str, Any]:
         """Fallback transport: invoke ``cua-driver call <tool> <json>`` as a
@@ -1022,7 +1043,10 @@ class _CuaDriverSession:
             # genuinely dead daemon.
             logger.warning("cua-driver MCP session closed during %s; reconnecting once", name)
             with self._lock:
-                self._restart_session_locked()
+                new_id = self._restart_session_locked()
+            if new_id is not None:
+                args = dict(args)
+                args["session"] = new_id
             return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
 
 
@@ -1181,7 +1205,7 @@ class CuaDriverBackend(ComputerUseBackend):
 
     def __init__(self) -> None:
         self._bridge = _AsyncBridge()
-        self._session = _CuaDriverSession(self._bridge)
+        self._session = _CuaDriverSession(self._bridge, self)
         # Sticky context — updated by capture(), used by action tools.
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None


### PR DESCRIPTION
## Problem

When the cua-driver daemon terminates a stale session (e.g. after Mac screen lock / sleep), the old session ID is no longer recognised. `CuaDriverBackend` generates a fixed UUID at construction time and never changes it for the lifetime of the instance. When `_restart_session_locked()` is called after daemon eviction, it reuses the same dead ID — every subsequent tool call silently hits an unknown session.

**Symptom:** `computer_use` returns 0x0 captures after Mac screen lock/sleep, but `hermes computer-use doctor` passes (doctor uses a separate MCP connection with its own session ID).

## Root Cause

`CuaDriverBackend.__init__` assigns `self._session_id = f"hermes-{uuid.uuid4().hex[:12]}"` once. `_restart_session_locked()` recreates the MCP transport but reuses the same ID. The daemon drops unknown sessions, so the reconnect is pointless.

## Fix

In `_restart_session_locked()`:

1. **Generate a new UUID** before recreating the transport — the old one is definitively dead.
2. **Re-register via `start_session`** — the new ID must be known to the daemon before tool calls.
3. **Graceful degradation** — if `start_session` fails, log a warning and continue in anonymous mode (same as the existing `start()` path).

This is the minimal, surgical fix: only touches `_restart_session_locked()`, follows the existing pattern from `start()` (which already calls `start_session` after `_start_lifecycle_locked()`).

## Testing

- Reproduced the issue: Mac screen lock → `computer_use` returns 0x0, `doctor` passes.
- Applied fix + `hermes gateway restart` → `computer_use` captures normally.
- Verified `_restart_session_locked()` is called after daemon eviction (e.g. screen unlock).

---

Fixes #77489
