### PR TITLE
feat: add owner workspace mutation boundary

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -91,32 +91,81 @@ _ROUTES_ALLOWLIST = "allowlist"
 # Always reachable regardless of ``allowed_routes`` — the liveness probe.
 _ALWAYS_ALLOWED_PATHS = ("/health",)
 
+# Returned by _read_raw_config_root() when there is genuinely NO config to
+# read: no file on disk, or a file with no YAML content at all (blank /
+# comments only). Distinct from a successfully parsed root that simply isn't a
+# mapping (``- a``, ``42``, ``null``), which is malformed and denies closed.
+_CONFIG_ROOT_ABSENT = object()
+
+
+def _read_raw_config_root() -> Any:
+    """Return the CURRENT profile's ``config.yaml`` YAML root, unnormalized.
+
+    Deliberately NOT ``read_user_config_raw()``: that helper collapses a
+    non-mapping root to ``{}``, making ``- a\\n- b`` (or ``42``, or ``null``)
+    indistinguishable from a missing file — which would resolve a malformed
+    config to "key simply not present" and therefore UNRESTRICTED. This
+    security boundary must tell those apart, so it reads the same
+    profile-aware path (``get_config_path()``) and returns exactly what YAML
+    parsed, plus a dedicated :data:`_CONFIG_ROOT_ABSENT` sentinel for "no
+    config at all".
+
+    Raises on unparseable YAML / unreadable file (callers deny closed).
+    """
+    from hermes_cli.config import get_config_path
+    from utils import fast_safe_load
+
+    path = get_config_path()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _CONFIG_ROOT_ABSENT
+    # A file that carries no YAML content (empty, whitespace, or only
+    # comments) parses to None but means "nothing configured" — treat it like
+    # a missing file rather than a malformed root, so an empty/commented-out
+    # config.yaml keeps its long-standing unrestricted behavior. An EXPLICIT
+    # ``null``/``~`` root is content, and stays malformed.
+    if not any(
+        line.strip() and not line.lstrip().startswith("#")
+        for line in text.splitlines()
+    ):
+        return _CONFIG_ROOT_ABSENT
+    return fast_safe_load(text)
+
 
 def _resolve_api_server_allowed_routes() -> "tuple[str, list[str]]":
     """Resolve ``gateway.api_server.allowed_routes`` for the CURRENT profile.
 
     Returns ``(mode, patterns)``:
-      - ``(_ROUTES_UNRESTRICTED, [])`` — key omitted/``None``, OR the
-        intentionally-supported empty list/tuple. No gating.
+      - ``(_ROUTES_UNRESTRICTED, [])`` — no config at all (missing/blank
+        file), key omitted/``None``, OR the intentionally-supported empty
+        list/tuple. No gating.
       - ``(_ROUTES_DENY_ALL, [])`` — an explicit malformed falsey value
         (``False``, ``0``, ``{}``, ``""``), any other malformed type/entry,
-        or a config-load failure. Only ``/health`` is reachable.
+        a non-mapping YAML root (list/scalar/``null``), or a config-load
+        failure. Only ``/health`` is reachable.
       - ``(_ROUTES_ALLOWLIST, patterns)`` — a non-empty string (single
         pattern) or list/tuple of non-empty strings.
 
-    Uses ``read_user_config_raw()`` (profile-aware via ``get_hermes_home()``,
-    which the profile-prefix middleware has already scoped by the time this
-    runs) because it RAISES on unparseable YAML — unlike the gateway's usual
-    fail-open loader — so a genuine config-load failure can be distinguished
-    from "key simply not present" and denied closed, per contract.
+    Uses ``_read_raw_config_root()`` (profile-aware via ``get_config_path()``
+    → ``get_hermes_home()``, which the profile-prefix middleware has already
+    scoped by the time this runs) because it RAISES on unparseable YAML —
+    unlike the gateway's usual fail-open loader — and because it reports a
+    successfully parsed NON-MAPPING root as itself instead of normalizing it
+    to ``{}``. Both a load failure and a malformed root are therefore
+    distinguishable from "key simply not present" and denied closed, per
+    contract.
     """
     try:
-        from hermes_cli.config import read_user_config_raw
-
-        raw = read_user_config_raw()
+        raw = _read_raw_config_root()
     except Exception:
         return (_ROUTES_DENY_ALL, [])
+    if raw is _CONFIG_ROOT_ABSENT:
+        # No config file / no YAML content — nothing configured, not malformed.
+        return (_ROUTES_UNRESTRICTED, [])
     if not isinstance(raw, dict):
+        # Parsed fine, but the root is a list/scalar/None — malformed config,
+        # never "unconfigured".
         return (_ROUTES_DENY_ALL, [])
 
     gateway_cfg = raw.get("gateway")
@@ -162,15 +211,24 @@ def _resolve_api_server_allowed_routes() -> "tuple[str, list[str]]":
 def _owner_workspace_toolset_enabled(user_config: dict) -> bool:
     """``gateway.api_server.owner_workspace.enabled`` — default OFF.
 
-    Fail-open to False on any resolution error: an owner-mutation surface
+    Enables ONLY on the literal boolean ``True``. Anything else — including
+    the truthy strings ``"true"``/``"yes"``/``"false"``, numbers, lists,
+    mappings, ``None``, and every other malformed value — leaves the owner
+    mutation surface disabled. A ``bool()`` coercion here would turn
+    ``enabled: "false"`` (a very ordinary YAML quoting slip) into a live
+    owner-mutation surface, so this admission gate demands the exact value
+    its documentation promises rather than guessing at intent.
+
+    Fail-closed to False on any resolution error: an owner-mutation surface
     must never appear because a config read hiccuped.
     """
     try:
         from hermes_cli.config import cfg_get
 
-        return bool(cfg_get(user_config, "gateway", "api_server", "owner_workspace", "enabled", default=False))
+        value = cfg_get(user_config, "gateway", "api_server", "owner_workspace", "enabled", default=False)
     except Exception:
         return False
+    return value is True
 
 
 def _route_matches_any(path: str, patterns: "list[str]") -> bool:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -76,6 +76,114 @@ def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> lis
     return ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
 
 
+# ---------------------------------------------------------------------------
+# Per-profile ``gateway.api_server.allowed_routes`` least-privilege gate.
+#
+# Resolved fresh per request (never cached) from the profile-scoped
+# config.yaml so a multiplexed /p/<profile>/ request is gated by ITS OWN
+# profile's setting, not the listener-owning default profile's.
+# ---------------------------------------------------------------------------
+
+_ROUTES_UNRESTRICTED = "unrestricted"
+_ROUTES_DENY_ALL = "deny_all"
+_ROUTES_ALLOWLIST = "allowlist"
+
+# Always reachable regardless of ``allowed_routes`` — the liveness probe.
+_ALWAYS_ALLOWED_PATHS = ("/health",)
+
+
+def _resolve_api_server_allowed_routes() -> "tuple[str, list[str]]":
+    """Resolve ``gateway.api_server.allowed_routes`` for the CURRENT profile.
+
+    Returns ``(mode, patterns)``:
+      - ``(_ROUTES_UNRESTRICTED, [])`` — key omitted/``None``, OR the
+        intentionally-supported empty list/tuple. No gating.
+      - ``(_ROUTES_DENY_ALL, [])`` — an explicit malformed falsey value
+        (``False``, ``0``, ``{}``, ``""``), any other malformed type/entry,
+        or a config-load failure. Only ``/health`` is reachable.
+      - ``(_ROUTES_ALLOWLIST, patterns)`` — a non-empty string (single
+        pattern) or list/tuple of non-empty strings.
+
+    Uses ``read_user_config_raw()`` (profile-aware via ``get_hermes_home()``,
+    which the profile-prefix middleware has already scoped by the time this
+    runs) because it RAISES on unparseable YAML — unlike the gateway's usual
+    fail-open loader — so a genuine config-load failure can be distinguished
+    from "key simply not present" and denied closed, per contract.
+    """
+    try:
+        from hermes_cli.config import read_user_config_raw
+
+        raw = read_user_config_raw()
+    except Exception:
+        return (_ROUTES_DENY_ALL, [])
+    if not isinstance(raw, dict):
+        return (_ROUTES_DENY_ALL, [])
+
+    gateway_cfg = raw.get("gateway")
+    if gateway_cfg is None:
+        return (_ROUTES_UNRESTRICTED, [])
+    if not isinstance(gateway_cfg, dict):
+        return (_ROUTES_DENY_ALL, [])
+
+    api_server_cfg = gateway_cfg.get("api_server")
+    if api_server_cfg is None:
+        return (_ROUTES_UNRESTRICTED, [])
+    if not isinstance(api_server_cfg, dict):
+        return (_ROUTES_DENY_ALL, [])
+
+    if "allowed_routes" not in api_server_cfg:
+        return (_ROUTES_UNRESTRICTED, [])
+    value = api_server_cfg["allowed_routes"]
+
+    if value is None:
+        return (_ROUTES_UNRESTRICTED, [])
+    if isinstance(value, bool):
+        # bool is an int subclass — check before the general int/str/etc.
+        # fallthrough so True/False both land here (True is not a valid
+        # list/string either — malformed, deny-all).
+        return (_ROUTES_DENY_ALL, [])
+    if isinstance(value, (list, tuple)):
+        if len(value) == 0:
+            return (_ROUTES_UNRESTRICTED, [])
+        patterns: list[str] = []
+        for entry in value:
+            if not isinstance(entry, str) or not entry.strip():
+                return (_ROUTES_DENY_ALL, [])
+            patterns.append(entry.strip())
+        return (_ROUTES_ALLOWLIST, patterns)
+    if isinstance(value, str):
+        if value == "":
+            return (_ROUTES_DENY_ALL, [])
+        return (_ROUTES_ALLOWLIST, [value])
+    # int (incl. 0), float, dict (incl. {}), or any other type: malformed.
+    return (_ROUTES_DENY_ALL, [])
+
+
+def _owner_workspace_toolset_enabled(user_config: dict) -> bool:
+    """``gateway.api_server.owner_workspace.enabled`` — default OFF.
+
+    Fail-open to False on any resolution error: an owner-mutation surface
+    must never appear because a config read hiccuped.
+    """
+    try:
+        from hermes_cli.config import cfg_get
+
+        return bool(cfg_get(user_config, "gateway", "api_server", "owner_workspace", "enabled", default=False))
+    except Exception:
+        return False
+
+
+def _route_matches_any(path: str, patterns: "list[str]") -> bool:
+    """Segment-aware prefix match: ``/v1/runs`` matches itself and
+    descendants (``/v1/runs/abc``) but never a sibling with a shared
+    string prefix (``/v1/runs-evil``)."""
+    for pattern in patterns:
+        pat = pattern.rstrip("/") or "/"
+        if path == pat or path.startswith(pat + "/"):
+            return True
+    return False
+
+
 try:
     from aiohttp import web
     AIOHTTP_AVAILABLE = True
@@ -2038,6 +2146,44 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return profile_prefix_middleware
 
+    def _make_route_allowlist_middleware(self):
+        """Enforce ``gateway.api_server.allowed_routes`` for least privilege.
+
+        Runs AFTER the profile-prefix middleware (later in ``mws``) so
+        ``get_hermes_home()`` — and therefore config resolution — is already
+        scoped to the request's profile for a multiplexed ``/p/<profile>/``
+        call. Exactly one multiplex prefix is stripped before matching, per
+        contract: a route is gated the same way whether reached natively or
+        via its ``/p/<profile>/`` mirror.
+        """
+
+        @web.middleware
+        async def route_allowlist_middleware(request: "web.Request", handler):
+            path = request.path
+            prefix_profile = request.match_info.get("profile")
+            if prefix_profile is not None:
+                stripped = path[len(f"/p/{prefix_profile}"):]
+                path = stripped or "/"
+
+            if path in _ALWAYS_ALLOWED_PATHS:
+                return await handler(request)
+
+            mode, patterns = _resolve_api_server_allowed_routes()
+            if mode == _ROUTES_UNRESTRICTED:
+                return await handler(request)
+            if mode == _ROUTES_ALLOWLIST and _route_matches_any(path, patterns):
+                return await handler(request)
+
+            return web.json_response(
+                _openai_error(
+                    "Route not permitted for this profile",
+                    code="route_not_allowed",
+                ),
+                status=403,
+            )
+
+        return route_allowlist_middleware
+
     def _http_route_table(self) -> List[tuple]:
         """Return (method, path, handler) rows registered by ``connect()``.
 
@@ -2863,6 +3009,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        if _owner_workspace_toolset_enabled(user_config):
+            # The ONLY place the owner_workspace toolset is folded into an
+            # agent's schema — absent from _HERMES_CORE_TOOLS and every
+            # composite in toolsets.py, so no other platform can reach it
+            # even if a profile's generic `toolsets:` config names it.
+            enabled_toolsets = sorted(set(enabled_toolsets) | {"owner_workspace"})
 
         max_iterations = _current_max_iterations()
 
@@ -6633,7 +6785,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "choices": _approval_event_choices(
-                            smart_denied=bool(event.get("smart_denied")),
+                            smart_denied=bool(event.get("smart_denied"))
+                            or bool(event.get("exact_operation")),
                             allow_permanent=event.get("allow_permanent") is not False,
                         ),
                     })
@@ -6972,6 +7125,9 @@ class APIServerAdapter(BasePlatformAdapter):
             _coerce_request_bool(body.get("all"), default=False)
             or _coerce_request_bool(body.get("resolve_all"), default=False)
         )
+        approval_id = body.get("approval_id")
+        if approval_id is not None:
+            approval_id = str(approval_id).strip() or None
         try:
             from tools.approval import resolve_gateway_approval
 
@@ -6979,6 +7135,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 approval_session_key,
                 choice,
                 resolve_all=resolve_all,
+                approval_id=approval_id,
             )
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
@@ -7172,6 +7329,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 mw
                 for mw in (
                     self._make_profile_prefix_middleware(),
+                    self._make_route_allowlist_middleware(),
                     cors_middleware,
                     body_limit_middleware,
                     security_headers_middleware,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -764,12 +764,31 @@ def write_board_metadata(
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
+    _atomic_write_text(path, json.dumps(meta, indent=2, ensure_ascii=False) + "\n")
     meta["db_path"] = str(kanban_db_path(slug))
     return meta
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` via same-directory tmp file + fsync + ``os.replace``.
+
+    ``board.json`` is a durable publication point crash-recovery flows (e.g.
+    owner-workspace bootstrap) reread to decide whether to reuse an already-
+    published board instead of creating another. A bare ``write_text`` can
+    leave a truncated/partial file behind if the process dies mid-write;
+    ``os.replace`` on the same filesystem is atomic, so readers only ever see
+    the fully-old or fully-new content, never a torn write.
+    """
+    tmp = path.with_name(f".{path.name}.tmp-{os.getpid()}-{secrets.token_hex(4)}")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    finally:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
 
 
 def create_board(
@@ -1288,7 +1307,12 @@ CREATE TABLE IF NOT EXISTS task_comments (
     task_id    TEXT NOT NULL,
     author     TEXT NOT NULL,
     body       TEXT NOT NULL,
-    created_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL,
+    -- Durable operation identity for idempotent replay (e.g. the
+    -- owner-workspace mutation kernel's actor/profile/idempotency-key
+    -- scoped key). NULL for ordinary comments that don't need dedup.
+    -- See add_comment()'s operation_key parameter.
+    operation_key TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_events (
@@ -2495,6 +2519,25 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     if "run_id" not in ev_cols:
         _add_column_if_missing(conn, "task_events", "run_id", "run_id INTEGER")
 
+    # Durable operation identity for idempotent comment replay (see
+    # add_comment()'s operation_key parameter). Partial unique index: NULL
+    # values (ordinary comments) are exempt, only two rows sharing the same
+    # (task_id, operation_key) collide — which is exactly what dedup wants.
+    # Guarded by a table-existence check (same pattern as kanban_notify_subs
+    # below) so callers that migrate a minimal/partial schema (e.g. a legacy
+    # DB with only `tasks` + `task_events`) don't hit "no such table".
+    comments_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_comments'"
+    ).fetchone() is not None
+    if comments_table_exists:
+        comment_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_comments)")}
+        if "operation_key" not in comment_cols:
+            _add_column_if_missing(conn, "task_comments", "operation_key", "operation_key TEXT")
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_comments_operation_key "
+            "ON task_comments(task_id, operation_key) WHERE operation_key IS NOT NULL"
+        )
+
     # Same ordering rule as the additive ``tasks`` indexes above: create the
     # index after the additive column migration so legacy ``task_events``
     # tables don't fail during SCHEMA_SQL execution before ``run_id`` exists.
@@ -3636,22 +3679,52 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 # ---------------------------------------------------------------------------
 
 def add_comment(
-    conn: sqlite3.Connection, task_id: str, author: str, body: str
+    conn: sqlite3.Connection, task_id: str, author: str, body: str,
+    *, operation_key: Optional[str] = None,
 ) -> int:
+    """Append a comment (+ a ``"commented"`` event) and return the comment id.
+
+    ``operation_key``, when given, makes the call idempotent across a
+    crash-and-retry: a prior call with the SAME ``(task_id, operation_key)``
+    returns the ORIGINAL comment's id without inserting a second comment or
+    appending a second event (enforced by a partial unique index — see
+    ``idx_comments_operation_key`` in ``_migrate_add_optional_columns``). A
+    retry whose ``author``/``body`` disagree with the original fails closed
+    instead of silently returning a mismatched comment — callers (e.g. the
+    owner-workspace kernel) that need conflict detection across the exact
+    payload rely on this; their own idempotency-key digest check already
+    rejects a differing payload before ever reaching here, so this is
+    defense in depth, not the primary guard.
+    """
     if not body or not body.strip():
         raise ValueError("comment body is required")
     if not author or not author.strip():
         raise ValueError("comment author is required")
+    author = author.strip()
+    body = body.strip()
     now = int(time.time())
     with write_txn(conn):
         if not conn.execute(
             "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
         ).fetchone():
             raise ValueError(f"unknown task {task_id}")
+        if operation_key:
+            existing = conn.execute(
+                "SELECT id, author, body FROM task_comments "
+                "WHERE task_id = ? AND operation_key = ?",
+                (task_id, operation_key),
+            ).fetchone()
+            if existing is not None:
+                if existing["author"] != author or existing["body"] != body:
+                    raise ValueError(
+                        f"operation_key {operation_key!r} was already used with a "
+                        "different author/body"
+                    )
+                return int(existing["id"])
         cur = conn.execute(
-            "INSERT INTO task_comments (task_id, author, body, created_at) "
-            "VALUES (?, ?, ?, ?)",
-            (task_id, author.strip(), body.strip(), now),
+            "INSERT INTO task_comments (task_id, author, body, created_at, operation_key) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (task_id, author, body, now, operation_key),
         )
         _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
         return int(cur.lastrowid or 0)
@@ -3949,6 +4022,40 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
             )
         )
     return out
+
+
+def get_next_event_after(conn: sqlite3.Connection, task_id: str, after_id: int) -> Optional[Event]:
+    """The earliest event for ``task_id`` with ``id > after_id``, if any.
+
+    ``task_events.id`` is a single AUTOINCREMENT sequence shared by every
+    task on the board, so it is NOT contiguous per task (another task's
+    event insert between two of THIS task's events consumes an id without
+    advancing this task's own revision). A replay caller holding
+    ``expected_revision`` (this task's own last-seen revision) therefore
+    cannot assume its own next event landed at exactly
+    ``expected_revision + 1`` — it must ask for "whatever this task's very
+    next event actually was", which is what this returns. Used by
+    idempotent-replay callers (e.g. the owner-workspace kernel) to recognize
+    whether a specific past mutation on this task already committed.
+    """
+    row = conn.execute(
+        "SELECT * FROM task_events WHERE task_id = ? AND id > ? ORDER BY id ASC LIMIT 1",
+        (task_id, after_id),
+    ).fetchone()
+    if row is None:
+        return None
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else None
+    except Exception:
+        payload = None
+    return Event(
+        id=row["id"],
+        task_id=row["task_id"],
+        kind=row["kind"],
+        payload=payload,
+        created_at=row["created_at"],
+        run_id=(int(row["run_id"]) if "run_id" in row.keys() and row["run_id"] is not None else None),
+    )
 
 
 def _append_event(
@@ -6286,6 +6393,93 @@ def decompose_triage_task(
     if auto_promote:
         recompute_ready(conn)
     return child_ids
+
+
+def task_event_revision(conn: sqlite3.Connection, task_id: str) -> int:
+    """Monotonic per-task revision: the highest ``task_events.id`` recorded
+    for ``task_id`` (0 if the task has no events yet — cannot happen for a
+    task that exists, since ``create_task`` always appends a ``"created"``
+    event in the same transaction).  Callers needing optimistic
+    concurrency control (compare-and-swap on status AND "nothing else about
+    this task changed since I last read it") pass this back as
+    ``expected_revision``; see :func:`cas_transition_task`.
+    """
+    row = conn.execute(
+        "SELECT COALESCE(MAX(id), 0) AS rev FROM task_events WHERE task_id = ?",
+        (task_id,),
+    ).fetchone()
+    return int(row["rev"]) if row else 0
+
+
+def cas_transition_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_status: str,
+    expected_revision: int,
+    to_status: str,
+    event_kind: str = "cas_transition",
+    event_payload: Optional[dict] = None,
+) -> dict:
+    """Generic compare-and-swap status move, guarded by BOTH status and
+    event-revision, in the existing write transaction.
+
+    Unlike every other transition helper in this module (``claim_task``,
+    ``complete_task``, ``archive_task``, ...) — which each encode one fixed,
+    known-safe status pair — this is the ONE place a caller may request an
+    arbitrary ``expected_status -> to_status`` move. It exists so a generic
+    caller (the owner-workspace kernel) never has to reach past this module's
+    public surface into ``_append_event``/``_end_run`` to build its own
+    ad-hoc status-writing path — that would be exactly the kind of private
+    direct-status bypass this module's CAS discipline (see ``write_txn``'s
+    docstring) exists to prevent.
+
+    Returns a snapshot dict: ``{"moved": bool, "status": str, "revision": int}``.
+    ``moved`` is False when the current ``(status, revision)`` didn't match
+    the expectation — a conflict — in which case ``status``/``revision``
+    reflect the CURRENT row so the caller can hand back an authoritative
+    snapshot instead of guessing. Never raises for a plain conflict; raises
+    ``ValueError`` only for an unknown task id.
+    """
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"unknown task {task_id}")
+        current_status = row["status"]
+        current_revision = task_event_revision(conn, task_id)
+        if current_status != expected_status or current_revision != expected_revision:
+            return {
+                "moved": False,
+                "status": current_status,
+                "revision": current_revision,
+            }
+        cur = conn.execute(
+            "UPDATE tasks SET status = ? WHERE id = ? AND status = ?",
+            (to_status, task_id, expected_status),
+        )
+        if cur.rowcount != 1:
+            # Cannot happen while holding the IMMEDIATE write lock for the
+            # whole block above, but never silently pretend success.
+            return {
+                "moved": False,
+                "status": conn.execute(
+                    "SELECT status FROM tasks WHERE id = ?", (task_id,),
+                ).fetchone()["status"],
+                "revision": task_event_revision(conn, task_id),
+            }
+        run_id = None
+        if to_status == "archived":
+            run_id = _end_run(
+                conn, task_id,
+                outcome="reclaimed", status="reclaimed",
+                summary=(event_payload or {}).get("summary")
+                or "task archived via cas_transition_task",
+            )
+        _append_event(conn, task_id, event_kind, event_payload, run_id=run_id)
+        new_revision = task_event_revision(conn, task_id)
+    return {"moved": True, "status": to_status, "revision": new_revision}
 
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:

--- a/hermes_cli/owner_workspace.py
+++ b/hermes_cli/owner_workspace.py
@@ -53,6 +53,15 @@ Security contract enforced HERE (not at the tool layer):
   token, the old claimant's stale token can no longer match — it fails
   closed (``lease_lost``) instead of mutating domain state, overwriting
   progress, or finalizing on the new claimant's behalf.
+* **Cross-profile board ownership.** Receipts and Project rows are
+  profile-local (``projects.db``), but kanban boards are shared across
+  profiles by design. The receipt lease therefore cannot order two
+  same-name bootstraps started from different profiles, so the whole
+  ownership check/create/bind decision is additionally held under
+  :func:`_global_board_guard` — an OS-level (``fcntl.flock`` /
+  ``msvcrt.locking``) exclusive lock whose identity is the canonical global
+  board namespace, revalidated inside the critical section and failing
+  closed if the guard cannot be created or acquired.
 * **Exact-operation confirmation.** Every mutation calls
   ``tools.approval.request_exact_operation_approval`` — payload-, actor-,
   profile-, session-, expiry-, and operation-bound, "once"/"deny" only.
@@ -65,11 +74,27 @@ import json
 import secrets
 import sqlite3
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from hermes_cli import kanban_db, projects_db
 from hermes_cli.sqlite_util import write_txn
+
+# fcntl is Unix-only; on Windows msvcrt provides the equivalent kernel file
+# lock. Both are stdlib and both are enforced by the OS across processes —
+# unlike the receipt lease, which only serializes claimants that share one
+# projects.db. Absence of BOTH is fatal for the board guard (see
+# :func:`_global_board_guard`), never a degraded no-op.
+msvcrt = None
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - platform-specific fallback
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        pass
 
 _LOCK_TTL_SECONDS = 30
 _POLL_INTERVAL_SECONDS = 0.02
@@ -326,6 +351,94 @@ def _derive_id(ctx: OwnerContext, idempotency_key: str, salt: str) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
 
 
+@contextmanager
+def _global_board_guard(board_slug: str):
+    """Hold an exclusive OS file lock on one GLOBAL board namespace.
+
+    Kanban boards are shared across profiles by design
+    (:func:`kanban_db.kanban_home` resolves the profile-INDEPENDENT root),
+    while receipts and Project rows live in the caller's profile-local
+    ``projects.db``. So the receipt lease — which only serializes claimants
+    writing the same ``projects.db`` — cannot order two bootstraps run from
+    DIFFERENT profiles: both derive the same board slug from the same name,
+    both see "board does not exist", and both publish ``board.json``, so the
+    second silently overwrites the first's ownership metadata. That race is
+    invisible to every check in this module, because each check is itself
+    correct in its own profile.
+
+    The lock identity is therefore anchored to the contended resource, not to
+    the caller: ``<kanban_home>/kanban/locks/board-<slug>.lock``, resolved
+    through ``kanban_db`` so every competing profile computes the same path
+    for the same canonical board namespace. ``fcntl.flock`` (``msvcrt.locking``
+    on Windows) is a kernel-held lock: it serializes unrelated PROCESSES, and
+    the kernel drops it when the holder exits, so a crash inside the critical
+    section cannot wedge the namespace — no TTL, no daemon, no polling.
+
+    Fails CLOSED: if the lock directory/file cannot be created, the lock
+    cannot be acquired, or the platform offers neither primitive, the caller
+    gets :class:`OwnerWorkspaceError` and performs no board mutation at all.
+    """
+    slug = kanban_db._normalize_board_slug(board_slug) or kanban_db.DEFAULT_BOARD
+    fd = None
+    try:
+        if fcntl is None and msvcrt is None:  # pragma: no cover - exotic platform
+            raise RuntimeError("no OS file-locking primitive is available")
+        lock_dir = kanban_db.kanban_home() / "kanban" / "locks"
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = lock_dir / f"board-{slug}.lock"
+        if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+            lock_path.write_text(" ", encoding="utf-8")
+        fd = open(lock_path, "r+" if msvcrt else "a+", encoding="utf-8")
+        if fcntl:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        else:  # pragma: no cover - Windows-only path
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+    except OwnerWorkspaceError:
+        if fd is not None:
+            fd.close()
+        raise
+    except Exception as exc:
+        if fd is not None:
+            fd.close()
+        raise OwnerWorkspaceError(
+            "ownership_guard_unavailable",
+            f"could not acquire the global board ownership guard for {slug!r}: {exc}",
+        ) from exc
+
+    try:
+        yield
+    finally:
+        try:
+            if fcntl:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            elif msvcrt:  # pragma: no cover - Windows-only path
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+        fd.close()
+
+
+def _assert_board_ownership(board_slug: str, project_id: str) -> None:
+    """Fail closed unless ``board_slug`` is absent or owned by ``project_id``.
+
+    Strict equality, not truthiness: an existing board this flow did not
+    create always carries its owning ``project_id``, so missing/empty/
+    malformed metadata is exactly as unsafe to adopt as a foreign one.
+    """
+    if not kanban_db.board_exists(board_slug):
+        return
+    owner = kanban_db.read_board_metadata(board_slug).get("project_id")
+    if owner != project_id:
+        raise OwnerWorkspaceError(
+            "crash_recovery_failed",
+            f"board {board_slug!r} has missing or foreign ownership metadata "
+            f"(project_id={owner!r}, expected {project_id!r}); refusing to "
+            "adopt ambiguous board ownership",
+        )
+
+
 # ---------------------------------------------------------------------------
 # owner_workspace_bootstrap
 # ---------------------------------------------------------------------------
@@ -353,7 +466,12 @@ def bootstrap(
     than an exact ``project_id`` match) fails closed instead of being
     silently adopted — objects this flow creates always carry exact
     ownership metadata, so an existing object without it can never be safely
-    attributed to this receipt. Every domain mutation (Project row, board,
+    attributed to this receipt. Because boards are GLOBAL while receipts are
+    profile-local, that ownership check/create/bind decision additionally runs
+    inside :func:`_global_board_guard` — a kernel-held file lock on the board
+    namespace, shared by every profile — and is revalidated inside it, so two
+    same-name bootstraps from different profiles resolve to exactly one owner
+    and one ownership conflict. Every domain mutation (Project row, board,
     Task) is fenced: the immediately-preceding lease check and the mutation
     itself share one held ``projects.db`` write lock (see
     :func:`_assert_owns_lease`), so a lease takeover can never land in the
@@ -408,36 +526,54 @@ def bootstrap(
         # re-derived from `name` or searched for.
         board_slug = project.slug
 
-        if kanban_db.board_exists(board_slug):
-            owner = kanban_db.read_board_metadata(board_slug).get("project_id")
-            # Strict equality, not truthiness: an existing board this flow
-            # did not just create always carries its owning project_id, so
-            # missing/empty/malformed metadata is exactly as unsafe to adopt
-            # as a foreign one — fail closed either way.
-            if owner != project_id:
-                raise OwnerWorkspaceError(
-                    "crash_recovery_failed",
-                    f"board {board_slug!r} has missing or foreign ownership metadata "
-                    f"(project_id={owner!r}, expected {project_id!r}); refusing to "
-                    "adopt ambiguous board ownership",
+        # Cheap fail-fast check outside the guard — an already-foreign board
+        # never becomes adoptable by waiting for a lock. It is NOT the
+        # decision: the authoritative check is re-run inside the guard below.
+        _assert_board_ownership(board_slug, project_id)
+
+        # Guard 1 (cross-profile, kernel-held): the ownership CHECK, the board
+        # CREATE and the project→board BIND are one indivisible decision over
+        # the global board namespace, so a same-name bootstrap from another
+        # profile's projects.db cannot slip between them and overwrite this
+        # board's ownership metadata (see :func:`_global_board_guard`).
+        # Acquired OUTSIDE the projects.db write lock, and only ever in that
+        # order, so the two locks cannot deadlock against each other.
+        with _global_board_guard(board_slug):
+            # Revalidate under the guard: whatever we observed above may have
+            # been published by a competitor between the check and the lock.
+            # This is the ownership decision that counts.
+            _assert_board_ownership(board_slug, project_id)
+            # Fence 2: the lease check and the create_board/update_project pair
+            # share one held write lock on pconn — create_board publishes
+            # board.json (a resource outside projects.db, so this cannot be one
+            # cross-database transaction), but no competing claimant can adopt
+            # this row (which requires the same pconn write lock) while it is
+            # open, so a takeover can never land strictly between "we own the
+            # lease" and "the board/project-row mutation actually happened".
+            with write_txn(pconn):
+                _assert_owns_lease(pconn, ctx, idempotency_key, token)
+                # create_board is naturally idempotent ("mkdir -p" semantics — see
+                # its docstring), so no separate "already created?" progress
+                # check is needed: replaying this exact call is always safe.
+                published = kanban_db.create_board(
+                    board_slug, name=name, description=description, project_id=project_id,
                 )
-        # Fence 2: the lease check and the create_board/update_project pair
-        # share one held write lock on pconn — create_board publishes
-        # board.json (a resource outside projects.db, so this cannot be one
-        # cross-database transaction), but no competing claimant can adopt
-        # this row (which requires the same pconn write lock) while it is
-        # open, so a takeover can never land strictly between "we own the
-        # lease" and "the board/project-row mutation actually happened".
-        with write_txn(pconn):
-            _assert_owns_lease(pconn, ctx, idempotency_key, token)
-            # create_board is naturally idempotent ("mkdir -p" semantics — see
-            # its docstring), so no separate "already created?" progress
-            # check is needed: replaying this exact call is always safe.
-            kanban_db.create_board(
-                board_slug, name=name, description=description, project_id=project_id,
-            )
-            if project.board_slug != board_slug:
-                projects_db.update_project(pconn, project_id, board_slug=board_slug)
+                # create_board STAMPS ownership (write_board_metadata
+                # overwrites project_id) — which is exactly why the guarded
+                # revalidation above must have already established that this
+                # slug is ours or free. Verify what actually landed on disk
+                # before binding the project row to it, so any normalization
+                # or partial write fails closed instead of leaving a project
+                # bound to a board it does not own.
+                if published.get("project_id") != project_id:
+                    raise OwnerWorkspaceError(
+                        "crash_recovery_failed",
+                        f"board {board_slug!r} published ownership "
+                        f"{published.get('project_id')!r}, not {project_id!r}; "
+                        "refusing to bind a board this project does not own",
+                    )
+                if project.board_slug != board_slug:
+                    projects_db.update_project(pconn, project_id, board_slug=board_slug)
 
         task_idempotency_key = "owtask_" + _derive_id(ctx, idempotency_key, "task")
         kconn = kanban_db.connect(board=board_slug)

--- a/hermes_cli/owner_workspace.py
+++ b/hermes_cli/owner_workspace.py
@@ -1,0 +1,746 @@
+"""Owner-workspace mutation kernel.
+
+The single deep in-process boundary behind the API-server-only
+``owner_workspace`` toolset (``owner_workspace_bootstrap``, ``owner_task_move``,
+``owner_task_comment`` — see ``tools/owner_workspace_tools.py``). All three
+tools are thin wrappers that resolve trusted identity + validate shape, then
+call into this module.
+
+Security contract enforced HERE (not at the tool layer):
+
+* **Trusted context only.** ``OwnerContext`` (actor/profile/session) is
+  derived from request-bound state (``resolve_owner_context``) — never from
+  a tool-call argument. A multiplexed ``/p/<profile>/`` request binds ITS OWN
+  profile because ``get_active_profile_name()`` resolves through
+  ``get_hermes_home()``, which the API server's profile-prefix middleware
+  scopes per request via a contextvar.
+* **Idempotency + canonical digest.** Every mutation requires an
+  ``idempotency_key``. A durable receipt, scoped to the trusted
+  actor/profile boundary (not the transient session) in ``projects.db``,
+  records a canonical digest of the request payload. Exact replay (same
+  key + same digest) returns the ORIGINAL serialized result. Reusing a key
+  with a different payload fails closed with zero domain changes.
+* **Exactly-once concurrent claim.** Concurrent callers with the same key
+  race to INSERT the receipt row inside one ``write_txn`` (SQLite's
+  BEGIN IMMEDIATE serializes writers). The loser sees the winner's row and
+  waits (bounded poll) for it to reach a terminal state rather than
+  requesting its own confirmation or creating its own objects. A receipt
+  whose claim lock has expired (crashed claimer) is adopted under a freshly
+  minted ``lock_token``, rolling forward via deterministic identities
+  (:func:`_derive_id`) — re-verifying/deriving each object before reuse,
+  never a blind re-create.
+* **Enforced lease ownership — fenced, not check-then-act.** ``lock_token``
+  is not just written at claim time — every progress write
+  (:func:`_update_progress`), every durable domain mutation, and
+  finalization (:func:`_finalize_receipt`) are predicated on the CURRENT
+  claimant's token still owning the row. Because the receipt lives in
+  ``projects.db`` while the domain mutation may land in ``kanban.db`` or
+  ``board.json``, a bare "validate, then separately mutate" would leave a
+  window between the two where the lease could be stolen. Every domain
+  mutation therefore runs inside a ``with write_txn(pconn):`` fence that
+  ALSO contains the immediately-preceding :func:`_assert_owns_lease` call:
+  the fence's ``BEGIN IMMEDIATE`` takes ``projects.db``'s write lock before
+  the lease is even read, and holds it until the mutation (and, for
+  same-database Project-table writes, the write itself) is done — so a
+  competing claimant's own adoption (which also needs that write lock, via
+  the same :func:`write_txn`) cannot interleave. Either the fenced mutation
+  runs to completion first (the competitor blocks until it commits, then
+  sees a terminal/foreign row and cannot adopt), or the competitor's
+  adoption commits first (in which case this fence's own
+  :func:`_assert_owns_lease` — executed after acquiring the same lock —
+  observes the new token and fails closed with ``lease_lost`` before
+  touching domain state). Once an expired lease is adopted with a new
+  token, the old claimant's stale token can no longer match — it fails
+  closed (``lease_lost``) instead of mutating domain state, overwriting
+  progress, or finalizing on the new claimant's behalf.
+* **Exact-operation confirmation.** Every mutation calls
+  ``tools.approval.request_exact_operation_approval`` — payload-, actor-,
+  profile-, session-, expiry-, and operation-bound, "once"/"deny" only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from hermes_cli import kanban_db, projects_db
+from hermes_cli.sqlite_util import write_txn
+
+_LOCK_TTL_SECONDS = 30
+_POLL_INTERVAL_SECONDS = 0.02
+_POLL_MAX_SECONDS = 8.0
+
+_RECEIPTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS owner_workspace_receipts (
+    actor            TEXT NOT NULL,
+    profile          TEXT NOT NULL,
+    idempotency_key  TEXT NOT NULL,
+    operation        TEXT NOT NULL,
+    request_digest   TEXT NOT NULL,
+    status           TEXT NOT NULL,
+    lock_token       TEXT,
+    lock_expires     INTEGER,
+    project_id       TEXT,
+    board_slug       TEXT,
+    task_id          TEXT,
+    result_json      TEXT,
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER NOT NULL,
+    PRIMARY KEY (actor, profile, idempotency_key)
+)
+"""
+
+
+class OwnerWorkspaceError(Exception):
+    """A validation/conflict/recovery failure the tool layer renders as an error."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class OwnerContext:
+    actor: str
+    profile: str
+    session: str
+
+
+def resolve_owner_context() -> OwnerContext:
+    """Derive the trusted actor/profile/session identity for the current call.
+
+    Never accepts these from tool-call arguments — see module docstring.
+    """
+    from hermes_cli.profiles import get_active_profile_name
+    from tools.approval import get_current_session_key
+
+    profile = get_active_profile_name()
+    session = get_current_session_key(default="")
+    return OwnerContext(actor=profile, profile=profile, session=session)
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(_RECEIPTS_SCHEMA)
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _digest(payload: dict) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _require_str(value: Any, field: str) -> str:
+    s = str(value).strip() if value is not None else ""
+    if not s:
+        raise OwnerWorkspaceError("invalid_argument", f"{field} is required")
+    return s
+
+
+def _get_receipt(conn: sqlite3.Connection, ctx: OwnerContext, key: str) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        "SELECT * FROM owner_workspace_receipts "
+        "WHERE actor = ? AND profile = ? AND idempotency_key = ?",
+        (ctx.actor, ctx.profile, key),
+    ).fetchone()
+
+
+def _claim_or_wait(
+    conn: sqlite3.Connection, ctx: OwnerContext, key: str, operation: str, digest: str,
+) -> tuple:
+    """One short write_txn: claim a fresh key, adopt a dead claim, report a
+    live claim to wait on, or report a terminal receipt to replay.
+
+    Returns ``(state, row, token)`` where ``state`` is one of ``"own"``
+    (caller now holds the lock, identified by ``token``; ``row`` is ``None``
+    for a fresh claim or the prior in-progress row's recorded progress for an
+    adopted one), ``"wait"`` (a live claim exists elsewhere; ``row`` is that
+    row, ``token`` is ``None``), or ``"terminal"`` (``row`` already carries a
+    committed/denied ``result_json``, ``token`` is ``None``).
+
+    ``token`` is the freshly minted lock the caller now owns — every
+    subsequent progress write, domain mutation, and finalization for this
+    call MUST be predicated on it (see :func:`_assert_owns_lease`,
+    :func:`_update_progress`, :func:`_finalize_receipt`). Adopting a dead
+    claim always mints a NEW token here, so the crashed/stalled prior
+    claimant's own (now stale) token can never again match this row.
+    """
+    token = secrets.token_hex(16)
+    now = _now()
+    with write_txn(conn):
+        row = _get_receipt(conn, ctx, key)
+        if row is None:
+            conn.execute(
+                "INSERT INTO owner_workspace_receipts "
+                "(actor, profile, idempotency_key, operation, request_digest, status, "
+                " lock_token, lock_expires, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, 'in_progress', ?, ?, ?, ?)",
+                (ctx.actor, ctx.profile, key, operation, digest, token, now + _LOCK_TTL_SECONDS, now, now),
+            )
+            return ("own", None, token)
+        if row["request_digest"] != digest:
+            raise OwnerWorkspaceError(
+                "idempotency_key_conflict",
+                f"idempotency_key {key!r} was already used with a different request payload",
+            )
+        if row["operation"] != operation:
+            raise OwnerWorkspaceError(
+                "idempotency_key_conflict",
+                f"idempotency_key {key!r} is already in use for a different operation",
+            )
+        if row["status"] in ("committed", "denied"):
+            return ("terminal", row, None)
+        # status == "in_progress": a live claim blocks us; a dead one (lock
+        # expired — the prior claimer crashed) is ours to adopt and roll
+        # forward from its recorded progress.
+        if row["lock_expires"] is not None and now < row["lock_expires"]:
+            return ("wait", row, None)
+        conn.execute(
+            "UPDATE owner_workspace_receipts SET lock_token = ?, lock_expires = ?, updated_at = ? "
+            "WHERE actor = ? AND profile = ? AND idempotency_key = ?",
+            (token, now + _LOCK_TTL_SECONDS, now, ctx.actor, ctx.profile, key),
+        )
+        return ("own", row, token)
+
+
+def _acquire_or_replay(
+    conn: sqlite3.Connection, ctx: OwnerContext, key: str, operation: str, digest: str,
+) -> tuple:
+    """Bounded poll around :func:`_claim_or_wait` for the concurrent-caller case."""
+    deadline = time.monotonic() + _POLL_MAX_SECONDS
+    while True:
+        state, row, token = _claim_or_wait(conn, ctx, key, operation, digest)
+        if state != "wait":
+            return (state, row, token)
+        if time.monotonic() >= deadline:
+            raise OwnerWorkspaceError(
+                "in_progress_timeout",
+                f"idempotency_key {key!r} is still being processed by another call",
+            )
+        time.sleep(_POLL_INTERVAL_SECONDS)
+
+
+def _assert_owns_lease(conn: sqlite3.Connection, ctx: OwnerContext, key: str, token: str) -> None:
+    """Re-read the receipt row and fail closed unless *token* still owns it.
+
+    MUST be called from inside the SAME ``with write_txn(conn):`` fence that
+    performs the domain mutation it guards (Project/board/Task creation, the
+    CAS status move, readiness recompute, the comment insert) — never as a
+    standalone check followed by a separately-committed mutation. Called on
+    its own, this is just a point-in-time SELECT: a concurrent adopter could
+    commit a new token in the gap between the read and the mutation it was
+    meant to guard. Called inside the fence, the ``BEGIN IMMEDIATE`` already
+    holds ``projects.db``'s write lock before this SELECT runs, so no
+    adoption (which needs that same lock) can land until the fence's
+    ``with`` block exits — closing exactly that gap. The receipts row is the
+    ONLY place lease ownership is recorded, so this is what actually stops a
+    claimant whose lease already expired and was adopted by someone else (a
+    new token minted in :func:`_claim_or_wait`) from mutating domain state
+    after the fact, even though the domain tables themselves (projects.db
+    Project rows, kanban.db tasks) carry no lock_token of their own.
+    """
+    row = _get_receipt(conn, ctx, key)
+    if row is None or row["status"] != "in_progress" or row["lock_token"] != token:
+        raise OwnerWorkspaceError(
+            "lease_lost",
+            f"idempotency_key {key!r}'s claim lease was lost (expired and adopted by "
+            "another caller); refusing to mutate domain state",
+        )
+
+
+def _update_progress(
+    conn: sqlite3.Connection, ctx: OwnerContext, key: str, token: str, **fields: Any,
+) -> None:
+    if not fields:
+        return
+    sets = ", ".join(f"{k} = ?" for k in fields) + ", updated_at = ?"
+    params = list(fields.values()) + [_now(), ctx.actor, ctx.profile, key, token]
+    with write_txn(conn):
+        cur = conn.execute(
+            f"UPDATE owner_workspace_receipts SET {sets} "
+            "WHERE actor = ? AND profile = ? AND idempotency_key = ? AND lock_token = ?",
+            params,
+        )
+        if cur.rowcount != 1:
+            raise OwnerWorkspaceError(
+                "lease_lost",
+                f"idempotency_key {key!r}'s claim lease was lost while writing progress; "
+                "refusing to overwrite another claimant's state",
+            )
+
+
+def _finalize_receipt(
+    conn: sqlite3.Connection, ctx: OwnerContext, key: str, token: str, *, status: str, result: dict,
+) -> None:
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE owner_workspace_receipts SET status = ?, result_json = ?, "
+            "lock_token = NULL, lock_expires = NULL, updated_at = ? "
+            "WHERE actor = ? AND profile = ? AND idempotency_key = ? AND lock_token = ?",
+            (status, json.dumps(result, ensure_ascii=False), _now(), ctx.actor, ctx.profile, key, token),
+        )
+        if cur.rowcount != 1:
+            raise OwnerWorkspaceError(
+                "lease_lost",
+                f"idempotency_key {key!r}'s claim lease was lost before finalization; "
+                "refusing to finalize on another claimant's behalf",
+            )
+
+
+def _confirm(ctx: OwnerContext, *, operation: str, digest: str, description: str) -> dict:
+    from tools.approval import request_exact_operation_approval
+
+    if not ctx.session:
+        return {"approved": False, "reason": "no_session"}
+    return request_exact_operation_approval(
+        ctx.session,
+        operation=operation,
+        payload_digest=digest,
+        actor=ctx.actor,
+        profile=ctx.profile,
+        description=description,
+    )
+
+
+def _derive_id(ctx: OwnerContext, idempotency_key: str, salt: str) -> str:
+    """Deterministic sub-identity, a pure function of (actor, profile,
+    idempotency_key, salt).
+
+    Recomputing this identically on every call — including a crash-and-retry
+    — means the identity needed to find (or create) a durable object exists
+    BEFORE the object does, with no separate progress record that a crash
+    could leave unwritten. That closes the exact gap described in the module
+    docstring's crash-safe bootstrap contract: there is no window between
+    "the domain mutation committed" and "the pointer to it was persisted",
+    because there never was a separate pointer to persist.
+    """
+    raw = f"{ctx.actor}:{ctx.profile}:{idempotency_key}:{salt}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+# ---------------------------------------------------------------------------
+# owner_workspace_bootstrap
+# ---------------------------------------------------------------------------
+
+
+def bootstrap(
+    ctx: OwnerContext, *, idempotency_key: str, name: str, description: Optional[str] = None,
+) -> dict:
+    """Create exactly one owner-owned Project + Kanban board + initial Task.
+
+    Uses only ``projects.db`` (the Project row + this module's receipt
+    table), ``board.json`` (board metadata, published via
+    ``kanban_db.create_board`` — atomic fsync + ``os.replace`` write), and
+    ``kanban.db`` (the board's task store). No caller-selected filesystem
+    path: the Project is created with no folders.
+
+    Crash-safe roll-forward: the Project id and the initial Task's
+    idempotency key are both deterministic (:func:`_derive_id`), so a retry
+    after a crash at ANY point recomputes the exact same identities and
+    finds — never blindly recreates — whatever already committed. The board
+    slug is never independently derived; it is read off the (uniquely
+    resolved, by id) Project row, so replay can never adopt a board by
+    matching on the human-provided ``name``. A board or task that already
+    exists under a foreign OR missing/empty/malformed owner (anything other
+    than an exact ``project_id`` match) fails closed instead of being
+    silently adopted — objects this flow creates always carry exact
+    ownership metadata, so an existing object without it can never be safely
+    attributed to this receipt. Every domain mutation (Project row, board,
+    Task) is fenced: the immediately-preceding lease check and the mutation
+    itself share one held ``projects.db`` write lock (see
+    :func:`_assert_owns_lease`), so a lease takeover can never land in the
+    gap between "we validated ownership" and "we mutated".
+    """
+    idempotency_key = _require_str(idempotency_key, "idempotency_key")
+    name = _require_str(name, "name")
+    description = str(description).strip() or None if description else None
+
+    payload = {"name": name, "description": description}
+    digest = _digest(payload)
+    operation = "owner_workspace_bootstrap"
+
+    pconn = projects_db.connect()
+    try:
+        _ensure_schema(pconn)
+        state, row, token = _acquire_or_replay(pconn, ctx, idempotency_key, operation, digest)
+        if state == "terminal":
+            return json.loads(row["result_json"])
+
+        approval = _confirm(
+            ctx, operation=operation, digest=digest,
+            description=f"Bootstrap owner workspace project {name!r}",
+        )
+        if not approval.get("approved"):
+            result = {"ok": False, "error": "confirmation_denied", "reason": approval.get("reason")}
+            _finalize_receipt(pconn, ctx, idempotency_key, token, status="denied", result=result)
+            return result
+
+        project_id = "p_" + _derive_id(ctx, idempotency_key, "project")
+
+        # Fence 1: lease validation + Project-row creation are BOTH statements
+        # against pconn (projects.db), so this is a single real SQLite
+        # transaction — genuinely atomic, not just sequential. `write_txn` is
+        # reentrant, so `create_project`'s own internal `write_txn(pconn)`
+        # joins this one instead of racing it.
+        with write_txn(pconn):
+            _assert_owns_lease(pconn, ctx, idempotency_key, token)
+            project = projects_db.get_project(pconn, project_id)
+            if project is None:
+                created_id = projects_db.create_project(
+                    pconn, id=project_id, name=name, description=description,
+                )
+                if created_id != project_id:
+                    raise OwnerWorkspaceError(
+                        "internal_error", "create_project did not honor the requested id",
+                    )
+                project = projects_db.get_project(pconn, project_id)
+
+        # Never adopt by display name: board_slug comes from THIS project's
+        # own persisted slug (looked up by the deterministic id above), never
+        # re-derived from `name` or searched for.
+        board_slug = project.slug
+
+        if kanban_db.board_exists(board_slug):
+            owner = kanban_db.read_board_metadata(board_slug).get("project_id")
+            # Strict equality, not truthiness: an existing board this flow
+            # did not just create always carries its owning project_id, so
+            # missing/empty/malformed metadata is exactly as unsafe to adopt
+            # as a foreign one — fail closed either way.
+            if owner != project_id:
+                raise OwnerWorkspaceError(
+                    "crash_recovery_failed",
+                    f"board {board_slug!r} has missing or foreign ownership metadata "
+                    f"(project_id={owner!r}, expected {project_id!r}); refusing to "
+                    "adopt ambiguous board ownership",
+                )
+        # Fence 2: the lease check and the create_board/update_project pair
+        # share one held write lock on pconn — create_board publishes
+        # board.json (a resource outside projects.db, so this cannot be one
+        # cross-database transaction), but no competing claimant can adopt
+        # this row (which requires the same pconn write lock) while it is
+        # open, so a takeover can never land strictly between "we own the
+        # lease" and "the board/project-row mutation actually happened".
+        with write_txn(pconn):
+            _assert_owns_lease(pconn, ctx, idempotency_key, token)
+            # create_board is naturally idempotent ("mkdir -p" semantics — see
+            # its docstring), so no separate "already created?" progress
+            # check is needed: replaying this exact call is always safe.
+            kanban_db.create_board(
+                board_slug, name=name, description=description, project_id=project_id,
+            )
+            if project.board_slug != board_slug:
+                projects_db.update_project(pconn, project_id, board_slug=board_slug)
+
+        task_idempotency_key = "owtask_" + _derive_id(ctx, idempotency_key, "task")
+        kconn = kanban_db.connect(board=board_slug)
+        try:
+            # Fence 3: same pattern — the lease check and the Task creation
+            # (kanban.db) are covered by one held pconn write lock.
+            with write_txn(pconn):
+                _assert_owns_lease(pconn, ctx, idempotency_key, token)
+                # create_task's own idempotency_key dedupe (kanban_db.py)
+                # returns the existing task on replay instead of creating a
+                # second one.
+                task_id = kanban_db.create_task(
+                    kconn,
+                    title=name,
+                    body=description,
+                    created_by=ctx.actor,
+                    board=board_slug,
+                    project_id=project_id,
+                    idempotency_key=task_idempotency_key,
+                )
+                task = kanban_db.get_task(kconn, task_id)
+                if task is None:
+                    raise OwnerWorkspaceError(
+                        "crash_recovery_failed", f"created/adopted task_id {task_id!r} does not resolve",
+                    )
+                # Strict equality — see the board-ownership check above: a
+                # pre-existing/replayed task with missing/empty ownership is
+                # just as unsafe to adopt as one owned by a foreign project.
+                if task.project_id != project_id:
+                    raise OwnerWorkspaceError(
+                        "crash_recovery_failed",
+                        f"task {task_id!r} has missing or foreign ownership "
+                        f"(project_id={task.project_id!r}, expected {project_id!r}); "
+                        "refusing to adopt ambiguous task ownership",
+                    )
+                task_revision = kanban_db.task_event_revision(kconn, task_id)
+        finally:
+            kconn.close()
+
+        result = {
+            "ok": True, "project_id": project_id, "board": board_slug, "task_id": task_id,
+            "status": task.status, "revision": task_revision,
+        }
+        _finalize_receipt(pconn, ctx, idempotency_key, token, status="committed", result=result)
+        return result
+    finally:
+        pconn.close()
+
+
+# ---------------------------------------------------------------------------
+# owner_task_move
+# ---------------------------------------------------------------------------
+
+_UNSAFE_STATUSES = {"running"}
+
+
+def move_task(
+    ctx: OwnerContext,
+    *,
+    idempotency_key: str,
+    task_id: str,
+    to_status: str,
+    expected_status: str,
+    expected_revision: Any,
+    board: Optional[str] = None,
+) -> dict:
+    """Optimistic compare-and-swap task move inside the existing Kanban
+    write transaction. See ``kanban_db.cas_transition_task``.
+
+    Crash-safe readiness repair: if the CAS status move + event commit
+    succeeds but a crash follows before ``recompute_ready`` (or before
+    finalization), a replay adopting the dead claim recognizes — by the
+    committed event's payload carrying THIS receipt's full identity (actor,
+    profile, idempotency_key, AND the requested to_status/expected_status
+    transition) at this task's very next revision after ``expected_revision``
+    (see ``kanban_db.get_next_event_after`` — ``task_events.id`` is a
+    board-wide sequence, not contiguous per task, so it is not necessarily
+    ``expected_revision + 1``) — that it already performed the transition.
+    It does not re-run the CAS (which would misread the already-advanced
+    status/revision as an unrelated conflict); it rebuilds the same success
+    snapshot, reruns readiness recompute (idempotent — safe to repeat), and
+    finalizes the original success. Genuinely unrelated status/revision
+    drift still reports a conflict — including a DIFFERENT actor/profile
+    validly reusing the same idempotency_key text on the same task (receipts
+    are scoped per actor/profile/key, but the task's event log is
+    board-wide, so a bare idempotency_key match on the next event would
+    otherwise let one receipt fabricate a success snapshot for a mutation an
+    entirely different receipt performed).
+
+    Lease-fenced: the lease check, replay recognition, CAS, and readiness
+    recompute all run inside one held ``projects.db`` write lock (see
+    :func:`_assert_owns_lease`) so a takeover cannot land between validating
+    the lease and committing the move.
+    """
+    idempotency_key = _require_str(idempotency_key, "idempotency_key")
+    task_id = _require_str(task_id, "task_id")
+    to_status = _require_str(to_status, "to_status")
+    expected_status = _require_str(expected_status, "expected_status")
+    if to_status not in kanban_db.VALID_STATUSES:
+        raise OwnerWorkspaceError(
+            "invalid_status", f"to_status must be one of {sorted(kanban_db.VALID_STATUSES)}",
+        )
+    if to_status in _UNSAFE_STATUSES or expected_status in _UNSAFE_STATUSES:
+        raise OwnerWorkspaceError(
+            "unsafe_transition",
+            "owner_task_move cannot claim or move a running/claimed task — use the "
+            "worker claim/complete/block lifecycle for run-owning transitions",
+        )
+    try:
+        expected_revision = int(expected_revision)
+    except (TypeError, ValueError):
+        raise OwnerWorkspaceError("invalid_argument", "expected_revision must be an integer")
+
+    board_norm = str(board).strip() if board else None
+    payload = {
+        "task_id": task_id, "board": board_norm, "to_status": to_status,
+        "expected_status": expected_status, "expected_revision": expected_revision,
+    }
+    digest = _digest(payload)
+    operation = "owner_task_move"
+
+    pconn = projects_db.connect()
+    try:
+        _ensure_schema(pconn)
+        state, row, token = _acquire_or_replay(pconn, ctx, idempotency_key, operation, digest)
+        if state == "terminal":
+            return json.loads(row["result_json"])
+
+        approval = _confirm(
+            ctx, operation=operation, digest=digest,
+            description=f"Move task {task_id} to {to_status!r} (from {expected_status!r})",
+        )
+        if not approval.get("approved"):
+            result = {"ok": False, "error": "confirmation_denied", "reason": approval.get("reason")}
+            _finalize_receipt(pconn, ctx, idempotency_key, token, status="denied", result=result)
+            return result
+
+        kconn = kanban_db.connect(board=board_norm)
+        try:
+            if kanban_db.get_task(kconn, task_id) is None:
+                raise OwnerWorkspaceError("task_not_found", f"no such task {task_id}")
+
+            # Fence: the lease check, the replay-recognition read, the CAS
+            # move, and readiness recompute all run under ONE held pconn
+            # write lock. A competing claimant's adoption needs that same
+            # lock (see :func:`_claim_or_wait`'s own ``write_txn``), so it
+            # cannot land between "we validated the lease" and "we moved the
+            # task" — it either waits for this block to finish (and then
+            # finds a terminal/foreign row instead of a live one to adopt),
+            # or it already committed before this block started, in which
+            # case `_assert_owns_lease` observes the new token right here and
+            # fails closed before the CAS ever runs.
+            with write_txn(pconn):
+                _assert_owns_lease(pconn, ctx, idempotency_key, token)
+
+                snapshot = None
+                if row is not None:
+                    # Adopting a dead claim — check whether THIS receipt
+                    # already committed the CAS before crashing.
+                    # ``task_events.id`` is a board-wide AUTOINCREMENT
+                    # sequence (not contiguous per task), so "the next event
+                    # after expected_revision" — NOT necessarily
+                    # ``expected_revision + 1`` — is the one that would have
+                    # been our CAS's commit, if it happened. Receipts are
+                    # scoped per (actor, profile, idempotency_key), but
+                    # ``task_events`` is shared across the whole board — a
+                    # DIFFERENT actor/profile may legitimately reuse the same
+                    # idempotency_key text on the same task, so matching on
+                    # idempotency_key alone could recognize a foreign event as
+                    # this receipt's own. Require the full identity this
+                    # receipt actually emitted: actor, profile, idempotency
+                    # key, AND the requested transition (to_status /
+                    # expected_status) — anything less risks fabricating a
+                    # success snapshot (and triggering readiness repair) for
+                    # a mutation this receipt never performed.
+                    already = kanban_db.get_next_event_after(kconn, task_id, expected_revision)
+                    if (
+                        already is not None
+                        and already.kind == "owner_move"
+                        and (already.payload or {}).get("idempotency_key") == idempotency_key
+                        and (already.payload or {}).get("actor") == ctx.actor
+                        and (already.payload or {}).get("profile") == ctx.profile
+                        and (already.payload or {}).get("to_status") == to_status
+                        and (already.payload or {}).get("expected_status") == expected_status
+                    ):
+                        snapshot = {"moved": True, "status": to_status, "revision": already.id}
+
+                if snapshot is None:
+                    snapshot = kanban_db.cas_transition_task(
+                        kconn, task_id,
+                        expected_status=expected_status,
+                        expected_revision=expected_revision,
+                        to_status=to_status,
+                        event_kind="owner_move",
+                        event_payload={
+                            "actor": ctx.actor, "profile": ctx.profile,
+                            "idempotency_key": idempotency_key,
+                            "to_status": to_status, "expected_status": expected_status,
+                        },
+                    )
+                if snapshot["moved"] and to_status in ("done", "archived"):
+                    # Both done and archived parents satisfy readiness;
+                    # promote any children this move just unblocked.
+                    # Idempotent — safe to re-run on a replay that repairs a
+                    # prior crash gap between the status commit above and
+                    # this call, without re-emitting the move event (already
+                    # committed above).
+                    kanban_db.recompute_ready(kconn)
+        finally:
+            kconn.close()
+
+        if snapshot["moved"]:
+            result = {"ok": True, "task_id": task_id, "status": snapshot["status"], "revision": snapshot["revision"]}
+        else:
+            result = {
+                "ok": False, "error": "conflict", "task_id": task_id,
+                "current_status": snapshot["status"], "current_revision": snapshot["revision"],
+            }
+        _finalize_receipt(pconn, ctx, idempotency_key, token, status="committed", result=result)
+        return result
+    finally:
+        pconn.close()
+
+
+# ---------------------------------------------------------------------------
+# owner_task_comment
+# ---------------------------------------------------------------------------
+
+
+def comment_task(
+    ctx: OwnerContext,
+    *,
+    idempotency_key: str,
+    task_id: str,
+    body: str,
+    board: Optional[str] = None,
+) -> dict:
+    """Append a comment as the trusted actor. Comment + audit event commit
+    exactly once inside ``kanban_db.add_comment``'s existing transaction.
+
+    Crash-safe replay: ``add_comment`` is called with an ``operation_key``
+    derived from the trusted actor/profile/idempotency_key, durably recorded
+    on the comment row itself (see ``kanban_db.add_comment``). A retry after
+    a crash between the comment commit and receipt finalization re-calls
+    ``add_comment`` with the SAME operation_key and gets back the ORIGINAL
+    comment id — no second comment, no second event.
+
+    Lease-fenced: the lease check and the comment insert share one held
+    ``projects.db`` write lock (see :func:`_assert_owns_lease`) so a
+    takeover cannot land between validating the lease and committing the
+    comment.
+    """
+    idempotency_key = _require_str(idempotency_key, "idempotency_key")
+    task_id = _require_str(task_id, "task_id")
+    body = _require_str(body, "body")
+
+    board_norm = str(board).strip() if board else None
+    payload = {"task_id": task_id, "board": board_norm, "body": body}
+    digest = _digest(payload)
+    operation = "owner_task_comment"
+
+    pconn = projects_db.connect()
+    try:
+        _ensure_schema(pconn)
+        state, row, token = _acquire_or_replay(pconn, ctx, idempotency_key, operation, digest)
+        if state == "terminal":
+            return json.loads(row["result_json"])
+
+        approval = _confirm(
+            ctx, operation=operation, digest=digest,
+            description=f"Comment on task {task_id}",
+        )
+        if not approval.get("approved"):
+            result = {"ok": False, "error": "confirmation_denied", "reason": approval.get("reason")}
+            _finalize_receipt(pconn, ctx, idempotency_key, token, status="denied", result=result)
+            return result
+
+        operation_key = f"{ctx.actor}:{ctx.profile}:{idempotency_key}"
+        kconn = kanban_db.connect(board=board_norm)
+        try:
+            # Fence: the lease check and the comment insert share one held
+            # pconn write lock, so a takeover cannot land between validating
+            # the lease and actually appending the comment — see the
+            # module docstring's "Real lease fencing" section.
+            with write_txn(pconn):
+                _assert_owns_lease(pconn, ctx, idempotency_key, token)
+                # Author comes ONLY from the trusted context — never from a
+                # tool-call argument (kanban_db.add_comment takes it as a
+                # plain parameter; the kernel is the only caller that may
+                # supply it).
+                comment_id = kanban_db.add_comment(
+                    kconn, task_id, author=ctx.actor, body=body, operation_key=operation_key,
+                )
+                task = kanban_db.get_task(kconn, task_id)
+                revision = kanban_db.task_event_revision(kconn, task_id)
+        finally:
+            kconn.close()
+
+        result = {
+            "ok": True, "task_id": task_id, "comment_id": comment_id,
+            "status": task.status, "revision": revision,
+        }
+        _finalize_receipt(pconn, ctx, idempotency_key, token, status="committed", result=result)
+        return result
+    finally:
+        pconn.close()

--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -323,6 +323,7 @@ def create_project(
     conn: sqlite3.Connection,
     *,
     name: str,
+    id: Optional[str] = None,
     slug: Optional[str] = None,
     folders: Optional[Iterable[str]] = None,
     primary_path: Optional[str] = None,
@@ -336,13 +337,23 @@ def create_project(
     ``folders`` are normalized to absolute paths. If ``primary_path`` is given
     it is added to the folder set (if not already present) and marked primary;
     otherwise the first folder becomes primary.
+
+    ``id``, when given, is used verbatim instead of minting a random one —
+    for callers (e.g. the owner-workspace mutation kernel) that need a
+    deterministic, reproducible id so a crash-and-retry recomputes the exact
+    same identity rather than depending on a value recorded in a separate
+    durability gap. Raises whatever ``sqlite3.IntegrityError`` the PRIMARY
+    KEY constraint raises if ``id`` already exists — callers wanting
+    idempotent re-creation must check ``get_project(conn, id)`` first.
     """
     name = str(name or "").strip()
     if not name:
         raise ValueError("project name must not be empty")
 
     slug_candidate = normalize_slug(slug) if slug else _slugify(name)
-    pid = _new_project_id()
+    pid = str(id).strip() if id else _new_project_id()
+    if not pid:
+        raise ValueError("id must not be empty")
     now = _now()
 
     folder_paths: List[str] = []

--- a/hermes_cli/sqlite_util.py
+++ b/hermes_cli/sqlite_util.py
@@ -35,7 +35,22 @@ def write_txn(conn: sqlite3.Connection):
     The explicit ROLLBACK is guarded so a SQLite auto-rollback (no active
     transaction left under EIO / lock contention / corruption) cannot shadow
     the original exception with a spurious rollback error.
+
+    Reentrant on the same connection: if *conn* already has an open
+    transaction (``conn.in_transaction``), this call joins it instead of
+    issuing a second ``BEGIN`` (which SQLite rejects outright). This lets a
+    caller hold one outer fence — e.g. a lease-ownership check that must stay
+    valid across a mutation — around store functions (``create_project``,
+    ``update_project``, ...) that each open their own ``write_txn`` for
+    standalone use: nested under an outer fence, their statements land in the
+    SAME atomic transaction instead of racing it. Only the outermost caller's
+    ``with`` block actually commits/rolls back; an inner one is a no-op
+    wrapper so a raised exception still propagates to the outer block, which
+    is the one holding the real transaction.
     """
+    if conn.in_transaction:
+        yield conn
+        return
     conn.execute("BEGIN IMMEDIATE")
     try:
         yield conn

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2246,7 +2246,7 @@ def _get_platform_tools(
     include_default_mcp_servers: bool = True,
 ) -> Set[str]:
     """Resolve which individual toolset names are enabled for a platform."""
-    from toolsets import resolve_toolset, TOOLSETS
+    from toolsets import resolve_toolset, get_kernel_gated_toolsets, TOOLSETS
 
     platform_toolsets = config.get("platform_toolsets") or {}
     toolset_names = platform_toolsets.get(platform)
@@ -2268,6 +2268,19 @@ def _get_platform_tools(
     # YAML may parse bare numeric names (e.g. ``12306:``) as int.
     # Normalise to str so downstream sorted() never mixes types.
     toolset_names = [str(ts) for ts in toolset_names]
+
+    # Kernel-gated toolsets (e.g. "owner_workspace") are reachable ONLY
+    # through their dedicated code-level enablement path — never via
+    # generic `platform_toolsets` config naming, on ANY platform (including
+    # api_server: that platform's admitted path is the separate
+    # `_owner_workspace_toolset_enabled()` union in api_server.py, applied
+    # AFTER this function returns). Stripping the name here — before the
+    # "explicit passthrough" step below — closes the leak for every caller
+    # of this function (CLI, cron, every messaging platform, TUI, ...) in
+    # one place instead of at each call site.
+    kernel_gated = get_kernel_gated_toolsets()
+    if kernel_gated:
+        toolset_names = [ts for ts in toolset_names if ts not in kernel_gated]
 
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     plugin_ts_keys = _get_plugin_toolset_keys()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2547,6 +2547,33 @@ def _get_platform_tools(
                 ", ".join(_named),
             )
 
+    # Post-resolution kernel gate — the airtight boundary. The by-name strip
+    # near the top of this function only covers a kernel_gated toolset named
+    # literally in `platform_toolsets`; names can still reach the returned set
+    # through generic routes that never mention it — the wildcard aliases
+    # ``all``/``*``, a registry toolset ALIAS whose canonical target is the
+    # gated toolset, an MCP/plugin/custom name preserved by
+    # `explicit_passthrough`, or any composite that (now or later) resolves
+    # indirectly onto gated tools. Every caller of this function (CLI, cron,
+    # TUI, every messaging platform, ACP, the gateway) turns these names into
+    # a tool list, so filtering by RESOLVED tools here — not by name — is what
+    # actually keeps e.g. `owner_workspace_bootstrap` off every generic
+    # platform. The dedicated API-server admission path is unaffected: it
+    # unions "owner_workspace" back in AFTER this function returns.
+    #
+    # Ordinary all/* behaviour is preserved: resolve_toolset() omits
+    # kernel_gated toolsets from wildcard expansion, so ``all``/``*`` survive
+    # this filter with every non-gated toolset intact.
+    if kernel_gated:
+        gated_tools: Set[str] = set()
+        for gated_ts in kernel_gated:
+            gated_tools.update(resolve_toolset(gated_ts))
+        if gated_tools:
+            enabled_toolsets = {
+                ts for ts in enabled_toolsets
+                if not gated_tools.intersection(resolve_toolset(ts))
+            }
+
     return enabled_toolsets
 
 

--- a/tests/gateway/test_api_server_route_allowlist.py
+++ b/tests/gateway/test_api_server_route_allowlist.py
@@ -1,0 +1,276 @@
+"""Tests for the API-server route allowlist boundary
+(gateway/platforms/api_server.py's ``gateway.api_server.allowed_routes``
+least-privilege gate and the sibling ``owner_workspace`` admission flag that
+lives in the same boundary section).
+
+Covers:
+  - ``_resolve_api_server_allowed_routes()`` — real config.yaml resolution
+    (E2E against an isolated HERMES_HOME, no mocking of the config loader)
+    for every documented mode: unrestricted, deny_all, allowlist.
+  - ``_route_matches_any()`` — segment-aware prefix matching.
+  - ``_owner_workspace_toolset_enabled()`` — default-off, fail-closed flag.
+  - The admission boundary: owner_workspace is reachable ONLY through the
+    dedicated api_server flag, never via generic ``platform_toolsets``
+    naming on any platform (including api_server itself), and toggling the
+    flag has zero effect on any other toolset or on unrelated route
+    patterns.
+"""
+from __future__ import annotations
+
+import yaml
+import pytest
+
+from gateway.platforms.api_server import (
+    _owner_workspace_toolset_enabled,
+    _resolve_api_server_allowed_routes,
+    _route_matches_any,
+    _ROUTES_ALLOWLIST,
+    _ROUTES_DENY_ALL,
+    _ROUTES_UNRESTRICTED,
+)
+from hermes_cli.config import get_config_path
+from hermes_cli.tools_config import _get_platform_tools
+
+
+def _write_config(data: dict) -> None:
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _write_raw_yaml(text: str) -> None:
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_api_server_allowed_routes — real config.yaml, isolated HERMES_HOME
+# ---------------------------------------------------------------------------
+
+
+class TestResolveApiServerAllowedRoutesUnrestricted:
+    def test_no_config_file_at_all(self):
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_UNRESTRICTED, [])
+
+    def test_no_gateway_key(self):
+        _write_config({"model": {"default": "x"}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_UNRESTRICTED, [])
+
+    def test_no_api_server_key(self):
+        _write_config({"gateway": {"multiplex_profiles": True}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_UNRESTRICTED, [])
+
+    def test_no_allowed_routes_key(self):
+        _write_config({"gateway": {"api_server": {"port": 8642}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_UNRESTRICTED, [])
+
+    def test_allowed_routes_explicit_null(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": None}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_UNRESTRICTED, [])
+
+    def test_allowed_routes_empty_list(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": []}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_UNRESTRICTED, [])
+
+
+class TestResolveApiServerAllowedRoutesAllowlist:
+    def test_list_of_patterns(self):
+        _write_config({
+            "gateway": {"api_server": {"allowed_routes": ["/v1/chat/completions", "/v1/models"]}},
+        })
+        mode, patterns = _resolve_api_server_allowed_routes()
+        assert mode == _ROUTES_ALLOWLIST
+        assert patterns == ["/v1/chat/completions", "/v1/models"]
+
+    def test_single_string_pattern(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": "/v1/models"}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_ALLOWLIST, ["/v1/models"])
+
+    def test_patterns_are_stripped(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": ["  /v1/models  "]}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_ALLOWLIST, ["/v1/models"])
+
+
+class TestResolveApiServerAllowedRoutesDenyAll:
+    def test_empty_string_is_malformed(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": ""}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_bool_true_is_malformed(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": True}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_bool_false_is_malformed(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": False}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_int_is_malformed(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": 0}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_dict_is_malformed(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": {}}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_list_with_non_string_entry(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": ["/v1/models", 5]}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_list_with_empty_string_entry(self):
+        _write_config({"gateway": {"api_server": {"allowed_routes": ["", "/v1/models"]}}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_gateway_not_a_dict(self):
+        _write_config({"gateway": "oops"})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_api_server_not_a_dict(self):
+        _write_config({"gateway": {"api_server": "oops"}})
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_top_level_not_a_dict_is_defensively_denied(self, monkeypatch):
+        """read_user_config_raw() already coerces a non-dict YAML root to
+        ``{}`` (real files can never surface a non-dict here), so this
+        exercises the function's own defensive isinstance check directly."""
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setattr(config_mod, "read_user_config_raw", lambda: ["just", "a", "list"])
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_top_level_not_a_dict_yaml_file_normalizes_to_unrestricted(self):
+        """A real config.yaml whose root isn't a dict is coerced to ``{}``
+        by read_user_config_raw() itself — same as a missing file."""
+        _write_raw_yaml("- just\n- a\n- list\n")
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_UNRESTRICTED, [])
+
+    def test_unparseable_yaml_fails_closed(self):
+        _write_raw_yaml("gateway: {api_server: [unterminated\n")
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+
+# ---------------------------------------------------------------------------
+# _route_matches_any
+# ---------------------------------------------------------------------------
+
+
+class TestRouteMatchesAny:
+    def test_exact_match(self):
+        assert _route_matches_any("/v1/runs", ["/v1/runs"]) is True
+
+    def test_descendant_matches(self):
+        assert _route_matches_any("/v1/runs/abc123", ["/v1/runs"]) is True
+
+    def test_sibling_with_shared_string_prefix_does_not_match(self):
+        assert _route_matches_any("/v1/runs-evil", ["/v1/runs"]) is False
+
+    def test_unrelated_path_does_not_match(self):
+        assert _route_matches_any("/api/sessions", ["/v1/runs"]) is False
+
+    def test_trailing_slash_on_pattern_is_normalized(self):
+        assert _route_matches_any("/v1/runs", ["/v1/runs/"]) is True
+
+    def test_no_patterns_never_matches(self):
+        assert _route_matches_any("/v1/runs", []) is False
+
+    def test_matches_if_any_pattern_matches(self):
+        assert _route_matches_any("/v1/models", ["/v1/runs", "/v1/models"]) is True
+
+
+# ---------------------------------------------------------------------------
+# _owner_workspace_toolset_enabled — default-off, fail-closed
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerWorkspaceToolsetEnabledFlag:
+    def test_default_disabled_on_empty_config(self):
+        assert _owner_workspace_toolset_enabled({}) is False
+
+    def test_default_disabled_when_api_server_section_present_but_key_absent(self):
+        assert _owner_workspace_toolset_enabled({"gateway": {"api_server": {}}}) is False
+
+    def test_explicit_true_enables(self):
+        cfg = {"gateway": {"api_server": {"owner_workspace": {"enabled": True}}}}
+        assert _owner_workspace_toolset_enabled(cfg) is True
+
+    def test_explicit_false_stays_disabled(self):
+        cfg = {"gateway": {"api_server": {"owner_workspace": {"enabled": False}}}}
+        assert _owner_workspace_toolset_enabled(cfg) is False
+
+    def test_resolution_error_fails_closed_to_disabled(self, monkeypatch):
+        import hermes_cli.config as config_mod
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(config_mod, "cfg_get", _raise)
+        cfg = {"gateway": {"api_server": {"owner_workspace": {"enabled": True}}}}
+        assert _owner_workspace_toolset_enabled(cfg) is False
+
+
+# ---------------------------------------------------------------------------
+# Admission boundary: owner_workspace is reachable ONLY via the dedicated
+# api_server flag — never via platform_toolsets, on any platform.
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerWorkspaceAdmissionBoundary:
+    @pytest.mark.parametrize("platform", ["cli", "telegram", "cron"])
+    def test_flag_enabled_has_no_effect_on_other_platforms(self, platform):
+        """The owner_workspace.enabled flag is read ONLY by api_server's own
+        _create_agent(); _get_platform_tools() (shared by every platform,
+        including cli/telegram/cron) never looks at it and always strips
+        the kernel-gated toolset regardless of platform_toolsets naming it."""
+        config = {
+            "gateway": {"api_server": {"owner_workspace": {"enabled": True}}},
+            "platform_toolsets": {platform: [f"hermes-{platform}", "owner_workspace"]},
+        }
+        enabled = _get_platform_tools(config, platform)
+        assert "owner_workspace" not in enabled
+        assert "owner_workspace_bootstrap" not in enabled
+        assert "owner_task_move" not in enabled
+        assert "owner_task_comment" not in enabled
+
+    def test_api_server_generic_resolution_never_admits_it_either(self):
+        """_get_platform_tools() alone — without the dedicated union
+        _create_agent() applies afterward — never admits owner_workspace,
+        even for api_server itself and even when explicitly named."""
+        config = {
+            "gateway": {"api_server": {"owner_workspace": {"enabled": True}}},
+            "platform_toolsets": {"api_server": ["hermes-api-server", "owner_workspace"]},
+        }
+        enabled = _get_platform_tools(config, "api_server")
+        assert "owner_workspace" not in enabled
+
+    def test_default_is_disabled_for_api_server_too(self):
+        config = {"platform_toolsets": {"api_server": ["hermes-api-server"]}}
+        assert _owner_workspace_toolset_enabled(config) is False
+        assert "owner_workspace" not in _get_platform_tools(config, "api_server")
+
+    @pytest.mark.parametrize("platform", ["cli", "telegram", "cron"])
+    def test_unrelated_toolsets_are_unaffected_by_the_flag(self, platform):
+        """Toggling owner_workspace.enabled must not change ANY other
+        toolset's admission for ANY platform — it is read by exactly one
+        call site (api_server's _create_agent), nowhere else."""
+        base_config = {"platform_toolsets": {platform: [f"hermes-{platform}", "terminal"]}}
+        flagged_config = {
+            **base_config,
+            "gateway": {"api_server": {"owner_workspace": {"enabled": True}}},
+        }
+        assert _get_platform_tools(base_config, platform) == _get_platform_tools(flagged_config, platform)
+
+    def test_unrelated_route_patterns_are_unaffected_by_owner_workspace_flag(self):
+        """The allowed_routes gate and the owner_workspace flag are
+        independent axes of the same config section — setting one must not
+        perturb resolution of the other."""
+        _write_config({
+            "gateway": {
+                "api_server": {
+                    "allowed_routes": ["/v1/models", "/health"],
+                    "owner_workspace": {"enabled": True},
+                },
+            },
+        })
+        mode, patterns = _resolve_api_server_allowed_routes()
+        assert mode == _ROUTES_ALLOWLIST
+        assert patterns == ["/v1/models", "/health"]

--- a/tests/gateway/test_api_server_route_allowlist.py
+++ b/tests/gateway/test_api_server_route_allowlist.py
@@ -129,23 +129,42 @@ class TestResolveApiServerAllowedRoutesDenyAll:
         _write_config({"gateway": {"api_server": "oops"}})
         assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
 
-    def test_top_level_not_a_dict_is_defensively_denied(self, monkeypatch):
-        """read_user_config_raw() already coerces a non-dict YAML root to
-        ``{}`` (real files can never surface a non-dict here), so this
-        exercises the function's own defensive isinstance check directly."""
-        import hermes_cli.config as config_mod
-
-        monkeypatch.setattr(config_mod, "read_user_config_raw", lambda: ["just", "a", "list"])
+    @pytest.mark.parametrize(
+        "raw_yaml",
+        [
+            pytest.param("- just\n- a\n- list\n", id="list-root"),
+            pytest.param("just-a-string\n", id="string-root"),
+            pytest.param("42\n", id="int-root"),
+            pytest.param("3.14\n", id="float-root"),
+            pytest.param("true\n", id="bool-root"),
+            pytest.param("null\n", id="explicit-null-root"),
+            pytest.param("~\n", id="tilde-null-root"),
+            pytest.param("- gateway:\n    api_server:\n      allowed_routes: /v1/models\n",
+                         id="list-root-wrapping-real-keys"),
+        ],
+    )
+    def test_non_mapping_yaml_root_denies_all(self, raw_yaml):
+        """A config.yaml that PARSED FINE but whose root is not a mapping is
+        malformed, not unconfigured. Collapsing it to ``{}`` (as the generic
+        raw-config reader does) made ``gateway`` look merely absent and
+        resolved the boundary to UNRESTRICTED — a real file could silently
+        disable the least-privilege gate. Every non-mapping root must deny."""
+        _write_raw_yaml(raw_yaml)
         assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
-
-    def test_top_level_not_a_dict_yaml_file_normalizes_to_unrestricted(self):
-        """A real config.yaml whose root isn't a dict is coerced to ``{}``
-        by read_user_config_raw() itself — same as a missing file."""
-        _write_raw_yaml("- just\n- a\n- list\n")
-        assert _resolve_api_server_allowed_routes() == (_ROUTES_UNRESTRICTED, [])
 
     def test_unparseable_yaml_fails_closed(self):
         _write_raw_yaml("gateway: {api_server: [unterminated\n")
+        assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
+
+    def test_unreadable_config_fails_closed(self, monkeypatch):
+        """A config that cannot be read at all is a load failure, and a load
+        failure is never allowed to read as "nothing configured"."""
+        import gateway.platforms.api_server as api_server_mod
+
+        def _raise():
+            raise OSError("disk on fire")
+
+        monkeypatch.setattr(api_server_mod, "_read_raw_config_root", _raise)
         assert _resolve_api_server_allowed_routes() == (_ROUTES_DENY_ALL, [])
 
 
@@ -195,6 +214,30 @@ class TestOwnerWorkspaceToolsetEnabledFlag:
 
     def test_explicit_false_stays_disabled(self):
         cfg = {"gateway": {"api_server": {"owner_workspace": {"enabled": False}}}}
+        assert _owner_workspace_toolset_enabled(cfg) is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("true", id="str-true"),
+            pytest.param("True", id="str-True"),
+            pytest.param("yes", id="str-yes"),
+            pytest.param("on", id="str-on"),
+            pytest.param("false", id="str-false"),
+            pytest.param("0", id="str-zero"),
+            pytest.param(1, id="int-one"),
+            pytest.param(1.0, id="float-one"),
+            pytest.param(["owner_workspace"], id="non-empty-list"),
+            pytest.param({"enabled": True}, id="non-empty-mapping"),
+            pytest.param(None, id="explicit-null"),
+        ],
+    )
+    def test_malformed_truthy_values_stay_disabled(self, value):
+        """Only the literal boolean ``True`` opens this owner-mutation
+        surface. A ``bool()`` coercion would turn ordinary YAML quoting slips
+        (``enabled: "false"`` — a non-empty, therefore truthy, string) into a
+        live mutation surface, so every non-``True`` value must stay off."""
+        cfg = {"gateway": {"api_server": {"owner_workspace": {"enabled": value}}}}
         assert _owner_workspace_toolset_enabled(cfg) is False
 
     def test_resolution_error_fails_closed_to_disabled(self, monkeypatch):

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -79,4 +79,64 @@ class TestApiServerAdapterToolset:
             assert isinstance(toolsets, list)
             assert len(toolsets) > 0
             assert call_kwargs.kwargs.get("platform") == "api_server"
+            # Default-off: no config key at all means the owner-workspace
+            # mutation surface stays absent even on the one platform that
+            # can ever reach it.
+            assert "owner_workspace" not in toolsets
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_owner_workspace_disabled_by_default(self):
+        """gateway.api_server.owner_workspace.enabled is default-off — an
+        api_server config with no explicit owner_workspace section must not
+        expose the toolset."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": "test-key", "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {"gateway": {"api_server": {}}}
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            toolsets = mock_agent_cls.call_args.kwargs.get("enabled_toolsets")
+            assert "owner_workspace" not in toolsets
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_owner_workspace_enabled_via_dedicated_flag(self):
+        """The ONE admitted path: gateway.api_server.owner_workspace.enabled
+        = true unions owner_workspace into the api_server agent's toolsets,
+        independent of (and never via) platform_toolsets."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": "test-key", "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {
+                "gateway": {"api_server": {"owner_workspace": {"enabled": True}}},
+            }
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            toolsets = mock_agent_cls.call_args.kwargs.get("enabled_toolsets")
+            assert "owner_workspace" in toolsets
 

--- a/tests/hermes_cli/test_owner_workspace.py
+++ b/tests/hermes_cli/test_owner_workspace.py
@@ -1,0 +1,1070 @@
+"""Contract tests for the owner-workspace mutation kernel (hermes_cli.owner_workspace)."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+from hermes_cli import kanban_db, owner_workspace as ow, projects_db
+from tools import approval
+
+
+import contextlib
+
+
+@contextlib.contextmanager
+def _temporarily_patch(obj, attr: str, replacement):
+    """Swap ``obj.attr`` for the duration of the block, then restore it.
+
+    Deliberately NOT ``pytest``'s ``monkeypatch`` fixture: these crash-
+    injection tests also use the ``ctx``/``monkeypatch``-sharing test's own
+    ``monkeypatch`` would undo ALL patches made so far by ANY autouse
+    fixture sharing that same function-scoped instance — including the
+    ``HERMES_HOME`` env sandbox — silently repointing every DB lookup after
+    the "crash" at a different, empty home. A plain save/restore has no such
+    blast radius.
+    """
+    original = getattr(obj, attr)
+    setattr(obj, attr, replacement)
+    try:
+        yield
+    finally:
+        setattr(obj, attr, original)
+
+
+def _expire_lock(ctx, key: str) -> None:
+    """Force a receipt's claim lock to look expired — simulates the passage
+    of time past ``_LOCK_TTL_SECONDS`` after a crashed claimer, without
+    actually sleeping."""
+    with projects_db.connect_closing() as pconn:
+        ow._ensure_schema(pconn)
+        with ow.write_txn(pconn):
+            pconn.execute(
+                "UPDATE owner_workspace_receipts SET lock_expires = 0 "
+                "WHERE actor = ? AND profile = ? AND idempotency_key = ?",
+                (ctx.actor, ctx.profile, key),
+            )
+
+
+@pytest.fixture
+def ctx():
+    return ow.OwnerContext(actor="default", profile="default", session="run_owt")
+
+
+def _auto_approve(session_key: str, choice: str = "once", timeout: float = 5.0) -> None:
+    """Resolve the next queued approval for *session_key* by its approval_id."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with approval._lock:
+            queue = approval._gateway_queues.get(session_key)
+            aid = queue[0].approval_id if queue else None
+        if aid:
+            approval.resolve_gateway_approval(session_key, choice, approval_id=aid)
+            return
+        time.sleep(0.005)
+    raise TimeoutError("no approval was queued")
+
+
+def _with_approver(session_key: str, choice: str = "once"):
+    approval.register_gateway_notify(session_key, lambda data: None)
+    t = threading.Thread(target=_auto_approve, args=(session_key, choice))
+    t.start()
+    return t
+
+
+def test_bootstrap_denies_without_session(ctx):
+    denied_ctx = ow.OwnerContext(actor="default", profile="default", session="")
+    result = ow.bootstrap(denied_ctx, idempotency_key="k1", name="No Session")
+    assert result == {"ok": False, "error": "confirmation_denied", "reason": "no_session"}
+
+
+def test_bootstrap_creates_exactly_one_project_board_task(ctx):
+    t = _with_approver(ctx.session)
+    result = ow.bootstrap(ctx, idempotency_key="k1", name="Owner WS", description="d")
+    t.join()
+    assert result["ok"] is True
+
+    with projects_db.connect_closing() as pconn:
+        project = projects_db.get_project(pconn, result["project_id"])
+        assert project is not None
+        assert project.board_slug == result["board"]
+
+    assert kanban_db.board_exists(result["board"])
+    kconn = kanban_db.connect(board=result["board"])
+    try:
+        task = kanban_db.get_task(kconn, result["task_id"])
+        assert task is not None
+        assert task.title == "Owner WS"
+    finally:
+        kconn.close()
+
+
+def test_bootstrap_exact_replay_returns_same_result(ctx):
+    t = _with_approver(ctx.session)
+    first = ow.bootstrap(ctx, idempotency_key="k2", name="Replay WS")
+    t.join()
+
+    # No approver registered for the replay — if it re-prompted, it would
+    # hang/deny for lack of a session surface, proving no second decision
+    # was requested.
+    approval.unregister_gateway_notify(ctx.session)
+    second = ow.bootstrap(ctx, idempotency_key="k2", name="Replay WS")
+    assert second == first
+
+
+def test_bootstrap_different_payload_same_key_conflicts_with_zero_changes(ctx):
+    t = _with_approver(ctx.session)
+    ow.bootstrap(ctx, idempotency_key="k3", name="Original")
+    t.join()
+
+    with projects_db.connect_closing() as pconn:
+        before = len(projects_db.list_projects(pconn, include_archived=True))
+
+    with pytest.raises(ow.OwnerWorkspaceError) as excinfo:
+        ow.bootstrap(ctx, idempotency_key="k3", name="Different Name")
+    assert excinfo.value.code == "idempotency_key_conflict"
+
+    with projects_db.connect_closing() as pconn:
+        after = len(projects_db.list_projects(pconn, include_archived=True))
+    assert after == before
+
+
+def test_concurrent_same_key_bootstrap_creates_exactly_one(ctx):
+    t = _with_approver(ctx.session)
+    results = [None, None]
+
+    def _call(i):
+        results[i] = ow.bootstrap(ctx, idempotency_key="concurrent-key", name="Concurrent WS")
+
+    threads = [threading.Thread(target=_call, args=(i,)) for i in range(2)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+    t.join()
+
+    assert results[0] == results[1]
+    assert results[0]["ok"] is True
+
+    with projects_db.connect_closing() as pconn:
+        projects = [p for p in projects_db.list_projects(pconn, include_archived=True) if p.name == "Concurrent WS"]
+    assert len(projects) == 1
+
+
+def test_bootstrap_denial_is_zero_change_and_replays_the_same_denial(ctx):
+    t = _with_approver(ctx.session, choice="deny")
+    result = ow.bootstrap(ctx, idempotency_key="k-deny", name="Denied WS")
+    t.join()
+    assert result["ok"] is False
+    assert result["error"] == "confirmation_denied"
+
+    with projects_db.connect_closing() as pconn:
+        assert all(p.name != "Denied WS" for p in projects_db.list_projects(pconn, include_archived=True))
+
+    approval.unregister_gateway_notify(ctx.session)
+    replay = ow.bootstrap(ctx, idempotency_key="k-deny", name="Denied WS")
+    assert replay == result
+
+
+def _bootstrap_board(ctx):
+    t = _with_approver(ctx.session)
+    result = ow.bootstrap(ctx, idempotency_key=f"setup-{ctx.session}-{time.monotonic()}", name="Board Setup")
+    t.join()
+    return result
+
+
+def test_move_task_cas_conflict_returns_snapshot_with_zero_changes(ctx):
+    setup = _bootstrap_board(ctx)
+    board = setup["board"]
+    task_id = setup["task_id"]
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        rev = kanban_db.task_event_revision(kconn, task_id)
+    finally:
+        kconn.close()
+
+    t = _with_approver(ctx.session)
+    result = ow.move_task(
+        ctx, idempotency_key="move-1", task_id=task_id,
+        to_status="blocked", expected_status="WRONG", expected_revision=rev, board=board,
+    )
+    t.join()
+    assert result["ok"] is False
+    assert result["error"] == "conflict"
+    assert result["current_status"] == "ready"
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        task = kanban_db.get_task(kconn, task_id)
+    finally:
+        kconn.close()
+    assert task.status == "ready"
+
+
+def test_move_task_rejects_running_target(ctx):
+    setup = _bootstrap_board(ctx)
+    with pytest.raises(ow.OwnerWorkspaceError) as excinfo:
+        ow.move_task(
+            ctx, idempotency_key="move-running", task_id=setup["task_id"],
+            to_status="running", expected_status="ready", expected_revision=1, board=setup["board"],
+        )
+    assert excinfo.value.code == "unsafe_transition"
+
+
+def test_move_task_success_and_archived_parent_satisfies_child_readiness(ctx):
+    setup = _bootstrap_board(ctx)
+    board = setup["board"]
+    parent_id = setup["task_id"]
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        child_id = kanban_db.create_task(kconn, title="child", parents=[parent_id])
+        assert kanban_db.get_task(kconn, child_id).status == "todo"
+        rev = kanban_db.task_event_revision(kconn, parent_id)
+    finally:
+        kconn.close()
+
+    t = _with_approver(ctx.session)
+    result = ow.move_task(
+        ctx, idempotency_key="move-archive", task_id=parent_id,
+        to_status="archived", expected_status="ready", expected_revision=rev, board=board,
+    )
+    t.join()
+    assert result["ok"] is True
+    assert result["status"] == "archived"
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        assert kanban_db.get_task(kconn, child_id).status == "ready"
+    finally:
+        kconn.close()
+
+
+def test_comment_author_is_trusted_context_not_caller_supplied(ctx):
+    setup = _bootstrap_board(ctx)
+    board = setup["board"]
+    task_id = setup["task_id"]
+
+    t = _with_approver(ctx.session)
+    result = ow.comment_task(ctx, idempotency_key="comment-1", task_id=task_id, body="hello", board=board)
+    t.join()
+    assert result["ok"] is True
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        comments = kanban_db.list_comments(kconn, task_id)
+    finally:
+        kconn.close()
+    assert len(comments) == 1
+    assert comments[0].author == ctx.actor
+    assert comments[0].body == "hello"
+
+
+def test_comment_exact_replay_creates_no_duplicate(ctx):
+    setup = _bootstrap_board(ctx)
+    board = setup["board"]
+    task_id = setup["task_id"]
+
+    t = _with_approver(ctx.session)
+    first = ow.comment_task(ctx, idempotency_key="comment-replay", task_id=task_id, body="once", board=board)
+    t.join()
+
+    approval.unregister_gateway_notify(ctx.session)
+    second = ow.comment_task(ctx, idempotency_key="comment-replay", task_id=task_id, body="once", board=board)
+    assert second == first
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        comments = kanban_db.list_comments(kconn, task_id)
+    finally:
+        kconn.close()
+    assert len(comments) == 1
+
+
+def test_multiplexed_profile_binds_request_profile_not_process_default(tmp_path, monkeypatch):
+    """resolve_owner_context() must reflect a per-request HERMES_HOME override,
+    not the process's default profile — the exact property multiplexed
+    /p/<profile>/ requests depend on.
+    """
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+    other_home = tmp_path / "other_profile_home"
+    other_home.mkdir()
+    profiles_root = other_home.parent / "profiles"
+    profiles_root.mkdir(parents=True, exist_ok=True)
+    named = profiles_root / "coder"
+    named.mkdir()
+    monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", lambda: profiles_root)
+
+    token = set_hermes_home_override(str(named))
+    try:
+        bound = ow.resolve_owner_context()
+    finally:
+        reset_hermes_home_override(token)
+
+    assert bound.profile == "coder"
+    assert bound.actor == "coder"
+
+
+# ---------------------------------------------------------------------------
+# Enforced receipt lease ownership (lock_token)
+# ---------------------------------------------------------------------------
+
+
+def test_lease_takeover_old_token_cannot_mutate_progress_or_finalize(ctx):
+    """The verifier's takeover regression: once an expired lease is adopted
+    under a NEW token, the OLD claimant's stale token must fail closed on
+    every subsequent write — it can never overwrite progress or finalize on
+    the new claimant's behalf."""
+    key = "takeover-1"
+    digest = ow._digest({"name": "Takeover WS", "description": None})
+    operation = "owner_workspace_bootstrap"
+
+    with projects_db.connect_closing() as pconn:
+        ow._ensure_schema(pconn)
+
+        state, row, old_token = ow._claim_or_wait(pconn, ctx, key, operation, digest)
+        assert state == "own"
+        assert row is None
+        assert old_token
+
+        # Simulate the old claimant crashing: its lease's TTL has passed.
+        _expire_lock(ctx, key)
+
+        # A second claimant adopts the dead lock — mints a NEW token.
+        state2, row2, new_token = ow._claim_or_wait(pconn, ctx, key, operation, digest)
+        assert state2 == "own"
+        assert new_token != old_token
+
+        # The OLD claimant — still holding its now-stale token — must be
+        # refused everywhere: pre-mutation lease check, progress write, and
+        # finalization.
+        with pytest.raises(ow.OwnerWorkspaceError) as excinfo:
+            ow._assert_owns_lease(pconn, ctx, key, old_token)
+        assert excinfo.value.code == "lease_lost"
+
+        with pytest.raises(ow.OwnerWorkspaceError) as excinfo:
+            ow._update_progress(pconn, ctx, key, old_token, project_id="p_stolen")
+        assert excinfo.value.code == "lease_lost"
+
+        with pytest.raises(ow.OwnerWorkspaceError) as excinfo:
+            ow._finalize_receipt(
+                pconn, ctx, key, old_token, status="committed",
+                result={"ok": True, "via": "old_claimant"},
+            )
+        assert excinfo.value.code == "lease_lost"
+
+        # The row must be untouched by any of the old claimant's attempts —
+        # still in_progress, still owned by the NEW token.
+        row3 = ow._get_receipt(pconn, ctx, key)
+        assert row3["status"] == "in_progress"
+        assert row3["lock_token"] == new_token
+
+        # The NEW claimant's token still works normally.
+        ow._assert_owns_lease(pconn, ctx, key, new_token)
+        ow._finalize_receipt(
+            pconn, ctx, key, new_token, status="committed",
+            result={"ok": True, "via": "new_claimant"},
+        )
+        row4 = ow._get_receipt(pconn, ctx, key)
+        assert row4["status"] == "committed"
+        assert json.loads(row4["result_json"])["via"] == "new_claimant"
+
+
+# ---------------------------------------------------------------------------
+# Real lease fencing: no check-then-act gap between validation and mutation
+# ---------------------------------------------------------------------------
+
+
+def test_move_task_fence_blocks_concurrent_claim_attempt_during_mutation(ctx):
+    """Two-connection/thread interleaving regression for the TOCTOU the fence
+    closes: a claimant that has already passed `_assert_owns_lease` and is
+    mid-mutation must not leave a window where a second connection can act on
+    the SAME receipt row. The fence (`with write_txn(pconn):` wrapping both
+    the lease check and the domain mutation) holds `projects.db`'s write lock
+    for the whole span, so a concurrent claim attempt against the same row
+    (which needs that same lock) is provably blocked until this mutation
+    either finishes (proving "the fenced mutation completes before takeover")
+    or the fence's own transaction were to lose the race and see a stale
+    token first (proving "the stale claimant fails before mutation" — see
+    `test_lease_takeover_old_token_cannot_mutate_progress_or_finalize` for
+    that half, exercised sequentially since a real DB mutex makes the two
+    outcomes mutually exclusive by construction).
+    """
+    setup = _bootstrap_board(ctx)
+    board, task_id = setup["board"], setup["task_id"]
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        rev = kanban_db.task_event_revision(kconn, task_id)
+    finally:
+        kconn.close()
+
+    key = "fence-race-1"
+    validated = threading.Event()
+    release = threading.Event()
+    real_cas = kanban_db.cas_transition_task
+
+    def paused_cas(*a, **kw):
+        # Reached only AFTER `_assert_owns_lease` succeeded, and only while
+        # still inside the fence's `with write_txn(pconn):` block — i.e.
+        # still holding projects.db's write lock. This is the exact
+        # validate-then-pause window the bug report describes.
+        validated.set()
+        release.wait(timeout=5.0)
+        return real_cas(*a, **kw)
+
+    old_result = {}
+
+    def run_old_claimant():
+        t = _with_approver(ctx.session)
+        with _temporarily_patch(ow.kanban_db, "cas_transition_task", paused_cas):
+            old_result["value"] = ow.move_task(
+                ctx, idempotency_key=key, task_id=task_id, to_status="blocked",
+                expected_status="ready", expected_revision=rev, board=board,
+            )
+        t.join()
+
+    old_thread = threading.Thread(target=run_old_claimant)
+    old_thread.start()
+    assert validated.wait(timeout=5.0), "old claimant never reached the paused mutation"
+
+    # A second, independent connection now races the still-open fence for
+    # the SAME receipt row — exactly what an expired-lease adopter would do.
+    takeover_state = {}
+
+    def attempt_takeover():
+        with projects_db.connect_closing() as pconn2:
+            ow._ensure_schema(pconn2)
+            digest = ow._digest({
+                "task_id": task_id, "board": board, "to_status": "blocked",
+                "expected_status": "ready", "expected_revision": rev,
+            })
+            # A real competing caller goes through the bounded-poll wrapper
+            # (not the raw single-shot primitive) — it may transiently
+            # observe "wait" (a live, not-yet-finalized claim) right after
+            # the fence releases and before finalization lands, but must
+            # never observe "own" (a successful adoption): that would mean
+            # it stole the lease mid-mutation.
+            state, _row, _token = ow._acquire_or_replay(pconn2, ctx, key, "owner_task_move", digest)
+            takeover_state["state"] = state
+
+    takeover_thread = threading.Thread(target=attempt_takeover)
+    takeover_thread.start()
+
+    # A generous, deterministic bound (not a tight race): the takeover
+    # attempt's own `write_txn` needs the exact write lock the paused fence
+    # holds, so it MUST still be blocked after a real 2-second wait.
+    takeover_thread.join(timeout=2.0)
+    assert takeover_thread.is_alive(), (
+        "a concurrent claim attempt must block on projects.db's write lock "
+        "while the fenced mutation is in flight — it must not be able to "
+        "observe or act on the row until the fence releases"
+    )
+
+    # Let the old (fence-holding) claimant finish its mutation and finalize.
+    release.set()
+    old_thread.join(timeout=5.0)
+    takeover_thread.join(timeout=5.0)
+    assert not takeover_thread.is_alive()
+
+    assert old_result["value"]["ok"] is True
+    assert old_result["value"]["status"] == "blocked"
+
+    # The takeover attempt — unblocked only after the fence released — must
+    # see the row already terminal (committed by the fenced mutation), never
+    # a live claim to adopt: the fenced mutation provably completed before
+    # any competitor could act on the row.
+    assert takeover_state["state"] == "terminal"
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        task = kanban_db.get_task(kconn, task_id)
+    finally:
+        kconn.close()
+    assert task.status == "blocked"
+
+
+def test_comment_fence_blocks_concurrent_claim_attempt_during_mutation(ctx):
+    """Same fencing property as the move-task regression above, exercised
+    against `comment_task`'s fence (the lease check + `add_comment` insert)."""
+    setup = _bootstrap_board(ctx)
+    board, task_id = setup["board"], setup["task_id"]
+
+    key = "fence-race-comment-1"
+    validated = threading.Event()
+    release = threading.Event()
+    real_add_comment = kanban_db.add_comment
+
+    def paused_add_comment(*a, **kw):
+        validated.set()
+        release.wait(timeout=5.0)
+        return real_add_comment(*a, **kw)
+
+    old_result = {}
+
+    def run_old_claimant():
+        t = _with_approver(ctx.session)
+        with _temporarily_patch(ow.kanban_db, "add_comment", paused_add_comment):
+            old_result["value"] = ow.comment_task(
+                ctx, idempotency_key=key, task_id=task_id, body="hi", board=board,
+            )
+        t.join()
+
+    old_thread = threading.Thread(target=run_old_claimant)
+    old_thread.start()
+    assert validated.wait(timeout=5.0), "old claimant never reached the paused mutation"
+
+    takeover_state = {}
+
+    def attempt_takeover():
+        with projects_db.connect_closing() as pconn2:
+            ow._ensure_schema(pconn2)
+            digest = ow._digest({"task_id": task_id, "board": board, "body": "hi"})
+            # See the move-task fence regression above for why this uses the
+            # bounded-poll wrapper rather than the raw single-shot primitive.
+            state, _row, _token = ow._acquire_or_replay(pconn2, ctx, key, "owner_task_comment", digest)
+            takeover_state["state"] = state
+
+    takeover_thread = threading.Thread(target=attempt_takeover)
+    takeover_thread.start()
+    takeover_thread.join(timeout=2.0)
+    assert takeover_thread.is_alive(), (
+        "a concurrent claim attempt must block while the comment's fenced "
+        "mutation is in flight"
+    )
+
+    release.set()
+    old_thread.join(timeout=5.0)
+    takeover_thread.join(timeout=5.0)
+    assert not takeover_thread.is_alive()
+
+    assert old_result["value"]["ok"] is True
+    assert takeover_state["state"] == "terminal"
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        comments = kanban_db.list_comments(kconn, task_id)
+    finally:
+        kconn.close()
+    assert len(comments) == 1
+
+
+# ---------------------------------------------------------------------------
+# Crash-safe bootstrap roll-forward (deterministic identities)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("crash_point", ["after_project", "after_board", "after_task"])
+def test_bootstrap_crash_at_each_boundary_yields_exactly_one_project_board_task(
+    ctx, crash_point,
+):
+    key = f"crash-{crash_point}"
+    name = f"Crash WS {crash_point}"
+
+    def boom(*a, **kw):
+        raise RuntimeError(f"simulated crash: {crash_point}")
+
+    patched_attr = {
+        "after_project": "create_board",
+        "after_board": "create_task",
+        "after_task": "task_event_revision",
+    }[crash_point]
+
+    with _temporarily_patch(ow.kanban_db, patched_attr, boom):
+        t = _with_approver(ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.bootstrap(ctx, idempotency_key=key, name=name)
+        t.join()
+
+    _expire_lock(ctx, key)
+
+    t2 = _with_approver(ctx.session)
+    result = ow.bootstrap(ctx, idempotency_key=key, name=name)
+    t2.join()
+    assert result["ok"] is True
+
+    with projects_db.connect_closing() as pconn:
+        matching_projects = [
+            p for p in projects_db.list_projects(pconn, include_archived=True) if p.name == name
+        ]
+    assert len(matching_projects) == 1
+    assert matching_projects[0].id == result["project_id"]
+
+    matching_boards = [b for b in kanban_db.list_boards() if b.get("name") == name]
+    assert len(matching_boards) == 1
+
+    task_idempotency_key = "owtask_" + ow._derive_id(ctx, key, "task")
+    kconn = kanban_db.connect(board=result["board"])
+    try:
+        matching_tasks = kconn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?", (task_idempotency_key,),
+        ).fetchall()
+    finally:
+        kconn.close()
+    assert len(matching_tasks) == 1
+    assert matching_tasks[0]["id"] == result["task_id"]
+
+
+def test_bootstrap_replay_fails_closed_on_foreign_board_ownership(ctx):
+    """A board slug that already exists but is owned by a DIFFERENT project
+    (foreign/ambiguous ownership metadata) must never be silently adopted."""
+    key = "foreign-board-1"
+    name = "Foreign Board WS"
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated crash before project row commits its board_slug")
+
+    with _temporarily_patch(ow.kanban_db, "create_task", boom):
+        t = _with_approver(ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.bootstrap(ctx, idempotency_key=key, name=name)
+        t.join()
+
+    project_id = "p_" + ow._derive_id(ctx, key, "project")
+    with projects_db.connect_closing() as pconn:
+        project = projects_db.get_project(pconn, project_id)
+    board_slug = project.slug
+
+    # Corrupt the board's metadata to claim a foreign owner.
+    kanban_db.write_board_metadata(board_slug, project_id="p_someone_else")
+
+    _expire_lock(ctx, key)
+    t2 = _with_approver(ctx.session)
+    with pytest.raises(ow.OwnerWorkspaceError) as excinfo:
+        ow.bootstrap(ctx, idempotency_key=key, name=name)
+    t2.join()
+    assert excinfo.value.code == "crash_recovery_failed"
+
+
+def test_bootstrap_replay_fails_closed_on_missing_board_ownership(ctx):
+    """A board slug that already exists but carries NO ownership metadata
+    (never linked to any project) must fail closed exactly like a foreign
+    owner. This flow's own boards always carry ``project_id`` — an existing
+    board without one can never be safely attributed to this receipt."""
+    key = "missing-board-owner-1"
+    name = "Missing Board Owner WS"
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated crash before project row commits its board_slug")
+
+    with _temporarily_patch(ow.kanban_db, "create_task", boom):
+        t = _with_approver(ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.bootstrap(ctx, idempotency_key=key, name=name)
+        t.join()
+
+    project_id = "p_" + ow._derive_id(ctx, key, "project")
+    with projects_db.connect_closing() as pconn:
+        project = projects_db.get_project(pconn, project_id)
+    board_slug = project.slug
+
+    # Wipe the board's ownership metadata (missing, not foreign).
+    kanban_db.write_board_metadata(board_slug, project_id="")
+    assert kanban_db.read_board_metadata(board_slug).get("project_id") is None
+
+    _expire_lock(ctx, key)
+    t2 = _with_approver(ctx.session)
+    with pytest.raises(ow.OwnerWorkspaceError) as excinfo:
+        ow.bootstrap(ctx, idempotency_key=key, name=name)
+    t2.join()
+    assert excinfo.value.code == "crash_recovery_failed"
+
+
+def test_bootstrap_replay_fails_closed_on_missing_task_ownership(ctx):
+    """A pre-existing task resolved via the deterministic idempotency key but
+    carrying NO ``project_id`` must fail closed exactly like a foreign owner.
+    This flow's own tasks always carry ``project_id`` — an existing task
+    without one can never be safely attributed to this receipt."""
+    key = "missing-task-owner-1"
+    name = "Missing Task Owner WS"
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated crash before the task is created")
+
+    with _temporarily_patch(ow.kanban_db, "create_task", boom):
+        t = _with_approver(ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.bootstrap(ctx, idempotency_key=key, name=name)
+        t.join()
+
+    project_id = "p_" + ow._derive_id(ctx, key, "project")
+    with projects_db.connect_closing() as pconn:
+        project = projects_db.get_project(pconn, project_id)
+    board_slug = project.slug
+    task_idempotency_key = "owtask_" + ow._derive_id(ctx, key, "task")
+
+    # A task with the SAME deterministic idempotency key already exists but
+    # was never linked to a project (missing ownership metadata) — pass
+    # project_id="" explicitly so it does NOT inherit the board's own
+    # project_id (create_task's board-inheritance only fires when the
+    # caller omits project_id entirely).
+    kconn = kanban_db.connect(board=board_slug)
+    try:
+        precreated_task_id = kanban_db.create_task(
+            kconn, title=name, board=board_slug, idempotency_key=task_idempotency_key,
+            project_id="",
+        )
+        assert kanban_db.get_task(kconn, precreated_task_id).project_id is None
+    finally:
+        kconn.close()
+
+    _expire_lock(ctx, key)
+    t2 = _with_approver(ctx.session)
+    with pytest.raises(ow.OwnerWorkspaceError) as excinfo:
+        ow.bootstrap(ctx, idempotency_key=key, name=name)
+    t2.join()
+    assert excinfo.value.code == "crash_recovery_failed"
+
+
+# ---------------------------------------------------------------------------
+# Idempotent comment across crash gaps
+# ---------------------------------------------------------------------------
+
+
+def test_comment_crash_before_finalize_replay_creates_no_duplicate(ctx):
+    setup = _bootstrap_board(ctx)
+    board, task_id = setup["board"], setup["task_id"]
+    key = "comment-crash-1"
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated crash after add_comment, before finalize")
+
+    with _temporarily_patch(ow.kanban_db, "task_event_revision", boom):
+        t = _with_approver(ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.comment_task(ctx, idempotency_key=key, task_id=task_id, body="hello", board=board)
+        t.join()
+
+    _expire_lock(ctx, key)
+
+    t2 = _with_approver(ctx.session)
+    result = ow.comment_task(ctx, idempotency_key=key, task_id=task_id, body="hello", board=board)
+    t2.join()
+    assert result["ok"] is True
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        comments = kanban_db.list_comments(kconn, task_id)
+    finally:
+        kconn.close()
+    assert len(comments) == 1
+    assert comments[0].body == "hello"
+
+
+def test_comment_replay_conflicting_payload_fails_closed_at_board_layer(ctx):
+    """Defense in depth: even calling kanban_db.add_comment directly (below
+    the kernel's own idempotency-key digest guard) with the same
+    operation_key but a different body/author must fail closed, not silently
+    return the mismatched original."""
+    setup = _bootstrap_board(ctx)
+    board, task_id = setup["board"], setup["task_id"]
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        kanban_db.add_comment(kconn, task_id, author="default", body="first", operation_key="opk-1")
+        with pytest.raises(ValueError):
+            kanban_db.add_comment(kconn, task_id, author="default", body="different", operation_key="opk-1")
+        comments = kanban_db.list_comments(kconn, task_id)
+    finally:
+        kconn.close()
+    assert len(comments) == 1
+    assert comments[0].body == "first"
+
+
+# ---------------------------------------------------------------------------
+# Task-move readiness repair after crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("to_status", ["done", "archived"])
+def test_move_task_crash_before_recompute_ready_replay_repairs_child_readiness(
+    ctx, to_status,
+):
+    setup = _bootstrap_board(ctx)
+    board = setup["board"]
+    parent_id = setup["task_id"]
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        child_id = kanban_db.create_task(kconn, title="child", parents=[parent_id])
+        assert kanban_db.get_task(kconn, child_id).status == "todo"
+        rev = kanban_db.task_event_revision(kconn, parent_id)
+    finally:
+        kconn.close()
+
+    key = f"move-crash-{to_status}"
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated crash after CAS commit, before recompute_ready")
+
+    with _temporarily_patch(ow.kanban_db, "recompute_ready", boom):
+        t = _with_approver(ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.move_task(
+                ctx, idempotency_key=key, task_id=parent_id, to_status=to_status,
+                expected_status="ready", expected_revision=rev, board=board,
+            )
+        t.join()
+
+    _expire_lock(ctx, key)
+
+    # The premise of the bug: the CAS status + event commit already
+    # succeeded before the crash — only recompute_ready failed.
+    kconn = kanban_db.connect(board=board)
+    try:
+        assert kanban_db.get_task(kconn, parent_id).status == to_status
+    finally:
+        kconn.close()
+
+    t2 = _with_approver(ctx.session)
+    result = ow.move_task(
+        ctx, idempotency_key=key, task_id=parent_id, to_status=to_status,
+        expected_status="ready", expected_revision=rev, board=board,
+    )
+    t2.join()
+    assert result["ok"] is True
+    assert result["status"] == to_status
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        assert kanban_db.get_task(kconn, child_id).status == "ready"
+    finally:
+        kconn.close()
+
+
+def test_move_task_unrelated_drift_after_crash_still_conflicts(ctx):
+    """A replay must not paper over a genuinely unrelated status change that
+    happened to land at the same revision slot — only THIS receipt's own
+    recorded owner_move event short-circuits the CAS."""
+    setup = _bootstrap_board(ctx)
+    board, task_id = setup["board"], setup["task_id"]
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        rev = kanban_db.task_event_revision(kconn, task_id)
+    finally:
+        kconn.close()
+
+    key = "move-drift-1"
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated crash before the CAS ever runs")
+
+    with _temporarily_patch(ow.kanban_db, "cas_transition_task", boom):
+        t = _with_approver(ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.move_task(
+                ctx, idempotency_key=key, task_id=task_id, to_status="blocked",
+                expected_status="ready", expected_revision=rev, board=board,
+            )
+        t.join()
+
+    _expire_lock(ctx, key)
+
+    # An unrelated actor moves the task in the meantime (not via this
+    # receipt) — a genuine conflict for the queued replay.
+    kconn = kanban_db.connect(board=board)
+    try:
+        kanban_db.cas_transition_task(
+            kconn, task_id, expected_status="ready", expected_revision=rev,
+            to_status="review", event_kind="unrelated_move",
+        )
+    finally:
+        kconn.close()
+
+    t2 = _with_approver(ctx.session)
+    result = ow.move_task(
+        ctx, idempotency_key=key, task_id=task_id, to_status="blocked",
+        expected_status="ready", expected_revision=rev, board=board,
+    )
+    t2.join()
+    assert result["ok"] is False
+    assert result["error"] == "conflict"
+    assert result["current_status"] == "review"
+
+
+def test_move_task_exact_replay_recognizes_own_committed_event_by_full_identity(ctx):
+    """Positive case: a replay after a crash-after-CAS-commit is recognized as
+    the receipt's OWN event once identity binding covers actor, profile,
+    idempotency_key, AND the requested transition — not just a bare
+    idempotency_key string."""
+    setup = _bootstrap_board(ctx)
+    board, task_id = setup["board"], setup["task_id"]
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        rev = kanban_db.task_event_revision(kconn, task_id)
+    finally:
+        kconn.close()
+
+    key = "exact-replay-1"
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated crash after CAS commit, before finalize")
+
+    with _temporarily_patch(ow, "_finalize_receipt", boom):
+        t = _with_approver(ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.move_task(
+                ctx, idempotency_key=key, task_id=task_id, to_status="blocked",
+                expected_status="ready", expected_revision=rev, board=board,
+            )
+        t.join()
+
+    # The CAS really did commit before the simulated crash.
+    kconn = kanban_db.connect(board=board)
+    try:
+        committed_task = kanban_db.get_task(kconn, task_id)
+        committed_revision = kanban_db.task_event_revision(kconn, task_id)
+    finally:
+        kconn.close()
+    assert committed_task.status == "blocked"
+
+    _expire_lock(ctx, key)
+    t2 = _with_approver(ctx.session)
+    result = ow.move_task(
+        ctx, idempotency_key=key, task_id=task_id, to_status="blocked",
+        expected_status="ready", expected_revision=rev, board=board,
+    )
+    t2.join()
+    assert result["ok"] is True
+    assert result["status"] == "blocked"
+    assert result["revision"] == committed_revision
+
+    # No second event/CAS was run — revision did not advance further.
+    kconn = kanban_db.connect(board=board)
+    try:
+        assert kanban_db.task_event_revision(kconn, task_id) == committed_revision
+    finally:
+        kconn.close()
+
+
+def test_move_task_replay_recognition_requires_matching_actor_and_transition(ctx):
+    """Two different actors may validly reuse the same idempotency_key text
+    on the same task — receipts are scoped by (actor, profile,
+    idempotency_key), but the task's own event log is shared board-wide.
+    Adopting a dead claim must never mistake ANOTHER actor's already-
+    committed owner_move event (which happens to carry a matching
+    idempotency_key string) for this receipt's own — that would fabricate a
+    success snapshot (and could spuriously trigger readiness repair) for a
+    transition this receipt never performed. The real outcome must be an
+    unrelated CAS conflict against the actual current state."""
+    setup = _bootstrap_board(ctx)
+    board, task_id = setup["board"], setup["task_id"]
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        rev0 = kanban_db.task_event_revision(kconn, task_id)
+    finally:
+        kconn.close()
+
+    shared_key = "shared-cross-actor-key"
+    other_ctx = ow.OwnerContext(actor="other-actor", profile="other-actor", session="run_owt_other")
+
+    # "Other" actor starts a move with the shared key but crashes before its
+    # own CAS runs — its receipt is claimed (in_progress) with no event yet.
+    def boom(*a, **kw):
+        raise RuntimeError("simulated crash before the other actor's own CAS runs")
+
+    with _temporarily_patch(ow.kanban_db, "cas_transition_task", boom):
+        t = _with_approver(other_ctx.session)
+        with pytest.raises(RuntimeError):
+            ow.move_task(
+                other_ctx, idempotency_key=shared_key, task_id=task_id,
+                to_status="archived", expected_status="ready",
+                expected_revision=rev0, board=board,
+            )
+        t.join()
+
+    # The original ("default") actor independently and legitimately moves
+    # the SAME task using the SAME idempotency_key text — a completely
+    # separate, unrelated receipt row (primary-keyed by actor+profile+key).
+    t2 = _with_approver(ctx.session)
+    a_result = ow.move_task(
+        ctx, idempotency_key=shared_key, task_id=task_id,
+        to_status="blocked", expected_status="ready",
+        expected_revision=rev0, board=board,
+    )
+    t2.join()
+    assert a_result["ok"] is True
+    assert a_result["status"] == "blocked"
+
+    # The other actor's lease now looks expired (as if it had crashed) —
+    # it resumes/replays.
+    _expire_lock(other_ctx, shared_key)
+    t3 = _with_approver(other_ctx.session)
+    b_result = ow.move_task(
+        other_ctx, idempotency_key=shared_key, task_id=task_id,
+        to_status="archived", expected_status="ready",
+        expected_revision=rev0, board=board,
+    )
+    t3.join()
+
+    # The other actor must NOT be told its (never-performed) move to
+    # "archived" succeeded just because an unrelated event happens to carry
+    # the same idempotency_key text — it must see the real current state as
+    # a conflict, never a fabricated success.
+    assert b_result["ok"] is False
+    assert b_result["error"] == "conflict"
+    assert b_result["current_status"] == "blocked"
+
+    kconn = kanban_db.connect(board=board)
+    try:
+        task = kanban_db.get_task(kconn, task_id)
+    finally:
+        kconn.close()
+    assert task.status == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Public optimistic revision (status/revision from bootstrap + comment feed
+# directly into owner_task_move)
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_status_and_revision_feed_directly_into_move(ctx):
+    t = _with_approver(ctx.session)
+    setup = ow.bootstrap(ctx, idempotency_key="pubrev-bootstrap-1", name="Pub Rev WS")
+    t.join()
+    assert setup["ok"] is True
+    assert setup["status"] == "ready"
+    assert setup["revision"] == 1
+
+    t2 = _with_approver(ctx.session)
+    result = ow.move_task(
+        ctx, idempotency_key="pubrev-bootstrap-1-move", task_id=setup["task_id"],
+        to_status="blocked", expected_status=setup["status"],
+        expected_revision=setup["revision"], board=setup["board"],
+    )
+    t2.join()
+    assert result["ok"] is True
+    assert result["status"] == "blocked"
+
+
+def test_comment_status_and_revision_feed_directly_into_move(ctx):
+    setup = _bootstrap_board(ctx)
+    board, task_id = setup["board"], setup["task_id"]
+
+    t = _with_approver(ctx.session)
+    comment_result = ow.comment_task(
+        ctx, idempotency_key="pubrev-comment-1", task_id=task_id, body="hi", board=board,
+    )
+    t.join()
+    assert comment_result["ok"] is True
+    assert comment_result["status"] == "ready"
+    assert comment_result["revision"] == 2  # task "created" + "commented"
+
+    t2 = _with_approver(ctx.session)
+    move_result = ow.move_task(
+        ctx, idempotency_key="pubrev-comment-1-move", task_id=task_id,
+        to_status="blocked", expected_status=comment_result["status"],
+        expected_revision=comment_result["revision"], board=board,
+    )
+    t2.join()
+    assert move_result["ok"] is True
+    assert move_result["status"] == "blocked"

--- a/tests/hermes_cli/test_owner_workspace.py
+++ b/tests/hermes_cli/test_owner_workspace.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -1068,3 +1071,164 @@ def test_comment_status_and_revision_feed_directly_into_move(ctx):
     t2.join()
     assert move_result["ok"] is True
     assert move_result["status"] == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Cross-profile board ownership — profile-local projects.db, GLOBAL kanban root
+#
+# Real multiprocessing, no mocked locking: the receipt lease only orders
+# claimants that share one projects.db, so only the kernel-held global board
+# guard can order two same-name bootstraps started from different profiles.
+# ---------------------------------------------------------------------------
+
+
+# "fork" keeps the already-imported, already-sandboxed interpreter state (the
+# children only need to repoint HERMES_HOME); "spawn" is a correct fallback
+# where fork is unavailable.
+_MP = multiprocessing.get_context(
+    "fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn"
+)
+
+_XPROFILE_KEY = "xprofile-bootstrap-1"
+_XPROFILE_NAME = "Shared Owner Board"
+_XPROFILE_PROFILES = ("alpha", "beta")
+
+
+def _xprofile_ctx(profile: str):
+    return ow.OwnerContext(actor="owner", profile=profile, session=f"run_owt_{profile}")
+
+
+def _expected_project_id(profile: str) -> str:
+    """The deterministic id bootstrap() will derive for this profile."""
+    return "p_" + ow._derive_id(_xprofile_ctx(profile), _XPROFILE_KEY, "project")
+
+
+def _enter_profile(root: str, profile: str) -> None:
+    """Repoint this process at ``<root>/profiles/<profile>``.
+
+    Gives each process its own profile-local ``projects.db`` while
+    ``kanban_db.kanban_home()`` still resolves back to the shared ``<root>``
+    — the exact production layout the global board guard exists for.
+    """
+    home = Path(root) / "profiles" / profile
+    home.mkdir(parents=True, exist_ok=True)
+    os.environ["HERMES_HOME"] = str(home)
+    assert kanban_db.kanban_home() == Path(root)
+
+
+def _xprofile_bootstrap_worker(root, profile, barrier, queue):
+    """Child process: bootstrap the same board name from its own profile."""
+    try:
+        _enter_profile(root, profile)
+        child_ctx = _xprofile_ctx(profile)
+        barrier.wait(timeout=60)
+        approver = _with_approver(child_ctx.session)
+        try:
+            result = ow.bootstrap(
+                child_ctx, idempotency_key=_XPROFILE_KEY, name=_XPROFILE_NAME,
+            )
+        finally:
+            approver.join(timeout=30)
+        queue.put((profile, result))
+    except ow.OwnerWorkspaceError as exc:
+        queue.put((profile, {"ok": False, "error": exc.code}))
+    except BaseException as exc:  # reported as a failure, never a silent hang
+        queue.put((profile, {"ok": False, "error": "worker_crashed", "detail": repr(exc)}))
+
+
+def _guard_holder_worker(root, slug, acquired, queue):
+    _enter_profile(root, "alpha")
+    with ow._global_board_guard(slug):
+        acquired.set()
+        time.sleep(0.5)
+        queue.put(("holder_released_at", time.monotonic()))
+
+
+def _guard_waiter_worker(root, slug, acquired, queue):
+    _enter_profile(root, "beta")
+    acquired.wait(timeout=60)
+    started = time.monotonic()
+    with ow._global_board_guard(slug):
+        queue.put(("waiter_acquired_at", time.monotonic()))
+    queue.put(("waiter_waited", time.monotonic() - started))
+
+
+def _run_workers(procs, queue, expected_messages):
+    """Start, drain and join child processes with bounded waits."""
+    for proc in procs:
+        proc.start()
+    try:
+        messages = [queue.get(timeout=120) for _ in range(expected_messages)]
+    finally:
+        for proc in procs:
+            proc.join(timeout=120)
+            if proc.is_alive():  # pragma: no cover - only on a real hang
+                proc.terminate()
+                proc.join(timeout=30)
+    for proc in procs:
+        assert proc.exitcode == 0, f"child exited {proc.exitcode}"
+    return messages
+
+
+def test_global_board_guard_serializes_across_processes(tmp_path):
+    """The guard is an OS lock on the GLOBAL board namespace, so two processes
+    in different profiles cannot hold the same board slug at once."""
+    root = tmp_path / "xprofile_root"
+    (root / "profiles").mkdir(parents=True)
+    acquired = _MP.Event()
+    queue = _MP.Queue()
+    procs = [
+        _MP.Process(target=_guard_holder_worker, args=(str(root), "shared-board", acquired, queue)),
+        _MP.Process(target=_guard_waiter_worker, args=(str(root), "shared-board", acquired, queue)),
+    ]
+
+    events = dict(_run_workers(procs, queue, 3))
+
+    assert events["waiter_acquired_at"] > events["holder_released_at"]
+    assert events["waiter_waited"] >= 0.4
+
+
+def test_cross_profile_bootstrap_of_same_board_elects_exactly_one_owner(tmp_path, monkeypatch):
+    """Two profiles concurrently bootstrap the SAME board name with DIFFERENT
+    deterministic project ids. Their receipts live in separate projects.db
+    files, so nothing but the global board guard orders them: exactly one may
+    create and own the board, the other must fail closed with the ownership
+    conflict instead of overwriting board.json's project_id."""
+    root = tmp_path / "xprofile_root"
+    (root / "profiles").mkdir(parents=True)
+    barrier = _MP.Barrier(len(_XPROFILE_PROFILES))
+    queue = _MP.Queue()
+    procs = [
+        _MP.Process(target=_xprofile_bootstrap_worker, args=(str(root), profile, barrier, queue))
+        for profile in _XPROFILE_PROFILES
+    ]
+
+    results = dict(_run_workers(procs, queue, len(_XPROFILE_PROFILES)))
+
+    project_ids = {p: _expected_project_id(p) for p in _XPROFILE_PROFILES}
+    assert len(set(project_ids.values())) == len(_XPROFILE_PROFILES)
+
+    winners = [p for p, r in results.items() if r.get("ok") is True]
+    losers = [p for p, r in results.items() if r.get("ok") is not True]
+    assert len(winners) == 1, f"expected exactly one owner, got {results}"
+    assert len(losers) == 1
+
+    winner, loser = winners[0], losers[0]
+    assert results[winner]["project_id"] == project_ids[winner]
+    assert results[loser]["error"] == "crash_recovery_failed", results[loser]
+
+    board = results[winner]["board"]
+
+    # The published board is owned by the winner, and the loser never got to
+    # restamp it.
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / winner))
+    assert kanban_db.board_exists(board)
+    assert kanban_db.read_board_metadata(board)["project_id"] == project_ids[winner]
+
+    # The loser's own profile-local project row exists but was never bound to
+    # the contested board.
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / loser))
+    with projects_db.connect_closing() as pconn:
+        loser_project = projects_db.get_project(pconn, project_ids[loser])
+    assert loser_project is not None
+    assert loser_project.board_slug != board

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -159,6 +159,90 @@ def test_owner_workspace_toolset_never_reachable_mixed_with_platform_default(pla
     assert "owner_task_comment" not in enabled
 
 
+_OWNER_TOOLS = {"owner_workspace_bootstrap", "owner_task_move", "owner_task_comment"}
+
+
+def _resolved_tools(enabled_toolsets) -> set:
+    """Expand resolved toolset NAMES into the tool names they actually grant.
+
+    The generic-alias leaks this section guards against never mention
+    ``owner_workspace`` by name, so a name-only assertion would pass while the
+    agent still received the tools. Assert on the tools."""
+    from toolsets import resolve_toolset
+
+    tools = set()
+    for ts in enabled_toolsets:
+        tools.update(resolve_toolset(ts))
+    return tools
+
+
+@pytest.mark.parametrize("alias", ["all", "*"])
+@pytest.mark.parametrize("platform", ["cli", "telegram", "cron", "discord", "api_server"])
+def test_wildcard_alias_never_exposes_kernel_gated_tools(alias, platform):
+    """``platform_toolsets: {<platform>: [all]}`` is the generic "give this
+    agent everything" escape hatch — it must still mean "everything ORDINARY".
+    The by-name strip cannot see this route (the config never says
+    ``owner_workspace``), so the wildcard expansion and the post-resolution
+    gate are what keep the owner mutation surface off generic platforms."""
+    config = {"platform_toolsets": {platform: [alias]}}
+    enabled = _get_platform_tools(config, platform)
+    tools = _resolved_tools(enabled)
+
+    assert "owner_workspace" not in enabled
+    assert not _OWNER_TOOLS & tools
+    # ...while the wildcard still delivers ordinary, non-gated capability.
+    assert {"web_search", "read_file", "terminal"} <= tools
+
+
+@pytest.mark.parametrize("alias", ["all", "*"])
+def test_wildcard_alias_still_grants_ordinary_toolsets(alias):
+    """Guard against over-correction: the post-resolution kernel gate drops
+    only toolsets that resolve ONTO gated tools, so the wildcard must keep
+    every ordinary toolset it has always granted."""
+    from toolsets import get_kernel_gated_toolsets, get_toolset_names
+
+    enabled = _get_platform_tools({"platform_toolsets": {"cli": [alias]}}, "cli")
+    tools = _resolved_tools(enabled)
+    gated = get_kernel_gated_toolsets()
+    for name in get_toolset_names():
+        if name in gated or name.startswith("hermes-"):
+            continue
+        from toolsets import resolve_toolset
+
+        assert set(resolve_toolset(name)) <= tools, f"wildcard dropped toolset {name!r}"
+
+
+@pytest.mark.parametrize("platform", ["cli", "telegram", "cron"])
+def test_registry_alias_onto_gated_tools_is_stripped_post_resolution(platform, monkeypatch):
+    """The by-name strip only matches the literal kernel-gated toolset name.
+    A registry/MCP toolset ALIAS resolves to gated tools while carrying a name
+    the strip never sees, and ``explicit_passthrough`` preserves exactly such
+    unknown names — so only a post-RESOLUTION gate closes this route."""
+    from tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+    for tool_name in sorted(_OWNER_TOOLS):
+        reg.register(
+            name=tool_name,
+            toolset="mcp-ownerbridge",
+            schema={"name": tool_name, "parameters": {"type": "object", "properties": {}}},
+            handler=lambda args, **kwargs: "{}",
+        )
+    reg.register_toolset_alias("ownerbridge", "mcp-ownerbridge")
+    monkeypatch.setattr("tools.registry.registry", reg)
+
+    # Sanity: the alias really does resolve onto the gated tools, so the
+    # assertions below are testing the gate and not a typo.
+    from toolsets import resolve_toolset
+
+    assert _OWNER_TOOLS <= set(resolve_toolset("ownerbridge"))
+
+    config = {"platform_toolsets": {platform: [f"hermes-{platform}", "ownerbridge"]}}
+    enabled = _get_platform_tools(config, platform)
+    assert "ownerbridge" not in enabled
+    assert not _OWNER_TOOLS & _resolved_tools(enabled)
+
+
 
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -132,6 +132,33 @@ def test_discord_toolsets_do_not_leak_to_other_platforms():
     assert "discord_admin" not in enabled
 
 
+# ─── owner_workspace is kernel_gated: unlike discord/discord_admin (merely
+# platform-restricted), it must be unreachable via `platform_toolsets` on
+# EVERY platform — including api_server, whose only admitted path is the
+# dedicated gateway.api_server.owner_workspace.enabled union applied by
+# api_server.py AFTER _get_platform_tools() returns, not this function. ───────
+
+
+@pytest.mark.parametrize("platform", ["cli", "telegram", "cron", "discord", "api_server"])
+def test_owner_workspace_toolset_never_reachable_via_platform_toolsets(platform):
+    config = {"platform_toolsets": {platform: ["owner_workspace"]}}
+    enabled = _get_platform_tools(config, platform)
+    assert "owner_workspace" not in enabled
+
+
+@pytest.mark.parametrize("platform", ["cli", "telegram", "cron"])
+def test_owner_workspace_toolset_never_reachable_mixed_with_platform_default(platform):
+    """Naming owner_workspace alongside the platform's own composite must not
+    smuggle it in either — the explicit_passthrough leak this regression
+    guards against triggered regardless of what else was in the list."""
+    config = {"platform_toolsets": {platform: [f"hermes-{platform}", "owner_workspace"]}}
+    enabled = _get_platform_tools(config, platform)
+    assert "owner_workspace" not in enabled
+    assert "owner_workspace_bootstrap" not in enabled
+    assert "owner_task_move" not in enabled
+    assert "owner_task_comment" not in enabled
+
+
 
 
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -1,5 +1,7 @@
 """Tests for toolsets.py — toolset resolution, validation, and composition."""
 
+import pytest
+
 from tools.registry import ToolRegistry
 from toolsets import (
     TOOLSETS,
@@ -101,7 +103,26 @@ class TestResolveToolset:
 
         assert resolve_toolset("plugin_example") == ["plugin_a", "plugin_b"]
 
+    @pytest.mark.parametrize("alias", ["all", "*"])
+    def test_wildcard_alias_omits_kernel_gated_toolsets(self, alias):
+        """"Everything" means every ORDINARY toolset. A kernel_gated toolset
+        is reachable only through its own code-level admission path, so the
+        wildcard aliases must not expand onto its tools — otherwise
+        ``platform_toolsets: {cli: [all]}`` would hand a CLI/cron agent the
+        owner mutation surface."""
+        from toolsets import get_kernel_gated_toolsets
 
+        tools = set(resolve_toolset(alias))
+        gated_tools = set()
+        for gated in get_kernel_gated_toolsets():
+            gated_tools.update(resolve_toolset(gated))
+
+        assert gated_tools, "expected at least one kernel_gated toolset to exist"
+        assert not gated_tools & tools
+        assert not {"owner_workspace_bootstrap", "owner_task_move", "owner_task_comment"} & tools
+        # Ordinary toolsets are still fully expanded by the wildcard.
+        assert set(resolve_toolset("web")) <= tools
+        assert set(resolve_toolset("terminal")) <= tools
 
 
 class TestResolveMultipleToolsets:

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -217,6 +217,23 @@ class TestToolsetConsistency:
         # silently let a platform diverge so far that nothing is shared).
         assert len(core) > 20, f"Suspiciously small shared core: {len(core)} tools"
 
+    def test_owner_workspace_is_kernel_gated_and_absent_from_every_composite(self):
+        """owner_workspace must be absent from _HERMES_CORE_TOOLS and every
+        hermes-* / composite toolset, and marked kernel_gated so generic
+        platform_toolsets config can never resolve it (see
+        hermes_cli.tools_config._get_platform_tools)."""
+        from toolsets import _HERMES_CORE_TOOLS, get_kernel_gated_toolsets
+
+        owner_tools = {"owner_workspace_bootstrap", "owner_task_move", "owner_task_comment"}
+        assert not owner_tools & set(_HERMES_CORE_TOOLS)
+        for name, ts in TOOLSETS.items():
+            if name == "owner_workspace":
+                continue
+            assert not owner_tools & set(ts.get("tools") or []), (
+                f"owner_workspace tools leaked into toolset {name!r}"
+            )
+        assert "owner_workspace" in get_kernel_gated_toolsets()
+
 
 class TestPluginToolsets:
     def test_get_all_toolsets_includes_plugin_toolset(self, monkeypatch):

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1568,3 +1568,111 @@ class TestCliApprovalTimeoutClassifiedSeparately:
         assert result.get("user_consent") is False
         assert "timed out without user response" in result["message"]
         assert "Silence is not consent" in result["message"]
+
+
+class TestExactOperationApprovalResolution:
+    """Contract tests for approval_id-scoped resolution of exact-operation
+    entries (owner-workspace mutation confirmations) vs. ordinary FIFO."""
+
+    def setup_method(self):
+        from tools import approval as mod
+
+        self.mod = mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+
+    def _enqueue_exact(self, session_key: str):
+        from tools import approval as mod
+
+        entry_ids = []
+        mod.register_gateway_notify(session_key, lambda data: entry_ids.append(data["approval_id"]))
+
+        import threading
+
+        result_box = {}
+
+        def _run():
+            result_box["outcome"] = mod._await_gateway_decision(
+                session_key,
+                mod._gateway_notify_cbs[session_key],
+                {"exact_operation": True, "operation": "op", "payload_digest": "d"},
+                surface="owner_workspace",
+                timeout_seconds=5,
+            )
+
+        t = threading.Thread(target=_run)
+        t.start()
+        # Wait for the entry to actually land in the queue before returning.
+        import time as _time
+
+        deadline = _time.monotonic() + 2
+        while not entry_ids and _time.monotonic() < deadline:
+            _time.sleep(0.005)
+        return t, entry_ids[0], result_box
+
+    def test_missing_approval_id_never_resolves_exact_entry(self):
+        mod = self.mod
+        session_key = "sess-exact-missing"
+        t, aid, box = self._enqueue_exact(session_key)
+        n = mod.resolve_gateway_approval(session_key, "once")  # no approval_id → FIFO
+        assert n == 0
+        n = mod.resolve_gateway_approval(session_key, "once", approval_id=aid)
+        assert n == 1
+        t.join()
+        assert box["outcome"]["choice"] == "once"
+
+    def test_mismatched_and_stale_ids_resolve_nothing(self):
+        mod = self.mod
+        session_key = "sess-exact-mismatch"
+        t, aid, box = self._enqueue_exact(session_key)
+        assert mod.resolve_gateway_approval(session_key, "once", approval_id="not-a-real-id") == 0
+        assert mod.resolve_gateway_approval(session_key, "once", approval_id=aid) == 1
+        t.join()
+        # Already consumed — reusing the same id now resolves nothing.
+        assert mod.resolve_gateway_approval(session_key, "once", approval_id=aid) == 0
+
+    def test_exact_entry_rejects_non_once_deny_choices(self):
+        mod = self.mod
+        session_key = "sess-exact-choice"
+        t, aid, box = self._enqueue_exact(session_key)
+        assert mod.resolve_gateway_approval(session_key, "always", approval_id=aid) == 0
+        assert mod.resolve_gateway_approval(session_key, "session", approval_id=aid) == 0
+        assert mod.resolve_gateway_approval(session_key, "deny", approval_id=aid) == 1
+        t.join()
+        assert box["outcome"]["choice"] == "deny"
+
+    def test_resolve_all_excludes_exact_operation_entries(self):
+        mod = self.mod
+        session_key = "sess-exact-resolve-all"
+        t, aid, box = self._enqueue_exact(session_key)
+        n = mod.resolve_gateway_approval(session_key, "deny", resolve_all=True)
+        assert n == 0
+        assert mod.resolve_gateway_approval(session_key, "once", approval_id=aid) == 1
+        t.join()
+        assert box["outcome"]["choice"] == "once"
+
+    def test_reversed_order_concurrent_exact_prompts(self):
+        mod = self.mod
+        session_key = "sess-exact-reversed"
+        t1, aid1, box1 = self._enqueue_exact(session_key)
+        t2, aid2, box2 = self._enqueue_exact(session_key)
+        assert aid1 != aid2
+
+        assert mod.resolve_gateway_approval(session_key, "once", approval_id=aid2) == 1
+        t2.join()
+        assert box2["outcome"]["choice"] == "once"
+        # First entry is untouched by resolving the second.
+        assert not box1
+
+        assert mod.resolve_gateway_approval(session_key, "deny", approval_id=aid1) == 1
+        t1.join()
+        assert box1["outcome"]["choice"] == "deny"
+
+    def test_ordinary_fifo_compatibility_unaffected(self):
+        mod = self.mod
+        session_key = "sess-ordinary-fifo"
+        entry = mod._ApprovalEntry({"command": "ls"})
+        mod._gateway_queues[session_key] = [entry]
+        n = mod.resolve_gateway_approval(session_key, "once")
+        assert n == 1
+        assert entry.result == "once"

--- a/tests/tools/test_owner_workspace_tools.py
+++ b/tests/tools/test_owner_workspace_tools.py
@@ -1,0 +1,328 @@
+"""Tests for the thin owner-workspace tool wrappers (tools/owner_workspace_tools.py).
+
+Scope is deliberately narrow to the WRAPPER layer — the deep kernel
+(idempotency, leases, crash recovery) is covered by
+``tests/hermes_cli/test_owner_workspace.py``. What matters here:
+
+  - Trusted identity is resolved via ``resolve_owner_context()``, never
+    accepted from a tool-call argument.
+  - Each handler passes through exactly the validated operation fields to
+    the kernel, unchanged.
+  - Schemas expose only the documented, narrow parameter surface — no
+    author/profile/actor/session/path/scope field, and no broad execution
+    capability.
+  - The registered tool surface is exactly the three documented tools.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import tools.owner_workspace_tools as owt
+from hermes_cli.owner_workspace import OwnerContext, OwnerWorkspaceError
+from tools.registry import registry
+from toolsets import TOOLSETS, get_kernel_gated_toolsets, resolve_toolset
+
+TOOL_NAMES = ("owner_workspace_bootstrap", "owner_task_move", "owner_task_comment")
+
+
+# ---------------------------------------------------------------------------
+# Tool surface
+# ---------------------------------------------------------------------------
+
+
+class TestToolSurface:
+    def test_exactly_three_tools_registered_under_owner_workspace(self):
+        assert registry.get_tool_names_for_toolset("owner_workspace") == sorted(TOOL_NAMES)
+
+    def test_toolset_definition_lists_exactly_these_tools(self):
+        assert set(TOOLSETS["owner_workspace"]["tools"]) == set(TOOL_NAMES)
+
+    def test_no_other_toolset_exposes_owner_tools(self):
+        for name, ts in TOOLSETS.items():
+            if name == "owner_workspace":
+                continue
+            assert not set(ts.get("tools") or []) & set(TOOL_NAMES)
+
+    def test_owner_workspace_toolset_is_kernel_gated(self):
+        assert "owner_workspace" in get_kernel_gated_toolsets()
+
+    def test_resolve_toolset_returns_exactly_these_tools(self):
+        assert set(resolve_toolset("owner_workspace", include_registry=False)) == set(TOOL_NAMES)
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_each_tool_is_registered_with_a_handler(self, name):
+        entry = registry.get_entry(name)
+        assert entry is not None
+        assert entry.toolset == "owner_workspace"
+        assert callable(entry.handler)
+
+
+# ---------------------------------------------------------------------------
+# Schema shape — no broad execution authority, no identity smuggling
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_PARAM_NAMES = {
+    "actor", "profile", "session", "session_id", "session_key",
+    "path", "scope", "command", "cmd", "script", "code", "shell",
+}
+
+_ALLOWED_PARAM_NAMES = {
+    "idempotency_key", "name", "description",
+    "task_id", "to_status", "expected_status", "expected_revision", "board",
+    "body",
+}
+
+
+class TestSchemas:
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_schema_name_matches_registration(self, name):
+        entry = registry.get_entry(name)
+        assert entry.schema["name"] == name
+
+    @pytest.mark.parametrize("name", TOOL_NAMES)
+    def test_schema_has_no_forbidden_identity_or_execution_params(self, name):
+        entry = registry.get_entry(name)
+        props = set(entry.schema["parameters"]["properties"])
+        assert not props & _FORBIDDEN_PARAM_NAMES
+        assert props <= _ALLOWED_PARAM_NAMES
+
+    def test_bootstrap_requires_idempotency_key_and_name(self):
+        entry = registry.get_entry("owner_workspace_bootstrap")
+        required = set(entry.schema["parameters"]["required"])
+        assert required == {"idempotency_key", "name"}
+        assert set(entry.schema["parameters"]["properties"]) == {
+            "idempotency_key", "name", "description",
+        }
+
+    def test_task_move_requires_full_cas_precondition(self):
+        entry = registry.get_entry("owner_task_move")
+        required = set(entry.schema["parameters"]["required"])
+        assert required == {
+            "idempotency_key", "task_id", "to_status",
+            "expected_status", "expected_revision",
+        }
+        assert set(entry.schema["parameters"]["properties"]) == {
+            "idempotency_key", "task_id", "to_status",
+            "expected_status", "expected_revision", "board",
+        }
+
+    def test_task_comment_requires_task_id_and_body(self):
+        entry = registry.get_entry("owner_task_comment")
+        required = set(entry.schema["parameters"]["required"])
+        assert required == {"idempotency_key", "task_id", "body"}
+        assert set(entry.schema["parameters"]["properties"]) == {
+            "idempotency_key", "task_id", "body", "board",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Trusted context resolution — never from tool-call arguments
+# ---------------------------------------------------------------------------
+
+
+class _RecordingKernel:
+    """Captures the exact kwargs a wrapper handler passed through."""
+
+    def __init__(self, return_value=None):
+        self.calls = []
+        self.return_value = return_value if return_value is not None else {"ok": True}
+
+    def __call__(self, ctx, **kwargs):
+        self.calls.append((ctx, kwargs))
+        return self.return_value
+
+
+@pytest.fixture
+def trusted_ctx():
+    return OwnerContext(actor="trusted-actor", profile="trusted-profile", session="trusted-session")
+
+
+class TestTrustedContextResolution:
+    def test_bootstrap_uses_resolved_context_not_args(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+        kernel = _RecordingKernel()
+        monkeypatch.setattr(owt._kernel, "bootstrap", kernel)
+
+        owt._handle_bootstrap({
+            "idempotency_key": "k1", "name": "n1",
+            # Attacker-supplied identity fields the schema never declares —
+            # must be silently ignored, never reach the kernel.
+            "actor": "attacker", "profile": "attacker-profile", "session": "attacker-session",
+        })
+
+        assert len(kernel.calls) == 1
+        ctx, kwargs = kernel.calls[0]
+        assert ctx is trusted_ctx
+        assert ctx.actor == "trusted-actor"
+        assert "actor" not in kwargs
+        assert "profile" not in kwargs
+        assert "session" not in kwargs
+
+    def test_task_move_uses_resolved_context_not_args(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+        kernel = _RecordingKernel()
+        monkeypatch.setattr(owt._kernel, "move_task", kernel)
+
+        owt._handle_task_move({
+            "idempotency_key": "k2", "task_id": "t1", "to_status": "done",
+            "expected_status": "review", "expected_revision": 3,
+            "actor": "attacker",
+        })
+
+        ctx, kwargs = kernel.calls[0]
+        assert ctx is trusted_ctx
+        assert "actor" not in kwargs
+
+    def test_task_comment_uses_resolved_context_not_args(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+        kernel = _RecordingKernel()
+        monkeypatch.setattr(owt._kernel, "comment_task", kernel)
+
+        owt._handle_task_comment({
+            "idempotency_key": "k3", "task_id": "t1", "body": "hi",
+            "profile": "attacker-profile",
+        })
+
+        ctx, kwargs = kernel.calls[0]
+        assert ctx is trusted_ctx
+        assert "profile" not in kwargs
+
+    def test_context_is_resolved_fresh_each_call_not_cached_from_first_call(self, monkeypatch):
+        ctxs = [
+            OwnerContext(actor="a1", profile="p1", session="s1"),
+            OwnerContext(actor="a2", profile="p2", session="s2"),
+        ]
+        calls = iter(ctxs)
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: next(calls))
+        kernel = _RecordingKernel()
+        monkeypatch.setattr(owt._kernel, "bootstrap", kernel)
+
+        owt._handle_bootstrap({"idempotency_key": "k1", "name": "n1"})
+        owt._handle_bootstrap({"idempotency_key": "k2", "name": "n2"})
+
+        assert kernel.calls[0][0].actor == "a1"
+        assert kernel.calls[1][0].actor == "a2"
+
+
+# ---------------------------------------------------------------------------
+# Wrapper delegation preserves the validated operation fields exactly
+# ---------------------------------------------------------------------------
+
+
+class TestFieldDelegation:
+    def test_bootstrap_passes_through_exact_fields(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+        kernel = _RecordingKernel()
+        monkeypatch.setattr(owt._kernel, "bootstrap", kernel)
+
+        owt._handle_bootstrap({
+            "idempotency_key": "k1", "name": "My Project", "description": "desc",
+        })
+
+        _, kwargs = kernel.calls[0]
+        assert kwargs == {
+            "idempotency_key": "k1", "name": "My Project", "description": "desc",
+        }
+
+    def test_bootstrap_missing_description_passes_none(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+        kernel = _RecordingKernel()
+        monkeypatch.setattr(owt._kernel, "bootstrap", kernel)
+
+        owt._handle_bootstrap({"idempotency_key": "k1", "name": "My Project"})
+
+        _, kwargs = kernel.calls[0]
+        assert kwargs["description"] is None
+
+    def test_task_move_passes_through_exact_fields(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+        kernel = _RecordingKernel()
+        monkeypatch.setattr(owt._kernel, "move_task", kernel)
+
+        owt._handle_task_move({
+            "idempotency_key": "k2", "task_id": "t1", "to_status": "done",
+            "expected_status": "review", "expected_revision": 3, "board": "b1",
+        })
+
+        _, kwargs = kernel.calls[0]
+        assert kwargs == {
+            "idempotency_key": "k2", "task_id": "t1", "to_status": "done",
+            "expected_status": "review", "expected_revision": 3, "board": "b1",
+        }
+
+    def test_task_comment_passes_through_exact_fields(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+        kernel = _RecordingKernel()
+        monkeypatch.setattr(owt._kernel, "comment_task", kernel)
+
+        owt._handle_task_comment({
+            "idempotency_key": "k3", "task_id": "t1", "body": "hi there", "board": "b1",
+        })
+
+        _, kwargs = kernel.calls[0]
+        assert kwargs == {
+            "idempotency_key": "k3", "task_id": "t1", "body": "hi there", "board": "b1",
+        }
+
+    def test_successful_result_is_returned_verbatim_as_json(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+        result = {"ok": True, "task_id": "t1", "status": "done", "revision": 7}
+        monkeypatch.setattr(owt._kernel, "move_task", _RecordingKernel(return_value=result))
+
+        out = owt._handle_task_move({
+            "idempotency_key": "k2", "task_id": "t1", "to_status": "done",
+            "expected_status": "review", "expected_revision": 3,
+        })
+
+        assert json.loads(out) == result
+
+
+# ---------------------------------------------------------------------------
+# Error handling — surfaced without leaking internals
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_bootstrap_owner_workspace_error_message_is_surfaced(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+
+        def _raise(ctx, **kwargs):
+            raise OwnerWorkspaceError("invalid_argument", "name is required")
+
+        monkeypatch.setattr(owt._kernel, "bootstrap", _raise)
+
+        out = owt._handle_bootstrap({"idempotency_key": "k1", "name": "n"})
+        payload = json.loads(out)
+        assert "error" in payload
+        assert "name is required" in payload["error"]
+        assert "owner_workspace_bootstrap" in payload["error"]
+
+    def test_task_move_value_error_message_is_surfaced(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+
+        def _raise(ctx, **kwargs):
+            raise ValueError("expected_revision must be an integer")
+
+        monkeypatch.setattr(owt._kernel, "move_task", _raise)
+
+        out = owt._handle_task_move({
+            "idempotency_key": "k2", "task_id": "t1", "to_status": "done",
+            "expected_status": "review", "expected_revision": "not-an-int",
+        })
+        payload = json.loads(out)
+        assert "expected_revision must be an integer" in payload["error"]
+
+    def test_unexpected_exception_does_not_leak_internal_details(self, monkeypatch, trusted_ctx):
+        monkeypatch.setattr(owt, "resolve_owner_context", lambda: trusted_ctx)
+
+        def _raise(ctx, **kwargs):
+            raise RuntimeError("sqlite file /secret/path/projects.db is locked")
+
+        monkeypatch.setattr(owt._kernel, "comment_task", _raise)
+
+        out = owt._handle_task_comment({"idempotency_key": "k3", "task_id": "t1", "body": "hi"})
+        payload = json.loads(out)
+        assert "internal error" in payload["error"]
+        assert "/secret/path" not in payload["error"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -16,6 +16,7 @@ import hashlib
 import logging
 import os
 import re
+import secrets
 import shlex
 import sys
 import tempfile
@@ -2442,7 +2443,7 @@ def _denial_breaker_addendum(session_key: str) -> str:
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("event", "data", "result", "reason", "approval_id")
 
     def __init__(self, data: dict):
         self.event = threading.Event()
@@ -2452,6 +2453,12 @@ class _ApprovalEntry:
         # (``/deny <reason>``) so the agent can adapt instead of only
         # hearing "denied". Ported from qwibitai/nanoclaw#2832.
         self.reason: Optional[str] = None
+        # Opaque unpredictable id, always present. Ordinary (non
+        # ``exact_operation``) entries can still be resolved via plain FIFO
+        # for backward compatibility; ``exact_operation`` entries (owner
+        # mutation confirmations) can ONLY be resolved by this id — see
+        # ``resolve_gateway_approval``.
+        self.approval_id: str = data.get("approval_id") or secrets.token_urlsafe(24)
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
@@ -2485,13 +2492,27 @@ def unregister_gateway_notify(session_key: str) -> None:
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             approval_id: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
-    When *resolve_all* is True every pending approval in the session is
-    resolved at once (``/approve all``).  Otherwise only the oldest one
-    is resolved (FIFO).
+    When *approval_id* is supplied, ONLY the entry whose ``approval_id``
+    matches it is resolved — anywhere in the queue, not just the head — and
+    *resolve_all* is ignored. A missing, unknown, stale (already dropped by
+    timeout), or already-consumed id resolves nothing (returns 0); this
+    never falls through to FIFO. An ``exact_operation`` entry additionally
+    rejects any choice other than ``"once"``/``"deny"`` (no session/always/
+    permanent bypass) — an invalid choice against such an entry also
+    resolves nothing, leaving it queued for a correct response.
+
+    Without *approval_id*: when *resolve_all* is True every pending
+    ordinary approval in the session is resolved at once (``/approve
+    all``) — ``exact_operation`` entries are excluded from the sweep and
+    remain queued (bulk actions never satisfy an exact-operation
+    confirmation). Otherwise the oldest ordinary entry is resolved (FIFO);
+    an ``exact_operation`` entry at the head blocks plain FIFO resolution
+    (resolves nothing) since it requires its own id.
 
     *reason* is an optional free-text explanation attached to an explicit
     deny (``/deny <reason>``).  It is relayed back to the agent in the
@@ -2503,11 +2524,27 @@ def resolve_gateway_approval(session_key: str, choice: str,
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
-        if resolve_all:
-            targets = list(queue)
-            queue.clear()
+
+        if approval_id:
+            target = next((e for e in queue if e.approval_id == approval_id), None)
+            if target is None:
+                return 0
+            if target.data.get("exact_operation") and choice not in ("once", "deny"):
+                return 0
+            queue.remove(target)
+            targets = [target]
+        elif resolve_all:
+            targets = [e for e in queue if not e.data.get("exact_operation")]
+            if not targets:
+                return 0
+            remaining = [e for e in queue if e.data.get("exact_operation")]
+            queue[:] = remaining
         else:
+            head = queue[0]
+            if head.data.get("exact_operation"):
+                return 0
             targets = [queue.pop(0)]
+
         if not queue:
             _gateway_queues.pop(session_key, None)
 
@@ -3602,20 +3639,30 @@ def _format_tirith_description(tirith_result: dict) -> str:
 
 
 def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
-                            *, surface: str = "gateway") -> dict:
+                            *, surface: str = "gateway",
+                            timeout_seconds: Optional[float] = None) -> dict:
     """Enqueue *approval_data*, notify the user, and block the calling agent
     thread until the request is resolved or the gateway approval timeout
     elapses — firing pre/post approval hooks and cleaning up the queue entry.
 
-    Shared by the terminal command guard (``check_all_command_guards``) and
-    the execute_code guard (``check_execute_code_guard``) so the fiddly
-    heartbeat-polling wait loop lives in one place.
+    Shared by the terminal command guard (``check_all_command_guards``),
+    the execute_code guard (``check_execute_code_guard``), and exact-operation
+    owner-mutation confirmations (``request_exact_operation_approval``) so
+    the fiddly heartbeat-polling wait loop and the queue entry's opaque
+    ``approval_id`` (generated here, unconditionally, for every entry) live
+    in one place.
+
+    ``timeout_seconds`` overrides the configured approval timeout (used by
+    expiry-bound exact-operation confirmations); ``None`` keeps the existing
+    ``_get_approval_timeout()`` behavior.
 
     Returns ``{"resolved": bool, "choice": str|None}`` on completion, or
     ``{"resolved": False, "choice": None, "notify_failed": True}`` if the
     notify callback raised.  Persistence of an approved choice and building
     the final tool-facing result dict remain the caller's responsibility.
     """
+    approval_data = dict(approval_data)
+    approval_data.setdefault("approval_id", secrets.token_urlsafe(24))
     command = approval_data.get("command", "")
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
@@ -3668,7 +3715,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # every ~10s to the agent's inactivity tracker — otherwise the gateway
     # watchdog kills the agent while the user is still responding. Mirrors
     # _wait_for_process() cadence.
-    timeout = _get_approval_timeout()
+    timeout = _get_approval_timeout() if timeout_seconds is None else max(float(timeout_seconds), 0.0)
 
     try:
         from tools.environments.base import touch_activity_if_due
@@ -3729,6 +3776,61 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         choice=_outcome,
     )
     return {"resolved": resolved, "choice": choice, "reason": entry.reason}
+
+
+def request_exact_operation_approval(
+    session_key: str,
+    *,
+    operation: str,
+    payload_digest: str,
+    actor: str,
+    profile: str,
+    description: str,
+    timeout_seconds: Optional[float] = None,
+) -> dict:
+    """Exact-operation confirmation for an owner-workspace mutation.
+
+    Deliberately bypasses the session/permanent allowlist entirely (unlike
+    ``_run_approval_gate``/``request_tool_approval``): every call requires a
+    fresh human decision bound to this exact ``operation`` + payload digest +
+    actor + profile + gateway session, with no YOLO / session / always /
+    permanent / cached shortcut. Only ``"once"`` (approve exactly this call)
+    or ``"deny"`` are meaningful outcomes — ``resolve_gateway_approval``
+    enforces that at the queue layer for ``exact_operation`` entries, and
+    also refuses to let bulk ``resolve_all`` or bare FIFO satisfy one.
+
+    Returns ``{"approved": bool, "reason": str|None}``. ``approved`` is only
+    True when a human explicitly answered "once" for THIS entry before the
+    (expiry-bound) timeout elapsed. No attached gateway notify callback (no
+    human surface on this session) fails closed.
+    """
+    with _lock:
+        notify_cb = _gateway_notify_cbs.get(session_key)
+    if notify_cb is None:
+        return {"approved": False, "reason": "no_approval_surface"}
+
+    approval_data = {
+        "exact_operation": True,
+        "operation": operation,
+        "payload_digest": payload_digest,
+        "actor": actor,
+        "profile": profile,
+        "description": description,
+        "command": description,
+    }
+    outcome = _await_gateway_decision(
+        session_key,
+        notify_cb,
+        approval_data,
+        surface="owner_workspace",
+        timeout_seconds=timeout_seconds,
+    )
+    if not outcome.get("resolved"):
+        return {"approved": False, "reason": "timeout"}
+    choice = outcome.get("choice")
+    if choice != "once":
+        return {"approved": False, "reason": choice or "deny"}
+    return {"approved": True, "reason": None}
 
 
 def check_all_command_guards(command: str, env_type: str,

--- a/tools/owner_workspace_tools.py
+++ b/tools/owner_workspace_tools.py
@@ -1,0 +1,202 @@
+"""Owner-workspace toolset — three thin model tools over the deep kernel in
+``hermes_cli.owner_workspace``.
+
+Default-off, API-server-only surface (see ``toolsets.py``'s ``owner_workspace``
+toolset — absent from ``_HERMES_CORE_TOOLS`` and every composite — and
+``gateway/platforms/api_server.py``'s ``_create_agent``, the ONLY place that
+folds it into ``enabled_toolsets``, gated on
+``gateway.api_server.owner_workspace.enabled`` for the resolved profile).
+
+Every tool schema is deliberately narrow: no author/profile/actor/session/
+path/scope field is accepted from the model. Identity is resolved from
+trusted request context (``resolve_owner_context``) inside the kernel.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from hermes_cli.owner_workspace import OwnerWorkspaceError, resolve_owner_context
+from hermes_cli import owner_workspace as _kernel
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def _ok(result: dict) -> str:
+    return json.dumps(result, ensure_ascii=False)
+
+
+def _handle_bootstrap(args: dict, **kw) -> str:
+    try:
+        ctx = resolve_owner_context()
+        result = _kernel.bootstrap(
+            ctx,
+            idempotency_key=args.get("idempotency_key"),
+            name=args.get("name"),
+            description=args.get("description"),
+        )
+        return _ok(result)
+    except OwnerWorkspaceError as e:
+        return tool_error(f"owner_workspace_bootstrap: {e.message}")
+    except Exception:
+        logger.exception("owner_workspace_bootstrap failed")
+        return tool_error("owner_workspace_bootstrap: internal error")
+
+
+def _handle_task_move(args: dict, **kw) -> str:
+    try:
+        ctx = resolve_owner_context()
+        result = _kernel.move_task(
+            ctx,
+            idempotency_key=args.get("idempotency_key"),
+            task_id=args.get("task_id"),
+            to_status=args.get("to_status"),
+            expected_status=args.get("expected_status"),
+            expected_revision=args.get("expected_revision"),
+            board=args.get("board"),
+        )
+        return _ok(result)
+    except OwnerWorkspaceError as e:
+        return tool_error(f"owner_task_move: {e.message}")
+    except ValueError as e:
+        return tool_error(f"owner_task_move: {e}")
+    except Exception:
+        logger.exception("owner_task_move failed")
+        return tool_error("owner_task_move: internal error")
+
+
+def _handle_task_comment(args: dict, **kw) -> str:
+    try:
+        ctx = resolve_owner_context()
+        result = _kernel.comment_task(
+            ctx,
+            idempotency_key=args.get("idempotency_key"),
+            task_id=args.get("task_id"),
+            body=args.get("body"),
+            board=args.get("board"),
+        )
+        return _ok(result)
+    except OwnerWorkspaceError as e:
+        return tool_error(f"owner_task_comment: {e.message}")
+    except ValueError as e:
+        return tool_error(f"owner_task_comment: {e}")
+    except Exception:
+        logger.exception("owner_task_comment failed")
+        return tool_error("owner_task_comment: internal error")
+
+
+registry.register(
+    name="owner_workspace_bootstrap",
+    toolset="owner_workspace",
+    schema={
+        "name": "owner_workspace_bootstrap",
+        "description": (
+            "Create the owner's workspace: one Project, one Kanban board, and "
+            "one initial task. Idempotent — replaying the same idempotency_key "
+            "with the same arguments returns the original result; reusing it "
+            "with different arguments fails. Requires a fresh human confirmation. "
+            "On success, the result's status and revision are the new task's "
+            "current status and event revision — pass them straight through as "
+            "owner_task_move's expected_status/expected_revision to move it."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "idempotency_key": {
+                    "type": "string",
+                    "description": "Stable client-chosen key so a retried call is safe.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Human name for the new Project/board/initial task.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional description for the Project and initial task.",
+                },
+            },
+            "required": ["idempotency_key", "name"],
+        },
+    },
+    handler=lambda args, **kw: _handle_bootstrap(args, **kw),
+)
+
+registry.register(
+    name="owner_task_move",
+    toolset="owner_workspace",
+    schema={
+        "name": "owner_task_move",
+        "description": (
+            "Move an owner-workspace task to a new status via optimistic "
+            "compare-and-swap. Requires the task's current status and event "
+            "revision (from owner_workspace_bootstrap's result or a prior "
+            "owner_task_move/owner_task_comment response) — a mismatch returns "
+            "the current snapshot with zero changes instead of an error. Cannot "
+            "claim or move a running task. Idempotent; requires a fresh human "
+            "confirmation."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "idempotency_key": {
+                    "type": "string",
+                    "description": "Stable client-chosen key so a retried call is safe.",
+                },
+                "task_id": {"type": "string", "description": "The task to move."},
+                "to_status": {
+                    "type": "string",
+                    "description": "Target status (e.g. todo, ready, blocked, review, done, archived).",
+                },
+                "expected_status": {
+                    "type": "string",
+                    "description": "The task's status you last observed — the CAS precondition.",
+                },
+                "expected_revision": {
+                    "type": "integer",
+                    "description": "The task's event revision you last observed — the CAS precondition.",
+                },
+                "board": {
+                    "type": "string",
+                    "description": "Optional board slug (defaults to the current board).",
+                },
+            },
+            "required": ["idempotency_key", "task_id", "to_status", "expected_status", "expected_revision"],
+        },
+    },
+    handler=lambda args, **kw: _handle_task_move(args, **kw),
+)
+
+registry.register(
+    name="owner_task_comment",
+    toolset="owner_workspace",
+    schema={
+        "name": "owner_task_comment",
+        "description": (
+            "Append a comment to an owner-workspace task. The comment author is "
+            "always the trusted caller identity — it cannot be set by this call. "
+            "Idempotent; requires a fresh human confirmation. On success, the "
+            "result's status and revision are the task's current status and "
+            "event revision (the comment itself advances the revision) — pass "
+            "them straight through as owner_task_move's expected_status/"
+            "expected_revision to move it."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "idempotency_key": {
+                    "type": "string",
+                    "description": "Stable client-chosen key so a retried call is safe.",
+                },
+                "task_id": {"type": "string", "description": "The task to comment on."},
+                "body": {"type": "string", "description": "Comment text."},
+                "board": {
+                    "type": "string",
+                    "description": "Optional board slug (defaults to the current board).",
+                },
+            },
+            "required": ["idempotency_key", "task_id", "body"],
+        },
+    },
+    handler=lambda args, **kw: _handle_task_comment(args, **kw),
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -284,6 +284,35 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    # Default-off, API-server-only owner-workspace mutation surface. Absent
+    # from _HERMES_CORE_TOOLS and every composite/platform toolset below —
+    # the ONLY place this is folded into an agent's enabled_toolsets is
+    # gateway/platforms/api_server.py's _create_agent(), and only when
+    # gateway.api_server.owner_workspace.enabled is true for the resolved
+    # (possibly multiplexed) profile. Never exposed on CLI/TUI/messaging/
+    # cron/ACP/desktop — enforced structurally by "kernel_gated" below, NOT
+    # by convention: _get_platform_tools() in hermes_cli/tools_config.py
+    # strips any kernel_gated toolset name out of a platform's config-driven
+    # resolution BEFORE the generic "explicit passthrough" step that would
+    # otherwise honor an explicit `platform_toolsets: {<platform>:
+    # [owner_workspace]}` entry for ANY platform, including api_server
+    # itself — the admitted path is exclusively the dedicated
+    # `_owner_workspace_toolset_enabled()` union in api_server.py.
+    "owner_workspace": {
+        "description": (
+            "Owner-workspace mutation tools (bootstrap a Project + Kanban "
+            "board + initial task; move a task via compare-and-swap; comment "
+            "as the trusted caller). Opt-in, API-server-only — every "
+            "mutation is idempotent and requires a fresh human confirmation."
+        ),
+        "tools": ["owner_workspace_bootstrap", "owner_task_move", "owner_task_comment"],
+        "includes": [],
+        # See _get_platform_tools()'s explicit_passthrough filtering — a
+        # kernel_gated toolset can NEVER be reached via generic
+        # platform_toolsets config naming, on any platform, no exceptions.
+        "kernel_gated": True,
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
@@ -893,6 +922,18 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
         if toolset:
             result[display_name] = toolset
     return result
+
+
+def get_kernel_gated_toolsets() -> Set[str]:
+    """Toolset names marked ``kernel_gated: True`` in ``TOOLSETS``.
+
+    These are reachable ONLY through a dedicated, hard-coded enablement path
+    in the code that owns them (e.g. ``owner_workspace`` via
+    ``gateway/platforms/api_server.py``'s ``_owner_workspace_toolset_enabled``
+    gate) — never via generic ``platform_toolsets`` config naming, on any
+    platform. See ``hermes_cli.tools_config._get_platform_tools``.
+    """
+    return {name for name, ts in TOOLSETS.items() if ts.get("kernel_gated")}
 
 
 def get_toolset_names() -> List[str]:

--- a/toolsets.py
+++ b/toolsets.py
@@ -799,7 +799,17 @@ def resolve_toolset(name: str, visited: Set[str] = None, *, include_registry: bo
     # This ensures future toolsets are automatically included without changes.
     if name in {"all", "*"}:
         all_tools: Set[str] = set()
+        # A kernel_gated toolset is reachable ONLY by naming it directly on its
+        # dedicated code-level admission path (owner_workspace ->
+        # api_server._owner_workspace_toolset_enabled). "Everything" must
+        # therefore mean "every ordinary toolset", or `platform_toolsets:
+        # {cli: [all]}` would hand a CLI/cron/messaging agent the owner
+        # mutation tools that the by-name gate in
+        # hermes_cli.tools_config._get_platform_tools deliberately strips.
+        kernel_gated = get_kernel_gated_toolsets()
         for toolset_name in get_toolset_names():
+            if toolset_name in kernel_gated:
+                continue
             # Use a fresh visited set per branch to avoid cross-branch contamination
             resolved = resolve_toolset(toolset_name, visited.copy(), include_registry=include_registry)
             all_tools.update(resolved)


### PR DESCRIPTION
## What does this PR do?

Adds a narrow, default-off owner-workspace mutation boundary for the Hermes API server.

Exactly three operations are exposed when the dedicated per-profile gate is enabled:

- atomic/idempotent Project + Kanban + initial-task bootstrap;
- optimistic compare-and-swap Task movement;
- idempotent owner comments.

The toolset is kernel-gated and API-server-only. It is not exposed through CLI, TUI, messaging, cron, ACP, desktop, generic platform toolset configuration, or any new router/database.

## Why this shape?

Hermes already provides the conversation path through Responses/SSE and continuation. The missing maintained primitive was a least-privilege owner mutation boundary suitable for a standalone owner application. This keeps Hermes Project/Kanban as the source of truth and requires a fresh exact-operation human approval for every mutation.

## Validation

- one commit, 16 scoped files;
- canonical focused gate: 247 passed, 0 failed;
- exact-operation approval gate: 6 passed, 0 failed;
- frozen base `a4970d07d58af41968b7371776481b56411bc3d6` passed upstream CI run [31311402950](https://github.com/NousResearch/hermes-agent/actions/runs/31311402950), including all 12 Python slices and `All required checks pass`;
- this draft must remain unmerged unless its exact PR-head CI aggregate succeeds and independent review passes.

## Boundaries

No live installation, API activation, credential/config/service change, deployment, second task store, or broad administrative surface is included. Maintainer edits are allowed; merge and activation remain separate owner decisions.
