### PR TITLE
fix(docker): prefer explicit credential volume mounts

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1277,6 +1277,65 @@ def test_credential_mount_skipped_when_source_is_directory(monkeypatch, tmp_path
     )
 
 
+def test_explicit_volume_takes_precedence_over_automatic_credential_mount(
+    monkeypatch, tmp_path, caplog,
+):
+    """An explicit writable credential bind must replace the automatic RO bind."""
+    token_path = tmp_path / "google_token.json"
+    token_path.write_text("{}")
+    other_path = tmp_path / "other.json"
+    other_path.write_text("{}")
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts",
+        lambda: [
+            {
+                "host_path": str(token_path),
+                "container_path": "/root/.hermes/google_token.json",
+            },
+            {
+                "host_path": str(other_path),
+                "container_path": "/root/.hermes/other.json",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda: [],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.get_cache_directory_mounts",
+        lambda: [],
+    )
+
+    with caplog.at_level(logging.INFO):
+        _make_dummy_env(
+            volumes=[
+                f"{token_path}:/root/.hermes/google_token.json:rw",
+            ],
+        )
+
+    run_calls = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"
+    ]
+    assert run_calls, "docker run should have been called"
+    args = run_calls[0][0]
+    mounts = [args[idx + 1] for idx, value in enumerate(args[:-1]) if value == "-v"]
+    assert f"{token_path}:/root/.hermes/google_token.json:rw" in mounts
+    assert not any(
+        mount.endswith(":/root/.hermes/google_token.json:ro")
+        for mount in mounts
+    )
+    assert f"{other_path}:/root/.hermes/other.json:ro" in mounts
+    assert any(
+        "skipping automatic credential mount" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 def test_credential_mount_skipped_when_source_missing(monkeypatch, tmp_path, caplog):
     """Credential mount should be skipped when source file no longer exists."""
     missing_path = tmp_path / "deleted_token.json"

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -947,6 +947,7 @@ class DockerEnvironment(BaseEnvironment):
 
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
+        explicitly_mounted_destinations = set()
         workspace_explicitly_mounted = False
         for vol in (volumes or []):
             if not isinstance(vol, str):
@@ -957,6 +958,14 @@ class DockerEnvironment(BaseEnvironment):
                 continue
             if ":" in vol:
                 volume_args.extend(["-v", vol])
+                # The source path may itself contain a colon (for example on
+                # Windows), so split from the right and account for an
+                # optional mount mode.
+                volume_parts = vol.rsplit(":", 2)
+                destination = (
+                    volume_parts[-2] if len(volume_parts) == 3 else volume_parts[-1]
+                )
+                explicitly_mounted_destinations.add(destination)
                 if ":/workspace" in vol:
                     workspace_explicitly_mounted = True
             else:
@@ -1014,6 +1023,13 @@ class DockerEnvironment(BaseEnvironment):
             )
 
             for mount_entry in get_credential_file_mounts():
+                if mount_entry["container_path"] in explicitly_mounted_destinations:
+                    logger.info(
+                        "Docker: skipping automatic credential mount for explicitly "
+                        "mounted destination %s",
+                        mount_entry["container_path"],
+                    )
+                    continue
                 src = Path(mount_entry["host_path"])
                 if src.is_dir():
                     # Docker-in-Docker: Docker auto-created the source path as


### PR DESCRIPTION
## What does this PR do?

  Fixes duplicate Docker volume mounts for skill credentials.

  Explicit entries in `terminal.docker_volumes` now take precedence over automatically registered credential mounts. This allows credentials such as the Google Workspace
  OAuth token to be mounted writable for automatic refresh without also receiving a conflicting read-only mount.

  ## Related Issue

  Fixes #82484 

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests
  - [ ] ♻️ Refactor
  - [ ] 🎯 New skill

  ## Changes Made

  - Updated `tools/environments/docker.py` to track destinations from explicit Docker volume mounts.
  - Skipped automatic credential mounts when their container destination is already explicitly mounted.
  - Preserved read-only automatic mounts for unrelated credentials.
  - Added a regression test verifying that an explicit `:rw` Google token mount replaces the automatic `:ro` mount.

  ## How to Test

  1. Configure the Docker terminal backend.
  2. Add the Google token volume explicitly:
     ```yaml
     terminal:
       docker_volumes:
         - "/home/hermes/.hermes/google_token.json:/root/.hermes/google_token.json:rw"

  3. Start a Docker/Podman terminal and verify the generated command contains only the explicit writable mount for google_token.json.
  4. Run:

     pytest tests/tools/test_docker_environment.py -q

  The regression test was added but could not be executed in this checkout because pytest is not installed.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits
  - [x] I searched for existing PRs
  - [x] My PR contains only changes related to this fix
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes
  - [x] I've considered the Windows path parsing impact

  ### Documentation & Housekeeping

  - [x] Documentation update not applicable
  - [x] Config documentation update not applicable
  - [x] Architecture/workflow documentation update not applicable
  - [x] Cross-platform impact considered
  - [x] Tool descriptions/schemas not affected