### PR TITLE
fix(skills/llama-cpp): update build docs to current llama.cpp (CMake, ggml-org repo)

### DIFF
--- a/skills/mlops/inference/llama-cpp/references/advanced-usage.md
+++ b/skills/mlops/inference/llama-cpp/references/advanced-usage.md
@@ -5,11 +5,13 @@
 ### Draft Model Approach
 
 ```bash
-# Use smaller model as draft for faster generation (no separate llama-speculative binary;
-# speculative decoding runs via the existing llama-cli / llama-server with --model-draft / -md)
+# Use a smaller draft model for faster generation.
+# `llama-speculative` is still built as an example, but the same effect is achieved
+# with the existing llama-cli / llama-server using -md / --model-draft + --spec-type.
 llama-cli \
     -m large-model-q4_k_m.gguf \
     -md draft-model-q4_k_m.gguf \
+    --spec-type draft-simple \
     -p "Write a story about AI" \
     -n 500 \
     --spec-draft-n-max 8  # number of draft tokens to propose before verification (default 3)

--- a/skills/mlops/inference/llama-cpp/references/advanced-usage.md
+++ b/skills/mlops/inference/llama-cpp/references/advanced-usage.md
@@ -5,13 +5,14 @@
 ### Draft Model Approach
 
 ```bash
-# Use smaller model as draft for faster generation
-./llama-speculative \
+# Use smaller model as draft for faster generation (no separate llama-speculative binary;
+# speculative decoding runs via the existing llama-cli / llama-server with --model-draft / -md)
+llama-cli \
     -m large-model-q4_k_m.gguf \
     -md draft-model-q4_k_m.gguf \
     -p "Write a story about AI" \
     -n 500 \
-    --draft 8  # Draft tokens before verification
+    --spec-draft-n-max 8  # number of draft tokens to propose before verification (default 3)
 ```
 
 ### Self-Speculative Decoding
@@ -483,16 +484,17 @@ llm = Llama(
 ### Build with All Optimizations
 
 ```bash
-# Clean build with all CPU optimizations
-make clean
-LLAMA_OPENBLAS=1 LLAMA_BLAS_VENDOR=OpenBLAS make -j
+# Clean build with all CPU optimizations (CMake; the old Makefile build is deprecated upstream)
+cmake -B build -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -j
 
-# With CUDA and cuBLAS
-make clean
-GGML_CUDA=1 LLAMA_CUBLAS=1 make -j
+# With CUDA
+cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -j
 
-# With specific CUDA architecture
-GGML_CUDA=1 CUDA_DOCKER_ARCH=sm_86 make -j
+# With specific CUDA architecture (numeric compute capability, e.g. 86 = sm_86)
+cmake -B build -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -j
 ```
 
 ### CMake Build

--- a/skills/mlops/inference/llama-cpp/references/optimization.md
+++ b/skills/mlops/inference/llama-cpp/references/optimization.md
@@ -17,8 +17,9 @@ Maximize llama.cpp inference speed and efficiency.
 
 ### BLAS acceleration
 ```bash
-# OpenBLAS (faster matrix ops)
-make LLAMA_OPENBLAS=1
+# OpenBLAS (faster matrix ops) — build with CMake (Makefile build is deprecated upstream)
+cmake -B build -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -j
 
 # BLAS gives 2-3× speedup
 ```

--- a/skills/mlops/inference/llama-cpp/references/server.md
+++ b/skills/mlops/inference/llama-cpp/references/server.md
@@ -78,7 +78,7 @@ curl http://localhost:8080/v1/chat/completions \
 **Dockerfile**:
 ```dockerfile
 FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y git build-essential
+RUN apt-get update && apt-get install -y git build-essential cmake
 RUN git clone https://github.com/ggml-org/llama.cpp
 WORKDIR /llama.cpp
 RUN cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release

--- a/skills/mlops/inference/llama-cpp/references/server.md
+++ b/skills/mlops/inference/llama-cpp/references/server.md
@@ -79,12 +79,12 @@ curl http://localhost:8080/v1/chat/completions \
 ```dockerfile
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y git build-essential
-RUN git clone https://github.com/ggerganov/llama.cpp
+RUN git clone https://github.com/ggml-org/llama.cpp
 WORKDIR /llama.cpp
-RUN make LLAMA_CUDA=1
+RUN cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release
 COPY models/ /models/
 EXPOSE 8080
-CMD ["./llama-server", "-m", "/models/model.gguf", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["./build/bin/llama-server", "-m", "/models/model.gguf", "--host", "0.0.0.0", "--port", "8080"]
 ```
 
 **Run**:

--- a/skills/mlops/inference/llama-cpp/references/troubleshooting.md
+++ b/skills/mlops/inference/llama-cpp/references/troubleshooting.md
@@ -24,7 +24,8 @@ sudo apt install nvidia-cuda-toolkit
 # Or set CUDA path
 export CUDA_PATH=/usr/local/cuda
 export PATH=$CUDA_PATH/bin:$PATH
-make GGML_CUDA=1
+cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -j
 ```
 
 ### Python Bindings Issues
@@ -359,9 +360,9 @@ response = client.chat.completions.create(
 
 **Fix**:
 ```bash
-# Rebuild with Metal
-make clean
-make GGML_METAL=1
+# Rebuild with Metal (CMake; Makefile build is deprecated upstream)
+cmake -B build -DGGML_METAL=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -j
 
 # Python bindings
 CMAKE_ARGS="-DGGML_METAL=on" pip install llama-cpp-python --force-reinstall


### PR DESCRIPTION
## Summary
Updates the bundled `llama-cpp` skill's reference docs to match the current upstream llama.cpp (`ggml-org/llama.cpp`).

- Replace deprecated **Makefile** build instructions with the **CMake** build (the Makefile build now hard-errors: `docs/build.md` directs users to CMake). Affects `advanced-usage.md`, `optimization.md`, `troubleshooting.md`, and the `server.md` Dockerfile.
- Update clone URL `ggerganov/llama.cpp` → `ggml-org/llama.cpp` (repo transferred to `ggml-org` in Feb 2025 — see [ggml-org/llama.cpp#11801](https://github.com/ggml-org/llama.cpp/discussions/11801)).
- Fix server binary path `./llama-server` → `./build/bin/llama-server` (CMake output location).
- Fix the draft-token flag: `--draft` was removed upstream (now aborts with "use --spec-draft-n-max or --spec-ngram-mod-n-max"); the correct flag is `--spec-draft-n-max`. (`--draft-p-split` is *split probability*, not token count — using it would be a wrong command.) Kept `-np` since it is still the valid upstream parallel-slots flag.
- Clarify speculative decoding: `llama-speculative` is still built as a **demo example** to `./build/bin/llama-speculative` when `LLAMA_BUILD_EXAMPLES` is on, but the supported path is `llama-cli`/`llama-server` with `-md`/`--spec-draft-model`; a local draft file also requires an explicit `--spec-type draft-simple` (the default spec type is `none`).

## Verification
All flag/URL changes were cross-checked against `ggml-org/llama.cpp` master:
- `Makefile` — now errors out and points to CMake
- `docs/build.md` — CMake is the build system; `-DCMAKE_CUDA_ARCHITECTURES` (not `CUDA_DOCKER_ARCH`); `-DGGML_CUDA/GGML_BLAS/GGML_METAL=ON`
- `docs/speculative.md` — `--spec-draft-model`/`-md`/`--model-draft`, `--spec-draft-n-max` (default 3), `--spec-type` values incl. `draft-simple`
- `tools/server/README.md` — `-np` still documented; binary at `./build/bin/llama-server`
- `examples/speculative/CMakeLists.txt` — `llama-speculative` is a demo example, not the supported server path

Patch was generated and dry-run applied cleanly against the stock skill tree (`patch -p1`, 0 rejected hunks).