### PR TITLE
fix(docker): let OAuth refresh use explicit writable token mounts

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1315,6 +1315,74 @@ def test_credential_mount_skipped_when_source_missing(monkeypatch, tmp_path, cap
     )
 
 
+@pytest.mark.parametrize(
+    "explicit_mount",
+    [
+        "/host/google_token.json:/root/.hermes/google_token.json:rw",
+        r"C:\Users\me\google_token.json:/root/.hermes/google_token.json:rw",
+    ],
+)
+def test_explicit_volume_destination_overrides_automatic_credential_mount(
+    monkeypatch, tmp_path, explicit_mount,
+):
+    """An explicit bind must not be followed by a duplicate read-only bind."""
+    token = tmp_path / "google_token.json"
+    token.write_text("fixture")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: [{
+            "host_path": str(token),
+            "container_path": "/root/.hermes/google_token.json",
+        }],
+    )
+    monkeypatch.setattr("tools.credential_files.get_skills_directory_mount", lambda: [])
+    monkeypatch.setattr("tools.credential_files.get_cache_directory_mounts", lambda: [])
+
+    _make_dummy_env(volumes=[explicit_mount])
+
+    run_args = next(
+        cmd for cmd, _ in calls
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[1] == "run"
+    )
+    mounts = [run_args[index + 1] for index, arg in enumerate(run_args[:-1]) if arg == "-v"]
+    credential_mounts = [
+        mount for mount in mounts
+        if ":/root/.hermes/google_token.json" in mount
+    ]
+    assert credential_mounts == [explicit_mount]
+
+
+def test_automatic_credential_mount_remains_read_only_without_explicit_override(
+    monkeypatch, tmp_path,
+):
+    """Skill-declared credentials stay read-only unless the user opts in."""
+    token = tmp_path / "google_token.json"
+    token.write_text("fixture")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: [{
+            "host_path": str(token),
+            "container_path": "/root/.hermes/google_token.json",
+        }],
+    )
+    monkeypatch.setattr("tools.credential_files.get_skills_directory_mount", lambda: [])
+    monkeypatch.setattr("tools.credential_files.get_cache_directory_mounts", lambda: [])
+
+    _make_dummy_env()
+
+    run_args = next(
+        cmd for cmd, _ in calls
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[1] == "run"
+    )
+    assert f"{token}:/root/.hermes/google_token.json:ro" in run_args
+
+
 # ── s6-overlay /init image handling (issue #34628) ────────────────
 
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import os
+import posixpath
 import re
 import shlex
 import shutil
@@ -98,6 +99,21 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
         normalized[key] = value
 
     return normalized
+
+
+def _docker_volume_destination(volume: str) -> str | None:
+    """Return the normalized container path from Docker's short volume syntax."""
+    parts = volume.rsplit(":", 2)
+    if len(parts) < 2:
+        return None
+
+    # With no mode the destination is last; with ``:ro``/``:rw`` it is the
+    # penultimate field. Splitting from the right preserves Windows drive
+    # prefixes in the host path.
+    destination = parts[-1] if parts[-1].startswith("/") else parts[-2]
+    if not destination.startswith("/"):
+        return None
+    return posixpath.normpath("/" + destination.lstrip("/"))
 
 
 def _load_hermes_env_vars() -> dict[str, str]:
@@ -947,6 +963,7 @@ class DockerEnvironment(BaseEnvironment):
 
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
+        configured_volume_destinations: set[str] = set()
         workspace_explicitly_mounted = False
         for vol in (volumes or []):
             if not isinstance(vol, str):
@@ -957,6 +974,9 @@ class DockerEnvironment(BaseEnvironment):
                 continue
             if ":" in vol:
                 volume_args.extend(["-v", vol])
+                destination = _docker_volume_destination(vol)
+                if destination:
+                    configured_volume_destinations.add(destination)
                 if ":/workspace" in vol:
                     workspace_explicitly_mounted = True
             else:
@@ -1014,6 +1034,17 @@ class DockerEnvironment(BaseEnvironment):
             )
 
             for mount_entry in get_credential_file_mounts():
+                container_path = mount_entry["container_path"]
+                normalized_container_path = posixpath.normpath(
+                    "/" + container_path.lstrip("/")
+                )
+                if normalized_container_path in configured_volume_destinations:
+                    logger.info(
+                        "Docker: skipping automatic credential mount for %s; "
+                        "destination is explicitly configured",
+                        container_path,
+                    )
+                    continue
                 src = Path(mount_entry["host_path"])
                 if src.is_dir():
                     # Docker-in-Docker: Docker auto-created the source path as
@@ -1032,12 +1063,12 @@ class DockerEnvironment(BaseEnvironment):
                     continue
                 volume_args.extend([
                     "-v",
-                    f"{mount_entry['host_path']}:{mount_entry['container_path']}:ro",
+                    f"{mount_entry['host_path']}:{container_path}:ro",
                 ])
                 logger.info(
                     "Docker: mounting credential %s -> %s",
                     mount_entry["host_path"],
-                    mount_entry["container_path"],
+                    container_path,
                 )
 
             # Mount skill directories (local + external) so skill


### PR DESCRIPTION
## What does this PR do?

Docker sandbox users who explicitly opt a Google OAuth token into a writable bind no longer receive a second read-only mount for the same container destination, which made Podman reject every terminal command with exit code 125. Explicit `terminal.docker_volumes` targets now take precedence over automatic credential mounts for that destination, while credentials without an explicit override remain read-only by default.

### Symptom

An expired Google OAuth token cannot be persisted through the automatic read-only credential mount. Adding the documented explicit `:rw` bind then produces both writable and read-only mounts at `/root/.hermes/google_token.json`, and Podman rejects the duplicate destination before the sandbox starts.

### Impact

Docker and rootless Podman users cannot refresh the bundled Google Workspace OAuth token through the writable bind path. With Podman, the duplicate target prevents every terminal command in the sandbox from starting.

### Bug Cause

**Trigger:** `tools/environments/docker.py` in `DockerEnvironment.__init__`, when `terminal.docker_volumes` and a registered credential target the same container path.

**Causal chain:**
1. The user configures a writable bind for `/root/.hermes/google_token.json`.
2. Docker volume composition accepts that bind, then independently appends the skill-registered credential at the same destination with `:ro`.
3. Podman rejects the duplicate destination with exit code 125, so the sandbox never starts.

**Why it is wrong:** Explicit user volume configuration and automatic credential passthrough were composed without destination-level conflict detection.

**Working sibling / contrast:** When no explicit destination is configured, automatic credential mounts remain read-only as intended.

**Ruled out:** OAuth write-back logic and credential path containment are not the composition failure. The credential registry already deduplicates registered credential sources, but it cannot see explicit Docker volumes.

### Fix

Parse and normalize container destinations from Docker short volume syntax, including Windows host paths, and skip an automatic credential bind when an explicit volume already owns that destination. Focused tests cover Linux and Windows host syntax and preserve the default read-only credential boundary.

## Related Issue

Closes #82484

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py` - detect explicit volume destinations and suppress only conflicting automatic credential mounts.
- `tests/tools/test_docker_environment.py` - cover explicit writable precedence for Linux and Windows host paths and unchanged automatic read-only behavior.

## How to Test

1. Configure an explicit writable token bind to `/root/.hermes/google_token.json`, start the Podman sandbox, and verify exactly one target mount exists with `RW=true` and accepts a write probe.
2. Remove the explicit bind, start the sandbox again, and verify the automatic target remains `RW=false`, rejects a write probe, and leaves the host fixture unchanged.
3. Run the focused CI-parity tests and lint:

```bash
scripts/run_tests.sh tests/tools/test_docker_environment.py -k 'explicit_volume_destination_overrides_automatic_credential_mount or automatic_credential_mount_remains_read_only_without_explicit_override or credential_mount_skipped'
ruff check tools/environments/docker.py tests/tools/test_docker_environment.py
```

The focused test selection passes 5 tests. Real Podman 5.8.3 client / 5.8.5 server verification passes for the writable override and read-only default paths.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo's test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 host with rootless Podman 5.8.3 client / 5.8.5 server

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, behavior now matches the existing documented writable bind path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - Windows drive-prefixed host paths are covered
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model-facing schema changed

## Screenshots / Logs

No screenshots are applicable. Podman verification confirmed one writable mount for the explicit override and one read-only mount for the automatic default path.
