### PR TITLE
fix(tui): map lineage edit ordinals past compression prefix

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -4547,6 +4547,9 @@ describe('usePromptActions stale-closure session routing', () => {
 })
 
 describe('usePromptActions editMessage stale-target recovery (#82462)', () => {
+  type GatewayRequestFn = <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+  type GatewayMock = GatewayRequestFn & { mock: { calls: unknown[][] } }
+
   afterEach(() => {
     cleanup()
     clearNotifications()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1,3 +1,4 @@
+import { JsonRpcGatewayError } from '@hermes/shared'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
@@ -4542,5 +4543,73 @@ describe('usePromptActions stale-closure session routing', () => {
         expect(params.session_id).toBe(RUNTIME_SESSION_B)
       }
     }
+  })
+})
+
+describe('usePromptActions editMessage stale-target recovery (#82462)', () => {
+  afterEach(() => {
+    cleanup()
+    clearNotifications()
+    setMessages([])
+    $busy.set(false)
+  })
+
+  it('surfaces a compressed-away notice instead of plain-resubmitting without an ordinal', async () => {
+    let handle: HarnessHandle | undefined
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new JsonRpcGatewayError('target user message is no longer in session history', {
+          code: 4018,
+          data: {
+            user_turn_count: 1,
+            ordinal: 0,
+            segment_ordinal: -1,
+            prefix_user_count: 1
+          }
+        })
+      }
+
+      return {} as never
+    }) as unknown as GatewayMock
+
+    const seed = [
+      { id: 'u1', parts: [textPart('pre-compress')], role: 'user' as const, timestamp: 0 },
+      { id: 'a1', parts: [textPart('reply')], role: 'assistant' as const, timestamp: 1 }
+    ]
+    setMessages(seed)
+
+    await actRender(
+      <Harness
+        onReady={h => {
+          handle = h
+        }}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={seed}
+        storedSessionId="stored-1"
+      />
+    )
+
+    await handle!.editMessage({
+      content: [{ text: 'edited', type: 'text' }],
+      parentId: null,
+      role: 'user',
+      sourceId: 'u1'
+    } as never)
+
+    await waitFor(() => {
+      const titles = $notifications.get().map(n => n.title)
+      expect(titles.some(t => /no longer in server history|compressed/i.test(t || ''))).toBe(true)
+    })
+
+    const submitCalls = (requestGateway as unknown as { mock: { calls: unknown[][] } }).mock.calls.filter(
+      ([method]) => method === 'prompt.submit'
+    )
+    // First attempt only — no plain resubmit that drops truncate_before_user_ordinal.
+    expect(submitCalls).toHaveLength(1)
+    expect(submitCalls[0]?.[1]).toMatchObject({
+      truncate_before_user_ordinal: 0,
+      confirm_truncate: true
+    })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -1,4 +1,5 @@
 import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
+import { JsonRpcGatewayError } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
@@ -923,19 +924,49 @@ export function usePromptActions({
       const isStaleTargetError = (err: unknown) =>
         /no longer in session history|not in session history/i.test(err instanceof Error ? err.message : String(err))
 
+      const isCompressedAwayError = (err: unknown) => {
+        if (!(err instanceof JsonRpcGatewayError) || err.code !== 4018) {
+          return false
+        }
+
+        const data = err.data
+        if (!data || typeof data !== 'object') {
+          return false
+        }
+
+        const segmentOrdinal = (data as { segment_ordinal?: unknown }).segment_ordinal
+        return typeof segmentOrdinal === 'number' && segmentOrdinal < 0
+      }
+
       try {
         await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
       } catch (err) {
-        let surfaced = err
+        let surfaced: unknown = err
+        let unavailable = isCompressedAwayError(err)
 
-        if (!plan.isFailedTurn && isStaleTargetError(err)) {
+        // Stale tip ordinal after compression/resume drift: reload server
+        // history, recompute the ordinal against the refreshed transcript, and
+        // retry the real edit once. Do NOT plain-resubmit without an ordinal —
+        // that drops rewind semantics and still fails on long Grok sessions
+        // (#82462).
+        if (!plan.isFailedTurn && !unavailable && isStaleTargetError(err)) {
           try {
-            // Already interrupted on the first attempt — submit as a plain resend.
-            await submitRewindPrompt(sessionId, plan.text, undefined, false)
+            const storedId = selectedStoredSessionIdRef.current
+            if (storedId) {
+              await resumeStoredSession(storedId)
+            }
 
-            return
+            const refreshed = $messages.get()
+            const retryPlan = planEdit(refreshed, edited)
+            if (retryPlan && retryPlan.truncateOrdinal !== undefined) {
+              await submitRewindPrompt(sessionId, retryPlan.text, retryPlan.truncateOrdinal, false)
+              return
+            }
+
+            unavailable = true
           } catch (retryErr) {
             surfaced = retryErr
+            unavailable = isCompressedAwayError(retryErr) || isStaleTargetError(retryErr)
           }
         }
 
@@ -946,10 +977,19 @@ export function usePromptActions({
         setBusy(false)
         setAwaitingResponse(false)
         updateSessionState(sessionId, state => ({ ...state, busy: false, awaitingResponse: false, messages }))
-        notifyError(surfaced, copy.editFailed)
+        notifyError(surfaced, unavailable ? copy.editTurnUnavailable : copy.editFailed)
       }
     },
-    [activeSessionIdRef, busyRef, copy.editFailed, submitRewindPrompt, updateSessionState]
+    [
+      activeSessionIdRef,
+      busyRef,
+      copy.editFailed,
+      copy.editTurnUnavailable,
+      resumeStoredSession,
+      selectedStoredSessionIdRef,
+      submitRewindPrompt,
+      updateSessionState
+    ]
   )
 
   const handleThreadMessagesChange = useCallback(

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2541,6 +2541,7 @@ export const ar = defineLocale({
     stopFailed: 'فشل الإيقاف',
     regenerateFailed: 'فشلت إعادة التوليد',
     editFailed: 'فشل التحرير',
+    editTurnUnavailable: 'هذه الجولة لم تعد في سجل الخادم (ربما أزيلت بالضغط).',
     resumeFailed: 'فشل الاستئناف',
     resumeStrandedTitle: 'تعذّر تحميل هذه الجلسة',
     resumeStrandedBody:

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2929,6 +2929,7 @@ export const en: Translations = {
     stopFailed: 'Stop failed',
     regenerateFailed: 'Regenerate failed',
     editFailed: 'Edit failed',
+    editTurnUnavailable: 'This turn is no longer in server history (it may have been compressed away).',
     resumeFailed: 'Resume failed',
     resumeStrandedTitle: "Couldn't load this session",
     resumeStrandedBody:

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2754,6 +2754,7 @@ export const ja = defineLocale({
     stopFailed: '停止に失敗しました',
     regenerateFailed: '再生成に失敗しました',
     editFailed: '編集に失敗しました',
+    editTurnUnavailable: 'このターンはサーバー履歴にありません（圧縮で削除された可能性があります）。',
     resumeFailed: '再開に失敗しました',
     resumeStrandedTitle: 'このセッションを読み込めませんでした',
     resumeStrandedBody:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2481,6 +2481,7 @@ export interface Translations {
     stopFailed: string
     regenerateFailed: string
     editFailed: string
+    editTurnUnavailable: string
     resumeFailed: string
     resumeStrandedTitle: string
     resumeStrandedBody: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2642,6 +2642,7 @@ export const zhHant = defineLocale({
     stopFailed: '停止失敗',
     regenerateFailed: '重新生成失敗',
     editFailed: '編輯失敗',
+    editTurnUnavailable: '此回合已不在伺服器歷史中（可能已被壓縮移除）。',
     resumeFailed: '繼續失敗',
     resumeStrandedTitle: '無法載入此工作階段',
     resumeStrandedBody: '與此工作階段的連線失敗，自動重試已停止。請確認閘道正在執行，然後重試。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3090,6 +3090,7 @@ export const zh: Translations = {
     stopFailed: '停止失败',
     regenerateFailed: '重新生成失败',
     editFailed: '编辑失败',
+    editTurnUnavailable: '此回合已不在服务器历史中（可能已被压缩移除）。',
     resumeFailed: '恢复失败',
     resumeStrandedTitle: '无法加载此会话',
     resumeStrandedBody: '与此会话的连接失败，自动重试已停止。请确认网关正在运行，然后重试。',

--- a/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-url-guard.test.ts
@@ -1,7 +1,7 @@
 // connect() must reject before WebSocket coerces garbage into
 // `ws://<origin>/[object%20Object]` (#68250 stale-emit boot loop).
 
-import { JsonRpcGatewayClient } from '@hermes/shared'
+import { JsonRpcGatewayClient, JsonRpcGatewayError } from '@hermes/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 class FakeSocket {
@@ -60,6 +60,68 @@ describe('JsonRpcGatewayClient connect() URL guard', () => {
       const client = new JsonRpcGatewayClient({ socketFactory: () => new FakeSocket() as unknown as WebSocket })
       await client.connect(url)
       expect(client.connectionState).toBe('open')
+    }
+  })
+})
+
+describe('JsonRpcGatewayClient structured errors', () => {
+  it('rejects with JsonRpcGatewayError including code and data', async () => {
+    class RespondingSocket {
+      static OPEN = 1
+      readyState = 0
+      private messageHandler: ((event: { data: string }) => void) | null = null
+
+      addEventListener = vi.fn((type: string, handler: (event?: { data: string }) => void) => {
+        if (type === 'open') {
+          setTimeout(() => {
+            this.readyState = RespondingSocket.OPEN
+            handler()
+          }, 0)
+        }
+
+        if (type === 'message') {
+          this.messageHandler = handler as (event: { data: string }) => void
+        }
+      })
+      removeEventListener = vi.fn()
+      close = vi.fn()
+      send = vi.fn((raw: string) => {
+        const req = JSON.parse(raw) as { id: string }
+        queueMicrotask(() => {
+          this.messageHandler?.({
+            data: JSON.stringify({
+              jsonrpc: '2.0',
+              id: req.id,
+              error: {
+                code: 4018,
+                message: 'target user message is no longer in session history',
+                data: { user_turn_count: 2, ordinal: 5, segment_ordinal: 3 }
+              }
+            })
+          })
+        })
+      })
+    }
+
+    vi.stubGlobal('WebSocket', RespondingSocket)
+    try {
+      const client = new JsonRpcGatewayClient({
+        requestTimeoutMs: 5_000,
+        socketFactory: () => new RespondingSocket() as unknown as WebSocket
+      })
+      await client.connect('ws://127.0.0.1:1234/api/ws?token=t')
+
+      await expect(client.request('prompt.submit', { session_id: 's' })).rejects.toEqual(
+        expect.objectContaining({
+          name: 'JsonRpcGatewayError',
+          code: 4018,
+          message: 'target user message is no longer in session history',
+          data: { user_turn_count: 2, ordinal: 5, segment_ordinal: 3 }
+        })
+      )
+      expect(new JsonRpcGatewayError('x')).toBeInstanceOf(Error)
+    } finally {
+      vi.unstubAllGlobals()
     }
   })
 })

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -40,8 +40,10 @@ export {
   type GatewayEvent,
   type GatewayEventName,
   type GatewayRequestId,
+  type JsonRpcErrorPayload,
   type JsonRpcFrame,
   JsonRpcGatewayClient,
+  JsonRpcGatewayError,
   type WebSocketLike
 } from './json-rpc-gateway'
 export { skillInvocationText } from './skill-scaffold'

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -33,12 +33,31 @@ export interface GatewayEvent<P = unknown> {
 export type ConnectionState = 'idle' | 'connecting' | 'open' | 'closed' | 'error'
 export type GatewayRequestId = number | string
 
+export interface JsonRpcErrorPayload {
+  code?: number
+  data?: unknown
+  message?: string
+}
+
 export interface JsonRpcFrame {
-  error?: { message?: string }
+  error?: JsonRpcErrorPayload
   id?: GatewayRequestId | null
   method?: string
   params?: GatewayEvent
   result?: unknown
+}
+
+/** JSON-RPC error with optional structured `data` from the gateway. */
+export class JsonRpcGatewayError extends Error {
+  readonly code?: number
+  readonly data?: unknown
+
+  constructor(message: string, options?: { code?: number; data?: unknown }) {
+    super(message)
+    this.name = 'JsonRpcGatewayError'
+    this.code = options?.code
+    this.data = options?.data
+  }
 }
 
 export type WebSocketLike = WebSocket
@@ -371,7 +390,12 @@ export class JsonRpcGatewayClient {
       this.clearPending(frame.id)
 
       if (frame.error) {
-        call.reject(new Error(frame.error.message || 'Hermes RPC failed'))
+        call.reject(
+          new JsonRpcGatewayError(frame.error.message || 'Hermes RPC failed', {
+            code: typeof frame.error.code === 'number' ? frame.error.code : undefined,
+            data: frame.error.data
+          })
+        )
       } else {
         call.resolve(frame.result)
       }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9653,6 +9653,138 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_prompt_submit_truncate_translates_display_prefix_ordinal(monkeypatch):
+    """Full-lineage Desktop ordinals must truncate the tip segment (#82462).
+
+    After compression, session["history"] is the tip while display_history_prefix
+    still holds ancestor user turns the UI shows. A client ordinal that includes
+    those ancestors must map into the tip, not 4018.
+    """
+
+    seen = {}
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            seen["prompt"] = prompt
+            seen["history"] = conversation_history
+            return {
+                "final_response": "edited reply",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "edited reply"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    tip_history = [
+        {"role": "user", "content": "post-compress A"},
+        {"role": "assistant", "content": "reply A"},
+        {"role": "user", "content": "post-compress B"},
+        {"role": "assistant", "content": "reply B"},
+    ]
+    display_prefix = [
+        {"role": "user", "content": "pre-compress 1"},
+        {"role": "assistant", "content": "pre reply 1"},
+        {"role": "user", "content": "pre-compress 2"},
+        {"role": "assistant", "content": "pre reply 2"},
+    ]
+    # Desktop lineage: pre1=0, pre2=1, postA=2, postB=3
+    desktop_ordinal_for_post_b = 3
+
+    server._sessions["sid"] = _session(
+        agent=_Agent(),
+        history=tip_history,
+        display_history_prefix=display_prefix,
+    )
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def replace_messages(self, session_id, messages, active_only=False):
+            self.replaced.append((session_id, list(messages)))
+
+    stub_db = _StubDb()
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edited post B",
+                    "truncate_before_user_ordinal": desktop_ordinal_for_post_b,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert seen["prompt"] == "edited post B"
+        assert seen["history"] == tip_history[:2]
+        assert stub_db.replaced == [("session-key", tip_history[:2])]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_truncate_oor_includes_structured_user_turn_count(monkeypatch):
+    """4018 after compaction must carry recovery fields for Desktop (#82462)."""
+
+    tip_history = [
+        {"role": "user", "content": "post-compress A"},
+        {"role": "assistant", "content": "reply A"},
+    ]
+    display_prefix = [
+        {"role": "user", "content": "pre-compress 1"},
+        {"role": "assistant", "content": "pre reply 1"},
+    ]
+    # Ordinal 0 points at the ancestor prefix — not editable from the tip.
+    server._sessions["sid"] = _session(
+        history=tip_history,
+        display_history_prefix=display_prefix,
+    )
+
+    try:
+        monkeypatch.setattr(
+            server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        )
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "sid",
+                    "text": "edit ancestor",
+                    "truncate_before_user_ordinal": 0,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        err = resp.get("error") or {}
+        assert err.get("code") == 4018
+        assert "no longer in session history" in (err.get("message") or "")
+        data = err.get("data") or {}
+        assert data.get("user_turn_count") == 1
+        assert data.get("ordinal") == 0
+        assert data.get("segment_ordinal") == -1
+        assert data.get("prefix_user_count") == 1
+    finally:
+        server._sessions.pop("sid", None)
+
+
 # ---------------------------------------------------------------------------
 # session.interrupt must only cancel pending prompts owned by the calling
 # session — it must not blast-resolve clarify/sudo/secret prompts on

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -193,6 +193,18 @@ def _(rid, params: dict) -> dict:
                     "an ordinary prompt.submit must not drop session history "
                     "(update your Hermes client if a rewind was intended)",
                 )
+            # Desktop/TUI ordinals count the full displayed lineage. After
+            # compression, session["history"] holds only the tip segment while
+            # display_history_prefix holds the immutable ancestor display rows
+            # still shown in the transcript (#82462 / #69107). Translate to a
+            # tip-relative ordinal instead of loading ancestors into the tip
+            # (which would duplicate compressed history on later resumes).
+            prefix_user_count = sum(
+                1
+                for message in session.get("display_history_prefix", [])
+                if message.get("role") == "user" and not message.get("display_kind")
+            )
+            segment_ordinal = ordinal - prefix_user_count
             user_indices = [
                 i for i, m in enumerate(history)
                 if m.get("role") == "user" and not m.get("display_kind")
@@ -202,9 +214,21 @@ def _(rid, params: dict) -> dict:
             # indexing below (user_indices[-1] -> the LAST user turn), silently
             # truncating history to everything before it and persisting that loss
             # via replace_messages — an unrecoverable overwrite of the session DB.
-            if ordinal < 0 or ordinal >= len(user_indices):
-                return _err(rid, 4018, "target user message is no longer in session history")
-            truncated = history[: user_indices[ordinal]]
+            # Ancestor-only targets (segment_ordinal < 0) are not editable from
+            # this continuation segment — same stale-target path as tip OOR.
+            if segment_ordinal < 0 or segment_ordinal >= len(user_indices):
+                return _err(
+                    rid,
+                    4018,
+                    "target user message is no longer in session history",
+                    data={
+                        "user_turn_count": len(user_indices),
+                        "ordinal": ordinal,
+                        "segment_ordinal": segment_ordinal,
+                        "prefix_user_count": prefix_user_count,
+                    },
+                )
+            truncated = history[: user_indices[segment_ordinal]]
             # Second gate, on top of confirm_truncate: ordinal 0 resolves to
             # history[:0] == [] and replace_messages() DELETEs every durable
             # row. A confirmed rewind that happens to erase the whole

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1891,8 +1891,11 @@ def _ok(rid, result: dict) -> dict:
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
 
-def _err(rid, code: int, msg: str) -> dict:
-    return {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": msg}}
+def _err(rid, code: int, msg: str, data=None) -> dict:
+    error = {"code": code, "message": msg}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": error}
 
 
 def method(name: str):


### PR DESCRIPTION
## What does this PR do?

After context compression, Desktop/TUI still show ancestor turns from `display_history_prefix` while `prompt.submit`'s `truncate_before_user_ordinal` validates against tip-only `session["history"]`. A full-lineage ordinal was treated as tip-relative and failed with `4018` / `target user message is no longer in session history`.

This translates the client ordinal into a tip-relative `segment_ordinal` (`ordinal - prefix_user_count`), returns structured recovery fields on still-stale `4018`, and teaches Desktop to resume + recompute the ordinal once (or show a clear "compressed away" toast when `segment_ordinal < 0`) instead of a plain failed edit.

## Related Issue

Fixes #82462

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/methods_prompt.py` — subtract `display_history_prefix` user turns before indexing tip `user_indices`; include `user_turn_count` / `ordinal` / `segment_ordinal` / `prefix_user_count` on OOR `4018`
- `tui_gateway/server.py` — `_err(..., data=)` optional structured error payload
- `apps/shared/src/json-rpc-gateway.ts` (+ export) — `JsonRpcGatewayError` with `code` + `data`
- `apps/desktop/.../use-prompt-actions/index.ts` — on stale-target `4018`, resume stored session, recompute edit ordinal, retry once; `segment_ordinal < 0` → `editTurnUnavailable` (no plain resubmit)
- i18n (`en` / `zh` / `zh-hant` / `ja` / `ar` + types) — `editTurnUnavailable`
- Tests — gateway prefix-ordinal translation + structured `4018`; Desktop compressed-away / shared RPC error coverage

## How to Test

1. Gateway: `scripts/run_tests.sh tests/test_tui_gateway_server.py -k "truncate_translates_display_prefix_ordinal or truncate_oor_includes_structured"`
2. Desktop (from `apps/desktop`): `npx vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx src/lib/json-rpc-gateway-url-guard.test.ts`
3. Manual: on a compression-child session whose UI still shows ancestor user turns from the prefix, edit a tip user turn — `prompt.submit` should truncate tip history via the mapped `segment_ordinal` and resubmit. Editing a turn that only exists in the compressed ancestor prefix should surface the unavailable message (`segment_ordinal < 0`), not a silent/plain failure.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (gateway unit coverage for lineage ordinal mapping)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A for UI screenshots. Behavior is covered by gateway unit tests: full-lineage ordinal with `display_history_prefix` maps into the tip and truncates correctly; OOR / ancestor-only targets return `4018` with `segment_ordinal` / `prefix_user_count` for Desktop recovery. Related open work in #69109 reloads fresh history instead; this PR keeps tip-only history and maps the ordinal.

Made with [Cursor](https://cursor.com)