### PR TITLE
fix(tests): isolate suite fixtures from host auth

### DIFF
--- a/tests/agent/test_anthropic_output_field_leak.py
+++ b/tests/agent/test_anthropic_output_field_leak.py
@@ -10,9 +10,6 @@ Fix: whitelist input-permitted fields per block type at three points —
 normalize_response capture, _sanitize_replay_block (ordered-blocks replay), and
 _convert_content_part_to_anthropic (content-list replay).
 """
-import sys, os
-sys.path.insert(0, os.path.expanduser("~/.hermes/hermes-agent"))
-
 import pytest
 from agent.anthropic_adapter import (
     _sanitize_replay_block,

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -371,15 +371,35 @@ class TestFailureAttribution:
     """
 
     def _make_pool(self, tmp_path, monkeypatch, entries):
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # Keep host Anthropic/Claude credentials out of this fixture. load_pool()
+        # auto-seeds ~/.claude/.credentials.json and env keys when anthropic is
+        # explicitly configured on the machine, which turns a deliberate
+        # single-entry pool into a multi-entry pool and invalidates isolation
+        # assertions (see test_unmatched_key_does_not_retry_only_pool_entry).
+        for env_var in (
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.auth.is_provider_explicitly_configured",
+            lambda provider: False,
+        )
         (hermes_home / "auth.json").write_text(
-            json.dumps({"version": 1, "credential_pool": {"anthropic": entries}})
+            json.dumps({"version": 1, "credential_pool": {"anthropic": entries}}),
+            encoding="utf-8",
         )
         from agent.credential_pool import load_pool
 
-        return load_pool("anthropic")
+        pool = load_pool("anthropic")
+        assert [entry.id for entry in pool.entries()] == [
+            entry["id"] for entry in entries
+        ], "pool fixture leaked host credentials into the test pool"
+        return pool
 
     def _entry(self, idx, key, **overrides):
         entry = {


### PR DESCRIPTION
## What does this PR do?

Makes the affected test fixtures independent of credentials and source trees present on the host machine.

- Removes a test-local `sys.path` insertion that could import a stale `~/.hermes/hermes-agent` checkout instead of the checkout under test.
- Prevents the Anthropic credential-pool fixture from auto-seeding host Claude Code OAuth or Anthropic environment credentials, and asserts that the pool contains exactly the configured fixture entries.

This fixes machine-dependent failures without changing runtime credential behavior.

## Related Issue

No existing issue found. This updates the previously opened fixture-isolation PR on a current `main` base.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/agent/test_anthropic_output_field_leak.py`: remove the host-specific import-path override.
- `tests/agent/test_credential_pool_routing.py`: isolate the fixture from host auth discovery and assert the exact credential-pool contents.

## How to Test

1. Run the focused regression tests:
   ```bash
   scripts/run_tests.sh tests/agent/test_anthropic_output_field_leak.py tests/agent/test_credential_pool_routing.py -q
   ```
   Result: `21 passed`.
2. Run the cross-platform guard:
   ```bash
   python3 scripts/check-windows-footguns.py --diff origin/main
   ```
   Result: `No Windows footguns found (2 file(s) scanned)`.
3. Run the full suite:
   ```bash
   scripts/run_tests.sh
   ```
   The changed modules pass, but the full suite is currently blocked by unrelated failures outside this diff. A targeted rerun of all reported failure files on untouched `origin/main` reproduced 20 failing tests across 10 files and a 300-second timeout in `tests/cli/test_worktree.py`. Reproduced upstream failures include Hindsight provider, readiness, systemd socket, worktree, approval, computer-use, file-tools, execution-flag, and voice-mode tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Blocked by pre-existing upstream failures documented above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 13.7.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test result:

```text
21 passed, 0 failed
```

The full-suite blocker is documented above with a matching `origin/main` reproduction.
