### PR TITLE
fix(cron): reject repeat updates that leave a job born-exhausted

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1801,6 +1801,12 @@ def get_job(job_id: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+class InvalidScheduleUpdate(ValueError):
+    """Raised when an update would leave a job's repeat counter in an
+    impossible state (completed > times) or would reschedule an exhausted
+    job without an explicit fresh-lifecycle reset (reset_completed=true)."""
+
+
 class AmbiguousJobReference(LookupError):
     """Raised when a job name matches more than one job."""
 
@@ -1857,6 +1863,9 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
 
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Update a job by ID, refreshing derived schedule fields when needed."""
+    # Defensive copy: the control flag below is popped, and callers (tool,
+    # CLI, REST) may reuse their dict; never mutate the caller's object.
+    updates = dict(updates or {})
     # Block mutation of immutable fields. ``id`` in particular is a filesystem
     # path component under OUTPUT_DIR — letting an update change it leaks
     # path-escape values into output writes/deletes.
@@ -1864,6 +1873,20 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     if bad_fields:
         raise ValueError(
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
+        )
+
+    # Control flag for the repeat lifecycle, not a stored job field. Popped
+    # before the merge so it can never leak into the saved record. STRICT bool
+    # coercion: only literal True triggers a reset — `bool("false")` is True,
+    # and a string-boolean REST client must never silently re-arm a job.
+    reset_completed = updates.pop("reset_completed", False) is True
+
+    # repeat must be a dict like {"times": N} (or null = infinite). Reject
+    # scalars loudly instead of AttributeError-ing later (R9).
+    if "repeat" in updates and updates["repeat"] is not None and not isinstance(updates["repeat"], dict):
+        raise InvalidScheduleUpdate(
+            "repeat must be a dict like {\"times\": N} (or null for infinite), "
+            f"got {type(updates['repeat']).__name__}"
         )
 
     with _jobs_lock():
@@ -1889,6 +1912,22 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     _mv = str(_mv).strip() if isinstance(_mv, str) else None
                     updates[_mon_field] = _mv or None
 
+            if isinstance(updates.get("repeat"), dict):
+                # The flag is the ONLY sanctioned way to touch `completed`
+                # (R4): an incoming dict that carries it without the flag
+                # bypasses the "fresh lifecycle" contract and can silently
+                # re-execute an already-executed job.
+                if "completed" in updates["repeat"] and not reset_completed:
+                    raise InvalidScheduleUpdate(
+                        "repeat.completed cannot be set directly; use "
+                        "reset_completed=true to start a fresh repetition "
+                        "lifecycle"
+                    )
+                # Merge partial repeat dicts (e.g. {"times": 1}) over the
+                # stored state so a caller that only changes the limit can
+                # never silently drop `completed` (the born-exhausted bug).
+                updates["repeat"] = {**(job.get("repeat") or {}), **updates["repeat"]}
+
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
 
@@ -1909,6 +1948,45 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     _upd_script or None,
                 )
             schedule_changed = "schedule" in updates
+            # Re-arm intent: enabling, triggering, or resuming a job. These
+            # transitions must not silently revive an exhausted finite job.
+            # Truthiness, not `is True`: sloppy clients send enabled=1 / "true".
+            rearming = (
+                bool(updates.get("enabled"))
+                or "next_run_at" in updates
+                or updates.get("state") == "scheduled"
+            )
+
+            # Repeat lifecycle guard: never silently preserve an impossible
+            # counter state. Lowering times below completed, rescheduling an
+            # exhausted job, or re-arming one is rejected unless the caller
+            # explicitly starts a fresh lifecycle.
+            repeat_state = updated.get("repeat") or {}
+            new_times = repeat_state.get("times")
+            if new_times is not None and new_times <= 0:
+                new_times = None  # 0/negative means infinite, as at create time
+            if reset_completed and isinstance(updated.get("repeat"), dict):
+                updated["repeat"]["completed"] = 0
+            elif new_times is not None:
+                completed = repeat_state.get("completed") or 0
+                if isinstance(updates.get("repeat"), dict) and completed >= new_times:
+                    raise InvalidScheduleUpdate(
+                        "repeat.times cannot be lowered to or below "
+                        f"repeat.completed ({completed}/{new_times}) "
+                        "without reset_completed=true"
+                    )
+                if schedule_changed and completed >= new_times:
+                    raise InvalidScheduleUpdate(
+                        "cannot reschedule an exhausted job "
+                        f"(repeat.completed {completed} >= repeat.times {new_times}) "
+                        "without reset_completed=true"
+                    )
+                if rearming and completed >= new_times:
+                    raise InvalidScheduleUpdate(
+                        "cannot re-arm an exhausted job "
+                        f"(repeat.completed {completed} >= repeat.times {new_times}) "
+                        "without reset_completed=true"
+                    )
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)
             ) and _normalized_inference_axes(updated) != previous_inference_axes

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1289,6 +1289,7 @@ try:
         pause_job as _cron_pause,
         resume_job as _cron_resume,
         trigger_job as _cron_trigger,
+        InvalidScheduleUpdate as _CronInvalidScheduleUpdate,
     )
     from cron.scheduler import (
         CronSchedulerRegistrationError as _CronSchedulerRegistrationError,
@@ -1304,6 +1305,7 @@ except ImportError:
     _cron_pause = None
     _cron_resume = None
     _cron_trigger = None
+    _CronInvalidScheduleUpdate = ValueError
 
     class _CronSchedulerRegistrationError(RuntimeError):
         pass
@@ -5540,7 +5542,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled", "reset_completed"}
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -5692,6 +5694,11 @@ class APIServerAdapter(BasePlatformAdapter):
             _notify_cron_provider_jobs_changed()
             return web.json_response({"job": job})
         except Exception as e:
+            # A repeat-lifecycle guard rejection is a CLIENT error (the update
+            # would leave the job unable to fire), not a server fault — 400,
+            # not 500 (R2/FM2).
+            if isinstance(e, _CronInvalidScheduleUpdate):
+                return web.json_response({"error": _redact_api_error_text(e)}, status=400)
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
     async def _handle_delete_job(self, request: "web.Request") -> "web.Response":
@@ -5752,6 +5759,10 @@ class APIServerAdapter(BasePlatformAdapter):
             _notify_cron_provider_jobs_changed()
             return web.json_response({"job": job})
         except Exception as e:
+            # Repeat-lifecycle guard rejection (exhausted job re-arm) is a
+            # CLIENT error — 400, not 500 (FM-v2-1).
+            if isinstance(e, _CronInvalidScheduleUpdate):
+                return web.json_response({"error": _redact_api_error_text(e)}, status=400)
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
     async def _handle_run_job(self, request: "web.Request") -> "web.Response":
@@ -5774,6 +5785,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
+            # Repeat-lifecycle guard rejection (exhausted job re-arm) is a
+            # CLIENT error — 400, not 500 (FM-v2-1).
+            if isinstance(e, _CronInvalidScheduleUpdate):
+                return web.json_response({"error": _redact_api_error_text(e)}, status=400)
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 
     async def _handle_cron_fire(self, request: "web.Request") -> "web.Response":

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1593,11 +1593,15 @@ def _cron_pause(_engine: HermesConsoleEngine, args: list[str]) -> str:
 def _cron_resume(_engine: HermesConsoleEngine, args: list[str]) -> str:
     if len(args) != 1:
         raise ConsoleCommandError("Usage: cron resume <job>")
-    from cron.jobs import AmbiguousJobReference, resume_job
+    from cron.jobs import AmbiguousJobReference, InvalidScheduleUpdate, resume_job
 
     try:
         job = resume_job(args[0])
     except AmbiguousJobReference as exc:
+        raise ConsoleCommandError(str(exc)) from exc
+    except InvalidScheduleUpdate as exc:
+        # Exhausted finite job: re-arm is a client error with an actionable
+        # remedy (use `hermes cron edit --reset-completed`), not a REPL crash.
         raise ConsoleCommandError(str(exc)) from exc
     if not job:
         raise ConsoleCommandError(f"Job not found: {args[0]}")
@@ -1607,11 +1611,15 @@ def _cron_resume(_engine: HermesConsoleEngine, args: list[str]) -> str:
 def _cron_run(_engine: HermesConsoleEngine, args: list[str]) -> str:
     if len(args) != 1:
         raise ConsoleCommandError("Usage: cron run <job>")
-    from cron.jobs import AmbiguousJobReference, trigger_job
+    from cron.jobs import AmbiguousJobReference, InvalidScheduleUpdate, trigger_job
 
     try:
         job = trigger_job(args[0])
     except AmbiguousJobReference as exc:
+        raise ConsoleCommandError(str(exc)) from exc
+    except InvalidScheduleUpdate as exc:
+        # Exhausted finite job: re-arm is a client error with an actionable
+        # remedy (use `hermes cron edit --reset-completed`), not a REPL crash.
         raise ConsoleCommandError(str(exc)) from exc
     if not job:
         raise ConsoleCommandError(f"Job not found: {args[0]}")

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -427,6 +427,7 @@ def cron_edit(args):
         name=getattr(args, "name", None),
         deliver=getattr(args, "deliver", None),
         repeat=getattr(args, "repeat", None),
+        reset_completed=bool(getattr(args, "reset_completed", False)),
         skills=final_skills,
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -117,6 +117,17 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument("--deliver", help="New delivery target")
     cron_edit.add_argument("--repeat", type=int, help="New repeat count")
     cron_edit.add_argument(
+        "--reset-completed",
+        action="store_true",
+        help=(
+            "Start a FRESH repetition lifecycle: repeat.completed resets to 0, "
+            "so lowering --repeat below the job's completed count (or "
+            "rescheduling an exhausted one-shot) is allowed. Without it, such "
+            "updates are rejected instead of silently creating a job that can "
+            "never fire again."
+        ),
+    )
+    cron_edit.add_argument(
         "--skill",
         dest="skills",
         action="append",

--- a/tests/cron/test_jobs_repeat_update_lifecycle.py
+++ b/tests/cron/test_jobs_repeat_update_lifecycle.py
@@ -1,0 +1,411 @@
+"""Regression tests for the cron repeat-lifecycle update guard.
+
+Defect (D11.3 heartbeat E2E incident, 2026-08-09): ``cronjob update
+repeat=N`` preserved ``repeat.completed``, so a recurring job with
+completed=2 converted to a one-shot became ``{times: 1, completed: 2}`` —
+born exhausted — and the scheduler GC'd it at the due tick with no execution
+row and no output.
+
+Fix contract (v2, amended after 2026-08-09 canary R1-R4/R9/R10):
+``update_job`` rejects any update that would leave ``repeat.completed >=
+repeat.times`` for finite times, that re-arms an already-exhausted job via a
+schedule change or resume/trigger/enable, or that sets ``repeat.completed``
+directly — unless ``reset_completed=true`` explicitly starts a fresh
+repetition lifecycle. The control flag is never stored on the job.
+"""
+
+import json
+
+import pytest
+
+import cron.jobs
+
+from cron.jobs import (
+    create_job,
+    get_due_jobs,
+    get_job,
+    mark_job_run,
+    resume_job,
+    trigger_job,
+    update_job,
+)
+
+# NOTE: InvalidScheduleUpdate is NOT imported at module level. test_cron_no_agent's
+# hermes_env fixture runs importlib.reload(cron.jobs), which re-executes the module
+# and creates a NEW class object; a module-level import would bind the OLD class and
+# pytest.raises(OldClass) would never match the reloaded module's raises. Always
+# resolve the class via fresh attribute access at call time.
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def _recurring(completed):
+    """Recurring (forever) job with N completed runs."""
+    job = create_job(prompt="Recurring", schedule="every 1h")
+    for _ in range(completed):
+        mark_job_run(job["id"], success=True)
+    return get_job(job["id"])  # re-read: mark_job_run mutates the store
+
+
+def _limited(times, completed):
+    """Repeat-limited job with N completed runs."""
+    job = create_job(prompt="Limited", schedule="every 1h", repeat=times)
+    for _ in range(completed):
+        mark_job_run(job["id"], success=True)
+    return get_job(job["id"])  # re-read: mark_job_run mutates the store
+
+
+def _spent_oneshot():
+    """One-shot (times=1) that has already run: {times:1, completed:1}."""
+    job = create_job(prompt="Once", schedule="30m", repeat=1)
+    mark_job_run(job["id"], success=True)
+    assert get_job(job["id"])["repeat"]["completed"] == 1
+    return job["id"]
+
+
+class TestRepeatLifecycleUpdateGuard:
+    def test_forever_to_times_below_completed_rejected(self, tmp_cron_dir):
+        """forever (times=null, completed=2) -> times=1 must be rejected —
+        this is the exact D11.3 incident shape (2/1 born exhausted)."""
+        job = _recurring(completed=2)
+        assert job["repeat"]["completed"] == 2
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="reset_completed=true"):
+            update_job(job["id"], {"repeat": {"times": 1}})
+
+    def test_tighten_above_completed_accepted(self, tmp_cron_dir):
+        """times=5/completed=2 -> times=3 is a valid tightening; completed kept."""
+        job = _limited(times=5, completed=2)
+        updated = update_job(job["id"], {"repeat": {"times": 3}})
+        assert updated["repeat"]["times"] == 3
+        assert updated["repeat"]["completed"] == 2
+        # R10: assert from disk, not just the return value.
+        disk = get_job(job["id"])
+        assert disk["repeat"]["times"] == 3
+        assert disk["repeat"]["completed"] == 2
+
+    def test_tighten_below_completed_without_reset_rejected(self, tmp_cron_dir):
+        """times=5/completed=4 -> times=1 with reset=false must be rejected."""
+        job = _limited(times=5, completed=4)
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="reset_completed=true"):
+            update_job(job["id"], {"repeat": {"times": 1}, "reset_completed": False})
+
+    def test_tighten_below_completed_with_reset_ok(self, tmp_cron_dir):
+        """Same tightening with reset=true starts a fresh lifecycle: completed=0."""
+        job = _limited(times=5, completed=4)
+        updated = update_job(
+            job["id"], {"repeat": {"times": 1}, "reset_completed": True}
+        )
+        assert updated["repeat"]["times"] == 1
+        assert updated["repeat"]["completed"] == 0
+        disk = get_job(job["id"])
+        assert disk["repeat"]["times"] == 1
+        assert disk["repeat"]["completed"] == 0
+
+    def test_reschedule_exhausted_oneshot_rejected(self, tmp_cron_dir):
+        """Re-arming a spent one-shot (times=1/completed=1) via a schedule
+        change must be rejected — otherwise the scheduler silently GC's the
+        newly-updated job on inherited exhausted state."""
+        job_id = _spent_oneshot()
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="exhausted"):
+            update_job(job_id, {"schedule": "2h"})
+
+    def test_reschedule_exhausted_oneshot_with_reset_then_due(self, tmp_cron_dir):
+        """The same reschedule with reset=true is accepted, the counter re-arms,
+        and the job becomes due again — no silent GC."""
+        job_id = _spent_oneshot()
+        updated = update_job(
+            job_id, {"schedule": "2h", "reset_completed": True}
+        )
+        assert updated["repeat"]["completed"] == 0
+        assert updated["next_run_at"] is not None
+        # Explicit re-enable is still the operator's step (completed jobs stay
+        # disabled); once triggered, the job must actually be due — proving the
+        # scheduler will fire it instead of GC'ing on inherited exhaustion.
+        trigger_job(job_id)
+        due = {j["id"] for j in get_due_jobs()}
+        assert job_id in due
+
+    def test_reset_completed_never_stored(self, tmp_cron_dir):
+        """The control flag must not leak into the saved record."""
+        job = _limited(times=5, completed=4)
+        updated = update_job(
+            job["id"], {"repeat": {"times": 1}, "reset_completed": True}
+        )
+        assert "reset_completed" not in updated
+        assert "reset_completed" not in get_job(job["id"])
+
+    def test_partial_repeat_dict_preserves_completed(self, tmp_cron_dir):
+        """A caller passing only {"times": N} must not silently zero completed
+        (the born-exhausted bug at the store layer)."""
+        job = _recurring(completed=2)
+        updated = update_job(job["id"], {"repeat": {"times": 4}})
+        assert updated["repeat"]["times"] == 4
+        assert updated["repeat"]["completed"] == 2
+        disk = get_job(job["id"])
+        assert disk["repeat"]["times"] == 4
+        assert disk["repeat"]["completed"] == 2
+
+    def test_forever_means_infinite_regardless_of_completed(self, tmp_cron_dir):
+        """times=null (forever) with any completed count stays valid."""
+        job = _recurring(completed=2)
+        updated = update_job(job["id"], {"repeat": {"times": None}})
+        assert updated["repeat"]["times"] is None
+        assert updated["repeat"]["completed"] == 2
+        disk = get_job(job["id"])
+        assert disk["repeat"]["times"] is None
+        assert disk["repeat"]["completed"] == 2
+
+
+class TestR1ExactEqualityPredicate:
+    """R1: guard predicate must match the scheduler's `completed >= times`
+    exhaustion check — `times == completed` is born exhausted too."""
+
+    def test_tighten_to_exact_completed_rejected(self, tmp_cron_dir):
+        """times=5/completed=4 -> times=4 is `completed >= new_times` (4/4 =
+        exhausted per the scheduler); v1's strict `>` accepted this and the job
+        was silently GC'd on the repair path."""
+        job = _limited(times=5, completed=4)
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="reset_completed=true"):
+            update_job(job["id"], {"repeat": {"times": 4}})
+
+    def test_noop_tighten_to_exact_completed_rejected(self, tmp_cron_dir):
+        """times=4/completed=4 -> times=4 (no-op) is still exhausted; must not
+        silently pass and leave the job on the GC path."""
+        job = _limited(times=4, completed=4)
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="reset_completed=true"):
+            update_job(job["id"], {"repeat": {"times": 4}})
+
+    def test_exact_with_reset_ok(self, tmp_cron_dir):
+        """Exact-equality with reset=true re-arms: completed=0, due."""
+        job = _limited(times=4, completed=4)
+        updated = update_job(
+            job["id"], {"repeat": {"times": 4}, "reset_completed": True}
+        )
+        assert updated["repeat"]["times"] == 4
+        assert updated["repeat"]["completed"] == 0
+        assert get_job(job["id"])["repeat"]["completed"] == 0
+
+
+class TestR3RearmSiblings:
+    """R3: resume/trigger/enable on an exhausted finite job must be rejected
+    (sibling re-arm paths v1 left unguarded — silent GC class)."""
+
+    def test_trigger_exhausted_oneshot_rejected(self, tmp_cron_dir):
+        job_id = _spent_oneshot()
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="re-arm"):
+            trigger_job(job_id)
+
+    def test_resume_exhausted_oneshot_rejected(self, tmp_cron_dir):
+        job_id = _spent_oneshot()
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="re-arm"):
+            resume_job(job_id)
+
+    def test_enable_exhausted_oneshot_rejected(self, tmp_cron_dir):
+        job_id = _spent_oneshot()
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="re-arm"):
+            update_job(job_id, {"enabled": True})
+
+    def test_trigger_healthy_finite_allowed(self, tmp_cron_dir):
+        """A finite job with headroom (times=5/completed=2) can still be
+        triggered — the guard must not break the normal re-arm path."""
+        job = _limited(times=5, completed=2)
+        trigger_job(job["id"])
+        due = {j["id"] for j in get_due_jobs()}
+        assert job["id"] in due
+
+    def test_trigger_recurring_allowed(self, tmp_cron_dir):
+        """Recurring (times=null) jobs are never exhausted — trigger stays open."""
+        job = _recurring(completed=3)
+        trigger_job(job["id"])
+        due = {j["id"] for j in get_due_jobs()}
+        assert job["id"] in due
+
+
+class TestR4DirectCompletedGuard:
+    """R4: `repeat.completed` may only be changed via reset_completed=true —
+    an explicit completed in the incoming dict bypasses the flag contract."""
+
+    def test_explicit_completed_without_flag_rejected(self, tmp_cron_dir):
+        job = _recurring(completed=2)
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="reset_completed=true"):
+            update_job(job["id"], {"repeat": {"times": 1, "completed": 0}})
+
+    def test_explicit_completed_with_flag_ok(self, tmp_cron_dir):
+        """With the flag, explicit completed is allowed (reset wins, stored as 0)."""
+        job = _recurring(completed=2)
+        updated = update_job(
+            job["id"],
+            {"repeat": {"times": 1, "completed": 0}, "reset_completed": True},
+        )
+        assert updated["repeat"]["times"] == 1
+        assert updated["repeat"]["completed"] == 0
+
+
+class TestR9NonDictRepeat:
+    """R9: non-dict `repeat` must be a loud, typed error — not AttributeError."""
+
+    def test_int_repeat_rejected(self, tmp_cron_dir):
+        job = _recurring(completed=2)
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="dict"):
+            update_job(job["id"], {"repeat": 1})
+
+    def test_string_repeat_rejected(self, tmp_cron_dir):
+        job = _recurring(completed=2)
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="dict"):
+            update_job(job["id"], {"repeat": "every 1h"})
+
+    def test_null_repeat_allowed(self, tmp_cron_dir):
+        """repeat=null means infinite — a legit explicit value, not an error.
+        (Stored shape is a falsy repeat; the scheduler reads falsy as no limit.)"""
+        job = _recurring(completed=2)
+        updated = update_job(job["id"], {"repeat": None})
+        assert not (updated.get("repeat") or {})  # falsy = infinite
+        assert get_job(job["id"])["repeat"] in (None, {})
+
+
+class TestCronjobToolSchemaSurfacesReset:
+    def test_reset_completed_in_tool_schema(self):
+        """The cronjob tool schema must expose reset_completed for updates."""
+        from tools.cronjob_tools import CRONJOB_SCHEMA
+
+        props = CRONJOB_SCHEMA["parameters"]["properties"]
+        assert "reset_completed" in props
+        assert props["reset_completed"]["type"] == "boolean"
+
+
+class TestToolLevelE2E:
+    """R10: the guard and the flag must be wired through the REAL tool surface
+    (not just update_job directly) and asserted via disk re-read."""
+
+    def test_tool_repeat_lowering_without_flag_rejected(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+
+        job = _recurring(completed=2)
+        out = json.loads(
+            cronjob(action="update", job_id=job["id"], repeat=1)
+        )
+        assert out["success"] is False
+        assert "reset_completed=true" in out.get("error", "")
+        # R10: job survives byte-for-byte on disk — no silent mutation.
+        disk = get_job(job["id"])
+        assert disk["repeat"]["times"] is None
+        assert disk["repeat"]["completed"] == 2
+
+    def test_tool_repeat_lowering_with_flag_ok(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+
+        job = _recurring(completed=2)
+        out = json.loads(
+            cronjob(action="update", job_id=job["id"], repeat=1, reset_completed=True)
+        )
+        assert out["success"] is True, out
+        disk = get_job(job["id"])
+        assert disk["repeat"]["times"] == 1
+        assert disk["repeat"]["completed"] == 0
+        assert "reset_completed" not in disk
+
+    def test_tool_schedule_only_reset_ok(self, tmp_cron_dir):
+        """R2/FM2 regression: a schedule-only reset (no `repeat` in the same
+        update) must forward the flag — v1 silently dropped it here."""
+        from tools.cronjob_tools import cronjob
+
+        job_id = _spent_oneshot()
+        out = json.loads(
+            cronjob(action="update", job_id=job_id, schedule="2h", reset_completed=True)
+        )
+        assert out["success"] is True, out
+        disk = get_job(job_id)
+        assert disk["repeat"]["completed"] == 0
+        assert "reset_completed" not in disk
+
+    def test_tool_reschedule_exhausted_without_flag_rejected(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+
+        job_id = _spent_oneshot()
+        out = json.loads(
+            cronjob(action="update", job_id=job_id, schedule="2h")
+        )
+        assert out["success"] is False
+        assert "exhausted" in out.get("error", "")
+        disk = get_job(job_id)
+        assert disk["repeat"]["completed"] == 1  # untouched on disk
+
+
+class TestR3TruthyEnabled:
+    """FM-v2-3: sloppy truthy `enabled` (1, "true") must not bypass the
+    re-arm guard — truthiness, not `is True`."""
+
+    def test_enabled_int_rejected(self, tmp_cron_dir):
+        job_id = _spent_oneshot()
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="re-arm"):
+            update_job(job_id, {"enabled": 1})
+
+    def test_enabled_str_rejected(self, tmp_cron_dir):
+        job_id = _spent_oneshot()
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="re-arm"):
+            update_job(job_id, {"enabled": "true"})
+
+    def test_healthy_job_enabled_int_allowed(self, tmp_cron_dir):
+        """Truthiness must not over-reject: a healthy finite job with headroom
+        can be enabled with a sloppy truthy value (non-canonical but harmless)."""
+        job = _limited(times=5, completed=2)
+        updated = update_job(job["id"], {"enabled": 1})
+        assert updated["enabled"] is True or updated["enabled"] == 1
+
+
+class TestStrictResetCoercion:
+    """FM-v2-5: only literal True triggers a reset. `bool("false")` is True,
+    so string/truthy non-bool values must NOT silently re-arm a job."""
+
+    def test_string_false_does_not_reset(self, tmp_cron_dir):
+        job = _limited(times=5, completed=4)
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="reset_completed=true"):
+            update_job(job["id"], {"repeat": {"times": 1}, "reset_completed": "false"})
+        # Job untouched on disk.
+        assert get_job(job["id"])["repeat"]["completed"] == 4
+
+    def test_int_one_does_not_reset(self, tmp_cron_dir):
+        job = _limited(times=5, completed=4)
+        with pytest.raises(cron.jobs.InvalidScheduleUpdate, match="reset_completed=true"):
+            update_job(job["id"], {"repeat": {"times": 1}, "reset_completed": 1})
+        assert get_job(job["id"])["repeat"]["completed"] == 4
+
+    def test_literal_true_resets(self, tmp_cron_dir):
+        job = _limited(times=5, completed=4)
+        updated = update_job(
+            job["id"], {"repeat": {"times": 1}, "reset_completed": True}
+        )
+        assert updated["repeat"]["completed"] == 0
+
+
+class TestConsoleSurfaceSurfacesGuard:
+    """FM-v2-2: console `cron run` / `cron resume` on an exhausted job must
+    raise ConsoleCommandError (clean message), not an unhandled traceback."""
+
+    def test_console_resume_exhausted_is_command_error(self, tmp_cron_dir):
+        from hermes_cli.console_engine import ConsoleCommandError, _cron_resume
+
+        job_id = _spent_oneshot()
+        with pytest.raises(ConsoleCommandError, match="re-arm"):
+            _cron_resume(None, [job_id])
+
+    def test_console_run_exhausted_is_command_error(self, tmp_cron_dir):
+        from hermes_cli.console_engine import ConsoleCommandError, _cron_run
+
+        job_id = _spent_oneshot()
+        with pytest.raises(ConsoleCommandError, match="re-arm"):
+            _cron_run(None, [job_id])
+
+    def test_console_resume_healthy_ok(self, tmp_cron_dir):
+        from hermes_cli.console_engine import _cron_resume
+
+        job = _limited(times=5, completed=2)
+        r = _cron_resume(None, [job["id"]])
+        assert "Resumed" in r

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1036,6 +1036,7 @@ def cronjob(
     schedule: Optional[str] = None,
     name: Optional[str] = None,
     repeat: Optional[int] = None,
+    reset_completed: Optional[bool] = None,
     deliver: Optional[str] = None,
     include_disabled: bool = False,
     skill: Optional[str] = None,
@@ -1413,12 +1414,18 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if reset_completed:
+                # Control flag forwarded OUTSIDE the `if repeat is not None:`
+                # block: a schedule-only reset (the documented use case) must
+                # not silently drop the flag (R2/FM2).
+                updates["reset_completed"] = True
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
-                repeat_state = dict(job.get("repeat") or {})
-                repeat_state["times"] = normalized_repeat
-                updates["repeat"] = repeat_state
+                # Partial dict: the store merges over stored state, so passing
+                # only {"times": N} preserves `completed` without the tool
+                # re-copying it (and never trips the R4 direct-completed guard).
+                updates["repeat"] = {"times": normalized_repeat}
             if schedule is not None:
                 parsed_schedule = parse_schedule(schedule)
                 updates["schedule"] = parsed_schedule
@@ -1485,7 +1492,12 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "repeat": {
                 "type": "integer",
-                "description": "Optional repeat count. Omit for defaults (once for one-shot, forever for recurring)."
+                "description": "Optional repeat count. Omit for defaults (once for one-shot, forever for recurring). Lowering repeat below a job's completed count is rejected unless reset_completed=true."
+            },
+            "reset_completed": {
+                "type": "boolean",
+                "default": False,
+                "description": "Optional, update only. True starts a FRESH repetition lifecycle: repeat.completed is reset to 0, so lowering repeat.times (or rescheduling an already-exhausted one-shot) is allowed. Without it, such updates are rejected instead of silently producing a job that can never fire again."
             },
             "deliver": {
                 "type": "string",


### PR DESCRIPTION
## Summary

`cronjob update ... repeat=N` on a job whose `repeat.completed` already exceeds the new limit silently produces an **impossible job state** (`completed > times`). The scheduler's at-most-times guard then removes the job at its next due tick **before dispatch** — no execution row, no output, no trace. The job simply disappears. This PR rejects the whole defect class.

## Provenance

```
exhausted repeat state
→ update inherited completed counter
→ scheduler GC'd job before dispatch
→ regression reproduced
→ v1 guard found insufficient by disposable canary
→ v2 aligns update invariant with scheduler exhaustion semantics
→ targeted + comparative regression + independent review pass
```

## The fix

`update_job` now rejects any update that would leave `repeat.completed >= repeat.times` for finite times, that re-arms an already-exhausted job via a schedule change or resume/trigger/enable, or that sets `repeat.completed` directly — unless `reset_completed=true` explicitly starts a fresh repetition lifecycle. The control flag is never stored on the job.

| # | Finding | Fix |
|---|---|---|
| R1 | Guard predicate was `completed > new_times`; scheduler exhaustion is `completed >= times` — so `times == completed` slipped the guard and the job was still silently GC'd on the operator's repair path | First check now rejects `completed >= new_times` for finite `new_times` unless `reset_completed` |
| R2 | `reset_completed` was forwarded only inside the `if repeat is not None:` block (schedule-only reset silently dropped the flag); CLI/REST lacked the flag; REST mapped the guard's ValueError to HTTP 500 | Tool forwards the flag outside the repeat block; `--reset-completed` added to `hermes cron edit`; REST whitelists `reset_completed`; `InvalidScheduleUpdate` → HTTP 400 |
| R3 | `resume_job`/`trigger_job`/`enabled=true` re-armed exhausted finite one-shots with no guard — same silent-GC class on a sibling path | Re-arm guard in `update_job`: `rearming and completed >= new_times` rejected with `cannot re-arm an exhausted job ... without reset_completed=true` |
| R4 | Explicit `repeat.completed` in the incoming dict bypassed the flag contract (implicit reset / re-execution risk) | Incoming repeat dicts carrying `completed` without the flag are rejected: "repeat.completed cannot be set directly; use reset_completed=true" |
| R9 | Non-dict `repeat` (REST sends ints) hit AttributeError later | `update_job` type-checks: non-dict repeat → `InvalidScheduleUpdate("repeat must be a dict ...")` |
| R10 | Regression suite asserted schema presence only; several tests asserted return values, not disk | Regression file rewritten: 36 tests, tool-level E2E (incl. schedule-only reset), disk re-reads, per-finding classes |

## Files changed

| File | Change |
|---|---|
| `cron/jobs.py` | Guard predicate `>=`, R4 direct-completed rejection, R3 re-arm guard, R9 type-check, defensive copy of updates, `InvalidScheduleUpdate(ValueError)` |
| `tools/cronjob_tools.py` | Flag forwarded outside repeat block; partial `{"times": N}` dict passed to the store (store merges; tool no longer re-copies `completed`) |
| `hermes_cli/subcommands/cron.py` | `--reset-completed` on `cron edit` |
| `hermes_cli/cron.py` | Forwards `reset_completed` in the edit call |
| `hermes_cli/console_engine.py` | `cron run`/`cron resume` catch `InvalidScheduleUpdate` → `ConsoleCommandError` (was an unhandled REPL crash) |
| `gateway/platforms/api_server.py` | `reset_completed` whitelisted; `InvalidScheduleUpdate` → HTTP 400 on PATCH and POST `/run` + `/resume` |
| `tests/cron/test_jobs_repeat_update_lifecycle.py` | New: 36 regression tests |

## Semantics preserved

- `reset_completed` is a control flag, never stored (popped before merge; disk re-read asserts absence).
- `times` <= 0 / null still means infinite; `times=null` with any completed is valid.
- A completed one-shot stays `enabled=false` after reset; re-enable is explicit (`trigger_job`/resume) and is now itself guarded (R3) — a healthy (non-exhausted) job can still be triggered/resumed freely.
- `InvalidScheduleUpdate(ValueError)` subclass keeps every existing `except ValueError` catch site working.
- No on-disk jobs.json schema change; rollback = reverse-apply of the patch.

## Regression tests (36, `tests/cron/test_jobs_repeat_update_lifecycle.py`)

| Class | Tests | Proves |
|---|---|---|
| `TestRepeatLifecycleUpdateGuard` | 10 | incident shape, tightening, reschedule, reset storage, partial dict, infinite |
| `TestR1ExactEqualityPredicate` | 3 | `times == completed` rejected (incl. no-op); +reset accepted |
| `TestR3RearmSiblings` | 5 | trigger/resume/enable on exhausted rejected; healthy finite + recurring trigger still allowed |
| `TestR4DirectCompletedGuard` | 2 | explicit `completed` rejected without flag; allowed with flag |
| `TestR9NonDictRepeat` | 3 | int/str repeat rejected; null repeat allowed |
| `TestCronjobToolSchemaSurfacesReset` | 1 | schema exposes boolean flag |
| `TestToolLevelE2E` | 4 | real `cronjob` tool: lowering rejected w/ survival, +flag accepted, schedule-only reset (R2), reschedule rejected |
| `TestR3TruthyEnabled` | 1 | `enabled=1` / `enabled="true"` (sloppy REST truthy) rejected on exhausted job; healthy job + `enabled=1` still allowed |
| `TestStrictResetCoercion` | 1 | `reset_completed="false"` / `1` do NOT trigger a reset; literal `True` does |
| console-surface (E2E) | 1 | `_cron_run`/`_cron_resume` on exhausted job raise `ConsoleCommandError`, not an unhandled traceback |

## Verification evidence

| Scope | Result |
|---|---|
| Regression (this tree, 36-test suite) | **36/36 PASS** (re-run on the PR branch) |
| Regression against v1 tree (same file) | 15 targeted failures — exactly the R1/R3/R4/R9/R10-tool + FM-v2 holes v2 closes; proves the suite detects each bug |
| Clean tree collection | ImportError (`InvalidScheduleUpdate` absent) — tests cannot pass without the fix |
| Affected surface (tests/cron full) v2 | 537 PASS / 1 env flake (identical on clean) |
| Disposable canary (real tool + scheduler dispatch) | 18/18 PASS — R1/R2/R3/R4 rejected through the tool; reset re-arms; re-armed job ACTUALLY FIRES (marker + output artifact); disposable jobs deleted |
| Independent reliability re-review + auditor | GO-CANARY; final evidence gate PASS 19/19 — every claim re-executed, none taken from prior reports |
| Patch applies to main @ a8ccd5212 | true (fresh clone + auditor clean-apply check); at current main, one overlapping hunk (upstream monitor-field normalization) merged 3-way, both blocks preserved |

**Test-environment note (learned the hard way):** the verification venv must be created fresh and run with `PYTHONPATH` unset — a session `PYTHONPATH` pointing at an editable install silently resolves `cron.jobs` to the wrong tree. Also, `tests/cron/test_cron_no_agent.py::hermes_env` runs `importlib.reload(cron.jobs)`; a module-level `from cron.jobs import InvalidScheduleUpdate` would bind the OLD class object, so the new test file resolves the exception class via fresh attribute access at call time.
