### PR TITLE
feat(cli): provision isolated uv worktree environments

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -30,6 +30,7 @@ import shutil
 import sys
 import json
 import re
+import subprocess
 import concurrent.futures
 import base64
 import atexit
@@ -1606,6 +1607,91 @@ def _resolve_worktree_base(
     return "HEAD", "HEAD (local — could not reach remote)"
 
 
+def _worktree_test_environment_ready(wt_path: Path) -> bool:
+    """Return whether a conventional local environment can run pytest."""
+    for environment in (wt_path / ".venv", wt_path / "venv"):
+        candidates = (
+            environment / "bin" / "python",
+            environment / "bin" / "python3",
+            environment / "Scripts" / "python.exe",
+        )
+        for python in candidates:
+            if not python.is_file():
+                continue
+            try:
+                probe = subprocess.run(
+                    [str(python), "-c", "import pytest"],
+                    cwd=wt_path,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=10,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                continue
+            if probe.returncode == 0:
+                return True
+    return False
+
+
+def _provision_uv_worktree(wt_path: Path) -> bool:
+    """Best-effort provision a worktree-local uv environment.
+
+    The project remains the dependency authority: Hermes only selects an
+    existing ``dev``/``test`` extras and groups and never guesses package names.
+    """
+    pyproject_path = wt_path / "pyproject.toml"
+    if (
+        not pyproject_path.is_file()
+        or not (wt_path / "uv.lock").is_file()
+        or _worktree_test_environment_ready(wt_path)
+    ):
+        return False
+
+    uv = shutil.which("uv")
+    if not uv:
+        logger.warning("uv worktree detected, but uv is unavailable; environment not provisioned")
+        return False
+
+    try:
+        import tomllib
+
+        project = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+        command = [uv, "sync", "--locked", "--no-default-groups"]
+        optional = project.get("project", {}).get("optional-dependencies", {})
+        groups = project.get("dependency-groups", {})
+        if isinstance(optional, dict):
+            for name in ("dev", "test"):
+                if name in optional:
+                    command.extend(["--extra", name])
+        if isinstance(groups, dict):
+            for name in ("dev", "test"):
+                if name in groups:
+                    command.extend(["--group", name])
+
+        result = subprocess.run(
+            command,
+            cwd=wt_path,
+            env={**os.environ, "UV_PROJECT_ENVIRONMENT": str(wt_path / ".venv")},
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=300,
+        )
+        if result.returncode == 0:
+            if _worktree_test_environment_ready(wt_path):
+                return True
+            logger.warning(
+                "uv worktree provisioning completed, but the local environment cannot import pytest"
+            )
+            return False
+        detail = (result.stderr or result.stdout).strip()
+        logger.warning("uv worktree provisioning failed: %s", detail or result.returncode)
+    except (AttributeError, OSError, ValueError, TimeoutError, subprocess.TimeoutExpired) as exc:
+        logger.warning("uv worktree provisioning failed: %s", exc)
+    return False
+
+
 def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[Dict[str, str]]:
     """Create an isolated git worktree for this CLI session.
 
@@ -1763,6 +1849,13 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
                                 raise
         except Exception as e:
             logger.debug("Error copying .worktreeinclude entries: %s", e)
+
+    # Provision declared uv development dependencies unless an explicit
+    # .worktreeinclude entry (or tracked path) already populated an environment.
+    try:
+        _provision_uv_worktree(wt_path)
+    except Exception as exc:
+        logger.warning("Unexpected uv worktree provisioning failure: %s", exc)
 
     # Lock the worktree so other processes (and `git worktree remove`) can see
     # it is actively in use.  Fail-soft: a lock failure never blocks the session.

--- a/tests/cli/test_worktree_security.py
+++ b/tests/cli/test_worktree_security.py
@@ -170,3 +170,309 @@ class TestWorktreeIncludeEncoding:
         finally:
             _force_remove_worktree(info)
 
+
+class TestUvWorktreeProvisioning:
+    def test_syncs_declared_dev_and_test_extras_and_groups(self, tmp_path, monkeypatch):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text(
+            """
+[project]
+name = "demo"
+version = "0.1.0"
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio"]
+test = ["pytest-cov"]
+docs = ["mkdocs"]
+[dependency-groups]
+dev = ["mypy", "pydantic"]
+test = ["coverage"]
+docs = ["sphinx"]
+[tool.uv]
+default-groups = ["docs"]
+"""
+        )
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+        monkeypatch.setattr(cli_mod.subprocess, "run", fake_run)
+        monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", str(tmp_path / "external-venv"))
+        readiness = iter([False, True])
+        monkeypatch.setattr(
+            cli_mod,
+            "_worktree_test_environment_ready",
+            lambda _path: next(readiness),
+        )
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is True
+        assert captured["command"] == [
+            "/usr/bin/uv",
+            "sync",
+            "--locked",
+            "--no-default-groups",
+            "--extra",
+            "dev",
+            "--extra",
+            "test",
+            "--group",
+            "dev",
+            "--group",
+            "test",
+        ]
+        assert captured["kwargs"]["cwd"] == tmp_path
+        assert captured["kwargs"]["env"]["UV_PROJECT_ENVIRONMENT"] == str(
+            tmp_path / ".venv"
+        )
+
+    @pytest.mark.parametrize("existing", [".venv", "venv"])
+    def test_preserves_existing_environment(self, tmp_path, monkeypatch, existing):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        environment = tmp_path / existing
+        (environment / "bin").mkdir(parents=True)
+        python = environment / "bin" / "python"
+        python.touch()
+        calls = []
+        monkeypatch.setattr(
+            cli_mod.subprocess,
+            "run",
+            lambda command, **_kwargs: calls.append(command)
+            or subprocess.CompletedProcess(command, 0, "", ""),
+        )
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert calls == [[str(python), "-c", "import pytest"]]
+
+    def test_preserves_ready_windows_environment(self, tmp_path, monkeypatch):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        python = tmp_path / ".venv" / "Scripts" / "python.exe"
+        python.parent.mkdir(parents=True)
+        python.touch()
+        calls = []
+        monkeypatch.setattr(
+            cli_mod.subprocess,
+            "run",
+            lambda command, **_kwargs: calls.append(command)
+            or subprocess.CompletedProcess(command, 0, "", ""),
+        )
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert calls == [[str(python), "-c", "import pytest"]]
+
+    def test_partial_venv_does_not_suppress_retry(self, tmp_path, monkeypatch):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        (tmp_path / ".venv").mkdir()
+        calls = []
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+        readiness = iter([False, True])
+        monkeypatch.setattr(
+            cli_mod,
+            "_worktree_test_environment_ready",
+            lambda _path: next(readiness),
+        )
+        monkeypatch.setattr(
+            cli_mod.subprocess,
+            "run",
+            lambda command, **_kwargs: calls.append(command)
+            or subprocess.CompletedProcess(command, 0, "", ""),
+        )
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is True
+        assert calls == [["/usr/bin/uv", "sync", "--locked", "--no-default-groups"]]
+
+    def test_unusable_launcher_files_do_not_suppress_retry(self, tmp_path, monkeypatch):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        bin_dir = tmp_path / ".venv" / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "python").touch()
+        (bin_dir / "pytest").touch()
+        sync_calls = []
+        synced = False
+
+        def fake_run(command, **_kwargs):
+            nonlocal synced
+            if command[0] == str(bin_dir / "python"):
+                if not synced:
+                    raise OSError("incomplete launcher")
+                return subprocess.CompletedProcess(command, 0, "", "")
+            sync_calls.append(command)
+            synced = True
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+        monkeypatch.setattr(cli_mod.subprocess, "run", fake_run)
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is True
+        assert sync_calls == [
+            ["/usr/bin/uv", "sync", "--locked", "--no-default-groups"]
+        ]
+
+    def test_successful_sync_without_importable_pytest_is_not_success(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+        monkeypatch.setattr(
+            cli_mod.subprocess,
+            "run",
+            lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, "", ""),
+        )
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert "cannot import pytest" in caplog.text
+
+    def test_failed_sync_with_unusable_launchers_retries_next_call(self, tmp_path, monkeypatch):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        python = tmp_path / ".venv" / "bin" / "python"
+        sync_calls = []
+
+        def fake_run(command, **_kwargs):
+            if command[0] == str(python):
+                raise OSError("incomplete launcher")
+            sync_calls.append(command)
+            python.parent.mkdir(parents=True, exist_ok=True)
+            python.touch()
+            (python.parent / "pytest").touch()
+            return subprocess.CompletedProcess(command, 1, "", "offline")
+
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+        monkeypatch.setattr(cli_mod.subprocess, "run", fake_run)
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert sync_calls == [
+            ["/usr/bin/uv", "sync", "--locked", "--no-default-groups"],
+            ["/usr/bin/uv", "sync", "--locked", "--no-default-groups"],
+        ]
+
+    def test_missing_uv_is_non_fatal(self, tmp_path, monkeypatch, caplog):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: None)
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert "uv is unavailable" in caplog.text
+
+    @pytest.mark.parametrize(
+        "pyproject",
+        ["[project", 'project = "not-a-table"\n'],
+    )
+    def test_malformed_pyproject_is_non_fatal(self, tmp_path, monkeypatch, caplog, pyproject):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text(pyproject)
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert "uv worktree provisioning failed" in caplog.text
+
+    def test_sync_failure_is_non_fatal(self, tmp_path, monkeypatch, caplog):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+        monkeypatch.setattr(
+            cli_mod.subprocess,
+            "run",
+            lambda command, **kwargs: subprocess.CompletedProcess(command, 1, "", "offline"),
+        )
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert "uv worktree provisioning failed" in caplog.text
+
+    def test_sync_timeout_is_non_fatal(self, tmp_path, monkeypatch, caplog):
+        import cli as cli_mod
+
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1'\n")
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+        monkeypatch.setattr(
+            cli_mod.subprocess,
+            "run",
+            lambda command, **kwargs: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired(command, kwargs["timeout"])
+            ),
+        )
+
+        assert cli_mod._provision_uv_worktree(tmp_path) is False
+        assert "uv worktree provisioning failed" in caplog.text
+
+    def test_setup_calls_provisioner_with_new_worktree(self, git_repo, monkeypatch):
+        import cli as cli_mod
+
+        provisioned = []
+        monkeypatch.setattr(
+            cli_mod,
+            "_provision_uv_worktree",
+            lambda path: provisioned.append(path) or True,
+        )
+
+        info = None
+        try:
+            info = cli_mod._setup_worktree(str(git_repo), sync_base=False)
+            assert info is not None
+            assert provisioned == [Path(info["path"])]
+        finally:
+            _force_remove_worktree(info)
+
+    def test_setup_contains_unexpected_provisioner_exception(
+        self, git_repo, monkeypatch, caplog
+    ):
+        import cli as cli_mod
+
+        monkeypatch.setattr(
+            cli_mod,
+            "_provision_uv_worktree",
+            lambda _path: (_ for _ in ()).throw(RuntimeError("unexpected")),
+        )
+
+        info = None
+        try:
+            info = cli_mod._setup_worktree(str(git_repo), sync_base=False)
+            assert info is not None
+            assert "Unexpected uv worktree provisioning failure" in caplog.text
+            listing = subprocess.run(
+                ["git", "worktree", "list", "--porcelain"],
+                cwd=git_repo,
+                text=True,
+                capture_output=True,
+                check=True,
+            ).stdout
+            section = listing.split(f"worktree {info['path']}", 1)[1]
+            assert "\nlocked hermes pid=" in section
+            subprocess.run(
+                ["git", "worktree", "unlock", info["path"]],
+                cwd=git_repo,
+                check=True,
+                capture_output=True,
+            )
+        finally:
+            _force_remove_worktree(info)
+


### PR DESCRIPTION
## Summary
- provision a worktree-local `.venv` from the repository's locked uv project when copied/tracked files do not already provide a usable environment
- select only declared `dev`/`test` extras and dependency groups while disabling unrelated default groups
- verify the resulting Python can import pytest, retry partial environments, and keep worktree setup/locking fail-soft
- contain inherited `UV_PROJECT_ENVIRONMENT` so provisioning cannot escape the worktree

## Verification
- 73 focused tests passed
- repository-native `scripts/run_tests.sh` passed
- real-uv adversarial provisioning probe passed
- Ruff, compilation, and `git diff --check` passed
- deterministic privacy/Gitleaks/Noreply pre-push gate passed
- independent exact-SHA review: PASS, no class-(a) or class-(b) findings

## Backlog
- None from the final independent review.
