### PR TITLE
fix(kanban): quarantine block-loop triage from auto-decompose

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -457,12 +457,26 @@ def decompose_task(
 
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
-    """Return task ids currently in the triage column."""
+    """Return rough-input triage tasks eligible for automatic decomposition.
+
+    A ``block_loop_detected`` event means the task was routed to triage as a
+    human escalation, not submitted as an underspecified idea. Keep those
+    tasks out of the gateway's automatic LLM rewrite path. Explicit
+    ``hermes kanban decompose <id>`` remains available to an operator.
+    """
     with kb.connect_closing() as conn:
-        rows = kb.list_tasks(
-            conn,
-            status="triage",
-            tenant=tenant,
-            limit=1000,
+        query = (
+            "SELECT t.id FROM tasks AS t "
+            "WHERE t.status = 'triage' "
+            "AND NOT EXISTS ("
+            "  SELECT 1 FROM task_events AS e "
+            "  WHERE e.task_id = t.id AND e.kind = 'block_loop_detected'"
+            ")"
         )
-    return [row.id for row in rows]
+        params: list[str] = []
+        if tenant is not None:
+            query += " AND t.tenant = ?"
+            params.append(tenant)
+        query += " ORDER BY t.created_at ASC, t.id ASC LIMIT 1000"
+        rows = conn.execute(query, params).fetchall()
+    return [str(row["id"]) for row in rows]

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,53 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_auto_candidates_exclude_block_loop_escalations(kanban_home):
+    """Human-escalation triage must not be rewritten by auto-decompose.
+
+    ``block_loop_detected`` intentionally moves a repeatedly blocked task to
+    triage for operator attention.  Audit comments after the transition must
+    not make that task look like a new rough idea, while ordinary triage stays
+    eligible for the gateway's auto-decompose tick.
+    """
+    with kb.connect_closing() as conn:
+        rough = kb.create_task(
+            conn,
+            title="rough idea",
+            body="please turn this into concrete work",
+            triage=True,
+        )
+        escalated = kb.create_task(
+            conn,
+            title="preserve canonical body",
+            body='{"workflow_stage":"planning","staged_manifest":{"id":"exact"}}',
+            assignee="worker",
+        )
+        assert kb.claim_task(conn, escalated, claimer="worker") is not None
+        assert kb.block_task(
+            conn, escalated, reason="missing capability", kind="capability",
+        )
+        assert kb.unblock_task(conn, escalated)
+        assert kb.claim_task(conn, escalated, claimer="worker") is not None
+        assert kb.block_task(
+            conn, escalated, reason="missing capability", kind="capability",
+        )
+        escalated_task = kb.get_task(conn, escalated)
+        assert escalated_task is not None
+        assert escalated_task.status == "triage"
+        kb.add_comment(
+            conn, escalated, author="worker", body="operator repair required",
+        )
+        escalated_task = kb.get_task(conn, escalated)
+        assert escalated_task is not None
+        original_body = escalated_task.body
+
+    candidates = decomp.list_triage_ids()
+
+    assert rough in candidates
+    assert escalated not in candidates
+    with kb.connect_closing() as conn:
+        escalated_task = kb.get_task(conn, escalated)
+        assert escalated_task is not None
+        assert escalated_task.body == original_body
+
+


### PR DESCRIPTION
## Summary
- exclude tasks escalated by `block_loop_detected` from the gateway auto-decompose candidate query
- preserve explicit `hermes kanban decompose <id>` as an operator override
- add a regression proving escalation triage remains quarantined even after audit comments, while ordinary rough-input triage stays eligible

## Root cause
`block_task()` intentionally routes repeated same-cause failures to triage for human intervention. The gateway then treated every triage task as rough input, sent a truncated body to an auxiliary LLM, replaced the canonical body, and promoted the task back into dispatch. This defeated the loop breaker and could destroy structured task provenance.

The candidate query now treats any task carrying a `block_loop_detected` event as operator-owned escalation triage.

## Test plan
- `python -m pytest -q tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_block_kinds.py tests/gateway/test_kanban_auto_decompose_live.py` (10 passed)
- `python -m ruff check hermes_cli/kanban_decompose.py tests/hermes_cli/test_kanban_decompose.py`
- `git diff --check`