### PR TITLE
fix(browser): create CDP targets in background

### DIFF
--- a/tests/tools/test_browser_background_tab.py
+++ b/tests/tools/test_browser_background_tab.py
@@ -1,0 +1,62 @@
+"""Regression tests for browser CDP target creation without focus theft."""
+
+import asyncio
+import json
+
+
+def test_supervisor_creates_background_target(monkeypatch):
+    from tools.browser_supervisor import CDPSupervisor
+
+    calls = []
+    supervisor = object.__new__(CDPSupervisor)
+    supervisor._page_session_id = None
+
+    async def fake_cdp(method, params=None, **kwargs):
+        calls.append({"method": method, "params": params, "kwargs": kwargs})
+        if method == "Target.getTargets":
+            return {"result": {"targetInfos": []}}
+        if method == "Target.createTarget":
+            return {"result": {"targetId": "synthetic-target"}}
+        if method == "Target.attachToTarget":
+            return {"result": {"sessionId": "synthetic-session"}}
+        return {"result": {}}
+
+    async def fake_dialog_bridge(session_id):
+        calls.append({"method": "_install_dialog_bridge", "session_id": session_id})
+
+    monkeypatch.setattr(supervisor, "_cdp", fake_cdp)
+    monkeypatch.setattr(supervisor, "_install_dialog_bridge", fake_dialog_bridge)
+    asyncio.run(supervisor._attach_initial_page())
+
+    create = next(call for call in calls if call["method"] == "Target.createTarget")
+    assert (create["params"] or {}).get("background") is True
+
+
+def test_raw_browser_cdp_creates_background_target(monkeypatch):
+    import tools.browser_cdp_tool as tool
+
+    calls = {}
+
+    async def fake_call(endpoint, method, params, target_id, timeout):
+        calls.update(
+            {
+                "endpoint": endpoint,
+                "method": method,
+                "params": dict(params),
+                "target_id": target_id,
+                "timeout": timeout,
+            }
+        )
+        return {"targetId": "synthetic-target"}
+
+    monkeypatch.setattr(tool, "_WS_AVAILABLE", True)
+    monkeypatch.setattr(tool, "_resolve_cdp_endpoint", lambda: "ws://synthetic-endpoint")
+    monkeypatch.setattr(tool, "_browser_cdp_private_guard", lambda **kwargs: None)
+    monkeypatch.setattr(tool, "_cdp_call", fake_call)
+    monkeypatch.setattr(tool, "_run_async", lambda coroutine: asyncio.run(coroutine))
+
+    result = tool.browser_cdp("Target.createTarget", {"url": "about:blank"})
+
+    payload = json.loads(result)
+    assert payload["result"]["targetId"] == "synthetic-target"
+    assert calls["params"]["background"] is True

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -489,6 +489,21 @@ def browser_cdp(
     if blocked:
         return blocked
 
+    # --- Background-tab enforcement (2026-08-02 operator directive) ------
+    # The CDP browser on the Windows host is shared infrastructure. A
+    # Target.createTarget WITHOUT background:True activates the new tab and
+    # raises the Chrome window, stealing focus from the user's desktop. This
+    # raw tool is an agent escape hatch, so enforce the background flag here
+    # rather than relying on every agent to remember it. See 3xstanbrain
+    # 2026-06-03 cdp-windows-focus-steal and the 2026-08-02 enforcement pass.
+    if method == "Target.createTarget":
+        if not isinstance(call_params, dict):
+            return tool_error(
+                "Target.createTarget params must be an object/dict",
+                method=method,
+            )
+        call_params["background"] = True
+
     try:
         safe_timeout = float(timeout) if timeout else 30.0
     except (TypeError, ValueError):

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -744,7 +744,15 @@ class CDPSupervisor:
         targets = resp.get("result", {}).get("targetInfos", [])
         page_target = next((t for t in targets if t.get("type") == "page"), None)
         if page_target is None:
-            created = await self._cdp("Target.createTarget", {"url": "about:blank"})
+            # Create the initial tab in the BACKGROUND so the browser window
+            # is never raised on the user's desktop (Windows focus steal).
+            # See 3xstanbrain 2026-06-03 cdp-windows-focus-steal + 2026-08-02
+            # enforcement pass: every Target.createTarget MUST pass
+            # background: True unless a task explicitly needs foreground.
+            created = await self._cdp(
+                "Target.createTarget",
+                {"url": "about:blank", "background": True},
+            )
             target_id = created["result"]["targetId"]
         else:
             target_id = page_target["targetId"]


### PR DESCRIPTION
## Problem

Hermes can drive an already-running Chrome over CDP (an attached or residential-IP browser, e.g. `127.0.0.1:9222`). In two paths the CDP layer creates a page target:

1. `CDPSupervisor._attach_initial_page()` — when no page target exists yet, the supervisor creates one.
2. the raw `browser_cdp` tool — an agent escape hatch that forwards arbitrary CDP methods.

`Target.createTarget` without `background: true` **activates the new tab and raises the browser window**, stealing desktop focus from the operator while agents work in the browser. For an attached everyday browser this is disruptive: the user's window pops to the foreground mid-task.

## Fix

- `tools/browser_cdp_tool.py`: `Target.createTarget` params are forced to `background: true`, so the escape hatch cannot forget it.
- `tools/browser_supervisor.py`: initial page creation passes `background: true`.

No change to the existing browser workflow — tabs created this way simply never raise the window.

## Tests

`tests/tools/test_browser_background_tab.py` — regression tests for both paths (supervisor `_attach_initial_page` and the raw `browser_cdp` tool), asserting the background flag is always present.

## Validation

Verified against a real attached Chrome over CDP (`127.0.0.1:9222`): `Target.createTarget` succeeds with the background flag, the window is not raised, and the created target closes cleanly.
