### PR TITLE
fix(desktop): persist backend-sourced skins so they survive restarts

### DIFF
--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { $activeGatewayProfile } from '@/store/profile'
+
 import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
+import { skinToDesktopTheme } from './skin'
+import { $userThemes } from './user-themes'
 
 const skin = (name: string) => ({
   name,
@@ -8,7 +12,12 @@ const skin = (name: string) => ({
 })
 
 describe('ingestBackendSkin', () => {
-  beforeEach(() => __resetBackendSkinSync())
+  beforeEach(() => {
+    __resetBackendSkinSync()
+    window.localStorage.clear()
+    $activeGatewayProfile.set('default')
+    $userThemes.set({})
+  })
 
   it('registers a converted skin without applying when apply=false', () => {
     ingestBackendSkin(skin('neon'), { apply: false })
@@ -84,6 +93,52 @@ describe('ingestBackendSkin', () => {
     ingestBackendSkin(skin('default'), { apply: false })
 
     expect($pendingSkinApply.get()).toBeNull()
+  })
+
+  it('seed applies when the persisted desktop theme IS the backend skin (restart recovery)', () => {
+    // User picked the backend-sourced skin last session; boot paint couldn't
+    // resolve it before the gateway registered it, so it stored the name and
+    // fell back to the default. The connect-time seed must finish that pick.
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'neon')
+    ingestBackendSkin(skin('neon'), { apply: false })
+
+    expect($pendingSkinApply.get()).toBe('neon')
+  })
+
+  it('seed applies a persisted per-profile backend skin', () => {
+    window.localStorage.setItem('hermes-desktop-profile-themes-v1', JSON.stringify({ work: 'neon' }))
+    $activeGatewayProfile.set('work')
+    ingestBackendSkin(skin('neon'), { apply: false })
+
+    expect($pendingSkinApply.get()).toBe('neon')
+  })
+
+  it('seed still does not apply when the persisted skin differs from the backend skin', () => {
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'mono')
+    ingestBackendSkin(skin('neon'), { apply: false })
+
+    expect($pendingSkinApply.get()).toBeNull()
+  })
+
+  it('persists a backend skin as a user theme so the next boot paint can resolve it', () => {
+    ingestBackendSkin(skin('neon'), { apply: false })
+
+    // Boot paint (before the gateway registers backend themes) resolves
+    // built-ins and user themes from localStorage — so storing the converted
+    // theme here makes a backend-sourced skin paint correctly on the very
+    // first frame of the NEXT launch, not just after `gateway.ready`.
+    expect($userThemes.get().neon?.name).toBe('neon')
+    expect(window.localStorage.getItem('hermes-desktop-user-themes-v1')).toContain('"neon"')
+  })
+
+  it('does not rewrite a user theme that is already persisted unchanged', () => {
+    const theme = skinToDesktopTheme(skin('neon'))!
+    $userThemes.set({ neon: theme })
+    window.localStorage.setItem('hermes-desktop-user-themes-v1', JSON.stringify({ neon: theme }))
+
+    ingestBackendSkin(skin('neon'), { apply: false })
+
+    expect($userThemes.get().neon?.name).toBe('neon')
   })
 
   it('applies a runtime switch back to default (repaints the desktop to its own default)', () => {

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -19,9 +19,13 @@
 import type { HermesSkin } from '@hermes/shared/skin'
 import { atom } from 'nanostores'
 
+import { storedString, storedStringRecord } from '@/lib/storage'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+
 import { BUILTIN_THEMES } from './presets'
 import { skinToDesktopTheme } from './skin'
 import type { DesktopTheme } from './types'
+import { $userThemes, installUserTheme } from './user-themes'
 
 /** Skins pushed by the backend, keyed by name. Merged by `listAllThemes`. */
 export const $backendThemes = atom<Record<string, DesktopTheme>>({})
@@ -42,6 +46,33 @@ export function __resetBackendSkinSync(): void {
   lastSynced = null
   $backendThemes.set({})
   $pendingSkinApply.set(null)
+}
+
+// Skin keys — keep in sync with `themes/context.tsx` (read-only use here,
+// avoiding a circular import: context.tsx imports this module).
+const SKIN_LEGACY_KEY = 'hermes-desktop-theme-v2'
+const PROFILE_SKINS_KEY = 'hermes-desktop-profile-themes-v1'
+
+/**
+ * Whether `name` is what the user persisted for the live profile. Boot paint
+ * runs before the gateway registers backend themes, so a backend-sourced skin
+ * (e.g. one from `display.skin`) that the user picked is stored but NOT
+ * resolvable on the first frame — `normalizeSkin` falls back to the default
+ * and the connect-time seed deliberately never repaints. Seeding an already
+ * persisted skin is not stomping a manual choice; it's finishing it.
+ */
+function isPersistedSkin(name: string): boolean {
+  if (name === 'default') {
+    return false
+  }
+
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+  const stored =
+    profile === 'default'
+      ? storedString(SKIN_LEGACY_KEY)
+      : (storedStringRecord(PROFILE_SKINS_KEY)[profile] ?? storedString(SKIN_LEGACY_KEY))
+
+  return stored === name
 }
 
 /**
@@ -75,11 +106,32 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
     if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
       $backendThemes.set({ ...current, [name]: theme })
     }
+
+    // Persist backend skins as user themes so the NEXT boot's first paint can
+    // resolve them synchronously — boot paint runs before the gateway connects
+    // and registers backend themes, so without this a backend-sourced skin
+    // (e.g. one from `display.skin`) paints the default on the connecting
+    // screen and only repaints after `gateway.ready`. Storing the converted
+    // theme in localStorage makes it resolve exactly like a built-in.
+    const installed = $userThemes.get()[name]
+
+    if (JSON.stringify(installed) !== JSON.stringify(theme)) {
+      installUserTheme(theme)
+    }
   }
 
   if (!apply) {
     // Connect-time seed: record without painting. A reconnect re-seed keeps an
     // earlier real apply's flag so repeat events can't override a manual switch.
+    // Exception: the user's persisted skin IS this backend skin — it was picked
+    // last session, so repaint it now that it's finally resolvable.
+    if (isPersistedSkin(name)) {
+      lastSynced = { applied: true, name }
+      $pendingSkinApply.set(name)
+
+      return
+    }
+
     if (lastSynced?.name !== name || !lastSynced.applied) {
       lastSynced = { applied: false, name }
     }


### PR DESCRIPTION
## Problem

A backend-sourced skin (e.g. one set via `display.skin`, like `sisyphus`) does not survive a desktop restart. The picked skin shows while connected, but every launch comes back as the default.

Root cause is a gateway-timing dependency: the desktop's boot-time paint runs **before** the gateway connects and registers backend themes, so the persisted skin name cannot be resolved on the first frame — `normalizeSkin` falls back to `DEFAULT_SKIN_NAME`. The connect-time seed (`ingestBackendSkin` with `apply: false`) deliberately never repaints, so the default sticks for the whole session.

This affects the whole class of backend-sourced skins (ares, daylight, warm-lightmode, poseidon, sisyphus, charizard — anything in `skin_engine.py` but not in the desktop's `BUILTIN_THEMES`), not just one name. Built-in desktop skins are unaffected because they resolve locally on the first frame.

## Fix

Two changes in `apps/desktop/src/themes/backend-sync.ts`:

1. **Seed recovery** — on connect, if the pushed skin name matches the user's persisted choice, repaint it. This *finishes* the user's pick instead of *stomping* it (the guard for manual switches is untouched: a persisted name differing from the backend skin still never repaints).

2. **User-theme persistence** — backend skins are converted via `skinToDesktopTheme` and installed as user themes (localStorage), so the *next* boot's first paint resolves them synchronously, exactly like a built-in. No timing dependency, and the connecting screen paints the right skin from frame one.

## Tests

`backend-sync.test.ts` grows from 11 to 16 cases: seed recovery when the persisted skin equals the backend skin, per-profile persisted backend skins, no-apply when they differ, user-theme persistence to localStorage, and no rewrite when the persisted theme is unchanged.