### PR TITLE
feat(terminal): add bounded CI completion wakeup

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -382,7 +382,13 @@ class TestStubSchemaDrift(unittest.TestCase):
     # Parameters that are internal (injected by the handler, not user-facing)
     _INTERNAL_PARAMS = {"task_id", "user_task"}
     # Parameters intentionally blocked in the sandbox
-    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
+    _BLOCKED_TERMINAL_PARAMS = {
+        "background",
+        "pty",
+        "notify_on_complete",
+        "watch_patterns",
+        "ci_wait_timeout",
+    }
 
     def test_stubs_cover_all_schema_params(self):
         """Every user-facing parameter in the real schema must appear in the

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -130,6 +130,38 @@ class TestCompletionQueue:
         ids = {c["session_id"] for c in completions}
         assert ids == {"proc_0", "proc_1", "proc_2"}
 
+    def test_arming_after_ultrafast_exit_enqueues_exactly_once(self, registry):
+        session = _make_session(notify_on_complete=False, output="done")
+        session.exited = True
+        session.exit_code = 0
+        registry._finished[session.id] = session
+
+        registry.arm_completion_notification(session)
+        registry.arm_completion_notification(session)
+
+        assert registry.completion_queue.qsize() == 1
+        completion = registry.completion_queue.get_nowait()
+        assert completion["session_id"] == session.id
+        assert completion["exit_code"] == 0
+
+    def test_ultrafast_local_processes_never_lose_completion(self, registry, tmp_path):
+        with patch.object(registry, "_write_checkpoint"):
+            sessions = []
+            for _ in range(50):
+                session = registry.spawn_local("true", cwd=str(tmp_path))
+                registry.arm_completion_notification(session)
+                sessions.append(session)
+
+            assert all(session._completion_event.wait(5) for session in sessions)
+
+        completions = []
+        while not registry.completion_queue.empty():
+            completions.append(registry.completion_queue.get_nowait())
+        assert len(completions) == len(sessions)
+        assert {event["session_id"] for event in completions} == {
+            session.id for session in sessions
+        }
+
 
 # =========================================================================
 # Checkpoint persistence
@@ -195,6 +227,10 @@ class TestCodeExecutionBlocked:
     def test_notify_on_complete_blocked_in_sandbox(self):
         from tools.code_execution_tool import _TERMINAL_BLOCKED_PARAMS
         assert "notify_on_complete" in _TERMINAL_BLOCKED_PARAMS
+
+    def test_ci_wait_timeout_blocked_in_sandbox(self):
+        from tools.code_execution_tool import _TERMINAL_BLOCKED_PARAMS
+        assert "ci_wait_timeout" in _TERMINAL_BLOCKED_PARAMS
 
 
 # =========================================================================
@@ -301,17 +337,10 @@ def _silent_bg_harness(monkeypatch, tmp_path):
     dummy_env = SimpleNamespace(env={})
 
     def fake_spawn_local(**kwargs):
-        return SimpleNamespace(
+        return ProcessSession(
             id="proc_silent_test",
+            command=kwargs["command"],
             pid=4242,
-            notify_on_complete=False,
-            watcher_platform="",
-            watcher_chat_id="",
-            watcher_user_id="",
-            watcher_user_name="",
-            watcher_thread_id="",
-            watcher_message_id="",
-            watcher_interval=0,
         )
 
     monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
@@ -435,3 +464,436 @@ def test_non_ci_background_command_does_not_emit_homebrew_hint(monkeypatch, tmp_
     assert "hint" not in result, (
         f"Non-CI command using awk must not be flagged as homebrew CI poller, got: {result.get('hint')!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Bounded CI wait promotion
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_schema_exposes_bounded_ci_wait():
+    from tools.terminal_tool import TERMINAL_SCHEMA
+
+    prop = TERMINAL_SCHEMA["parameters"]["properties"]["ci_wait_timeout"]
+    assert prop["type"] == "integer"
+    assert prop["minimum"] == 30
+    assert prop["maximum"] == 3600
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh pr checks --watch",
+        "gh pr checks 123 | cat",
+        "gh pr checks 123 && echo unsafe",
+        "gh issue checks 123",
+    ],
+)
+def test_ci_wait_rejects_unrecognized_command_shapes(command):
+    from tools.terminal_tool import _parse_gh_pr_checks
+
+    assert _parse_gh_pr_checks(command) is None
+
+
+def test_ci_wait_builds_checks_and_sha_drift_guard():
+    from tools.terminal_tool import _build_bounded_ci_wait_command, _parse_gh_pr_checks
+
+    parsed = _parse_gh_pr_checks("gh pr checks 123 --required --repo owner/repo")
+    assert parsed is not None
+
+    wrapper = _build_bounded_ci_wait_command(parsed, timeout=300)
+
+    assert "gh pr checks 123 --required --repo owner/repo" in wrapper
+    assert "gh pr view 123 --repo owner/repo --json headRefOid" in wrapper
+    assert "CI_WAIT_SUCCESS" in wrapper
+    assert "CI_WAIT_FAILURE" in wrapper
+    assert "CI_WAIT_TIMEOUT" in wrapper
+    assert "CI_WAIT_SHA_DRIFT" in wrapper
+
+
+def test_pending_ci_check_promotes_to_notifying_background_wait(monkeypatch, tmp_path):
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    from tools import process_registry as process_registry_module
+    from types import SimpleNamespace
+
+    spawned = {}
+
+    class PendingEnv:
+        env = {}
+        cwd = str(tmp_path)
+
+        def execute(self, command, **kwargs):
+            if command.startswith("gh pr view"):
+                return {"returncode": 0, "output": f"{1:040d}"}
+            assert command == "gh pr checks 123 --required"
+            return {"returncode": 8, "output": "build\tpending"}
+
+    def fake_spawn_local(**kwargs):
+        spawned.update(kwargs)
+        return ProcessSession(
+            id="proc_ci_wait",
+            command=kwargs["command"],
+            pid=4242,
+        )
+
+    monkeypatch.setitem(tt._active_environments, "default", PendingEnv())
+    monkeypatch.setattr(process_registry_module.process_registry, "spawn_local", fake_spawn_local)
+    monkeypatch.setattr("gateway.session_context.async_delivery_supported", lambda: True)
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command="gh pr checks 123 --required",
+                ci_wait_timeout=300,
+            )
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert result["exit_code"] == 8
+    assert result["ci_wait_status"] == "pending"
+    assert result["ci_wait_session_id"] == "proc_ci_wait"
+    assert result["notify_on_complete"] is True
+    assert "CI_WAIT_SHA_DRIFT" in spawned["command"]
+    assert f"ci_wait_expected_sha={1:040d}" in spawned["command"]
+
+
+@pytest.mark.parametrize(
+    ("kill_status", "expected_wait_status"),
+    [
+        ("error", "cleanup_failed"),
+        ("not_found", "cleanup_failed"),
+        ("killed", "not_started"),
+        ("already_exited", "not_started"),
+    ],
+)
+def test_pending_ci_reports_verified_waiter_cleanup(
+    monkeypatch, tmp_path, kill_status, expected_wait_status
+):
+    """Claim cleanup only for registry statuses that prove the waiter stopped."""
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    from tools import process_registry as process_registry_module
+
+    class PendingEnv:
+        env = {}
+        cwd = str(tmp_path)
+
+        def execute(self, command, **kwargs):
+            if command.startswith("gh pr view"):
+                return {"returncode": 0, "output": f"{1:040d}"}
+            assert command == "gh pr checks 123"
+            return {"returncode": 8, "output": "build\tpending"}
+
+    def fake_spawn_local(**kwargs):
+        return ProcessSession(
+            id="proc_cleanup_failed",
+            command=kwargs["command"],
+            pid=4242,
+        )
+
+    monkeypatch.setitem(tt._active_environments, "default", PendingEnv())
+    monkeypatch.setattr(process_registry_module.process_registry, "spawn_local", fake_spawn_local)
+    monkeypatch.setattr(
+        process_registry_module.process_registry,
+        "kill_process",
+        lambda _session_id: {"status": kill_status, "error": "synthetic refusal"},
+    )
+    monkeypatch.setattr("gateway.session_context.async_delivery_supported", lambda: False)
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command="gh pr checks 123",
+                ci_wait_timeout=300,
+            )
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert result["status"] == "error"
+    assert result["ci_wait_status"] == expected_wait_status
+    if expected_wait_status == "cleanup_failed":
+        assert result["ci_wait_session_id"] == "proc_cleanup_failed"
+        assert "could not be verified" in result["error"]
+        assert "no CI waiter was left running" not in result["error"]
+    else:
+        assert "ci_wait_session_id" not in result
+        assert "no CI waiter was left running" in result["error"]
+
+
+def test_promoted_ci_wait_enqueues_completion_wakeup(monkeypatch, tmp_path):
+    """Prove the promoted waiter reaches the existing async completion rail."""
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    from tools import process_registry as process_registry_module
+    from tools.process_registry import ProcessRegistry
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    gh = fake_bin / "gh"
+    gh.write_text(
+        """#!/bin/bash
+if [ "$1 $2" = "pr view" ]; then
+  printf '%040d\n' 1
+  exit 0
+fi
+printf 'build\tpass\n'
+exit 0
+"""
+    )
+    gh.chmod(0o755)
+    fake_shell = fake_bin / "shell"
+    fake_shell.write_text('#!/bin/bash\nexec /bin/bash -c "$2"\n')
+    fake_shell.chmod(0o755)
+
+    class PendingEnv:
+        cwd = str(tmp_path)
+        env = {**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"}
+
+        def execute(self, command, **kwargs):
+            if command.startswith("gh pr view"):
+                return {"returncode": 0, "output": f"{1:040d}"}
+            assert command == "gh pr checks 123"
+            return {"returncode": 8, "output": "build\tpending"}
+
+    fresh_registry = ProcessRegistry()
+    monkeypatch.setattr(process_registry_module, "process_registry", fresh_registry)
+    monkeypatch.setattr(process_registry_module, "_find_shell", lambda: str(fake_shell))
+    monkeypatch.setitem(tt._active_environments, "default", PendingEnv())
+    monkeypatch.setattr("gateway.session_context.async_delivery_supported", lambda: True)
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command="gh pr checks 123",
+                ci_wait_timeout=300,
+                task_id="ci-wakeup-test",
+            )
+        )
+        process_id = result["ci_wait_session_id"]
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            session = fresh_registry.get(process_id)
+            if (
+                session is not None
+                and session.exited
+                and not fresh_registry.completion_queue.empty()
+            ):
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("promoted CI waiter did not exit")
+
+        notifications = fresh_registry.drain_notifications(
+            skip_poll_observed=False,
+        )
+    finally:
+        fresh_registry.kill_all()
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert len(notifications) == 1
+    event, synthetic_message = notifications[0]
+    assert event["session_id"] == process_id
+    assert event["exit_code"] == 0
+    assert "CI_WAIT_SUCCESS" in synthetic_message
+
+
+def test_ci_wait_option_fails_closed_for_non_gh_command(monkeypatch, tmp_path):
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+
+    result = json.loads(
+        tt.terminal_tool(command="pytest -q", ci_wait_timeout=300)
+    )
+
+    assert "requires an exact `gh pr checks" in result["error"]
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_rc", "marker", "expected_checks", "expected_views"),
+    [
+        ("success", 0, "CI_WAIT_SUCCESS", 2, 4),
+        ("success-drift", 75, "CI_WAIT_SHA_DRIFT", 2, 4),
+        ("failure", 1, "CI_WAIT_FAILURE", 1, 2),
+        ("failure-drift", 75, "CI_WAIT_SHA_DRIFT", 1, 2),
+        ("timeout", 124, "CI_WAIT_TIMEOUT", 1, 2),
+        ("drift", 75, "CI_WAIT_SHA_DRIFT", 0, 1),
+        ("post-pending-drift", 75, "CI_WAIT_SHA_DRIFT", 1, 2),
+        ("in-loop-drift", 75, "CI_WAIT_SHA_DRIFT", 1, 3),
+        ("lookup-pre", 70, "CI_WAIT_SHA_LOOKUP_FAILURE", 0, 1),
+        ("lookup-post", 70, "CI_WAIT_SHA_LOOKUP_FAILURE", 1, 2),
+    ],
+)
+def test_bounded_ci_wait_wrapper_resolves_explicitly(
+    tmp_path, mode, expected_rc, marker, expected_checks, expected_views
+):
+    """Exercise the generated poller as a real shell process.
+
+    Fake date/sleep binaries make backoff deterministic and instantaneous;
+    the wrapper itself, its gh exit-code handling, and every terminal state are
+    real rather than mocked.
+    """
+    import subprocess
+
+    from tools.terminal_tool import _build_bounded_ci_wait_command, _parse_gh_pr_checks
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    gh = fake_bin / "gh"
+    gh.write_text(
+        """#!/bin/bash
+mode=$CI_WAIT_TEST_MODE
+if [ "$1 $2" = "pr view" ]; then
+  count=$(cat "$CI_WAIT_TEST_DIR/view_count" 2>/dev/null || printf 0)
+  printf '%s' $((count + 1)) > "$CI_WAIT_TEST_DIR/view_count"
+  [ "$mode" = lookup-pre ] && [ "$count" -ge 0 ] && exit 1
+  [ "$mode" = lookup-post ] && [ "$count" -ge 1 ] && exit 1
+  if { [ "$mode" = drift ] && [ "$count" -ge 0 ]; } ||
+     { [ "$mode" = post-pending-drift ] && [ "$count" -ge 1 ]; } ||
+     { [ "$mode" = in-loop-drift ] && [ "$count" -ge 2 ]; } ||
+     { [ "$mode" = success-drift ] && [ "$count" -ge 3 ]; } ||
+     { [ "$mode" = failure-drift ] && [ "$count" -ge 1 ]; }; then
+    printf '%040d\n' 2
+  else
+    printf '%040d\n' 1
+  fi
+  exit 0
+fi
+count=$(cat "$CI_WAIT_TEST_DIR/check_count" 2>/dev/null || printf 0)
+printf '%s' $((count + 1)) > "$CI_WAIT_TEST_DIR/check_count"
+case "$mode" in
+  success|success-drift) [ "$count" -eq 0 ] && exit 8; printf 'build\tpass\n'; exit 0 ;;
+  failure|failure-drift) printf 'build\tfail\n'; exit 1 ;;
+  timeout) exit 8 ;;
+esac
+exit 8
+"""
+    )
+    gh.chmod(0o755)
+
+    fake_date = fake_bin / "date"
+    fake_date.write_text(
+        """#!/bin/bash
+count=$(cat "$CI_WAIT_TEST_DIR/date_count" 2>/dev/null || printf 0)
+printf '%s' $((count + 1)) > "$CI_WAIT_TEST_DIR/date_count"
+if [ "$CI_WAIT_TEST_MODE" = timeout ] && [ "$count" -ge 1 ]; then
+  printf '101\n'
+else
+  printf '100\n'
+fi
+"""
+    )
+    fake_date.chmod(0o755)
+    fake_sleep = fake_bin / "sleep"
+    fake_sleep.write_text("#!/bin/bash\nexit 0\n")
+    fake_sleep.chmod(0o755)
+
+    parsed = _parse_gh_pr_checks("gh pr checks 123")
+    assert parsed is not None
+    wrapper = _build_bounded_ci_wait_command(
+        parsed, timeout=1, expected_sha=f"{1:040d}"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "CI_WAIT_TEST_MODE": mode,
+            "CI_WAIT_TEST_DIR": str(tmp_path),
+        }
+    )
+
+    completed = subprocess.run(
+        ["/bin/bash", "-c", wrapper],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=5,
+        check=False,
+    )
+
+    assert completed.returncode == expected_rc, completed.stdout + completed.stderr
+    assert marker in completed.stdout
+    check_count = tmp_path / "check_count"
+    actual_checks = int(check_count.read_text()) if check_count.exists() else 0
+    assert actual_checks == expected_checks
+    assert int((tmp_path / "view_count").read_text()) == expected_views
+
+
+@pytest.mark.parametrize("checks_rc", [0, 1, 8])
+def test_foreground_ci_result_fails_closed_when_head_changes(
+    monkeypatch, tmp_path, checks_rc
+):
+    """Success and failure are both invalid when the PR head moved mid-check."""
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+
+    class DriftingEnv:
+        env = {}
+        cwd = str(tmp_path)
+        view_calls = 0
+        checks_calls = 0
+
+        def execute(self, command, **kwargs):
+            if command.startswith("gh pr view"):
+                self.view_calls += 1
+                return {
+                    "returncode": 0,
+                    "output": f"{self.view_calls:040d}",
+                }
+            assert command == "gh pr checks 123"
+            self.checks_calls += 1
+            return {"returncode": checks_rc, "output": "checks result"}
+
+    env = DriftingEnv()
+    monkeypatch.setitem(tt._active_environments, "default", env)
+    try:
+        result = json.loads(
+            tt.terminal_tool(command="gh pr checks 123", ci_wait_timeout=300)
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert result["exit_code"] == 75
+    assert "CI_WAIT_SHA_DRIFT" in result["output"]
+    assert env.view_calls == 2
+    assert env.checks_calls == 1
+
+
+@pytest.mark.parametrize(("failure_at", "expected_checks"), [(1, 0), (2, 1)])
+def test_foreground_ci_fails_closed_on_sha_lookup_error(
+    monkeypatch, tmp_path, failure_at, expected_checks
+):
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+
+    class LookupFailureEnv:
+        env = {}
+        cwd = str(tmp_path)
+        view_calls = 0
+        checks_calls = 0
+
+        def execute(self, command, **kwargs):
+            if command.startswith("gh pr view"):
+                self.view_calls += 1
+                if self.view_calls == failure_at:
+                    return {"returncode": 1, "output": "lookup failed"}
+                return {"returncode": 0, "output": f"{1:040d}"}
+            assert command == "gh pr checks 123"
+            self.checks_calls += 1
+            return {"returncode": 0, "output": "build\tpass"}
+
+    env = LookupFailureEnv()
+    monkeypatch.setitem(tt._active_environments, "default", env)
+    try:
+        result = json.loads(
+            tt.terminal_tool(command="gh pr checks 123", ci_wait_timeout=300)
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert set(result) == {"error"}
+    if failure_at == 1:
+        assert "Unable to bind the CI wait" in result["error"]
+        assert "no checks command or waiter was started" in result["error"]
+    else:
+        assert "Unable to revalidate the PR head" in result["error"]
+    assert env.view_calls == failure_at
+    assert env.checks_calls == expected_checks

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -647,7 +647,13 @@ def _call(tool_name, args):
 # ---------------------------------------------------------------------------
 
 # Terminal parameters that must not be used from ephemeral sandbox scripts
-_TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
+_TERMINAL_BLOCKED_PARAMS = {
+    "background",
+    "pty",
+    "notify_on_complete",
+    "watch_patterns",
+    "ci_wait_timeout",
+}
 
 
 def _rpc_server_loop(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -386,6 +386,7 @@ class ProcessSession:
     _watch_strike_candidate: bool = field(default=False, repr=False)
     _watch_consecutive_strikes: int = field(default=0, repr=False)
     _completion_event: threading.Event = field(default_factory=threading.Event, repr=False)
+    _completion_enqueued: bool = field(default=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
@@ -1555,23 +1556,45 @@ class ProcessRegistry:
         # Only enqueue completion notification on the FIRST move.  Without
         # this guard, kill_process() and the reader thread can both call
         # _move_to_finished(), producing duplicate [IMPORTANT: ...] messages.
-        if was_running and session.notify_on_complete:
-            from tools.ansi_strip import strip_ansi
-            output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
-            self.completion_queue.put({
-                "type": "completion",
-                "session_id": session.id,
-                "session_key": session.session_key,
-                "command": session.command,
-                "exit_code": session.exit_code,
-                "completion_reason": session.completion_reason,
-                "termination_source": session.termination_source,
-                "output": output_tail,
-                # Stable producer identity across checkpoint recovery; unlike
-                # a consumer-observed completion timestamp, this does not vary
-                # based on which watcher notices exit first.
-                "started_at": session.started_at,
-            })
+        if was_running:
+            with session._lock:
+                self._enqueue_completion_locked(session)
+
+    def arm_completion_notification(self, session: ProcessSession) -> None:
+        """Enable completion delivery without losing an ultra-fast exit.
+
+        Background reader threads start inside ``spawn_*``.  A short process can
+        therefore finish before the terminal handler has attached notification
+        metadata.  Arming and enqueueing under the session lock closes that race
+        while ``_completion_enqueued`` preserves exactly-once delivery.
+        """
+        with session._lock:
+            session.notify_on_complete = True
+            if session.exited:
+                self._enqueue_completion_locked(session)
+
+    def _enqueue_completion_locked(self, session: ProcessSession) -> None:
+        """Queue one completion event; caller must hold ``session._lock``."""
+        if not session.notify_on_complete or session._completion_enqueued:
+            return
+        from tools.ansi_strip import strip_ansi
+
+        output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
+        self.completion_queue.put({
+            "type": "completion",
+            "session_id": session.id,
+            "session_key": session.session_key,
+            "command": session.command,
+            "exit_code": session.exit_code,
+            "completion_reason": session.completion_reason,
+            "termination_source": session.termination_source,
+            "output": output_tail,
+            # Stable producer identity across checkpoint recovery; unlike
+            # a consumer-observed completion timestamp, this does not vary
+            # based on which watcher notices exit first.
+            "started_at": session.started_at,
+        })
+        session._completion_enqueued = True
 
     # ----- Query Methods -----
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2352,6 +2352,151 @@ def _resolve_command_cwd(
     return get_session_cwd(session_key) or default_cwd
 
 
+def _parse_gh_pr_checks(command: str) -> Optional[Dict[str, List[str]]]:
+    """Recognize the narrow ``gh pr checks`` shape eligible for CI waiting.
+
+    This deliberately rejects shell composition, watch/structured-output modes,
+    and unknown flags.  ``ci_wait_timeout`` must never turn an arbitrary model-
+    supplied shell command into a durable background process.
+    """
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+    if argv[:3] != ["gh", "pr", "checks"]:
+        return None
+
+    selector: Optional[str] = None
+    repo: Optional[str] = None
+    index = 3
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--required":
+            index += 1
+            continue
+        if arg in {"--repo", "-R"}:
+            if index + 1 >= len(argv) or repo is not None:
+                return None
+            repo = argv[index + 1]
+            if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
+                return None
+            index += 2
+            continue
+        if arg.startswith("-") or selector is not None:
+            return None
+        # gh accepts a PR number, URL, or branch name. Keep that flexibility,
+        # but reject every shell metacharacter rather than trying to sanitize it.
+        if not re.fullmatch(r"[A-Za-z0-9_./:#-]+", arg):
+            return None
+        selector = arg
+        index += 1
+
+    checks_argv = argv
+    view_argv = ["gh", "pr", "view"]
+    if selector:
+        view_argv.append(selector)
+    if repo:
+        view_argv.extend(["--repo", repo])
+    view_argv.extend(["--json", "headRefOid", "--jq", ".headRefOid"])
+    return {"checks_argv": checks_argv, "view_argv": view_argv}
+
+
+def _build_bounded_ci_wait_command(
+    parsed: Dict[str, List[str]],
+    *,
+    timeout: int,
+    expected_sha: Optional[str] = None,
+) -> str:
+    """Build a bounded, exit-code-driven CI poller for the active backend."""
+    checks = shlex.join(parsed["checks_argv"])
+    view = shlex.join(parsed["view_argv"])
+    expected_setup = (
+        f"ci_wait_expected_sha={shlex.quote(expected_sha)}"
+        if expected_sha is not None
+        else f"ci_wait_expected_sha=$({view} 2>/dev/null)"
+    )
+    return f"""\
+ci_wait_deadline=$(( $(date +%s) + {timeout} ))
+ci_wait_delay=10
+{expected_setup}
+if [ "${{#ci_wait_expected_sha}}" -ne 40 ]; then
+  printf '%s\n' 'CI_WAIT_SETUP_FAILURE unable to resolve PR head SHA'
+  exit 70
+fi
+case "$ci_wait_expected_sha" in
+  *[!0-9a-fA-F]*) printf '%s\n' 'CI_WAIT_SETUP_FAILURE invalid PR head SHA'; exit 70 ;;
+esac
+while :; do
+  ci_wait_current_sha=$({view} 2>/dev/null)
+  if [ "${{#ci_wait_current_sha}}" -ne 40 ]; then
+    printf '%s\n' 'CI_WAIT_SHA_LOOKUP_FAILURE unable to resolve current PR head SHA'
+    exit 70
+  fi
+  case "$ci_wait_current_sha" in
+    *[!0-9a-fA-F]*) printf '%s\n' 'CI_WAIT_SHA_LOOKUP_FAILURE invalid current PR head SHA'; exit 70 ;;
+  esac
+  if [ "$ci_wait_current_sha" != "$ci_wait_expected_sha" ]; then
+    printf 'CI_WAIT_SHA_DRIFT expected=%s actual=%s\n' "$ci_wait_expected_sha" "$ci_wait_current_sha"
+    exit 75
+  fi
+  ci_wait_output=$({checks} 2>&1)
+  ci_wait_rc=$?
+  ci_wait_verified_sha=$({view} 2>/dev/null)
+  if [ "${{#ci_wait_verified_sha}}" -ne 40 ]; then
+    printf '%s\n' 'CI_WAIT_SHA_LOOKUP_FAILURE unable to verify PR head after checks'
+    exit 70
+  fi
+  case "$ci_wait_verified_sha" in
+    *[!0-9a-fA-F]*) printf '%s\n' 'CI_WAIT_SHA_LOOKUP_FAILURE invalid PR head after checks'; exit 70 ;;
+  esac
+  if [ "$ci_wait_verified_sha" != "$ci_wait_expected_sha" ]; then
+    printf 'CI_WAIT_SHA_DRIFT expected=%s actual=%s\n' "$ci_wait_expected_sha" "$ci_wait_verified_sha"
+    exit 75
+  fi
+  if [ "$ci_wait_rc" -eq 0 ]; then
+    [ -n "$ci_wait_output" ] && printf '%s\n' "$ci_wait_output"
+    printf 'CI_WAIT_SUCCESS sha=%s\n' "$ci_wait_expected_sha"
+    exit 0
+  fi
+  if [ "$ci_wait_rc" -ne 8 ]; then
+    [ -n "$ci_wait_output" ] && printf '%s\n' "$ci_wait_output"
+    printf 'CI_WAIT_FAILURE exit_code=%s sha=%s\n' "$ci_wait_rc" "$ci_wait_expected_sha"
+    exit "$ci_wait_rc"
+  fi
+  ci_wait_now=$(date +%s)
+  if [ "$ci_wait_now" -ge "$ci_wait_deadline" ]; then
+    printf 'CI_WAIT_TIMEOUT timeout_seconds={timeout} sha=%s\n' "$ci_wait_expected_sha"
+    exit 124
+  fi
+  ci_wait_remaining=$(( ci_wait_deadline - ci_wait_now ))
+  ci_wait_sleep=$ci_wait_delay
+  [ "$ci_wait_sleep" -gt "$ci_wait_remaining" ] && ci_wait_sleep=$ci_wait_remaining
+  sleep "$ci_wait_sleep"
+  [ "$ci_wait_delay" -lt 60 ] && ci_wait_delay=$(( ci_wait_delay * 2 ))
+  [ "$ci_wait_delay" -gt 60 ] && ci_wait_delay=60
+done"""
+
+
+def _resolve_ci_wait_expected_sha(
+    env: Any,
+    parsed: Dict[str, List[str]],
+    *,
+    cwd: str,
+    timeout: int,
+) -> Optional[str]:
+    """Resolve and validate the PR head through the active terminal backend."""
+    result = env.execute(
+        shlex.join(parsed["view_argv"]),
+        timeout=min(timeout, 30),
+        cwd=cwd,
+        bounded_capture=True,
+    )
+    candidate = str(result.get("output") or "").strip()
+    if result.get("returncode") != 0 or not re.fullmatch(r"[0-9a-fA-F]{40}", candidate):
+        return None
+    return candidate
+
+
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -2363,6 +2508,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    ci_wait_timeout: Optional[int] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2378,6 +2524,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        ci_wait_timeout: For an exact foreground ``gh pr checks`` command, promote exit 8 (pending) to a bounded background poller and notify on resolution.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2470,6 +2617,29 @@ def terminal_tool(
                 f"timeout must be a positive number of seconds (got {timeout})."
             )
         effective_timeout = timeout or default_timeout
+
+        ci_wait_parsed = None
+        if ci_wait_timeout is not None:
+            if (
+                isinstance(ci_wait_timeout, bool)
+                or not isinstance(ci_wait_timeout, int)
+                or not 30 <= ci_wait_timeout <= 3600
+            ):
+                return tool_error(
+                    "ci_wait_timeout must be an integer from 30 to 3600 seconds."
+                )
+            if background or notify_on_complete or watch_patterns:
+                return tool_error(
+                    "ci_wait_timeout owns background notification; do not combine it "
+                    "with background, notify_on_complete, or watch_patterns."
+                )
+            ci_wait_parsed = _parse_gh_pr_checks(command)
+            if ci_wait_parsed is None:
+                return tool_error(
+                    "ci_wait_timeout requires an exact `gh pr checks [PR] "
+                    "[--required] [--repo OWNER/REPO]` command without pipes, "
+                    "shell composition, watch mode, or structured-output flags."
+                )
 
         # Reject foreground commands where the model explicitly requests
         # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.
@@ -3011,7 +3181,7 @@ def terminal_tool(
 
                 # Mark for agent notification on completion
                 if notify_on_complete and background:
-                    proc_session.notify_on_complete = True
+                    process_registry.arm_completion_notification(proc_session)
                     result_data["notify_on_complete"] = True
 
                     # In gateway mode, auto-register a fast watcher so the
@@ -3052,6 +3222,29 @@ def terminal_tool(
             retry_count = 0
             result = None
             command_cwd = None
+            ci_wait_expected_sha = None
+
+            # Bind the foreground pending check to the exact PR head before
+            # executing it. The promoted waiter receives this immutable SHA;
+            # a head change during the handoff is drift rather than a silently
+            # accepted new baseline.
+            if ci_wait_parsed is not None:
+                command_cwd = _resolve_command_cwd(
+                    workdir=workdir,
+                    default_cwd=cwd,
+                    session_key=session_key,
+                )
+                ci_wait_expected_sha = _resolve_ci_wait_expected_sha(
+                    env,
+                    ci_wait_parsed,
+                    cwd=command_cwd,
+                    timeout=effective_timeout,
+                )
+                if ci_wait_expected_sha is None:
+                    return tool_error(
+                        "Unable to bind the CI wait to the current PR head SHA; "
+                        "no checks command or waiter was started."
+                    )
 
             # Clean interrupt slate for an approved command, ONCE before the
             # retry loop: drop a stale bit that landed on this thread during the
@@ -3129,6 +3322,35 @@ def terminal_tool(
             # Extract output
             output = result.get("output", "")
             returncode = result.get("returncode", 0)
+
+            # Every foreground terminal state belongs to the pre-check head,
+            # not only the pending state that gets promoted. Revalidate after
+            # success and failure as well so a concurrent push cannot make an
+            # old result look authoritative for the new PR head.
+            if ci_wait_parsed is not None:
+                verified_sha = _resolve_ci_wait_expected_sha(
+                    env,
+                    ci_wait_parsed,
+                    cwd=command_cwd,
+                    timeout=effective_timeout,
+                )
+                if verified_sha is None:
+                    return tool_error(
+                        "Unable to revalidate the PR head after the foreground "
+                        "checks command; its result is not authoritative."
+                    )
+                if verified_sha != ci_wait_expected_sha:
+                    return json.dumps(
+                        {
+                            "output": (
+                                "CI_WAIT_SHA_DRIFT "
+                                f"expected={ci_wait_expected_sha} actual={verified_sha}"
+                            ),
+                            "exit_code": 75,
+                            "error": None,
+                        },
+                        ensure_ascii=False,
+                    )
             # Spill metadata from the bounded collector: present only when
             # output overflowed the capture window (see _wait_for_process).
             spill_total_chars = result.get("output_total_chars")
@@ -3305,6 +3527,70 @@ def terminal_tool(
                 result_dict["sudo_auth_failed"] = True
             if sudo_cache_cleared:
                 result_dict["sudo_cache_cleared"] = True
+
+            # ``gh pr checks`` uses exit 8 for pending.  With the explicit
+            # bounded-wait option, hand that state to the existing managed
+            # background-process completion rail.  No notification is emitted
+            # while checks remain pending; the wrapper exits only on success,
+            # failure, timeout, setup failure, or PR-head SHA drift.
+            if ci_wait_parsed is not None and returncode == 8:
+                # Validation above narrows this Optional to the bounded integer.
+                assert ci_wait_timeout is not None
+                wait_command = _build_bounded_ci_wait_command(
+                    ci_wait_parsed,
+                    timeout=ci_wait_timeout,
+                    expected_sha=ci_wait_expected_sha,
+                )
+                promoted = json.loads(terminal_tool(
+                    command=wait_command,
+                    background=True,
+                    task_id=task_id,
+                    session_id=session_id,
+                    workdir=command_cwd,
+                    notify_on_complete=True,
+                ))
+                promoted_id = promoted.get("session_id")
+                if not promoted_id or promoted.get("notify_on_complete") is not True:
+                    cleanup_verified = not promoted_id
+                    if promoted_id:
+                        try:
+                            from tools.process_registry import process_registry
+
+                            cleanup = process_registry.kill_process(promoted_id)
+                            cleanup_verified = cleanup.get("status") in {
+                                "killed",
+                                "already_exited",
+                            }
+                        except Exception:
+                            logger.warning(
+                                "Could not stop CI waiter after async-delivery refusal",
+                                exc_info=True,
+                            )
+                    result_dict["status"] = "error"
+                    if cleanup_verified:
+                        result_dict["error"] = (
+                            "CI is pending, but this session cannot receive an async "
+                            "completion; no CI waiter was left running."
+                        )
+                        result_dict["ci_wait_status"] = "not_started"
+                    else:
+                        logger.error(
+                            "CI waiter cleanup could not be verified: %s",
+                            promoted_id,
+                        )
+                        result_dict["error"] = (
+                            "CI is pending and async completion is unavailable. "
+                            "Cleanup of the promoted waiter could not be verified; "
+                            f"inspect process {promoted_id}."
+                        )
+                        result_dict["ci_wait_status"] = "cleanup_failed"
+                        result_dict["ci_wait_session_id"] = promoted_id
+                    return json.dumps(result_dict, ensure_ascii=False)
+
+                result_dict["ci_wait_status"] = "pending"
+                result_dict["ci_wait_session_id"] = promoted_id
+                result_dict["ci_wait_timeout"] = ci_wait_timeout
+                result_dict["notify_on_complete"] = True
 
             return json.dumps(result_dict, ensure_ascii=False)
 
@@ -3590,6 +3876,12 @@ TERMINAL_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Strings to watch for in background output. ONLY for rare one-shot mid-process signals on processes that never exit (e.g. ['Application startup complete'] on a server). NOT for end-of-run markers (use notify_on_complete) and NOT for per-iteration patterns like 'ERROR' in loops — rate-limited to 1 notification/15s; repeated over-firing auto-disables it and falls back to notify-on-exit. When in doubt, use notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete."
+            },
+            "ci_wait_timeout": {
+                "type": "integer",
+                "minimum": 30,
+                "maximum": 3600,
+                "description": "For an exact foreground `gh pr checks [PR] [--required] [--repo OWNER/REPO]` command: if GitHub returns pending (exit 8), start bounded polling with exponential backoff and wake a new turn via notify_on_complete only when checks resolve, fail, time out, or the PR head SHA drifts. Omit for ordinary commands."
             }
         },
         "required": ["command"]
@@ -3608,6 +3900,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        ci_wait_timeout=args.get("ci_wait_timeout"),
     )
 
 


### PR DESCRIPTION
## Summary
- promote narrowly recognized pending `gh pr checks` commands to bounded background waiters
- bind foreground and promoted checks to one immutable PR-head SHA and fail closed on drift or lookup failure
- deliver race-safe exactly-once completion notifications and verify unsupported-delivery cleanup

## Verification
- 88 focused tests passed
- repository-native `scripts/run_tests.sh` passed
- Ruff, compilation, and `git diff --check` passed
- deterministic privacy/Gitleaks/Noreply pre-push gate passed
- independent exact-SHA review found no class-(a) or class-(b) findings