### PR TITLE
fix(codex): require correlated steer acknowledgement

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -423,8 +423,7 @@ class CodexAppServerSession:
         except (CodexAppServerError, TimeoutError):
             logger.debug("turn/steer rejected for active Codex turn", exc_info=True)
             return False
-        accepted_turn_id = response.get("turnId") if isinstance(response, dict) else None
-        return accepted_turn_id in {None, turn_id}
+        return isinstance(response, dict) and response.get("turnId") == turn_id
 
     # ---------- diagnostics ----------
 

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -385,6 +385,28 @@ class TestRunTurn:
             "expectedTurnId": "turn-live-123",
         }
 
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {},
+            None,
+            [],
+            "invalid",
+            {"turnId": None},
+            {"turnId": ""},
+            {"turnId": "foreign"},
+        ],
+    )
+    def test_steer_rejects_malformed_acknowledgement(self, response):
+        client = FakeClient()
+        session = make_session(client)
+        session.ensure_started()
+        client._request_handler = lambda method, params: response
+        with session._active_turn_lock:
+            session._active_turn_id = "turn-live-123"
+
+        assert session.request_steer("Use Postgres instead") is False
+
 
 
 


### PR DESCRIPTION
## Summary

- Require `turn/steer` responses to acknowledge the exact active `turnId`.
- Reject malformed, empty, and foreign-turn acknowledgements.
- Add focused regression coverage for acknowledgement validation.

## Why

`CodexAppServerSession.request_steer()` currently treats a missing `turnId` as success. The Codex app-server protocol has required a string `turnId` in successful `turn/steer` responses since the operation was introduced.

Requiring the acknowledgement to equal the active turn ID leaves compliant responses unchanged while preventing malformed results from being reported and persisted as accepted redirects.

## Scope and trade-off

This changes only the optional Codex app-server runtime. It does not affect Anthropic/Claude or Hermes' other provider paths.

A malformed JSON-RPC success response is inherently an unknown-delivery case: the server may have applied the steer before emitting an invalid result. Returning `False` delegates to Hermes' existing redirect fallback, which may redeliver the correction in that unsupported-peer scenario. This PR chooses fail-closed correlation rather than reporting an uncorrelated response as accepted; compliant supported Codex versions always return the required `turnId`.

## Tests

- `scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py` — 41 passed
- Ruff — passed
- `py_compile` — passed
- `git diff --check` — passed
