### PR TITLE
docs: document memory-provider on_turn_start/on_delegation/backup_paths hooks

### DIFF
--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -75,12 +75,15 @@ class MyMemoryProvider(MemoryProvider):
 | Method | When Called | Use Case |
 |--------|-----------|----------|
 | `system_prompt_block()` | System prompt assembly | Static provider info |
-| `prefetch(query, *, session_id="")` | Before each API call | Return recalled context |
+| `prefetch(query, *, session_id="")` | Before each API call | Return recalled context (non-empty results are injected into the agent context) |
 | `queue_prefetch(query, *, session_id="")` | After each turn | Pre-warm for next turn |
 | `sync_turn(user, assistant, *, session_id="", messages=None)` | After each completed turn | Persist conversation |
 | `on_session_end(messages)` | Conversation ends | Final extraction/flush |
 | `on_pre_compress(messages)` | Before context compression | Save insights before discard |
 | `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
+| `on_turn_start(turn_number, message, **kwargs)` | Before each turn | Per-turn tick; results are NOT injected — use `prefetch()` for injection |
+| `on_delegation(task, result, **kwargs)` | Parent observes subagent work | Capture delegated work results |
+| `backup_paths()` | `hermes backup` | Extra on-disk paths to include in backups |
 | `shutdown()` | Process exit | Clean up connections |
 
 ## Config Schema


### PR DESCRIPTION
The optional-hooks table was missing `on_turn_start`, `on_delegation`, and `backup_paths` — all real, called hooks (agent/memory_provider.py:195/270/341, memory_manager.py:851, turn_context.py:1151, delegate_tool.py:2671). Also clarifies that non-empty `prefetch()` results are injected into the agent context. Docs-only change.