### PR TITLE
fix search files on windows with rg

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -294,6 +294,35 @@ class TestShellFileOpsHelpers:
             "C:/Users/alice/notes.txt"
         ) == "'/c/Users/alice/notes.txt'"
 
+    def test_rg_escape_path_converts_msys_paths_back_to_windows(self, monkeypatch, file_ops):
+        import platform
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        assert file_ops._rg_escape_path("/c/Users/alice/notes.txt") == (
+            r"'C:\Users\alice\notes.txt'"
+        )
+
+    def test_rg_file_search_uses_native_windows_path(self, mock_env, monkeypatch):
+        import platform
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        mock_env.execute.return_value = {
+            "output": "C:/Users/alice/skills/SKILL.md\n",
+            "returncode": 0,
+        }
+
+        ops = ShellFileOperations(mock_env)
+        ops._search_files_rg("SKILL.md", "/c/Users/alice/skills", 50, 0)
+
+        command = mock_env.execute.call_args.args[0]
+        assert "'/c/Users/alice/skills'" not in command
+        assert r"'C:\Users\alice\skills'" in command
+
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env, monkeypatch):
         import tools.environments.local as local_mod
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1075,6 +1075,16 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _rg_escape_path(self, path: str) -> str:
+        """escape a path for rg, which is a native windows binary."""
+        if not path:
+            return "''"
+        import platform
+        if platform.system() == "Windows":
+            from tools.environments.local import _msys_to_windows_path
+            path = _msys_to_windows_path(path)
+        return "'" + path.replace("'", "'\"'\"'") + "'"
+
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` to ``path`` atomically via temp-file + rename.
 
@@ -2463,7 +2473,7 @@ class ShellFileOperations(FileOperations):
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._rg_escape_path(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2485,7 +2495,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {self._rg_escape_path(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2505,7 +2515,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+                f"{self._escape_shell_arg(pattern)} {self._rg_escape_path(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2627,7 +2637,7 @@ class ShellFileOperations(FileOperations):
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{self._rg_escape_path(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2638,7 +2648,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{self._rg_escape_path(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2722,7 +2732,7 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._rg_escape_path(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,
@@ -2858,7 +2868,7 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._rg_escape_path(path))
         
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)


### PR DESCRIPTION
## What does this PR do?

  Fixes file searching on Windows when using rg. MSYS-style paths such as /c/Users/... are now converted to
  native Windows paths before being passed to the native rg binary. This prevents search and file-discovery
  operations from failing on Windows while preserving existing behavior on other platforms.

  ## Related Issue

  Fixes # <!-- Add the relevant issue number -->

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests
  - [ ] ♻️ Refactor
  - [ ] 🎯 New skill

  ## Changes Made

  - Added _rg_escape_path() in tools/file_operations.py to convert MSYS paths to native Windows paths.
  - Updated rg search and file-discovery commands to use the Windows-aware path escaping helper.
  - Added regression tests covering path conversion and native Windows paths passed to rg in tests/tools/
    test_file_operations.py.

  ## How to Test

  1. Run pytest tests/tools/test_file_operations.py -q.
  2. On Windows, search for a file or text pattern using a path such as C:\Users\<user>\....
  3. Verify that rg receives a native Windows path and returns the expected results.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits
  - [x] I searched for existing PRs
  - [x] My PR contains only changes related to this fix
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes
  - [x] I've tested on my platform: Windows 

  ### Documentation & Housekeeping

  - [x] Documentation update not applicable
  - [x] Config documentation update not applicable
  - [x] Architecture/workflow documentation update not applicable
  - [x] Cross-platform impact considered
  - [x] Tool descriptions/schemas not affected