### PR TITLE
fix(computer-use): harden session lifecycle and runtime attestation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4762,6 +4762,7 @@ class TurnRunner:
             if _peek_entry and len(_peek_entry) > 3:
                 _peek_cached_sid = _peek_entry[3]
         _cached_sid_is_dead = False
+        _peek_cached_cua_generation = None
         if (
             _peek_cached_sid is not None
             and ctx.session_id is not None
@@ -4773,6 +4774,19 @@ class TurnRunner:
                 )
             except Exception:
                 _cached_sid_is_dead = False
+            if _cached_sid_is_dead and _peek_cached_sid:
+                try:
+                    from tools.computer_use import get_computer_use_session_generation
+
+                    _peek_cached_cua_generation = get_computer_use_session_generation(
+                        _peek_cached_sid
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not snapshot computer_use generation for dead session %s",
+                        _peek_cached_sid,
+                        exc_info=True,
+                    )
 
         # Detect cross-process writes: when another process (e.g. hermes
         # dashboard) appends to the same session in the shared SessionDB,
@@ -4791,6 +4805,7 @@ class TurnRunner:
                 pass
 
         _xproc_evicted_agent = None
+        _xproc_evicted_cua_release = None
         if _cache_lock and _cache is not None:
             with _cache_lock:
                 cached = _cache.get(ctx.session_key)
@@ -4856,6 +4871,15 @@ class TurnRunner:
                             # block the event loop / cache lock on
                             # memory-provider shutdown or socket teardown.
                             _xproc_evicted_agent = _ev_agent
+                            if (
+                                isinstance(_cached_sid, str)
+                                and _cached_sid.strip()
+                                and _peek_cached_cua_generation is not None
+                            ):
+                                _xproc_evicted_cua_release = (
+                                    _cached_sid,
+                                    _peek_cached_cua_generation,
+                                )
                     elif (
                         not _session_id_mismatch
                         and _cached_mc is not None
@@ -4915,25 +4939,22 @@ class TurnRunner:
                 agent, self._runner._refresh_fallback_model(),
             )
 
-        # Lock released — now schedule cleanup of any cross-process-evicted
-        # agent on a daemon thread so memory-provider shutdown / socket
-        # teardown never blocks the gateway event loop or the cache lock
-        # the session-expiry watcher needs (#52197).
+        # Lock released — perform cleanup in this tracked turn worker. The
+        # helper itself uses bounded computer_use quiescence and an exact
+        # (session_id, generation) token for hard dead-session boundaries.
+        # Generic same-session transcript refresh remains soft.
         if _xproc_evicted_agent is not None:
             try:
-                threading.Thread(
-                    target=self._runner._release_evicted_agent_soft,
-                    args=(_xproc_evicted_agent,),
-                    daemon=True,
-                    name=f"agent-xproc-evict-{str(ctx.session_key)[:24]}",
-                ).start()
+                self._runner._release_evicted_agent_soft(
+                    _xproc_evicted_agent,
+                    computer_use_release=_xproc_evicted_cua_release,
+                )
             except Exception:
-                # Interpreter shutdown or thread-spawn failure — release
-                # inline as a best-effort fallback.
-                try:
-                    self._runner._release_evicted_agent_soft(_xproc_evicted_agent)
-                except Exception:
-                    pass
+                logger.warning(
+                    "Tracked cross-process agent cleanup failed for %s",
+                    ctx.session_key,
+                    exc_info=True,
+                )
 
         if agent is None:
             # Config changed or first message — create fresh agent
@@ -13285,6 +13306,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if hasattr(self, '_busy_ack_ts'):
                 self._busy_ack_ts.clear()
             self._shutdown_event.set()
+
+            # Drain exact-generation CUA cleanup submitted by dead-cache
+            # invalidation. Keep the event loop responsive and bound the wait;
+            # the final process sweep below remains the last-resort containment.
+            try:
+                from tools.computer_use import (
+                    computer_use_cleanup_snapshot,
+                    drain_computer_use_cleanup,
+                )
+
+                _cua_drained = await asyncio.to_thread(
+                    drain_computer_use_cleanup,
+                    10.0,
+                )
+                if not _cua_drained:
+                    logger.warning(
+                        "Timed out draining computer_use cleanup supervisor: %s",
+                        computer_use_cleanup_snapshot(),
+                    )
+            except Exception as _e:
+                logger.debug("computer_use cleanup drain error: %s", _e)
 
             # Global cleanup: kill any remaining tool subprocesses not tied
             # to a specific agent (catch-all for zombie prevention). On the
@@ -24105,18 +24147,75 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._commit_memory_before_soft_evict(agent, key)
         self._release_evicted_agent_soft(agent)
 
-    def _release_evicted_agent_soft(self, agent: Any) -> None:
-        """Soft cleanup for cache-evicted agents — preserves session tool state.
-
-        Called from _enforce_agent_cache_cap and _sweep_idle_cached_agents.
-        Distinct from _cleanup_agent_resources (full teardown) because a
-        cache-evicted session may resume at any time — its terminal
-        sandbox, browser daemon, and tracked bg processes must outlive
-        the Python AIAgent instance so the next agent built for the
-        same task_id inherits them.
-        """
+    def _release_evicted_agent_soft(
+        self,
+        agent: Any,
+        *,
+        computer_use_release: Optional[tuple[str, int]] = None,
+    ) -> Any:
+        """Release agent clients; optionally close one exact dead-session CUA generation."""
         if agent is None:
-            return
+            return None
+        release_result = None
+        if computer_use_release is not None:
+            sid, generation = computer_use_release
+            agent_sid = str(getattr(agent, "session_id", "") or "")
+            if (
+                not sid
+                or not isinstance(generation, int)
+                or isinstance(generation, bool)
+                or generation <= 0
+                or agent_sid != sid
+            ):
+                logger.error(
+                    "Rejected computer_use hard release: agent_sid=%s request_sid=%s "
+                    "generation=%r",
+                    agent_sid,
+                    sid,
+                    generation,
+                )
+            else:
+                try:
+                    from tools.computer_use import submit_computer_use_session_release
+
+                    release_result = submit_computer_use_session_release(
+                        sid,
+                        expected_generation=generation,
+                        timeout=5.0,
+                        reason="dead_cached_session",
+                        max_attempts=3,
+                        retry_delay=0.25,
+                    )
+
+                    def _log_cua_release(done: Any) -> None:
+                        try:
+                            result = done.result()
+                        except Exception:
+                            logger.exception(
+                                "computer_use hard release future raised: "
+                                "session=%s generation=%s",
+                                sid,
+                                generation,
+                            )
+                            return
+                        if result.status not in {"released", "already_absent"}:
+                            logger.error(
+                                "computer_use hard release did not complete: "
+                                "session=%s generation=%s status=%s error=%s",
+                                sid,
+                                generation,
+                                result.status,
+                                result.error,
+                            )
+
+                    release_result.add_done_callback(_log_cua_release)
+                except Exception:
+                    logger.exception(
+                        "computer_use hard release submission raised: "
+                        "session=%s generation=%s",
+                        sid,
+                        generation,
+                    )
         try:
             if hasattr(agent, "release_clients"):
                 agent.release_clients()
@@ -24125,7 +24224,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # fall back to the legacy full-close path.
                 self._cleanup_agent_resources(agent)
         except Exception:
-            pass
+            logger.debug("Soft agent client release failed", exc_info=True)
         # Free conversation history memory — can be tens of MB with tool
         # outputs (file reads, terminal output, search results) on heavy
         # 100+-tool-call sessions. release_clients() deliberately preserves
@@ -24141,6 +24240,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # agents the memory valve targets.
         if hasattr(agent, "_db_flush_scan_prefix"):
             agent._db_flush_scan_prefix = None
+        return release_result
 
     def _agent_cache_bounds(self):
         """Operator-configured agent-cache bounds, resolved once per process.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6037,6 +6037,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(
                 key, max_active_age=_bg_max_age_seconds,
             ),
+            before_auto_reset_fn=lambda sid, reset_reason: (
+                self._begin_terminal_computer_use_sync(
+                    sid,
+                    reason=f"auto_reset:{reset_reason}",
+                )
+            ),
+            before_terminal_completion_fn=(
+                self._prepare_terminal_route_completion_sync
+            ),
+            after_auto_reset_fn=lambda _sid, transition, succeeded: (
+                self._end_terminal_computer_use_sync(
+                    transition,
+                    succeeded=succeeded,
+                )
+            ),
+        )
+        from tools.computer_use import set_computer_use_session_validator
+
+        set_computer_use_session_validator(
+            lambda sid: self.session_store.lookup_by_session_id(sid) is not None
         )
         # One enforced loop-side boundary for the synchronous SessionStore.
         # Sync helpers keep using ``session_store`` directly; async gateway
@@ -6184,6 +6204,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         import threading as _threading
         self._agent_cache: "OrderedDict[str, tuple]" = OrderedDict()
         self._agent_cache_lock = _threading.Lock()
+        self._terminal_reactivations: Dict[int, Any] = {}
+        self._terminal_reactivations_lock = _threading.Lock()
+        self._terminal_cleanup_agents: Dict[int, Any] = {}
+        self._terminal_cleanup_agents_lock = _threading.Lock()
 
         # Conversation-scoped per-session state (/model, /model --once,
         # /reasoning, /fast overrides; per-turn sidecar notes; ephemeral
@@ -9798,6 +9822,244 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         tasks.add(task)
         task.add_done_callback(tasks.discard)
 
+    def _begin_terminal_computer_use_sync(
+        self,
+        session_id: str,
+        *,
+        reason: str,
+    ) -> Any:
+        """Fence admission, then confirm exact teardown while retaining the fence."""
+        sid = str(session_id or "")
+        if not sid:
+            return None
+        from tools.computer_use import (
+            begin_computer_use_terminal_transition,
+            end_computer_use_terminal_transition,
+        )
+
+        transition = begin_computer_use_terminal_transition(sid)
+        try:
+            result = self._release_terminal_computer_use_exact_sync(
+                sid,
+                expected_generation=transition.generation,
+                reason=reason,
+            )
+            return transition, result, reason
+        except BaseException:
+            end_computer_use_terminal_transition(transition)
+            raise
+
+    def _prepare_terminal_route_completion_sync(
+        self,
+        session_id: str,
+        lease: Any,
+        session_key: str,
+    ) -> None:
+        """Finish old-route resources and fence any explicit reactivation."""
+        reason = lease[2] if isinstance(lease, tuple) and len(lease) > 2 else ""
+        is_expiry = reason == "auto_reset:session_expired"
+        transition_key = id(lease[0])
+        evicted_agent = None
+        cleanup_agents = getattr(self, "_terminal_cleanup_agents", None)
+        cleanup_agents_lock = getattr(
+            self,
+            "_terminal_cleanup_agents_lock",
+            None,
+        )
+        if is_expiry and cleanup_agents is not None and cleanup_agents_lock is not None:
+            with cleanup_agents_lock:
+                evicted_agent = cleanup_agents.get(transition_key)
+        if evicted_agent is None:
+            evicted_agent = self._evict_cached_agent(
+                session_key,
+                soft_release=not is_expiry,
+            )
+            if (
+                is_expiry
+                and evicted_agent is not None
+                and cleanup_agents is not None
+                and cleanup_agents_lock is not None
+            ):
+                with cleanup_agents_lock:
+                    cleanup_agents[transition_key] = evicted_agent
+        self._clear_conversation_scope(
+            session_key,
+            reason="terminal_route_replaced",
+        )
+        if is_expiry:
+            if evicted_agent is not None:
+                try:
+                    evicted_agent._end_session_on_close = False
+                except Exception:
+                    pass
+            try:
+                from hermes_cli.lifecycle import finalize_session
+
+                parts = session_key.split(":")
+                platform = parts[2] if len(parts) > 2 else ""
+                finalize_session(
+                    session_id=session_id,
+                    platform=platform,
+                    reason="session_expired",
+                )
+            except Exception:
+                pass
+            if evicted_agent is not None:
+                self._cleanup_agent_resources(evicted_agent, strict=True)
+                if cleanup_agents is not None and cleanup_agents_lock is not None:
+                    with cleanup_agents_lock:
+                        if cleanup_agents.get(transition_key) is evicted_agent:
+                            cleanup_agents.pop(transition_key, None)
+
+        replacement_id = self.session_store.peek_session_id(session_key)
+        if not replacement_id or replacement_id == session_id:
+            return
+        reactivations_lock = getattr(
+            self,
+            "_terminal_reactivations_lock",
+            None,
+        )
+        reactivations = getattr(self, "_terminal_reactivations", None)
+        if reactivations_lock is None or reactivations is None:
+            # Compatibility for partial GatewayRunner test/embedding objects.
+            return
+        from tools.computer_use import (
+            begin_computer_use_session_reactivation,
+            is_computer_use_session_retired,
+        )
+
+        if is_computer_use_session_retired(replacement_id):
+            reactivation = begin_computer_use_session_reactivation(replacement_id)
+            transition = lease[0]
+            with self._terminal_reactivations_lock:
+                self._terminal_reactivations[id(transition)] = reactivation
+
+    def _end_terminal_computer_use_sync(
+        self,
+        lease: Any,
+        *,
+        succeeded: bool,
+    ) -> None:
+        if lease is None:
+            return
+        from tools.computer_use import (
+            end_computer_use_session_reactivation,
+            end_computer_use_terminal_transition,
+        )
+
+        transition = lease[0]
+        reactivation = None
+        reactivation_lock = getattr(
+            self,
+            "_terminal_reactivations_lock",
+            None,
+        )
+        reactivations = getattr(self, "_terminal_reactivations", None)
+        if reactivation_lock is not None and reactivations is not None:
+            with reactivation_lock:
+                reactivation = reactivations.pop(id(transition), None)
+        if not succeeded:
+            if reactivation is not None:
+                end_computer_use_session_reactivation(
+                    reactivation,
+                    succeeded=False,
+                )
+            return
+        try:
+            end_computer_use_terminal_transition(transition, retire=True)
+        except BaseException:
+            if reactivation is not None:
+                end_computer_use_session_reactivation(
+                    reactivation,
+                    succeeded=False,
+                )
+            raise
+        if reactivation is not None:
+            end_computer_use_session_reactivation(
+                reactivation,
+                succeeded=True,
+            )
+
+    def _release_terminal_computer_use_sync(
+        self,
+        session_id: str,
+        *,
+        reason: str,
+    ) -> Any:
+        """Confirm teardown with admission fenced for this bounded call."""
+        lease = self._begin_terminal_computer_use_sync(
+            session_id, reason=reason
+        )
+        try:
+            return lease[1] if lease is not None else None
+        finally:
+            self._end_terminal_computer_use_sync(lease, succeeded=True)
+
+    def _release_terminal_computer_use_exact_sync(
+        self,
+        session_id: str,
+        *,
+        expected_generation: Optional[int],
+        reason: str,
+    ) -> Any:
+        """Confirm exact CUA teardown before publishing a terminal boundary."""
+        sid = str(session_id or "")
+        if not sid:
+            return None
+        from tools.computer_use import (
+            get_computer_use_session_generation,
+            submit_computer_use_session_release,
+        )
+
+        generation = expected_generation
+        if generation is None:
+            return None
+        if type(generation) is not int or generation <= 0:
+            raise RuntimeError(
+                f"invalid computer_use generation for terminal boundary: {generation!r}"
+            )
+        future = submit_computer_use_session_release(
+            sid,
+            expected_generation=generation,
+            timeout=5.0,
+            reason=reason,
+            max_attempts=3,
+            retry_delay=0.25,
+        )
+        try:
+            result = future.result(timeout=20.0)
+        except TimeoutError as exc:
+            raise RuntimeError(
+                f"computer_use terminal release timed out: session={sid} generation={generation}"
+            ) from exc
+        if result.status not in {"released", "already_absent"}:
+            raise RuntimeError(
+                "computer_use terminal release failed: "
+                f"session={sid} generation={generation} status={result.status} "
+                f"error={result.error or ''}"
+            )
+        remaining_generation = get_computer_use_session_generation(sid)
+        if remaining_generation is not None:
+            raise RuntimeError(
+                "computer_use terminal release completed but the session remained active: "
+                f"session={sid} released_generation={generation} "
+                f"current_generation={remaining_generation}"
+            )
+        return result
+
+    async def _release_terminal_computer_use(
+        self,
+        session_id: str,
+        *,
+        reason: str,
+    ) -> Any:
+        """Async facade for exact terminal-boundary CUA teardown."""
+        return await asyncio.to_thread(
+            self._release_terminal_computer_use_sync,
+            session_id,
+            reason=reason,
+        )
+
     async def _cleanup_agent_resources_off_loop(
         self, agent: Any, *, context: str = ""
     ) -> None:
@@ -9838,10 +10100,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 cleanup_exc,
             )
 
-    def _cleanup_agent_resources(self, agent: Any) -> None:
-        """Best-effort cleanup for temporary or cached agent instances."""
+    def _cleanup_agent_resources(self, agent: Any, *, strict: bool = False) -> None:
+        """Clean up temporary or cached agent resources.
+
+        Normal cache cleanup is best-effort. Terminal route retirement passes
+        ``strict=True`` so a failed route-owned shutdown preserves the terminal
+        fence instead of reopening admission over a partially live old agent.
+        """
         if agent is None:
             return
+        cleanup_errors: list[BaseException] = []
         try:
             if hasattr(agent, "shutdown_memory_provider"):
                 # Drain queued memory writes BEFORE tearing the provider down.
@@ -9877,16 +10145,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     agent.shutdown_memory_provider(session_messages)
                 else:
                     agent.shutdown_memory_provider()
-        except Exception:
-            pass
+        except Exception as exc:
+            cleanup_errors.append(exc)
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) to prevent zombie
         # process accumulation.
         try:
             if hasattr(agent, "close"):
                 agent.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            cleanup_errors.append(exc)
         # Auxiliary async clients (session_search/web/vision/etc.) live in a
         # process-global cache and are created inside worker threads. Clean up
         # any entries whose event loop is now dead so their httpx transports do
@@ -9896,6 +10164,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             cleanup_stale_async_clients()
         except Exception:
             pass
+        if strict and cleanup_errors:
+            messages = "; ".join(str(exc) for exc in cleanup_errors)
+            raise RuntimeError(f"agent resource cleanup failed: {messages}") from cleanup_errors[0]
 
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
@@ -12184,7 +12455,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         await asyncio.sleep(60)  # initial delay — let the gateway fully start
         _finalize_failures: dict[str, int] = {}  # session_id -> consecutive failure count
-        _MAX_FINALIZE_RETRIES = 3
         while self._running:
             try:
                 await self.async_session_store._ensure_loaded()
@@ -12213,88 +12483,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         len(_expired_entries), _plat_summary,
                     )
 
+                _retired_session_ids: set[str] = set()
                 for key, entry in _expired_entries:
                     try:
-                        try:
-                            from hermes_cli.lifecycle import finalize_session
-                            _parts = key.split(":")
-                            _platform = _parts[2] if len(_parts) > 2 else ""
-                            finalize_session(
-                                session_id=entry.session_id,
-                                platform=_platform,
-                                reason="session_expired",
-                            )
-                        except Exception:
-                            pass
-                        # Shut down memory provider and close tool resources
-                        # on the cached agent.  Idle agents live in
-                        # _agent_cache (not _running_agents), so look there.
-                        _cached_agent = None
-                        _cache_lock = getattr(self, "_agent_cache_lock", None)
-                        if _cache_lock is not None:
-                            with _cache_lock:
-                                _cached = self._agent_cache.get(key)
-                                _cached_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
-                        # Fall back to _running_agents in case the agent is
-                        # still mid-turn when the expiry fires.
-                        if _cached_agent is None:
-                            _exp_state = self._peek_session_state(key)
-                            _cached_agent = _exp_state.turn.agent if _exp_state else None
-                        if _cached_agent and _cached_agent is not _AGENT_PENDING_SENTINEL:
-                            await self._cleanup_agent_resources_off_loop(
-                                _cached_agent, context="session expiry"
-                            )
-                        # Drop the cache entry so the AIAgent (and its LLM
-                        # clients, tool schemas, memory provider refs) can
-                        # be garbage-collected.  Otherwise the cache grows
-                        # unbounded across the gateway's lifetime.
-                        self._evict_cached_agent(key)
-                        # Permanently finalizing this session — one funnel
-                        # call drops every conversation-scoped dict AND the
-                        # boundary security state (approvals, update
-                        # prompts, slash-confirm) so the dicts don't grow
-                        # unbounded across the gateway's lifetime. (Idle
-                        # agent-cache eviction must NOT do this: the
-                        # session is still alive and a resumed turn rebuilds
-                        # its agent from these overrides. Only true session
-                        # finalization, /new, and /reset clear them.) See
-                        # _CONVERSATION_SCOPED_STATE.
-                        self._clear_conversation_scope(
-                            key, reason="expiry_finalized"
+                        # Expiry is a real route retirement, not a metadata-only
+                        # flag. SessionStore owns the per-key reservation, durable
+                        # recovery marker, exact CUA release, replacement routing
+                        # writes, and old-ID retirement as one terminal boundary.
+                        replacement = await self.async_session_store.reset_session(
+                            key,
+                            reset_reason="session_expired",
+                            expected_session_id=entry.session_id,
                         )
-                        # Persist the finalized flag to sessions.json AND
-                        # state.db (single write-path, #9006) — also drops
-                        # the persisted /model override, since finalization
-                        # is a conversation boundary.
-                        await self.async_session_store.set_expiry_finalized(entry)
+                        if replacement is None:
+                            raise RuntimeError(
+                                "expired route disappeared before terminal reset"
+                            )
                         logger.debug(
-                            "Session expiry finalized for %s",
+                            "Session expiry retired %s and published %s",
                             entry.session_id,
+                            replacement.session_id,
                         )
+                        _retired_session_ids.add(entry.session_id)
                         _finalize_failures.pop(entry.session_id, None)
                     except Exception as e:
                         failures = _finalize_failures.get(entry.session_id, 0) + 1
                         _finalize_failures[entry.session_id] = failures
-                        if failures >= _MAX_FINALIZE_RETRIES:
-                            logger.warning(
-                                "Session finalize gave up after %d attempts for %s: %s. "
-                                "Marking as finalized to prevent infinite retry loop.",
-                                failures, entry.session_id, e,
-                            )
-                            await self.async_session_store.set_expiry_finalized(
-                                entry, clear_model_override=False
-                            )
-                            _finalize_failures.pop(entry.session_id, None)
-                        else:
-                            logger.debug(
-                                "Session finalize failed (%d/%d) for %s: %s",
-                                failures, _MAX_FINALIZE_RETRIES, entry.session_id, e,
-                            )
+                        logger.error(
+                            "Session expiry retained pending after attempt %d for %s: %s",
+                            failures,
+                            entry.session_id,
+                            e,
+                        )
 
                 if _expired_entries:
-                    _done = sum(
-                        1 for _, e in _expired_entries if e.expiry_finalized
-                    )
+                    _done = len(_retired_session_ids)
                     _failed = len(_expired_entries) - _done
                     if _failed:
                         logger.info(
@@ -16881,6 +17104,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # wiping model/reasoning overrides set between turns (Closes #48031).
         _was_auto_reset = getattr(session_entry, "was_auto_reset", False)
         if _was_auto_reset:
+            # Exact CUA teardown already completed inside SessionStore's
+            # single-flight pre-rotation callback, before this replacement was
+            # published or persisted.
             # Treat auto-reset as a full conversation boundary — clear every
             # conversation-scoped per-session dict in one funnel call so the
             # fresh session does not inherit the previous conversation's
@@ -18064,21 +18290,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # session_entry.session_id while the old run is still unwinding.
             _run_start_session_id = session_entry.session_id
             _turn_started_monotonic = time.monotonic()
-            agent_result = await self._run_agent(
-                message=message_text,
-                context_prompt=context_prompt,
-                history=history,
-                source=source,
-                session_id=_run_start_session_id,
-                session_key=session_key,
-                run_generation=run_generation,
-                event_message_id=self._reply_anchor_for_event(event),
-                channel_prompt=event.channel_prompt,
-                moa_config=getattr(event, "_moa_config", None),
-                persist_user_message=persist_user_message,
-                persist_user_timestamp=persist_user_timestamp,
-                message_type=event.message_type,
+            from tools.computer_use import (
+                publish_computer_use_session,
+                unpublish_computer_use_session,
             )
+
+            _cua_publication = publish_computer_use_session(
+                _run_start_session_id
+            )
+            try:
+                agent_result = await self._run_agent(
+                    message=message_text,
+                    context_prompt=context_prompt,
+                    history=history,
+                    source=source,
+                    session_id=_run_start_session_id,
+                    session_key=session_key,
+                    run_generation=run_generation,
+                    event_message_id=self._reply_anchor_for_event(event),
+                    channel_prompt=event.channel_prompt,
+                    moa_config=getattr(event, "_moa_config", None),
+                    persist_user_message=persist_user_message,
+                    persist_user_timestamp=persist_user_timestamp,
+                    message_type=event.message_type,
+                )
+            finally:
+                unpublish_computer_use_session(_cua_publication)
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
             # Stop persistent typing indicator now that the agent is done.
@@ -18432,7 +18669,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
                 )
-                new_entry = await self.async_session_store.reset_session(session_key)
+                new_entry = await self.async_session_store.reset_session(
+                    session_key,
+                    reset_reason="compression_exhausted",
+                )
                 self._evict_cached_agent(session_key)
                 # Conversation boundary: one funnel call clears every
                 # conversation-scoped per-session dict (#58403 and siblings).
@@ -23982,7 +24222,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         return hashlib.sha256(repr(key_tuple).encode("utf-8")).hexdigest()
 
-    def _evict_cached_agent(self, session_key: str) -> None:
+    def _evict_cached_agent(
+        self,
+        session_key: str,
+        *,
+        soft_release: bool = True,
+    ) -> Any:
         """Remove a cached agent for a session (called on /new, /model, etc).
 
         Pops the entry AND soft-releases the evicted agent's LLM client
@@ -24026,7 +24271,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         agent = evicted[0] if isinstance(evicted, tuple) and evicted else evicted
         if agent is None or agent is _AGENT_PENDING_SENTINEL:
-            return
+            return None
+        if not soft_release:
+            return agent
 
         # Don't tear down an agent that's actively mid-turn — its client,
         # sandbox and child subagents are in use by the running request.
@@ -24036,7 +24283,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if a is not None and a is not _AGENT_PENDING_SENTINEL
         }
         if id(agent) in running_ids:
-            return
+            return agent
 
         try:
             threading.Thread(
@@ -24052,6 +24299,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._release_evicted_agent_soft(agent)
             except Exception:
                 pass
+        return agent
 
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6053,11 +6053,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             ),
         )
+        from tools.computer_use import write_computer_use_runtime_attestation
+
+        session_validator = lambda route_key, sid: (
+            self.session_store.route_matches(route_key, sid)
+            if route_key
+            else self.session_store.lookup_by_session_id(sid) is not None
+        )
+        try:
+            write_computer_use_runtime_attestation({
+                "GatewayRunner._run_agent": self._run_agent,
+                "SessionStore.route_matches": self.session_store.route_matches,
+                "SessionStore._run_route_transition": (
+                    self.session_store._run_route_transition
+                ),
+                "SessionStore.prune_old_entries": (
+                    self.session_store.prune_old_entries
+                ),
+            })
+        except Exception as exc:
+            logger.exception("Could not write CUA gateway runtime attestation")
+            raise RuntimeError(
+                "CUA gateway runtime attestation is required for startup"
+            ) from exc
+        # Publish process-global route authority only after this runner's
+        # required attestation is durable. A failed constructor therefore
+        # cannot overwrite or clear authority owned by an existing runner.
         from tools.computer_use import set_computer_use_session_validator
 
-        set_computer_use_session_validator(
-            lambda sid: self.session_store.lookup_by_session_id(sid) is not None
-        )
+        set_computer_use_session_validator(session_validator)
         # One enforced loop-side boundary for the synchronous SessionStore.
         # Sync helpers keep using ``session_store`` directly; async gateway
         # handlers call this facade and await every operation.
@@ -18296,7 +18320,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
             _cua_publication = publish_computer_use_session(
-                _run_start_session_id
+                _run_start_session_id,
+                route_key=session_key,
             )
             try:
                 agent_result = await self._run_agent(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6056,13 +6056,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from tools.computer_use import write_computer_use_runtime_attestation
 
         session_validator = lambda route_key, sid: (
-            self.session_store.route_matches(route_key, sid)
-            if route_key
-            else self.session_store.lookup_by_session_id(sid) is not None
+            self.session_store.ensure_route_matches(route_key, sid)
         )
         try:
             write_computer_use_runtime_attestation({
                 "GatewayRunner._run_agent": self._run_agent,
+                "SessionStore.ensure_route_matches": (
+                    self.session_store.ensure_route_matches
+                ),
                 "SessionStore.route_matches": self.session_store.route_matches,
                 "SessionStore._run_route_transition": (
                     self.session_store._run_route_transition

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -15,10 +15,11 @@ import os
 import json
 import threading
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Any
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -771,6 +772,13 @@ def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict
 
 
 @dataclass
+class _RouteTerminalTransition:
+    session_id: str
+    callback_token: Any
+    rollback_entry_data: Dict[str, Any]
+
+
+@dataclass
 class SessionEntry:
     """
     Entry in the session store.
@@ -1215,6 +1223,12 @@ class _SessionFlight:
         self.error: Optional[BaseException] = None
 
 
+@dataclass
+class _RouteTransitionLockEntry:
+    lock: Any = field(default_factory=threading.RLock)
+    users: int = 0
+
+
 class AsyncSessionStore:
     """Async boundary for the synchronous, thread-safe SessionStore."""
 
@@ -1240,10 +1254,22 @@ class SessionStore:
     Falls back to legacy JSONL files if SQLite is unavailable.
     """
     
-    def __init__(self, sessions_dir: Path, config: GatewayConfig,
-                 has_active_processes_fn=None):
+    def __init__(
+        self,
+        sessions_dir: Path,
+        config: GatewayConfig,
+        has_active_processes_fn=None,
+        before_auto_reset_fn: Optional[Callable[[str, str], Any]] = None,
+        before_terminal_completion_fn: Optional[
+            Callable[[str, Any, str], None]
+        ] = None,
+        after_auto_reset_fn: Optional[Callable[[str, Any, bool], None]] = None,
+    ):
         self.sessions_dir = sessions_dir
         self.config = config
+        self._before_auto_reset_fn = before_auto_reset_fn
+        self._before_terminal_completion_fn = before_terminal_completion_fn
+        self._after_auto_reset_fn = after_auto_reset_fn
         self._entries: Dict[str, SessionEntry] = {}
         self._loaded = False
         self._lock = threading.Lock()
@@ -1260,6 +1286,21 @@ class SessionStore:
         self._fast_persisted_entries: Dict[str, tuple[int, str]] = {}
         self._inflight_lock = threading.Lock()
         self._inflight_sessions: Dict[str, _SessionFlight] = {}
+        # Every route-changing operation for one key participates in this lock,
+        # including get/create auto-reset, explicit reset, compression advance,
+        # and session switch. This reservation spans lock-free persistence/DB
+        # phases so no competing writer can cross a terminal teardown boundary.
+        self._route_transition_locks_guard = threading.Lock()
+        self._route_transition_locks: Dict[
+            str, _RouteTransitionLockEntry
+        ] = {}
+        self._active_route_transitions: set[str] = set()
+        self._route_terminal_transitions: Dict[
+            str, _RouteTerminalTransition
+        ] = {}
+        self._retained_terminal_transitions: Dict[
+            str, _RouteTerminalTransition
+        ] = {}
         # An unscoped pre-migration Slack key can represent at most one
         # workspace. Claim it once per process so simultaneous first messages
         # from two workspaces cannot both revive the same legacy session.
@@ -1508,10 +1549,14 @@ class SessionStore:
         if stale_keys or recovered_keys:
             self._save()
 
-    def _save(self) -> None:
+    def _save(self, *, require_primary_db: bool = False) -> None:
         """Persist the routing index while the caller holds ``_lock``."""
         data, generation = self._snapshot_routing_locked()
-        self._persist_routing_data(data, generation)
+        self._persist_routing_data(
+            data,
+            generation,
+            require_primary_db=require_primary_db,
+        )
 
     def _next_routing_generation_locked(self) -> int:
         """Bump and return the shared routing counter. Caller holds ``_lock``.
@@ -1532,7 +1577,13 @@ class SessionStore:
             self._next_routing_generation_locked(),
         )
 
-    def _persist_routing_data(self, data: Dict[str, Any], generation: int) -> None:
+    def _persist_routing_data(
+        self,
+        data: Dict[str, Any],
+        generation: int,
+        *,
+        require_primary_db: bool = False,
+    ) -> None:
         """Serialize all whole-index writers through one durable write lock."""
         save_lock = getattr(self, "_save_lock", None)
         if save_lock is None:
@@ -1566,6 +1617,10 @@ class SessionStore:
                         logger.warning(
                             "gateway.session: state.db routing save failed: %s", exc
                         )
+                        if require_primary_db:
+                            raise RuntimeError(
+                                "terminal route transition could not persist state.db routing"
+                            ) from exc
             if getattr(self, "_write_sessions_json", True) or not db_saved:
                 try:
                     self._save_sessions_json(data)
@@ -1629,11 +1684,15 @@ class SessionStore:
                 logger.debug("Could not remove temp file %s: %s", tmp_path, e)
             raise
     
-    def _save_entries(self) -> None:
+    def _save_entries(self, *, require_primary_db: bool = False) -> None:
         """Snapshot latest state under ``_lock`` and persist after releasing it."""
         with self._lock:
             data, generation = self._snapshot_routing_locked()
-        self._persist_routing_data(data, generation)
+        self._persist_routing_data(
+            data,
+            generation,
+            require_primary_db=require_primary_db,
+        )
 
     def _save_entry(
         self,
@@ -1641,6 +1700,7 @@ class SessionStore:
         *,
         entry_data: Optional[Dict[str, Any]] = None,
         lock_held: bool = False,
+        require_primary_db: bool = False,
     ) -> None:
         """Persist ONE routing entry via UPSERT — the per-turn fast path.
 
@@ -1737,6 +1797,10 @@ class SessionStore:
                     "(%s); falling back to full index rewrite",
                     session_key, exc,
                 )
+                if require_primary_db:
+                    raise RuntimeError(
+                        "terminal route marker could not persist state.db routing"
+                    ) from exc
         if candidate_entry is not None:
             # DB upsert failed (or no DB): build the full snapshot now, carrying
             # the candidate entry so the fallback persists the intended
@@ -1754,9 +1818,13 @@ class SessionStore:
                         for key, current in self._entries.items()
                     }
             fallback_data[session_key] = candidate_entry
-            self._persist_routing_data(fallback_data, revision)
+            self._persist_routing_data(
+                fallback_data,
+                revision,
+                require_primary_db=require_primary_db,
+            )
         else:
-            self._save_entries()
+            self._save_entries(require_primary_db=require_primary_db)
 
     def _resolve_profile_for_key(self, source: Optional[SessionSource] = None) -> Optional[str]:
         """Return the profile namespace for session keys, or None when off.
@@ -2281,6 +2349,8 @@ class SessionStore:
         Sessions with active background processes are never reset.
         """
         session_key = self._generate_session_key(source)
+        if entry.metadata.get("terminal_transition"):
+            return "terminal_transition_recovery"
         if self._has_active_processes_safe(session_key, context="reset"):
             logger.debug(
                 "Session reset skipped for %s — active background processes",
@@ -2382,6 +2452,172 @@ class SessionStore:
             self._ensure_loaded_locked()
             return len(self._entries) > 1
 
+    @contextmanager
+    def _route_transition_lock(self, session_key: str):
+        """Reserve a per-key route lock and reclaim it after the final user.
+
+        Waiters increment ``users`` before blocking on the RLock, so the map
+        entry cannot be removed while any holder or waiter can still reference
+        it. The final releaser removes only the same identity it reserved,
+        preventing a late cleanup from deleting a newer entry.
+        """
+        guard = getattr(self, "_route_transition_locks_guard", None)
+        if guard is None:
+            # Compatibility for tests/embedders that construct a partial store.
+            with self._lock:
+                guard = getattr(self, "_route_transition_locks_guard", None)
+                if guard is None:
+                    guard = threading.Lock()
+                    self._route_transition_locks_guard = guard
+                    self._route_transition_locks = {}
+        with guard:
+            locks = self._route_transition_locks
+            entry = locks.get(session_key)
+            if entry is None:
+                entry = _RouteTransitionLockEntry()
+                locks[session_key] = entry
+            entry.users += 1
+        try:
+            with entry.lock:
+                yield entry.lock
+        finally:
+            with guard:
+                entry.users -= 1
+                if entry.users == 0 and locks.get(session_key) is entry:
+                    locks.pop(session_key, None)
+
+    def _arm_route_terminal_transition(
+        self,
+        session_key: str,
+        session_id: str,
+        reason: str,
+    ) -> None:
+        before_terminal_reset = getattr(self, "_before_auto_reset_fn", None)
+
+        with self._lock:
+            retained = self._retained_terminal_transitions.pop(session_key, None)
+            if retained is not None:
+                if retained.session_id != session_id:
+                    self._retained_terminal_transitions[session_key] = retained
+                    raise RuntimeError(
+                        "retained terminal transition does not own current route"
+                    )
+                self._route_terminal_transitions[session_key] = retained
+                return
+
+            current = self._entries.get(session_key)
+            if current is None or current.session_id != session_id:
+                raise RuntimeError("terminal route changed before durable marker")
+            marker = {
+                "session_id": session_id,
+                "reason": reason,
+                "token": uuid.uuid4().hex,
+                "started_at": _now().isoformat(),
+            }
+            candidate = current.to_dict()
+            metadata = dict(candidate.get("metadata") or {})
+            metadata["terminal_transition"] = marker
+            candidate["metadata"] = metadata
+            current.metadata["terminal_transition"] = marker
+            rollback_entry_data = current.to_dict()
+
+        # Persist the recovery marker before releasing CUA. A crash or any
+        # later persistence failure therefore restarts in fail-closed reset
+        # recovery instead of reviving the old route. The per-key route
+        # reservation protects route ownership while blocking I/O stays outside
+        # ``self._lock``.
+        self._save_entry(
+            session_key,
+            entry_data=candidate,
+            require_primary_db=True,
+        )
+
+        callback_token = (
+            before_terminal_reset(session_id, reason)
+            if callable(before_terminal_reset)
+            else None
+        )
+        with self._lock:
+            self._route_terminal_transitions[session_key] = _RouteTerminalTransition(
+                session_id=session_id,
+                callback_token=callback_token,
+                rollback_entry_data=rollback_entry_data,
+            )
+
+    def _run_route_transition(self, session_key: str, operation: Callable[[], Any]) -> Any:
+        """Run one route mutation with a per-key reservation visible to pruners."""
+        with self._route_transition_lock(session_key):
+            with self._lock:
+                active = getattr(self, "_active_route_transitions", None)
+                if active is None:
+                    active = set()
+                    self._active_route_transitions = active
+                active.add(session_key)
+            operation_succeeded = False
+            try:
+                result = operation()
+                with self._lock:
+                    completing_transition = self._route_terminal_transitions.get(
+                        session_key
+                    )
+                before_terminal_completion = getattr(
+                    self, "_before_terminal_completion_fn", None
+                )
+                if (
+                    completing_transition is not None
+                    and callable(before_terminal_completion)
+                ):
+                    before_terminal_completion(
+                        completing_transition.session_id,
+                        completing_transition.callback_token,
+                        session_key,
+                    )
+                operation_succeeded = True
+                return result
+            finally:
+                terminal_transition = None
+                route_replaced = False
+                with self._lock:
+                    terminal_transition = self._route_terminal_transitions.pop(
+                        session_key, None
+                    )
+                    if terminal_transition is not None:
+                        current = self._entries.get(session_key)
+                        route_replaced = (
+                            current is not None
+                            and current.session_id != terminal_transition.session_id
+                        )
+                        if not (operation_succeeded and route_replaced):
+                            # Restore the durably marked old route. Keep the CUA
+                            # admission token retained so no caller can recreate
+                            # the released generation before a retry completes.
+                            self._entries[session_key] = SessionEntry.from_dict(
+                                terminal_transition.rollback_entry_data
+                            )
+                            self._retained_terminal_transitions[
+                                session_key
+                            ] = terminal_transition
+                try:
+                    if terminal_transition is not None:
+                        succeeded = operation_succeeded and route_replaced
+                        if not succeeded:
+                            # A replacement may already have reached the routing
+                            # DB before later SQLite work failed. Restore the old
+                            # marked route while the admission fence is retained.
+                            self._save_entries(require_primary_db=True)
+                        after_terminal_reset = getattr(
+                            self, "_after_auto_reset_fn", None
+                        )
+                        if after_terminal_reset is not None:
+                            after_terminal_reset(
+                                terminal_transition.session_id,
+                                terminal_transition.callback_token,
+                                succeeded,
+                            )
+                finally:
+                    with self._lock:
+                        self._active_route_transitions.discard(session_key)
+
     def get_or_create_session(
         self,
         source: SessionSource,
@@ -2417,7 +2653,12 @@ class SessionStore:
             return slot.result
 
         try:
-            result = self._get_or_create_session_impl(source, force_new=force_new)
+            result = self._run_route_transition(
+                session_key,
+                lambda: self._get_or_create_session_impl(
+                    source, force_new=force_new
+                ),
+            )
             slot.result = result
             return result
         except BaseException as exc:
@@ -2549,6 +2790,23 @@ class SessionStore:
                             _reset_reason = "resume_pending_expired"
             else:
                 _reset_reason = self._should_reset(_entry_for_checks, source)
+
+        # The per-key route-transition reservation is held across this entire
+        # implementation, including the lock-free teardown wait and Phase 3
+        # persistence. Revalidate the exact route under ``_lock``, then release
+        # that lock before bounded CUA I/O; reset/switch/compression writers for
+        # this key cannot cross the reservation.
+        if _reset_reason and _stale_session_id:
+            with self._lock:
+                current = self._entries.get(session_key)
+                reset_target_is_current = (
+                    current is not None
+                    and current.session_id == _stale_session_id
+                )
+            if reset_target_is_current:
+                self._arm_route_terminal_transition(
+                    session_key, _stale_session_id, _reset_reason
+                )
 
         # ---- Phase 2: lock write -- apply decisions to _entries ----
         _needs_save = False
@@ -2689,13 +2947,19 @@ class SessionStore:
                     "profile_name": source.profile,
                 }
 
+        terminal_route_transition = (
+            session_key in self._route_terminal_transitions
+        )
         if _needs_save:
             if _metadata_only_save:
                 self._save_entry(session_key)
             else:
-                self._save_entries()
+                if terminal_route_transition:
+                    self._save_entries(require_primary_db=True)
+                else:
+                    self._save_entries()
 
-        # SQLite operations outside the lock (unchanged).
+        # SQLite operations outside the lock. Terminal transitions fail closed
         if self._db and db_end_session_id:
             # Use the specific reset reason so state.db is auditable (e.g.
             # "resume_pending_expired" is distinguishable from a normal
@@ -2713,6 +2977,10 @@ class SessionStore:
                 else:
                     self._db.end_session(db_end_session_id, _db_end_reason)
             except Exception as e:
+                if terminal_route_transition:
+                    raise RuntimeError(
+                        "terminal transition could not close prior SQLite session"
+                    ) from e
                 logger.debug("Session DB operation failed: %s", e)
 
         if self._db and db_create_kwargs:
@@ -2725,6 +2993,10 @@ class SessionStore:
                     display_name=entry.display_name,
                 )
             except Exception as e:
+                if terminal_route_transition:
+                    raise RuntimeError(
+                        "terminal transition could not create replacement SQLite session"
+                    ) from e
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
 
         return entry
@@ -3053,7 +3325,10 @@ class SessionStore:
 
         with self._lock:
             self._ensure_loaded_locked()
+            active_transitions = getattr(self, "_active_route_transitions", set())
             for key, entry in list(self._entries.items()):
+                if key in active_transitions:
+                    continue
                 if entry.suspended:
                     continue
                 # Never prune sessions with an active background process
@@ -3113,7 +3388,53 @@ class SessionStore:
                 self._save()
         return count
 
-    def reset_session(self, session_key: str, display_name: Optional[str] = None) -> Optional[SessionEntry]:
+    def reset_session(
+        self,
+        session_key: str,
+        display_name: Optional[str] = None,
+        reset_reason: str = "session_reset",
+        expected_session_id: Optional[str] = None,
+    ) -> Optional[SessionEntry]:
+        """Force reset a session under the shared per-key transition fence."""
+        return self._run_route_transition(
+            session_key,
+            lambda: self._reset_session_impl(
+                session_key,
+                display_name,
+                reset_reason,
+                expected_session_id,
+            ),
+        )
+
+    def _reset_session_impl(
+        self,
+        session_key: str,
+        display_name: Optional[str] = None,
+        reset_reason: str = "session_reset",
+        expected_session_id: Optional[str] = None,
+    ) -> Optional[SessionEntry]:
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            if (
+                expected_session_id is not None
+                and entry.session_id != expected_session_id
+            ):
+                return None
+            terminal_session_id = entry.session_id
+
+        self._arm_route_terminal_transition(
+            session_key, terminal_session_id, reset_reason
+        )
+        return self._apply_reset_session_impl(session_key, display_name)
+
+    def _apply_reset_session_impl(
+        self,
+        session_key: str,
+        display_name: Optional[str] = None,
+    ) -> Optional[SessionEntry]:
         """Force reset a session, creating a new session ID."""
         db_end_session_id = None
         db_create_kwargs = None
@@ -3144,7 +3465,7 @@ class SessionStore:
             )
 
             self._entries[session_key] = new_entry
-            self._save()
+            self._save(require_primary_db=True)
             db_create_kwargs = {
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
@@ -3168,7 +3489,9 @@ class SessionStore:
                 else:
                     self._db.end_session(db_end_session_id, "session_reset")
             except Exception as e:
-                logger.debug("Session DB operation failed: %s", e)
+                raise RuntimeError(
+                    "terminal reset could not close prior SQLite session"
+                ) from e
 
         if self._db and db_create_kwargs:
             try:
@@ -3180,7 +3503,9 @@ class SessionStore:
                     display_name=new_entry.display_name if new_entry else None,
                 )
             except Exception as e:
-                logger.debug("Session DB operation failed: %s", e)
+                raise RuntimeError(
+                    "terminal reset could not create replacement SQLite session"
+                ) from e
 
         return new_entry
 
@@ -3190,14 +3515,22 @@ class SessionStore:
         expected_session_id: str,
         target_session_id: str,
     ) -> Optional[SessionEntry]:
-        """CAS-advance one route along an already-verified compression lineage.
+        return self._run_route_transition(
+            session_key,
+            lambda: self._advance_compression_session_impl(
+                session_key,
+                expected_session_id,
+                target_session_id,
+            ),
+        )
 
-        Unlike ``switch_session``, this does not end or reopen SQLite rows. The
-        compression transaction already owns that lifecycle; this method only
-        repairs the persisted gateway key→session mapping. Returning ``None``
-        means the route moved after the caller's snapshot (for example /new),
-        so the caller must fail closed instead of overwriting the newer route.
-        """
+    def _advance_compression_session_impl(
+        self,
+        session_key: str,
+        expected_session_id: str,
+        target_session_id: str,
+    ) -> Optional[SessionEntry]:
+        """CAS-advance one route along an already-verified compression lineage."""
         if not session_key or not expected_session_id or not target_session_id:
             return None
 
@@ -3210,17 +3543,41 @@ class SessionStore:
                 return entry
             if entry.session_id != expected_session_id:
                 return None
+
+        self._arm_route_terminal_transition(
+            session_key,
+            expected_session_id,
+            "compression_advance",
+        )
+        with self._lock:
+            entry = self._entries.get(session_key)
+            if entry is None or entry.session_id != expected_session_id:
+                raise RuntimeError("compression route changed inside terminal boundary")
             if not self._heal_compression_tip_locked(
                 entry,
                 expected_session_id,
                 target_session_id,
             ):
-                return None
+                raise RuntimeError("compression route advance failed ownership check")
             entry.updated_at = _now()
-            self._save()
-            return entry
+        self._save_entries(require_primary_db=True)
+        return entry
 
-    def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
+    def switch_session(
+        self,
+        session_key: str,
+        target_session_id: str,
+    ) -> Optional[SessionEntry]:
+        return self._run_route_transition(
+            session_key,
+            lambda: self._switch_session_impl(session_key, target_session_id),
+        )
+
+    def _switch_session_impl(
+        self,
+        session_key: str,
+        target_session_id: str,
+    ) -> Optional[SessionEntry]:
         """Switch a session key to point at an existing session ID.
 
         Used by ``/resume`` to restore a previously-named session.
@@ -3229,23 +3586,26 @@ class SessionStore:
         old transcript is loaded on the next message. If the target session was
         previously ended, re-open it so gateway resume semantics match the CLI.
         """
-        db_end_session_id = None
-        new_entry = None
-
         with self._lock:
             self._ensure_loaded_locked()
-
-            if session_key not in self._entries:
+            old_entry = self._entries.get(session_key)
+            if old_entry is None:
                 return None
-
-            old_entry = self._entries[session_key]
-
-            # Don't switch if already on that session
             if old_entry.session_id == target_session_id:
                 return old_entry
-
             db_end_session_id = old_entry.session_id
+            old_entry_data = old_entry.to_dict()
 
+        self._arm_route_terminal_transition(
+            session_key,
+            db_end_session_id,
+            "session_switch",
+        )
+        with self._lock:
+            current = self._entries.get(session_key)
+            if current is None or current.session_id != db_end_session_id:
+                raise RuntimeError("session switch route changed inside terminal boundary")
+            old_entry = SessionEntry.from_dict(old_entry_data)
             now = _now()
             new_entry = SessionEntry(
                 session_key=session_key,
@@ -3257,36 +3617,28 @@ class SessionStore:
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
             )
-
             self._entries[session_key] = new_entry
-            self._save()
+        self._save_entries(require_primary_db=True)
 
-        if self._db and db_end_session_id:
+        if self._db:
             try:
-                # Promote (not plain end_session): a stale agent_close /
-                # ws_orphan_reap end on the outgoing session must be upgraded
-                # to the explicit switch boundary, or recovery can resurrect
-                # it over the user's /resume choice (#61220 bug class).
                 _promote = getattr(self._db, "promote_to_session_reset", None)
                 if callable(_promote):
                     _promote(db_end_session_id, "session_switch")
                 else:
                     self._db.end_session(db_end_session_id, "session_switch")
-            except Exception as e:
-                logger.debug("Session DB end_session failed: %s", e)
-
-        if self._db:
-            try:
                 self._db.reopen_session(target_session_id)
-            except Exception as e:
-                logger.debug("Session DB reopen_session failed: %s", e)
-            self._record_gateway_session_peer(
-                target_session_id,
-                session_key,
-                new_entry.origin if new_entry else None,
-                display_name=new_entry.display_name if new_entry else None,
-                include_compression_ancestors=True,
-            )
+                self._record_gateway_session_peer(
+                    target_session_id,
+                    session_key,
+                    new_entry.origin,
+                    display_name=new_entry.display_name,
+                    include_compression_ancestors=True,
+                )
+            except Exception as exc:
+                raise RuntimeError(
+                    "terminal session switch SQLite publication failed"
+                ) from exc
 
         return new_entry
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3913,6 +3913,75 @@ class SessionStore:
 
         return entries
 
+    def ensure_route_matches(
+        self,
+        session_key: Optional[str],
+        session_id: str,
+    ) -> bool:
+        """Validate an exact route, healing only a proven compression tip.
+
+        Compression can rotate ``AIAgent.session_id`` in the middle of one
+        gateway turn, before another inbound message reaches
+        ``get_or_create_session``.  A later tool call therefore carries the
+        committed child id while the durable gateway route still names its
+        ended compression parent.  Admit that child only by performing the
+        normal serialized compression route transition first; unrelated,
+        missing, ended, or ambiguous ids fail closed.
+        """
+        if not session_id:
+            return False
+        if session_key and self.route_matches(session_key, session_id):
+            return True
+        if not session_key and self.lookup_by_session_id(session_id) is not None:
+            return True
+        if self._db is None:
+            return False
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            if session_key:
+                entry = self._entries.get(session_key)
+                candidates = [entry] if entry is not None else []
+            else:
+                candidates = list(self._entries.values())
+
+        matching: list[tuple[str, str]] = []
+        for entry in candidates:
+            prior_session_id = entry.session_id
+            if prior_session_id == session_id:
+                matching.append((entry.session_key, prior_session_id))
+                continue
+            try:
+                tip = self._compression_tip_for_session_id(prior_session_id)
+                target_row = self._db.get_session(session_id)
+            except Exception:
+                return False
+            if (
+                tip == session_id
+                and target_row is not None
+                and not target_row.get("ended_at")
+            ):
+                matching.append((entry.session_key, prior_session_id))
+
+        if len(matching) != 1:
+            return False
+        matched_key, prior_session_id = matching[0]
+        if prior_session_id == session_id:
+            return self.route_matches(matched_key, session_id)
+        try:
+            advanced = self.advance_compression_session(
+                matched_key,
+                prior_session_id,
+                session_id,
+            )
+        except Exception:
+            return False
+        return bool(
+            advanced is not None
+            and advanced.session_id == session_id
+            and self.route_matches(matched_key, session_id)
+        )
+
     def route_matches(self, session_key: str, session_id: str) -> bool:
         """Atomically validate one exact persisted route binding."""
         if not session_key or not session_id:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -776,6 +776,7 @@ class _RouteTerminalTransition:
     session_id: str
     callback_token: Any
     rollback_entry_data: Dict[str, Any]
+    allow_route_absent: bool = False
 
 
 @dataclass
@@ -1482,6 +1483,14 @@ class SessionStore:
         recovered_keys = 0
         try:
             for key, entry in self._entries.items():
+                # A durable terminal marker is authoritative even when an
+                # earlier hard phase already ended the old SQLite session.
+                # Preserve it so routing-time recovery can finish publication
+                # instead of silently discarding exact retry state on restart.
+                if isinstance(
+                    entry.metadata.get("terminal_transition"), dict
+                ):
+                    continue
                 row = db.get_session(entry.session_id)
                 # row is None        -> not in DB (legacy / pre-SQLite) — keep
                 # end_reason is None  -> session alive — keep
@@ -2491,6 +2500,9 @@ class SessionStore:
         session_key: str,
         session_id: str,
         reason: str,
+        *,
+        allow_route_absent: bool = False,
+        target_session_id: Optional[str] = None,
     ) -> None:
         before_terminal_reset = getattr(self, "_before_auto_reset_fn", None)
 
@@ -2514,6 +2526,14 @@ class SessionStore:
                 "token": uuid.uuid4().hex,
                 "started_at": _now().isoformat(),
             }
+            existing_marker = current.metadata.get("terminal_transition")
+            if isinstance(existing_marker, dict):
+                target_session_id = (
+                    existing_marker.get("target_session_id")
+                    or target_session_id
+                )
+            if target_session_id:
+                marker["target_session_id"] = target_session_id
             candidate = current.to_dict()
             metadata = dict(candidate.get("metadata") or {})
             metadata["terminal_transition"] = marker
@@ -2542,6 +2562,7 @@ class SessionStore:
                 session_id=session_id,
                 callback_token=callback_token,
                 rollback_entry_data=rollback_entry_data,
+                allow_route_absent=allow_route_absent,
             )
 
     def _run_route_transition(self, session_key: str, operation: Callable[[], Any]) -> Any:
@@ -2584,8 +2605,15 @@ class SessionStore:
                     if terminal_transition is not None:
                         current = self._entries.get(session_key)
                         route_replaced = (
-                            current is not None
-                            and current.session_id != terminal_transition.session_id
+                            (
+                                current is None
+                                and terminal_transition.allow_route_absent
+                            )
+                            or (
+                                current is not None
+                                and current.session_id
+                                != terminal_transition.session_id
+                            )
                         )
                         if not (operation_succeeded and route_replaced):
                             # Restore the durably marked old route. Keep the CUA
@@ -2752,6 +2780,8 @@ class SessionStore:
         # ---- Phase 1: lock read -- get entry snapshot for stale/reset checks ----
         _stale_session_id = None
         _entry_for_checks = None
+        _terminal_target_session_id = None
+        _terminal_recovery_reason = None
         with self._lock:
             self._ensure_loaded_locked()
             if force_new:
@@ -2759,6 +2789,64 @@ class SessionStore:
             if session_key in self._entries and not force_new:
                 _entry_for_checks = self._entries[session_key]
                 _stale_session_id = _entry_for_checks.session_id
+                _existing_terminal_marker = _entry_for_checks.metadata.get(
+                    "terminal_transition"
+                )
+                if isinstance(_existing_terminal_marker, dict):
+                    _terminal_target_session_id = _existing_terminal_marker.get(
+                        "target_session_id"
+                    )
+                    _terminal_recovery_reason = _existing_terminal_marker.get(
+                        "reason"
+                    )
+
+        # A crashed prune must first finish its terminal publication of route
+        # absence. Only after that durable boundary may this incoming message
+        # create a fresh route. Treating the marker as a reset would skip the
+        # absence state and blur two independently recoverable transactions.
+        if (
+            _terminal_recovery_reason == "session_prune"
+            and _stale_session_id is not None
+        ):
+            with self._lock:
+                current = self._entries.get(session_key)
+                prune_target_is_current = (
+                    current is not None
+                    and current.session_id == _stale_session_id
+                )
+            if prune_target_is_current:
+                self._arm_route_terminal_transition(
+                    session_key,
+                    _stale_session_id,
+                    "session_prune",
+                    allow_route_absent=True,
+                )
+                if self._db:
+                    try:
+                        self._db.end_session(
+                            _stale_session_id, "session_prune"
+                        )
+                    except Exception as exc:
+                        raise RuntimeError(
+                            "terminal prune recovery could not close prior "
+                            "SQLite session"
+                        ) from exc
+                with self._lock:
+                    current = self._entries.get(session_key)
+                    if (
+                        current is None
+                        or current.session_id != _stale_session_id
+                    ):
+                        raise RuntimeError(
+                            "prune recovery route changed before absence publication"
+                        )
+                    self._entries.pop(session_key)
+                self._save_entries(require_primary_db=True)
+                _entry_for_checks = None
+                _stale_session_id = None
+                existing_session_id = None
+                canonical_existing_session_id = None
+                _terminal_recovery_reason = None
 
         # ---- Phase 1b: no-lock I/O -- stale check + reset policy ----
         _is_stale = False
@@ -2804,8 +2892,15 @@ class SessionStore:
                     and current.session_id == _stale_session_id
                 )
             if reset_target_is_current:
+                if not _terminal_target_session_id:
+                    _terminal_target_session_id = (
+                        f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+                    )
                 self._arm_route_terminal_transition(
-                    session_key, _stale_session_id, _reset_reason
+                    session_key,
+                    _stale_session_id,
+                    _reset_reason,
+                    target_session_id=_terminal_target_session_id,
                 )
 
         # ---- Phase 2: lock write -- apply decisions to _entries ----
@@ -2907,7 +3002,9 @@ class SessionStore:
         if entry is None:
             # Create a candidate outside the lock, then publish only if another
             # worker has not already populated this routing key.
-            session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            session_id = _terminal_target_session_id or (
+                f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            )
             candidate = SessionEntry(
                 session_key=session_key,
                 session_id=session_id,
@@ -2950,21 +3047,22 @@ class SessionStore:
         terminal_route_transition = (
             session_key in self._route_terminal_transitions
         )
-        if _needs_save:
+        if _needs_save and not terminal_route_transition:
             if _metadata_only_save:
                 self._save_entry(session_key)
             else:
-                if terminal_route_transition:
-                    self._save_entries(require_primary_db=True)
-                else:
-                    self._save_entries()
+                self._save_entries()
 
         # SQLite operations outside the lock. Terminal transitions fail closed
         if self._db and db_end_session_id:
             # Use the specific reset reason so state.db is auditable (e.g.
             # "resume_pending_expired" is distinguishable from a normal
             # "session_reset" caused by idle/daily expiry).
-            _db_end_reason = auto_reset_reason if auto_reset_reason else "session_reset"
+            _db_end_reason = (
+                _terminal_recovery_reason
+                or auto_reset_reason
+                or "session_reset"
+            )
             try:
                 # promote_to_session_reset, not end_session: the row may
                 # already be ended with a recoverable accidental reason
@@ -2985,7 +3083,10 @@ class SessionStore:
 
         if self._db and db_create_kwargs:
             try:
-                self._db.create_session(**db_create_kwargs)
+                if _terminal_recovery_reason == "session_switch":
+                    self._db.reopen_session(session_id)
+                elif _terminal_recovery_reason != "compression_advance":
+                    self._db.create_session(**db_create_kwargs)
                 self._record_gateway_session_peer(
                     session_id,
                     session_key,
@@ -2998,6 +3099,13 @@ class SessionStore:
                         "terminal transition could not create replacement SQLite session"
                     ) from e
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
+
+        # Keep the old-route write-ahead marker durable until all hard SQLite
+        # work commits. Publishing the replacement route is the final durable
+        # step, so process death earlier restarts into exact recovery with the
+        # same target_session_id rather than exposing a partial replacement.
+        if _needs_save and terminal_route_transition:
+            self._save_entries(require_primary_db=True)
 
         return entry
 
@@ -3321,29 +3429,62 @@ class SessionStore:
         from datetime import timedelta
 
         cutoff = _now() - timedelta(days=max_age_days)
-        removed_keys: list[str] = []
-
         with self._lock:
             self._ensure_loaded_locked()
-            active_transitions = getattr(self, "_active_route_transitions", set())
-            for key, entry in list(self._entries.items()):
-                if key in active_transitions:
-                    continue
-                if entry.suspended:
-                    continue
-                # Never prune sessions with an active background process
-                # attached — the user may still be waiting on output.
-                # The callback is keyed by session_key (see process_registry.
-                # has_active_for_session); passing session_id here used to
-                # never match, so active sessions got pruned anyway.
-                if self._has_active_processes_safe(entry.session_key, context="prune"):
-                    continue
-                if entry.updated_at < cutoff:
-                    removed_keys.append(key)
-            for key in removed_keys:
-                self._entries.pop(key, None)
-            if removed_keys:
-                self._save()
+            candidates = [
+                (key, entry.session_id)
+                for key, entry in self._entries.items()
+                if not entry.suspended and entry.updated_at < cutoff
+            ]
+
+        removed_keys: list[str] = []
+
+        def _prune_exact(key: str, expected_sid: str) -> bool:
+            with self._lock:
+                current = self._entries.get(key)
+                if (
+                    current is None
+                    or current.session_id != expected_sid
+                    or current.suspended
+                    or current.updated_at >= cutoff
+                ):
+                    return False
+            # The process check is deliberately inside the per-route
+            # transition reservation, so work cannot be admitted between the
+            # last check and the durable terminal marker.
+            if self._has_active_processes_safe(key, context="prune"):
+                return False
+            self._arm_route_terminal_transition(
+                key,
+                expected_sid,
+                "session_prune",
+                allow_route_absent=True,
+            )
+            if self._db:
+                try:
+                    self._db.end_session(expected_sid, "session_prune")
+                except Exception as exc:
+                    raise RuntimeError(
+                        "terminal prune could not close prior SQLite session"
+                    ) from exc
+            with self._lock:
+                current = self._entries.get(key)
+                if current is None or current.session_id != expected_sid:
+                    raise RuntimeError("prune route changed after SQLite close")
+                self._entries.pop(key)
+            # Route absence is the terminal publication and therefore commits
+            # last. Until this succeeds, the durable marked old route remains
+            # sufficient for fail-closed restart recovery and exact retry.
+            self._save_entries(require_primary_db=True)
+            return True
+
+        for key, expected_sid in candidates:
+            removed = self._run_route_transition(
+                key,
+                lambda key=key, sid=expected_sid: _prune_exact(key, sid),
+            )
+            if removed:
+                removed_keys.append(key)
 
         if removed_keys:
             logger.info(
@@ -3424,16 +3565,33 @@ class SessionStore:
             ):
                 return None
             terminal_session_id = entry.session_id
+            existing_marker = entry.metadata.get("terminal_transition")
+            target_session_id = (
+                existing_marker.get("target_session_id")
+                if isinstance(existing_marker, dict)
+                else None
+            )
+            if not target_session_id:
+                now = _now()
+                target_session_id = (
+                    f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+                )
 
         self._arm_route_terminal_transition(
-            session_key, terminal_session_id, reset_reason
+            session_key,
+            terminal_session_id,
+            reset_reason,
+            target_session_id=target_session_id,
         )
-        return self._apply_reset_session_impl(session_key, display_name)
+        return self._apply_reset_session_impl(
+            session_key, display_name, target_session_id
+        )
 
     def _apply_reset_session_impl(
         self,
         session_key: str,
         display_name: Optional[str] = None,
+        target_session_id: Optional[str] = None,
     ) -> Optional[SessionEntry]:
         """Force reset a session, creating a new session ID."""
         db_end_session_id = None
@@ -3450,7 +3608,9 @@ class SessionStore:
             db_end_session_id = old_entry.session_id
 
             now = _now()
-            session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            session_id = target_session_id
+            if not session_id:
+                raise RuntimeError("terminal reset is missing its durable target")
 
             new_entry = SessionEntry(
                 session_key=session_key,
@@ -3464,8 +3624,6 @@ class SessionStore:
                 is_fresh_reset=True,
             )
 
-            self._entries[session_key] = new_entry
-            self._save(require_primary_db=True)
             db_create_kwargs = {
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
@@ -3506,6 +3664,13 @@ class SessionStore:
                 raise RuntimeError(
                     "terminal reset could not create replacement SQLite session"
                 ) from e
+
+        with self._lock:
+            current = self._entries.get(session_key)
+            if current is None or current.session_id != db_end_session_id:
+                raise RuntimeError("terminal reset route changed before publication")
+            self._entries[session_key] = new_entry
+        self._save_entries(require_primary_db=True)
 
         return new_entry
 
@@ -3548,6 +3713,7 @@ class SessionStore:
             session_key,
             expected_session_id,
             "compression_advance",
+            target_session_id=target_session_id,
         )
         with self._lock:
             entry = self._entries.get(session_key)
@@ -3600,6 +3766,7 @@ class SessionStore:
             session_key,
             db_end_session_id,
             "session_switch",
+            target_session_id=target_session_id,
         )
         with self._lock:
             current = self._entries.get(session_key)
@@ -3617,8 +3784,6 @@ class SessionStore:
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
             )
-            self._entries[session_key] = new_entry
-        self._save_entries(require_primary_db=True)
 
         if self._db:
             try:
@@ -3640,6 +3805,13 @@ class SessionStore:
                     "terminal session switch SQLite publication failed"
                 ) from exc
 
+        with self._lock:
+            current = self._entries.get(session_key)
+            if current is None or current.session_id != db_end_session_id:
+                raise RuntimeError("session switch route changed before publication")
+            self._entries[session_key] = new_entry
+        self._save_entries(require_primary_db=True)
+
         return new_entry
 
     def list_sessions(self, active_minutes: Optional[int] = None) -> List[SessionEntry]:
@@ -3655,6 +3827,15 @@ class SessionStore:
         entries.sort(key=lambda e: e.updated_at, reverse=True)
 
         return entries
+
+    def route_matches(self, session_key: str, session_id: str) -> bool:
+        """Atomically validate one exact persisted route binding."""
+        if not session_key or not session_id:
+            return False
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            return bool(entry is not None and entry.session_id == session_id)
 
     def lookup_by_session_id(self, session_id: str) -> Optional[SessionEntry]:
         """Return the active session entry for a persisted session ID, if any."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2358,7 +2358,16 @@ class SessionStore:
         Sessions with active background processes are never reset.
         """
         session_key = self._generate_session_key(source)
-        if entry.metadata.get("terminal_transition"):
+        terminal_transition = entry.metadata.get("terminal_transition")
+        if terminal_transition:
+            # Compression publication already committed the child before the
+            # route marker is armed.  A restart must advance to that exact
+            # child, not turn the marker into a second reset transition.
+            if (
+                isinstance(terminal_transition, dict)
+                and terminal_transition.get("reason") == "compression_advance"
+            ):
+                return None
             return "terminal_transition_recovery"
         if self._has_active_processes_safe(session_key, context="reset"):
             logger.debug(
@@ -2495,6 +2504,12 @@ class SessionStore:
                 if entry.users == 0 and locks.get(session_key) is entry:
                     locks.pop(session_key, None)
 
+    def _lifecycle_failpoint(self, stage: str) -> None:
+        """Invoke the private test-only lifecycle crash seam, when installed."""
+        callback = getattr(self, "_test_lifecycle_failpoint", None)
+        if callable(callback):
+            callback(stage)
+
     def _arm_route_terminal_transition(
         self,
         session_key: str,
@@ -2550,6 +2565,16 @@ class SessionStore:
             session_key,
             entry_data=candidate,
             require_primary_db=True,
+        )
+        lifecycle_reason = {
+            "session_reset": "reset",
+            "session_switch": "switch",
+            "session_prune": "prune",
+            "idle": "auto_reset",
+            "daily": "auto_reset",
+        }.get(reason, reason)
+        self._lifecycle_failpoint(
+            f"gateway.{lifecycle_reason}.after_marker_persisted"
         )
 
         callback_token = (
@@ -2929,6 +2954,23 @@ class SessionStore:
                     entry, existing_session_id, canonical_existing_session_id
                 )
 
+                # The compression child is the committed continuation. Once
+                # the stale parent route has been healed to it, retire the
+                # write-ahead marker in the same durable route publication.
+                # Leaving it behind would make a later restart manufacture a
+                # reset boundary instead of preserving the compression lineage.
+                compression_marker = entry.metadata.get("terminal_transition")
+                if (
+                    isinstance(compression_marker, dict)
+                    and compression_marker.get("reason") == "compression_advance"
+                    and (
+                        _healed
+                        or entry.session_id
+                        == compression_marker.get("target_session_id")
+                    )
+                ):
+                    entry.metadata.pop("terminal_transition", None)
+
                 if _is_stale and entry.session_id == _stale_session_id:
                     # Stale routing self-heal (#54878): the in-memory entry
                     # points at a session that has ALREADY been ended in
@@ -3074,6 +3116,10 @@ class SessionStore:
                     _promote(db_end_session_id, _db_end_reason)
                 else:
                     self._db.end_session(db_end_session_id, _db_end_reason)
+                if was_auto_reset:
+                    self._lifecycle_failpoint(
+                        "gateway.auto_reset.after_old_promoted"
+                    )
             except Exception as e:
                 if terminal_route_transition:
                     raise RuntimeError(
@@ -3087,12 +3133,20 @@ class SessionStore:
                     self._db.reopen_session(session_id)
                 elif _terminal_recovery_reason != "compression_advance":
                     self._db.create_session(**db_create_kwargs)
+                if was_auto_reset:
+                    self._lifecycle_failpoint(
+                        "gateway.auto_reset.after_replacement_created"
+                    )
                 self._record_gateway_session_peer(
                     session_id,
                     session_key,
                     source,
                     display_name=entry.display_name,
                 )
+                if was_auto_reset:
+                    self._lifecycle_failpoint(
+                        "gateway.auto_reset.after_peer_recorded"
+                    )
             except Exception as e:
                 if terminal_route_transition:
                     raise RuntimeError(
@@ -3106,6 +3160,10 @@ class SessionStore:
         # same target_session_id rather than exposing a partial replacement.
         if _needs_save and terminal_route_transition:
             self._save_entries(require_primary_db=True)
+            if was_auto_reset:
+                self._lifecycle_failpoint(
+                    "gateway.auto_reset.after_final_route_published"
+                )
 
         return entry
 
@@ -3463,6 +3521,7 @@ class SessionStore:
             if self._db:
                 try:
                     self._db.end_session(expected_sid, "session_prune")
+                    self._lifecycle_failpoint("gateway.prune.after_old_closed")
                 except Exception as exc:
                     raise RuntimeError(
                         "terminal prune could not close prior SQLite session"
@@ -3476,6 +3535,7 @@ class SessionStore:
             # last. Until this succeeds, the durable marked old route remains
             # sufficient for fail-closed restart recovery and exact retry.
             self._save_entries(require_primary_db=True)
+            self._lifecycle_failpoint("gateway.prune.after_route_absence_published")
             return True
 
         for key, expected_sid in candidates:
@@ -3646,6 +3706,7 @@ class SessionStore:
                     _promote(db_end_session_id, "session_reset")
                 else:
                     self._db.end_session(db_end_session_id, "session_reset")
+                self._lifecycle_failpoint("gateway.reset.after_old_promoted")
             except Exception as e:
                 raise RuntimeError(
                     "terminal reset could not close prior SQLite session"
@@ -3654,12 +3715,14 @@ class SessionStore:
         if self._db and db_create_kwargs:
             try:
                 self._db.create_session(**db_create_kwargs)
+                self._lifecycle_failpoint("gateway.reset.after_replacement_created")
                 self._record_gateway_session_peer(
                     session_id,
                     session_key,
                     old_entry.origin,
                     display_name=new_entry.display_name if new_entry else None,
                 )
+                self._lifecycle_failpoint("gateway.reset.after_peer_recorded")
             except Exception as e:
                 raise RuntimeError(
                     "terminal reset could not create replacement SQLite session"
@@ -3671,6 +3734,7 @@ class SessionStore:
                 raise RuntimeError("terminal reset route changed before publication")
             self._entries[session_key] = new_entry
         self._save_entries(require_primary_db=True)
+        self._lifecycle_failpoint("gateway.reset.after_final_route_published")
 
         return new_entry
 
@@ -3727,6 +3791,7 @@ class SessionStore:
                 raise RuntimeError("compression route advance failed ownership check")
             entry.updated_at = _now()
         self._save_entries(require_primary_db=True)
+        self._lifecycle_failpoint("gateway.compression_advance.after_final_route_published")
         return entry
 
     def switch_session(
@@ -3792,7 +3857,9 @@ class SessionStore:
                     _promote(db_end_session_id, "session_switch")
                 else:
                     self._db.end_session(db_end_session_id, "session_switch")
+                self._lifecycle_failpoint("gateway.switch.after_old_promoted")
                 self._db.reopen_session(target_session_id)
+                self._lifecycle_failpoint("gateway.switch.after_target_reopened")
                 self._record_gateway_session_peer(
                     target_session_id,
                     session_key,
@@ -3800,6 +3867,7 @@ class SessionStore:
                     display_name=new_entry.display_name,
                     include_compression_ancestors=True,
                 )
+                self._lifecycle_failpoint("gateway.switch.after_peer_recorded")
             except Exception as exc:
                 raise RuntimeError(
                     "terminal session switch SQLite publication failed"
@@ -3811,6 +3879,7 @@ class SessionStore:
                 raise RuntimeError("session switch route changed before publication")
             self._entries[session_key] = new_entry
         self._save_entries(require_primary_db=True)
+        self._lifecycle_failpoint("gateway.switch.after_final_route_published")
 
         return new_entry
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2510,6 +2510,28 @@ class SessionStore:
         if callable(callback):
             callback(stage)
 
+    def _promote_prior_sqlite_session(self, session_id: str, reason: str) -> None:
+        """Require a durable reset promotion, including a retry's prior commit."""
+        if self._db is None:
+            return
+        promote = getattr(self._db, "promote_to_session_reset", None)
+        if not callable(promote):
+            self._db.end_session(session_id, reason)
+            return
+        if promote(session_id, reason) is True:
+            return
+        # ``False`` is normally a failed/declined promotion, but is also the
+        # idempotent result after a crash between promotion and publication.
+        # Only the exact already-durable boundary may resume that retry.
+        row = self._db.get_session(session_id)
+        if (
+            row is not None
+            and row.get("ended_at") is not None
+            and row.get("end_reason") == reason
+        ):
+            return
+        raise RuntimeError("prior SQLite session promotion was not confirmed")
+
     def _arm_route_terminal_transition(
         self,
         session_key: str,
@@ -3111,11 +3133,9 @@ class SessionStore:
                 # (agent_close / ws_orphan_reap), which first-reason-wins
                 # end_session would preserve — leaving the reset session
                 # resurrectable by stale-route recovery (#61220, #61993).
-                _promote = getattr(self._db, "promote_to_session_reset", None)
-                if callable(_promote):
-                    _promote(db_end_session_id, _db_end_reason)
-                else:
-                    self._db.end_session(db_end_session_id, _db_end_reason)
+                self._promote_prior_sqlite_session(
+                    db_end_session_id, _db_end_reason
+                )
                 if was_auto_reset:
                     self._lifecycle_failpoint(
                         "gateway.auto_reset.after_old_promoted"
@@ -3701,11 +3721,9 @@ class SessionStore:
                 # agent_close/ws_orphan_reap end must not survive an explicit
                 # user reset, or recovery resurrects the reset session
                 # (#61993 — the user's /new was silently undone).
-                _promote = getattr(self._db, "promote_to_session_reset", None)
-                if callable(_promote):
-                    _promote(db_end_session_id, "session_reset")
-                else:
-                    self._db.end_session(db_end_session_id, "session_reset")
+                self._promote_prior_sqlite_session(
+                    db_end_session_id, "session_reset"
+                )
                 self._lifecycle_failpoint("gateway.reset.after_old_promoted")
             except Exception as e:
                 raise RuntimeError(
@@ -3852,11 +3870,9 @@ class SessionStore:
 
         if self._db:
             try:
-                _promote = getattr(self._db, "promote_to_session_reset", None)
-                if callable(_promote):
-                    _promote(db_end_session_id, "session_switch")
-                else:
-                    self._db.end_session(db_end_session_id, "session_switch")
+                self._promote_prior_sqlite_session(
+                    db_end_session_id, "session_switch"
+                )
                 self._lifecycle_failpoint("gateway.switch.after_old_promoted")
                 self._db.reopen_session(target_session_id)
                 self._lifecycle_failpoint("gateway.switch.after_target_reopened")

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -130,9 +130,10 @@ class GatewaySlashCommandsMixin:
         # Idempotent, so the run's finally calling it again is harmless.
         self._release_running_agent_state(session_key)
 
-        # Snapshot the old entry so on_session_finalize can report the
-        # expiring session id before reset_session() rotates it.
-        old_entry = self.session_store._entries.get(session_key)
+        # Snapshot the old ID through SessionStore's lock-protected API for
+        # finalization metadata. CUA teardown itself is owned by the fenced
+        # reset transition below.
+        _old_sid = await self.async_session_store.peek_session_id(session_key)
 
         # Close tool resources on the old agent (terminal sandboxes, browser
         # daemons, background processes) before evicting from cache.
@@ -195,7 +196,7 @@ class GatewaySlashCommandsMixin:
 
             interrupt_for_session(
                 session_key=session_key,
-                parent_session_id=str(getattr(old_entry, "session_id", "") or ""),
+                parent_session_id=str(_old_sid or ""),
                 reason="session_reset",
             )
         except Exception:
@@ -214,12 +215,13 @@ class GatewaySlashCommandsMixin:
             pass
 
         # Reset the session
-        new_entry = await self.async_session_store.reset_session(session_key)
+        new_entry = await self.async_session_store.reset_session(
+            session_key,
+            reset_reason="session_reset",
+        )
 
         # (Conversation-scoped overrides + security state were already
         # cleared via _clear_conversation_scope above.)
-
-        _old_sid = old_entry.session_id if old_entry else None
 
         # Fire plugin on_session_finalize hook (session boundary)
         try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3068,6 +3068,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._warn_fts5_unavailable(exc)
             return False
 
+    def _lifecycle_failpoint(self, stage: str) -> None:
+        """Invoke a private test-only crash callback, if the test installed one."""
+        callback = getattr(self, "_test_lifecycle_failpoint", None)
+        if callable(callback):
+            callback(stage)
+
     def _execute_write(
         self,
         fn: Callable[[sqlite3.Connection], T],
@@ -4176,18 +4182,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     time.time(),
                 ),
             )
+            self._lifecycle_failpoint("db.compression.after_child_insert")
             total_messages, total_tool_calls = self._insert_message_rows(
                 conn, child_session_id, messages
             )
+            self._lifecycle_failpoint("db.compression.after_handoff_messages")
             conn.execute(
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (total_messages, total_tool_calls, child_session_id),
             )
+            self._lifecycle_failpoint("db.compression.after_child_counts")
             updated = conn.execute(
                 "UPDATE sessions SET ended_at = ?, end_reason = 'compression' "
                 "WHERE id = ? AND ended_at IS NULL",
                 (time.time(), parent_session_id),
             )
+            self._lifecycle_failpoint("db.compression.after_parent_close")
             if updated.rowcount != 1:
                 raise RuntimeError(
                     f"Compression parent changed during publication: {parent_session_id}"

--- a/scripts/verify_cua_gateway_attestation.py
+++ b/scripts/verify_cua_gateway_attestation.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import os
 import platform
 import subprocess
 import sys
+import sysconfig
+import threading
 import types
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -21,8 +25,8 @@ MODULES = (
 )
 CALLABLES = (
     "tools.computer_use.tool:set_computer_use_session_validator", "tools.computer_use.tool:_validate_managed_publication", "tools.computer_use.tool:publish_computer_use_session", "tools.computer_use.tool:unpublish_computer_use_session", "tools.computer_use.tool:begin_computer_use_terminal_transition", "tools.computer_use.tool:end_computer_use_terminal_transition", "tools.computer_use.tool:_cua_permission_mode", "tools.computer_use.tool:_get_backend", "tools.computer_use.tool:_acquire_backend_for_call", "tools.computer_use.tool:release_computer_use_session_result", "tools.computer_use.tool:handle_computer_use", "tools.computer_use.tool:_dispatch",
-    "tools.computer_use.cua_backend:_AsyncBridge.run", "tools.computer_use.cua_backend:_CuaDriverSession._lifecycle_coro", "tools.computer_use.cua_backend:_CuaDriverSession.call_tool", "tools.computer_use.cua_backend:_CuaDriverSession._call_tool_via_cli", "tools.computer_use.cua_backend:_CuaDriverSession._restart_session_locked", "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.start", "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.stop", "tools.computer_use.cua_backend:CuaDriverBackend.start", "tools.computer_use.cua_backend:CuaDriverBackend.stop", "tools.computer_use.cua_backend:CuaDriverBackend.capture", "tools.computer_use.cua_backend:CuaDriverBackend._apply_delivery", "tools.computer_use.cua_backend:CuaDriverBackend._run_input_action", "tools.computer_use.cua_backend:CuaDriverBackend._action", "tools.computer_use.cua_backend:CuaDriverBackend._maybe_attach_element_token", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_state", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_prepare", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_action",
-    "gateway.run:GatewayRunner._run_agent", "gateway.session:SessionStore.route_matches", "gateway.session:SessionStore._run_route_transition", "gateway.session:SessionStore.prune_old_entries", "tools.approval:get_current_session_key", "tools.approval:is_approval_bypass_active_for_session",
+    "tools.computer_use.cua_backend:_AsyncBridge.run", "tools.computer_use.cua_backend:_CuaDriverSession._lifecycle_coro", "tools.computer_use.cua_backend:_CuaDriverSession.start", "tools.computer_use.cua_backend:_CuaDriverSession._attest_runtime_locked", "tools.computer_use.cua_backend:_CuaDriverSession.call_tool", "tools.computer_use.cua_backend:_CuaDriverSession._call_tool_via_cli", "tools.computer_use.cua_backend:_CuaDriverSession._restart_session_locked", "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.start", "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.stop", "tools.computer_use.cua_backend:CuaDriverBackend.set_runtime_attestation_callback", "tools.computer_use.cua_backend:CuaDriverBackend.start", "tools.computer_use.cua_backend:CuaDriverBackend.stop", "tools.computer_use.cua_backend:CuaDriverBackend.capture", "tools.computer_use.cua_backend:CuaDriverBackend._apply_delivery", "tools.computer_use.cua_backend:CuaDriverBackend._run_input_action", "tools.computer_use.cua_backend:CuaDriverBackend._action", "tools.computer_use.cua_backend:CuaDriverBackend._maybe_attach_element_token", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_state", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_prepare", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_action",
+    "gateway.run:GatewayRunner._run_agent", "gateway.session:SessionStore.ensure_route_matches", "gateway.session:SessionStore.route_matches", "gateway.session:SessionStore._run_route_transition", "gateway.session:SessionStore.prune_old_entries", "tools.approval:get_current_session_key", "tools.approval:is_approval_bypass_active_for_session",
     "hermes_state:SessionDB._execute_write", "hermes_state:SessionDB.publish_compression_child", "hermes_state:SessionDB.promote_to_session_reset",
 )
 
@@ -85,6 +89,238 @@ def _verify_process(receipt: dict[str, Any]) -> None:
     except Exception as exc: raise VerificationError("cannot determine live process identity") from exc
 
 
+_NATIVE_RUNTIME_ARTIFACTS = (
+    "python_runtime",
+    "sqlite3_extension",
+    "psutil_extension",
+    "cua_driver_launcher",
+    "cua_driver_executable",
+)
+
+
+def _native_file_identity(path: Path) -> dict[str, Any]:
+    try:
+        canonical = path.resolve(strict=True)
+        if not canonical.is_file():
+            raise OSError("not a regular file")
+        raw = canonical.read_bytes()
+    except (OSError, RuntimeError) as exc:
+        raise VerificationError("cannot independently read native runtime artifact") from exc
+    return {
+        "canonical_path": str(canonical),
+        "size": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }
+
+
+def _python_runtime_library() -> Path:
+    names = [
+        value for value in (
+            sysconfig.get_config_var("LDLIBRARY"),
+            sysconfig.get_config_var("LIBRARY"),
+            f"python{sys.version_info.major}{sys.version_info.minor}.dll" if os.name == "nt" else None,
+        ) if isinstance(value, str) and value
+    ]
+    directories = [Path(sys.base_prefix), Path(sys.prefix), Path(sys.executable).resolve().parent]
+    libdir = sysconfig.get_config_var("LIBDIR")
+    if isinstance(libdir, str) and libdir:
+        directories.insert(0, Path(libdir))
+    for directory in directories:
+        for name in names:
+            candidate = directory / name
+            if candidate.is_file():
+                return candidate.resolve(strict=True)
+    raise VerificationError("cannot independently resolve Python runtime library")
+
+
+def _live_cua_driver_processes(
+    *,
+    owner_pid: int,
+    owner_create_time: float,
+    owner_executable: str,
+) -> list[dict[str, Any]]:
+    """Independently bind the exact direct cua-driver children of one gateway."""
+    try:
+        import psutil
+    except Exception as exc:
+        raise VerificationError("cannot import psutil for cua-driver process verification") from exc
+    try:
+        owner = psutil.Process(int(owner_pid))
+        if abs(owner.create_time() - float(owner_create_time)) > 0.001:
+            raise VerificationError("gateway owner process create time mismatch")
+        if Path(owner.exe()).resolve(strict=True) != Path(owner_executable).resolve(strict=True):
+            raise VerificationError("gateway owner executable mismatch")
+    except VerificationError:
+        raise
+    except Exception as exc:
+        raise VerificationError("cannot resolve gateway owner process") from exc
+
+    parent_identity = {
+        "pid": int(owner_pid),
+        "process_create_time": float(owner_create_time),
+        "executable": str(owner_executable),
+    }
+    rows: list[dict[str, Any]] = []
+    for process in psutil.process_iter(["pid", "name"]):
+        try:
+            if "cua-driver" not in str(process.info.get("name") or "").lower():
+                continue
+            if process.ppid() != int(owner_pid):
+                continue
+            parent = process.parent()
+            if parent is None or parent.pid != int(owner_pid):
+                continue
+            if abs(parent.create_time() - float(owner_create_time)) > 0.001:
+                continue
+            if Path(parent.exe()).resolve(strict=True) != Path(
+                owner_executable
+            ).resolve(strict=True):
+                continue
+            argv = process.cmdline()
+            if not isinstance(argv, list) or not argv or not all(
+                isinstance(value, str) for value in argv
+            ):
+                raise VerificationError("owned cua-driver argv is unavailable")
+            _native_file_identity(Path(argv[0]))
+            rows.append({
+                "pid": process.pid,
+                "process_create_time": process.create_time(),
+                "ppid": int(owner_pid),
+                "executable": _native_file_identity(Path(process.exe())),
+                "parent": dict(parent_identity),
+                "argv": argv,
+            })
+        except VerificationError:
+            raise
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+    rows.sort(key=lambda row: (row["process_create_time"], row["pid"]))
+    if not rows:
+        raise VerificationError("no gateway-owned cua-driver process is live")
+    executable_identities = {
+        (row["executable"]["canonical_path"], row["executable"]["sha256"])
+        for row in rows
+    }
+    launcher_identities = {
+        (
+            identity["canonical_path"],
+            identity["sha256"],
+        )
+        for identity in (
+            _native_file_identity(Path(row["argv"][0])) for row in rows
+        )
+    }
+    if len(executable_identities) != 1:
+        raise VerificationError("owned cua-driver processes use ambiguous executable bytes")
+    if len(launcher_identities) != 1:
+        raise VerificationError("owned cua-driver processes use ambiguous launcher bytes")
+    return rows
+
+
+def _live_native_runtime_artifacts(
+    cua_driver_processes: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Resolve and hash the verifier runtime's fixed native dependency policy."""
+    try:
+        import _sqlite3
+        import psutil
+
+        extension_name = {
+            "win32": "psutil._psutil_windows",
+            "darwin": "psutil._psutil_osx",
+        }.get(sys.platform, "psutil._psutil_linux")
+        psutil_extension = __import__(extension_name, fromlist=["*"])
+        if not cua_driver_processes:
+            raise VerificationError("active native policy requires a live owned driver")
+        launcher = _native_file_identity(Path(cua_driver_processes[0]["argv"][0]))
+        artifacts = {
+            "python_runtime": _native_file_identity(_python_runtime_library()),
+            "sqlite3_extension": _native_file_identity(Path(_sqlite3.__file__)),
+            "psutil_extension": _native_file_identity(Path(psutil_extension.__file__)),
+            "cua_driver_launcher": launcher,
+            "cua_driver_executable": dict(cua_driver_processes[0]["executable"]),
+        }
+    except VerificationError:
+        raise
+    except Exception as exc:
+        raise VerificationError("cannot independently resolve native runtime artifacts") from exc
+    if set(artifacts) != set(_NATIVE_RUNTIME_ARTIFACTS):
+        raise VerificationError("fixed native runtime artifact policy is incomplete")
+    return artifacts
+
+
+def _verify_cua_driver_processes(
+    receipt: dict[str, Any],
+    live_rows: list[dict[str, Any]],
+) -> None:
+    if receipt.get("runtime_phase") != "cua_active":
+        raise VerificationError("final verification requires cua_active runtime phase")
+    recorded = receipt.get("cua_driver_processes")
+    if not isinstance(recorded, list) or not recorded:
+        raise VerificationError("receipt lacks live cua-driver process identities")
+    recorded_keys = [
+        (row.get("pid"), row.get("process_create_time"))
+        for row in recorded
+        if isinstance(row, dict)
+    ]
+    if len(recorded_keys) != len(recorded):
+        raise VerificationError("invalid cua-driver process identity row")
+    if len(set(recorded_keys)) != len(recorded_keys):
+        raise VerificationError("duplicate cua-driver process identity row")
+    live_keys = [(row["pid"], row["process_create_time"]) for row in live_rows]
+    if set(recorded_keys) != set(live_keys) or len(recorded_keys) != len(live_keys):
+        raise VerificationError("receipt does not match exact live process set")
+    expected_parent = {
+        "pid": receipt.get("pid"),
+        "process_create_time": receipt.get("process_create_time"),
+        "executable": receipt.get("executable"),
+    }
+    by_key = {
+        (row["pid"], row["process_create_time"]): row for row in live_rows
+    }
+    for row in recorded:
+        if row.get("ppid") != receipt.get("pid") or row.get("parent") != expected_parent:
+            raise VerificationError("cua-driver gateway ancestry mismatch")
+        live = by_key[(row["pid"], row["process_create_time"])]
+        if row != live:
+            if row.get("executable") != live["executable"]:
+                raise VerificationError("cua-driver executable identity mismatch")
+            if row.get("argv") != live["argv"]:
+                raise VerificationError("cua-driver argv mismatch")
+            raise VerificationError("cua-driver process identity mismatch")
+
+
+def _verify_native_runtime_artifacts(
+    receipt: dict[str, Any],
+    live_processes: list[dict[str, Any]],
+) -> None:
+    rows = receipt.get("native_runtime_artifacts")
+    if not isinstance(rows, dict) or set(rows) != set(_NATIVE_RUNTIME_ARTIFACTS):
+        raise VerificationError("fixed native runtime artifact policy mismatch")
+    for name, actual in _live_native_runtime_artifacts(live_processes).items():
+        row = rows.get(name)
+        if not isinstance(row, dict) or set(row) != set(actual):
+            raise VerificationError(f"invalid native runtime artifact row: {name}")
+        if row.get("canonical_path") != actual["canonical_path"]:
+            raise VerificationError(f"native runtime artifact path mismatch: {name}")
+        if row.get("size") != actual["size"]:
+            raise VerificationError(f"native runtime artifact size mismatch: {name}")
+        if row.get("sha256") != actual["sha256"]:
+            raise VerificationError(f"native runtime artifact hash mismatch: {name}")
+
+
+def _verify_live_runtime_snapshot(receipt: dict[str, Any]) -> None:
+    """Revalidate the exact gateway/driver/native snapshot at one boundary."""
+    _verify_process(receipt)
+    live_cua_driver_processes = _live_cua_driver_processes(
+        owner_pid=receipt.get("pid"),
+        owner_create_time=receipt.get("process_create_time"),
+        owner_executable=receipt.get("executable"),
+    )
+    _verify_cua_driver_processes(receipt, live_cua_driver_processes)
+    _verify_native_runtime_artifacts(receipt, live_cua_driver_processes)
+
+
 def verify(
     receipt: dict[str, Any],
     review_root: Path,
@@ -97,7 +333,7 @@ def verify(
     runtime = receipt.get("runtime")
     if not isinstance(runtime, dict) or runtime.get("python_implementation") != platform.python_implementation() or runtime.get("python_version") != list(sys.version_info[:3]) or runtime.get("python_cache_tag") != sys.implementation.cache_tag or runtime.get("optimization") != sys.flags.optimize:
         raise VerificationError("runtime Python semantics mismatch")
-    _verify_process(receipt)
+    _verify_live_runtime_snapshot(receipt)
     root = review_root.resolve()
     deployment = deployed_root.resolve()
     if not deployment.is_dir():
@@ -147,11 +383,48 @@ def verify(
     kind = source.get("kind") if isinstance(source, dict) else None
     if kind not in {"git-clean", "dirty-attested-source", "unversioned"}: raise VerificationError("invalid source identity kind")
     if kind == "git-clean":
+        if not isinstance(expected_commit, str) or not expected_commit:
+            raise VerificationError("expected commit is required for git-clean verification")
         repository = source.get("repository", {})
         commit = repository.get("head_commit") if isinstance(repository, dict) else None
+        attested_tree = repository.get("head_tree") if isinstance(repository, dict) else None
         try: actual = subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL).strip()
         except (OSError, subprocess.CalledProcessError) as exc: raise VerificationError("clean receipt requires review Git repository") from exc
         if actual != commit or (expected_commit is not None and actual != expected_commit): raise VerificationError("review commit mismatch")
+        try:
+            actual_tree = subprocess.check_output(
+                ["git", "-C", str(root), "rev-parse", "HEAD^{tree}"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            expected_tree = (
+                subprocess.check_output(
+                    ["git", "-C", str(root), "rev-parse", f"{expected_commit}^{{tree}}"],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+                if expected_commit is not None
+                else actual_tree
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise VerificationError("cannot independently resolve review Git tree") from exc
+        if not isinstance(attested_tree, str) or attested_tree != actual_tree or actual_tree != expected_tree:
+            raise VerificationError("review tree mismatch")
+        try:
+            deployed_commit = subprocess.check_output(
+                ["git", "-C", str(deployment), "rev-parse", "HEAD"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            deployed_tree = subprocess.check_output(
+                ["git", "-C", str(deployment), "rev-parse", "HEAD^{tree}"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise VerificationError("cannot independently resolve deployed Git tree") from exc
+        if deployed_commit != actual or deployed_tree != actual_tree:
+            raise VerificationError("deployed Git tree mismatch")
         for relative in MODULES:
             path_row = source.get("attested_paths", {}).get(relative, {})
             if not path_row.get("matches_head"):
@@ -172,35 +445,92 @@ def verify(
                 raise VerificationError(f"reviewed path does not match clean HEAD: {relative}") from exc
             if path_row.get("head_blob") != head_blob:
                 raise VerificationError(f"receipt HEAD blob mismatch: {relative}")
-        return f"verified commit identity: {actual}"
+        _verify_live_runtime_snapshot(receipt)
+        return f"verified commit identity: {actual}; verified tree identity: {actual_tree}"
     if expected_commit is not None: raise VerificationError("expected commit cannot verify dirty or unversioned receipt")
+    _verify_live_runtime_snapshot(receipt)
     return "verified reviewed content identity (dirty/unversioned source; no commit identity claimed)"
+
+
+def _durable_replace(temporary: Path, destination: Path) -> None:
+    """Replace an evidence receipt only after a platform durability barrier."""
+    if os.name == "nt":
+        import ctypes
+        from ctypes import wintypes
+
+        move_file = ctypes.WinDLL("kernel32", use_last_error=True).MoveFileExW
+        move_file.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD]
+        move_file.restype = wintypes.BOOL
+        # MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH. Concurrent
+        # verifier processes may briefly hold the destination metadata open;
+        # bounded retries preserve durability without sharing a temp file.
+        import time as _time
+
+        for attempt in range(50):
+            if move_file(str(temporary), str(destination), 0x1 | 0x8):
+                return
+            error = ctypes.get_last_error()
+            if error not in {5, 32} or attempt == 49:
+                raise OSError(error, "MoveFileExW failed")
+            _time.sleep(min(0.002 * (attempt + 1), 0.05))
+        raise RuntimeError("unreachable durable replacement retry state")
+    os.replace(temporary, destination)
+    directory_fd = os.open(destination.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
 
 
 def _write_verification_receipt(
     path: Path,
     args: argparse.Namespace,
     exit_code: int,
-    stdout: str,
-    stderr: str,
+    stdout: bytes,
+    stderr: bytes,
 ) -> None:
-    """Persist the exact verifier invocation and its complete result."""
+    """Atomically persist the exact verifier invocation and byte result."""
+    def stream(raw: bytes) -> dict[str, Any]:
+        return {
+            "base64": base64.b64encode(raw).decode("ascii"),
+            "length": len(raw),
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        }
+
     payload = {
-        "schema": 1,
-        "command": list(sys.argv),
-        "receipt_path": str(args.receipt),
-        "review_root": str(args.review_root),
-        "deployed_root": str(args.deployed_root),
-        "expected_commit": args.expected_commit,
+        "schema": 2,
+        "invocation": {
+            "interpreter": str(Path(sys.executable).resolve()),
+            "verifier_path": str(Path(__file__).resolve()),
+            "cwd": str(Path.cwd().resolve()),
+            "argv": [
+                str(Path(sys.executable).resolve()),
+                str(Path(__file__).resolve()),
+                *sys.argv[1:],
+            ],
+            "receipt_path": str(args.receipt),
+            "review_root": str(args.review_root),
+            "deployed_root": str(args.deployed_root),
+            "expected_commit": args.expected_commit,
+        },
         "verifier_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
-        "exit_code": exit_code,
-        "stdout": stdout,
-        "stderr": stderr,
+        "result": {"exit_code": exit_code, "stdout": stream(stdout), "stderr": stream(stderr)},
     }
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    os.replace(temporary, path)
+    temporary = path.parent / (
+        f".cua-verify-{os.getpid()}-{threading.get_ident()}-{uuid.uuid4().hex}.tmp"
+    )
+    try:
+        with temporary.open("wb") as handle:
+            handle.write(json.dumps(payload, indent=2).encode("utf-8"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        _durable_replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def main() -> int:
@@ -211,21 +541,19 @@ def main() -> int:
     parser.add_argument("--expected-commit")
     parser.add_argument("--verification-receipt", type=Path)
     args = parser.parse_args()
-    stdout = ""
-    stderr = ""
+    stdout = b""
+    stderr = b""
     try:
         receipt = json.loads(args.receipt.read_text(encoding="utf-8"))
-        stdout = verify(receipt, args.review_root, args.deployed_root, args.expected_commit)
+        stdout = (verify(receipt, args.review_root, args.deployed_root, args.expected_commit) + "\n").encode("utf-8")
         exit_code = 0
     except (OSError, ValueError, KeyError, VerificationError) as exc:
-        stderr = f"CUA attestation verification failed: {exc}"
+        stderr = f"CUA attestation verification failed: {exc}\n".encode("utf-8")
         exit_code = 1
     if stdout:
-        print(stdout)
-        stdout += "\n"
+        sys.stdout.buffer.write(stdout)
     if stderr:
-        print(stderr, file=sys.stderr)
-        stderr += "\n"
+        sys.stderr.buffer.write(stderr)
     if args.verification_receipt is not None:
         _write_verification_receipt(args.verification_receipt, args, exit_code, stdout, stderr)
     return exit_code

--- a/scripts/verify_cua_gateway_attestation.py
+++ b/scripts/verify_cua_gateway_attestation.py
@@ -16,12 +16,14 @@ from typing import Any
 MODULES = (
     "tools/computer_use/tool.py", "tools/computer_use/cua_backend.py",
     "tools/computer_use/browser_route.py", "gateway/run.py", "gateway/session.py",
+    "hermes_state.py",
     "tools/approval.py",
 )
 CALLABLES = (
     "tools.computer_use.tool:set_computer_use_session_validator", "tools.computer_use.tool:_validate_managed_publication", "tools.computer_use.tool:publish_computer_use_session", "tools.computer_use.tool:unpublish_computer_use_session", "tools.computer_use.tool:begin_computer_use_terminal_transition", "tools.computer_use.tool:end_computer_use_terminal_transition", "tools.computer_use.tool:_cua_permission_mode", "tools.computer_use.tool:_get_backend", "tools.computer_use.tool:_acquire_backend_for_call", "tools.computer_use.tool:release_computer_use_session_result", "tools.computer_use.tool:handle_computer_use", "tools.computer_use.tool:_dispatch",
     "tools.computer_use.cua_backend:_AsyncBridge.run", "tools.computer_use.cua_backend:_CuaDriverSession._lifecycle_coro", "tools.computer_use.cua_backend:_CuaDriverSession.call_tool", "tools.computer_use.cua_backend:_CuaDriverSession._call_tool_via_cli", "tools.computer_use.cua_backend:_CuaDriverSession._restart_session_locked", "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.start", "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.stop", "tools.computer_use.cua_backend:CuaDriverBackend.start", "tools.computer_use.cua_backend:CuaDriverBackend.stop", "tools.computer_use.cua_backend:CuaDriverBackend.capture", "tools.computer_use.cua_backend:CuaDriverBackend._apply_delivery", "tools.computer_use.cua_backend:CuaDriverBackend._run_input_action", "tools.computer_use.cua_backend:CuaDriverBackend._action", "tools.computer_use.cua_backend:CuaDriverBackend._maybe_attach_element_token", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_state", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_prepare", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_action",
     "gateway.run:GatewayRunner._run_agent", "gateway.session:SessionStore.route_matches", "gateway.session:SessionStore._run_route_transition", "gateway.session:SessionStore.prune_old_entries", "tools.approval:get_current_session_key", "tools.approval:is_approval_bypass_active_for_session",
+    "hermes_state:SessionDB._execute_write", "hermes_state:SessionDB.publish_compression_child", "hermes_state:SessionDB.promote_to_session_reset",
 )
 
 
@@ -69,6 +71,16 @@ def _verify_process(receipt: dict[str, Any]) -> None:
         process = psutil.Process(int(receipt["pid"]))
         if abs(process.create_time() - float(receipt["process_create_time"])) > 0.001: raise VerificationError("live process create time mismatch")
         if Path(process.exe()).resolve() != Path(str(receipt["executable"])).resolve(): raise VerificationError("live process executable mismatch")
+        if Path(sys.executable).resolve() != Path(str(receipt["launcher"])).resolve(): raise VerificationError("live process launcher mismatch")
+        parent = receipt["parent"]
+        live_parent = process.parent()
+        if (
+            not isinstance(parent, dict)
+            or live_parent is None
+            or live_parent.pid != int(parent["pid"])
+            or abs(live_parent.create_time() - float(parent["process_create_time"])) > 0.001
+            or Path(live_parent.exe()).resolve() != Path(str(parent["executable"])).resolve()
+        ): raise VerificationError("live parent process identity mismatch")
     except VerificationError: raise
     except Exception as exc: raise VerificationError("cannot determine live process identity") from exc
 
@@ -107,6 +119,9 @@ def verify(
             raise VerificationError(f"deployed source path escapes root: {relative}")
         if not isinstance(receipt_source, str) or Path(receipt_source).resolve() != canonical_deployed:
             raise VerificationError(f"receipt deployed source path mismatch: {relative}")
+        deployed_raw = canonical_deployed.read_bytes()
+        if len(deployed_raw) != row.get("size") or hashlib.sha256(deployed_raw).hexdigest() != row.get("sha256"):
+            raise VerificationError(f"deployed module hash mismatch: {relative}")
         code = compile(
             raw,
             str(canonical_deployed),
@@ -162,20 +177,58 @@ def verify(
     return "verified reviewed content identity (dirty/unversioned source; no commit identity claimed)"
 
 
+def _write_verification_receipt(
+    path: Path,
+    args: argparse.Namespace,
+    exit_code: int,
+    stdout: str,
+    stderr: str,
+) -> None:
+    """Persist the exact verifier invocation and its complete result."""
+    payload = {
+        "schema": 1,
+        "command": list(sys.argv),
+        "receipt_path": str(args.receipt),
+        "review_root": str(args.review_root),
+        "deployed_root": str(args.deployed_root),
+        "expected_commit": args.expected_commit,
+        "verifier_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "exit_code": exit_code,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(temporary, path)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--receipt", type=Path, required=True)
     parser.add_argument("--review-root", type=Path, required=True)
     parser.add_argument("--deployed-root", type=Path, required=True)
     parser.add_argument("--expected-commit")
+    parser.add_argument("--verification-receipt", type=Path)
     args = parser.parse_args()
+    stdout = ""
+    stderr = ""
     try:
         receipt = json.loads(args.receipt.read_text(encoding="utf-8"))
-        print(verify(receipt, args.review_root, args.deployed_root, args.expected_commit))
-        return 0
-    except (OSError, ValueError, VerificationError) as exc:
-        print(f"CUA attestation verification failed: {exc}", file=sys.stderr)
-        return 1
+        stdout = verify(receipt, args.review_root, args.deployed_root, args.expected_commit)
+        exit_code = 0
+    except (OSError, ValueError, KeyError, VerificationError) as exc:
+        stderr = f"CUA attestation verification failed: {exc}"
+        exit_code = 1
+    if stdout:
+        print(stdout)
+        stdout += "\n"
+    if stderr:
+        print(stderr, file=sys.stderr)
+        stderr += "\n"
+    if args.verification_receipt is not None:
+        _write_verification_receipt(args.verification_receipt, args, exit_code, stdout, stderr)
+    return exit_code
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/verify_cua_gateway_attestation.py
+++ b/scripts/verify_cua_gateway_attestation.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+"""Independently verify schema-v3 CUA gateway runtime attestation receipts."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+MODULES = (
+    "tools/computer_use/tool.py", "tools/computer_use/cua_backend.py",
+    "tools/computer_use/browser_route.py", "gateway/run.py", "gateway/session.py",
+    "tools/approval.py",
+)
+CALLABLES = (
+    "tools.computer_use.tool:set_computer_use_session_validator", "tools.computer_use.tool:_validate_managed_publication", "tools.computer_use.tool:publish_computer_use_session", "tools.computer_use.tool:unpublish_computer_use_session", "tools.computer_use.tool:begin_computer_use_terminal_transition", "tools.computer_use.tool:end_computer_use_terminal_transition", "tools.computer_use.tool:_cua_permission_mode", "tools.computer_use.tool:_get_backend", "tools.computer_use.tool:_acquire_backend_for_call", "tools.computer_use.tool:release_computer_use_session_result", "tools.computer_use.tool:handle_computer_use", "tools.computer_use.tool:_dispatch",
+    "tools.computer_use.cua_backend:_AsyncBridge.run", "tools.computer_use.cua_backend:_CuaDriverSession._lifecycle_coro", "tools.computer_use.cua_backend:_CuaDriverSession.call_tool", "tools.computer_use.cua_backend:_CuaDriverSession._call_tool_via_cli", "tools.computer_use.cua_backend:_CuaDriverSession._restart_session_locked", "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.start", "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.stop", "tools.computer_use.cua_backend:CuaDriverBackend.start", "tools.computer_use.cua_backend:CuaDriverBackend.stop", "tools.computer_use.cua_backend:CuaDriverBackend.capture", "tools.computer_use.cua_backend:CuaDriverBackend._apply_delivery", "tools.computer_use.cua_backend:CuaDriverBackend._run_input_action", "tools.computer_use.cua_backend:CuaDriverBackend._action", "tools.computer_use.cua_backend:CuaDriverBackend._maybe_attach_element_token", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_state", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_prepare", "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_action",
+    "gateway.run:GatewayRunner._run_agent", "gateway.session:SessionStore.route_matches", "gateway.session:SessionStore._run_route_transition", "gateway.session:SessionStore.prune_old_entries", "tools.approval:get_current_session_key", "tools.approval:is_approval_bypass_active_for_session",
+)
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def _payload(code: types.CodeType) -> dict[str, Any]:
+    def constant(value: Any) -> Any:
+        if isinstance(value, types.CodeType): return {"type": "code", "value": _payload(value)}
+        if value is None or isinstance(value, (bool, int, str)): return {"type": type(value).__name__, "value": value}
+        if isinstance(value, float): return {"type": "float", "value": value.hex()}
+        if isinstance(value, complex): return {"type": "complex", "real": value.real.hex(), "imag": value.imag.hex()}
+        if isinstance(value, bytes): return {"type": "bytes", "value": value.hex()}
+        if isinstance(value, tuple): return {"type": "tuple", "value": [constant(item) for item in value]}
+        if isinstance(value, frozenset): return {"type": "frozenset", "value": sorted((constant(item) for item in value), key=lambda item: json.dumps(item, sort_keys=True))}
+        raise VerificationError(f"unsupported code constant type: {type(value)!r}")
+    return {"argcount": code.co_argcount, "posonlyargcount": code.co_posonlyargcount, "kwonlyargcount": code.co_kwonlyargcount, "nlocals": code.co_nlocals, "stacksize": code.co_stacksize, "flags": code.co_flags, "code": code.co_code.hex(), "consts": [constant(value) for value in code.co_consts], "names": list(code.co_names), "varnames": list(code.co_varnames), "freevars": list(code.co_freevars), "cellvars": list(code.co_cellvars), "filename": code.co_filename, "qualname": code.co_qualname, "firstlineno": code.co_firstlineno, "linetable": code.co_linetable.hex(), "exceptiontable": code.co_exceptiontable.hex()}
+
+
+def _fingerprint(code: types.CodeType) -> str:
+    return hashlib.sha256(json.dumps(_payload(code), sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("ascii")).hexdigest()
+
+
+def _codes(code: types.CodeType, found: dict[str, types.CodeType]) -> None:
+    found[code.co_qualname] = code
+    for constant in code.co_consts:
+        if isinstance(constant, types.CodeType): _codes(constant, found)
+
+
+def _review_path(root: Path, relative: str) -> Path:
+    if not isinstance(relative, str) or Path(relative).is_absolute() or ".." in Path(relative).parts:
+        raise VerificationError(f"unsafe review path: {relative!r}")
+    root = root.resolve()
+    path = (root / relative).resolve()
+    if root not in path.parents or path == root:
+        raise VerificationError(f"review path escapes root: {relative!r}")
+    if not path.is_file(): raise VerificationError(f"review source missing: {relative}")
+    return path
+
+
+def _verify_process(receipt: dict[str, Any]) -> None:
+    try:
+        import psutil
+        process = psutil.Process(int(receipt["pid"]))
+        if abs(process.create_time() - float(receipt["process_create_time"])) > 0.001: raise VerificationError("live process create time mismatch")
+        if Path(process.exe()).resolve() != Path(str(receipt["executable"])).resolve(): raise VerificationError("live process executable mismatch")
+    except VerificationError: raise
+    except Exception as exc: raise VerificationError("cannot determine live process identity") from exc
+
+
+def verify(
+    receipt: dict[str, Any],
+    review_root: Path,
+    deployed_root: Path,
+    expected_commit: str | None,
+) -> str:
+    if receipt.get("schema") != 3: raise VerificationError("schema must be 3")
+    if set(receipt.get("modules", {})) != set(MODULES): raise VerificationError("receipt module surface does not match fixed policy")
+    if set(receipt.get("callables", {})) != set(CALLABLES): raise VerificationError("receipt callable surface does not match fixed callable policy")
+    runtime = receipt.get("runtime")
+    if not isinstance(runtime, dict) or runtime.get("python_implementation") != platform.python_implementation() or runtime.get("python_version") != list(sys.version_info[:3]) or runtime.get("python_cache_tag") != sys.implementation.cache_tag or runtime.get("optimization") != sys.flags.optimize:
+        raise VerificationError("runtime Python semantics mismatch")
+    _verify_process(receipt)
+    root = review_root.resolve()
+    deployment = deployed_root.resolve()
+    if not deployment.is_dir():
+        raise VerificationError("independently supplied deployed root is not a directory")
+    compiled: dict[str, dict[str, types.CodeType]] = {}
+    seen: set[Path] = set()
+    for relative in MODULES:
+        row = receipt["modules"][relative]
+        if not isinstance(row, dict): raise VerificationError(f"invalid module row: {relative}")
+        path = _review_path(root, relative)
+        if path in seen: raise VerificationError("duplicate or symlink-ambiguous review path")
+        seen.add(path)
+        raw = path.read_bytes()
+        if len(raw) != row.get("size") or hashlib.sha256(raw).hexdigest() != row.get("sha256"):
+            raise VerificationError(f"module hash mismatch: {relative}")
+        receipt_source = row.get("source_path")
+        canonical_deployed = (deployment / relative).resolve()
+        if deployment not in canonical_deployed.parents:
+            raise VerificationError(f"deployed source path escapes root: {relative}")
+        if not isinstance(receipt_source, str) or Path(receipt_source).resolve() != canonical_deployed:
+            raise VerificationError(f"receipt deployed source path mismatch: {relative}")
+        code = compile(
+            raw,
+            str(canonical_deployed),
+            "exec",
+            dont_inherit=True,
+            optimize=sys.flags.optimize,
+        )
+        found: dict[str, types.CodeType] = {}
+        _codes(code, found)
+        compiled[relative] = found
+    for identity in CALLABLES:
+        row = receipt["callables"][identity]
+        module, qualname = identity.split(":", 1)
+        if not isinstance(row, dict) or row.get("module") != module or row.get("qualname") != qualname:
+            raise VerificationError(f"invalid callable identity: {identity}")
+        relative = row.get("source_relative_path")
+        if relative not in compiled: raise VerificationError(f"callable source not in policy: {identity}")
+        code = compiled[relative].get(qualname)
+        if code is None: raise VerificationError(f"reviewed callable missing: {identity}")
+        if code.co_firstlineno != row.get("first_line") or _fingerprint(code) != row.get("code_sha256"):
+            raise VerificationError(f"callable fingerprint mismatch: {identity}")
+    source = receipt.get("source_identity", {})
+    kind = source.get("kind") if isinstance(source, dict) else None
+    if kind not in {"git-clean", "dirty-attested-source", "unversioned"}: raise VerificationError("invalid source identity kind")
+    if kind == "git-clean":
+        repository = source.get("repository", {})
+        commit = repository.get("head_commit") if isinstance(repository, dict) else None
+        try: actual = subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL).strip()
+        except (OSError, subprocess.CalledProcessError) as exc: raise VerificationError("clean receipt requires review Git repository") from exc
+        if actual != commit or (expected_commit is not None and actual != expected_commit): raise VerificationError("review commit mismatch")
+        for relative in MODULES:
+            path_row = source.get("attested_paths", {}).get(relative, {})
+            if not path_row.get("matches_head"):
+                raise VerificationError(f"clean receipt path not matched to HEAD: {relative}")
+            try:
+                head_blob = subprocess.check_output(
+                    ["git", "-C", str(root), "rev-parse", f"HEAD:{relative}"],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+                subprocess.run(
+                    ["git", "-C", str(root), "diff", "--quiet", "HEAD", "--", relative],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except (OSError, subprocess.CalledProcessError) as exc:
+                raise VerificationError(f"reviewed path does not match clean HEAD: {relative}") from exc
+            if path_row.get("head_blob") != head_blob:
+                raise VerificationError(f"receipt HEAD blob mismatch: {relative}")
+        return f"verified commit identity: {actual}"
+    if expected_commit is not None: raise VerificationError("expected commit cannot verify dirty or unversioned receipt")
+    return "verified reviewed content identity (dirty/unversioned source; no commit identity claimed)"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--review-root", type=Path, required=True)
+    parser.add_argument("--deployed-root", type=Path, required=True)
+    parser.add_argument("--expected-commit")
+    args = parser.parse_args()
+    try:
+        receipt = json.loads(args.receipt.read_text(encoding="utf-8"))
+        print(verify(receipt, args.review_root, args.deployed_root, args.expected_commit))
+        return 0
+    except (OSError, ValueError, VerificationError) as exc:
+        print(f"CUA attestation verification failed: {exc}", file=sys.stderr)
+        return 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_cua_gateway_attestation.py
+++ b/scripts/verify_cua_gateway_attestation.py
@@ -488,6 +488,8 @@ def _write_verification_receipt(
     exit_code: int,
     stdout: bytes,
     stderr: bytes,
+    input_receipt_bytes: bytes | None = None,
+    input_receipt_path: Path | None = None,
 ) -> None:
     """Atomically persist the exact verifier invocation and byte result."""
     def stream(raw: bytes) -> dict[str, Any]:
@@ -497,8 +499,22 @@ def _write_verification_receipt(
             "sha256": hashlib.sha256(raw).hexdigest(),
         }
 
+    receipt_path = (
+        input_receipt_path
+        if input_receipt_path is not None
+        else args.receipt.resolve(strict=input_receipt_bytes is not None)
+    )
     payload = {
-        "schema": 2,
+        "schema": 3,
+        "input_attestation": {
+            "path": str(receipt_path),
+            "length": len(input_receipt_bytes) if input_receipt_bytes is not None else None,
+            "sha256": (
+                hashlib.sha256(input_receipt_bytes).hexdigest()
+                if input_receipt_bytes is not None
+                else None
+            ),
+        },
         "invocation": {
             "interpreter": str(Path(sys.executable).resolve()),
             "verifier_path": str(Path(__file__).resolve()),
@@ -508,7 +524,7 @@ def _write_verification_receipt(
                 str(Path(__file__).resolve()),
                 *sys.argv[1:],
             ],
-            "receipt_path": str(args.receipt),
+            "receipt_path": str(receipt_path),
             "review_root": str(args.review_root),
             "deployed_root": str(args.deployed_root),
             "expected_commit": args.expected_commit,
@@ -543,8 +559,12 @@ def main() -> int:
     args = parser.parse_args()
     stdout = b""
     stderr = b""
+    receipt_bytes: bytes | None = None
+    receipt_path: Path | None = None
     try:
-        receipt = json.loads(args.receipt.read_text(encoding="utf-8"))
+        receipt_path = args.receipt.resolve(strict=True)
+        receipt_bytes = receipt_path.read_bytes()
+        receipt = json.loads(receipt_bytes.decode("utf-8"))
         stdout = (verify(receipt, args.review_root, args.deployed_root, args.expected_commit) + "\n").encode("utf-8")
         exit_code = 0
     except (OSError, ValueError, KeyError, VerificationError) as exc:
@@ -555,7 +575,15 @@ def main() -> int:
     if stderr:
         sys.stderr.buffer.write(stderr)
     if args.verification_receipt is not None:
-        _write_verification_receipt(args.verification_receipt, args, exit_code, stdout, stderr)
+        _write_verification_receipt(
+            args.verification_receipt,
+            args,
+            exit_code,
+            stdout,
+            stderr,
+            receipt_bytes,
+            receipt_path,
+        )
     return exit_code
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -468,19 +468,10 @@ def _hermetic_environment(tmp_path, monkeypatch):
     (fake_hermes_home / "skills").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_hermes_home))
 
-    # 3b. hermes_state computes ``DEFAULT_DB_PATH = get_hermes_home() / "state.db"``
-    #     at import time. When the module is first imported at collection (any
-    #     test file with a top-level ``from hermes_state import ...``) that
-    #     happens BEFORE this fixture ever runs, so every argless
-    #     ``SessionDB()`` in every test opens the developer's REAL state.db —
-    #     reading real sessions into assertions and writing test rows into the
-    #     real profile. Re-pin the constant to this test's home. (Several test
-    #     files already do this locally; this makes it an invariant.)
-    hermes_state_mod = sys.modules.get("hermes_state")
-    if hermes_state_mod is not None and hasattr(hermes_state_mod, "DEFAULT_DB_PATH"):
-        monkeypatch.setattr(
-            hermes_state_mod, "DEFAULT_DB_PATH", fake_hermes_home / "state.db"
-        )
+    # ``SessionDB`` now resolves ``get_hermes_home()`` at construction time.
+    # Do not re-pin its legacy import-time constant here: doing so overrides a
+    # test's later, intentional HERMES_HOME redirect and makes outcomes depend
+    # on whether another test imported hermes_state during collection.
 
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -39,6 +39,15 @@ from unittest.mock import MagicMock
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_computer_use_route_validator_after_gateway_test():
+    """Prevent constructed GatewayRunner instances from leaking global state."""
+    yield
+    from tools.computer_use import set_computer_use_session_validator
+
+    set_computer_use_session_validator(None)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _bind_lark_sdk_globals_when_installed():
     """Bind the feishu adapter's lark SDK globals once per test session.

--- a/tests/gateway/lifecycle_crash_worker.py
+++ b/tests/gateway/lifecycle_crash_worker.py
@@ -1,0 +1,121 @@
+"""Real-process worker for lifecycle durability crash tests.
+
+This module deliberately installs failpoints only on the objects it creates;
+production code never reads an environment variable to change lifecycle flow.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import SessionSource, SessionStore, _now
+from hermes_state import SessionDB
+
+
+EXIT_CODE = 86
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="lifecycle-crash-chat",
+        user_id="lifecycle-crash-user",
+        chat_type="dm",
+        thread_id="lifecycle-crash-thread",
+    )
+
+
+def _die_at(stage: str):
+    requested = sys.argv[2]
+    if stage == requested:
+        os._exit(EXIT_CODE)
+
+
+def _store(reset_policy: SessionResetPolicy | None = None) -> SessionStore:
+    sessions_dir = Path(os.environ["LIFECYCLE_SESSIONS_DIR"])
+    db_path = Path(os.environ["LIFECYCLE_DB"])
+    store = SessionStore(
+        sessions_dir=sessions_dir,
+        config=GatewayConfig(
+            default_reset_policy=reset_policy or SessionResetPolicy(mode="none")
+        ),
+    )
+    # Do not rely on DEFAULT_DB_PATH import timing in a subprocess fixture.
+    if store._db is not None:
+        store._db.close()
+    store._db = SessionDB(db_path=db_path)
+    store._test_lifecycle_failpoint = _die_at
+    store._db._test_lifecycle_failpoint = _die_at
+    return store
+
+
+def _message() -> list[dict]:
+    return [{"role": "user", "content": "compressed handoff"}]
+
+
+def run(case: str) -> None:
+    if case == "db-compression":
+        db = SessionDB(db_path=Path(os.environ["LIFECYCLE_DB"]))
+        db._test_lifecycle_failpoint = _die_at
+        db.create_session(session_id="parent", source="telegram", session_key="key")
+        db.publish_compression_child(
+            parent_session_id="parent", child_session_id="child", source="telegram",
+            messages=_message(), require_compression_lease=False,
+        )
+        return
+
+    reset_policy = (
+        SessionResetPolicy(mode="idle", idle_minutes=1, notify=False)
+        if case == "auto-reset"
+        else None
+    )
+    store = _store(reset_policy)
+    source = _source()
+    original = store.get_or_create_session(source)
+    if case == "reset":
+        store.reset_session(original.session_key)
+    elif case == "auto-reset":
+        original.updated_at = _now() - timedelta(minutes=2)
+        store._save_entry(original.session_key, require_primary_db=True)
+        store.get_or_create_session(source)
+    elif case == "switch":
+        target = "resume-target"
+        store._db.create_session(
+            session_id="resume-parent", source="telegram", user_id=source.user_id,
+            session_key=original.session_key, chat_id=source.chat_id,
+            chat_type=source.chat_type, thread_id=source.thread_id,
+        )
+        store._record_gateway_session_peer("resume-parent", original.session_key, source)
+        store._db.publish_compression_child(
+            parent_session_id="resume-parent", child_session_id=target,
+            source="telegram", messages=_message(), require_compression_lease=False,
+        )
+        store._db.end_session(target, "named")
+        store.switch_session(original.session_key, target)
+    elif case == "compression-advance":
+        child = "compression-child"
+        store._db.publish_compression_child(
+            parent_session_id=original.session_id, child_session_id=child,
+            source="telegram", messages=_message(), require_compression_lease=False,
+        )
+        store.advance_compression_session(original.session_key, original.session_id, child)
+    elif case == "prune":
+        original.updated_at = _now() - timedelta(days=500)
+        store._save_entries(require_primary_db=True)
+        store.prune_old_entries(90)
+    else:
+        raise ValueError(case)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: lifecycle_crash_worker CASE FAILPOINT")
+    run(sys.argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gateway/test_10710_auto_reset_evicts_cached_agent.py
+++ b/tests/gateway/test_10710_auto_reset_evicts_cached_agent.py
@@ -77,6 +77,10 @@ def test_auto_reset_cleanup_evicts_cached_agent():
                 "context_compressor._previous_summary into new compaction "
                 "summaries (#10710)."
             )
+            assert "_release_terminal_computer_use" not in calls, (
+                "auto-reset CUA release must happen inside SessionStore's single-flight "
+                "pre-rotation boundary, not after the replacement was published"
+            )
             found = True
             break
     assert found, (

--- a/tests/gateway/test_35809_auto_reset_clean_context.py
+++ b/tests/gateway/test_35809_auto_reset_clean_context.py
@@ -76,6 +76,27 @@ def _find_compression_exhausted_reset_block() -> ast.If:
 
 
 class TestAutoResetBlockReSyncsBinding:
+    def test_terminal_release_is_owned_by_fenced_reset(self):
+        block = _find_compression_exhausted_reset_block()
+        calls = [
+            node
+            for node in ast.walk(block)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        ]
+        assert not any(
+            node.func.attr == "_release_terminal_computer_use" for node in calls
+        )
+        reset_call = next(
+            node for node in calls if node.func.attr == "reset_session"
+        )
+        reset_reason = next(
+            keyword.value
+            for keyword in reset_call.keywords
+            if keyword.arg == "reset_reason"
+        )
+        assert isinstance(reset_reason, ast.Constant)
+        assert reset_reason.value == "compression_exhausted"
+
     def test_reset_session_return_is_captured(self):
         """``reset_session`` must be assigned, not called-and-discarded —
         the fresh entry is needed to re-point the binding and drop the stale

--- a/tests/gateway/test_35994_reset_button_deadlock.py
+++ b/tests/gateway/test_35994_reset_button_deadlock.py
@@ -73,6 +73,7 @@ def _make_runner_with_cached_agent(close_fn):
     runner.session_store.reset_session.return_value = new_entry
     runner.session_store._entries = {session_key: session_entry}
     runner.session_store._generate_session_key.return_value = session_key
+    runner.session_store.peek_session_id.return_value = "sess-old"
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
@@ -87,6 +88,26 @@ def _make_runner_with_cached_agent(close_fn):
     agent.shutdown_memory_provider = MagicMock()
     runner._agent_cache = {session_key: agent}
     return runner
+
+
+def test_reset_delegates_terminal_cua_boundary_to_session_store():
+    runner = _make_runner_with_cached_agent(lambda: None)
+    order = []
+    runner._release_terminal_computer_use = AsyncMock()
+    new_entry = runner.session_store.reset_session.return_value
+
+    def reset_session(session_key, *, reset_reason):
+        order.append(("reset", session_key, reset_reason))
+        return new_entry
+
+    runner.session_store.reset_session.side_effect = reset_session
+
+    asyncio.run(runner._handle_reset_command(_make_event("/new")))
+
+    runner._release_terminal_computer_use.assert_not_awaited()
+    assert order == [
+        ("reset", new_entry.session_key, "session_reset")
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_cua_dead_session_cleanup.py
+++ b/tests/gateway/test_cua_dead_session_cleanup.py
@@ -26,6 +26,38 @@ def _agent(session_id: str):
     )
 
 
+def test_gateway_init_fails_closed_without_clobbering_existing_validator(tmp_path):
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner
+    from tools.computer_use import (
+        publish_computer_use_session,
+        set_computer_use_session_validator,
+        unpublish_computer_use_session,
+    )
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    set_computer_use_session_validator(
+        lambda route_key, sid: route_key == "existing-route" and sid == "existing"
+    )
+    try:
+        with patch(
+            "tools.computer_use.write_computer_use_runtime_attestation",
+            side_effect=OSError("attestation storage unavailable"),
+        ):
+            with pytest.raises(RuntimeError, match="runtime attestation"):
+                GatewayRunner(config)
+
+        with pytest.raises(RuntimeError, match="authoritative route"):
+            publish_computer_use_session("existing", route_key="wrong-route")
+        publication = publish_computer_use_session(
+            "existing", route_key="existing-route"
+        )
+        unpublish_computer_use_session(publication)
+    finally:
+        set_computer_use_session_validator(None)
+
+
 def test_soft_evict_hard_release_uses_exact_agent_sid_and_generation(runner):
     from tools.computer_use.tool import ComputerUseReleaseResult
 

--- a/tests/gateway/test_cua_dead_session_cleanup.py
+++ b/tests/gateway/test_cua_dead_session_cleanup.py
@@ -559,6 +559,7 @@ def test_auto_reset_sqlite_failure_retains_fence_and_retry_recovers(
     runner.session_store._save_entries()
 
     fake_db = MagicMock()
+    fake_db.promote_to_session_reset.return_value = True
     fake_db.save_gateway_routing_entry.return_value = None
     fake_db.replace_gateway_routing_entries.return_value = None
     fake_db.record_gateway_session_peer.return_value = None
@@ -623,6 +624,7 @@ def test_terminal_sqlite_failure_retains_fence_and_retry_recovers(
     )
     original = runner.session_store.get_or_create_session(source)
     fake_db = MagicMock()
+    fake_db.promote_to_session_reset.return_value = True
     fake_db.save_gateway_routing_entry.return_value = None
     fake_db.replace_gateway_routing_entries.return_value = None
     fake_db.record_gateway_session_peer.return_value = None

--- a/tests/gateway/test_cua_dead_session_cleanup.py
+++ b/tests/gateway/test_cua_dead_session_cleanup.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def runner():
+    from gateway.run import GatewayRunner
+
+    instance = GatewayRunner.__new__(GatewayRunner)
+    instance._cleanup_agent_resources = MagicMock()
+    return instance
+
+
+def _agent(session_id: str):
+    return SimpleNamespace(
+        session_id=session_id,
+        release_clients=MagicMock(),
+        _session_messages=[{"role": "user", "content": "x"}],
+        _db_flush_scan_prefix=[{"role": "user", "content": "x"}],
+    )
+
+
+def test_soft_evict_hard_release_uses_exact_agent_sid_and_generation(runner):
+    from tools.computer_use.tool import ComputerUseReleaseResult
+
+    agent = _agent("dead-session")
+    result = ComputerUseReleaseResult(
+        session_id="dead-session",
+        generation=7,
+        status="released",
+        reason="dead_cached_session",
+    )
+    future: Future = Future()
+    future.set_result(result)
+    with patch(
+        "tools.computer_use.submit_computer_use_session_release",
+        return_value=future,
+    ) as release:
+        returned = runner._release_evicted_agent_soft(
+            agent,
+            computer_use_release=("dead-session", 7),
+        )
+
+    release.assert_called_once_with(
+        "dead-session",
+        expected_generation=7,
+        timeout=5.0,
+        reason="dead_cached_session",
+        max_attempts=3,
+        retry_delay=0.25,
+    )
+    assert returned is future
+    agent.release_clients.assert_called_once_with()
+    assert agent._session_messages == []
+    assert agent._db_flush_scan_prefix is None
+
+
+@pytest.mark.parametrize(
+    "hard_request",
+    [
+        ("", 1),
+        ("dead-session", 0),
+        ("dead-session", -1),
+        ("dead-session", True),
+        ("different-session", 1),
+    ],
+)
+def test_invalid_hard_release_identity_is_rejected_but_generic_cleanup_continues(
+    runner, hard_request
+):
+    agent = _agent("dead-session")
+    with patch(
+        "tools.computer_use.submit_computer_use_session_release"
+    ) as release:
+        returned = runner._release_evicted_agent_soft(
+            agent,
+            computer_use_release=hard_request,
+        )
+
+    release.assert_not_called()
+    assert returned is None
+    agent.release_clients.assert_called_once_with()
+
+
+def test_failed_exact_release_is_truthful_and_does_not_skip_agent_cleanup(runner):
+    from tools.computer_use.tool import ComputerUseReleaseResult
+
+    agent = _agent("dead-session")
+    result = ComputerUseReleaseResult(
+        session_id="dead-session",
+        generation=4,
+        status="timed_out",
+        reason="dead_cached_session",
+        error="in-flight call did not quiesce",
+    )
+    future: Future = Future()
+    future.set_result(result)
+    with patch(
+        "tools.computer_use.submit_computer_use_session_release",
+        return_value=future,
+    ):
+        returned = runner._release_evicted_agent_soft(
+            agent,
+            computer_use_release=("dead-session", 4),
+        )
+
+    assert returned is future
+    assert returned.result().released is False
+    agent.release_clients.assert_called_once_with()
+
+
+def test_hard_release_is_submitted_without_blocking_agent_cleanup(runner):
+    agent = _agent("dead-session")
+    pending: Future = Future()
+    with patch(
+        "tools.computer_use.submit_computer_use_session_release",
+        return_value=pending,
+    ) as submit:
+        returned = runner._release_evicted_agent_soft(
+            agent,
+            computer_use_release=("dead-session", 9),
+        )
+
+    assert returned is pending
+    assert pending.done() is False
+    submit.assert_called_once()
+    agent.release_clients.assert_called_once_with()
+
+
+def test_generic_soft_evict_never_releases_computer_use(runner):
+    agent = _agent("live-session")
+    with patch(
+        "tools.computer_use.submit_computer_use_session_release"
+    ) as release:
+        returned = runner._release_evicted_agent_soft(agent)
+
+    assert returned is None
+    release.assert_not_called()
+    agent.release_clients.assert_called_once_with()

--- a/tests/gateway/test_cua_dead_session_cleanup.py
+++ b/tests/gateway/test_cua_dead_session_cleanup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from concurrent.futures import Future
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -130,6 +131,617 @@ def test_hard_release_is_submitted_without_blocking_agent_cleanup(runner):
     assert pending.done() is False
     submit.assert_called_once()
     agent.release_clients.assert_called_once_with()
+
+
+def test_gateway_wires_terminal_transition_into_session_store(tmp_path):
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    token = object()
+
+    with patch.object(
+        runner, "_begin_terminal_computer_use_sync", return_value=token
+    ) as begin, patch.object(
+        runner, "_end_terminal_computer_use_sync"
+    ) as end:
+        returned = runner.session_store._before_auto_reset_fn(
+            "old-session", "suspended"
+        )
+        runner.session_store._after_auto_reset_fn(
+            "old-session", returned, True
+        )
+
+    begin.assert_called_once_with(
+        "old-session", reason="auto_reset:suspended"
+    )
+    end.assert_called_once_with(token, succeeded=True)
+
+
+def test_gateway_terminal_fence_spans_exact_release_through_route_publication(
+    tmp_path,
+):
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from tools.computer_use import tool as computer_use
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="terminal-fence-user",
+        chat_id="terminal-fence-chat",
+        chat_type="dm",
+    )
+    entry = runner.session_store.get_or_create_session(source)
+    backend = MagicMock()
+
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend",
+        return_value=backend,
+    ):
+        computer_use._get_backend(entry.session_id)
+        original_apply = runner.session_store._apply_reset_session_impl
+
+        def apply_while_fenced(*args, **kwargs):
+            with pytest.raises(RuntimeError, match="terminal transition"):
+                computer_use._get_backend(entry.session_id)
+            return original_apply(*args, **kwargs)
+
+        with patch.object(
+            runner.session_store,
+            "_apply_reset_session_impl",
+            side_effect=apply_while_fenced,
+        ):
+            replacement = runner.session_store.reset_session(
+                entry.session_key,
+                reset_reason="session_reset",
+            )
+
+        assert replacement.session_id != entry.session_id
+        assert backend.stop.call_count == 1
+        assert computer_use.get_computer_use_session_generation(entry.session_id) is None
+
+        with pytest.raises(RuntimeError, match="retired"):
+            computer_use._get_backend(entry.session_id)
+
+
+def test_gateway_terminal_completion_evicts_route_state_before_admission_reopens(
+    tmp_path,
+):
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    order = []
+    old_agent = object()
+    lease = (object(), object(), "auto_reset:session_expired")
+
+    runner._evict_cached_agent = MagicMock(
+        side_effect=lambda key, soft_release=True: order.append(
+            ("evict", key, soft_release)
+        )
+        or old_agent
+    )
+    runner._clear_conversation_scope = MagicMock(
+        side_effect=lambda key, reason: order.append(("clear", key, reason))
+    )
+    runner._cleanup_agent_resources = MagicMock(
+        side_effect=lambda agent, strict=False: order.append(
+            ("hard_cleanup", agent, strict)
+        )
+    )
+    runner._end_terminal_computer_use_sync = MagicMock(
+        side_effect=lambda value, succeeded: order.append(
+            ("end", value, succeeded)
+        )
+    )
+
+    runner.session_store._before_terminal_completion_fn(
+        "old-expired-session",
+        lease,
+        "telegram:dm:expiry-key",
+    )
+    runner.session_store._after_auto_reset_fn(
+        "old-expired-session",
+        lease,
+        True,
+    )
+
+    assert order == [
+        ("evict", "telegram:dm:expiry-key", False),
+        (
+            "clear",
+            "telegram:dm:expiry-key",
+            "terminal_route_replaced",
+        ),
+        ("hard_cleanup", old_agent, True),
+        ("end", lease, True),
+    ]
+
+
+def test_terminal_expiry_cleanup_failure_keeps_admission_closed():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._evict_cached_agent = MagicMock()
+    old_agent = MagicMock()
+    old_agent.close.side_effect = [RuntimeError("hard cleanup failed"), None]
+    runner._evict_cached_agent.side_effect = [old_agent, None]
+    runner._clear_conversation_scope = MagicMock()
+    runner.session_store = MagicMock()
+    runner.session_store.peek_session_id.return_value = "replacement-session"
+    runner._terminal_cleanup_agents = {}
+    runner._terminal_cleanup_agents_lock = __import__("threading").Lock()
+    lease = (object(), object(), "auto_reset:session_expired")
+
+    with pytest.raises(RuntimeError, match="hard cleanup failed"):
+        runner._prepare_terminal_route_completion_sync(
+            "old-session",
+            lease,
+            "telegram:dm:expiry-key",
+        )
+
+    runner._prepare_terminal_route_completion_sync(
+        "old-session",
+        lease,
+        "telegram:dm:expiry-key",
+    )
+    assert old_agent.close.call_count == 2
+    runner._evict_cached_agent.assert_called_once()
+    assert not runner._terminal_cleanup_agents
+
+
+def test_terminal_expiry_cleanup_retry_reuses_retained_evicted_agent(tmp_path):
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    runner.session_store._db = None
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="expiry-cleanup-retry",
+        user_id="expiry-cleanup-user",
+        chat_type="dm",
+    )
+    original = runner.session_store.get_or_create_session(source)
+    old_agent = MagicMock()
+    old_agent.close.side_effect = [RuntimeError("hard cleanup failed"), None]
+    runner._agent_cache[original.session_key] = old_agent
+
+    with pytest.raises(RuntimeError, match="hard cleanup failed"):
+        runner.session_store.reset_session(
+            original.session_key,
+            reset_reason="session_expired",
+            expected_session_id=original.session_id,
+        )
+
+    retained = runner.session_store._entries[original.session_key]
+    assert retained.session_id == original.session_id
+    assert retained.metadata.get("terminal_transition")
+    assert old_agent.close.call_count == 1
+    assert runner._terminal_cleanup_agents
+
+    replacement = runner.session_store.reset_session(
+        original.session_key,
+        reset_reason="session_expired",
+        expected_session_id=original.session_id,
+    )
+    assert replacement is not None
+    assert replacement.session_id != original.session_id
+    assert old_agent.close.call_count == 2
+    assert not runner._terminal_cleanup_agents
+
+
+def test_switch_away_and_resume_historical_route_reactivates_cua_safely(tmp_path):
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from tools.computer_use import tool as computer_use
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    runner.session_store._db = None
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="resume-historical-cua",
+        user_id="resume-historical-user",
+        chat_type="dm",
+    )
+    original = runner.session_store.get_or_create_session(source)
+    first = MagicMock(permission_mode="standard")
+    second = MagicMock(permission_mode="standard")
+
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend",
+        side_effect=[first, second],
+    ):
+        assert computer_use._get_backend(original.session_id) is first
+        switched = runner.session_store.switch_session(
+            original.session_key,
+            "intermediate-session",
+        )
+        assert switched.session_id == "intermediate-session"
+        resumed = runner.session_store.switch_session(
+            original.session_key,
+            original.session_id,
+        )
+        assert resumed.session_id == original.session_id
+        assert computer_use._get_backend(original.session_id) is second
+
+    first.stop.assert_called_once_with()
+    assert computer_use.get_computer_use_session_generation(original.session_id)
+
+
+def test_terminal_persistence_failure_retains_fence_and_retry_recovers(tmp_path):
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from tools.computer_use import tool as computer_use
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    runner.session_store._db = None
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="terminal-persist-failure",
+        user_id="terminal-persist-user",
+        chat_type="dm",
+    )
+    original = runner.session_store.get_or_create_session(source)
+    backend = MagicMock()
+    backend.permission_mode = "standard"
+    backend.start.return_value = None
+    backend.stop.return_value = None
+
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend
+    ):
+        computer_use._get_backend(original.session_id)
+        original_persist = runner.session_store._persist_routing_data
+
+        def fail_replacement(data, generation, **kwargs):
+            routed = data[original.session_key]["session_id"]
+            if routed != original.session_id:
+                raise OSError("simulated terminal routing persistence failure")
+            return original_persist(data, generation, **kwargs)
+
+        with patch.object(
+            runner.session_store,
+            "_persist_routing_data",
+            side_effect=fail_replacement,
+        ):
+            with pytest.raises(OSError, match="simulated terminal"):
+                runner.session_store.reset_session(
+                    original.session_key,
+                    reset_reason="session_reset",
+                )
+
+        retained = runner.session_store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata["terminal_transition"]["session_id"] == original.session_id
+        with pytest.raises(RuntimeError, match="terminal transition"):
+            computer_use._get_backend(original.session_id)
+
+        replacement = runner.session_store.reset_session(
+            original.session_key,
+            reset_reason="session_reset",
+        )
+        assert replacement.session_id != original.session_id
+        with pytest.raises(RuntimeError, match="retired"):
+            computer_use._get_backend(original.session_id)
+
+    computer_use.reset_backend_for_tests()
+
+
+def test_auto_reset_persistence_failure_retains_fence_and_retry_recovers(tmp_path):
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from tools.computer_use import tool as computer_use
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    runner.session_store._db = None
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="auto-terminal-persist-failure",
+        user_id="auto-terminal-user",
+        chat_type="dm",
+    )
+    original = runner.session_store.get_or_create_session(source)
+    original.suspended = True
+    runner.session_store._save_entries()
+    backend = MagicMock()
+    backend.permission_mode = "standard"
+    backend.start.return_value = None
+    backend.stop.return_value = None
+
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend
+    ):
+        computer_use._get_backend(original.session_id)
+        original_persist = runner.session_store._persist_routing_data
+
+        def fail_replacement(data, generation, **kwargs):
+            routed = data[original.session_key]["session_id"]
+            if routed != original.session_id:
+                raise OSError("simulated auto-reset persistence failure")
+            return original_persist(data, generation, **kwargs)
+
+        with patch.object(
+            runner.session_store,
+            "_persist_routing_data",
+            side_effect=fail_replacement,
+        ):
+            with pytest.raises(OSError, match="simulated auto-reset"):
+                runner.session_store.get_or_create_session(source)
+
+        retained = runner.session_store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata.get("terminal_transition")
+        with pytest.raises(RuntimeError, match="terminal transition"):
+            computer_use._get_backend(original.session_id)
+
+        replacement = runner.session_store.get_or_create_session(source)
+        assert replacement.session_id != original.session_id
+        with pytest.raises(RuntimeError, match="retired"):
+            computer_use._get_backend(original.session_id)
+
+    computer_use.reset_backend_for_tests()
+
+
+@pytest.mark.parametrize("failure_layer", ["routing", "promote", "create"])
+def test_auto_reset_sqlite_failure_retains_fence_and_retry_recovers(
+    tmp_path, failure_layer
+):
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from tools.computer_use import tool as computer_use
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    runner.session_store._db = None
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=f"auto-db-{failure_layer}",
+        user_id="auto-db-user",
+        chat_type="dm",
+    )
+    original = runner.session_store.get_or_create_session(source)
+    original.suspended = True
+    runner.session_store._save_entries()
+
+    fake_db = MagicMock()
+    fake_db.save_gateway_routing_entry.return_value = None
+    fake_db.replace_gateway_routing_entries.return_value = None
+    fake_db.record_gateway_session_peer.return_value = None
+    fake_db.get_compression_tip.return_value = original.session_id
+    fake_db.get_session.return_value = None
+    if failure_layer == "routing":
+        fake_db.replace_gateway_routing_entries.side_effect = [
+            OSError("routing failed"),
+            None,
+        ]
+    elif failure_layer == "promote":
+        fake_db.promote_to_session_reset.side_effect = OSError("promote failed")
+    else:
+        fake_db.create_session.side_effect = OSError("create failed")
+    runner.session_store._db = fake_db
+
+    backend = MagicMock()
+    backend.permission_mode = "standard"
+    backend.start.return_value = None
+    backend.stop.return_value = None
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend
+    ):
+        computer_use._get_backend(original.session_id)
+        with pytest.raises(RuntimeError, match="terminal"):
+            runner.session_store.get_or_create_session(source)
+        retained = runner.session_store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata.get("terminal_transition")
+        with pytest.raises(RuntimeError, match="terminal transition"):
+            computer_use._get_backend(original.session_id)
+
+        fake_db.replace_gateway_routing_entries.side_effect = None
+        fake_db.promote_to_session_reset.side_effect = None
+        fake_db.create_session.side_effect = None
+        replacement = runner.session_store.get_or_create_session(source)
+        assert replacement.session_id != original.session_id
+        with pytest.raises(RuntimeError, match="retired"):
+            computer_use._get_backend(original.session_id)
+
+    computer_use.reset_backend_for_tests()
+
+
+@pytest.mark.parametrize("failure_layer", ["routing", "promote", "create"])
+def test_terminal_sqlite_failure_retains_fence_and_retry_recovers(
+    tmp_path, failure_layer
+):
+    from gateway.config import GatewayConfig, Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from tools.computer_use import tool as computer_use
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    runner.session_store._db = None
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=f"terminal-db-{failure_layer}",
+        user_id="terminal-db-user",
+        chat_type="dm",
+    )
+    original = runner.session_store.get_or_create_session(source)
+    fake_db = MagicMock()
+    fake_db.save_gateway_routing_entry.return_value = None
+    fake_db.replace_gateway_routing_entries.return_value = None
+    fake_db.record_gateway_session_peer.return_value = None
+    if failure_layer == "routing":
+        fake_db.replace_gateway_routing_entries.side_effect = [
+            OSError("routing failed"),
+            None,
+        ]
+    elif failure_layer == "promote":
+        fake_db.promote_to_session_reset.side_effect = OSError("promote failed")
+    else:
+        fake_db.create_session.side_effect = OSError("create failed")
+    runner.session_store._db = fake_db
+
+    backend = MagicMock()
+    backend.permission_mode = "standard"
+    backend.start.return_value = None
+    backend.stop.return_value = None
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend
+    ):
+        computer_use._get_backend(original.session_id)
+        with pytest.raises(RuntimeError, match="terminal"):
+            runner.session_store.reset_session(
+                original.session_key,
+                reset_reason="session_reset",
+            )
+        retained = runner.session_store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata.get("terminal_transition")
+        with pytest.raises(RuntimeError, match="terminal transition"):
+            computer_use._get_backend(original.session_id)
+
+        fake_db.replace_gateway_routing_entries.side_effect = None
+        fake_db.promote_to_session_reset.side_effect = None
+        fake_db.create_session.side_effect = None
+        replacement = runner.session_store.reset_session(
+            original.session_key,
+            reset_reason="session_reset",
+        )
+        assert replacement.session_id != original.session_id
+        with pytest.raises(RuntimeError, match="retired"):
+            computer_use._get_backend(original.session_id)
+
+    computer_use.reset_backend_for_tests()
+
+
+def test_terminal_boundary_release_submits_and_confirms_exact_generation(runner):
+    from tools.computer_use.tool import ComputerUseReleaseResult
+
+    result = ComputerUseReleaseResult(
+        session_id="old-session",
+        generation=11,
+        status="released",
+        reason="auto_reset",
+    )
+    future: Future = Future()
+    future.set_result(result)
+    transition = SimpleNamespace(generation=11)
+    with patch(
+        "tools.computer_use.begin_computer_use_terminal_transition",
+        return_value=transition,
+    ), patch(
+        "tools.computer_use.end_computer_use_terminal_transition"
+    ), patch(
+        "tools.computer_use.get_computer_use_session_generation",
+        return_value=None,
+    ), patch(
+        "tools.computer_use.submit_computer_use_session_release",
+        return_value=future,
+    ) as submit:
+        returned = asyncio.run(
+            runner._release_terminal_computer_use(
+                "old-session", reason="auto_reset"
+            )
+        )
+
+    assert returned is result
+    submit.assert_called_once_with(
+        "old-session",
+        expected_generation=11,
+        timeout=5.0,
+        reason="auto_reset",
+        max_attempts=3,
+        retry_delay=0.25,
+    )
+
+
+def test_terminal_boundary_release_detects_recreated_generation(runner):
+    from tools.computer_use.tool import ComputerUseReleaseResult
+
+    result = ComputerUseReleaseResult(
+        session_id="old-session",
+        generation=11,
+        status="released",
+        reason="session_reset",
+    )
+    future: Future = Future()
+    future.set_result(result)
+    transition = SimpleNamespace(generation=11)
+    with patch(
+        "tools.computer_use.begin_computer_use_terminal_transition",
+        return_value=transition,
+    ), patch(
+        "tools.computer_use.end_computer_use_terminal_transition"
+    ), patch(
+        "tools.computer_use.get_computer_use_session_generation",
+        return_value=12,
+    ), patch(
+        "tools.computer_use.submit_computer_use_session_release",
+        return_value=future,
+    ):
+        with pytest.raises(RuntimeError, match="remained active"):
+            asyncio.run(
+                runner._release_terminal_computer_use(
+                    "old-session", reason="session_reset"
+                )
+            )
+
+
+def test_terminal_boundary_release_fails_closed_when_exact_teardown_fails(runner):
+    from tools.computer_use.tool import ComputerUseReleaseResult
+
+    result = ComputerUseReleaseResult(
+        session_id="old-session",
+        generation=12,
+        status="timed_out",
+        reason="session_expired",
+        error="in-flight action",
+    )
+    future: Future = Future()
+    future.set_result(result)
+    transition = SimpleNamespace(generation=12)
+    with patch(
+        "tools.computer_use.begin_computer_use_terminal_transition",
+        return_value=transition,
+    ), patch(
+        "tools.computer_use.end_computer_use_terminal_transition"
+    ), patch(
+        "tools.computer_use.get_computer_use_session_generation",
+        return_value=12,
+    ), patch(
+        "tools.computer_use.submit_computer_use_session_release",
+        return_value=future,
+    ):
+        with pytest.raises(RuntimeError, match="timed_out"):
+            asyncio.run(
+                runner._release_terminal_computer_use(
+                    "old-session", reason="session_expired"
+                )
+            )
 
 
 def test_generic_soft_evict_never_releases_computer_use(runner):

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1243,6 +1243,479 @@ class TestLastPromptTokens:
         assert entry.last_prompt_tokens == 50000  # unchanged
 
 
+class TestAutoResetPreRotationBoundary:
+    @staticmethod
+    def _source():
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="auto-reset-chat",
+            user_id="auto-reset-user",
+            chat_type="dm",
+        )
+
+    @staticmethod
+    def _store(tmp_path, callback):
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            before_auto_reset_fn=callback,
+        )
+        store._db = None
+        source = TestAutoResetPreRotationBoundary._source()
+        original = store.get_or_create_session(source)
+        original.suspended = True
+        store._save_entries()
+        db = MagicMock()
+        store._db = db
+        store._compression_tip_for_session_id = MagicMock(
+            return_value=original.session_id
+        )
+        store._is_session_ended_in_db = MagicMock(return_value=False)
+        return store, source, original, db
+
+    def test_auto_reset_confirms_boundary_before_publish_and_db_transition(
+        self, tmp_path
+    ):
+        observed = []
+        holder = {}
+
+        def before_reset(session_id, reason):
+            store = holder["store"]
+            original = holder["original"]
+            observed.append((session_id, reason))
+            assert store._entries[original.session_key] is original
+            assert store._entries[original.session_key].session_id == session_id
+            holder["db"].promote_to_session_reset.assert_not_called()
+            holder["db"].create_session.assert_not_called()
+
+        store, source, original, db = self._store(tmp_path, before_reset)
+        holder.update(store=store, original=original, db=db)
+
+        replacement = store.get_or_create_session(source)
+
+        assert observed == [(original.session_id, "suspended")]
+        assert replacement.session_id != original.session_id
+        assert store._entries[original.session_key] is replacement
+        db.promote_to_session_reset.assert_called_once_with(
+            original.session_id, "suspended"
+        )
+        db.create_session.assert_called_once()
+
+    def test_auto_reset_release_failure_keeps_old_route_and_persistence(
+        self, tmp_path
+    ):
+        def before_reset(session_id, reason):
+            raise RuntimeError("exact CUA release failed")
+
+        store, source, original, db = self._store(tmp_path, before_reset)
+        sessions_file = tmp_path / "sessions.json"
+        before_json = sessions_file.read_text(encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="exact CUA release failed"):
+            store.get_or_create_session(source)
+
+        assert store._entries[original.session_key] is original
+        assert store._entries[original.session_key].session_id == original.session_id
+        assert sessions_file.read_text(encoding="utf-8") == before_json
+        db.promote_to_session_reset.assert_not_called()
+        db.end_session.assert_not_called()
+        db.create_session.assert_not_called()
+
+    def test_same_session_id_rebound_entry_cannot_bypass_pre_release(self, tmp_path):
+        import copy
+
+        events = []
+
+        def before_auto_reset(session_id, reason):
+            events.append((session_id, reason))
+
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            before_auto_reset_fn=before_auto_reset,
+        )
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        original.suspended = True
+
+        def rebind_same_id_then_reset(entry, _source):
+            rebound = copy.deepcopy(entry)
+            with store._lock:
+                store._entries[entry.session_key] = rebound
+            return "suspended"
+
+        store._should_reset = rebind_same_id_then_reset
+        replacement = store.get_or_create_session(source)
+
+        assert events == [(original.session_id, "suspended")]
+        assert replacement.session_id != original.session_id
+        assert replacement.prev_session_id == original.session_id
+
+    def test_auto_reset_releases_terminal_admission_after_publication(self, tmp_path):
+        token = object()
+        events = []
+
+        def before_terminal_reset(session_id, reason):
+            events.append(("begin", session_id, reason))
+            return token
+
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            before_auto_reset_fn=before_terminal_reset,
+        )
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        original.suspended = True
+
+        def after_terminal_reset(session_id, transition, succeeded):
+            current = store._entries[original.session_key]
+            events.append(
+                ("end", session_id, transition, succeeded, current.session_id)
+            )
+
+        store._after_auto_reset_fn = after_terminal_reset
+        replacement = store.get_or_create_session(source)
+
+        assert events == [
+            ("begin", original.session_id, "suspended"),
+            ("end", original.session_id, token, True, replacement.session_id),
+        ]
+
+    def test_explicit_reset_owns_pre_release_and_route_replacement_fence(
+        self, tmp_path
+    ):
+        import threading
+        import time
+        from concurrent.futures import ThreadPoolExecutor
+
+        release_started = threading.Event()
+        allow_release = threading.Event()
+        events = []
+
+        def before_terminal_reset(session_id, reason):
+            events.append(("before", session_id, reason))
+            release_started.set()
+            assert allow_release.wait(timeout=2)
+
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            before_auto_reset_fn=before_terminal_reset,
+        )
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            reset = pool.submit(
+                store.reset_session,
+                original.session_key,
+                None,
+                "session_reset",
+            )
+            assert release_started.wait(timeout=1)
+            switch = pool.submit(
+                store.switch_session,
+                original.session_key,
+                "concurrent-target",
+            )
+            time.sleep(0.05)
+            assert not switch.done()
+            allow_release.set()
+            replacement = reset.result(timeout=2)
+            switched = switch.result(timeout=2)
+
+        assert events == [
+            ("before", original.session_id, "session_reset"),
+            ("before", replacement.session_id, "session_switch"),
+        ]
+        assert replacement.session_id != original.session_id
+        assert switched.session_id == "concurrent-target"
+
+    def test_explicit_reset_releases_terminal_admission_after_publication(
+        self, tmp_path
+    ):
+        token = object()
+        events = []
+        store = None
+
+        def before_terminal_reset(session_id, reason):
+            events.append(("begin", session_id, reason))
+            return token
+
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            before_auto_reset_fn=before_terminal_reset,
+        )
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+
+        def after_terminal_reset(session_id, transition, succeeded):
+            current = store._entries[original.session_key]
+            events.append(
+                (
+                    "end",
+                    session_id,
+                    transition,
+                    succeeded,
+                    current.session_id,
+                )
+            )
+
+        store._after_auto_reset_fn = after_terminal_reset
+        replacement = store.reset_session(
+            original.session_key,
+            reset_reason="compression_exhausted",
+        )
+
+        assert events == [
+            ("begin", original.session_id, "compression_exhausted"),
+            (
+                "end",
+                original.session_id,
+                token,
+                True,
+                replacement.session_id,
+            ),
+        ]
+
+    @pytest.mark.parametrize(
+        ("transition", "reason"),
+        [
+            ("switch", "session_switch"),
+            ("advance", "compression_advance"),
+        ],
+    )
+    def test_route_replacement_paths_own_terminal_boundary(
+        self, tmp_path, transition, reason
+    ):
+        token = object()
+        events = []
+
+        def begin(session_id, actual_reason):
+            events.append(("begin", session_id, actual_reason))
+            return token
+
+        def before_complete(session_id, actual_token, session_key):
+            events.append(("complete", session_id, actual_token, session_key))
+
+        def end(session_id, actual_token, succeeded):
+            events.append(("end", session_id, actual_token, succeeded))
+
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            before_auto_reset_fn=begin,
+            before_terminal_completion_fn=before_complete,
+            after_auto_reset_fn=end,
+        )
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        old_session_id = original.session_id
+        target = "replacement-route-session"
+
+        if transition == "switch":
+            replacement = store.switch_session(original.session_key, target)
+        else:
+            def heal(entry, _expected, replacement_id):
+                entry.session_id = replacement_id
+                return True
+
+            store._heal_compression_tip_locked = MagicMock(side_effect=heal)
+            replacement = store.advance_compression_session(
+                original.session_key,
+                original.session_id,
+                target,
+            )
+
+        assert replacement.session_id == target
+        assert events == [
+            ("begin", old_session_id, reason),
+            ("complete", old_session_id, token, original.session_key),
+            ("end", old_session_id, token, True),
+        ]
+
+    def test_terminal_completion_failure_rolls_back_marked_route_for_retry(
+        self, tmp_path
+    ):
+        token = object()
+        completions = []
+
+        def fail_completion(session_id, transition, session_key):
+            completions.append((session_id, transition, session_key))
+            raise RuntimeError("route-keyed cleanup failed")
+
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            before_auto_reset_fn=lambda _sid, _reason: token,
+            before_terminal_completion_fn=fail_completion,
+        )
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+
+        with pytest.raises(RuntimeError, match="route-keyed cleanup failed"):
+            store.reset_session(
+                original.session_key,
+                reset_reason="session_expired",
+            )
+
+        retained = store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata.get("terminal_transition")
+        assert store._retained_terminal_transitions[original.session_key].callback_token is token
+        assert completions == [
+            (original.session_id, token, original.session_key)
+        ]
+
+        store._before_terminal_completion_fn = None
+        replacement = store.reset_session(
+            original.session_key,
+            reset_reason="terminal_transition_recovery",
+        )
+        assert replacement.session_id != original.session_id
+
+    def test_durable_terminal_marker_forces_reset_after_restart(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        original.metadata["terminal_transition"] = {
+            "session_id": original.session_id,
+            "reason": "session_reset",
+            "token": "crash-recovery-token",
+        }
+        store._save_entries()
+
+        restarted = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        restarted._db = None
+        replacement = restarted.get_or_create_session(source)
+
+        assert replacement.session_id != original.session_id
+        assert replacement.auto_reset_reason == "terminal_transition_recovery"
+        assert "terminal_transition" not in replacement.metadata
+
+    def test_expiry_reset_cas_does_not_rotate_newer_route(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = None
+        source = self._source()
+        current = store.get_or_create_session(source)
+
+        result = store.reset_session(
+            current.session_key,
+            reset_reason="session_expired",
+            expected_session_id="stale-expiry-snapshot",
+        )
+
+        assert result is None
+        assert store._entries[current.session_key].session_id == current.session_id
+
+    @pytest.mark.parametrize("mutator", ["reset", "switch", "advance"])
+    def test_concurrent_route_mutation_cannot_cross_pre_release_boundary(
+        self, tmp_path, mutator
+    ):
+        import threading
+        import time
+        from concurrent.futures import ThreadPoolExecutor
+
+        release_started = threading.Event()
+        allow_release = threading.Event()
+
+        def before_auto_reset(_session_id, _reason):
+            release_started.set()
+            assert allow_release.wait(timeout=2)
+
+        store = SessionStore(
+            sessions_dir=tmp_path,
+            config=GatewayConfig(),
+            before_auto_reset_fn=before_auto_reset,
+        )
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        original.suspended = True
+
+        target_session_id = "reserved-target-session"
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            auto_reset = pool.submit(store.get_or_create_session, source)
+            assert release_started.wait(timeout=1)
+            if mutator == "reset":
+                competing = pool.submit(store.reset_session, original.session_key)
+            elif mutator == "switch":
+                competing = pool.submit(
+                    store.switch_session,
+                    original.session_key,
+                    target_session_id,
+                )
+            else:
+                competing = pool.submit(
+                    store.advance_compression_session,
+                    original.session_key,
+                    original.session_id,
+                    target_session_id,
+                )
+            time.sleep(0.05)
+            assert not competing.done(), (
+                f"{mutator} crossed the terminal pre-release boundary"
+            )
+            allow_release.set()
+            auto_entry = auto_reset.result(timeout=2)
+            competing_result = competing.result(timeout=2)
+
+        assert auto_entry.session_id != original.session_id
+        if mutator == "reset":
+            assert competing_result.session_id != auto_entry.session_id
+        elif mutator == "switch":
+            assert competing_result.session_id == target_session_id
+        else:
+            assert competing_result is None
+
+    def test_concurrent_auto_reset_callers_share_failed_pre_rotation_boundary(
+        self, tmp_path
+    ):
+        from concurrent.futures import ThreadPoolExecutor
+        import threading
+
+        callback_started = threading.Event()
+        allow_failure = threading.Event()
+        callback_calls = []
+
+        def before_reset(session_id, reason):
+            callback_calls.append((session_id, reason))
+            callback_started.set()
+            assert allow_failure.wait(timeout=2.0)
+            raise RuntimeError("exact CUA release failed")
+
+        store, source, original, db = self._store(tmp_path, before_reset)
+        sessions_file = tmp_path / "sessions.json"
+        before_json = sessions_file.read_text(encoding="utf-8")
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(store.get_or_create_session, source)
+            assert callback_started.wait(timeout=2.0)
+            second = pool.submit(store.get_or_create_session, source)
+            assert store._entries[original.session_key] is original
+            allow_failure.set()
+            with pytest.raises(RuntimeError, match="exact CUA release failed"):
+                first.result(timeout=2.0)
+            with pytest.raises(RuntimeError, match="exact CUA release failed"):
+                second.result(timeout=2.0)
+
+        assert callback_calls == [(original.session_id, "suspended")]
+        assert store._entries[original.session_key] is original
+        assert sessions_file.read_text(encoding="utf-8") == before_json
+        db.promote_to_session_reset.assert_not_called()
+        db.end_session.assert_not_called()
+        db.create_session.assert_not_called()
+
+
 class TestSessionMetadata:
     """SessionEntry metadata should persist arbitrary lightweight state."""
 
@@ -1530,3 +2003,70 @@ class TestGatewayRoutingTable:
         restarted._db.close()
 
 
+def test_route_transition_lock_registry_reclaims_idle_keys(tmp_path):
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    store._db = None
+
+    for index in range(512):
+        with store._route_transition_lock(f"route-key-{index}"):
+            pass
+
+    assert store._route_transition_locks == {}
+
+
+def test_route_transition_lock_reclamation_preserves_waiter_serialisation(tmp_path):
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    store._db = None
+    key = "shared-route-key"
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    third_entered = threading.Event()
+    release_first = threading.Event()
+    release_second = threading.Event()
+    release_third = threading.Event()
+    active = 0
+    max_active = 0
+    active_guard = threading.Lock()
+
+    def worker(entered, release):
+        nonlocal active, max_active
+        with store._route_transition_lock(key):
+            with active_guard:
+                active += 1
+                max_active = max(max_active, active)
+            entered.set()
+            assert release.wait(timeout=3)
+            with active_guard:
+                active -= 1
+
+    def wait_for_users(expected):
+        for _ in range(300):
+            with store._route_transition_locks_guard:
+                entry = store._route_transition_locks.get(key)
+                if entry is not None and entry.users == expected:
+                    return
+            threading.Event().wait(0.01)
+        raise AssertionError(f"route lock never reached {expected} users")
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        first = pool.submit(worker, first_entered, release_first)
+        assert first_entered.wait(timeout=1)
+        second = pool.submit(worker, second_entered, release_second)
+        wait_for_users(2)
+        release_first.set()
+        assert second_entered.wait(timeout=1)
+        third = pool.submit(worker, third_entered, release_third)
+        wait_for_users(2)
+        assert not third_entered.is_set()
+        release_second.set()
+        assert third_entered.wait(timeout=1)
+        release_third.set()
+        first.result(timeout=3)
+        second.result(timeout=3)
+        third.result(timeout=3)
+
+    assert max_active == 1
+    assert store._route_transition_locks == {}

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1587,10 +1587,12 @@ class TestAutoResetPreRotationBoundary:
         store._db = None
         source = self._source()
         original = store.get_or_create_session(source)
+        durable_target = "durable-recovery-target"
         original.metadata["terminal_transition"] = {
             "session_id": original.session_id,
             "reason": "session_reset",
             "token": "crash-recovery-token",
+            "target_session_id": durable_target,
         }
         store._save_entries()
 
@@ -1598,9 +1600,43 @@ class TestAutoResetPreRotationBoundary:
         restarted._db = None
         replacement = restarted.get_or_create_session(source)
 
+        assert replacement.session_id == durable_target
         assert replacement.session_id != original.session_id
         assert replacement.auto_reset_reason == "terminal_transition_recovery"
         assert "terminal_transition" not in replacement.metadata
+
+    def test_terminal_reset_publishes_route_only_after_sqlite_commits(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        events = []
+        fake_db = MagicMock()
+        fake_db.save_gateway_routing_entry.return_value = None
+        fake_db.replace_gateway_routing_entries.return_value = None
+        fake_db.promote_to_session_reset.side_effect = (
+            lambda *_args, **_kwargs: events.append("sqlite:end")
+        )
+        fake_db.create_session.side_effect = (
+            lambda *_args, **_kwargs: events.append("sqlite:create")
+        )
+        fake_db.record_gateway_session_peer.return_value = None
+        store._db = fake_db
+        original_save_entries = store._save_entries
+
+        def _save_entries(*args, **kwargs):
+            current = store._entries[original.session_key]
+            events.append(f"route:{current.session_id}")
+            return original_save_entries(*args, **kwargs)
+
+        store._save_entries = _save_entries
+        replacement = store.reset_session(original.session_key)
+
+        assert replacement is not None
+        assert events.index("sqlite:end") < events.index("sqlite:create")
+        assert events.index("sqlite:create") < events.index(
+            f"route:{replacement.session_id}"
+        )
 
     def test_expiry_reset_cas_does_not_rotate_newer_route(self, tmp_path):
         store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1266,6 +1266,7 @@ class TestAutoResetPreRotationBoundary:
         original.suspended = True
         store._save_entries()
         db = MagicMock()
+        db.promote_to_session_reset.return_value = True
         store._db = db
         store._compression_tip_for_session_id = MagicMock(
             return_value=original.session_id
@@ -1300,6 +1301,88 @@ class TestAutoResetPreRotationBoundary:
             original.session_id, "suspended"
         )
         db.create_session.assert_called_once()
+
+    def test_auto_reset_promotion_false_retains_fence_until_retry_succeeds(
+        self, tmp_path
+    ):
+        store, source, original, db = self._store(tmp_path, lambda *_args: None)
+        db.promote_to_session_reset.return_value = False
+
+        with pytest.raises(RuntimeError, match="could not close prior SQLite session"):
+            store.get_or_create_session(source)
+
+        retained = store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata.get("terminal_transition")
+        db.create_session.assert_not_called()
+
+        db.promote_to_session_reset.return_value = True
+        replacement = store.get_or_create_session(source)
+        assert replacement.session_id != original.session_id
+        assert not replacement.metadata.get("terminal_transition")
+
+    def test_explicit_reset_promotion_false_retains_fence_until_retry_succeeds(
+        self, tmp_path
+    ):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        db = MagicMock()
+        db.promote_to_session_reset.return_value = False
+        store._db = db
+
+        with pytest.raises(RuntimeError, match="could not close prior SQLite session"):
+            store.reset_session(original.session_key)
+
+        retained = store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata.get("terminal_transition")
+        db.create_session.assert_not_called()
+
+        db.promote_to_session_reset.return_value = True
+        replacement = store.reset_session(original.session_key)
+        assert replacement.session_id != original.session_id
+        assert not replacement.metadata.get("terminal_transition")
+
+    def test_explicit_reset_promotion_non_boolean_is_not_success(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        db = MagicMock()
+        db.promote_to_session_reset.return_value = None
+        store._db = db
+
+        with pytest.raises(RuntimeError, match="could not close prior SQLite session"):
+            store.reset_session(original.session_key)
+
+        retained = store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata.get("terminal_transition")
+        db.create_session.assert_not_called()
+
+    def test_switch_promotion_false_retains_fence_until_retry_succeeds(self, tmp_path):
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = None
+        source = self._source()
+        original = store.get_or_create_session(source)
+        db = MagicMock()
+        db.promote_to_session_reset.return_value = False
+        store._db = db
+
+        with pytest.raises(RuntimeError, match="SQLite publication failed"):
+            store.switch_session(original.session_key, "retry-switch-target")
+
+        retained = store._entries[original.session_key]
+        assert retained.session_id == original.session_id
+        assert retained.metadata.get("terminal_transition")
+        db.reopen_session.assert_not_called()
+
+        db.promote_to_session_reset.return_value = True
+        replacement = store.switch_session(original.session_key, "retry-switch-target")
+        assert replacement.session_id == "retry-switch-target"
+        assert not replacement.metadata.get("terminal_transition")
 
     def test_auto_reset_release_failure_keeps_old_route_and_persistence(
         self, tmp_path
@@ -1615,7 +1698,7 @@ class TestAutoResetPreRotationBoundary:
         fake_db.save_gateway_routing_entry.return_value = None
         fake_db.replace_gateway_routing_entries.return_value = None
         fake_db.promote_to_session_reset.side_effect = (
-            lambda *_args, **_kwargs: events.append("sqlite:end")
+            lambda *_args, **_kwargs: events.append("sqlite:end") or True
         )
         fake_db.create_session.side_effect = (
             lambda *_args, **_kwargs: events.append("sqlite:create")

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1917,6 +1917,60 @@ class TestRewriteTranscriptPreservesReasoning:
         assert after[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]
 
 
+class TestGatewayCompressionRouteAuthority:
+    def test_current_compression_child_heals_route_before_tool_admission(self, tmp_path):
+        """A mid-turn compression child must not be rejected behind its ended parent route."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("parent", source="telegram")
+        db.end_session("parent", "compression")
+        db.create_session(
+            "child",
+            source="telegram",
+            parent_session_id="parent",
+        )
+
+        now = datetime.now()
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = db
+        store._loaded = True
+        store._entries = {
+            "route": SessionEntry(
+                session_key="route",
+                session_id="parent",
+                created_at=now,
+                updated_at=now,
+            )
+        }
+
+        assert store.route_matches("route", "child") is False
+        assert store.ensure_route_matches("route", "child") is True
+        assert store.route_matches("route", "child") is True
+        assert store.lookup_by_session_id("parent") is None
+        assert store.lookup_by_session_id("child") is not None
+        db.close()
+
+    def test_unrelated_child_cannot_heal_route(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("parent", source="telegram")
+        db.create_session("unrelated", source="telegram")
+        now = datetime.now()
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._db = db
+        store._loaded = True
+        store._entries = {
+            "route": SessionEntry(
+                session_key="route",
+                session_id="parent",
+                created_at=now,
+                updated_at=now,
+            )
+        }
+
+        assert store.ensure_route_matches("route", "unrelated") is False
+        assert store.route_matches("route", "parent") is True
+        db.close()
+
+
 class TestGatewaySessionDbRecovery:
     def test_compression_closed_parent_reroutes_without_retry_queue(self, tmp_path):
         import threading

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -1,4 +1,6 @@
 """Tests that on_session_finalize and on_session_reset plugin hooks fire in the gateway."""
+import asyncio
+import json
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -115,8 +117,28 @@ async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
     runner.session_store._lock.__enter__ = MagicMock(return_value=None)
     runner.session_store._lock.__exit__ = MagicMock(return_value=None)
     runner.session_store._save = MagicMock()
+    replacement_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-expired-replacement",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.peek_session_id.return_value = replacement_entry.session_id
+    runner._clear_conversation_scope = MagicMock()
 
-    runner._evict_cached_agent = MagicMock()
+    def reset_with_terminal_completion(*_args, **_kwargs):
+        runner._prepare_terminal_route_completion_sync(
+            expired_entry.session_id,
+            (object(), object(), "auto_reset:session_expired"),
+            session_key,
+        )
+        return replacement_entry
+
+    runner.session_store.reset_session.side_effect = reset_with_terminal_completion
+
+    runner._evict_cached_agent = MagicMock(return_value=None)
     runner._cleanup_agent_resources = MagicMock()
     runner._sweep_idle_cached_agents = MagicMock(return_value=0)
 
@@ -193,6 +215,26 @@ async def test_idle_expiry_clears_last_resolved_model(mock_invoke_hook):
     runner.session_store._lock.__enter__ = MagicMock(return_value=None)
     runner.session_store._lock.__exit__ = MagicMock(return_value=None)
     runner.session_store._save = MagicMock()
+    replacement_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-expired-replacement",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+
+    runner.session_store.peek_session_id.return_value = replacement_entry.session_id
+
+    def reset_with_terminal_completion(*args, **kwargs):
+        runner._prepare_terminal_route_completion_sync(
+            expired_entry.session_id,
+            (object(), object(), "auto_reset:session_expired"),
+            session_key,
+        )
+        return replacement_entry
+
+    runner.session_store.reset_session.side_effect = reset_with_terminal_completion
 
     runner._evict_cached_agent = MagicMock()
     runner._cleanup_agent_resources = MagicMock()
@@ -226,3 +268,178 @@ async def test_idle_expiry_clears_last_resolved_model(mock_invoke_hook):
         "session-expiry finalization must only clear the expired session's "
         "own key, not unrelated sessions' cached entries"
     )
+
+
+def test_idle_expiry_confirms_exact_computer_use_release_before_finalizing():
+    from datetime import timedelta
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._last_session_store_prune_ts = __import__("time").time()
+    runner._last_agent_cache_pressure_sweep_ts = __import__("time").time()
+
+    session_key = "agent:main:telegram:dm:cua-expiry"
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-cua-expired",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired.return_value = True
+    replacement = SessionEntry(
+        session_key=session_key,
+        session_id="sess-cua-replacement",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.peek_session_id.return_value = replacement.session_id
+
+    def reset_with_terminal_completion(*_args, **_kwargs):
+        runner._prepare_terminal_route_completion_sync(
+            expired_entry.session_id,
+            (object(), object(), "auto_reset:session_expired"),
+            session_key,
+        )
+        return replacement
+
+    runner.session_store.reset_session.side_effect = reset_with_terminal_completion
+    runner._evict_cached_agent = MagicMock(return_value=None)
+    runner._cleanup_agent_resources = MagicMock()
+    runner._clear_conversation_scope = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+    runner._sweep_agent_cache_under_pressure = MagicMock()
+
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(_):
+        await original_sleep(0)
+
+    def stop_after_finalize(*args, **kwargs):
+        runner._running = False
+        return []
+
+    with patch("gateway.run.asyncio.sleep", side_effect=fast_sleep), patch(
+        "hermes_cli.lifecycle.finalize_session", side_effect=stop_after_finalize
+    ):
+        asyncio.run(runner._session_expiry_watcher(interval=0))
+
+    runner.session_store.reset_session.assert_called_once_with(
+        session_key,
+        reset_reason="session_expired",
+        expected_session_id=expired_entry.session_id,
+    )
+    runner.session_store.set_expiry_finalized.assert_not_called()
+
+
+def test_idle_expiry_retires_old_cua_id_and_publishes_fresh_route(tmp_path):
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    from tools.computer_use import tool as computer_use
+
+    config = GatewayConfig()
+    config.sessions_dir = tmp_path
+    runner = GatewayRunner(config)
+    runner.session_store._db = None
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="expiry-race",
+        user_id="expiry-user",
+        chat_type="dm",
+    )
+    old_entry = runner.session_store.get_or_create_session(source)
+    old_id = old_entry.session_id
+    backend = MagicMock()
+    backend.permission_mode = "standard"
+    backend.start.return_value = None
+    backend.stop.return_value = None
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner._running = True
+
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(_):
+        await original_sleep(0)
+
+    def stop_after_finalize(*args, **kwargs):
+        runner._running = False
+
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend
+    ), patch("gateway.run.asyncio.sleep", side_effect=fast_sleep), patch(
+        "hermes_cli.lifecycle.finalize_session", side_effect=stop_after_finalize
+    ):
+        computer_use._get_backend(old_id)
+        asyncio.run(runner._session_expiry_watcher(interval=0))
+        replacement = runner.session_store._entries[old_entry.session_key]
+        assert replacement.session_id != old_id
+        with pytest.raises(RuntimeError, match="retired"):
+            computer_use._get_backend(old_id)
+
+    persisted = json.loads((tmp_path / "sessions.json").read_text(encoding="utf-8"))
+    assert persisted[old_entry.session_key]["session_id"] == replacement.session_id
+    computer_use.reset_backend_for_tests()
+
+
+def test_idle_expiry_never_marks_finalized_when_computer_use_release_fails():
+    from datetime import timedelta
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._last_session_store_prune_ts = __import__("time").time()
+
+    session_key = "agent:main:telegram:dm:cua-failed-expiry"
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-cua-failed",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired.return_value = True
+    runner._evict_cached_agent = MagicMock()
+    runner._clear_conversation_scope = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+    runner._sweep_agent_cache_under_pressure = MagicMock()
+
+    attempts = 0
+
+    def fail_reset(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts >= 3:
+            runner._running = False
+        raise RuntimeError("terminal reset failed")
+
+    runner.session_store.reset_session.side_effect = fail_reset
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(_):
+        await original_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=fast_sleep), patch(
+        "hermes_cli.lifecycle.finalize_session"
+    ) as finalize:
+        asyncio.run(runner._session_expiry_watcher(interval=0))
+
+    assert attempts == 3
+    finalize.assert_not_called()
+    runner.session_store.set_expiry_finalized.assert_not_called()
+    assert expired_entry.expiry_finalized is False

--- a/tests/gateway/test_session_sqlite_crash_recovery.py
+++ b/tests/gateway/test_session_sqlite_crash_recovery.py
@@ -1,0 +1,217 @@
+"""Process-kill crash matrix for durable gateway lifecycle transitions.
+
+Each worker uses the real SessionStore and SessionDB with an explicit fresh
+state.db. The only seam is a private callback which exits after a named,
+durable post-condition; SQLite is never mocked.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import SessionSource, SessionStore, build_session_key
+from hermes_state import SessionDB
+
+from tests.gateway.lifecycle_crash_worker import EXIT_CODE
+
+
+REPO = Path(__file__).resolve().parents[2]
+SOURCE = SessionSource(
+    platform=Platform.TELEGRAM, chat_id="lifecycle-crash-chat",
+    user_id="lifecycle-crash-user", chat_type="dm", thread_id="lifecycle-crash-thread",
+)
+KEY = build_session_key(SOURCE)
+PEER = {
+    "source": "telegram", "user_id": SOURCE.user_id, "session_key": KEY,
+    "chat_id": SOURCE.chat_id, "chat_type": SOURCE.chat_type,
+    "thread_id": SOURCE.thread_id,
+}
+
+CASES = [
+    ("reset", "gateway.reset.after_marker_persisted", True),
+    ("reset", "gateway.reset.after_old_promoted", False),
+    ("reset", "gateway.reset.after_replacement_created", False),
+    ("reset", "gateway.reset.after_peer_recorded", False),
+    ("reset", "gateway.reset.after_final_route_published", False),
+    ("auto-reset", "gateway.auto_reset.after_marker_persisted", True),
+    ("auto-reset", "gateway.auto_reset.after_old_promoted", False),
+    ("auto-reset", "gateway.auto_reset.after_replacement_created", False),
+    ("auto-reset", "gateway.auto_reset.after_peer_recorded", False),
+    ("auto-reset", "gateway.auto_reset.after_final_route_published", False),
+    ("switch", "gateway.switch.after_marker_persisted", True),
+    ("switch", "gateway.switch.after_old_promoted", False),
+    ("switch", "gateway.switch.after_target_reopened", False),
+    ("switch", "gateway.switch.after_peer_recorded", False),
+    ("switch", "gateway.switch.after_final_route_published", False),
+    ("compression-advance", "gateway.compression_advance.after_marker_persisted", True),
+    ("compression-advance", "gateway.compression_advance.after_final_route_published", False),
+    ("prune", "gateway.prune.after_old_closed", True),
+    ("prune", "gateway.prune.after_route_absence_published", False),
+]
+DB_COMPRESSION_CASES = [
+    "db.compression.after_child_insert", "db.compression.after_handoff_messages",
+    "db.compression.after_child_counts", "db.compression.after_parent_close",
+]
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    home = tmp_path / "home"
+    return {**os.environ, "HERMES_HOME": str(home), "LIFECYCLE_DB": str(home / "state.db"),
+            "LIFECYCLE_SESSIONS_DIR": str(tmp_path / "sessions"), "PYTHONDONTWRITEBYTECODE": "1"}
+
+
+def _run_worker(tmp_path: Path, case: str, stage: str) -> dict[str, str]:
+    env = _env(tmp_path)
+    result = subprocess.run([sys.executable, "-m", "tests.gateway.lifecycle_crash_worker", case, stage],
+                            cwd=REPO, env=env, capture_output=True, text=True, timeout=60)
+    assert result.returncode == EXIT_CODE, result.stderr
+    return env
+
+
+def _fresh_store(env: dict[str, str], *, delete_mirror: bool) -> SessionStore:
+    if delete_mirror:
+        (Path(env["LIFECYCLE_SESSIONS_DIR"]) / "sessions.json").unlink(missing_ok=True)
+    store = SessionStore(sessions_dir=Path(env["LIFECYCLE_SESSIONS_DIR"]),
+                         config=GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none")))
+    if store._db is not None:
+        store._db.close()
+    store._db = SessionDB(db_path=Path(env["LIFECYCLE_DB"]))
+    return store
+
+
+def _route(db: SessionDB) -> dict | None:
+    row = db._conn.execute("SELECT entry_json FROM gateway_routing WHERE session_key = ?", (KEY,)).fetchone()
+    return json.loads(row["entry_json"]) if row else None
+
+
+def _session(db: SessionDB, session_id: str):
+    return db._conn.execute(
+        """SELECT id, parent_session_id, ended_at, end_reason, source, user_id,
+                  session_key, chat_id, chat_type, thread_id, origin_json
+           FROM sessions WHERE id = ?""", (session_id,)
+    ).fetchone()
+
+
+def _assert_exact_peer(row, *, parent_session_id: str | None = None) -> None:
+    assert row is not None
+    assert {field: row[field] for field in PEER} == PEER
+    assert json.loads(row["origin_json"]) == SOURCE.to_dict()
+    if parent_session_id is not None:
+        assert row["parent_session_id"] == parent_session_id
+
+
+def _assert_one_live_head(db: SessionDB, expected_id: str) -> None:
+    live = db._conn.execute("SELECT id FROM sessions WHERE ended_at IS NULL ORDER BY id").fetchall()
+    assert [row["id"] for row in live] == [expected_id]
+
+
+def _assert_session_count(db: SessionDB, expected: int) -> None:
+    assert db._conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == expected
+
+
+@pytest.mark.parametrize(("case", "stage", "delete_mirror"), CASES)
+def test_gateway_lifecycle_kill_recovers_exact_durable_target(
+    tmp_path, case, stage, delete_mirror,
+):
+    """Every gateway failpoint restarts through new Store/DB objects only."""
+    env = _run_worker(tmp_path, case, stage)
+    db_path = Path(env["LIFECYCLE_DB"])
+    before = SessionDB(db_path=db_path)
+    try:
+        route_before = _route(before)
+        assert before._conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        if case == "prune" and stage == "gateway.prune.after_route_absence_published":
+            assert route_before is None
+            marker_target = None
+        else:
+            assert route_before is not None
+            marker = route_before["metadata"].get("terminal_transition")
+            marker_target = marker.get("target_session_id") if marker else None
+            if case in {"reset", "auto-reset", "switch", "compression-advance"} and marker:
+                assert marker_target
+            if case in {"reset", "auto-reset", "switch", "compression-advance"} and not marker:
+                marker_target = route_before["session_id"]
+    finally:
+        before.close()
+
+    store = _fresh_store(env, delete_mirror=delete_mirror)
+    try:
+        recovered = store.get_or_create_session(SOURCE)
+        db = store._db
+        assert db is not None
+        route_after = _route(db)
+        assert route_after is not None
+        assert route_after["session_id"] == recovered.session_id
+        assert "terminal_transition" not in route_after["metadata"]
+
+        if case in {"reset", "auto-reset"}:
+            assert recovered.session_id == marker_target
+            old = db._conn.execute("SELECT id FROM sessions WHERE id != ?", (recovered.session_id,)).fetchone()
+            assert old is not None
+            expected_reason = "idle" if case == "auto-reset" else "session_reset"
+            assert _session(db, old["id"])["end_reason"] == expected_reason
+            _assert_exact_peer(_session(db, recovered.session_id))
+            _assert_one_live_head(db, recovered.session_id)
+            _assert_session_count(db, 2)
+        elif case == "switch":
+            assert marker_target == "resume-target"
+            assert recovered.session_id == marker_target
+            old = db._conn.execute(
+                "SELECT id FROM sessions WHERE end_reason = 'session_switch'"
+            ).fetchone()
+            assert old is not None
+            assert _session(db, old["id"])["end_reason"] == "session_switch"
+            _assert_exact_peer(_session(db, recovered.session_id))
+            ancestor = db._conn.execute(
+                "SELECT id FROM sessions WHERE id = 'resume-parent'"
+            ).fetchone()
+            assert ancestor is not None
+            assert _session(db, ancestor["id"])["end_reason"] == "compression"
+            _assert_exact_peer(_session(db, ancestor["id"]))
+            _assert_one_live_head(db, recovered.session_id)
+            _assert_session_count(db, 3)
+        elif case == "compression-advance":
+            assert marker_target == "compression-child"
+            assert recovered.session_id == marker_target
+            parent = db._conn.execute("SELECT id FROM sessions WHERE id != ?", (recovered.session_id,)).fetchone()
+            assert parent is not None
+            assert _session(db, parent["id"])["end_reason"] == "compression"
+            _assert_exact_peer(_session(db, recovered.session_id), parent_session_id=parent["id"])
+            _assert_one_live_head(db, recovered.session_id)
+            _assert_session_count(db, 2)
+        else:
+            # A prune marker must publish route absence before a resolver can
+            # allocate a new ID; a post-publication kill starts from absence.
+            old = db._conn.execute(
+                "SELECT id FROM sessions WHERE id != ?", (recovered.session_id,)
+            ).fetchone()
+            assert old is not None and _session(db, old["id"])["end_reason"] == "session_prune"
+            assert recovered.session_id != old["id"]
+            _assert_exact_peer(_session(db, recovered.session_id))
+            _assert_one_live_head(db, recovered.session_id)
+            _assert_session_count(db, 2)
+
+    finally:
+        store._db.close()
+
+
+@pytest.mark.parametrize("stage", DB_COMPRESSION_CASES)
+def test_db_compression_kill_rolls_back_child_row_messages_and_peer_visible_state(tmp_path, stage):
+    """Each pure SQLite failpoint is atomic, including handoff messages/routes."""
+    env = _run_worker(tmp_path, "db-compression", stage)
+    db = SessionDB(db_path=Path(env["LIFECYCLE_DB"]))
+    try:
+        parent = _session(db, "parent")
+        assert parent is not None and parent["ended_at"] is None and parent["end_reason"] is None
+        assert db._conn.execute("SELECT 1 FROM sessions WHERE id = 'child'").fetchone() is None
+        assert db._conn.execute("SELECT 1 FROM messages WHERE session_id = 'child'").fetchone() is None
+        assert db._conn.execute("SELECT 1 FROM gateway_routing WHERE entry_json LIKE '%child%'").fetchone() is None
+        assert db._conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    finally:
+        db.close()

--- a/tests/gateway/test_session_sqlite_promotion_failure.py
+++ b/tests/gateway/test_session_sqlite_promotion_failure.py
@@ -1,0 +1,127 @@
+"""Real-SQLite fail-closed coverage for terminal session promotion failures."""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore
+from hermes_state import SessionDB
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="promotion-failure-chat",
+        user_id="promotion-failure-user",
+        chat_type="dm",
+    )
+
+
+def _store(tmp_path):
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    database = SessionDB(db_path=tmp_path / "state.db")
+    store._db = database
+    source = _source()
+    original = store.get_or_create_session(source)
+    return store, database, source, original
+
+
+def _install_promotion_failure(database: SessionDB, session_id: str) -> None:
+    assert session_id.replace("-", "").replace("_", "").isalnum()
+
+    def install(connection):
+        connection.execute(
+            f"""
+            CREATE TRIGGER fail_terminal_promotion
+            BEFORE UPDATE OF ended_at, end_reason ON sessions
+            WHEN OLD.id = '{session_id}'
+            BEGIN
+                SELECT RAISE(ABORT, 'forced promotion failure');
+            END
+            """
+        )
+
+    database._execute_write(install)
+
+
+def _drop_promotion_failure(database: SessionDB) -> None:
+    database._execute_write(
+        lambda connection: connection.execute(
+            "DROP TRIGGER IF EXISTS fail_terminal_promotion"
+        )
+    )
+
+
+def _assert_failed_boundary(database: SessionDB, session_key: str, session_id: str) -> None:
+    connection = sqlite3.connect(database.db_path)
+    try:
+        old = connection.execute(
+            "SELECT ended_at, end_reason FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+        assert old == (None, None)
+        active = connection.execute(
+            "SELECT id FROM sessions WHERE ended_at IS NULL ORDER BY id"
+        ).fetchall()
+        assert active == [(session_id,)]
+        route_row = connection.execute(
+            "SELECT entry_json FROM gateway_routing WHERE session_key = ?",
+            (session_key,),
+        ).fetchone()
+        assert route_row is not None
+        route = json.loads(route_row[0])
+        assert route["session_id"] == session_id
+        assert route["metadata"]["terminal_transition"]["session_id"] == session_id
+    finally:
+        connection.close()
+
+
+def test_explicit_reset_sqlite_promotion_failure_retains_durable_boundary(tmp_path):
+    store, database, _source_value, original = _store(tmp_path)
+    _install_promotion_failure(database, original.session_id)
+
+    with pytest.raises(RuntimeError, match="could not close prior SQLite session"):
+        store.reset_session(original.session_key)
+
+    _assert_failed_boundary(database, original.session_key, original.session_id)
+    _drop_promotion_failure(database)
+    replacement = store.reset_session(original.session_key)
+    assert replacement.session_id != original.session_id
+    assert database.get_session(original.session_id)["end_reason"] == "session_reset"
+
+
+def test_auto_reset_sqlite_promotion_failure_retains_durable_boundary(tmp_path):
+    store, database, source, original = _store(tmp_path)
+    original.suspended = True
+    store._save_entries()
+    _install_promotion_failure(database, original.session_id)
+
+    with pytest.raises(RuntimeError, match="could not close prior SQLite session"):
+        store.get_or_create_session(source)
+
+    _assert_failed_boundary(database, original.session_key, original.session_id)
+    _drop_promotion_failure(database)
+    replacement = store.get_or_create_session(source)
+    assert replacement.session_id != original.session_id
+    assert database.get_session(original.session_id)["end_reason"] == "suspended"
+
+
+def test_switch_sqlite_promotion_failure_retains_durable_boundary(tmp_path):
+    store, database, _source_value, original = _store(tmp_path)
+    target_session_id = "promotion-retry-target"
+    database.create_session(target_session_id, "telegram")
+    database.end_session(target_session_id, "session_reset")
+    _install_promotion_failure(database, original.session_id)
+
+    with pytest.raises(RuntimeError, match="SQLite publication failed"):
+        store.switch_session(original.session_key, target_session_id)
+
+    _assert_failed_boundary(database, original.session_key, original.session_id)
+    assert database.get_session(target_session_id)["ended_at"] is not None
+    _drop_promotion_failure(database)
+    replacement = store.switch_session(original.session_key, target_session_id)
+    assert replacement.session_id == target_session_id
+    assert database.get_session(original.session_id)["end_reason"] == "session_switch"
+    assert database.get_session(target_session_id)["ended_at"] is None

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -15,13 +15,17 @@ tests pin the prune behaviour:
 """
 
 import json
+import os
+import subprocess
+import sys
 import threading
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 
 from gateway.config import GatewayConfig, Platform, SessionResetPolicy
-from gateway.session import SessionEntry, SessionStore
+from gateway.session import SessionEntry, SessionSource, SessionStore
 
 
 def test_session_store_default_db_uses_runtime_hermes_home(tmp_path, monkeypatch):
@@ -150,6 +154,189 @@ class TestPruneBasics:
         assert removed == 1
         assert "active" not in store._entries
 
+
+    def test_prune_publishes_route_absence_only_after_sqlite_close(self, tmp_path):
+        store = _make_store(tmp_path)
+        store._entries["stale"] = _entry(
+            "stale", age_days=500, session_id="stale-sid"
+        )
+        events = []
+        fake_db = MagicMock()
+        fake_db.save_gateway_routing_entry.return_value = None
+        fake_db.replace_gateway_routing_entries.return_value = None
+        fake_db.end_session.side_effect = (
+            lambda *_args, **_kwargs: events.append("sqlite:end")
+        )
+        store._db = fake_db
+        original_save_entries = store._save_entries
+
+        def _save_entries(*args, **kwargs):
+            events.append(
+                "route:absent" if "stale" not in store._entries else "route:present"
+            )
+            return original_save_entries(*args, **kwargs)
+
+        store._save_entries = _save_entries
+
+        assert store.prune_old_entries(90) == 1
+        assert events.index("sqlite:end") < events.index("route:absent")
+
+    def test_prune_process_death_after_sqlite_close_recovers_durable_marker(
+        self, tmp_path
+    ):
+        repo = Path(__file__).resolve().parents[2]
+        hermes_home = tmp_path / "hermes-home"
+        sessions_dir = tmp_path / "sessions"
+        env = os.environ.copy()
+        env.update({
+            "HERMES_HOME": str(hermes_home),
+            "PRUNE_TEST_SESSIONS": str(sessions_dir),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        })
+        crash_script = r'''
+import os
+from datetime import timedelta
+from pathlib import Path
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore, _now
+
+store = SessionStore(
+    sessions_dir=Path(os.environ["PRUNE_TEST_SESSIONS"]),
+    config=GatewayConfig(),
+)
+source = SessionSource(
+    platform=Platform.TELEGRAM,
+    chat_id="prune-crash-chat",
+    user_id="prune-crash-user",
+    chat_type="dm",
+)
+entry = store.get_or_create_session(source)
+entry.updated_at = _now() - timedelta(days=500)
+store._save_entries(require_primary_db=True)
+real_end = store._db.end_session
+def end_then_die(*args, **kwargs):
+    real_end(*args, **kwargs)
+    os._exit(73)
+store._db.end_session = end_then_die
+store.prune_old_entries(90)
+'''
+        crashed = subprocess.run(
+            [sys.executable, "-c", crash_script],
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=60,
+        )
+        assert crashed.returncode == 73, crashed.stderr
+
+        recovery_script = r'''
+import json
+import os
+from pathlib import Path
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore, build_session_key
+
+store = SessionStore(
+    sessions_dir=Path(os.environ["PRUNE_TEST_SESSIONS"]),
+    config=GatewayConfig(),
+)
+source = SessionSource(
+    platform=Platform.TELEGRAM,
+    chat_id="prune-crash-chat",
+    user_id="prune-crash-user",
+    chat_type="dm",
+)
+key = build_session_key(source)
+store._ensure_loaded()
+before = store._entries[key]
+marker = before.metadata.get("terminal_transition")
+replacement = store.get_or_create_session(source)
+print("RESULT=" + json.dumps({
+    "old_session_id": before.session_id,
+    "marker_reason": marker.get("reason") if marker else None,
+    "replacement_session_id": replacement.session_id,
+    "replacement_has_marker": "terminal_transition" in replacement.metadata,
+}))
+'''
+        recovered = subprocess.run(
+            [sys.executable, "-c", recovery_script],
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=60,
+        )
+        assert recovered.returncode == 0, recovered.stderr
+        result_line = next(
+            line for line in recovered.stdout.splitlines() if line.startswith("RESULT=")
+        )
+        result = json.loads(result_line.removeprefix("RESULT="))
+        assert result["marker_reason"] == "session_prune"
+        assert result["replacement_session_id"] != result["old_session_id"]
+        assert result["replacement_has_marker"] is False
+
+    def test_prune_recovery_publishes_absence_before_fresh_route(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="prune-recovery-chat",
+            user_id="prune-recovery-user",
+            chat_type="dm",
+        )
+        original = store.get_or_create_session(source)
+        original.metadata["terminal_transition"] = {
+            "session_id": original.session_id,
+            "reason": "session_prune",
+            "token": "prune-recovery-token",
+        }
+        store._save_entries()
+        events = []
+        original_save_entries = store._save_entries
+
+        def _save_entries(*args, **kwargs):
+            current = store._entries.get(original.session_key)
+            events.append(
+                "route:absent"
+                if current is None
+                else f"route:{current.session_id}"
+            )
+            return original_save_entries(*args, **kwargs)
+
+        store._save_entries = _save_entries
+        replacement = store.get_or_create_session(source)
+
+        assert "route:absent" in events
+        assert events.index("route:absent") < events.index(
+            f"route:{replacement.session_id}"
+        )
+
+    def test_prune_routes_through_terminal_teardown_boundary(self, tmp_path):
+        store = _make_store(tmp_path)
+        store._entries["stale"] = _entry(
+            "stale", age_days=500, session_id="stale-sid"
+        )
+        events = []
+
+        def _begin(sid, reason):
+            events.append(("begin", sid, reason))
+            return object()
+
+        def _complete(sid, token, key):
+            assert key not in store._entries
+            events.append(("complete", sid, key, token))
+
+        def _end(sid, token, succeeded):
+            events.append(("end", sid, succeeded, token))
+
+        store._before_auto_reset_fn = _begin
+        store._before_terminal_completion_fn = _complete
+        store._after_auto_reset_fn = _end
+
+        assert store.prune_old_entries(max_age_days=90) == 1
+        assert events[0][:3] == ("begin", "stale-sid", "session_prune")
+        assert events[1][:3] == ("complete", "stale-sid", "stale")
+        assert events[2][0:3] == ("end", "stale-sid", True)
 
     def test_prune_is_thread_safe(self, tmp_path):
         """Prune acquires _lock internally; concurrent update_session is safe."""

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -316,7 +316,10 @@ async def test_group_new_keeps_existing_reset_semantics_when_dm_topic_mode_enabl
 
     assert "Started a new Hermes session in this topic" not in result
     assert "parallel work" not in result
-    runner.session_store.reset_session.assert_called_once_with(group_key)
+    runner.session_store.reset_session.assert_called_once_with(
+        group_key,
+        reset_reason="session_reset",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1090,6 +1090,122 @@ class TestCuaDriverSessionReconnect:
         assert len(bridge.calls) == 2
 
 
+    def test_reconnect_cleanup_failure_does_not_spawn_replacement(self):
+        from anyio import ClosedResourceError
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = 0
+
+            def run(self, value, timeout=None):
+                self.calls += 1
+                if self.calls == 1:
+                    raise ClosedResourceError()
+                return {"unexpected": "replacement action"}
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+        session._stop_lifecycle_locked = lambda: (_ for _ in ()).throw(
+            RuntimeError("old child cleanup unconfirmed")
+        )
+
+        with pytest.raises(RuntimeError, match="old child cleanup unconfirmed"):
+            session.call_tool("list_apps", {})
+        assert bridge.calls == 1
+        assert session._reconnect_log == []
+        assert session._started is False
+
+    def test_reconnect_attests_replacement_before_retrying_action(self):
+        """A replacement MCP child must be durably attested before it acts."""
+        from anyio import ClosedResourceError
+
+        class FakeBridge:
+            def __init__(self, session):
+                self.session = session
+                self.calls = 0
+
+            def run(self, value, timeout=None):
+                self.calls += 1
+                if self.calls == 1:
+                    raise ClosedResourceError()
+                assert self.session._reconnect_log == ["stop", "start", "attest"]
+                return {"ok": True}
+
+        session = self._make_session(None)
+        bridge = FakeBridge(session)
+        session._bridge = bridge
+        session._runtime_attestation_callback = (
+            lambda: session._reconnect_log.append("attest")
+        )
+
+        assert session.call_tool("list_apps", {}) == {"ok": True}
+        assert session._reconnect_log == ["stop", "start", "attest"]
+
+    def test_reconnect_attestation_failure_prevents_replacement_action(self):
+        from anyio import ClosedResourceError
+
+        class FakeBridge:
+            def __init__(self):
+                self.calls = 0
+
+            def run(self, value, timeout=None):
+                self.calls += 1
+                raise ClosedResourceError()
+
+        bridge = FakeBridge()
+        session = self._make_session(bridge)
+
+        def reject_attestation():
+            session._reconnect_log.append("attest")
+            raise RuntimeError("attestation rejected replacement")
+
+        session._runtime_attestation_callback = reject_attestation
+        with pytest.raises(RuntimeError, match="attestation rejected replacement"):
+            session.call_tool("list_apps", {})
+        assert bridge.calls == 1
+        assert session._reconnect_log == ["stop", "start", "attest", "stop"]
+        assert session._started is False
+
+    def test_session_start_attests_child_before_becoming_active(self):
+        from typing import Any, cast
+        import threading
+        from tools.computer_use.cua_backend import _CuaDriverSession
+
+        session = cast(Any, _CuaDriverSession.__new__(_CuaDriverSession))
+        session._lock = threading.Lock()
+        session._started = False
+        session._events = []
+        session._bridge = type(
+            "Bridge",
+            (),
+            {"start": lambda inner: session._events.append("bridge")},
+        )()
+        session._start_lifecycle_locked = lambda: session._events.append("start")
+        session._stop_lifecycle_locked = lambda: session._events.append("stop")
+        session._runtime_attestation_callback = lambda: session._events.append("attest")
+
+        session.start()
+
+        assert session._events == ["bridge", "start", "attest"]
+        assert session._started is True
+
+    def test_managed_session_rejects_unattestable_cli_fallback(self, monkeypatch):
+        from typing import Any, cast
+        from tools.computer_use.cua_backend import _CuaDriverSession
+
+        session = cast(Any, _CuaDriverSession.__new__(_CuaDriverSession))
+        session._runtime_attestation_callback = lambda: None
+        spawned = []
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: spawned.append((args, kwargs)),
+        )
+
+        with pytest.raises(RuntimeError, match="runtime attestation"):
+            session._call_tool_via_cli("list_apps", {}, 30.0)
+        assert spawned == []
+
+
     def test_cli_fallback_reads_screenshot_from_file(self, tmp_path, monkeypatch):
         """_call_tool_via_cli must base64-read a screenshot written to disk
         (screenshot_out_file path) when no inline base64 is present."""

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1113,9 +1113,13 @@ class TestCuaDriverSessionReconnect:
         class FakeProc:
             returncode = 0
             stderr = ""
-            # Daemon returns a path, not inline base64.
-            stdout = ('{"element_count": 7, "tree_markdown": "- [0] AXButton",'
-                      ' "screenshot_file_path": "%s"}' % str(shot))
+            # Daemon returns a path, not inline base64. json.dumps is required
+            # on Windows so backslashes in the temp path remain valid JSON.
+            stdout = json.dumps({
+                "element_count": 7,
+                "tree_markdown": "- [0] AXButton",
+                "screenshot_file_path": str(shot),
+            })
 
         import subprocess as _sp
         orig_run = _sp.run
@@ -1221,7 +1225,8 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid is None
         assert backend._active_window_id is None
 
-    def test_linux_default_capture_skips_gnome_shell_helper(self):
+    def test_linux_default_capture_skips_gnome_shell_helper(self, monkeypatch):
+        monkeypatch.setattr("tools.computer_use.cua_backend.sys.platform", "linux")
         windows = [
             {"app_name": "", "pid": 100, "window_id": 1,
              "is_on_screen": None, "title": "@!1921,0;BDHF", "z_index": 0},

--- a/tests/tools/test_computer_use_attestation_verifier.py
+++ b/tests/tools/test_computer_use_attestation_verifier.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import json
+import os
 import runpy
 import shutil
 import subprocess
 import sys
+import atexit
+import time
+import base64
+import concurrent.futures
+import hashlib
+import types
 from pathlib import Path
 
 import pytest
@@ -12,13 +19,64 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "verify_cua_gateway_attestation.py"
+_OWNED_DRIVER: subprocess.Popen | None = None
+
+
+def _stop_owned_driver() -> None:
+    global _OWNED_DRIVER
+    process = _OWNED_DRIVER
+    _OWNED_DRIVER = None
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=3)
+
+
+def _ensure_owned_driver() -> None:
+    global _OWNED_DRIVER
+    if _OWNED_DRIVER is not None and _OWNED_DRIVER.poll() is None:
+        return
+    from tools.computer_use.cua_backend import resolve_cua_driver_cmd
+
+    driver = resolve_cua_driver_cmd()
+    assert driver
+    _OWNED_DRIVER = subprocess.Popen(
+        [driver, "mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if _OWNED_DRIVER.poll() is not None:
+            raise RuntimeError("test-owned cua-driver exited during startup")
+        try:
+            import psutil
+
+            child = psutil.Process(_OWNED_DRIVER.pid)
+            if child.ppid() == os.getpid() and "cua-driver" in child.name().lower():
+                return
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+        time.sleep(0.05)
+    raise RuntimeError("test-owned cua-driver did not become visible")
+
+
+atexit.register(_stop_owned_driver)
 
 
 def _receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     from tools.computer_use import tool as computer_use
 
+    _ensure_owned_driver()
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
-    receipt = computer_use.write_computer_use_runtime_attestation()
+    receipt = computer_use.write_computer_use_runtime_attestation(
+        require_active_cua=True
+    )
     path = tmp_path / "receipt.json"
     path.write_text(json.dumps(receipt), encoding="utf-8")
     return path
@@ -61,25 +119,83 @@ def _committed_review_root(tmp_path: Path) -> Path:
         cwd=review,
         check=True,
     )
+    # Materialize the exact current candidate bytes into an authentic clean Git
+    # commit.  The production tree may be intentionally dirty during TDD, while
+    # the positive verifier fixture must still exercise a real commit/tree.
+    for relative in _CUA_ATTESTATION_MODULES:
+        destination = review / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / relative, destination)
+    subprocess.run(["git", "add", "--", *_CUA_ATTESTATION_MODULES], cwd=review, check=True)
+    subprocess.run(
+        [
+            "git", "-c", "user.name=Hermes Test", "-c",
+            "user.email=hermes-test@example.invalid", "commit", "--quiet",
+            "-m", "test: materialize current attestation candidate",
+        ],
+        cwd=review,
+        check=True,
+    )
     return review
 
 
+def _rebind_receipt_to_committed_review(receipt: Path, review: Path) -> str:
+    """Make a receipt describe the independently checked-out review bytes."""
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    verifier = runpy.run_path(str(SCRIPT))
+    compiled = {}
+    for relative, row in data["modules"].items():
+        source = review / relative
+        raw = source.read_bytes()
+        row.update(source_path=str(source.resolve()), size=len(raw), sha256=hashlib.sha256(raw).hexdigest())
+        found = {}
+        verifier["_codes"](
+            compile(raw, str(source.resolve()), "exec", dont_inherit=True, optimize=sys.flags.optimize), found,
+        )
+        compiled[relative] = found
+    for identity, row in data["callables"].items():
+        code = compiled[row["source_relative_path"]][row["qualname"]]
+        row["first_line"] = code.co_firstlineno
+        row["code_sha256"] = verifier["_fingerprint"](code)
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=review, text=True).strip()
+    source = data["source_identity"]
+    source["kind"] = "git-clean"
+    source["repository"] = {
+        "vcs": "git", "root": str(review.resolve()), "head_commit": head,
+        "head_tree": subprocess.check_output(["git", "rev-parse", "HEAD^{tree}"], cwd=review, text=True).strip(),
+    }
+    for relative, row in source["attested_paths"].items():
+        row["matches_head"] = True
+        row["worktree_sha256"] = data["modules"][relative]["sha256"]
+        row["head_blob"] = subprocess.check_output(
+            ["git", "rev-parse", f"HEAD:{relative}"], cwd=review, text=True,
+        ).strip()
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+    return head
+
+
 def _verify(
-    receipt: Path, review: Path, deployed: Path = ROOT
-) -> subprocess.CompletedProcess[str]:
+    receipt: Path, review: Path, deployed: Path = ROOT, *, expected_commit: str | None = None,
+    verification_receipt: Path | None = None, text: bool = True,
+) -> subprocess.CompletedProcess:
+    command = [
+        sys.executable,
+        str(SCRIPT),
+        "--receipt",
+        str(receipt),
+        "--review-root",
+        str(review),
+        "--deployed-root",
+        str(deployed),
+    ]
+    if expected_commit is not None:
+        command.extend(["--expected-commit", expected_commit])
+    if verification_receipt is not None:
+        command.extend(["--verification-receipt", str(verification_receipt)])
     return subprocess.run(
-        [
-            sys.executable,
-            str(SCRIPT),
-            "--receipt",
-            str(receipt),
-            "--review-root",
-            str(review),
-            "--deployed-root",
-            str(deployed),
-        ],
+        command,
         cwd=ROOT,
-        text=True,
+        text=text,
         capture_output=True,
         check=False,
     )
@@ -87,12 +203,425 @@ def _verify(
 
 def test_verifier_accepts_exact_reviewed_source(tmp_path, monkeypatch):
     receipt = _receipt(tmp_path, monkeypatch)
+    review = _committed_review_root(tmp_path)
+    expected_commit = _rebind_receipt_to_committed_review(receipt, review)
+    result = _verify(receipt, review, review, expected_commit=expected_commit)
+    assert result.returncode == 0, result.stderr
+    assert "verified commit identity" in result.stdout
+
+
+def test_verifier_revalidates_live_driver_set_after_content_verification(tmp_path, monkeypatch):
+    receipt_path = _receipt(tmp_path, monkeypatch)
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    review = _review_root(tmp_path)
+    verifier = runpy.run_path(str(SCRIPT))
+    original = verifier["_live_cua_driver_processes"]
+    calls = 0
+
+    def disappearing_driver_set(**kwargs):
+        nonlocal calls
+        calls += 1
+        rows = original(**kwargs)
+        return rows if calls == 1 else []
+
+    verifier["verify"].__globals__["_live_cua_driver_processes"] = disappearing_driver_set
+    with pytest.raises(verifier["VerificationError"], match="exact live process set"):
+        verifier["verify"](receipt, review, ROOT, None)
+    assert calls == 2
+
+
+def test_receipt_and_verifier_bind_fixed_native_runtime_artifacts(tmp_path, monkeypatch):
+    """Each critical native byte dependency is fixed, canonical, and rehashed."""
+    import hashlib
+
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    artifacts = data["native_runtime_artifacts"]
+    assert set(artifacts) == {
+        "python_runtime",
+        "sqlite3_extension",
+        "psutil_extension",
+        "cua_driver_launcher",
+        "cua_driver_executable",
+    }
+    for row in artifacts.values():
+        path = Path(row["canonical_path"])
+        raw = path.read_bytes()
+        assert path == path.resolve()
+        assert row["size"] == len(raw)
+        assert row["sha256"] == hashlib.sha256(raw).hexdigest()
+
     result = _verify(receipt, _review_root(tmp_path))
     assert result.returncode == 0, result.stderr
-    assert "verified reviewed content identity" in result.stdout
 
 
-def test_verifier_writes_complete_live_verification_receipt(tmp_path, monkeypatch):
+def test_verifier_rejects_missing_native_runtime_artifact(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["native_runtime_artifacts"].pop("sqlite3_extension")
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "fixed native runtime artifact policy" in result.stderr
+
+
+def test_verifier_rejects_native_runtime_path_substitution(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["native_runtime_artifacts"]["cua_driver_executable"]["canonical_path"] = "C:/forged/cua-driver.exe"
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "native runtime artifact path mismatch" in result.stderr
+
+
+def test_verifier_rejects_cua_driver_process_identity_or_ancestry_tamper(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["cua_driver_processes"][0]["process_create_time"] += 10.0
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "receipt does not match exact live process set" in result.stderr
+
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    row = data["cua_driver_processes"][0]
+    if row["parent"] is None:
+        row["parent"] = {
+            "pid": 1,
+            "process_create_time": 1.0,
+            "executable": "C:/forged-parent.exe",
+        }
+    else:
+        row["parent"]["pid"] = 0
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+    result = _verify(receipt, _review_root(tmp_path / "parent"))
+    assert result.returncode != 0
+    assert "cua-driver gateway ancestry mismatch" in result.stderr
+
+
+def test_verifier_rejects_real_owned_process_replacement(tmp_path, monkeypatch):
+    """A same-command replacement PID cannot inherit a captured live identity."""
+    receipt = _receipt(tmp_path, monkeypatch)
+    original = json.loads(receipt.read_text(encoding="utf-8"))[
+        "cua_driver_processes"
+    ][0]
+    _stop_owned_driver()
+    _ensure_owned_driver()
+    assert _OWNED_DRIVER is not None
+    assert _OWNED_DRIVER.pid != original["pid"]
+
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "receipt does not match exact live process set" in result.stderr
+
+
+def test_producer_binds_only_exact_gateway_child_processes(monkeypatch):
+    from tools.computer_use import tool as computer_use
+
+    class Parent:
+        pid = 4242
+
+        @staticmethod
+        def create_time():
+            return 12.5
+
+        @staticmethod
+        def exe():
+            return sys.executable
+
+    class Process:
+        def __init__(self, pid, ppid):
+            self.pid = pid
+            self._ppid = ppid
+            self.info = {"pid": pid, "name": "cua-driver.exe"}
+
+        def exe(self):
+            return sys.executable
+
+        def parent(self):
+            return Parent() if self._ppid == Parent.pid else None
+
+        def create_time(self):
+            return 20.0 + self.pid
+
+        def ppid(self):
+            return self._ppid
+
+        def cmdline(self):
+            return [sys.executable, "mcp"]
+
+    monkeypatch.setattr("psutil.Process", lambda pid: Parent())
+    monkeypatch.setattr(
+        "psutil.process_iter",
+        lambda _attrs: [Process(101, Parent.pid), Process(202, 9999)],
+    )
+    rows = computer_use._live_cua_driver_processes(
+        owner_pid=Parent.pid,
+        owner_create_time=Parent.create_time(),
+        owner_executable=Parent.exe(),
+        require_active=True,
+    )
+    assert [row["pid"] for row in rows] == [101]
+    assert rows[0]["parent"] == {
+        "pid": Parent.pid,
+        "process_create_time": Parent.create_time(),
+        "executable": Parent.exe(),
+    }
+
+
+def test_verifier_rejects_subset_duplicate_and_unrelated_driver_rows():
+    verifier = runpy.run_path(str(SCRIPT))
+    executable = verifier["_native_file_identity"](Path(sys.executable))
+    parent = {
+        "pid": 4242,
+        "process_create_time": 12.5,
+        "executable": sys.executable,
+    }
+    one = {
+        "pid": 101,
+        "process_create_time": 20.0,
+        "ppid": parent["pid"],
+        "executable": executable,
+        "parent": parent,
+        "argv": [sys.executable, "mcp"],
+    }
+    two = {**one, "pid": 202, "process_create_time": 21.0}
+    receipt = {
+        "runtime_phase": "cua_active",
+        "pid": parent["pid"],
+        "process_create_time": parent["process_create_time"],
+        "executable": parent["executable"],
+        "cua_driver_processes": [one],
+    }
+    with pytest.raises(Exception, match="exact live process set"):
+        verifier["_verify_cua_driver_processes"](receipt, [one, two])
+
+    receipt["cua_driver_processes"] = [one, one]
+    with pytest.raises(Exception, match="duplicate cua-driver"):
+        verifier["_verify_cua_driver_processes"](receipt, [one])
+
+    unrelated = {
+        **one,
+        "ppid": 9999,
+        "parent": {**parent, "pid": 9999},
+    }
+    receipt["cua_driver_processes"] = [unrelated]
+    with pytest.raises(Exception, match="gateway ancestry"):
+        verifier["_verify_cua_driver_processes"](receipt, [unrelated])
+
+
+def test_git_clean_verification_requires_independent_expected_commit(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    review = _committed_review_root(tmp_path)
+    _rebind_receipt_to_committed_review(receipt, review)
+    result = _verify(receipt, review, review)
+    assert result.returncode != 0
+    assert "expected commit is required" in result.stderr
+
+
+def test_producer_fsyncs_required_receipts_before_success(tmp_path, monkeypatch):
+    from tools.computer_use import tool as computer_use
+
+    calls = []
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setattr(computer_use.os, "fsync", lambda fd: calls.append(fd))
+    computer_use.write_computer_use_runtime_attestation()
+    assert len(calls) >= 2
+
+
+def test_atomic_attestation_fsync_failure_preserves_previous_receipt(
+    tmp_path, monkeypatch
+):
+    from tools.computer_use import tool as computer_use
+
+    destination = tmp_path / "receipt.json"
+    destination.write_bytes(b"previous")
+    monkeypatch.setattr(
+        computer_use.os,
+        "fsync",
+        lambda _fd: (_ for _ in ()).throw(OSError("forced fsync failure")),
+    )
+    with pytest.raises(OSError, match="forced fsync failure"):
+        computer_use._atomic_write_attestation(destination, b"replacement")
+    assert destination.read_bytes() == b"previous"
+    assert list(tmp_path.glob("*.tmp")) == []
+    assert list(tmp_path.glob(".*.tmp")) == []
+
+
+def _run_windows_durable_publish_probe(monkeypatch, tmp_path, publisher, outcomes, error):
+    import ctypes
+    from tools.computer_use import tool as computer_use
+
+    destination = tmp_path / f"{publisher}.json"
+    destination.write_bytes(b"prior")
+    calls = 0
+
+    class FakeMoveFile:
+        argtypes = None
+        restype = None
+
+        def __call__(self, source, target, _flags):
+            nonlocal calls
+            outcome = outcomes[min(calls, len(outcomes) - 1)]
+            calls += 1
+            if outcome:
+                os.replace(source, target)
+            return outcome
+
+    fake_move = FakeMoveFile()
+    fake_kernel = types.SimpleNamespace(MoveFileExW=fake_move)
+    monkeypatch.setattr(ctypes, "WinDLL", lambda *_args, **_kwargs: fake_kernel)
+    monkeypatch.setattr(ctypes, "get_last_error", lambda: error)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    if publisher == "producer":
+        publish = lambda: computer_use._atomic_write_attestation(destination, b"new")
+    else:
+        verifier = runpy.run_path(str(SCRIPT))
+        args = types.SimpleNamespace(
+            receipt=tmp_path / "input.json",
+            review_root=tmp_path / "review",
+            deployed_root=tmp_path / "deployed",
+            expected_commit=None,
+        )
+        publish = lambda: verifier["_write_verification_receipt"](
+            destination, args, 0, b"new", b""
+        )
+    return publish, destination, lambda: calls
+
+
+@pytest.mark.parametrize("publisher", ["producer", "verifier"])
+@pytest.mark.parametrize("error", [5, 32])
+def test_windows_durable_publish_retries_transient_contention(
+    tmp_path, monkeypatch, publisher, error
+):
+    publish, destination, call_count = _run_windows_durable_publish_probe(
+        monkeypatch, tmp_path, publisher, [False, False, True], error
+    )
+    publish()
+    assert call_count() == 3
+    assert destination.read_bytes() != b"prior"
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+@pytest.mark.parametrize("publisher", ["producer", "verifier"])
+@pytest.mark.parametrize("error", [5, 32])
+def test_windows_durable_publish_exhaustion_preserves_prior_receipt(
+    tmp_path, monkeypatch, publisher, error
+):
+    publish, destination, call_count = _run_windows_durable_publish_probe(
+        monkeypatch, tmp_path, publisher, [False], error
+    )
+    with pytest.raises(OSError, match="MoveFileExW failed"):
+        publish()
+    assert call_count() == 50
+    assert destination.read_bytes() == b"prior"
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+@pytest.mark.parametrize("publisher", ["producer", "verifier"])
+def test_windows_durable_publish_does_not_retry_nontransient_error(
+    tmp_path, monkeypatch, publisher
+):
+    publish, destination, call_count = _run_windows_durable_publish_probe(
+        monkeypatch, tmp_path, publisher, [False], 87
+    )
+    with pytest.raises(OSError, match="MoveFileExW failed"):
+        publish()
+    assert call_count() == 1
+    assert destination.read_bytes() == b"prior"
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_atomic_attestation_concurrent_writers_retry_destination_contention(tmp_path):
+    from tools.computer_use import tool as computer_use
+
+    destination = tmp_path / "concurrent-producer.json"
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        futures = [
+            pool.submit(
+                computer_use._atomic_write_attestation,
+                destination,
+                json.dumps({"writer": index}).encode("utf-8"),
+            )
+            for index in range(32)
+        ]
+        for future in futures:
+            future.result(timeout=15)
+
+    payload = json.loads(destination.read_text(encoding="utf-8"))
+    assert payload["writer"] in range(32)
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_atomic_attestation_temp_name_is_bounded_for_long_archive_destination(tmp_path):
+    from tools.computer_use import tool as computer_use
+
+    destination = tmp_path / ("a" * 110 + ".json")
+    computer_use._atomic_write_attestation(destination, b"bounded-temp")
+    assert destination.read_bytes() == b"bounded-temp"
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_runtime_attestation_archive_paths_are_unique_when_clock_collides(
+    tmp_path, monkeypatch
+):
+    import datetime as real_datetime
+    from tools.computer_use import tool as computer_use
+
+    frozen = real_datetime.datetime(2026, 8, 9, 12, 0, tzinfo=real_datetime.timezone.utc)
+
+    class FrozenDateTime:
+        @classmethod
+        def now(cls, tz=None):
+            return frozen if tz is not None else frozen.replace(tzinfo=None)
+
+    fake_datetime = types.SimpleNamespace(
+        datetime=FrozenDateTime,
+        timezone=real_datetime.timezone,
+    )
+    paths = []
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    monkeypatch.setattr(
+        computer_use,
+        "_atomic_write_attestation",
+        lambda path, _raw: paths.append(Path(path)),
+    )
+    # Warm every fixed callable import before substituting the datetime module.
+    computer_use.write_computer_use_runtime_attestation()
+    paths.clear()
+    monkeypatch.setitem(sys.modules, "datetime", fake_datetime)
+
+    computer_use.write_computer_use_runtime_attestation()
+    computer_use.write_computer_use_runtime_attestation()
+
+    archives = [path for path in paths if path.name != "cua_gateway_attestation.json"]
+    assert len(archives) == 2
+    assert len(set(archives)) == 2
+    assert all(path.suffix == ".json" for path in archives)
+
+
+def test_verifier_rejects_native_runtime_byte_mutation(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["native_runtime_artifacts"]["psutil_extension"]["sha256"] = "0" * 64
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "native runtime artifact hash mismatch" in result.stderr
+
+
+def test_verifier_writes_atomic_byte_exact_live_verification_receipt(tmp_path, monkeypatch):
     receipt = _receipt(tmp_path, monkeypatch)
     review = _review_root(tmp_path)
     verification_receipt = tmp_path / "live-verifier-receipt.json"
@@ -102,18 +631,146 @@ def test_verifier_writes_complete_live_verification_receipt(tmp_path, monkeypatc
         "--expected-commit", "4f818e9cf4f2ced855c0b73dee92a54a25b3df68",
         "--verification-receipt", str(verification_receipt),
     ]
-    result = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, check=False)
+    result = subprocess.run(command, cwd=ROOT, capture_output=True, check=False)
     assert result.returncode != 0  # The producer is dirty, so a commit claim must fail closed.
     live = json.loads(verification_receipt.read_text(encoding="utf-8"))
-    assert live["command"] == command[1:]
-    assert live["receipt_path"] == str(receipt)
-    assert live["review_root"] == str(review)
-    assert live["deployed_root"] == str(ROOT)
-    assert live["expected_commit"] == "4f818e9cf4f2ced855c0b73dee92a54a25b3df68"
+    assert live["schema"] == 2
+    assert live["invocation"]["interpreter"] == str(Path(sys.executable).resolve())
+    assert live["invocation"]["verifier_path"] == str(SCRIPT.resolve())
+    assert live["invocation"]["cwd"] == str(ROOT.resolve())
+    assert live["invocation"]["argv"] == [
+        str(Path(command[0]).resolve()),
+        str(Path(command[1]).resolve()),
+        *command[2:],
+    ]
+    assert live["invocation"]["receipt_path"] == str(receipt)
+    assert live["invocation"]["review_root"] == str(review)
+    assert live["invocation"]["deployed_root"] == str(ROOT)
+    assert live["invocation"]["expected_commit"] == "4f818e9cf4f2ced855c0b73dee92a54a25b3df68"
     assert live["verifier_sha256"]
-    assert live["exit_code"] == result.returncode
-    assert live["stdout"] == result.stdout
-    assert live["stderr"] == result.stderr
+    assert live["result"]["exit_code"] == result.returncode
+    for stream_name, actual in (("stdout", result.stdout), ("stderr", result.stderr)):
+        stream = live["result"][stream_name]
+        assert base64.b64decode(stream["base64"]) == actual
+        assert stream["length"] == len(actual)
+        assert stream["sha256"] == hashlib.sha256(actual).hexdigest()
+
+
+def test_verification_receipt_uses_durable_replace_boundary(tmp_path, monkeypatch):
+    verifier = runpy.run_path(str(SCRIPT))
+    output = tmp_path / "durable-receipt.json"
+    args = types.SimpleNamespace(
+        receipt=tmp_path / "input.json",
+        review_root=tmp_path / "review",
+        deployed_root=tmp_path / "deployed",
+        expected_commit=None,
+    )
+    calls = []
+
+    def durable_replace(temporary, destination):
+        calls.append((temporary, destination))
+        temporary.replace(destination)
+
+    writer = verifier["_write_verification_receipt"]
+    monkeypatch.setitem(writer.__globals__, "_durable_replace", durable_replace)
+    writer(output, args, 0, b"ok\n", b"")
+    assert len(calls) == 1
+    assert calls[0][1] == output
+    assert output.is_file()
+
+
+def test_runtime_process_replacement_gate_is_fixed_attested_policy():
+    from tools.computer_use import tool as computer_use
+
+    verifier = runpy.run_path(str(SCRIPT))
+    required = {
+        "tools.computer_use.cua_backend:_CuaDriverSession.start",
+        "tools.computer_use.cua_backend:_CuaDriverSession._attest_runtime_locked",
+        "tools.computer_use.cua_backend:_CuaDriverSession._restart_session_locked",
+        "tools.computer_use.cua_backend:_CuaDriverSession._call_tool_via_cli",
+        "tools.computer_use.cua_backend:CuaDriverBackend.set_runtime_attestation_callback",
+    }
+    assert required <= set(computer_use._CUA_ATTESTATION_CALLABLES)
+    assert required <= set(verifier["CALLABLES"])
+
+
+def test_verification_receipt_concurrent_writers_use_unique_temp_files(tmp_path):
+    verifier = runpy.run_path(str(SCRIPT))
+    output = tmp_path / "concurrent-receipt.json"
+    args = types.SimpleNamespace(
+        receipt=tmp_path / "input.json",
+        review_root=tmp_path / "review",
+        deployed_root=tmp_path / "deployed",
+        expected_commit=None,
+    )
+    writer = verifier["_write_verification_receipt"]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        futures = [
+            pool.submit(writer, output, args, index % 2, f"out-{index}".encode(), b"")
+            for index in range(32)
+        ]
+        for future in futures:
+            future.result(timeout=15)
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema"] == 2
+    assert payload["result"]["exit_code"] in {0, 1}
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_verification_receipt_temp_name_is_bounded_for_long_destination(tmp_path):
+    verifier = runpy.run_path(str(SCRIPT))
+    short_parent = Path("C:/") / f"cv-{os.getpid()}-{time.time_ns()}"
+    short_parent.mkdir(parents=True)
+    output = short_parent / ("v" * 220 + ".json")
+    vulnerable_temp = short_parent / (
+        f".{output.name}.{os.getpid()}.1.{('0' * 32)}.tmp"
+    )
+    args = types.SimpleNamespace(
+        receipt=tmp_path / "input.json",
+        review_root=tmp_path / "review",
+        deployed_root=tmp_path / "deployed",
+        expected_commit=None,
+    )
+    try:
+        assert len(vulnerable_temp.name) > 255
+        with pytest.raises(OSError):
+            vulnerable_temp.open("wb")
+        verifier["_write_verification_receipt"](output, args, 0, b"ok\n", b"")
+        assert json.loads(output.read_text(encoding="utf-8"))["schema"] == 2
+        assert not list(short_parent.glob("*.tmp"))
+        assert not list(short_parent.glob(".*.tmp"))
+    finally:
+        shutil.rmtree(short_parent, ignore_errors=True)
+
+
+def test_verification_receipt_preserves_crlf_stream_bytes_without_text_normalization(tmp_path):
+    verifier = runpy.run_path(str(SCRIPT))
+    output = tmp_path / "crlf-receipt.json"
+    args = types.SimpleNamespace(
+        receipt=tmp_path / "input.json",
+        review_root=tmp_path / "review",
+        deployed_root=tmp_path / "deployed",
+        expected_commit=None,
+    )
+    verifier["_write_verification_receipt"](output, args, 7, b"stdout\r\n", b"stderr\r\n")
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert base64.b64decode(data["result"]["stdout"]["base64"]) == b"stdout\r\n"
+    assert base64.b64decode(data["result"]["stderr"]["base64"]) == b"stderr\r\n"
+
+
+def test_verifier_rejects_tampered_attested_git_tree(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    review = _committed_review_root(tmp_path)
+    head = _rebind_receipt_to_committed_review(receipt, review)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["source_identity"]["repository"]["head_tree"] = "0" * 40
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+
+    result = _verify(receipt, review, review, expected_commit=head)
+    assert result.returncode != 0
+    assert "review tree mismatch" in result.stderr
 
 
 def test_verifier_recomputes_callable_fingerprint_from_reviewed_source(tmp_path, monkeypatch):

--- a/tests/tools/test_computer_use_attestation_verifier.py
+++ b/tests/tools/test_computer_use_attestation_verifier.py
@@ -639,7 +639,13 @@ def test_verifier_writes_atomic_byte_exact_live_verification_receipt(tmp_path, m
     result = subprocess.run(command, cwd=ROOT, capture_output=True, check=False)
     assert result.returncode != 0  # The producer is dirty, so a commit claim must fail closed.
     live = json.loads(verification_receipt.read_text(encoding="utf-8"))
-    assert live["schema"] == 2
+    input_attestation = receipt.read_bytes()
+    assert live["schema"] == 3
+    assert live["input_attestation"] == {
+        "path": str(receipt.resolve()),
+        "length": len(input_attestation),
+        "sha256": hashlib.sha256(input_attestation).hexdigest(),
+    }
     assert live["invocation"]["interpreter"] == str(Path(sys.executable).resolve())
     assert live["invocation"]["verifier_path"] == str(SCRIPT.resolve())
     assert live["invocation"]["cwd"] == str(ROOT.resolve())
@@ -684,6 +690,39 @@ def test_verification_receipt_uses_durable_replace_boundary(tmp_path, monkeypatc
     assert output.is_file()
 
 
+def test_verification_receipt_survives_input_removal_after_capture(tmp_path):
+    verifier = runpy.run_path(str(SCRIPT))
+    output = tmp_path / "final-result.json"
+    receipt = tmp_path / "input.json"
+    receipt.write_bytes(b'{"captured":true}')
+    canonical_receipt = receipt.resolve(strict=True)
+    captured_bytes = receipt.read_bytes()
+    receipt.unlink()
+    args = types.SimpleNamespace(
+        receipt=receipt,
+        review_root=tmp_path / "review",
+        deployed_root=tmp_path / "deployed",
+        expected_commit=None,
+    )
+
+    verifier["_write_verification_receipt"](
+        output,
+        args,
+        0,
+        b"ok\n",
+        b"",
+        captured_bytes,
+        canonical_receipt,
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["input_attestation"] == {
+        "path": str(canonical_receipt),
+        "length": len(captured_bytes),
+        "sha256": hashlib.sha256(captured_bytes).hexdigest(),
+    }
+
+
 def test_runtime_process_replacement_gate_is_fixed_attested_policy():
     from tools.computer_use import tool as computer_use
 
@@ -719,7 +758,7 @@ def test_verification_receipt_concurrent_writers_use_unique_temp_files(tmp_path)
             future.result(timeout=15)
 
     payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["schema"] == 2
+    assert payload["schema"] == 3
     assert payload["result"]["exit_code"] in {0, 1}
     assert not list(tmp_path.glob("*.tmp"))
 
@@ -743,7 +782,7 @@ def test_verification_receipt_temp_name_is_bounded_for_long_destination(tmp_path
         with pytest.raises(OSError):
             vulnerable_temp.open("wb")
         verifier["_write_verification_receipt"](output, args, 0, b"ok\n", b"")
-        assert json.loads(output.read_text(encoding="utf-8"))["schema"] == 2
+        assert json.loads(output.read_text(encoding="utf-8"))["schema"] == 3
         assert not list(short_parent.glob("*.tmp"))
         assert not list(short_parent.glob(".*.tmp"))
     finally:

--- a/tests/tools/test_computer_use_attestation_verifier.py
+++ b/tests/tools/test_computer_use_attestation_verifier.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import runpy
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +25,19 @@ def _receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _review_root(tmp_path: Path) -> Path:
+    """Copy the exact producer bytes, including an uncommitted safe-local fix."""
+    from tools.computer_use.tool import _CUA_ATTESTATION_MODULES
+
+    review = tmp_path / "review"
+    for relative in _CUA_ATTESTATION_MODULES:
+        source = ROOT / relative
+        destination = review / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    return review
+
+
+def _committed_review_root(tmp_path: Path) -> Path:
     from tools.computer_use.tool import _CUA_ATTESTATION_MODULES
 
     review = tmp_path / "review"
@@ -49,7 +64,9 @@ def _review_root(tmp_path: Path) -> Path:
     return review
 
 
-def _verify(receipt: Path, review: Path) -> subprocess.CompletedProcess[str]:
+def _verify(
+    receipt: Path, review: Path, deployed: Path = ROOT
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
             sys.executable,
@@ -59,7 +76,7 @@ def _verify(receipt: Path, review: Path) -> subprocess.CompletedProcess[str]:
             "--review-root",
             str(review),
             "--deployed-root",
-            str(ROOT),
+            str(deployed),
         ],
         cwd=ROOT,
         text=True,
@@ -72,7 +89,31 @@ def test_verifier_accepts_exact_reviewed_source(tmp_path, monkeypatch):
     receipt = _receipt(tmp_path, monkeypatch)
     result = _verify(receipt, _review_root(tmp_path))
     assert result.returncode == 0, result.stderr
-    assert "verified commit identity" in result.stdout
+    assert "verified reviewed content identity" in result.stdout
+
+
+def test_verifier_writes_complete_live_verification_receipt(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    review = _review_root(tmp_path)
+    verification_receipt = tmp_path / "live-verifier-receipt.json"
+    command = [
+        sys.executable, str(SCRIPT), "--receipt", str(receipt),
+        "--review-root", str(review), "--deployed-root", str(ROOT),
+        "--expected-commit", "4f818e9cf4f2ced855c0b73dee92a54a25b3df68",
+        "--verification-receipt", str(verification_receipt),
+    ]
+    result = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, check=False)
+    assert result.returncode != 0  # The producer is dirty, so a commit claim must fail closed.
+    live = json.loads(verification_receipt.read_text(encoding="utf-8"))
+    assert live["command"] == command[1:]
+    assert live["receipt_path"] == str(receipt)
+    assert live["review_root"] == str(review)
+    assert live["deployed_root"] == str(ROOT)
+    assert live["expected_commit"] == "4f818e9cf4f2ced855c0b73dee92a54a25b3df68"
+    assert live["verifier_sha256"]
+    assert live["exit_code"] == result.returncode
+    assert live["stdout"] == result.stdout
+    assert live["stderr"] == result.stderr
 
 
 def test_verifier_recomputes_callable_fingerprint_from_reviewed_source(tmp_path, monkeypatch):
@@ -117,13 +158,71 @@ def test_verifier_rejects_receipt_controlled_deployed_source_path(tmp_path, monk
     assert "receipt deployed source path mismatch" in result.stderr
 
 
+def test_verifier_rejects_deployed_only_source_mutation(tmp_path, monkeypatch):
+    """The deployed root is an independent byte-identity boundary."""
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    deployed = _review_root(tmp_path / "deployed")
+    for relative, row in data["modules"].items():
+        row["source_path"] = str((deployed / relative).resolve())
+    target = deployed / "tools/approval.py"
+    target.write_bytes(target.read_bytes() + b"\n# deployed-only mutation\n")
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+
+    result = _verify(receipt, _review_root(tmp_path / "review"), deployed)
+    assert result.returncode != 0
+    assert "deployed module hash mismatch" in result.stderr
+
+
+def test_verifier_rejects_live_launcher_or_parent_identity_mismatch(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["launcher"] = "C:/forged/launcher.exe"
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "live process launcher mismatch" in result.stderr
+
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["parent"]["pid"] = 0
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+    result = _verify(receipt, _review_root(tmp_path / "parent"))
+    assert result.returncode != 0
+    assert "live parent process identity mismatch" in result.stderr
+
+
 def test_verifier_rejects_forged_clean_claim_for_dirty_review_source(tmp_path, monkeypatch):
     import hashlib
 
     receipt = _receipt(tmp_path, monkeypatch)
     data = json.loads(receipt.read_text(encoding="utf-8"))
-    review = _review_root(tmp_path)
+    review = _committed_review_root(tmp_path)
     head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=review, text=True).strip()
+    for relative, row in data["modules"].items():
+        raw = (review / relative).read_bytes()
+        row.update(
+            source_path=str((review / relative).resolve()),
+            size=len(raw),
+            sha256=hashlib.sha256(raw).hexdigest(),
+        )
+    verifier = runpy.run_path(str(SCRIPT))
+    compiled = {}
+    for relative in data["modules"]:
+        found = {}
+        verifier["_codes"](
+            compile(
+                (review / relative).read_bytes(), str(review / relative), "exec",
+                dont_inherit=True, optimize=sys.flags.optimize,
+            ),
+            found,
+        )
+        compiled[relative] = found
+    for identity, row in data["callables"].items():
+        code = compiled[row["source_relative_path"]][row["qualname"]]
+        row["first_line"] = code.co_firstlineno
+        row["code_sha256"] = verifier["_fingerprint"](code)
     target_relative = "tools/approval.py"
     target = review / target_relative
     target.write_text(target.read_text(encoding="utf-8") + "\n# forged dirty review bytes\n", encoding="utf-8")
@@ -153,7 +252,7 @@ def test_verifier_rejects_forged_clean_claim_for_dirty_review_source(tmp_path, m
             "--review-root",
             str(review),
             "--deployed-root",
-            str(ROOT),
+            str(review),
             "--expected-commit",
             head,
         ],

--- a/tests/tools/test_computer_use_attestation_verifier.py
+++ b/tests/tools/test_computer_use_attestation_verifier.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -27,11 +26,26 @@ def _review_root(tmp_path: Path) -> Path:
     from tools.computer_use.tool import _CUA_ATTESTATION_MODULES
 
     review = tmp_path / "review"
-    for relative in _CUA_ATTESTATION_MODULES:
-        source = ROOT / relative
-        destination = review / relative
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source, destination)
+    subprocess.run(
+        ["git", "clone", "--quiet", "--no-checkout", "--shared", str(ROOT), str(review)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "core.autocrlf", "false"],
+        cwd=review,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "sparse-checkout", "set", "--no-cone", *_CUA_ATTESTATION_MODULES],
+        cwd=review,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "--quiet", "--detach", "HEAD"],
+        cwd=review,
+        check=True,
+    )
     return review
 
 
@@ -58,7 +72,7 @@ def test_verifier_accepts_exact_reviewed_source(tmp_path, monkeypatch):
     receipt = _receipt(tmp_path, monkeypatch)
     result = _verify(receipt, _review_root(tmp_path))
     assert result.returncode == 0, result.stderr
-    assert "reviewed content identity" in result.stdout
+    assert "verified commit identity" in result.stdout
 
 
 def test_verifier_recomputes_callable_fingerprint_from_reviewed_source(tmp_path, monkeypatch):
@@ -109,11 +123,6 @@ def test_verifier_rejects_forged_clean_claim_for_dirty_review_source(tmp_path, m
     receipt = _receipt(tmp_path, monkeypatch)
     data = json.loads(receipt.read_text(encoding="utf-8"))
     review = _review_root(tmp_path)
-    subprocess.run(["git", "init"], cwd=review, check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=review, check=True)
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=review, check=True)
-    subprocess.run(["git", "add", "."], cwd=review, check=True)
-    subprocess.run(["git", "commit", "-m", "review baseline"], cwd=review, check=True, capture_output=True)
     head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=review, text=True).strip()
     target_relative = "tools/approval.py"
     target = review / target_relative

--- a/tests/tools/test_computer_use_attestation_verifier.py
+++ b/tests/tools/test_computer_use_attestation_verifier.py
@@ -77,6 +77,11 @@ def _receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     receipt = computer_use.write_computer_use_runtime_attestation(
         require_active_cua=True
     )
+    # Most verifier unit tests exercise content identity without independent
+    # commit authority. Keep that fixture stable whether the developer's
+    # source tree is dirty (pre-commit review) or clean (post-deploy review).
+    if receipt.get("source_identity", {}).get("kind") == "git-clean":
+        receipt["source_identity"]["kind"] = "dirty-attested-source"
     path = tmp_path / "receipt.json"
     path.write_text(json.dumps(receipt), encoding="utf-8")
     return path
@@ -131,7 +136,7 @@ def _committed_review_root(tmp_path: Path) -> Path:
         [
             "git", "-c", "user.name=Hermes Test", "-c",
             "user.email=hermes-test@example.invalid", "commit", "--quiet",
-            "-m", "test: materialize current attestation candidate",
+            "--allow-empty", "-m", "test: materialize current attestation candidate",
         ],
         cwd=review,
         check=True,

--- a/tests/tools/test_computer_use_attestation_verifier.py
+++ b/tests/tools/test_computer_use_attestation_verifier.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "verify_cua_gateway_attestation.py"
+
+
+def _receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from tools.computer_use import tool as computer_use
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    receipt = computer_use.write_computer_use_runtime_attestation()
+    path = tmp_path / "receipt.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+    return path
+
+
+def _review_root(tmp_path: Path) -> Path:
+    from tools.computer_use.tool import _CUA_ATTESTATION_MODULES
+
+    review = tmp_path / "review"
+    for relative in _CUA_ATTESTATION_MODULES:
+        source = ROOT / relative
+        destination = review / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    return review
+
+
+def _verify(receipt: Path, review: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--receipt",
+            str(receipt),
+            "--review-root",
+            str(review),
+            "--deployed-root",
+            str(ROOT),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_verifier_accepts_exact_reviewed_source(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode == 0, result.stderr
+    assert "reviewed content identity" in result.stdout
+
+
+def test_verifier_recomputes_callable_fingerprint_from_reviewed_source(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    review = _review_root(tmp_path)
+    target = review / "tools/computer_use/cua_backend.py"
+    target.write_text(target.read_text(encoding="utf-8").replace("def _run_input_action(", "def _run_input_action(\n        # reviewed-source mutation\n", 1), encoding="utf-8")
+    result = _verify(receipt, review)
+    assert result.returncode != 0
+    assert "module hash mismatch" in result.stderr or "callable fingerprint mismatch" in result.stderr
+
+
+def test_verifier_rejects_missing_fixed_cua_policy_entry(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["callables"].pop("tools.computer_use.cua_backend:CuaDriverBackend._run_input_action")
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "fixed callable policy" in result.stderr
+
+
+def test_verifier_rejects_python_semantic_mismatch(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["runtime"]["python_version"] = [0, 0, 0]
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "runtime Python semantics mismatch" in result.stderr
+
+
+def test_verifier_rejects_receipt_controlled_deployed_source_path(tmp_path, monkeypatch):
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    data["modules"]["tools/computer_use/cua_backend.py"]["source_path"] = (
+        "C:/forged/deployment/tools/computer_use/cua_backend.py"
+    )
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+    result = _verify(receipt, _review_root(tmp_path))
+    assert result.returncode != 0
+    assert "receipt deployed source path mismatch" in result.stderr
+
+
+def test_verifier_rejects_forged_clean_claim_for_dirty_review_source(tmp_path, monkeypatch):
+    import hashlib
+
+    receipt = _receipt(tmp_path, monkeypatch)
+    data = json.loads(receipt.read_text(encoding="utf-8"))
+    review = _review_root(tmp_path)
+    subprocess.run(["git", "init"], cwd=review, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=review, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=review, check=True)
+    subprocess.run(["git", "add", "."], cwd=review, check=True)
+    subprocess.run(["git", "commit", "-m", "review baseline"], cwd=review, check=True, capture_output=True)
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=review, text=True).strip()
+    target_relative = "tools/approval.py"
+    target = review / target_relative
+    target.write_text(target.read_text(encoding="utf-8") + "\n# forged dirty review bytes\n", encoding="utf-8")
+    raw = target.read_bytes()
+    data["modules"][target_relative]["size"] = len(raw)
+    data["modules"][target_relative]["sha256"] = hashlib.sha256(raw).hexdigest()
+    data["source_identity"]["kind"] = "git-clean"
+    data["source_identity"]["repository"] = {
+        "vcs": "git",
+        "root": str(review),
+        "head_commit": head,
+        "head_tree": subprocess.check_output(["git", "rev-parse", "HEAD^{tree}"], cwd=review, text=True).strip(),
+    }
+    for relative, row in data["source_identity"]["attested_paths"].items():
+        row["matches_head"] = True
+        row["worktree_sha256"] = data["modules"][relative]["sha256"]
+        row["head_blob"] = subprocess.check_output(
+            ["git", "rev-parse", f"HEAD:{relative}"], cwd=review, text=True
+        ).strip()
+    receipt.write_text(json.dumps(data), encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--receipt",
+            str(receipt),
+            "--review-root",
+            str(review),
+            "--deployed-root",
+            str(ROOT),
+            "--expected-commit",
+            head,
+        ],
+        cwd=ROOT, text=True, capture_output=True, check=False,
+    )
+    assert result.returncode != 0
+    assert "does not match clean HEAD" in result.stderr

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -167,9 +167,9 @@ def test_unrestricted_embedded_daemon_uses_private_socket_and_two_part_ack():
     from tools.computer_use import cua_backend
 
     process = Mock()
-    process.poll.return_value = None
     process.stderr = []
     process.wait.return_value = 0
+    process.poll.side_effect = lambda: 0 if process.wait.called else None
     status = SimpleNamespace(returncode=0, stdout="running", stderr="")
     stopped = SimpleNamespace(returncode=0, stdout="", stderr="")
 

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -276,7 +276,7 @@ def test_release_seam_stops_exact_backend_and_clears_session_state():
     assert computer_use._backends["conversation-b"] is second
 
 
-def test_release_seam_evicts_state_even_when_backend_stop_fails():
+def test_release_seam_retains_failed_generation_when_backend_stop_fails():
     from tools.computer_use import tool as computer_use
 
     backend = MagicMock()
@@ -285,10 +285,11 @@ def test_release_seam_evicts_state_even_when_backend_stop_fails():
     computer_use._backend_call_locks["failed-run"] = computer_use.threading.RLock()
     computer_use._session_auto_approve["failed-run"] = True
 
-    assert computer_use.release_computer_use_session("failed-run") is True
-    assert "failed-run" not in computer_use._backends
-    assert "failed-run" not in computer_use._backend_call_locks
+    assert computer_use.release_computer_use_session("failed-run") is False
+    assert computer_use._backends["failed-run"] is backend
+    assert "failed-run" in computer_use._backend_call_locks
     assert "failed-run" not in computer_use._session_auto_approve
+    assert computer_use.computer_use_lifecycle_snapshot()["failed-run"]["state"] == "FAILED"
 
 
 def test_release_seam_waits_for_in_flight_action_before_stopping_backend():

--- a/tests/tools/test_computer_use_lifecycle.py
+++ b/tests/tools/test_computer_use_lifecycle.py
@@ -1069,6 +1069,7 @@ def test_runtime_attestation_binds_live_pid_to_loaded_source_bytes(
     import hashlib
     import json
     import os
+    import sys
     from pathlib import Path
 
     from tools.computer_use import tool as computer_use
@@ -1080,6 +1081,12 @@ def test_runtime_attestation_binds_live_pid_to_loaded_source_bytes(
     )
 
     assert persisted["pid"] == os.getpid() == receipt["pid"]
+    import psutil
+
+    assert Path(persisted["executable"]).resolve() == Path(
+        psutil.Process(os.getpid()).exe()
+    ).resolve()
+    assert Path(persisted["launcher"]).resolve() == Path(sys.executable).resolve()
     assert persisted["process_create_time"] > 0
     archive = Path(persisted["archive_path"])
     assert archive.exists()

--- a/tests/tools/test_computer_use_lifecycle.py
+++ b/tests/tools/test_computer_use_lifecycle.py
@@ -1251,3 +1251,111 @@ def test_async_bridge_stop_refuses_to_forget_a_live_thread():
 
     assert bridge._thread is thread
     assert bridge._loop is loop
+
+
+def test_magicmock_backend_does_not_synthesize_runtime_attestation_requirement():
+    from tools.computer_use import tool as computer_use
+
+    backend = MagicMock()
+    backend.start.return_value = None
+    attest = MagicMock()
+    computer_use.set_computer_use_session_validator(lambda _route, _sid: True)
+    publication = computer_use.publish_computer_use_session(
+        "mock-session",
+        route_key="telegram:dm:mock",
+    )
+    try:
+        with (
+            patch(
+                "tools.computer_use.cua_backend.CuaDriverBackend",
+                return_value=backend,
+            ),
+            patch.object(
+                computer_use,
+                "write_computer_use_runtime_attestation",
+                attest,
+            ),
+        ):
+            assert computer_use._get_backend("mock-session") is backend
+        attest.assert_not_called()
+    finally:
+        computer_use.unpublish_computer_use_session(publication)
+
+
+def test_backend_activation_refreshes_active_runtime_attestation_before_success():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    backend._requires_runtime_attestation = True
+    attest = MagicMock()
+    captured_attestation = {}
+    backend.set_runtime_attestation_callback = lambda callback: (
+        captured_attestation.update(callback=callback)
+    )
+    factory = MagicMock(return_value=backend)
+    computer_use.set_computer_use_session_validator(lambda _route, _sid: True)
+    publication = computer_use.publish_computer_use_session(
+        "attested-session",
+        route_key="telegram:dm:1",
+    )
+    try:
+        with (
+            patch(
+                "tools.computer_use.cua_backend.CuaDriverBackend",
+                factory,
+            ),
+            patch.object(
+                computer_use,
+                "write_computer_use_runtime_attestation",
+                attest,
+            ),
+        ):
+            assert computer_use._get_backend("attested-session") is backend
+            attest.assert_called_once_with(require_active_cua=True)
+            replacement_attestation = captured_attestation["callback"]
+            replacement_attestation()
+            assert attest.call_count == 2
+        assert computer_use.computer_use_lifecycle_snapshot()["attested-session"][
+            "state"
+        ] == "ACTIVE"
+    finally:
+        computer_use.unpublish_computer_use_session(publication)
+
+
+def test_installed_publication_validator_heals_current_compression_child(tmp_path):
+    from datetime import datetime
+
+    from gateway.config import GatewayConfig
+    from gateway.session import SessionEntry, SessionStore
+    from hermes_state import SessionDB
+    from tools.computer_use import tool as computer_use
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("parent", source="telegram")
+    db.end_session("parent", "compression")
+    db.create_session("child", source="telegram", parent_session_id="parent")
+    now = datetime.now()
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    store._db = db
+    store._loaded = True
+    store._entries = {
+        "telegram:dm:compression": SessionEntry(
+            session_key="telegram:dm:compression",
+            session_id="parent",
+            created_at=now,
+            updated_at=now,
+        )
+    }
+
+    assert not store.route_matches("telegram:dm:compression", "child")
+    computer_use.set_computer_use_session_validator(store.ensure_route_matches)
+    publication = computer_use.publish_computer_use_session(
+        "child",
+        route_key="telegram:dm:compression",
+    )
+    try:
+        assert publication.session_id == "child"
+        assert store.route_matches("telegram:dm:compression", "child")
+    finally:
+        computer_use.unpublish_computer_use_session(publication)
+        db.close()

--- a/tests/tools/test_computer_use_lifecycle.py
+++ b/tests/tools/test_computer_use_lifecycle.py
@@ -1104,6 +1104,7 @@ def test_runtime_attestation_binds_live_pid_to_loaded_source_bytes(
         "tools/computer_use/browser_route.py",
         "gateway/run.py",
         "gateway/session.py",
+        "hermes_state.py",
         "tools/approval.py",
     }
     assert set(persisted["modules"]) == expected_modules
@@ -1119,6 +1120,12 @@ def test_runtime_attestation_binds_live_pid_to_loaded_source_bytes(
         assert row["source_relative_path"] in expected_modules
     assert "tools.computer_use.cua_backend:CuaDriverBackend._run_input_action" in persisted["callables"]
     assert "tools.computer_use.cua_backend:_CuaDriverSession.call_tool" in persisted["callables"]
+    assert "hermes_state:SessionDB.promote_to_session_reset" in persisted["callables"]
+    assert "hermes_state:SessionDB.publish_compression_child" in persisted["callables"]
+    assert "hermes_state:SessionDB._execute_write" in persisted["callables"]
+    assert persisted["parent"]["pid"] == os.getppid()
+    assert persisted["parent"]["process_create_time"] > 0
+    assert persisted["parent"]["executable"]
 
 
 def test_runtime_attestation_fails_closed_when_process_identity_is_unavailable(

--- a/tests/tools/test_computer_use_lifecycle.py
+++ b/tests/tools/test_computer_use_lifecycle.py
@@ -1092,13 +1092,51 @@ def test_runtime_attestation_binds_live_pid_to_loaded_source_bytes(
     assert archive.exists()
     archived = json.loads(archive.read_text())
     assert archived == persisted
-    source = str(Path(computer_use.__file__).resolve())
-    assert persisted["modules"][source]["sha256"] == hashlib.sha256(
-        Path(source).read_bytes()
-    ).hexdigest()
-    assert persisted["callables"]["publish_computer_use_session"][
-        "code_sha256"
-    ]
+    assert persisted["schema"] == 3
+    assert persisted["runtime"]["python_implementation"]
+    assert persisted["runtime"]["python_version"]
+    assert persisted["source_identity"]["kind"] in {
+        "git-clean", "dirty-attested-source", "unversioned"
+    }
+    expected_modules = {
+        "tools/computer_use/tool.py",
+        "tools/computer_use/cua_backend.py",
+        "tools/computer_use/browser_route.py",
+        "gateway/run.py",
+        "gateway/session.py",
+        "tools/approval.py",
+    }
+    assert set(persisted["modules"]) == expected_modules
+    for relative_path, row in persisted["modules"].items():
+        assert row["source_path"].endswith(relative_path.replace("/", "\\"))
+        assert row["sha256"] == hashlib.sha256(
+            Path(row["source_path"]).read_bytes()
+        ).hexdigest()
+    expected_callables = set(computer_use._CUA_ATTESTATION_CALLABLES)
+    assert set(persisted["callables"]) == expected_callables
+    for row in persisted["callables"].values():
+        assert row["code_sha256"]
+        assert row["source_relative_path"] in expected_modules
+    assert "tools.computer_use.cua_backend:CuaDriverBackend._run_input_action" in persisted["callables"]
+    assert "tools.computer_use.cua_backend:_CuaDriverSession.call_tool" in persisted["callables"]
+
+
+def test_runtime_attestation_fails_closed_when_process_identity_is_unavailable(
+    tmp_path, monkeypatch
+):
+    import sys
+    from unittest.mock import MagicMock
+
+    from tools.computer_use import tool as computer_use
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    unavailable = MagicMock()
+    unavailable.Process.side_effect = OSError("denied")
+    monkeypatch.setitem(sys.modules, "psutil", unavailable)
+
+    with pytest.raises(RuntimeError, match="could not attest live gateway process identity"):
+        computer_use.write_computer_use_runtime_attestation()
+    assert not (tmp_path / "runtime" / "cua_gateway_attestation.json").exists()
 
 
 def test_unconfirmed_action_timeout_poisons_generation_before_lease_release():

--- a/tests/tools/test_computer_use_lifecycle.py
+++ b/tests/tools/test_computer_use_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import concurrent.futures
 import queue
 import threading
@@ -62,6 +63,343 @@ def test_release_result_rejects_empty_or_generation_mismatch_without_stopping():
     assert mismatch.status == "mismatch"
     assert backend.stop_calls == 0
     assert computer_use.get_computer_use_session_generation("session-a") == generation
+
+
+@pytest.mark.parametrize("invalid_generation", [None, True, False, 0, -1, "1", 1.0])
+def test_release_result_rejects_invalid_generation_without_stopping(invalid_generation):
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("strict-generation")
+
+    actual_generation = computer_use.get_computer_use_session_generation("strict-generation")
+    assert actual_generation is not None
+
+    result = computer_use.release_computer_use_session_result(
+        "strict-generation",
+        expected_generation=invalid_generation,
+        reason="strict_validation",
+    )
+
+    assert result.status == "mismatch"
+    assert result.error == "expected_generation must be a positive integer"
+    assert backend.stop_calls == 0
+    assert computer_use.get_computer_use_session_generation("strict-generation") == actual_generation
+
+
+def test_release_result_omitted_generation_snapshots_exact_active_generation():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("result-compat")
+
+    generation = computer_use.get_computer_use_session_generation("result-compat")
+    assert generation is not None
+
+    result = computer_use.release_computer_use_session_result("result-compat")
+
+    assert result.status == "released"
+    assert result.generation == generation
+    assert backend.stop_calls == 1
+    assert computer_use.get_computer_use_session_generation("result-compat") is None
+
+
+def test_release_result_omitted_generation_is_idempotent_when_absent():
+    from tools.computer_use import tool as computer_use
+
+    result = computer_use.release_computer_use_session_result("result-compat-absent")
+
+    assert result.status == "already_absent"
+    assert result.generation is None
+
+
+def test_terminal_transition_fence_blocks_same_session_backend_recreation():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("terminal-fence")
+        generation = computer_use.get_computer_use_session_generation("terminal-fence")
+        token = computer_use.begin_computer_use_terminal_transition(
+            "terminal-fence"
+        )
+        try:
+            result = computer_use.release_computer_use_session_result(
+                "terminal-fence",
+                expected_generation=generation,
+                reason="test_terminal_fence",
+            )
+            assert result.released
+            with pytest.raises(RuntimeError, match="terminal transition"):
+                computer_use._get_backend("terminal-fence")
+        finally:
+            computer_use.end_computer_use_terminal_transition(token)
+
+        replacement = computer_use._get_backend("terminal-fence")
+        assert replacement is backend
+        replacement_generation = computer_use.get_computer_use_session_generation(
+            "terminal-fence"
+        )
+        assert replacement_generation > generation
+        assert computer_use.release_computer_use_session_result(
+            "terminal-fence",
+            expected_generation=replacement_generation,
+            reason="test_cleanup",
+        ).released
+
+
+def test_terminal_transition_rejects_action_that_looked_up_before_fence():
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    lookup_complete = threading.Event()
+    allow_revalidation = threading.Event()
+
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("stale-terminal-call")
+        generation = computer_use.get_computer_use_session_generation(
+            "stale-terminal-call"
+        )
+
+        def stale_lookup(*, session_id):
+            lookup_complete.set()
+            assert allow_revalidation.wait(timeout=2)
+            return backend
+
+        with patch.object(computer_use, "_get_backend", side_effect=stale_lookup):
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                acquire = pool.submit(
+                    computer_use._acquire_backend_for_call,
+                    "stale-terminal-call",
+                )
+                assert lookup_complete.wait(timeout=1)
+                transition = computer_use.begin_computer_use_terminal_transition(
+                    "stale-terminal-call"
+                )
+                allow_revalidation.set()
+                with pytest.raises(RuntimeError, match="changed while acquiring"):
+                    acquire.result(timeout=2)
+
+        try:
+            assert computer_use.release_computer_use_session_result(
+                "stale-terminal-call",
+                expected_generation=generation,
+                reason="test_terminal_fence",
+            ).released
+        finally:
+            computer_use.end_computer_use_terminal_transition(transition)
+
+
+def test_successful_terminal_transition_retires_old_session_id():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("retired-route")
+        transition = computer_use.begin_computer_use_terminal_transition(
+            "retired-route"
+        )
+        released = computer_use.release_computer_use_session_result(
+            "retired-route",
+            expected_generation=transition.generation,
+            timeout=1.0,
+            reason="test-retire",
+        )
+        assert released.status == "released"
+        computer_use.end_computer_use_terminal_transition(
+            transition,
+            retire=True,
+        )
+        with pytest.raises(RuntimeError, match="retired"):
+            computer_use._get_backend("retired-route")
+
+
+def test_managed_route_publication_registry_reclaims_all_idle_sessions():
+    from tools.computer_use import tool as computer_use
+
+    for index in range(4096):
+        sid = f"managed-route-{index}"
+        publication = computer_use.publish_computer_use_session(sid)
+        computer_use.unpublish_computer_use_session(publication)
+
+    assert computer_use._managed_session_publications == {}
+    with pytest.raises(RuntimeError, match="retired or unpublished"):
+        computer_use._get_backend("managed-route-0")
+
+
+def test_managed_route_publication_is_reference_counted():
+    from tools.computer_use import tool as computer_use
+
+    sid = "concurrent-managed-route"
+    first = computer_use.publish_computer_use_session(sid)
+    second = computer_use.publish_computer_use_session(sid)
+    computer_use.unpublish_computer_use_session(first)
+    assert computer_use._managed_session_publications == {sid: {second}}
+    computer_use.unpublish_computer_use_session(second)
+    assert computer_use._managed_session_publications == {}
+
+
+def test_failed_terminal_transition_restores_exact_publication_lease():
+    from tools.computer_use import tool as computer_use
+
+    sid = "rollback-publication"
+    publication = computer_use.publish_computer_use_session(sid)
+    transition = computer_use.begin_computer_use_terminal_transition(sid)
+    assert publication.active is False
+
+    computer_use.end_computer_use_terminal_transition(
+        transition,
+        retire=False,
+    )
+    assert publication.active is True
+    computer_use.unpublish_computer_use_session(publication)
+    assert computer_use._managed_session_publications == {}
+
+
+def test_retired_session_reactivation_is_fenced_until_publication():
+    from tools.computer_use import tool as computer_use
+
+    first = _Backend()
+    second = _Backend()
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend",
+        side_effect=[first, second],
+    ):
+        computer_use._get_backend("historical-route")
+        first_generation = computer_use.get_computer_use_session_generation(
+            "historical-route"
+        )
+        terminal = computer_use.begin_computer_use_terminal_transition(
+            "historical-route"
+        )
+        released = computer_use.release_computer_use_session_result(
+            "historical-route",
+            expected_generation=first_generation,
+            reason="switch_away",
+        )
+        assert released.released
+        computer_use.end_computer_use_terminal_transition(terminal, retire=True)
+
+        reactivation = computer_use.begin_computer_use_session_reactivation(
+            "historical-route"
+        )
+        with pytest.raises(RuntimeError, match="fenced"):
+            computer_use._get_backend("historical-route")
+        computer_use.end_computer_use_session_reactivation(
+            reactivation,
+            succeeded=True,
+        )
+        publication = computer_use.publish_computer_use_session(
+            "historical-route"
+        )
+        try:
+            assert computer_use._get_backend("historical-route") is second
+            second_generation = computer_use.get_computer_use_session_generation(
+                "historical-route"
+            )
+        finally:
+            computer_use.unpublish_computer_use_session(publication)
+
+    assert second_generation > first_generation
+
+
+def test_reactivation_completion_advances_scalar_route_epoch():
+    from tools.computer_use import tool as computer_use
+
+    reactivation = computer_use.begin_computer_use_session_reactivation(
+        "reactivation-epoch"
+    )
+    before_completion = computer_use._session_route_epoch_sequence
+    computer_use.end_computer_use_session_reactivation(
+        reactivation,
+        succeeded=True,
+    )
+
+    assert computer_use._session_route_epoch_sequence == before_completion + 1
+
+
+def test_stale_lookup_cannot_hop_to_reactivated_backend_generation():
+    from tools.computer_use import tool as computer_use
+
+    first = _Backend()
+    second = _Backend()
+    looked_up = threading.Event()
+    continue_lookup = threading.Event()
+    original_get = computer_use._get_backend
+
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend",
+        side_effect=[first, second],
+    ):
+        original_get("historical-stale")
+        generation = computer_use.get_computer_use_session_generation(
+            "historical-stale"
+        )
+
+        def blocked_get(session_id=""):
+            backend = original_get(session_id)
+            looked_up.set()
+            assert continue_lookup.wait(timeout=2)
+            return backend
+
+        with patch.object(computer_use, "_get_backend", side_effect=blocked_get):
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                stale = pool.submit(
+                    computer_use._acquire_backend_for_call,
+                    "historical-stale",
+                )
+                assert looked_up.wait(timeout=1)
+
+                terminal = computer_use.begin_computer_use_terminal_transition(
+                    "historical-stale"
+                )
+                released = computer_use.release_computer_use_session_result(
+                    "historical-stale",
+                    expected_generation=generation,
+                    reason="switch_away",
+                )
+                assert released.released
+                computer_use.end_computer_use_terminal_transition(
+                    terminal,
+                    retire=True,
+                )
+                reactivation = computer_use.begin_computer_use_session_reactivation(
+                    "historical-stale"
+                )
+                computer_use.end_computer_use_session_reactivation(
+                    reactivation,
+                    succeeded=True,
+                )
+                publication = computer_use.publish_computer_use_session(
+                    "historical-stale"
+                )
+                try:
+                    original_get("historical-stale")
+                    continue_lookup.set()
+
+                    with pytest.raises(RuntimeError, match="changed while acquiring"):
+                        stale.result(timeout=2)
+                finally:
+                    computer_use.unpublish_computer_use_session(publication)
+
+
+def test_public_bool_release_snapshots_exact_generation_before_teardown():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("bool-adapter")
+
+    generation = computer_use.get_computer_use_session_generation("bool-adapter")
+    assert generation is not None
+    assert computer_use.release_computer_use_session("bool-adapter") is True
+    assert backend.stop_calls == 1
+    assert computer_use.get_computer_use_session_generation("bool-adapter") is None
 
 
 def test_start_failure_attempts_cleanup_and_removes_confirmed_stopped_record():
@@ -435,6 +773,18 @@ def test_cleanup_supervisor_shutdown_is_bounded_with_blocked_daemon_worker():
     assert not any(worker.is_alive() for worker in supervisor._workers)
 
 
+@pytest.mark.parametrize("invalid_generation", [None, True, False, 0, -1, "1", 1.0])
+def test_supervised_release_rejects_invalid_generation_before_enqueue(invalid_generation):
+    from tools.computer_use import tool as computer_use
+
+    with pytest.raises(ValueError, match="expected_generation must be a positive integer"):
+        computer_use.submit_computer_use_session_release(
+            "strict-submit",
+            expected_generation=invalid_generation,
+            reason="strict_submit",
+        )
+
+
 def test_tracked_cleanup_supervisor_returns_future_and_drains():
     from tools.computer_use import tool as computer_use
 
@@ -604,6 +954,29 @@ def test_cua_session_unconfirmed_cancellation_raises_and_remains_retryable():
     assert session._started is False
 
 
+def test_backend_stop_retains_bridge_when_session_stop_is_unconfirmed():
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    session = MagicMock()
+    session._started = False
+    session.stop.side_effect = RuntimeError("session teardown unconfirmed")
+    bridge = MagicMock()
+    backend._session = session
+    backend._bridge = bridge
+    backend._embedded_daemon = None
+
+    with pytest.raises(RuntimeError, match="session teardown unconfirmed"):
+        backend.stop()
+
+    bridge.stop.assert_not_called()
+
+    session.stop.side_effect = None
+    backend.stop()
+    assert session.stop.call_count == 2
+    bridge.stop.assert_called_once_with()
+
+
 def test_embedded_daemon_stop_failure_retains_process_for_retry():
     from tools.computer_use.cua_backend import _EmbeddedCuaDaemon
 
@@ -619,6 +992,86 @@ def test_embedded_daemon_stop_failure_retains_process_for_retry():
         daemon.stop()
 
     assert daemon._process is process
+
+
+def test_async_bridge_run_cancels_and_confirms_timed_out_coroutine():
+    from tools.computer_use.cua_backend import _AsyncBridge
+
+    bridge = _AsyncBridge()
+    started = threading.Event()
+    finalized = threading.Event()
+
+    async def blocked_action():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            finalized.set()
+
+    bridge.start()
+    try:
+        with pytest.raises(concurrent.futures.TimeoutError):
+            bridge.run(blocked_action(), timeout=0.02)
+        assert started.is_set()
+        assert finalized.wait(timeout=0.5)
+    finally:
+        bridge.stop()
+
+
+def test_async_bridge_run_retains_unconfirmed_timeout_until_coroutine_finishes():
+    from tools.computer_use.cua_backend import _AsyncBridge
+
+    bridge = _AsyncBridge()
+    bridge._CALL_CANCEL_CONFIRM_TIMEOUT = 0.02
+    release = threading.Event()
+    finalized = threading.Event()
+
+    async def cancellation_resistant_action():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            while not release.is_set():
+                await asyncio.sleep(0.005)
+        finally:
+            finalized.set()
+
+    bridge.start()
+    timer = threading.Timer(0.2, release.set)
+    timer.start()
+    try:
+        with pytest.raises(RuntimeError, match="cancellation was not confirmed"):
+            bridge.run(cancellation_resistant_action(), timeout=0.01)
+        with bridge._inflight_lock:
+            assert any(not event.is_set() for event in bridge._inflight_events)
+        assert finalized.wait(timeout=1.0)
+        bridge.stop()
+    finally:
+        timer.cancel()
+        release.set()
+        if bridge._thread is not None:
+            bridge.stop()
+
+
+def test_async_bridge_stop_refuses_to_stop_with_unconfirmed_inflight_call():
+    from tools.computer_use.cua_backend import _AsyncBridge
+
+    bridge = _AsyncBridge()
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    thread = MagicMock()
+    thread.is_alive.return_value = False
+    pending = threading.Event()
+    bridge._loop = loop
+    bridge._thread = thread
+    bridge._inflight_events.add(pending)
+    bridge._INFLIGHT_DRAIN_TIMEOUT = 0.01
+
+    with pytest.raises(RuntimeError, match="in-flight action"):
+        bridge.stop()
+
+    loop.stop.assert_not_called()
+    assert bridge._thread is thread
+    assert bridge._loop is loop
 
 
 def test_async_bridge_stop_refuses_to_forget_a_live_thread():

--- a/tests/tools/test_computer_use_lifecycle.py
+++ b/tests/tools/test_computer_use_lifecycle.py
@@ -232,6 +232,51 @@ def test_managed_route_publication_registry_reclaims_all_idle_sessions():
         computer_use._get_backend("managed-route-0")
 
 
+def test_stale_caller_cannot_republish_retired_route_after_fence_ends():
+    from tools.computer_use import tool as computer_use
+
+    routes = {"telegram:chat": "retired-session"}
+    computer_use.set_computer_use_session_validator(
+        lambda route_key, sid: routes.get(route_key) == sid
+    )
+    publication = computer_use.publish_computer_use_session(
+        "retired-session", route_key="telegram:chat"
+    )
+    computer_use.unpublish_computer_use_session(publication)
+
+    transition = computer_use.begin_computer_use_terminal_transition(
+        "retired-session"
+    )
+    routes["telegram:chat"] = "replacement-session"
+    computer_use.end_computer_use_terminal_transition(transition, retire=True)
+
+    with pytest.raises(RuntimeError, match="authoritative route"):
+        computer_use.publish_computer_use_session(
+            "retired-session", route_key="telegram:chat"
+        )
+    with pytest.raises(RuntimeError, match="retired or unpublished"):
+        computer_use._get_backend("retired-session")
+
+
+def test_publication_is_bound_to_exact_route_key_not_only_session_id():
+    from tools.computer_use import tool as computer_use
+
+    routes = {"route-a": "shared-session", "route-b": "other-session"}
+    computer_use.set_computer_use_session_validator(
+        lambda route_key, sid: routes.get(route_key) == sid
+    )
+
+    with pytest.raises(RuntimeError, match="authoritative route"):
+        computer_use.publish_computer_use_session(
+            "shared-session", route_key="route-b"
+        )
+    publication = computer_use.publish_computer_use_session(
+        "shared-session", route_key="route-a"
+    )
+    assert publication.route_key == "route-a"
+    computer_use.unpublish_computer_use_session(publication)
+
+
 def test_managed_route_publication_is_reference_counted():
     from tools.computer_use import tool as computer_use
 
@@ -1016,6 +1061,70 @@ def test_async_bridge_run_cancels_and_confirms_timed_out_coroutine():
         assert finalized.wait(timeout=0.5)
     finally:
         bridge.stop()
+
+
+def test_runtime_attestation_binds_live_pid_to_loaded_source_bytes(
+    tmp_path, monkeypatch
+):
+    import hashlib
+    import json
+    import os
+    from pathlib import Path
+
+    from tools.computer_use import tool as computer_use
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    receipt = computer_use.write_computer_use_runtime_attestation()
+    persisted = json.loads(
+        (tmp_path / "runtime" / "cua_gateway_attestation.json").read_text()
+    )
+
+    assert persisted["pid"] == os.getpid() == receipt["pid"]
+    assert persisted["process_create_time"] > 0
+    archive = Path(persisted["archive_path"])
+    assert archive.exists()
+    archived = json.loads(archive.read_text())
+    assert archived == persisted
+    source = str(Path(computer_use.__file__).resolve())
+    assert persisted["modules"][source]["sha256"] == hashlib.sha256(
+        Path(source).read_bytes()
+    ).hexdigest()
+    assert persisted["callables"]["publish_computer_use_session"][
+        "code_sha256"
+    ]
+
+
+def test_unconfirmed_action_timeout_poisons_generation_before_lease_release():
+    from tools.computer_use import tool as computer_use
+    from tools.computer_use.cua_backend import CuaActionTerminationUnconfirmed
+
+    class _TimeoutBackend(_Backend):
+        def __init__(self):
+            super().__init__()
+            self.capture_calls = 0
+
+        def capture(self, **_kwargs):
+            self.capture_calls += 1
+            raise CuaActionTerminationUnconfirmed(
+                "cua-driver action timed out and cancellation was not confirmed"
+            )
+
+    backend = _TimeoutBackend()
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend
+    ):
+        first = computer_use.handle_computer_use(
+            {"action": "capture"}, session_id="timeout-poison"
+        )
+        second = computer_use.handle_computer_use(
+            {"action": "capture"}, session_id="timeout-poison"
+        )
+
+    assert "cancellation was not confirmed" in first
+    assert "cleanup failed; retry release" in second
+    assert backend.capture_calls == 1
+    snapshot = computer_use.computer_use_lifecycle_snapshot()["timeout-poison"]
+    assert snapshot["state"] == "FAILED"
 
 
 def test_async_bridge_run_retains_unconfirmed_timeout_until_coroutine_finishes():

--- a/tests/tools/test_computer_use_lifecycle.py
+++ b/tests/tools/test_computer_use_lifecycle.py
@@ -1,0 +1,639 @@
+from __future__ import annotations
+
+import concurrent.futures
+import queue
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_lifecycle():
+    from tools.computer_use import tool as computer_use
+
+    computer_use.reset_backend_for_tests()
+    yield
+    computer_use.reset_backend_for_tests()
+
+
+class _Backend:
+    def __init__(self, *, stop_entered=None, stop_continue=None, stop_error=None):
+        self.stop_entered = stop_entered
+        self.stop_continue = stop_continue
+        self.stop_error = stop_error
+        self.started = False
+        self.stop_calls = 0
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stop_calls += 1
+        if self.stop_entered is not None:
+            self.stop_entered.set()
+        if self.stop_continue is not None:
+            assert self.stop_continue.wait(timeout=2)
+        if self.stop_error is not None:
+            raise self.stop_error
+        self.started = False
+
+
+def test_release_result_rejects_empty_or_generation_mismatch_without_stopping():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("session-a")
+
+    generation = computer_use.get_computer_use_session_generation("session-a")
+    assert generation is not None
+
+    empty = computer_use.release_computer_use_session_result(
+        "", expected_generation=generation, reason="dead_session"
+    )
+    mismatch = computer_use.release_computer_use_session_result(
+        "session-a", expected_generation=generation + 1, reason="dead_session"
+    )
+
+    assert empty.status == "mismatch"
+    assert mismatch.status == "mismatch"
+    assert backend.stop_calls == 0
+    assert computer_use.get_computer_use_session_generation("session-a") == generation
+
+
+def test_start_failure_attempts_cleanup_and_removes_confirmed_stopped_record():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    backend.start = MagicMock(side_effect=RuntimeError("partial startup"))
+    backend.stop = MagicMock()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        with pytest.raises(RuntimeError, match="partial startup"):
+            computer_use._get_backend("start-failed")
+
+    backend.stop.assert_called_once_with()
+    assert computer_use.get_computer_use_session_generation("start-failed") is None
+    assert "start-failed" not in computer_use._backends
+
+
+def test_same_sid_recreation_is_rejected_while_exact_generation_is_closing():
+    from tools.computer_use import tool as computer_use
+
+    stop_entered = threading.Event()
+    stop_continue = threading.Event()
+    backend = _Backend(stop_entered=stop_entered, stop_continue=stop_continue)
+    created = [backend]
+
+    def factory(permission_mode="standard"):
+        if len(created) == 1:
+            return created[0]
+        replacement = _Backend()
+        created.append(replacement)
+        return replacement
+
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", side_effect=factory):
+        computer_use._get_backend("session-a")
+        generation = computer_use.get_computer_use_session_generation("session-a")
+        assert generation is not None
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(
+                computer_use.release_computer_use_session_result,
+                "session-a",
+                expected_generation=generation,
+                timeout=1.0,
+                reason="dead_session",
+            )
+            assert stop_entered.wait(timeout=1)
+            with pytest.raises(RuntimeError, match="closing"):
+                computer_use._get_backend("session-a")
+            assert len(created) == 1
+            stop_continue.set()
+            result = future.result(timeout=2)
+
+    assert result.status == "released"
+    again = computer_use.release_computer_use_session_result(
+        "session-a",
+        expected_generation=generation,
+        timeout=0.2,
+        reason="duplicate",
+    )
+    assert again.status == "already_absent"
+    assert backend.stop_calls == 1
+    assert computer_use.get_computer_use_session_generation("session-a") is None
+
+
+def test_action_lease_revalidates_after_release_wins_post_lookup_race():
+    from tools.computer_use import tool as computer_use
+
+    old_backend = _Backend()
+    replacement = _Backend()
+    with patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend",
+        side_effect=[old_backend, replacement],
+    ):
+        computer_use._get_backend("session-a")
+        generation = computer_use.get_computer_use_session_generation("session-a")
+        original_get = computer_use._get_backend
+        looked_up = threading.Event()
+        continue_lookup = threading.Event()
+        calls = 0
+
+        def delayed_get(session_id=""):
+            nonlocal calls
+            backend = original_get(session_id)
+            calls += 1
+            if calls == 1:
+                looked_up.set()
+                assert continue_lookup.wait(timeout=2)
+            return backend
+
+        with patch.object(computer_use, "_get_backend", side_effect=delayed_get):
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                def acquire_and_release():
+                    backend, lease = computer_use._acquire_backend_for_call(
+                        "session-a"
+                    )
+                    lease.release()
+                    return backend
+
+                acquired = pool.submit(acquire_and_release)
+                assert looked_up.wait(timeout=1)
+                released = computer_use.release_computer_use_session_result(
+                    "session-a",
+                    expected_generation=generation,
+                    reason="race_test",
+                )
+                assert released.status == "released"
+                continue_lookup.set()
+                leased_backend = acquired.result(timeout=2)
+
+    assert leased_backend is replacement
+    assert leased_backend is not old_backend
+    assert old_backend.stop_calls == 1
+
+
+def test_call_quiescence_timeout_is_truthful_and_blocks_recreation():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("session-a")
+
+    generation = computer_use.get_computer_use_session_generation("session-a")
+    call_lock = computer_use._backend_call_locks["session-a"]
+    held = threading.Event()
+    release_hold = threading.Event()
+
+    def hold_call_lock():
+        with call_lock:
+            held.set()
+            release_hold.wait(timeout=2)
+
+    thread = threading.Thread(target=hold_call_lock)
+    thread.start()
+    assert held.wait(timeout=1)
+    try:
+        result = computer_use.release_computer_use_session_result(
+            "session-a",
+            expected_generation=generation,
+            timeout=0.02,
+            reason="dead_session",
+        )
+        assert result.status == "timed_out"
+        assert backend.stop_calls == 0
+        with pytest.raises(RuntimeError, match="failed"):
+            computer_use._get_backend("session-a")
+        snapshot = computer_use.computer_use_lifecycle_snapshot()
+        assert snapshot["session-a"]["state"] == "FAILED"
+    finally:
+        release_hold.set()
+        thread.join(timeout=2)
+
+
+def test_stop_failure_is_not_reported_as_success_and_can_be_retried():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend(stop_error=RuntimeError("driver teardown failed"))
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("session-a")
+
+    generation = computer_use.get_computer_use_session_generation("session-a")
+    failed = computer_use.release_computer_use_session_result(
+        "session-a",
+        expected_generation=generation,
+        timeout=0.2,
+        reason="dead_session",
+    )
+    assert failed.status == "failed"
+    assert bool(failed) is False
+    assert computer_use.release_computer_use_session("session-a") is False
+
+    backend.stop_error = None
+    released = computer_use.release_computer_use_session_result(
+        "session-a",
+        expected_generation=generation,
+        timeout=0.2,
+        reason="retry",
+    )
+    assert released.status == "released"
+    assert backend.stop_calls >= 2
+    assert computer_use.get_computer_use_session_generation("session-a") is None
+
+
+def test_cleanup_supervisor_defers_and_deduplicates_when_active_capacity_is_full():
+    from tools.computer_use import tool as computer_use
+
+    supervisor = computer_use._CleanupSupervisor(
+        max_workers=1,
+        max_pending=1,
+        max_deferred=2,
+    )
+    started = threading.Event()
+    unblock = threading.Event()
+
+    def blocking_release(sid, **kwargs):
+        if sid == "active":
+            started.set()
+            assert unblock.wait(timeout=2)
+        return computer_use.ComputerUseReleaseResult(
+            session_id=sid,
+            generation=kwargs.get("expected_generation"),
+            status="released",
+            reason=kwargs.get("reason", "test"),
+        )
+
+    with patch.object(
+        computer_use,
+        "_release_computer_use_session_with_retries",
+        side_effect=blocking_release,
+    ):
+        active = supervisor.submit(
+            "active",
+            expected_generation=1,
+            timeout=0.1,
+            reason="active",
+            allow_empty_session=False,
+        )
+        assert started.wait(timeout=1)
+        deferred = supervisor.submit(
+            "deferred",
+            expected_generation=2,
+            timeout=0.1,
+            reason="deferred",
+            allow_empty_session=False,
+        )
+        duplicate = supervisor.submit(
+            "deferred",
+            expected_generation=2,
+            timeout=0.1,
+            reason="duplicate",
+            allow_empty_session=False,
+        )
+        assert duplicate is deferred
+        assert deferred.done() is False
+        assert supervisor.snapshot()["pending"] == 1
+        assert supervisor.snapshot()["deferred"] == 1
+        unblock.set()
+        assert active.result(timeout=2).status == "released"
+        assert deferred.result(timeout=2).status == "released"
+
+    assert supervisor.drain(1.0) is True
+    assert supervisor.snapshot()["deferred"] == 0
+    supervisor.shutdown(0.1)
+
+
+def test_cleanup_supervisor_overflow_fails_exact_owner_closed_for_manual_retry():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("retained")
+    generation = computer_use.get_computer_use_session_generation("retained")
+
+    supervisor = computer_use._CleanupSupervisor(
+        max_workers=1,
+        max_pending=1,
+        max_deferred=0,
+    )
+    started = threading.Event()
+    unblock = threading.Event()
+
+    def blocking_release(sid, **kwargs):
+        started.set()
+        assert unblock.wait(timeout=2)
+        return computer_use.ComputerUseReleaseResult(
+            session_id=sid,
+            generation=kwargs.get("expected_generation"),
+            status="already_absent",
+            reason="blocker",
+        )
+
+    with patch.object(
+        computer_use,
+        "_release_computer_use_session_with_retries",
+        side_effect=blocking_release,
+    ):
+        blocker = supervisor.submit(
+            "blocker",
+            expected_generation=999,
+            timeout=0.1,
+            reason="blocker",
+            allow_empty_session=False,
+        )
+        assert started.wait(timeout=1)
+        overflow = supervisor.submit(
+            "retained",
+            expected_generation=generation,
+            timeout=0.1,
+            reason="overflow",
+            allow_empty_session=False,
+        )
+        result = overflow.result(timeout=1)
+        assert result.status == "queue_rejected"
+        assert computer_use.computer_use_lifecycle_snapshot()["retained"]["state"] == "FAILED"
+        unblock.set()
+        blocker.result(timeout=2)
+
+    supervisor.shutdown(0.5)
+    retried = computer_use.release_computer_use_session_result(
+        "retained",
+        expected_generation=generation,
+        timeout=0.2,
+        reason="manual_retry",
+    )
+    assert retried.status == "released"
+
+
+def test_cleanup_supervisor_submit_shutdown_race_is_rejected_without_slot_leak():
+    from tools.computer_use import tool as computer_use
+
+    supervisor = computer_use._CleanupSupervisor(max_workers=1, max_pending=1)
+    with patch.object(
+        supervisor._work_queue,
+        "put_nowait",
+        side_effect=queue.Full,
+    ):
+        future = supervisor.submit(
+            "session-race",
+            expected_generation=1,
+            timeout=0.1,
+            reason="shutdown_race",
+            allow_empty_session=False,
+        )
+    result = future.result(timeout=1)
+    assert result.status == "queue_rejected"
+    assert supervisor.snapshot()["pending"] == 0
+    assert supervisor._slots.acquire(blocking=False) is True
+    supervisor._slots.release()
+    supervisor.shutdown(0.1)
+
+
+def test_cleanup_supervisor_shutdown_is_bounded_with_blocked_daemon_worker():
+    from tools.computer_use import tool as computer_use
+
+    supervisor = computer_use._CleanupSupervisor(max_workers=1, max_pending=1)
+    started = threading.Event()
+    unblock = threading.Event()
+
+    def blocking_release(sid, **kwargs):
+        started.set()
+        assert unblock.wait(timeout=2)
+        return computer_use.ComputerUseReleaseResult(
+            session_id=sid,
+            generation=kwargs.get("expected_generation"),
+            status="released",
+            reason="bounded_shutdown",
+        )
+
+    with patch.object(
+        computer_use,
+        "_release_computer_use_session_with_retries",
+        side_effect=blocking_release,
+    ):
+        future = supervisor.submit(
+            "blocked",
+            expected_generation=1,
+            timeout=0.1,
+            reason="blocked",
+            allow_empty_session=False,
+        )
+        assert started.wait(timeout=1)
+        began = time.monotonic()
+        assert supervisor.shutdown(0.05) is False
+        assert time.monotonic() - began < 0.25
+        assert all(worker.daemon for worker in supervisor._workers)
+        unblock.set()
+        assert future.result(timeout=2).status == "released"
+        assert supervisor.shutdown(1.0) is True
+
+    for worker in supervisor._workers:
+        worker.join(timeout=1)
+    assert not any(worker.is_alive() for worker in supervisor._workers)
+
+
+def test_tracked_cleanup_supervisor_returns_future_and_drains():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend()
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("session-a")
+    generation = computer_use.get_computer_use_session_generation("session-a")
+
+    future = computer_use.submit_computer_use_session_release(
+        "session-a",
+        expected_generation=generation,
+        timeout=0.5,
+        reason="dead_session",
+    )
+    result = future.result(timeout=2)
+
+    assert result.status == "released"
+    assert computer_use.drain_computer_use_cleanup(timeout=1.0) is True
+    assert backend.stop_calls == 1
+    assert computer_use.computer_use_cleanup_snapshot() == {
+        "pending": 0,
+        "deferred": 0,
+        "capacity": 64,
+        "deferred_capacity": 256,
+        "closed": False,
+    }
+    assert isinstance(computer_use.computer_use_process_snapshot(), list)
+
+
+def test_supervised_release_retries_transient_stop_failures():
+    from tools.computer_use import tool as computer_use
+
+    backend = _Backend(stop_error=RuntimeError("transient"))
+    original_stop = backend.stop
+
+    def flaky_stop():
+        if backend.stop_calls < 2:
+            original_stop()
+        backend.stop_error = None
+        original_stop()
+
+    backend.stop = flaky_stop
+    with patch("tools.computer_use.cua_backend.CuaDriverBackend", return_value=backend):
+        computer_use._get_backend("session-retry")
+    generation = computer_use.get_computer_use_session_generation("session-retry")
+
+    future = computer_use.submit_computer_use_session_release(
+        "session-retry",
+        expected_generation=generation,
+        timeout=0.2,
+        reason="retry_test",
+        max_attempts=3,
+        retry_delay=0.0,
+    )
+    result = future.result(timeout=2)
+
+    assert result.status == "released"
+    assert backend.stop_calls == 3
+    assert computer_use.get_computer_use_session_generation("session-retry") is None
+
+
+def test_generation_tombstones_are_bounded_without_evicting_active_owners():
+    from tools.computer_use import tool as computer_use
+
+    with patch.object(computer_use, "_BACKEND_GENERATION_TOMBSTONE_CAP", 3), patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend",
+        side_effect=lambda permission_mode="standard": _Backend(),
+    ):
+        computer_use._get_backend("active")
+        for index in range(6):
+            sid = f"closed-{index}"
+            computer_use._get_backend(sid)
+            generation = computer_use.get_computer_use_session_generation(sid)
+            assert computer_use.release_computer_use_session_result(
+                sid,
+                expected_generation=generation,
+                reason="tombstone_test",
+            ).status == "released"
+
+    assert "active" in computer_use._backend_generation_counters
+    assert len(computer_use._backend_generation_counters) <= 3
+
+
+def test_evicted_tombstone_never_reuses_generation_or_accepts_stale_release():
+    from tools.computer_use import tool as computer_use
+
+    old_victim = _Backend()
+    other = _Backend()
+    fresh_victim = _Backend()
+    with patch.object(computer_use, "_BACKEND_GENERATION_TOMBSTONE_CAP", 1), patch(
+        "tools.computer_use.cua_backend.CuaDriverBackend",
+        side_effect=[old_victim, other, fresh_victim],
+    ):
+        computer_use._get_backend("victim")
+        stale_generation = computer_use.get_computer_use_session_generation("victim")
+        assert computer_use.release_computer_use_session_result(
+            "victim",
+            expected_generation=stale_generation,
+            timeout=0.2,
+            reason="first_close",
+        ).status == "released"
+
+        computer_use._get_backend("other")
+        other_generation = computer_use.get_computer_use_session_generation("other")
+        assert computer_use.release_computer_use_session_result(
+            "other",
+            expected_generation=other_generation,
+            timeout=0.2,
+            reason="evict_old_tombstone",
+        ).status == "released"
+
+        computer_use._get_backend("victim")
+        fresh_generation = computer_use.get_computer_use_session_generation("victim")
+        assert fresh_generation != stale_generation
+        stale = computer_use.release_computer_use_session_result(
+            "victim",
+            expected_generation=stale_generation,
+            timeout=0.2,
+            reason="delayed_stale_close",
+        )
+
+    assert stale.status == "mismatch"
+    assert fresh_victim.stop_calls == 0
+    assert computer_use.get_computer_use_session_generation("victim") == fresh_generation
+
+
+def test_cua_session_timeout_is_cancelled_and_only_then_confirmed_closed():
+    from tools.computer_use.cua_backend import _CuaDriverSession
+
+    future = MagicMock()
+    future.result.side_effect = [
+        concurrent.futures.TimeoutError(),
+        concurrent.futures.CancelledError(),
+    ]
+    future.done.return_value = True
+    session = _CuaDriverSession(MagicMock())
+    session._started = True
+    session._lifecycle_future = future
+    session._signal_shutdown_locked = MagicMock()
+    session._closed_event.set()
+
+    session.stop()
+
+    future.cancel.assert_called_once_with()
+    assert session._lifecycle_future is None
+
+
+def test_cua_session_unconfirmed_cancellation_raises_and_remains_retryable():
+    from tools.computer_use.cua_backend import _CuaDriverSession
+
+    future = MagicMock()
+    future.result.side_effect = [
+        concurrent.futures.TimeoutError(),
+        concurrent.futures.TimeoutError(),
+    ]
+    session = _CuaDriverSession(MagicMock())
+    session._started = True
+    session._lifecycle_future = future
+    session._signal_shutdown_locked = MagicMock()
+    session._closed_event = MagicMock()
+    session._closed_event.wait.return_value = False
+
+    with pytest.raises(RuntimeError, match="did not exit after cancellation"):
+        session.stop()
+
+    assert session._lifecycle_future is future
+    assert session._started is False
+
+
+def test_embedded_daemon_stop_failure_retains_process_for_retry():
+    from tools.computer_use.cua_backend import _EmbeddedCuaDaemon
+
+    daemon = _EmbeddedCuaDaemon("cua-driver", "unrestricted")
+    process = MagicMock()
+    process.poll.return_value = None
+    process.wait.side_effect = OSError("wait failed")
+    daemon._process = process
+
+    with patch("tools.computer_use.cua_backend.subprocess.run"), pytest.raises(
+        OSError, match="wait failed"
+    ):
+        daemon.stop()
+
+    assert daemon._process is process
+
+
+def test_async_bridge_stop_refuses_to_forget_a_live_thread():
+    from tools.computer_use.cua_backend import _AsyncBridge
+
+    bridge = _AsyncBridge()
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    thread = MagicMock()
+    thread.is_alive.return_value = True
+    bridge._loop = loop
+    bridge._thread = thread
+
+    with pytest.raises(RuntimeError, match="did not stop within 2s"):
+        bridge.stop()
+
+    assert bridge._thread is thread
+    assert bridge._loop is loop

--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -6,7 +6,6 @@ gateway deployments.
 """
 
 import os
-import signal
 import subprocess
 import sys
 import threading
@@ -36,30 +35,32 @@ class TestZombieReproduction:
         """REPRODUCTION: processes spawned directly survive if no one kills
         them — this models the gap that causes zombie accumulation when
         the gateway drops agent references without calling close()."""
-        pids = []
+        procs = []
 
         try:
             for _ in range(3):
-                proc = _spawn_sleep(60)
-                pids.append(proc.pid)
+                procs.append(_spawn_sleep(60))
+            pids = [proc.pid for proc in procs]
 
             for pid in pids:
                 assert _pid_alive(pid), f"PID {pid} should be alive after spawn"
 
-            # Simulate "session end" by just dropping the reference
-            del proc  # noqa: F821
+            # Dropping an unrelated local reference does not close the handles
+            # retained in procs; the children remain alive until explicit cleanup.
+            proc = procs[-1]
+            del proc
 
-            # BUG: processes are still alive after reference is dropped
             for pid in pids:
                 assert _pid_alive(pid), (
                     f"PID {pid} died after ref drop — "
                     f"expected it to survive (demonstrating the bug)"
                 )
         finally:
-            for pid in pids:
+            for proc in procs:
                 try:
-                    os.kill(pid, signal.SIGKILL)
-                except (ProcessLookupError, PermissionError):
+                    proc.kill()
+                    proc.wait(timeout=2)
+                except Exception:
                     pass
 
     def test_explicit_terminate_reaps_processes(self):

--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -36,16 +36,24 @@ from __future__ import annotations
 
 # Re-export the public surface so `from tools.computer_use import ...` works.
 from tools.computer_use.tool import (  # noqa: F401
+    begin_computer_use_session_reactivation,
+    begin_computer_use_terminal_transition,
     check_computer_use_requirements,
     computer_use_cleanup_snapshot,
     computer_use_lifecycle_snapshot,
     computer_use_process_snapshot,
     drain_computer_use_cleanup,
+    end_computer_use_session_reactivation,
+    end_computer_use_terminal_transition,
     get_computer_use_schema,
     get_computer_use_session_generation,
     handle_computer_use,
+    is_computer_use_session_retired,
+    publish_computer_use_session,
     release_computer_use_session,
     release_computer_use_session_result,
     set_approval_callback,
+    set_computer_use_session_validator,
     submit_computer_use_session_release,
+    unpublish_computer_use_session,
 )

--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -36,10 +36,16 @@ from __future__ import annotations
 
 # Re-export the public surface so `from tools.computer_use import ...` works.
 from tools.computer_use.tool import (  # noqa: F401
+    check_computer_use_requirements,
+    computer_use_cleanup_snapshot,
+    computer_use_lifecycle_snapshot,
+    computer_use_process_snapshot,
+    drain_computer_use_cleanup,
+    get_computer_use_schema,
+    get_computer_use_session_generation,
     handle_computer_use,
     release_computer_use_session,
+    release_computer_use_session_result,
     set_approval_callback,
-    check_computer_use_requirements,
-    get_computer_use_schema,
-    release_computer_use_session,
+    submit_computer_use_session_release,
 )

--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -42,6 +42,7 @@ from tools.computer_use.tool import (  # noqa: F401
     computer_use_cleanup_snapshot,
     computer_use_lifecycle_snapshot,
     computer_use_process_snapshot,
+    write_computer_use_runtime_attestation,
     drain_computer_use_cleanup,
     end_computer_use_session_reactivation,
     end_computer_use_terminal_transition,

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -52,7 +52,7 @@ import threading
 import time
 import uuid
 from pathlib import PureWindowsPath
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.computer_use.backend import (
@@ -1148,9 +1148,11 @@ class _CuaDriverSession:
         self,
         bridge: _AsyncBridge,
         embedded_daemon: Optional[_EmbeddedCuaDaemon] = None,
+        runtime_attestation_callback: Optional[Callable[[], None]] = None,
     ) -> None:
         self._bridge = bridge
         self._embedded_daemon = embedded_daemon
+        self._runtime_attestation_callback = runtime_attestation_callback
         self._session = None
         self._lock = threading.Lock()
         self._started = False
@@ -1330,7 +1332,26 @@ class _CuaDriverSession:
                 return
             self._bridge.start()
             self._start_lifecycle_locked()
+            self._attest_runtime_locked()
             self._started = True
+
+    def _attest_runtime_locked(self) -> None:
+        """Attest a newly spawned MCP child before it can perform an action."""
+        callback = getattr(self, "_runtime_attestation_callback", None)
+        if callback is None:
+            return
+        try:
+            callback()
+        except Exception as attestation_error:
+            self._started = False
+            try:
+                self._stop_lifecycle_locked()
+            except Exception as cleanup_error:
+                raise RuntimeError(
+                    "runtime attestation failed and replacement cleanup was unconfirmed: "
+                    f"attestation={attestation_error!r}; cleanup={cleanup_error!r}"
+                ) from attestation_error
+            raise
 
     def _start_lifecycle_locked(self) -> None:
         """Spawn the lifecycle owner and wait for it to reach ready.
@@ -1582,15 +1603,16 @@ class _CuaDriverSession:
         """Recreate the MCP session after the daemon/stdin transport was closed.
         Caller must hold self._lock (the reconnect-once retry path holds it)."""
         if self._started:
-            try:
-                self._stop_lifecycle_locked()
-            except Exception as e:
-                logger.debug("cua-driver session cleanup before reconnect failed: %s", e)
+            self._started = False
+            # An unconfirmed old-child teardown is an ownership failure. Do not
+            # overlap it with a replacement process or retry the action.
+            self._stop_lifecycle_locked()
         self._started = False
         # Clear stale capability state; the next start populates from scratch.
         self._capabilities = {}
         self._capability_version = ""
         self._start_lifecycle_locked()
+        self._attest_runtime_locked()
         self._started = True
 
     def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float) -> Dict[str, Any]:
@@ -1613,6 +1635,10 @@ class _CuaDriverSession:
         call is itself retried a few times with backoff, since the underlying
         daemon socket can still be momentarily busy.
         """
+        if getattr(self, "_runtime_attestation_callback", None) is not None:
+            raise RuntimeError(
+                "cua-driver CLI fallback cannot satisfy required runtime attestation"
+            )
         import subprocess as _subprocess
         import tempfile as _tempfile
         import time as _time
@@ -1985,7 +2011,13 @@ def _apps_from_windows(windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 class CuaDriverBackend(ComputerUseBackend):
     """Default computer-use backend. Cross-platform via cua-driver MCP."""
 
-    def __init__(self, permission_mode: str = "standard") -> None:
+    _requires_runtime_attestation = True
+
+    def __init__(
+        self,
+        permission_mode: str = "standard",
+        runtime_attestation_callback: Optional[Callable[[], None]] = None,
+    ) -> None:
         if permission_mode not in {"standard", "unrestricted"}:
             raise ValueError(f"unsupported cua-driver permission mode: {permission_mode}")
         self.permission_mode = permission_mode
@@ -1995,7 +2027,11 @@ class CuaDriverBackend(ComputerUseBackend):
             else None
         )
         self._bridge = _AsyncBridge()
-        self._session = _CuaDriverSession(self._bridge, self._embedded_daemon)
+        self._session = _CuaDriverSession(
+            self._bridge,
+            self._embedded_daemon,
+            runtime_attestation_callback,
+        )
         # Sticky context — updated by capture(), used by action tools.
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None
@@ -2034,6 +2070,15 @@ class CuaDriverBackend(ComputerUseBackend):
             call_tool=self._session.call_tool,
             has_tool=self._session._has_tool,
         )
+
+    def set_runtime_attestation_callback(
+        self,
+        callback: Callable[[], None],
+    ) -> None:
+        """Install the managed-gateway process replacement attestation gate."""
+        if not callable(callback):
+            raise TypeError("runtime attestation callback must be callable")
+        self._session._runtime_attestation_callback = callback
 
     def _browser_route(self) -> CuaTypedBrowserRoute:
         """Return the per-backend typed route, including test-constructed instances."""

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -504,7 +504,6 @@ class _EmbeddedCuaDaemon:
 
     def stop(self) -> None:
         process = self._process
-        self._process = None
         if process is not None and process.poll() is None:
             from tools.environments.local import _sanitize_subprocess_env
 
@@ -528,6 +527,12 @@ class _EmbeddedCuaDaemon:
                 except subprocess.TimeoutExpired:
                     process.kill()
                     process.wait(timeout=2.0)
+            if process.poll() is None:
+                raise RuntimeError("embedded cua-driver daemon did not exit")
+        # Forget ownership only after confirmed exit; a failed stop remains
+        # retryable and cannot be reported as a successful generation close.
+        if self._process is process:
+            self._process = None
         if sys.platform != "win32" and os.path.exists(self.socket_path):
             try:
                 os.remove(self.socket_path)
@@ -1056,10 +1061,14 @@ class _AsyncBridge:
         return fut.result(timeout=timeout)
 
     def stop(self) -> None:
-        if self._loop and self._loop.is_running():
-            self._loop.call_soon_threadsafe(self._loop.stop)
-        if self._thread:
-            self._thread.join(timeout=2.0)
+        loop = self._loop
+        thread = self._thread
+        if loop and loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+        if thread:
+            thread.join(timeout=2.0)
+            if thread.is_alive():
+                raise RuntimeError("cua-driver asyncio bridge did not stop within 2s")
         self._thread = None
         self._loop = None
 
@@ -1109,6 +1118,7 @@ class _CuaDriverSession:
         self._capability_version: str = ""
         # Lifecycle plumbing — see class docstring above.
         self._ready_event = threading.Event()
+        self._closed_event = threading.Event()
         self._shutdown_event: Optional[asyncio.Event] = None  # created on bridge loop
         self._lifecycle_future = None  # concurrent.futures.Future
         self._setup_error: Optional[BaseException] = None
@@ -1214,6 +1224,7 @@ class _CuaDriverSession:
             # the bridge-loop thread without taking self._lock (which stop()
             # may hold while awaiting this coro's future). See #55048 Bug 1.
             self._started = False
+            self._closed_event.set()
 
     async def _populate_capabilities(self, session: Any) -> None:
         """Surface 4: cache per-tool capability sets + capability_version
@@ -1274,6 +1285,7 @@ class _CuaDriverSession:
         Caller must hold self._lock."""
         # Reset per-session state.
         self._ready_event = threading.Event()
+        self._closed_event = threading.Event()
         self._setup_error = None
         self._shutdown_event = None
         # Fire-and-forget schedule on the bridge loop. The future tracks
@@ -1308,29 +1320,43 @@ class _CuaDriverSession:
 
     def stop(self) -> None:
         with self._lock:
-            if not self._started:
+            if not self._started and self._lifecycle_future is None:
                 return
             self._started = False
             self._stop_lifecycle_locked()
 
     def _stop_lifecycle_locked(self) -> None:
-        """Signal shutdown + wait for the lifecycle coroutine to unwind.
-        Caller must hold self._lock."""
+        """Signal shutdown and confirm the lifecycle owner actually exited."""
         self._signal_shutdown_locked()
         fut = self._lifecycle_future
         if fut is None:
             return
         try:
-            # 5s budget for context unwind (stdio_client teardown).
+            # 5s graceful budget for stdio_client / ClientSession unwind.
             fut.result(timeout=5.0)
         except concurrent.futures.TimeoutError:
-            logger.warning("cua-driver session shutdown timed out (5s)")
-        except Exception as e:
-            # Real shutdown errors (not the previous cancel-scope race
-            # which is now structurally impossible) still get surfaced.
-            logger.warning("cua-driver shutdown error: %s", e)
-        finally:
-            self._lifecycle_future = None
+            logger.warning(
+                "cua-driver session shutdown timed out (5s); cancelling lifecycle"
+            )
+            fut.cancel()
+            # The run_coroutine_threadsafe proxy can report CancelledError as
+            # soon as cancellation is requested, before async context managers
+            # finish terminating the stdio child. The lifecycle-owned event is
+            # set only after those contexts have exited.
+            if not self._closed_event.wait(timeout=2.0):
+                raise RuntimeError(
+                    "cua-driver lifecycle did not exit after cancellation"
+                )
+        except concurrent.futures.CancelledError:
+            if not self._closed_event.wait(timeout=2.0):
+                raise RuntimeError(
+                    "cancelled cua-driver lifecycle did not confirm context exit"
+                )
+        except Exception as exc:
+            raise RuntimeError(f"cua-driver shutdown error: {exc}") from exc
+        if not self._closed_event.is_set():
+            raise RuntimeError("cua-driver lifecycle stop returned before context exit")
+        self._lifecycle_future = None
 
     def _signal_shutdown_locked(self) -> None:
         """Set the asyncio shutdown event from the caller's thread."""
@@ -2038,7 +2064,11 @@ class CuaDriverBackend(ComputerUseBackend):
         # the session_end hook cua-driver registers internally.
         if self._session._started:
             try:
-                self._session.call_tool("end_session", {"session": self._session_id})
+                self._session.call_tool(
+                    "end_session",
+                    {"session": self._session_id},
+                    timeout=2.0,
+                )
             except Exception as e:
                 logger.debug("cua-driver end_session failed (continuing teardown): %s", e)
         try:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1022,10 +1022,15 @@ def _parse_key_combo(keys: str) -> Tuple[Optional[str], List[str]]:
 class _AsyncBridge:
     """Runs one asyncio loop on a daemon thread; marshals coroutines from the caller."""
 
+    _CALL_CANCEL_CONFIRM_TIMEOUT = 2.0
+    _INFLIGHT_DRAIN_TIMEOUT = 2.0
+
     def __init__(self) -> None:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[threading.Thread] = None
         self._ready = threading.Event()
+        self._inflight_lock = threading.Lock()
+        self._inflight_events: set[threading.Event] = set()
 
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
@@ -1055,12 +1060,53 @@ class _AsyncBridge:
             if asyncio.iscoroutine(coro):
                 coro.close()
             raise RuntimeError("cua-driver bridge not started")
-        fut = safe_schedule_threadsafe(coro, self._loop)
+
+        completed = threading.Event()
+
+        async def _tracked():
+            try:
+                return await coro
+            finally:
+                completed.set()
+                with self._inflight_lock:
+                    self._inflight_events.discard(completed)
+
+        tracked = _tracked()
+        with self._inflight_lock:
+            self._inflight_events.add(completed)
+        fut = safe_schedule_threadsafe(tracked, self._loop)
         if fut is None:
+            with self._inflight_lock:
+                self._inflight_events.discard(completed)
+            tracked.close()
+            if asyncio.iscoroutine(coro):
+                coro.close()
             raise RuntimeError("cua-driver bridge not started")
-        return fut.result(timeout=timeout)
+        try:
+            return fut.result(timeout=timeout)
+        except concurrent.futures.TimeoutError as exc:
+            fut.cancel()
+            if not completed.wait(timeout=self._CALL_CANCEL_CONFIRM_TIMEOUT):
+                raise RuntimeError(
+                    "cua-driver action timed out and cancellation was not confirmed"
+                ) from exc
+            raise
 
     def stop(self) -> None:
+        deadline = time.monotonic() + self._INFLIGHT_DRAIN_TIMEOUT
+        while True:
+            with self._inflight_lock:
+                pending = [event for event in self._inflight_events if not event.is_set()]
+                self._inflight_events.intersection_update(pending)
+            if not pending:
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(
+                    f"cua-driver bridge still has {len(pending)} in-flight action(s)"
+                )
+            pending[0].wait(timeout=remaining)
+
         loop = self._loop
         thread = self._thread
         if loop and loop.is_running():
@@ -2071,14 +2117,10 @@ class CuaDriverBackend(ComputerUseBackend):
                 )
             except Exception as e:
                 logger.debug("cua-driver end_session failed (continuing teardown): %s", e)
-        try:
-            self._session.stop()
-        finally:
-            try:
-                self._bridge.stop()
-            finally:
-                if self._embedded_daemon is not None:
-                    self._embedded_daemon.stop()
+        self._session.stop()
+        self._bridge.stop()
+        if self._embedded_daemon is not None:
+            self._embedded_daemon.stop()
 
     def is_available(self) -> bool:
         # cua-driver runs on macOS, Windows, and Linux. The Linux path is

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1019,6 +1019,12 @@ def _parse_key_combo(keys: str) -> Tuple[Optional[str], List[str]]:
 # Asyncio bridge — one long-lived loop on a background thread
 # ---------------------------------------------------------------------------
 
+class CuaActionTerminationUnconfirmed(RuntimeError):
+    """The caller returned while its exact driver action may still be live."""
+
+    cua_action_termination_unconfirmed = True
+
+
 class _AsyncBridge:
     """Runs one asyncio loop on a daemon thread; marshals coroutines from the caller."""
 
@@ -1087,7 +1093,7 @@ class _AsyncBridge:
         except concurrent.futures.TimeoutError as exc:
             fut.cancel()
             if not completed.wait(timeout=self._CALL_CANCEL_CONFIRM_TIMEOUT):
-                raise RuntimeError(
+                raise CuaActionTerminationUnconfirmed(
                     "cua-driver action timed out and cancellation was not confirmed"
                 ) from exc
             raise

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -40,13 +40,19 @@ from __future__ import annotations
 
 import atexit
 import base64
+import concurrent.futures
 import json
 import logging
 import os
+import queue
 import re
 import struct
 import sys
 import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 from tools.computer_use.backend import (
@@ -168,6 +174,398 @@ _session_auto_approve: Dict[str, bool] = {}
 _always_allow: Dict[str, set] = {}
 
 
+class BackendLifecycleState(str, Enum):
+    STARTING = "STARTING"
+    ACTIVE = "ACTIVE"
+    CLOSING = "CLOSING"
+    CLOSED = "CLOSED"
+    FAILED = "FAILED"
+
+
+@dataclass
+class ComputerUseReleaseResult:
+    session_id: str
+    generation: Optional[int]
+    status: str
+    reason: str
+    elapsed_ms: float = 0.0
+    error: Optional[str] = None
+
+    @property
+    def released(self) -> bool:
+        return self.status == "released"
+
+    def __bool__(self) -> bool:
+        return self.released
+
+
+@dataclass
+class _BackendRecord:
+    session_id: str
+    generation: int
+    permission_mode: str
+    backend: ComputerUseBackend
+    call_lock: threading.RLock
+    state: BackendLifecycleState = BackendLifecycleState.STARTING
+    close_requested_at: Optional[float] = None
+    close_reason: Optional[str] = None
+    last_error: Optional[str] = None
+    close_attempts: int = 0
+
+
+_backend_records: Dict[str, _BackendRecord] = {}
+_backend_generation_counters: OrderedDict[str, int] = OrderedDict()
+_backend_generation_sequence = 0
+_BACKEND_GENERATION_TOMBSTONE_CAP = 4096
+_DEFAULT_RELEASE_TIMEOUT = 5.0
+
+
+def _next_backend_generation_locked(sid: str) -> int:
+    global _backend_generation_sequence
+    _backend_generation_sequence += 1
+    generation = _backend_generation_sequence
+    _backend_generation_counters[sid] = generation
+    _backend_generation_counters.move_to_end(sid)
+    while len(_backend_generation_counters) > _BACKEND_GENERATION_TOMBSTONE_CAP:
+        for oldest_sid in tuple(_backend_generation_counters):
+            if oldest_sid != sid and oldest_sid not in _backend_records:
+                _backend_generation_counters.pop(oldest_sid, None)
+                break
+        else:
+            # More active sessions than the tombstone cap: keep their exact
+            # generations rather than corrupting ownership or looping forever.
+            break
+    return generation
+
+
+def _record_from_legacy_cache_locked(sid: str) -> Optional[_BackendRecord]:
+    """Normalize direct test/integration cache injection into lifecycle state."""
+    record = _backend_records.get(sid)
+    if record is not None:
+        return record
+    backend = _backends.get(sid)
+    if backend is None and sid == "":
+        backend = _backend
+    if backend is None:
+        return None
+    call_lock = _backend_call_locks.setdefault(sid, threading.RLock())
+    record = _BackendRecord(
+        session_id=sid,
+        generation=_next_backend_generation_locked(sid),
+        permission_mode=_backend_permission_modes.get(sid, "standard"),
+        backend=backend,
+        call_lock=call_lock,
+        state=BackendLifecycleState.ACTIVE,
+    )
+    _backend_records[sid] = record
+    return record
+
+
+def get_computer_use_session_generation(session_id: str) -> Optional[int]:
+    sid = str(session_id or "")
+    if not sid:
+        return None
+    with _backend_lock:
+        record = _record_from_legacy_cache_locked(sid)
+        return record.generation if record is not None else None
+
+
+def computer_use_lifecycle_snapshot() -> Dict[str, Dict[str, Any]]:
+    """Return a secret-free, operator-facing lifecycle snapshot."""
+    with _backend_lock:
+        return {
+            sid: {
+                "generation": record.generation,
+                "state": record.state.value,
+                "permission_mode": record.permission_mode,
+                "close_reason": record.close_reason,
+                "close_attempts": record.close_attempts,
+                "last_error": record.last_error,
+            }
+            for sid, record in _backend_records.items()
+        }
+
+
+class _CleanupSupervisor:
+    """Bounded, tracked executor with deduplicated deferred admission."""
+
+    def __init__(
+        self,
+        *,
+        max_workers: int = 2,
+        max_pending: int = 64,
+        max_deferred: int = 256,
+    ) -> None:
+        self._max_pending = max_pending
+        self._max_deferred = max_deferred
+        self._slots = threading.BoundedSemaphore(max_pending)
+        self._lock = threading.Lock()
+        self._work_queue: queue.Queue[
+            Optional[tuple[tuple[str, Optional[int]], str, Dict[str, Any]]]
+        ] = queue.Queue(maxsize=max_pending)
+        self._workers: list[threading.Thread] = []
+        for index in range(max_workers):
+            worker = threading.Thread(
+                target=self._worker_loop,
+                name=f"computer-use-cleanup-{index}",
+                daemon=True,
+            )
+            worker.start()
+            self._workers.append(worker)
+        self._active_keys: set[tuple[str, Optional[int]]] = set()
+        self._deferred: OrderedDict[
+            tuple[str, Optional[int]], tuple[str, Dict[str, Any]]
+        ] = OrderedDict()
+        self._inflight: Dict[
+            tuple[str, Optional[int]], concurrent.futures.Future
+        ] = {}
+        self._closed = False
+
+    @staticmethod
+    def _rejected_result(
+        sid: str,
+        kwargs: Dict[str, Any],
+        error: str,
+    ) -> ComputerUseReleaseResult:
+        return ComputerUseReleaseResult(
+            session_id=sid,
+            generation=kwargs.get("expected_generation"),
+            status="queue_rejected",
+            reason=str(kwargs.get("reason") or "unspecified"),
+            error=error,
+        )
+
+    def _launch_locked(
+        self,
+        key: tuple[str, Optional[int]],
+        sid: str,
+        kwargs: Dict[str, Any],
+    ) -> Optional[str]:
+        """Launch after one slot was acquired; caller holds ``_lock``."""
+        self._active_keys.add(key)
+        try:
+            self._work_queue.put_nowait((key, sid, kwargs))
+        except queue.Full:
+            self._active_keys.discard(key)
+            self._slots.release()
+            return "cleanup worker queue unexpectedly full"
+        return None
+
+    def _worker_loop(self) -> None:
+        while True:
+            item = self._work_queue.get()
+            try:
+                if item is None:
+                    return
+                key, sid, kwargs = item
+                self._run_release(key, sid, kwargs)
+            finally:
+                self._work_queue.task_done()
+
+    def _run_release(
+        self,
+        key: tuple[str, Optional[int]],
+        sid: str,
+        kwargs: Dict[str, Any],
+    ) -> None:
+        try:
+            result = _release_computer_use_session_with_retries(sid, **kwargs)
+        except Exception as exc:
+            result = ComputerUseReleaseResult(
+                session_id=sid,
+                generation=kwargs.get("expected_generation"),
+                status="failed",
+                reason=str(kwargs.get("reason") or "unspecified"),
+                error=f"cleanup worker raised: {exc!r}",
+            )
+        self._complete(key, result)
+
+    def _complete(
+        self,
+        key: tuple[str, Optional[int]],
+        result: ComputerUseReleaseResult,
+    ) -> None:
+        completions: list[
+            tuple[concurrent.futures.Future, ComputerUseReleaseResult]
+        ] = []
+        with self._lock:
+            external = self._inflight.pop(key, None)
+            self._active_keys.discard(key)
+            self._slots.release()
+            if external is not None:
+                completions.append((external, result))
+
+            # A completion admits the oldest deferred exact owner. If executor
+            # shutdown races admission, reject it truthfully and continue so no
+            # deferred future is left pending forever.
+            while self._deferred and self._slots.acquire(blocking=False):
+                deferred_key, (sid, kwargs) = self._deferred.popitem(last=False)
+                launch_error = self._launch_locked(deferred_key, sid, kwargs)
+                if launch_error is None:
+                    break
+                deferred_future = self._inflight.pop(deferred_key, None)
+                if deferred_future is not None:
+                    completions.append(
+                        (
+                            deferred_future,
+                            self._rejected_result(sid, kwargs, launch_error),
+                        )
+                    )
+        for future, completion in completions:
+            if not future.done():
+                future.set_result(completion)
+
+    def submit(self, session_id: str, **kwargs: Any) -> concurrent.futures.Future:
+        sid = str(session_id or "")
+        key = (sid, kwargs.get("expected_generation"))
+        rejected: Optional[ComputerUseReleaseResult] = None
+        with self._lock:
+            duplicate = self._inflight.get(key)
+            if duplicate is not None:
+                return duplicate
+            external: concurrent.futures.Future = concurrent.futures.Future()
+            if self._closed:
+                rejected = self._rejected_result(
+                    sid, kwargs, "cleanup supervisor closed"
+                )
+            else:
+                self._inflight[key] = external
+                if self._slots.acquire(blocking=False):
+                    launch_error = self._launch_locked(key, sid, dict(kwargs))
+                    if launch_error is not None:
+                        self._inflight.pop(key, None)
+                        rejected = self._rejected_result(
+                            sid, kwargs, launch_error
+                        )
+                elif len(self._deferred) < self._max_deferred:
+                    self._deferred[key] = (sid, dict(kwargs))
+                else:
+                    self._inflight.pop(key, None)
+                    rejected = self._rejected_result(
+                        sid,
+                        kwargs,
+                        "cleanup deferred-admission queue full; exact owner retained",
+                    )
+        if rejected is not None:
+            if "exact owner retained" in str(rejected.error or ""):
+                _mark_cleanup_admission_failure(
+                    sid,
+                    kwargs.get("expected_generation"),
+                    str(rejected.error),
+                )
+            external.set_result(rejected)
+            logger.error(
+                "computer_use cleanup rejected session=%s generation=%s reason=%s error=%s",
+                sid,
+                kwargs.get("expected_generation"),
+                kwargs.get("reason"),
+                rejected.error,
+            )
+        return external
+
+    def drain(self, timeout: float) -> bool:
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            with self._lock:
+                if not self._active_keys and not self._deferred:
+                    return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.01)
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "pending": len(self._active_keys),
+                "deferred": len(self._deferred),
+                "capacity": self._max_pending,
+                "deferred_capacity": self._max_deferred,
+                "closed": self._closed,
+            }
+
+    def shutdown(self, timeout: float) -> bool:
+        with self._lock:
+            self._closed = True
+        deadline = time.monotonic() + max(0.0, timeout)
+        drained = self.drain(timeout)
+        if not drained:
+            # Do not enqueue stop sentinels ahead of deferred work. Workers are
+            # daemonized, so a wedged backend cannot block interpreter exit;
+            # a later shutdown/drain call can still reap them if work unwinds.
+            return False
+        for _ in self._workers:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                self._work_queue.put(None, timeout=remaining)
+            except queue.Full:
+                break
+        for worker in self._workers:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            worker.join(timeout=remaining)
+        # Workers are daemonized deliberately: a backend violating its bounded
+        # stop contract cannot hold interpreter shutdown hostage. Active exact
+        # ownership remains visible in lifecycle state until process exit.
+        return drained and not any(worker.is_alive() for worker in self._workers)
+
+
+def _mark_cleanup_admission_failure(
+    sid: str,
+    expected_generation: Any,
+    error: str,
+) -> None:
+    """Fail closed if even the bounded deferred queue cannot admit ownership."""
+    if not isinstance(expected_generation, int) or isinstance(
+        expected_generation, bool
+    ):
+        return
+    with _backend_lock:
+        record = _backend_records.get(sid)
+        if record is None or record.generation != expected_generation:
+            return
+        record.state = BackendLifecycleState.FAILED
+        record.close_reason = "cleanup_admission_failure"
+        record.last_error = error
+
+
+_cleanup_supervisor = _CleanupSupervisor()
+
+
+def computer_use_cleanup_snapshot() -> Dict[str, Any]:
+    """Return bounded-supervisor queue depth without exposing session content."""
+    return _cleanup_supervisor.snapshot()
+
+
+def computer_use_process_snapshot() -> List[Dict[str, Any]]:
+    """Return direct/recursive cua-driver descendants for operator diagnostics."""
+    try:
+        import psutil
+
+        parent = psutil.Process()
+        rows = []
+        for child in parent.children(recursive=True):
+            try:
+                name = child.name()
+                if "cua-driver" not in name.lower():
+                    continue
+                rows.append({
+                    "pid": child.pid,
+                    "ppid": child.ppid(),
+                    "name": name,
+                    "create_time": child.create_time(),
+                    "status": child.status(),
+                })
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return sorted(rows, key=lambda row: (row["create_time"], row["pid"]))
+    except Exception:
+        logger.debug("computer_use process snapshot failed", exc_info=True)
+        return []
+
+
 def _cua_permission_mode(session_id: str) -> str:
     """Map Hermes's explicit approval bypass onto Cua's immutable mode.
 
@@ -202,31 +600,33 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
     global _backend
     sid = str(session_id or "")
     while True:
-        stale_backend: Optional[ComputerUseBackend] = None
-        stale_lock: Optional[threading.RLock] = None
+        release_generation: Optional[int] = None
         with _backend_lock:
-            # Resolve the mode while holding the cache lock. Session YOLO
-            # mutation never holds the approval lock while releasing this
-            # cache, so the lock order cannot cycle.
             permission_mode = _cua_permission_mode(sid)
             if sid == "" and _backend is not None and sid not in _backends:
-                # Preserve the long-standing empty-session injection hook used
-                # by integrations and tests while normalizing it into the
-                # session-owned cache/lifecycle path.
                 _backends[sid] = _backend
                 _backend_call_locks[sid] = threading.RLock()
                 _backend_permission_modes[sid] = permission_mode
-            cached = _backends.get(sid)
-            if cached is not None:
-                if _backend_permission_modes.get(sid, "standard") == permission_mode:
-                    return cached
-                # Cua's permission mode cannot change after daemon startup. A
-                # /yolo toggle replaces only this session's backend.
-                stale_backend = _backends.pop(sid)
-                stale_lock = _backend_call_locks.pop(sid, None)
-                _backend_permission_modes.pop(sid, None)
-                if sid == "":
-                    _backend = None
+            record = _record_from_legacy_cache_locked(sid)
+            if record is not None:
+                if record.state == BackendLifecycleState.ACTIVE:
+                    if record.permission_mode == permission_mode:
+                        return record.backend
+                    release_generation = record.generation
+                elif record.state == BackendLifecycleState.CLOSING:
+                    raise RuntimeError(
+                        f"computer_use backend for session {sid!r} is closing"
+                    )
+                elif record.state == BackendLifecycleState.FAILED:
+                    raise RuntimeError(
+                        f"computer_use backend for session {sid!r} cleanup failed; "
+                        "retry release before recreating it"
+                    )
+                else:
+                    raise RuntimeError(
+                        f"computer_use backend for session {sid!r} is "
+                        f"{record.state.value.lower()}"
+                    )
             else:
                 backend_name = os.environ.get(
                     "HERMES_COMPUTER_USE_BACKEND", "cua"
@@ -241,133 +641,399 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
                     raise RuntimeError(
                         f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}"
                     )
-                # Starting under the cache lock preserves the existing
-                # one-backend-per-session invariant. A concurrent mode toggle
-                # releases this backend before returning to its caller.
-                backend.start()
+                call_lock = threading.RLock()
+                record = _BackendRecord(
+                    session_id=sid,
+                    generation=_next_backend_generation_locked(sid),
+                    permission_mode=permission_mode,
+                    backend=backend,
+                    call_lock=call_lock,
+                )
+                _backend_records[sid] = record
                 _backends[sid] = backend
-                _backend_call_locks[sid] = threading.RLock()
+                _backend_call_locks[sid] = call_lock
                 _backend_permission_modes[sid] = permission_mode
                 if sid == "":
                     _backend = backend
+                try:
+                    backend.start()
+                except Exception as exc:
+                    record.state = BackendLifecycleState.FAILED
+                    record.last_error = repr(exc)
+                    try:
+                        backend.stop()
+                    except Exception as cleanup_exc:
+                        record.last_error = (
+                            f"start={exc!r}; cleanup={cleanup_exc!r}"
+                        )
+                        logger.error(
+                            "computer_use startup cleanup failed session=%s "
+                            "generation=%s error=%s",
+                            sid,
+                            record.generation,
+                            cleanup_exc,
+                        )
+                    else:
+                        _backend_records.pop(sid, None)
+                        _backends.pop(sid, None)
+                        _backend_call_locks.pop(sid, None)
+                        _backend_permission_modes.pop(sid, None)
+                        if sid == "" and _backend is backend:
+                            _backend = None
+                    raise
+                record.state = BackendLifecycleState.ACTIVE
+                logger.info(
+                    "computer_use lifecycle session=%s generation=%s state=ACTIVE",
+                    sid,
+                    record.generation,
+                )
                 return backend
 
-        # Stop a mismatched backend outside the global cache lock. Another
-        # session can continue creating or releasing its own backend, and the
-        # loop re-reads the authoritative mode before installing a replacement.
-        try:
-            if stale_lock is not None:
-                with stale_lock:
-                    stale_backend.stop()
-            elif stale_backend is not None:
-                stale_backend.stop()
-        except Exception:
-            pass
+        # Permission-mode changes are hard lifecycle boundaries. The exact
+        # generation stays installed while it closes, so no same-SID backend can
+        # be recreated until stop has succeeded.
+        result = release_computer_use_session_result(
+            sid,
+            expected_generation=release_generation,
+            timeout=_DEFAULT_RELEASE_TIMEOUT,
+            reason="permission_mode_change",
+            allow_empty_session=(sid == ""),
+        )
+        if not result.released:
+            raise RuntimeError(
+                f"computer_use permission-mode transition failed for {sid!r}: "
+                f"{result.status}: {result.error or ''}"
+            )
 
 
-def release_computer_use_session(session_id: str) -> bool:
-    """Release one session-owned computer-use backend.
-
-    This is the production lifecycle seam for hosts and policy plugins. It
-    removes the exact session backend, its call lock, and its recorded
-    permission mode before stopping the backend, so new lookups cannot retain
-    the stale target/ref namespace — and stops a private embedded daemon when
-    Hermes YOLO selected unrestricted mode. Approval state is cleared even
-    when no backend was started.
-
-    Returns ``True`` when a backend was found and released, ``False`` when the
-    session was already absent. Safe to call repeatedly.
-    """
+def _acquire_backend_for_call(
+    session_id: str,
+) -> tuple[ComputerUseBackend, threading.RLock]:
+    """Acquire an action lease that cannot outlive its exact active backend."""
     global _backend
     sid = str(session_id or "")
+    for _ in range(3):
+        backend = _get_backend(session_id=sid)
+        with _backend_lock:
+            record = _record_from_legacy_cache_locked(sid)
+            if record is None and sid == "":
+                # Preserve the long-standing test/plugin seam where _get_backend
+                # itself is replaced and returns a pre-started backend. Restrict
+                # this normalization to the legacy empty-session namespace so
+                # hard session cleanup still requires authoritative ownership.
+                call_lock = threading.RLock()
+                record = _BackendRecord(
+                    session_id=sid,
+                    generation=_next_backend_generation_locked(sid),
+                    permission_mode=_cua_permission_mode(sid),
+                    backend=backend,
+                    call_lock=call_lock,
+                    state=BackendLifecycleState.ACTIVE,
+                )
+                _backend_records[sid] = record
+                _backends[sid] = backend
+                _backend_call_locks[sid] = call_lock
+                _backend_permission_modes[sid] = record.permission_mode
+                _backend = backend
+            if record is None or record.backend is not backend:
+                continue
+            call_lock = record.call_lock
+        call_lock.acquire()
+        with _backend_lock:
+            current = _backend_records.get(sid)
+            if (
+                current is record
+                and current.backend is backend
+                and current.state == BackendLifecycleState.ACTIVE
+            ):
+                return backend, call_lock
+        call_lock.release()
+    raise RuntimeError(
+        f"computer_use backend for session {sid!r} changed while acquiring action lease"
+    )
+
+
+def release_computer_use_session_result(
+    session_id: str,
+    *,
+    expected_generation: Optional[int] = None,
+    timeout: float = _DEFAULT_RELEASE_TIMEOUT,
+    reason: str = "explicit",
+    allow_empty_session: bool = False,
+) -> ComputerUseReleaseResult:
+    """Close one exact backend generation with bounded, truthful lifecycle state."""
+    global _backend
+    sid = str(session_id or "")
+    started = time.monotonic()
+    if not sid and not allow_empty_session:
+        return ComputerUseReleaseResult(
+            session_id=sid,
+            generation=expected_generation,
+            status="mismatch",
+            reason=reason,
+            error="empty session id rejected",
+        )
+
     with _backend_lock:
-        backend = _backends.pop(sid, None)
-        call_lock = _backend_call_locks.pop(sid, None)
-        _backend_permission_modes.pop(sid, None)
-        # Preserve the backward-compatible empty-session injection hook:
-        # older callers/tests may populate only `_backend`.
-        if sid == "" and backend is None:
-            backend = _backend
-        if sid == "" and _backend is backend:
-            _backend = None
+        record = _record_from_legacy_cache_locked(sid)
+        if record is None:
+            last_generation = _backend_generation_counters.get(sid)
+            idempotent_absence = (
+                expected_generation is None
+                or (
+                    last_generation is not None
+                    and expected_generation == last_generation
+                )
+            )
+            status = "already_absent" if idempotent_absence else "mismatch"
+            return ComputerUseReleaseResult(
+                session_id=sid,
+                generation=expected_generation,
+                status=status,
+                reason=reason,
+                error=None if status == "already_absent" else "generation absent",
+            )
+        if expected_generation is not None and record.generation != expected_generation:
+            return ComputerUseReleaseResult(
+                session_id=sid,
+                generation=record.generation,
+                status="mismatch",
+                reason=reason,
+                error=f"expected generation {expected_generation}",
+            )
+        if record.state == BackendLifecycleState.CLOSING:
+            return ComputerUseReleaseResult(
+                session_id=sid,
+                generation=record.generation,
+                status="already_closing",
+                reason=reason,
+            )
+        if record.state == BackendLifecycleState.CLOSED:
+            return ComputerUseReleaseResult(
+                session_id=sid,
+                generation=record.generation,
+                status="already_absent",
+                reason=reason,
+            )
+        record.state = BackendLifecycleState.CLOSING
+        record.close_requested_at = time.monotonic()
+        record.close_reason = reason
+        record.close_attempts += 1
+        record.last_error = None
+        generation = record.generation
+        backend = record.backend
+        call_lock = record.call_lock
 
     with _approval_lock:
         _session_auto_approve.pop(sid, None)
         _always_allow.pop(sid, None)
 
-    if backend is None:
-        return False
+    logger.info(
+        "computer_use lifecycle session=%s generation=%s state=CLOSING reason=%s",
+        sid,
+        generation,
+        reason,
+    )
+    acquired = False
     try:
-        # Let an in-flight action finish before ending the driver session and
-        # dropping its target/ref state. Do not hold the global cache lock
-        # while waiting: unrelated Hermes sessions remain independent.
-        if call_lock is not None:
-            with call_lock:
-                backend.stop()
+        acquired = call_lock.acquire(timeout=max(0.0, timeout))
+        if not acquired:
+            error = f"in-flight call did not quiesce within {timeout:.3f}s"
+            with _backend_lock:
+                current = _backend_records.get(sid)
+                if current is record:
+                    record.state = BackendLifecycleState.FAILED
+                    record.last_error = error
+            status = "timed_out"
         else:
-            backend.stop()
-    except Exception:
-        logger.debug(
-            "computer_use backend release failed for session %s",
-            sid,
-            exc_info=True,
+            try:
+                backend.stop()
+            except Exception as exc:
+                error = repr(exc)
+                with _backend_lock:
+                    current = _backend_records.get(sid)
+                    if current is record:
+                        record.state = BackendLifecycleState.FAILED
+                        record.last_error = error
+                status = "failed"
+            else:
+                error = None
+                with _backend_lock:
+                    current = _backend_records.get(sid)
+                    if current is not record:
+                        status = "mismatch"
+                        error = "lifecycle record changed during close"
+                    else:
+                        record.state = BackendLifecycleState.CLOSED
+                        _backend_records.pop(sid, None)
+                        _backends.pop(sid, None)
+                        _backend_call_locks.pop(sid, None)
+                        _backend_permission_modes.pop(sid, None)
+                        if sid == "" and _backend is backend:
+                            _backend = None
+                        status = "released"
+    finally:
+        if acquired:
+            call_lock.release()
+
+    elapsed_ms = (time.monotonic() - started) * 1000.0
+    log = logger.info if status == "released" else logger.error
+    log(
+        "computer_use lifecycle session=%s generation=%s status=%s "
+        "reason=%s elapsed_ms=%.1f error=%s",
+        sid,
+        generation,
+        status,
+        reason,
+        elapsed_ms,
+        error,
+    )
+    return ComputerUseReleaseResult(
+        session_id=sid,
+        generation=generation,
+        status=status,
+        reason=reason,
+        elapsed_ms=elapsed_ms,
+        error=error,
+    )
+
+
+def _release_computer_use_session_with_retries(
+    session_id: str,
+    *,
+    expected_generation: Optional[int],
+    timeout: float,
+    reason: str,
+    allow_empty_session: bool,
+    max_attempts: int = 3,
+    retry_delay: float = 0.1,
+) -> ComputerUseReleaseResult:
+    """Run bounded retries for transient quiescence/stop failures."""
+    result: Optional[ComputerUseReleaseResult] = None
+    for attempt in range(1, max(1, max_attempts) + 1):
+        result = release_computer_use_session_result(
+            session_id,
+            expected_generation=expected_generation,
+            timeout=timeout,
+            reason=f"{reason}:attempt-{attempt}",
+            allow_empty_session=allow_empty_session,
         )
-    return True
+        if result.status not in {"timed_out", "failed"}:
+            return result
+        if attempt < max_attempts:
+            time.sleep(max(0.0, retry_delay) * attempt)
+    assert result is not None
+    return result
+
+
+def release_computer_use_session(session_id: str) -> bool:
+    """Backward-compatible bool adapter for explicit session teardown."""
+    result = release_computer_use_session_result(
+        session_id,
+        timeout=_DEFAULT_RELEASE_TIMEOUT,
+        reason="explicit",
+        allow_empty_session=True,
+    )
+    return result.released
+
+
+def submit_computer_use_session_release(
+    session_id: str,
+    *,
+    expected_generation: Optional[int],
+    timeout: float = _DEFAULT_RELEASE_TIMEOUT,
+    reason: str,
+    max_attempts: int = 3,
+    retry_delay: float = 0.1,
+) -> concurrent.futures.Future:
+    """Submit one exact generation close to the bounded cleanup supervisor."""
+    return _cleanup_supervisor.submit(
+        session_id,
+        expected_generation=expected_generation,
+        timeout=timeout,
+        reason=reason,
+        allow_empty_session=False,
+        max_attempts=max_attempts,
+        retry_delay=retry_delay,
+    )
+
+
+def drain_computer_use_cleanup(timeout: float = _DEFAULT_RELEASE_TIMEOUT) -> bool:
+    return _cleanup_supervisor.drain(timeout)
 
 
 def _shutdown_backend_atexit() -> None:
-    """Stop all cached backends so cua-driver children don't outlive us.
+    """Boundedly drain tracked cleanup, then close every remaining generation."""
+    try:
+        drain_computer_use_cleanup(timeout=_DEFAULT_RELEASE_TIMEOUT)
+    except Exception:
+        logger.debug("computer_use cleanup drain failed during shutdown", exc_info=True)
 
-    Each session backend holds a long-lived ``cua-driver`` subprocess, so
-    without this a driver can survive the Hermes process that spawned it
-    (#28152 item 3). #69903 kept the orphan from burning a core by disabling
-    the cursor overlay; the process itself still lingered.
-
-    Mirrors ``browser_tool``'s ``atexit.register(_emergency_cleanup_all_sessions)``
-    — same spawn-and-drive-a-subprocess shape. atexit only, no signal handlers:
-    a ``SystemExit`` raised from a prompt_toolkit key binding corrupts its
-    coroutine state and makes the process unkillable. Never raises, since an
-    exception escaping atexit prints a traceback on every exit.
-    """
-    global _backend
-    # Drop the global lock before stop() — teardown budgets 5s and shouldn't
-    # block an unrelated caller waiting to spawn.
     with _backend_lock:
-        unique = {
-            id(backend): (backend, _backend_call_locks.get(sid))
-            for sid, backend in _backends.items()
-        }
-        if _backend is not None:
-            unique.setdefault(
-                id(_backend),
-                (_backend, _backend_call_locks.get("")),
+        records = [
+            (sid, record.generation)
+            for sid, record in _backend_records.items()
+        ]
+        # Preserve direct legacy injection even if it has not been normalized.
+        for sid in tuple(_backends):
+            record = _record_from_legacy_cache_locked(sid)
+            if record is not None and (sid, record.generation) not in records:
+                records.append((sid, record.generation))
+        if _backend is not None and "" not in _backends:
+            record = _record_from_legacy_cache_locked("")
+            if record is not None and ("", record.generation) not in records:
+                records.append(("", record.generation))
+
+    for sid, generation in records:
+        try:
+            release_computer_use_session_result(
+                sid,
+                expected_generation=generation,
+                timeout=_DEFAULT_RELEASE_TIMEOUT,
+                reason="process_shutdown",
+                allow_empty_session=True,
             )
-        _backend = None
-        _backends.clear()
-        _backend_call_locks.clear()
-        _backend_permission_modes.clear()
+        except Exception:
+            logger.debug(
+                "computer_use shutdown release failed session=%s generation=%s",
+                sid,
+                generation,
+                exc_info=True,
+            )
 
     with _approval_lock:
         _session_auto_approve.clear()
         _always_allow.clear()
 
-    for backend, call_lock in unique.values():
+
+def _finalize_computer_use_atexit() -> None:
+    try:
+        _shutdown_backend_atexit()
+    finally:
         try:
-            if call_lock is not None:
-                with call_lock:
-                    backend.stop()
-            else:
-                backend.stop()
-        except Exception as e:
-            logger.debug("cua-driver atexit teardown failed: %s", e)
+            _cleanup_supervisor.shutdown(timeout=_DEFAULT_RELEASE_TIMEOUT)
+        except Exception:
+            pass
 
 
-atexit.register(_shutdown_backend_atexit)
+atexit.register(_finalize_computer_use_atexit)
 
 
 def reset_backend_for_tests() -> None:  # pragma: no cover
-    """Test helper — tear down the cached backend and per-session state."""
+    """Test helper — tear down cached backends and reset lifecycle state."""
+    global _backend, _backend_generation_sequence
     _shutdown_backend_atexit()
+    with _backend_lock:
+        _backend = None
+        _backends.clear()
+        _backend_call_locks.clear()
+        _backend_permission_modes.clear()
+        _backend_records.clear()
+        _backend_generation_counters.clear()
+        _backend_generation_sequence = 0
+    with _approval_lock:
+        _session_auto_approve.clear()
+        _always_allow.clear()
     _AUX_VISION_ROUTE_CACHE.clear()
 
 
@@ -491,24 +1157,26 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         if err is not None:
             return err
 
-    # Dispatch to backend.
+    # Dispatch through an exact-generation action lease. Teardown can mark the
+    # record CLOSING concurrently, but cannot stop the backend until this lease
+    # releases its per-session call lock.
+    call_lock = None
     try:
-        backend = _get_backend(session_id=session_id)
+        backend, call_lock = _acquire_backend_for_call(session_id)
     except Exception as e:
         return json.dumps({
             "error": f"computer_use backend unavailable: {e}",
             "hint": "If the cua-driver binary is missing, run `hermes computer-use install`. "
                     "If a Python dependency is missing, the error above shows the exact install command.",
         })
-
     try:
-        with _backend_lock:
-            call_lock = _backend_call_locks.setdefault(session_id, threading.RLock())
-        with call_lock:
-            return _dispatch(backend, action, args)
+        return _dispatch(backend, action, args)
     except Exception as e:
         logger.exception("computer_use %s failed", action)
         return json.dumps({"error": f"{action} failed: {e}"})
+    finally:
+        if call_lock is not None:
+            call_lock.release()
 
 
 def _request_approval(action: str, args: Dict[str, Any],

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -41,15 +41,20 @@ from __future__ import annotations
 import atexit
 import base64
 import concurrent.futures
+import hashlib
+import importlib
 import json
 import logging
 import os
+import platform
 import queue
 import re
 import struct
+import subprocess
 import sys
 import threading
 import time
+import types
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
@@ -825,81 +830,172 @@ def computer_use_process_snapshot() -> List[Dict[str, Any]]:
         return []
 
 
-def write_computer_use_runtime_attestation(
-    extra_callables: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
-    """Atomically bind the live gateway PID to loaded CUA source/code bytes."""
-    import hashlib
-    import inspect
-    import marshal
+_CUA_ATTESTATION_MODULES = (
+    "tools/computer_use/tool.py",
+    "tools/computer_use/cua_backend.py",
+    "tools/computer_use/browser_route.py",
+    "gateway/run.py",
+    "gateway/session.py",
+    "tools/approval.py",
+)
+_CUA_ATTESTATION_CALLABLES = (
+    "tools.computer_use.tool:set_computer_use_session_validator",
+    "tools.computer_use.tool:_validate_managed_publication",
+    "tools.computer_use.tool:publish_computer_use_session",
+    "tools.computer_use.tool:unpublish_computer_use_session",
+    "tools.computer_use.tool:begin_computer_use_terminal_transition",
+    "tools.computer_use.tool:end_computer_use_terminal_transition",
+    "tools.computer_use.tool:_cua_permission_mode",
+    "tools.computer_use.tool:_get_backend",
+    "tools.computer_use.tool:_acquire_backend_for_call",
+    "tools.computer_use.tool:release_computer_use_session_result",
+    "tools.computer_use.tool:handle_computer_use",
+    "tools.computer_use.tool:_dispatch",
+    "tools.computer_use.cua_backend:_AsyncBridge.run",
+    "tools.computer_use.cua_backend:_CuaDriverSession._lifecycle_coro",
+    "tools.computer_use.cua_backend:_CuaDriverSession.call_tool",
+    "tools.computer_use.cua_backend:_CuaDriverSession._call_tool_via_cli",
+    "tools.computer_use.cua_backend:_CuaDriverSession._restart_session_locked",
+    "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.start",
+    "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.stop",
+    "tools.computer_use.cua_backend:CuaDriverBackend.start",
+    "tools.computer_use.cua_backend:CuaDriverBackend.stop",
+    "tools.computer_use.cua_backend:CuaDriverBackend.capture",
+    "tools.computer_use.cua_backend:CuaDriverBackend._apply_delivery",
+    "tools.computer_use.cua_backend:CuaDriverBackend._run_input_action",
+    "tools.computer_use.cua_backend:CuaDriverBackend._action",
+    "tools.computer_use.cua_backend:CuaDriverBackend._maybe_attach_element_token",
+    "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_state",
+    "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_prepare",
+    "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_action",
+    "gateway.run:GatewayRunner._run_agent",
+    "gateway.session:SessionStore.route_matches",
+    "gateway.session:SessionStore._run_route_transition",
+    "gateway.session:SessionStore.prune_old_entries",
+    "tools.approval:get_current_session_key",
+    "tools.approval:is_approval_bypass_active_for_session",
+)
+
+
+def _canonical_code_payload(code: types.CodeType) -> Dict[str, Any]:
+    """Serialize code semantics without marshal's construction-sensitive graph."""
+    def constant(value: Any) -> Any:
+        if isinstance(value, types.CodeType):
+            return {"type": "code", "value": _canonical_code_payload(value)}
+        if value is None or isinstance(value, (bool, int, str)):
+            return {"type": type(value).__name__, "value": value}
+        if isinstance(value, float):
+            return {"type": "float", "value": value.hex()}
+        if isinstance(value, complex):
+            return {"type": "complex", "real": value.real.hex(), "imag": value.imag.hex()}
+        if isinstance(value, bytes):
+            return {"type": "bytes", "value": value.hex()}
+        if isinstance(value, tuple):
+            return {"type": "tuple", "value": [constant(item) for item in value]}
+        if isinstance(value, frozenset):
+            return {"type": "frozenset", "value": sorted(
+                (constant(item) for item in value), key=lambda item: json.dumps(item, sort_keys=True)
+            )}
+        raise TypeError(f"unsupported code constant type: {type(value)!r}")
+
+    return {
+        "argcount": code.co_argcount, "posonlyargcount": code.co_posonlyargcount,
+        "kwonlyargcount": code.co_kwonlyargcount, "nlocals": code.co_nlocals,
+        "stacksize": code.co_stacksize, "flags": code.co_flags,
+        "code": code.co_code.hex(), "consts": [constant(value) for value in code.co_consts],
+        "names": list(code.co_names), "varnames": list(code.co_varnames),
+        "freevars": list(code.co_freevars), "cellvars": list(code.co_cellvars),
+        "filename": code.co_filename, "qualname": code.co_qualname,
+        "firstlineno": code.co_firstlineno, "linetable": code.co_linetable.hex(),
+        "exceptiontable": code.co_exceptiontable.hex(),
+    }
+
+
+def _code_fingerprint(code: types.CodeType) -> str:
+    payload = json.dumps(_canonical_code_payload(code), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()
+
+
+def _attestation_repo_root() -> "Path":
+    from pathlib import Path
+    return Path(__file__).resolve().parents[2]
+
+
+def _git_output(repo_root: "Path", *args: str) -> Optional[str]:
+    try:
+        return subprocess.check_output(["git", "-C", str(repo_root), *args], text=True, stderr=subprocess.DEVNULL).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _collect_attested_source_identity(repo_root: "Path", paths: tuple[str, ...], modules: Dict[str, Any]) -> Dict[str, Any]:
+    head = _git_output(repo_root, "rev-parse", "HEAD")
+    tree = _git_output(repo_root, "rev-parse", "HEAD^{tree}")
+    rows: Dict[str, Any] = {}
+    all_match = bool(head and tree)
+    for relative_path in paths:
+        head_blob = _git_output(repo_root, "rev-parse", f"HEAD:{relative_path}") if head else None
+        tracked = _git_output(repo_root, "ls-files", "--error-unmatch", "--", relative_path) is not None
+        dirty = _git_output(repo_root, "diff", "--quiet", "HEAD", "--", relative_path)
+        matches_head = bool(head_blob and tracked and dirty == "")
+        all_match = all_match and matches_head
+        rows[relative_path] = {"worktree_sha256": modules[relative_path]["sha256"], "head_blob": head_blob, "matches_head": matches_head}
+    manifest = json.dumps(rows, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    if not head or not tree:
+        return {"kind": "unversioned", "attested_paths": rows, "review_source_sha256": hashlib.sha256(manifest.encode("ascii")).hexdigest()}
+    return {"repository": {"vcs": "git", "root": str(repo_root), "head_commit": head, "head_tree": tree}, "kind": "git-clean" if all_match else "dirty-attested-source", "attested_paths": rows, "review_source_sha256": hashlib.sha256(manifest.encode("ascii")).hexdigest()}
+
+
+def _resolve_attested_callable(identity: str, supplied: Dict[str, Any]) -> Any:
+    module_name, qualname = identity.split(":", 1)
+    for value in supplied.values():
+        target = getattr(value, "__func__", value)
+        if getattr(target, "__module__", None) == module_name and getattr(target, "__qualname__", None) == qualname:
+            return target
+    target: Any = importlib.import_module(module_name)
+    for part in qualname.split("."):
+        target = getattr(target, part)
+    return getattr(target, "__func__", target)
+
+
+def write_computer_use_runtime_attestation(extra_callables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Atomically bind the live gateway PID to a fixed CUA code/source surface."""
     from datetime import datetime, timezone
     from pathlib import Path
-
     from hermes_constants import get_hermes_home
 
-    callables: Dict[str, Any] = {
-        "publish_computer_use_session": publish_computer_use_session,
-        "_get_backend": _get_backend,
-        "_acquire_backend_for_call": _acquire_backend_for_call,
-        "release_computer_use_session_result": release_computer_use_session_result,
-    }
-    callables.update(extra_callables or {})
-    code_rows = {}
-    module_paths = set()
-    for name, value in callables.items():
-        target = getattr(value, "__func__", value)
+    importlib.import_module("tools.computer_use.cua_backend")
+    repo_root = _attestation_repo_root()
+    modules: Dict[str, Any] = {}
+    for relative_path in _CUA_ATTESTATION_MODULES:
+        source_path = (repo_root / relative_path).resolve()
+        raw = source_path.read_bytes()
+        modules[relative_path] = {"source_path": str(source_path), "size": len(raw), "sha256": hashlib.sha256(raw).hexdigest()}
+    supplied = extra_callables or {}
+    callables: Dict[str, Any] = {}
+    for identity in _CUA_ATTESTATION_CALLABLES:
+        target = _resolve_attested_callable(identity, supplied)
         code = getattr(target, "__code__", None)
-        source_path = inspect.getsourcefile(target)
-        if source_path:
-            module_paths.add(str(Path(source_path).resolve()))
-        code_rows[name] = {
-            "source_path": str(Path(source_path).resolve()) if source_path else None,
-            "first_line": getattr(code, "co_firstlineno", None),
-            "code_sha256": (
-                hashlib.sha256(marshal.dumps(code)).hexdigest()
-                if code is not None
-                else None
-            ),
-        }
-    modules = {}
-    for source_path in sorted(module_paths):
-        path = Path(source_path)
-        modules[source_path] = {
-            "size": path.stat().st_size,
-            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
-        }
+        if code is None:
+            raise RuntimeError(f"attestation callable has no code: {identity}")
+        source_path = Path(code.co_filename).resolve()
+        try:
+            relative_path = source_path.relative_to(repo_root).as_posix()
+        except ValueError as exc:
+            raise RuntimeError(f"attestation callable outside repository: {identity}") from exc
+        callables[identity] = {"module": target.__module__, "qualname": target.__qualname__, "source_relative_path": relative_path, "first_line": code.co_firstlineno, "code_sha256": _code_fingerprint(code)}
     try:
         import psutil
-
         process = psutil.Process(os.getpid())
-        process_create_time = process.create_time()
-        process_executable = process.exe()
+        process_create_time, process_executable = process.create_time(), process.exe()
         if not process_executable:
             raise RuntimeError("live gateway process executable is unavailable")
-    except Exception:
-        # Process creation time and the OS-reported executable are required
-        # for PID-reuse-safe external verification. Fail instead of publishing
-        # a weaker receipt.
-        raise RuntimeError("could not attest live gateway process identity")
+    except Exception as exc:
+        raise RuntimeError("could not attest live gateway process identity") from exc
     output = get_hermes_home() / "runtime" / "cua_gateway_attestation.json"
     archive_dir = output.parent / "cua_gateway_attestations"
-    archive = archive_dir / (
-        f"{os.getpid()}-{int(process_create_time * 1_000_000)}.json"
-    )
-    receipt = {
-        "schema": 2,
-        "captured_at": datetime.now(timezone.utc).isoformat(),
-        "pid": os.getpid(),
-        "ppid": os.getppid(),
-        "process_create_time": process_create_time,
-        "executable": process_executable,
-        "launcher": sys.executable,
-        "argv": list(sys.argv),
-        "modules": modules,
-        "callables": code_rows,
-        "archive_path": str(archive),
-        "path": str(output),
-    }
+    archive = archive_dir / f"{os.getpid()}-{int(process_create_time * 1_000_000)}.json"
+    receipt = {"schema": 3, "captured_at": datetime.now(timezone.utc).isoformat(), "pid": os.getpid(), "ppid": os.getppid(), "process_create_time": process_create_time, "executable": process_executable, "launcher": sys.executable, "argv": list(sys.argv), "runtime": {"python_implementation": platform.python_implementation(), "python_version": list(sys.version_info[:3]), "python_cache_tag": sys.implementation.cache_tag, "optimization": sys.flags.optimize}, "source_identity": _collect_attested_source_identity(repo_root, _CUA_ATTESTATION_MODULES, modules), "modules": modules, "callables": callables, "archive_path": str(archive), "path": str(output)}
     output.parent.mkdir(parents=True, exist_ok=True)
     archive_dir.mkdir(parents=True, exist_ok=True)
     encoded = json.dumps(receipt, indent=2)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -214,6 +214,8 @@ class ComputerUseSessionReactivation:
 @dataclass(eq=False)
 class ComputerUseSessionPublication:
     session_id: str
+    route_key: Optional[str] = None
+    route_epoch: int = 0
     active: bool = True
 
 
@@ -321,7 +323,7 @@ def set_computer_use_session_validator(validator) -> None:
 
 
 def _validate_managed_publication(sid: str) -> tuple[bool, int]:
-    """Validate without lock inversion, retrying across route-epoch changes."""
+    """Validate admission without lock inversion across route epoch changes."""
     while True:
         with _backend_lock:
             epoch = _session_route_epoch_sequence
@@ -331,7 +333,10 @@ def _validate_managed_publication(sid: str) -> tuple[bool, int]:
                 return True, epoch
             validator = _managed_session_validator
         try:
-            allowed = bool(validator(sid)) if callable(validator) else False
+            # ``None`` requests a current-session-id lookup, not authority to
+            # mint a run publication. Publication itself always supplies and
+            # validates an exact route key.
+            allowed = bool(validator(None, sid)) if callable(validator) else False
         except Exception:
             allowed = False
         with _backend_lock:
@@ -341,21 +346,58 @@ def _validate_managed_publication(sid: str) -> tuple[bool, int]:
 
 def publish_computer_use_session(
     session_id: str,
+    *,
+    route_key: Optional[str] = None,
 ) -> ComputerUseSessionPublication:
-    """Publish one run-scoped gateway route lease for CUA acquisition."""
+    """Publish one route-bound run lease after authoritative validation.
+
+    The validator runs outside ``_backend_lock`` to avoid lock inversion with
+    SessionStore.  The scalar route epoch is then rechecked under the lock, so
+    a terminal transition or reactivation that starts during validation makes
+    this attempt retry instead of minting a stale capability.
+    """
     global _managed_routing_enabled
     sid = str(session_id or "")
     if not sid:
         raise ValueError("managed computer_use publication requires a session id")
-    with _backend_lock:
-        _managed_routing_enabled = True
-        if sid in _terminal_transitions or sid in _session_reactivations:
-            raise RuntimeError(
-                f"computer_use backend for session {sid!r} is fenced by a terminal transition"
+    normalized_route_key = str(route_key or "") or None
+    while True:
+        with _backend_lock:
+            epoch = _session_route_epoch_sequence
+            validator = _managed_session_validator
+            validator_required = callable(validator)
+        if validator_required:
+            if normalized_route_key is None:
+                raise ValueError(
+                    "managed computer_use publication requires an exact route key"
+                )
+            try:
+                allowed = bool(validator(normalized_route_key, sid))
+            except Exception:
+                allowed = False
+        else:
+            # Backward-compatible unmanaged CLI/test seam.  The first lease
+            # still enables publication-only admission after it is removed.
+            allowed = True
+        with _backend_lock:
+            if epoch != _session_route_epoch_sequence:
+                continue
+            if sid in _terminal_transitions or sid in _session_reactivations:
+                raise RuntimeError(
+                    f"computer_use backend for session {sid!r} is fenced by a terminal transition"
+                )
+            if not allowed:
+                raise RuntimeError(
+                    f"computer_use session {sid!r} does not match the authoritative route"
+                )
+            _managed_routing_enabled = True
+            publication = ComputerUseSessionPublication(
+                session_id=sid,
+                route_key=normalized_route_key,
+                route_epoch=epoch,
             )
-        publication = ComputerUseSessionPublication(session_id=sid)
-        _managed_session_publications.setdefault(sid, set()).add(publication)
-        return publication
+            _managed_session_publications.setdefault(sid, set()).add(publication)
+            return publication
 
 
 def unpublish_computer_use_session(
@@ -781,6 +823,87 @@ def computer_use_process_snapshot() -> List[Dict[str, Any]]:
     except Exception:
         logger.debug("computer_use process snapshot failed", exc_info=True)
         return []
+
+
+def write_computer_use_runtime_attestation(
+    extra_callables: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Atomically bind the live gateway PID to loaded CUA source/code bytes."""
+    import hashlib
+    import inspect
+    import marshal
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from hermes_constants import get_hermes_home
+
+    callables: Dict[str, Any] = {
+        "publish_computer_use_session": publish_computer_use_session,
+        "_get_backend": _get_backend,
+        "_acquire_backend_for_call": _acquire_backend_for_call,
+        "release_computer_use_session_result": release_computer_use_session_result,
+    }
+    callables.update(extra_callables or {})
+    code_rows = {}
+    module_paths = set()
+    for name, value in callables.items():
+        target = getattr(value, "__func__", value)
+        code = getattr(target, "__code__", None)
+        source_path = inspect.getsourcefile(target)
+        if source_path:
+            module_paths.add(str(Path(source_path).resolve()))
+        code_rows[name] = {
+            "source_path": str(Path(source_path).resolve()) if source_path else None,
+            "first_line": getattr(code, "co_firstlineno", None),
+            "code_sha256": (
+                hashlib.sha256(marshal.dumps(code)).hexdigest()
+                if code is not None
+                else None
+            ),
+        }
+    modules = {}
+    for source_path in sorted(module_paths):
+        path = Path(source_path)
+        modules[source_path] = {
+            "size": path.stat().st_size,
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+    try:
+        import psutil
+
+        process_create_time = psutil.Process(os.getpid()).create_time()
+    except Exception:
+        # Process creation time is required for PID-reuse-safe external
+        # verification. Fail instead of publishing a weaker receipt.
+        raise RuntimeError("could not attest gateway process creation time")
+    output = get_hermes_home() / "runtime" / "cua_gateway_attestation.json"
+    archive_dir = output.parent / "cua_gateway_attestations"
+    archive = archive_dir / (
+        f"{os.getpid()}-{int(process_create_time * 1_000_000)}.json"
+    )
+    receipt = {
+        "schema": 2,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "pid": os.getpid(),
+        "ppid": os.getppid(),
+        "process_create_time": process_create_time,
+        "executable": sys.executable,
+        "argv": list(sys.argv),
+        "modules": modules,
+        "callables": code_rows,
+        "archive_path": str(archive),
+        "path": str(output),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(receipt, indent=2)
+    archive_temporary = archive.with_suffix(".tmp")
+    archive_temporary.write_text(encoded, encoding="utf-8")
+    os.replace(archive_temporary, archive)
+    temporary = output.with_suffix(".tmp")
+    temporary.write_text(encoded, encoding="utf-8")
+    os.replace(temporary, output)
+    return receipt
 
 
 def _cua_permission_mode(session_id: str) -> str:
@@ -1490,6 +1613,21 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
     try:
         return _dispatch(backend, action, args)
     except Exception as e:
+        if getattr(e, "cua_action_termination_unconfirmed", False):
+            # The action lease is about to be released, but the exact driver
+            # coroutine may still be running. Poison this generation before
+            # releasing the lock so no successor action can overlap it. Only
+            # exact-generation teardown may clear the failed record.
+            with _backend_lock:
+                record = _backend_records.get(session_id)
+                if (
+                    record is not None
+                    and record.backend is backend
+                    and record.state == BackendLifecycleState.ACTIVE
+                ):
+                    record.state = BackendLifecycleState.FAILED
+                    record.close_reason = "action_termination_unconfirmed"
+                    record.last_error = repr(e)
         logger.exception("computer_use %s failed", action)
         return json.dumps({"error": f"{action} failed: {e}"})
     finally:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -836,6 +836,7 @@ _CUA_ATTESTATION_MODULES = (
     "tools/computer_use/browser_route.py",
     "gateway/run.py",
     "gateway/session.py",
+    "hermes_state.py",
     "tools/approval.py",
 )
 _CUA_ATTESTATION_CALLABLES = (
@@ -872,6 +873,9 @@ _CUA_ATTESTATION_CALLABLES = (
     "gateway.session:SessionStore.route_matches",
     "gateway.session:SessionStore._run_route_transition",
     "gateway.session:SessionStore.prune_old_entries",
+    "hermes_state:SessionDB._execute_write",
+    "hermes_state:SessionDB.publish_compression_child",
+    "hermes_state:SessionDB.promote_to_session_reset",
     "tools.approval:get_current_session_key",
     "tools.approval:is_approval_bypass_active_for_session",
 )
@@ -987,15 +991,21 @@ def write_computer_use_runtime_attestation(extra_callables: Optional[Dict[str, A
     try:
         import psutil
         process = psutil.Process(os.getpid())
+        parent = process.parent()
         process_create_time, process_executable = process.create_time(), process.exe()
-        if not process_executable:
-            raise RuntimeError("live gateway process executable is unavailable")
+        parent_identity = {
+            "pid": parent.pid,
+            "process_create_time": parent.create_time(),
+            "executable": parent.exe(),
+        }
+        if not process_executable or not parent_identity["executable"]:
+            raise RuntimeError("live gateway process identity is unavailable")
     except Exception as exc:
         raise RuntimeError("could not attest live gateway process identity") from exc
     output = get_hermes_home() / "runtime" / "cua_gateway_attestation.json"
     archive_dir = output.parent / "cua_gateway_attestations"
     archive = archive_dir / f"{os.getpid()}-{int(process_create_time * 1_000_000)}.json"
-    receipt = {"schema": 3, "captured_at": datetime.now(timezone.utc).isoformat(), "pid": os.getpid(), "ppid": os.getppid(), "process_create_time": process_create_time, "executable": process_executable, "launcher": sys.executable, "argv": list(sys.argv), "runtime": {"python_implementation": platform.python_implementation(), "python_version": list(sys.version_info[:3]), "python_cache_tag": sys.implementation.cache_tag, "optimization": sys.flags.optimize}, "source_identity": _collect_attested_source_identity(repo_root, _CUA_ATTESTATION_MODULES, modules), "modules": modules, "callables": callables, "archive_path": str(archive), "path": str(output)}
+    receipt = {"schema": 3, "captured_at": datetime.now(timezone.utc).isoformat(), "pid": os.getpid(), "ppid": os.getppid(), "process_create_time": process_create_time, "executable": process_executable, "launcher": sys.executable, "parent": parent_identity, "argv": list(sys.argv), "runtime": {"python_implementation": platform.python_implementation(), "python_version": list(sys.version_info[:3]), "python_cache_tag": sys.implementation.cache_tag, "optimization": sys.flags.optimize}, "source_identity": _collect_attested_source_identity(repo_root, _CUA_ATTESTATION_MODULES, modules), "modules": modules, "callables": callables, "archive_path": str(archive), "path": str(output)}
     output.parent.mkdir(parents=True, exist_ok=True)
     archive_dir.mkdir(parents=True, exist_ok=True)
     encoded = json.dumps(receipt, indent=2)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -199,6 +199,24 @@ class ComputerUseReleaseResult:
         return self.released
 
 
+@dataclass(frozen=True)
+class ComputerUseTerminalTransition:
+    session_id: str
+    generation: Optional[int]
+    invalidated_publications: tuple["ComputerUseSessionPublication", ...] = ()
+
+
+@dataclass(frozen=True)
+class ComputerUseSessionReactivation:
+    session_id: str
+
+
+@dataclass(eq=False)
+class ComputerUseSessionPublication:
+    session_id: str
+    active: bool = True
+
+
 @dataclass
 class _BackendRecord:
     session_id: str
@@ -214,10 +232,20 @@ class _BackendRecord:
 
 
 _backend_records: Dict[str, _BackendRecord] = {}
+_terminal_transitions: Dict[str, ComputerUseTerminalTransition] = {}
+_session_reactivations: Dict[str, ComputerUseSessionReactivation] = {}
+_managed_session_publications: Dict[
+    str, set[ComputerUseSessionPublication]
+] = {}
+_managed_routing_enabled = False
+_managed_session_validator = None
+_session_route_epoch_sequence = 0
+_backend_lookup_state = threading.local()
 _backend_generation_counters: OrderedDict[str, int] = OrderedDict()
 _backend_generation_sequence = 0
 _BACKEND_GENERATION_TOMBSTONE_CAP = 4096
 _DEFAULT_RELEASE_TIMEOUT = 5.0
+_EXPECTED_GENERATION_UNSET = object()
 
 
 def _next_backend_generation_locked(sid: str) -> int:
@@ -236,6 +264,20 @@ def _next_backend_generation_locked(sid: str) -> int:
             # generations rather than corrupting ownership or looping forever.
             break
     return generation
+
+
+def _stamp_backend_lookup_locked(
+    sid: str,
+    backend: ComputerUseBackend,
+    *,
+    route_allowed: bool,
+) -> None:
+    _backend_lookup_state.value = (
+        sid,
+        id(backend),
+        _session_route_epoch_sequence,
+        route_allowed,
+    )
 
 
 def _record_from_legacy_cache_locked(sid: str) -> Optional[_BackendRecord]:
@@ -261,6 +303,75 @@ def _record_from_legacy_cache_locked(sid: str) -> Optional[_BackendRecord]:
     return record
 
 
+def _has_active_publication_locked(sid: str) -> bool:
+    return any(
+        publication.active
+        for publication in _managed_session_publications.get(sid, ())
+    )
+
+
+def set_computer_use_session_validator(validator) -> None:
+    """Install the gateway's authoritative current-route validator."""
+    global _managed_routing_enabled, _managed_session_validator
+    global _session_route_epoch_sequence
+    with _backend_lock:
+        _managed_session_validator = validator
+        _managed_routing_enabled = validator is not None
+        _session_route_epoch_sequence += 1
+
+
+def _validate_managed_publication(sid: str) -> tuple[bool, int]:
+    """Validate without lock inversion, retrying across route-epoch changes."""
+    while True:
+        with _backend_lock:
+            epoch = _session_route_epoch_sequence
+            if not sid or not _managed_routing_enabled:
+                return True, epoch
+            if _has_active_publication_locked(sid):
+                return True, epoch
+            validator = _managed_session_validator
+        try:
+            allowed = bool(validator(sid)) if callable(validator) else False
+        except Exception:
+            allowed = False
+        with _backend_lock:
+            if epoch == _session_route_epoch_sequence:
+                return allowed, epoch
+
+
+def publish_computer_use_session(
+    session_id: str,
+) -> ComputerUseSessionPublication:
+    """Publish one run-scoped gateway route lease for CUA acquisition."""
+    global _managed_routing_enabled
+    sid = str(session_id or "")
+    if not sid:
+        raise ValueError("managed computer_use publication requires a session id")
+    with _backend_lock:
+        _managed_routing_enabled = True
+        if sid in _terminal_transitions or sid in _session_reactivations:
+            raise RuntimeError(
+                f"computer_use backend for session {sid!r} is fenced by a terminal transition"
+            )
+        publication = ComputerUseSessionPublication(session_id=sid)
+        _managed_session_publications.setdefault(sid, set()).add(publication)
+        return publication
+
+
+def unpublish_computer_use_session(
+    publication: ComputerUseSessionPublication,
+) -> None:
+    """Release one exact run-scoped publication and reclaim its map entry."""
+    with _backend_lock:
+        publications = _managed_session_publications.get(publication.session_id)
+        if publications is None or publication not in publications:
+            raise RuntimeError("computer_use session publication token mismatch")
+        publications.remove(publication)
+        publication.active = False
+        if not publications:
+            _managed_session_publications.pop(publication.session_id, None)
+
+
 def get_computer_use_session_generation(session_id: str) -> Optional[int]:
     sid = str(session_id or "")
     if not sid:
@@ -268,6 +379,112 @@ def get_computer_use_session_generation(session_id: str) -> Optional[int]:
     with _backend_lock:
         record = _record_from_legacy_cache_locked(sid)
         return record.generation if record is not None else None
+
+
+def begin_computer_use_terminal_transition(
+    session_id: str,
+) -> ComputerUseTerminalTransition:
+    """Fence one session ID against CUA acquisition through route publication."""
+    sid = str(session_id or "")
+    if not sid:
+        raise ValueError("terminal computer_use transition requires a session id")
+    global _session_route_epoch_sequence
+    with _backend_lock:
+        if sid in _terminal_transitions or sid in _session_reactivations:
+            raise RuntimeError(
+                f"computer_use backend for session {sid!r} already has a lifecycle transition"
+            )
+        _session_route_epoch_sequence += 1
+        invalidated_publications = tuple(
+            publication
+            for publication in _managed_session_publications.get(sid, ())
+            if publication.active
+        )
+        for publication in invalidated_publications:
+            publication.active = False
+        record = _record_from_legacy_cache_locked(sid)
+        token = ComputerUseTerminalTransition(
+            session_id=sid,
+            generation=record.generation if record is not None else None,
+            invalidated_publications=invalidated_publications,
+        )
+        _terminal_transitions[sid] = token
+        return token
+
+
+def end_computer_use_terminal_transition(
+    transition: ComputerUseTerminalTransition,
+    *,
+    retire: bool = False,
+) -> None:
+    """Remove one exact fence after confirmed route publication."""
+    global _managed_routing_enabled, _session_route_epoch_sequence
+    with _backend_lock:
+        current = _terminal_transitions.get(transition.session_id)
+        if current is not transition:
+            raise RuntimeError("computer_use terminal transition token mismatch")
+        _terminal_transitions.pop(transition.session_id, None)
+        _session_route_epoch_sequence += 1
+        if retire:
+            _managed_routing_enabled = True
+        else:
+            publications = _managed_session_publications.get(
+                transition.session_id,
+                set(),
+            )
+            for publication in transition.invalidated_publications:
+                if publication in publications:
+                    publication.active = True
+
+
+def is_computer_use_session_retired(session_id: str) -> bool:
+    sid = str(session_id or "")
+    if not sid:
+        return False
+    with _backend_lock:
+        return _managed_routing_enabled and not _has_active_publication_locked(sid)
+
+
+def begin_computer_use_session_reactivation(
+    session_id: str,
+) -> ComputerUseSessionReactivation:
+    """Fence and re-arm one explicitly republished historical route ID."""
+    sid = str(session_id or "")
+    if not sid:
+        raise ValueError("computer_use reactivation requires a session id")
+    global _session_route_epoch_sequence
+    with _backend_lock:
+        if _has_active_publication_locked(sid):
+            raise RuntimeError(
+                f"computer_use session {sid!r} is already published"
+            )
+        if sid in _terminal_transitions or sid in _session_reactivations:
+            raise RuntimeError(
+                f"computer_use session {sid!r} already has a lifecycle fence"
+            )
+        if _record_from_legacy_cache_locked(sid) is not None:
+            raise RuntimeError(
+                f"computer_use retired session {sid!r} still owns a backend"
+            )
+        token = ComputerUseSessionReactivation(session_id=sid)
+        _session_route_epoch_sequence += 1
+        _session_reactivations[sid] = token
+        return token
+
+
+def end_computer_use_session_reactivation(
+    reactivation: ComputerUseSessionReactivation,
+    *,
+    succeeded: bool,
+) -> None:
+    """Finish one exact reactivation fence or restore retirement on failure."""
+    global _session_route_epoch_sequence
+    with _backend_lock:
+        current = _session_reactivations.get(reactivation.session_id)
+        if current is not reactivation:
+            raise RuntimeError("computer_use session reactivation token mismatch")
+        _session_reactivations.pop(reactivation.session_id, None)
+        _session_route_epoch_sequence += 1
 
 
 def computer_use_lifecycle_snapshot() -> Dict[str, Dict[str, Any]]:
@@ -601,7 +818,18 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
     sid = str(session_id or "")
     while True:
         release_generation: Optional[int] = None
+        route_allowed, route_epoch = _validate_managed_publication(sid)
         with _backend_lock:
+            if route_epoch != _session_route_epoch_sequence:
+                continue
+            if sid in _terminal_transitions or sid in _session_reactivations:
+                raise RuntimeError(
+                    f"computer_use backend for session {sid!r} is fenced by a terminal transition"
+                )
+            if not route_allowed:
+                raise RuntimeError(
+                    f"computer_use backend for retired or unpublished session {sid!r} is unavailable"
+                )
             permission_mode = _cua_permission_mode(sid)
             if sid == "" and _backend is not None and sid not in _backends:
                 _backends[sid] = _backend
@@ -611,6 +839,11 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
             if record is not None:
                 if record.state == BackendLifecycleState.ACTIVE:
                     if record.permission_mode == permission_mode:
+                        _stamp_backend_lookup_locked(
+                            sid,
+                            record.backend,
+                            route_allowed=route_allowed,
+                        )
                         return record.backend
                     release_generation = record.generation
                 elif record.state == BackendLifecycleState.CLOSING:
@@ -687,6 +920,11 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
                     sid,
                     record.generation,
                 )
+                _stamp_backend_lookup_locked(
+                    sid,
+                    backend,
+                    route_allowed=route_allowed,
+                )
                 return backend
 
         # Permission-mode changes are hard lifecycle boundaries. The exact
@@ -714,6 +952,18 @@ def _acquire_backend_for_call(
     sid = str(session_id or "")
     for _ in range(3):
         backend = _get_backend(session_id=sid)
+        lookup = getattr(_backend_lookup_state, "value", None)
+        expected_route_epoch = (
+            lookup[2]
+            if (
+                isinstance(lookup, tuple)
+                and len(lookup) == 4
+                and lookup[0] == sid
+                and lookup[1] == id(backend)
+                and lookup[3] is True
+            )
+            else None
+        )
         with _backend_lock:
             record = _record_from_legacy_cache_locked(sid)
             if record is None and sid == "":
@@ -736,18 +986,42 @@ def _acquire_backend_for_call(
                 _backend_permission_modes[sid] = record.permission_mode
                 _backend = backend
             if record is None or record.backend is not backend:
+                if (
+                    expected_route_epoch is not None
+                    and expected_route_epoch != _session_route_epoch_sequence
+                ):
+                    raise RuntimeError(
+                        f"computer_use backend for session {sid!r} changed while acquiring action lease"
+                    )
                 continue
             call_lock = record.call_lock
         call_lock.acquire()
         with _backend_lock:
             current = _backend_records.get(sid)
+            current_route_epoch = _session_route_epoch_sequence
             if (
                 current is record
                 and current.backend is backend
                 and current.state == BackendLifecycleState.ACTIVE
+                and sid not in _terminal_transitions
+                and sid not in _session_reactivations
+                and (
+                    not sid
+                    or (
+                        expected_route_epoch is not None
+                        and expected_route_epoch == current_route_epoch
+                    )
+                )
             ):
                 return backend, call_lock
         call_lock.release()
+        if (
+            expected_route_epoch is not None
+            and expected_route_epoch != current_route_epoch
+        ):
+            raise RuntimeError(
+                f"computer_use backend for session {sid!r} changed while acquiring action lease"
+            )
     raise RuntimeError(
         f"computer_use backend for session {sid!r} changed while acquiring action lease"
     )
@@ -756,19 +1030,37 @@ def _acquire_backend_for_call(
 def release_computer_use_session_result(
     session_id: str,
     *,
-    expected_generation: Optional[int] = None,
+    expected_generation: Any = _EXPECTED_GENERATION_UNSET,
     timeout: float = _DEFAULT_RELEASE_TIMEOUT,
     reason: str = "explicit",
     allow_empty_session: bool = False,
 ) -> ComputerUseReleaseResult:
-    """Close one exact backend generation with bounded, truthful lifecycle state."""
+    """Close one exact backend generation with bounded, truthful lifecycle state.
+
+    Omitting ``expected_generation`` preserves the historical public call shape,
+    but it never authorizes wildcard teardown: the exact active generation is
+    snapshotted under ``_backend_lock``. Passing ``None`` explicitly remains an
+    invalid generation.
+    """
     global _backend
     sid = str(session_id or "")
     started = time.monotonic()
-    if not sid and not allow_empty_session:
+    generation_omitted = expected_generation is _EXPECTED_GENERATION_UNSET
+    if (
+        not generation_omitted
+        and (type(expected_generation) is not int or expected_generation <= 0)
+    ):
         return ComputerUseReleaseResult(
             session_id=sid,
             generation=expected_generation,
+            status="mismatch",
+            reason=reason,
+            error="expected_generation must be a positive integer",
+        )
+    if not sid and not allow_empty_session:
+        return ComputerUseReleaseResult(
+            session_id=sid,
+            generation=None if generation_omitted else expected_generation,
             status="mismatch",
             reason=reason,
             error="empty session id rejected",
@@ -776,6 +1068,15 @@ def release_computer_use_session_result(
 
     with _backend_lock:
         record = _record_from_legacy_cache_locked(sid)
+        if generation_omitted:
+            if record is None:
+                return ComputerUseReleaseResult(
+                    session_id=sid,
+                    generation=None,
+                    status="already_absent",
+                    reason=reason,
+                )
+            expected_generation = record.generation
         if record is None:
             last_generation = _backend_generation_counters.get(sid)
             idempotent_absence = (
@@ -901,7 +1202,7 @@ def release_computer_use_session_result(
 def _release_computer_use_session_with_retries(
     session_id: str,
     *,
-    expected_generation: Optional[int],
+    expected_generation: int,
     timeout: float,
     reason: str,
     allow_empty_session: bool,
@@ -927,9 +1228,16 @@ def _release_computer_use_session_with_retries(
 
 
 def release_computer_use_session(session_id: str) -> bool:
-    """Backward-compatible bool adapter for explicit session teardown."""
+    """Backward-compatible bool adapter that snapshots one exact generation."""
+    sid = str(session_id or "")
+    with _backend_lock:
+        record = _record_from_legacy_cache_locked(sid)
+        if record is None:
+            return False
+        generation = record.generation
     result = release_computer_use_session_result(
-        session_id,
+        sid,
+        expected_generation=generation,
         timeout=_DEFAULT_RELEASE_TIMEOUT,
         reason="explicit",
         allow_empty_session=True,
@@ -940,13 +1248,15 @@ def release_computer_use_session(session_id: str) -> bool:
 def submit_computer_use_session_release(
     session_id: str,
     *,
-    expected_generation: Optional[int],
+    expected_generation: int,
     timeout: float = _DEFAULT_RELEASE_TIMEOUT,
     reason: str,
     max_attempts: int = 3,
     retry_delay: float = 0.1,
 ) -> concurrent.futures.Future:
     """Submit one exact generation close to the bounded cleanup supervisor."""
+    if type(expected_generation) is not int or expected_generation <= 0:
+        raise ValueError("expected_generation must be a positive integer")
     return _cleanup_supervisor.submit(
         session_id,
         expected_generation=expected_generation,
@@ -1022,6 +1332,8 @@ atexit.register(_finalize_computer_use_atexit)
 def reset_backend_for_tests() -> None:  # pragma: no cover
     """Test helper — tear down cached backends and reset lifecycle state."""
     global _backend, _backend_generation_sequence
+    global _managed_routing_enabled, _managed_session_validator
+    global _session_route_epoch_sequence
     _shutdown_backend_atexit()
     with _backend_lock:
         _backend = None
@@ -1029,6 +1341,12 @@ def reset_backend_for_tests() -> None:  # pragma: no cover
         _backend_call_locks.clear()
         _backend_permission_modes.clear()
         _backend_records.clear()
+        _terminal_transitions.clear()
+        _session_reactivations.clear()
+        _managed_session_publications.clear()
+        _managed_routing_enabled = False
+        _managed_session_validator = None
+        _session_route_epoch_sequence = 0
         _backend_generation_counters.clear()
         _backend_generation_sequence = 0
     with _approval_lock:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -871,11 +871,16 @@ def write_computer_use_runtime_attestation(
     try:
         import psutil
 
-        process_create_time = psutil.Process(os.getpid()).create_time()
+        process = psutil.Process(os.getpid())
+        process_create_time = process.create_time()
+        process_executable = process.exe()
+        if not process_executable:
+            raise RuntimeError("live gateway process executable is unavailable")
     except Exception:
-        # Process creation time is required for PID-reuse-safe external
-        # verification. Fail instead of publishing a weaker receipt.
-        raise RuntimeError("could not attest gateway process creation time")
+        # Process creation time and the OS-reported executable are required
+        # for PID-reuse-safe external verification. Fail instead of publishing
+        # a weaker receipt.
+        raise RuntimeError("could not attest live gateway process identity")
     output = get_hermes_home() / "runtime" / "cua_gateway_attestation.json"
     archive_dir = output.parent / "cua_gateway_attestations"
     archive = archive_dir / (
@@ -887,7 +892,8 @@ def write_computer_use_runtime_attestation(
         "pid": os.getpid(),
         "ppid": os.getppid(),
         "process_create_time": process_create_time,
-        "executable": sys.executable,
+        "executable": process_executable,
+        "launcher": sys.executable,
         "argv": list(sys.argv),
         "modules": modules,
         "callables": code_rows,

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -854,11 +854,14 @@ _CUA_ATTESTATION_CALLABLES = (
     "tools.computer_use.tool:_dispatch",
     "tools.computer_use.cua_backend:_AsyncBridge.run",
     "tools.computer_use.cua_backend:_CuaDriverSession._lifecycle_coro",
+    "tools.computer_use.cua_backend:_CuaDriverSession.start",
+    "tools.computer_use.cua_backend:_CuaDriverSession._attest_runtime_locked",
     "tools.computer_use.cua_backend:_CuaDriverSession.call_tool",
     "tools.computer_use.cua_backend:_CuaDriverSession._call_tool_via_cli",
     "tools.computer_use.cua_backend:_CuaDriverSession._restart_session_locked",
     "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.start",
     "tools.computer_use.cua_backend:_EmbeddedCuaDaemon.stop",
+    "tools.computer_use.cua_backend:CuaDriverBackend.set_runtime_attestation_callback",
     "tools.computer_use.cua_backend:CuaDriverBackend.start",
     "tools.computer_use.cua_backend:CuaDriverBackend.stop",
     "tools.computer_use.cua_backend:CuaDriverBackend.capture",
@@ -870,6 +873,7 @@ _CUA_ATTESTATION_CALLABLES = (
     "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_prepare",
     "tools.computer_use.cua_backend:CuaDriverBackend.typed_browser_action",
     "gateway.run:GatewayRunner._run_agent",
+    "gateway.session:SessionStore.ensure_route_matches",
     "gateway.session:SessionStore.route_matches",
     "gateway.session:SessionStore._run_route_transition",
     "gateway.session:SessionStore.prune_old_entries",
@@ -962,10 +966,237 @@ def _resolve_attested_callable(identity: str, supplied: Dict[str, Any]) -> Any:
     return getattr(target, "__func__", target)
 
 
-def write_computer_use_runtime_attestation(extra_callables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Atomically bind the live gateway PID to a fixed CUA code/source surface."""
+_NATIVE_RUNTIME_ARTIFACTS = (
+    "python_runtime",
+    "sqlite3_extension",
+    "psutil_extension",
+    "cua_driver_launcher",
+    "cua_driver_executable",
+)
+
+
+def _attested_native_file(path: "Path") -> Dict[str, Any]:
+    """Return a canonical, byte-bound native file identity or fail closed."""
+    canonical = path.resolve(strict=True)
+    if not canonical.is_file():
+        raise RuntimeError(f"required native runtime artifact is not a file: {canonical}")
+    raw = canonical.read_bytes()
+    return {
+        "canonical_path": str(canonical),
+        "size": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }
+
+
+def _python_runtime_library() -> "Path":
+    """Resolve the loaded Python runtime library without accepting receipt input."""
+    from pathlib import Path
+    import sysconfig
+
+    names = [
+        value for value in (
+            sysconfig.get_config_var("LDLIBRARY"),
+            sysconfig.get_config_var("LIBRARY"),
+            f"python{sys.version_info.major}{sys.version_info.minor}.dll" if os.name == "nt" else None,
+        ) if isinstance(value, str) and value
+    ]
+    directories = [
+        Path(sys.base_prefix), Path(sys.prefix), Path(sys.executable).resolve().parent,
+    ]
+    libdir = sysconfig.get_config_var("LIBDIR")
+    if isinstance(libdir, str) and libdir:
+        directories.insert(0, Path(libdir))
+    for directory in directories:
+        for name in names:
+            candidate = directory / name
+            if candidate.is_file():
+                return candidate.resolve(strict=True)
+    raise RuntimeError("could not resolve the Python runtime library")
+
+
+def _live_cua_driver_processes(
+    *,
+    owner_pid: Optional[int] = None,
+    owner_create_time: Optional[float] = None,
+    owner_executable: Optional[str] = None,
+    require_active: bool = False,
+) -> List[Dict[str, Any]]:
+    """Bind only direct cua-driver children of one exact gateway process."""
+    from pathlib import Path
+    import psutil
+
+    owner_pid = os.getpid() if owner_pid is None else int(owner_pid)
+    owner = psutil.Process(owner_pid)
+    actual_owner_create_time = owner.create_time()
+    actual_owner_executable = owner.exe()
+    if owner_create_time is None:
+        owner_create_time = actual_owner_create_time
+    if owner_executable is None:
+        owner_executable = actual_owner_executable
+    if abs(float(owner_create_time) - actual_owner_create_time) > 0.001:
+        raise RuntimeError("gateway owner process create time changed during attestation")
+    if Path(owner_executable).resolve(strict=True) != Path(
+        actual_owner_executable
+    ).resolve(strict=True):
+        raise RuntimeError("gateway owner executable changed during attestation")
+
+    parent_identity = {
+        "pid": owner_pid,
+        "process_create_time": float(owner_create_time),
+        "executable": str(owner_executable),
+    }
+    rows: List[Dict[str, Any]] = []
+    for process in psutil.process_iter(["pid", "name"]):
+        try:
+            if "cua-driver" not in str(process.info.get("name") or "").lower():
+                continue
+            if process.ppid() != owner_pid:
+                continue
+            parent = process.parent()
+            if parent is None or parent.pid != owner_pid:
+                continue
+            if abs(parent.create_time() - float(owner_create_time)) > 0.001:
+                continue
+            if Path(parent.exe()).resolve(strict=True) != Path(
+                owner_executable
+            ).resolve(strict=True):
+                continue
+            argv = process.cmdline()
+            if not isinstance(argv, list) or not argv or not all(
+                isinstance(value, str) for value in argv
+            ):
+                raise RuntimeError("owned cua-driver command line is unavailable")
+            # argv[0] is the concrete launcher actually used for this process;
+            # it is intentionally distinct from Process.exe() on shim installs.
+            _attested_native_file(Path(argv[0]))
+            rows.append({
+                "pid": process.pid,
+                "process_create_time": process.create_time(),
+                "ppid": owner_pid,
+                "executable": _attested_native_file(Path(process.exe())),
+                "parent": dict(parent_identity),
+                "argv": argv,
+            })
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+    rows.sort(key=lambda row: (row["process_create_time"], row["pid"]))
+    if require_active and not rows:
+        raise RuntimeError("no gateway-owned cua-driver process is available for attestation")
+    executable_identities = {
+        (row["executable"]["canonical_path"], row["executable"]["sha256"])
+        for row in rows
+    }
+    launcher_identities = {
+        (
+            artifact["canonical_path"],
+            artifact["sha256"],
+        )
+        for artifact in (
+            _attested_native_file(Path(row["argv"][0])) for row in rows
+        )
+    }
+    if len(executable_identities) > 1:
+        raise RuntimeError("owned cua-driver processes use ambiguous executable bytes")
+    if len(launcher_identities) > 1:
+        raise RuntimeError("owned cua-driver processes use ambiguous launcher bytes")
+    return rows
+
+
+def _native_runtime_artifacts(
+    cua_driver_processes: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Bind the exact native dependencies and concrete CUA launch/runtime files."""
+    from pathlib import Path
+    import _sqlite3
+    import psutil
+    from tools.computer_use.cua_backend import resolve_cua_driver_cmd
+
+    extension_name = {
+        "win32": "psutil._psutil_windows",
+        "darwin": "psutil._psutil_osx",
+    }.get(sys.platform, "psutil._psutil_linux")
+    psutil_extension = importlib.import_module(extension_name)
+    process_rows = list(cua_driver_processes or [])
+    if process_rows:
+        launcher = _attested_native_file(Path(process_rows[0]["argv"][0]))
+        runtime_executable = dict(process_rows[0]["executable"])
+    else:
+        driver = resolve_cua_driver_cmd()
+        if not driver:
+            raise RuntimeError("could not resolve the cua-driver launcher in use")
+        launcher = _attested_native_file(Path(driver))
+        # Startup-phase evidence is prospective only. Final verification
+        # rejects that phase and requires a refreshed gateway-owned process.
+        runtime_executable = dict(launcher)
+    artifacts = {
+        "python_runtime": _attested_native_file(_python_runtime_library()),
+        "sqlite3_extension": _attested_native_file(Path(_sqlite3.__file__)),
+        "psutil_extension": _attested_native_file(Path(psutil_extension.__file__)),
+        "cua_driver_launcher": launcher,
+        "cua_driver_executable": runtime_executable,
+    }
+    if set(artifacts) != set(_NATIVE_RUNTIME_ARTIFACTS):
+        raise RuntimeError("native runtime artifact policy is incomplete")
+    return artifacts
+
+
+def _atomic_write_attestation(path: "Path", raw: bytes) -> None:
+    """Durably replace one required receipt before reporting success."""
+    from pathlib import Path
+    import uuid
+
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.parent / (
+        f".cua-attest-{os.getpid()}-{threading.get_ident()}-{uuid.uuid4().hex}.tmp"
+    )
+    try:
+        with temporary.open("wb") as stream:
+            stream.write(raw)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if os.name == "nt":
+            import ctypes
+            from ctypes import wintypes
+
+            move_file = ctypes.WinDLL("kernel32", use_last_error=True).MoveFileExW
+            move_file.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD]
+            move_file.restype = wintypes.BOOL
+            # MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH. Concurrent
+            # runtime refreshes may briefly contend on the current receipt;
+            # retry only Windows access/sharing violations within a fixed bound.
+            import time as _time
+
+            for attempt in range(50):
+                if move_file(str(temporary), str(destination), 0x1 | 0x8):
+                    break
+                error = ctypes.get_last_error()
+                if error not in {5, 32} or attempt == 49:
+                    raise OSError(error, "MoveFileExW failed")
+                _time.sleep(min(0.002 * (attempt + 1), 0.05))
+        else:
+            os.replace(temporary, destination)
+            directory_fd = os.open(destination.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def write_computer_use_runtime_attestation(
+    extra_callables: Optional[Dict[str, Any]] = None,
+    *,
+    require_active_cua: bool = False,
+) -> Dict[str, Any]:
+    """Durably bind the gateway and, after startup, its exact CUA children."""
     from datetime import datetime, timezone
     from pathlib import Path
+    import uuid
     from hermes_constants import get_hermes_home
 
     importlib.import_module("tools.computer_use.cua_backend")
@@ -1004,17 +1235,25 @@ def write_computer_use_runtime_attestation(extra_callables: Optional[Dict[str, A
         raise RuntimeError("could not attest live gateway process identity") from exc
     output = get_hermes_home() / "runtime" / "cua_gateway_attestation.json"
     archive_dir = output.parent / "cua_gateway_attestations"
-    archive = archive_dir / f"{os.getpid()}-{int(process_create_time * 1_000_000)}.json"
-    receipt = {"schema": 3, "captured_at": datetime.now(timezone.utc).isoformat(), "pid": os.getpid(), "ppid": os.getppid(), "process_create_time": process_create_time, "executable": process_executable, "launcher": sys.executable, "parent": parent_identity, "argv": list(sys.argv), "runtime": {"python_implementation": platform.python_implementation(), "python_version": list(sys.version_info[:3]), "python_cache_tag": sys.implementation.cache_tag, "optimization": sys.flags.optimize}, "source_identity": _collect_attested_source_identity(repo_root, _CUA_ATTESTATION_MODULES, modules), "modules": modules, "callables": callables, "archive_path": str(archive), "path": str(output)}
-    output.parent.mkdir(parents=True, exist_ok=True)
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    encoded = json.dumps(receipt, indent=2)
-    archive_temporary = archive.with_suffix(".tmp")
-    archive_temporary.write_text(encoded, encoding="utf-8")
-    os.replace(archive_temporary, archive)
-    temporary = output.with_suffix(".tmp")
-    temporary.write_text(encoded, encoding="utf-8")
-    os.replace(temporary, output)
+    captured_at = datetime.now(timezone.utc)
+    archive = archive_dir / (
+        f"{os.getpid()}-{int(process_create_time * 1_000_000)}-"
+        f"{int(captured_at.timestamp() * 1_000_000)}-{uuid.uuid4().hex}.json"
+    )
+    cua_driver_processes = _live_cua_driver_processes(
+        owner_pid=os.getpid(),
+        owner_create_time=process_create_time,
+        owner_executable=process_executable,
+        require_active=require_active_cua,
+    )
+    runtime_phase = "cua_active" if cua_driver_processes else "gateway_startup"
+    receipt = {"schema": 3, "runtime_phase": runtime_phase, "captured_at": captured_at.isoformat(), "pid": os.getpid(), "ppid": os.getppid(), "process_create_time": process_create_time, "executable": process_executable, "launcher": sys.executable, "parent": parent_identity, "argv": list(sys.argv), "runtime": {"python_implementation": platform.python_implementation(), "python_version": list(sys.version_info[:3]), "python_cache_tag": sys.implementation.cache_tag, "optimization": sys.flags.optimize}, "native_runtime_artifacts": _native_runtime_artifacts(cua_driver_processes), "cua_driver_processes": cua_driver_processes, "source_identity": _collect_attested_source_identity(repo_root, _CUA_ATTESTATION_MODULES, modules), "modules": modules, "callables": callables, "archive_path": str(archive), "path": str(output)}
+    encoded = json.dumps(receipt, indent=2).encode("utf-8")
+    # Archive first, then publish the current pointer. A crash between these
+    # writes leaves either the previous current receipt or a final verifier
+    # failure; it cannot publish a current receipt without its archive.
+    _atomic_write_attestation(archive, encoded)
+    _atomic_write_attestation(output, encoded)
     return receipt
 
 
@@ -1099,7 +1338,8 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
                 backend_name = os.environ.get(
                     "HERMES_COMPUTER_USE_BACKEND", "cua"
                 ).lower()
-                if backend_name in {"cua", "cua-driver", ""}:
+                is_cua_backend = backend_name in {"cua", "cua-driver", ""}
+                if is_cua_backend:
                     from tools.computer_use.cua_backend import CuaDriverBackend
 
                     backend = CuaDriverBackend(permission_mode=permission_mode)
@@ -1108,6 +1348,25 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
                 else:
                     raise RuntimeError(
                         f"Unknown HERMES_COMPUTER_USE_BACKEND={backend_name!r}"
+                    )
+                requires_runtime_attestation = (
+                    getattr(backend, "_requires_runtime_attestation", False) is True
+                )
+                if requires_runtime_attestation:
+                    configure_attestation = getattr(
+                        backend,
+                        "set_runtime_attestation_callback",
+                        None,
+                    )
+                    if not callable(configure_attestation):
+                        raise RuntimeError(
+                            "CUA backend requires runtime attestation but exposes no "
+                            "replacement-attestation hook"
+                        )
+                    configure_attestation(
+                        lambda: write_computer_use_runtime_attestation(
+                            require_active_cua=True
+                        )
                     )
                 call_lock = threading.RLock()
                 record = _BackendRecord(
@@ -1125,6 +1384,14 @@ def _get_backend(session_id: str = "") -> ComputerUseBackend:
                     _backend = backend
                 try:
                     backend.start()
+                    if requires_runtime_attestation:
+                        # The gateway-startup receipt is prospective. Refresh it
+                        # only after this backend has spawned its exact direct
+                        # cua-driver child, and do not publish ACTIVE authority
+                        # unless the durable active-runtime receipt succeeds.
+                        write_computer_use_runtime_attestation(
+                            require_active_cua=True
+                        )
                 except Exception as exc:
                     record.state = BackendLifecycleState.FAILED
                     record.last_error = repr(exc)


### PR DESCRIPTION
## Summary

Fixes the Windows computer-use lifecycle bug class that can leave stale or overlapping `cua-driver.exe` processes and stale session routes across cancellation, reset, compression, reconnect, crash recovery, and gateway restart.

This ports the reviewed remediation onto current `NousResearch/hermes-agent:main` (`2446c8bb6`) rather than relying on the older local deployment lineage.

## What changed

- Serialize CUA session ownership, generation authority, cancellation, reset, route publication, compression, pruning, and recovery.
- Poison generations whose cancellation/termination cannot be confirmed; refuse replacement spawn until teardown is confirmed.
- Validate managed route/session authority through persisted `SessionStore` state and permit stale-route healing only for the proven current compression tip.
- Attest initial and reconnect replacement processes before activation or action retry.
- Prohibit unmanaged CLI fallback when managed runtime attestation is installed.
- Bind gateway and direct gateway-owned `cua-driver.exe` children to PID + creation time, parent identity, executable/launcher bytes, argv, Python/native artifacts, deployed source, callable fingerprints, Git commit/tree, and SQLite implementation.
- Revalidate the full live gateway/driver/native snapshot immediately before verifier success to close process-substitution TOCTOU.
- Make producer/verifier receipts durable and concurrency-safe with unique bounded same-directory temp names, Windows write-through replacement retries, and unique runtime archives.
- Add real-SQLite promotion/crash-recovery coverage and cross-test-order coverage for dynamic `HERMES_HOME` resolution.

## Verification

On the ported branch:

- Computer-use affected scope: **279 passed**
- Gateway lifecycle/SQLite/crash/dead-session scope: **138 passed**
- Gateway/session/conftest affected scope after order-fix: **143 passed**
- Cross-file import-order regression: authentic RED (`1 failed, 96 passed`) then **97 passed** GREEN
- Ruff: passed
- `git diff --check`: passed
- Independent lifecycle/concurrency review: passed after the import-order blocker was fixed
- Independent security/provenance review: passed
- Independent narrow order-fix review: passed

`tests/hermes_state` currently reports 5 Windows live-DB isolation-guard failures and 67 passes on this branch. The exact current upstream baseline (`2446c8bb6`) produces the identical 5 failures and 67 passes, so those failures are pre-existing and are not counted as passing evidence for this PR.

## Runtime evidence

The corresponding local build was committed, restarted, activated, and independently verified against its exact expected commit. Live evidence includes direct-child replacement/re-attestation, real compression lineage repair, doctor output, SQLite integrity checks, scheduler state, and process-accumulation inventory. Those environment-specific artifacts are intentionally not committed to the repository.

## Update-lineage truth

Opening this PR puts the remediation into the official review path. It is **not** claimed as merged or present in future Hermes releases until maintainers merge it.
