### PR TITLE
fix(desktop): stop double-click from hijacking word selection for reactions

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -19,7 +19,7 @@ import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/messa
 import { ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
 import { ResponseLoadingIndicator, StreamStallIndicator } from '@/components/assistant-ui/thread/status'
 import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
-import { useMessageReactions, useTapbackDoubleClick } from '@/components/assistant-ui/thread/use-message-reactions'
+import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { Codicon } from '@/components/ui/codicon'
@@ -112,17 +112,12 @@ export const AssistantMessage: FC<{
 
   const enterRef = useEnterAnimation(isRunning, `assistant-message:${messageId}`)
 
-  // Double-click the reply to heart it (iMessage). Undefined while reactions
-  // are off, so the root carries no listener at all.
-  const onDoubleClick = useTapbackDoubleClick(messageId, 'assistant')
-
   return (
     <MessagePrimitive.Root
       className="group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden"
       data-role="assistant"
       data-slot="aui_assistant-message-root"
       data-streaming={isRunning ? 'true' : undefined}
-      onDoubleClick={onDoubleClick}
       ref={enterRef}
     >
       <div

--- a/apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx
@@ -1,5 +1,5 @@
-// Double-click an assistant reply to heart it (the iMessage gesture), gated on
-// the same opt-in toggle as the rest of message reactions.
+// Double-click on assistant message text must not hijack native word selection
+// for reactions — reactions stay on the dedicated picker only.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,8 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ReactionsStore from '@/store/reactions'
 import { $reactionsEnabled } from '@/store/reactions-enabled'
 import { $localReactions } from '@/store/reactions-local'
-
-import { isTapbackDoubleClick } from './use-message-reactions'
 
 import { Thread } from '.'
 
@@ -28,8 +26,6 @@ vi.stubGlobal('CSS', { escape: (str: string) => str })
 
 Element.prototype.scrollTo = function scrollTo() {}
 
-// The gesture persists through the gateway; this suite is about the local
-// paint, which is what the user actually sees on the click.
 vi.mock('@/store/reactions', async importOriginal => ({
   ...(await importOriginal<typeof ReactionsStore>()),
   toggleMessageReaction: vi.fn(async () => {})
@@ -69,29 +65,8 @@ afterEach(() => {
   cleanup()
 })
 
-describe('isTapbackDoubleClick', () => {
-  it('claims a plain double-click on message body', () => {
-    expect(isTapbackDoubleClick({ detail: 2, target: document.createElement('span') })).toBe(true)
-  })
-
-  it('ignores a triple-click, so selecting a paragraph does not re-toggle', () => {
-    expect(isTapbackDoubleClick({ detail: 3, target: document.createElement('span') })).toBe(false)
-  })
-
-  it('leaves double-click alone where it already means something', () => {
-    const code = document.createElement('pre')
-    const inner = document.createElement('code')
-
-    code.append(inner)
-
-    expect(isTapbackDoubleClick({ detail: 2, target: inner })).toBe(false)
-    expect(isTapbackDoubleClick({ detail: 2, target: document.createElement('a') })).toBe(false)
-    expect(isTapbackDoubleClick({ detail: 2, target: document.createElement('button') })).toBe(false)
-  })
-})
-
-describe('double-click to heart an assistant message', () => {
-  it('hearts the message, and a second double-click retracts it', async () => {
+describe('double-click on assistant message text', () => {
+  it('does not add a reaction when reactions are enabled', async () => {
     $reactionsEnabled.set(true)
     render(<Harness />)
 
@@ -100,10 +75,7 @@ describe('double-click to heart an assistant message', () => {
     expect(message).toBeTruthy()
 
     fireEvent.doubleClick(message!, { detail: 2 })
-    await waitFor(() => expect($localReactions.get()['assistant-1']?.[0]?.emoji).toBe('❤️'))
-
-    fireEvent.doubleClick(message!, { detail: 2 })
-    await waitFor(() => expect($localReactions.get()['assistant-1']).toEqual([]))
+    await waitFor(() => expect($localReactions.get()['assistant-1']).toBeUndefined())
   })
 
   it('does nothing while reactions are off', async () => {

--- a/apps/desktop/src/components/assistant-ui/thread/use-message-reactions.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-message-reactions.ts
@@ -1,39 +1,15 @@
-import { useAuiState, useMessageRuntime } from '@assistant-ui/react'
+import { useAuiState } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
-import { type MouseEvent, useCallback } from 'react'
+import { useCallback } from 'react'
 
 import type { ChatMessage } from '@/lib/chat-messages'
-import { triggerHaptic } from '@/lib/haptics'
-import { QUICK_REACTIONS, toggleMessageReaction } from '@/store/reactions'
+import { toggleMessageReaction } from '@/store/reactions'
 import { $reactionsEnabled } from '@/store/reactions-enabled'
 import { $agentReactions, $localReactions, mergeReactions, setLocalReaction } from '@/store/reactions-local'
 import type { MessageReaction } from '@/types/hermes'
 
 // Stable empty identity — a fresh [] per render would re-run every consumer.
 const EMPTY_REACTIONS: MessageReaction[] = []
-
-/** The tapback a double-click lands: Apple's first Tapback, and ours. */
-export const DOUBLE_CLICK_REACTION = QUICK_REACTIONS[0]
-
-// Double-click means something else on these: links and controls act, inputs
-// and code blocks select. The gesture only claims plain message body.
-const NOT_A_TAPBACK = 'a, button, input, pre, select, textarea, [contenteditable="true"], [role="button"]'
-
-/**
- * Is this double-click the "heart it" gesture?
- *
- * `detail === 2` keeps a triple-click (select-the-paragraph) from re-firing,
- * and anything the browser already gives a double-click meaning keeps it.
- */
-export function isTapbackDoubleClick(event: { detail: number; target: EventTarget | null }): boolean {
-  if (event.detail !== 2) {
-    return false
-  }
-
-  const target = event.target
-
-  return target instanceof Element ? !target.closest(NOT_A_TAPBACK) : true
-}
 
 /** Paint the tapback locally, then persist behind it. */
 function commitReaction(
@@ -55,8 +31,8 @@ function commitReaction(
  * Reads the durable list off `metadata.custom`, layers this window's live
  * overlays on top (the user's own click, the agent's mid-turn event), and
  * hands back a `react` that paints locally first and persists behind it.
- * Shared by the assistant footer slot, the user bubble's picker, and the
- * double-click gesture so all three apply identical tapback semantics.
+ * Shared by the assistant footer slot and the user bubble's picker so both
+ * apply identical tapback semantics.
  */
 export function useMessageReactions(
   messageId: string,
@@ -92,55 +68,3 @@ export function useMessageReactions(
   }
 }
 
-/**
- * Double-click a message to heart it — the iMessage gesture.
- *
- * Reads the message's reaction state lazily at event time (the same trick the
- * footer uses for its text): the gesture renders nothing, so subscribing the
- * perf-sensitive message root to every reaction change would be pure cost.
- * Returns `undefined` while reactions are off, so the element carries no
- * listener at all.
- */
-export function useTapbackDoubleClick(
-  messageId: string,
-  role: ChatMessage['role']
-): ((event: MouseEvent<HTMLElement>) => void) | undefined {
-  const enabled = useStore($reactionsEnabled)
-  const messageRuntime = useMessageRuntime()
-
-  const onDoubleClick = useCallback(
-    (event: MouseEvent<HTMLElement>) => {
-      if (!isTapbackDoubleClick(event)) {
-        return
-      }
-
-      // Double-click has already selected the word underneath — the tapback,
-      // not a stray selection, is what the gesture meant.
-      window.getSelection()?.removeAllRanges()
-      triggerHaptic('selection')
-
-      const custom = (messageRuntime.getState().metadata?.custom ?? {}) as {
-        reactions?: MessageReaction[]
-        rowId?: number
-      }
-
-      const reactions = custom.reactions ?? EMPTY_REACTIONS
-
-      // Same toggle semantics as the picker: a second double-click retracts.
-      const mine = mergeReactions(reactions, $localReactions.get()[messageId]).find(
-        reaction => reaction.author === 'user'
-      )
-
-      commitReaction(
-        messageId,
-        role,
-        custom.rowId,
-        reactions,
-        mine?.emoji === DOUBLE_CLICK_REACTION ? null : DOUBLE_CLICK_REACTION
-      )
-    },
-    [messageId, messageRuntime, role]
-  )
-
-  return enabled ? onDoubleClick : undefined
-}


### PR DESCRIPTION
## What does this PR do?

Removes the iMessage-style double-click tapback gesture on Hermes Desktop assistant messages. Double-clicking message text no longer adds a reaction or clears the browser selection, so users can select and copy individual words from answers using native text-selection behavior. Message reactions remain available through the dedicated reaction picker when the feature is enabled.

## Related Issue

Fixes #82466

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx` — removed the `onDoubleClick` tapback handler from assistant message roots
- `apps/desktop/src/components/assistant-ui/thread/use-message-reactions.ts` — removed `useTapbackDoubleClick`, `isTapbackDoubleClick`, and the selection-clearing reaction commit path
- `apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx` — updated tests to assert double-click does not add reactions when reactions are enabled

## How to Test

1. Enable message reactions in Desktop settings (Appearance → Message Reactions).
2. Open a chat with at least one assistant reply containing selectable text.
3. Double-click a word in the assistant message body.
4. Confirm the word is selected (native selection) and no reaction emoji is added.
5. Run `npm test -- src/components/assistant-ui/thread/double-click-reaction.test.tsx` from `apps/desktop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Cloud Agent CI environment)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — behavior verified via vitest (`double-click-reaction.test.tsx`).