### PR TITLE
fix: suppress Windows console flashes from Python git/gh subprocess calls

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -40,6 +40,8 @@ from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 
@@ -481,6 +483,7 @@ def workspace_fingerprint(cwd: Optional[str] = None) -> str:
             ["git", "rev-parse", "HEAD"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=10, cwd=workdir,
+            creationflags=windows_hide_flags(),
         )
         if head.returncode != 0:
             return ""
@@ -488,6 +491,7 @@ def workspace_fingerprint(cwd: Optional[str] = None) -> str:
             ["git", "status", "--porcelain"],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=30, cwd=workdir,
+            creationflags=windows_hide_flags(),
         )
         if status.returncode != 0:
             return ""

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from hermes_cli._subprocess_compat import noninteractive_git_env
+from hermes_cli._subprocess_compat import noninteractive_git_env, windows_hide_flags
 
 _GIT_TIMEOUT = 30
 _GH_TIMEOUT = 30
@@ -49,6 +49,7 @@ def _git(cwd: str, args: list[str], *, timeout: int = _GIT_TIMEOUT) -> tuple[int
             timeout=timeout,
             stdin=subprocess.DEVNULL,
             env=noninteractive_git_env(),
+            creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.SubprocessError):
         return 1, "", "git invocation failed"
@@ -438,6 +439,7 @@ def _gh(cwd: str, args: list[str]) -> tuple[bool, str]:
         proc = subprocess.run(
             ["gh", *args], cwd=cwd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=_GH_TIMEOUT,
             stdin=subprocess.DEVNULL, env=env,
+            creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.SubprocessError):
         return False, ""


### PR DESCRIPTION
## Problem

On Windows, `subprocess.run()` creates a visible `conhost.exe` console window
for every console-subsystem child process unless `CREATE_NO_WINDOW` is passed
via `creationflags`. This causes visible terminal flashes when Hermes is idle
with the desktop open (coding rail refresh), and after goal completion
(workspace fingerprint verifier).

Windows Security Event 4688 confirms `Hermes.exe` launches `git.exe status
--porcelain -b -u --null --untracked-files=normal` and that Git subsequently
creates `conhost.exe ... -ForceV1`.

## Root Cause

Two Python call sites were missing `creationflags`, while all other git
subprocess invocations in the codebase already had it:

- `hermes_cli/web_git.py:_git()` -- central REST API git subprocess launcher
- `hermes_cli/web_git.py:_gh()` -- `gh` CLI subprocess launcher
- `hermes_cli/goals.py:workspace_fingerprint()` -- post-goal workspace verifier

## Fix

Add `creationflags=windows_hide_flags()` to the `subprocess.run()` calls in
the three functions above. `windows_hide_flags()` (from `_subprocess_compat`)
returns:
- Windows: `0x08000000` (`CREATE_NO_WINDOW`) — hidden console, no visible flash
- Non-Windows: `0` — no-op, zero behavioral change

## Already Safe

| Area | Mechanism | Status |
|---|---|---|
| electron/git-review-ops.ts | simple-git v3.36.0 | windowsHide:true in spawn defaults |
| electron/git-worktree-ops.ts | execFile | passes windowsHide:true |
| electron/main.ts:runGit() | spawn via hiddenWindowsChildOptions() | OK |
| electron/bootstrap-runner.ts | execFileSync via hiddenWindowsChildOptions() | OK |
| agent/coding_context.py:_git() | bounded_git_probe() | uses windows_hide_flags() |
| tui_gateway/git_probe.py:run_git() | bounded_git_probe() | uses windows_hide_flags() |

## Verification

- `conhost.exe` may still appear in the process tree but its window stays invisible
- Git output and exit codes are identical
- Non-Windows behavior is unchanged (`creationflags=0` is a no-op)
- Uses the same `windows_hide_flags()` helper already established in the codebase

## Related

- Original daemon-level console-flash fix: commit `aa2ae36c3f`
- See `_subprocess_compat.py` lines 100-120 for the DETACHED_PROCESS /
  CREATE_NO_WINDOW interaction rationale
