### PR TITLE
fix(auth): stop Spotify OAuth callback server hanging on keep-alive connections

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -36,7 +36,7 @@ import webbrowser
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -2930,6 +2930,12 @@ def _make_spotify_callback_handler(expected_path: str) -> tuple[type[BaseHTTPReq
     }
 
     class _SpotifyCallbackHandler(BaseHTTPRequestHandler):
+        # HTTP/1.0 closes the connection after each response. With HTTP/1.1
+        # keep-alive, a browser connection that stays open blocks the handler's
+        # next read, which wedges a single-threaded server forever (see
+        # _spotify_wait_for_callback below).
+        protocol_version = "HTTP/1.0"
+
         def do_GET(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
             if parsed.path != expected_path:
@@ -2967,8 +2973,11 @@ def _spotify_wait_for_callback(
     host, port, path = _spotify_validate_redirect_uri(redirect_uri)
     handler_cls, result = _make_spotify_callback_handler(path)
 
-    class _ReuseHTTPServer(HTTPServer):
+    class _ReuseHTTPServer(ThreadingHTTPServer):
         allow_reuse_address = True
+        # Each connection is handled in its own thread, so a slow/keep-alive
+        # client can never block serve_forever from noticing server.shutdown().
+        daemon_threads = True
 
     try:
         server = _ReuseHTTPServer((host, port), handler_cls)

--- a/tests/hermes_cli/test_spotify_auth.py
+++ b/tests/hermes_cli/test_spotify_auth.py
@@ -166,3 +166,88 @@ def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure
     assert auth_mod.get_active_provider() == "nous"
 
 
+def test_spotify_wait_for_callback_does_not_deadlock_on_keepalive_connection() -> None:
+    """A keep-alive browser connection must not wedge the callback server.
+
+    Regression for the `hermes auth spotify` deadlock (2026-08): the old
+    server was a single-threaded HTTPServer whose server.shutdown() blocks
+    until serve_forever() returns. An HTTP/1.1 keep-alive connection that
+    stays open after the callback blocked the handler's next read, so
+    serve_forever never noticed the shutdown flag and the wizard hung
+    forever — even though the browser had already been served the
+    "Spotify authorization received" page and the code was captured.
+    """
+    import socket
+    import threading
+    import time
+
+    # Grab a free ephemeral port, then let the callback server bind it.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    redirect_uri = f"http://127.0.0.1:{port}/spotify/callback"
+    result_box: dict = {}
+
+    def _run_wait() -> None:
+        result_box["res"] = auth_mod._spotify_wait_for_callback(
+            redirect_uri, timeout_seconds=10
+        )
+
+    thread = threading.Thread(target=_run_wait, daemon=True)
+    thread.start()
+
+    # Bounded, positive sync: wait until the callback server is listening.
+    deadline = time.monotonic() + 5.0
+    while True:
+        try:
+            sock = socket.create_connection(("127.0.0.1", port), timeout=1.0)
+            break
+        except OSError:
+            if time.monotonic() >= deadline:
+                raise AssertionError("callback server never came up")
+            time.sleep(0.05)
+
+    # Send the real callback over HTTP/1.1 (Chrome-style). The server answers
+    # and closes this connection (HTTP/1.0 semantics), capturing the code.
+    sock.sendall(
+        (
+            f"GET /spotify/callback?code=abc123&state=xyz HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            f"Connection: keep-alive\r\n\r\n"
+        ).encode()
+    )
+    # Read until EOF: the handler flushes headers, then the body, then closes
+    # (HTTP/1.0). A single recv can return headers before the buffered body
+    # lands, so collect until the connection closes.
+    sock.settimeout(2.0)
+    chunks = [sock.recv(4096)]
+    while True:
+        try:
+            data = sock.recv(4096)
+            if not data:
+                break
+            chunks.append(data)
+        except socket.timeout:
+            break
+    response = b"".join(chunks)
+    sock.close()
+
+    # Now open a SECOND connection that sends nothing — Chrome's speculative
+    # preconnect. On the old single-threaded HTTPServer, serve_forever accepts
+    # it after the callback and blocks reading the (never-sent) request, so
+    # server.shutdown() never returns — the wizard hangs forever even though
+    # the callback was already captured. ThreadingHTTPServer handles this
+    # idle connection in its own thread, so shutdown() cannot wedge.
+    idle = socket.create_connection(("127.0.0.1", port), timeout=1.0)
+    time.sleep(0.5)  # generous settle: serve_forever accepts idle within µs
+
+    thread.join(timeout=10.0)
+    idle.close()
+
+    assert not thread.is_alive(), "wait_for_callback deadlocked (shutdown hang)"
+    assert result_box["res"]["code"] == "abc123"
+    assert b"authorization received" in response
+
+


### PR DESCRIPTION
## Problem

`hermes auth spotify` hangs after the user approves consent. The wizard captures the authorization code and serves the "Spotify authorization received" page in the browser, but never exchanges the code for tokens — `hermes auth status spotify` stays `logged out` forever (observed twice, deterministically, on macOS with Chrome; ~2min+ hang).

## Root cause

`_spotify_wait_for_callback` in `hermes_cli/auth.py` runs a **single-threaded** `HTTPServer`:

- The wait loop returns as soon as the callback code is captured, then calls `server.shutdown()` in its `finally` block.
- `HTTPServer.shutdown()` blocks until `serve_forever()` returns.
- Chrome opens a **speculative second connection** to the loopback callback (connected, sends nothing). The single-threaded server accepts it after the callback and blocks reading the never-sent request — so `serve_forever()` never notices the stop flag and the wait never completes.

The hang is deterministic: the wizard also passes `timeout_seconds=180`, but the blocked `readline` is inside the server loop, not the wait loop, so even the timeout can't unblock it.

## Fix

- `ThreadingHTTPServer` with `daemon_threads = True` — each connection is handled in its own thread, so an idle keep-alive client can never block `serve_forever()` from noticing the stop request.
- `protocol_version = "HTTP/1.0"` on the callback handler — the connection closes after each response (belt-and-braces; also avoids lingering keep-alive connections).

## Test

Regression test `test_spotify_wait_for_callback_does_not_deadlock_on_keepalive_connection` reproduces the exact browser pattern (callback + idle second connection) and asserts the wait returns promptly. Verified:

- **Red** on the old server: wait thread still alive after 10s (hang) — test fails.
- **Green** on the fix: passes; 10/10 repeated runs, no flakes.
- Full `tests/hermes_cli/test_spotify_auth.py` and `test_auth_commands.py` pass via `scripts/run_tests.sh`.
