### PR TITLE
fix(slack): preserve interactive context and surface delegated profiles

### DIFF
--- a/contributors/emails/minwoopark@talentedmusicians.co
+++ b/contributors/emails/minwoopark@talentedmusicians.co
@@ -1,0 +1,2 @@
+rooroosu
+# Hermes Crew Slack routing fixes

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21250,6 +21250,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if team_id:
                 metadata = dict(metadata or {})
                 metadata["slack_team_id"] = str(team_id)
+            user_id = getattr(source, "user_id", None)
+            if user_id:
+                metadata = dict(metadata or {})
+                metadata["slack_requester_user_id"] = str(user_id)
         return metadata
 
     def _thread_metadata_for_target(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3772,9 +3772,127 @@ class TurnRunner:
         self._runner = runner
         self._ctx = ctx
 
+    async def _send_delegation_message(
+        self, profile_name: str, content: str
+    ) -> None:
+        """Post one specialist child utterance into the originating thread."""
+        ctx = self._ctx
+        adapter = self._runner._adapter_for_source(ctx.source)
+        if adapter is None or not content.strip():
+            return
+        metadata = dict(ctx._progress_metadata or {})
+        resolver = getattr(adapter, "profile_persona_for_name", None)
+        if not callable(resolver):
+            slack_identity_adapter = self._runner.adapters.get(Platform.SLACK)
+            resolver = getattr(
+                slack_identity_adapter, "profile_persona_for_name", None
+            )
+            if slack_identity_adapter is not None and callable(resolver):
+                adapter = slack_identity_adapter
+        persona = resolver(profile_name) if callable(resolver) else None
+        if isinstance(persona, dict):
+            metadata["_slack_profile_persona"] = persona
+        result = await adapter.send(
+            chat_id=ctx.source.chat_id,
+            content=content,
+            reply_to=ctx._progress_reply_to,
+            metadata=metadata or None,
+        )
+        if not getattr(result, "success", False):
+            logger.warning(
+                "Delegated profile message delivery failed for %s: %s",
+                profile_name,
+                getattr(result, "error", "unknown error"),
+            )
+
+    def _schedule_delegation_message(self, profile_name: str, content: str) -> None:
+        future = safe_schedule_threadsafe(
+            self._send_delegation_message(profile_name, content),
+            self._runner._gateway_loop,
+            logger=logger,
+            log_message="delegated profile message scheduling failed",
+        )
+        if future is None:
+            logger.warning(
+                "Delegated profile message was not scheduled for %s: gateway loop unavailable",
+                profile_name,
+            )
+            return
+
+        def _observe_delivery(done) -> None:
+            try:
+                done.result()
+            except Exception:
+                logger.warning(
+                    "Delegated profile message task failed for %s",
+                    profile_name,
+                    exc_info=True,
+                )
+
+        future.add_done_callback(_observe_delivery)
+
     def progress_callback(self, event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
         """Callback invoked by agent on tool lifecycle events."""
         ctx = self._ctx
+        # Transparent specialist delegation for Slack. delegate_task children
+        # often outlive the parent turn, so this cannot use the per-turn
+        # progress sender (it is cancelled when Luffy's immediate turn ends).
+        # Keep a tiny per-child transcript buffer and post only start + final
+        # utterance under the configured profile persona; internal tool calls
+        # and reasoning remain hidden.
+        if str(event_type).startswith("subagent."):
+            if not ctx.delegation_progress_enabled:
+                return
+            profile_name = str(kwargs.get("profile_name") or "").strip().lower()
+            if not profile_name:
+                return
+            child_key = str(
+                kwargs.get("child_session_id")
+                or kwargs.get("subagent_id")
+                or f"task-{kwargs.get('task_index', 0)}"
+            )
+            lock = ctx.delegation_lock
+            if event_type == "subagent.start":
+                logger.info(
+                    "Relaying Slack delegation transcript for profile=%s child=%s",
+                    profile_name,
+                    child_key,
+                )
+                if lock:
+                    with lock:
+                        ctx.delegation_text[child_key] = []
+                        ctx.delegation_profiles[child_key] = profile_name
+                self._schedule_delegation_message(
+                    profile_name,
+                    (
+                        f"_{profile_name.title()}가 위임 작업을 시작했습니다._\n"
+                        f"> {str(preview or kwargs.get('goal') or '').strip()[:240]}"
+                    ).rstrip(),
+                )
+                return
+            if event_type == "subagent.text":
+                if preview:
+                    if lock:
+                        with lock:
+                            ctx.delegation_text.setdefault(child_key, []).append(str(preview))
+                return
+            if event_type == "subagent.complete":
+                if lock:
+                    with lock:
+                        text = "".join(ctx.delegation_text.pop(child_key, [])).strip()
+                        ctx.delegation_profiles.pop(child_key, None)
+                else:
+                    text = ""
+                status = str(kwargs.get("status") or "completed")
+                if not text:
+                    text = str(kwargs.get("summary") or preview or "").strip()
+                if not text:
+                    text = "작업을 완료했습니다." if status == "completed" else f"작업 상태: {status}"
+                if status != "completed":
+                    text = f"⚠️ 작업이 {status} 상태로 끝났습니다.\n{text}"
+                self._schedule_delegation_message(profile_name, text)
+                return
+            return
         # Live status line (Slack's assistant status): stash the current
         # tool phrase on the adapter; the _keep_typing refresh renders it
         # within a couple of seconds. Handled before every other gate
@@ -5004,9 +5122,16 @@ class TurnRunner:
                 ctx.needs_progress_queue
                 or ctx.log_mode_enabled
                 or ctx._live_status_adapter is not None
+                or ctx.delegation_progress_enabled
             )
             else None
         )
+        if ctx.delegation_progress_enabled:
+            logger.info(
+                "Slack delegation transcript callback armed session=%s adapter=%s",
+                ctx.session_key,
+                type(self._runner._adapter_for_source(ctx.source)).__name__,
+            )
         # Discord voice verbal-ack hook (fires once per turn on first tool
         # call; armed only when in a voice channel with the mixer running).
         agent.tool_start_callback = (
@@ -25219,6 +25344,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         _thinking_enabled = _thinking_mode != "off"
         needs_progress_queue = tool_progress_enabled or _thinking_enabled
+        # Capability-gate this instead of comparing the source enum. In a
+        # multiplex gateway the same native Slack adapter can be reached
+        # through a routed source whose platform wrapper is not identity-equal
+        # to this module's Platform.SLACK enum. The adapter capability is the
+        # actual requirement for truthful name/icon attribution.
+        _delegation_adapter = self._adapter_for_source(source)
+        _source_platform_name = str(
+            getattr(getattr(source, "platform", None), "value", None)
+            or getattr(source, "platform", "")
+        ).strip().lower()
+        delegation_progress_enabled = (
+            _source_platform_name == "slack"
+            or callable(
+                getattr(_delegation_adapter, "profile_persona_for_name", None)
+            )
+        )
 
 
         # Queue for progress messages (thread-safe)
@@ -25291,6 +25432,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             progress_mode=progress_mode,
             progress_grouping=progress_grouping,
             tool_progress_enabled=tool_progress_enabled,
+            delegation_progress_enabled=delegation_progress_enabled,
             progress_queue=progress_queue,
             log_queue=log_queue,
             last_progress_msg=last_progress_msg,
@@ -25298,6 +25440,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             last_was_terminal_block=last_was_terminal_block,
             repeat_count=repeat_count,
             long_tool_hint_fired=long_tool_hint_fired,
+            delegation_lock=threading.Lock(),
             _LONG_TOOL_THRESHOLD_S=_LONG_TOOL_THRESHOLD_S,
             _cleanup_progress=_cleanup_progress,
             _cleanup_msg_ids=_cleanup_msg_ids,

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -42,6 +42,7 @@ class TurnContext:
     progress_mode: str = "off"
     progress_grouping: str = "grouped"
     tool_progress_enabled: bool = False
+    delegation_progress_enabled: bool = False
 
     # --- queues ----------------------------------------------------------
     progress_queue: Any = None
@@ -53,6 +54,9 @@ class TurnContext:
     last_was_terminal_block: list = field(default_factory=lambda: [False])
     repeat_count: list = field(default_factory=lambda: [0])
     long_tool_hint_fired: list = field(default_factory=lambda: [False])
+    delegation_text: dict = field(default_factory=dict)
+    delegation_profiles: dict = field(default_factory=dict)
+    delegation_lock: Any = None
     agent_holder: list = field(default_factory=lambda: [None])
 
     # --- constants / cleanup bookkeeping ---------------------------------

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -27,6 +27,73 @@ SLACK_LONG_DESCRIPTION_MIN_CHARACTERS = 175
 SLACK_LONG_DESCRIPTION_MAX_CHARACTERS = 4000
 
 
+def _configured_profile_slashes() -> list[dict]:
+    """Build manifest entries for opt-in Slack profile invocations."""
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        if not config.multiplex_profiles:
+            return []
+        slack = config.platforms.get(Platform.SLACK)
+        raw = (slack.extra if slack else {}).get("profile_invocations", [])
+    except Exception as exc:
+        raise RuntimeError(
+            "could not load Slack profile invocation configuration"
+        ) from exc
+    if not isinstance(raw, list):
+        return []
+    entries: list[dict] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        profile = str(item.get("profile") or "").strip().lower()
+        slash = str(item.get("slash") or profile).strip().lower().lstrip("/")
+        if (
+            not profile
+            or not slash
+            or slash in seen
+            or len(slash) > 32
+            or any(ch not in "abcdefghijklmnopqrstuvwxyz0123456789-_" for ch in slash)
+        ):
+            continue
+        seen.add(slash)
+        display_name = str(item.get("display_name") or profile.title())
+        entries.append(
+            {
+                "command": f"/{slash}",
+                "description": f"Run the {display_name} Hermes profile"[:140],
+                "usage_hint": "[request]",
+                "should_escape": False,
+                "url": "https://hermes-agent.local/slack/commands",
+            }
+        )
+    return entries
+
+
+def _merge_profile_slashes(
+    slashes: list[dict], profile_slashes: list[dict] | None = None
+) -> list[dict]:
+    """Pin configured profile slashes while preserving Slack's 50-command cap."""
+    if profile_slashes is None:
+        profile_slashes = _configured_profile_slashes()
+    if not profile_slashes:
+        return slashes
+    profile_names = {entry["command"] for entry in profile_slashes}
+    remaining = [
+        entry
+        for entry in slashes
+        if entry["command"] != "/hermes" and entry["command"] not in profile_names
+    ]
+    hermes_entry = next(
+        (entry for entry in slashes if entry["command"] == "/hermes"),
+        None,
+    )
+    merged = ([hermes_entry] if hermes_entry else []) + profile_slashes + remaining
+    return merged[:50]
+
+
 def _build_full_manifest(
     bot_name: str,
     bot_description: str,
@@ -61,7 +128,13 @@ def _build_full_manifest(
         )
 
     partial = slack_app_manifest()
-    slashes = partial["features"]["slash_commands"]
+    # Slack caps an app at 50 slash commands. Keep /hermes first, then pin
+    # configured profile invocations ahead of lower-priority native commands;
+    # every displaced command remains reachable via /hermes.
+    profile_slashes = _configured_profile_slashes()
+    slashes = _merge_profile_slashes(
+        partial["features"]["slash_commands"], profile_slashes
+    )
 
     features = {
         "app_home": {
@@ -94,6 +167,8 @@ def _build_full_manifest(
         "reactions:read",
         "users:read",
     ]
+    if profile_slashes:
+        bot_scopes.append("chat:write.customize")
 
     bot_events = [
         "app_mention",
@@ -241,7 +316,9 @@ def slack_manifest_command(args) -> int:
     if getattr(args, "slashes_only", False):
         from hermes_cli.commands import slack_app_manifest
 
-        manifest = slack_app_manifest()["features"]["slash_commands"]
+        manifest = _merge_profile_slashes(
+            slack_app_manifest()["features"]["slash_commands"]
+        )
     else:
         manifest = _build_full_manifest(
             name,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1056,6 +1056,13 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        # The Slack SDK performs its own reconnect while the websocket is
+        # momentarily disconnected.  Do not tear the handler down on the first
+        # failed probe: doing so can close the SDK's shared aiohttp session
+        # while its reconnect coroutine is still inside connect(), leaving a
+        # zombie task that retries "Session is closed" forever.
+        self._socket_unhealthy_since_monotonic: Optional[float] = None
+        self._socket_reconnect_grace_s = 30.0
         # Monotonic timestamp of the most recent Socket Mode handler (re)start,
         # used to grant a grace window for the first ping/pong after connect.
         self._socket_handler_started_monotonic: Optional[float] = None
@@ -1214,7 +1221,26 @@ class SlackAdapter(BasePlatformAdapter):
         task = asyncio.create_task(self._handler.start_async())
         self._socket_mode_task = task
         self._socket_handler_started_monotonic = time.monotonic()
+        self._socket_unhealthy_since_monotonic = None
         task.add_done_callback(self._on_socket_mode_task_done)
+
+    def _socket_restart_grace_elapsed(self) -> bool:
+        """Return True only after a transport fault survives the grace window.
+
+        A single disconnected/stale observation commonly occurs while
+        slack_sdk is already replacing its websocket.  Waiting for a second,
+        sustained observation lets that native reconnect finish and prevents
+        the watchdog from racing it.  Missing/stopped top-level handler tasks
+        remain immediate restart conditions because no SDK reconnect can
+        recover those states.
+        """
+        now = time.monotonic()
+        if self._socket_unhealthy_since_monotonic is None:
+            self._socket_unhealthy_since_monotonic = now
+            return False
+        return (
+            now - self._socket_unhealthy_since_monotonic
+        ) >= self._socket_reconnect_grace_s
 
     async def _stop_socket_mode_handler(self) -> None:
         """Stop Socket Mode handler and task.
@@ -1339,21 +1365,33 @@ class SlackAdapter(BasePlatformAdapter):
 
                 task = self._socket_mode_task
                 if task is None:
+                    self._socket_unhealthy_since_monotonic = None
                     await self._restart_socket_mode("socket task missing")
                     continue
 
                 if task.done():
+                    self._socket_unhealthy_since_monotonic = None
                     await self._restart_socket_mode("socket task stopped")
                     continue
 
                 connected = await self._socket_transport_connected()
-                if connected is False:
-                    await self._restart_socket_mode("transport disconnected")
-                elif self._socket_ping_pong_stale():
+                stale = self._socket_ping_pong_stale()
+                if connected is False or stale:
+                    if not self._socket_restart_grace_elapsed():
+                        continue
+                    reason = (
+                        "transport disconnected"
+                        if connected is False
+                        else "ping/pong stale"
+                    )
                     # is_connected() can lie when the aiohttp session is closed
                     # but the client keeps retrying; ping/pong staleness catches
                     # that wedged-zombie case that the bool check above misses.
-                    await self._restart_socket_mode("ping/pong stale")
+                    await self._restart_socket_mode(reason)
+                else:
+                    # A native Slack SDK reconnect completed within the grace
+                    # window, so a future fault must start a fresh observation.
+                    self._socket_unhealthy_since_monotonic = None
             except asyncio.CancelledError:
                 raise
             except Exception:  # pragma: no cover - defensive logging

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -9302,14 +9302,11 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     legacy ``slack_cfg`` block that used to live in
     ``gateway/config.py::load_gateway_config()`` before this migration.
 
-    The SlackAdapter reads its runtime configuration via ``os.getenv()``
-    throughout the connect / handle code paths, so rather than rewrite those
-    call sites to read from ``PlatformConfig.extra``, this hook keeps the
-    existing env-driven model and owns the YAML→env translation here, next to
-    the adapter that consumes it. Env vars take precedence over YAML — every
-    assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    Most SlackAdapter settings are env-driven. Profile invocation metadata is
+    intentionally different: it is structured, non-secret configuration read
+    from ``PlatformConfig.extra`` at dispatch time. Preserve those keys when
+    the Slack block lives under ``gateway.platforms.slack`` so live YAML loads
+    match adapters constructed directly in tests.
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -9361,7 +9358,11 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
         os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
-    return None  # all settings flow through env; nothing to merge into extras
+    extras = {}
+    for key in ("profile_invocations", "profile_invocation_store"):
+        if key in slack_cfg:
+            extras[key] = slack_cfg[key]
+    return extras or None
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -971,6 +971,13 @@ class SlackAdapter(BasePlatformAdapter):
         # user never clicks would otherwise leak its entry forever. Keys may
         # be workspace-scoped markers (team_id, ts) in multi-workspace mode.
         self._approval_resolved: Dict[Any, bool] = {}
+        # Approval prompt marker -> the already-authorized Slack user who
+        # triggered the agent turn. Interactive payloads do not carry the
+        # Hermes profile stamp, so re-running profile-scoped auth on a button
+        # click can reject the same owner who was authorized at message intake.
+        # Binding the button to its requester preserves least privilege without
+        # widening SLACK_ALLOWED_USERS globally.
+        self._approval_requesters: Dict[Any, str] = {}
         self._APPROVAL_RESOLVED_MAX = 1000
         # Same guard for clarify prompts (interactive multiple-choice
         # buttons); mirrors _approval_resolved.
@@ -6772,11 +6779,18 @@ class SlackAdapter(BasePlatformAdapter):
             msg_ts = result.get("ts", "")
             if msg_ts:
                 team_id = self._metadata_team_id(metadata)
-                self._approval_resolved[
-                    self._workspace_message_marker(team_id, msg_ts)
-                ] = False
+                approval_marker = self._workspace_message_marker(team_id, msg_ts)
+                self._approval_resolved[approval_marker] = False
+                requester_user_id = str(
+                    (metadata or {}).get("slack_requester_user_id") or ""
+                ).strip()
+                if requester_user_id:
+                    self._approval_requesters[approval_marker] = requester_user_id
                 self._trim_oldest_dict_entries(
                     self._approval_resolved, self._APPROVAL_RESOLVED_MAX
+                )
+                self._trim_oldest_dict_entries(
+                    self._approval_requesters, self._APPROVAL_RESOLVED_MAX
                 )
 
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
@@ -7191,11 +7205,17 @@ class SlackAdapter(BasePlatformAdapter):
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
 
-        if not self._is_interactive_user_authorized(
-            user_id,
-            channel_id=channel_id,
-            user_name=user_name,
-            team_id=team_id,
+        approval_key = self._workspace_message_marker(team_id, msg_ts)
+        # Older or metadata-poor send paths key prompts by timestamp only.
+        # Select that key before requester authorization so the initiating
+        # user receives the same least-privilege exception in both cases.
+        if msg_ts in self._approval_resolved:
+            approval_key = msg_ts
+        expected_requester = self._approval_requesters.get(approval_key)
+        requester_matches = bool(expected_requester and user_id == expected_requester)
+
+        if not requester_matches and not self._is_interactive_user_authorized(
+            user_id, channel_id=channel_id, user_name=user_name, team_id=team_id
         ):
             logger.warning(
                 "[Slack] Unauthorized approval click by %s (%s) - ignoring",
@@ -7231,11 +7251,9 @@ class SlackAdapter(BasePlatformAdapter):
         # may have been stored without a team id (metadata-poor send path)
         # while the click event carries one, and that mismatch must not
         # swallow a legitimate first click.
-        approval_key = self._workspace_message_marker(team_id, msg_ts)
-        if msg_ts in self._approval_resolved:
-            approval_key = msg_ts
         if self._approval_resolved.pop(approval_key, True):
             return
+        self._approval_requesters.pop(approval_key, None)
 
         # Resolve the approval FIRST — this unblocks the agent thread. Render
         # after, so a click that lands past the approval timeout (count == 0)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -982,6 +982,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Same guard for clarify prompts (interactive multiple-choice
         # buttons); mirrors _approval_resolved.
         self._clarify_resolved: Dict[Any, bool] = {}
+        self._clarify_requesters: Dict[Any, str] = {}
         self._CLARIFY_RESOLVED_MAX = 1000
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
@@ -6969,14 +6970,26 @@ class SlackAdapter(BasePlatformAdapter):
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
-            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            team_id = self._metadata_team_id(metadata)
+            result = await self._get_client(
+                chat_id, team_id=team_id
+            ).chat_postMessage(**kwargs)
             msg_ts = result.get("ts", "")
             if msg_ts:
                 # Mark unresolved so the action handler's atomic-pop guard can
                 # reject double-clicks (mirrors _approval_resolved).
-                self._clarify_resolved[msg_ts] = False
+                clarify_marker = self._workspace_message_marker(team_id, msg_ts)
+                self._clarify_resolved[clarify_marker] = False
+                requester_user_id = str(
+                    (metadata or {}).get("slack_requester_user_id") or ""
+                ).strip()
+                if requester_user_id:
+                    self._clarify_requesters[clarify_marker] = requester_user_id
                 self._trim_oldest_dict_entries(
                     self._clarify_resolved, self._CLARIFY_RESOLVED_MAX
+                )
+                self._trim_oldest_dict_entries(
+                    self._clarify_requesters, self._CLARIFY_RESOLVED_MAX
                 )
 
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
@@ -7366,13 +7379,18 @@ class SlackAdapter(BasePlatformAdapter):
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
+        team_id = self._event_team_id({}, body)
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
 
-        if not self._is_interactive_user_authorized(
-            user_id,
-            channel_id=channel_id,
-            user_name=user_name,
+        clarify_key = self._workspace_message_marker(team_id, msg_ts)
+        if msg_ts in self._clarify_resolved:
+            clarify_key = msg_ts
+        expected_requester = self._clarify_requesters.get(clarify_key)
+        requester_matches = bool(expected_requester and user_id == expected_requester)
+
+        if not requester_matches and not self._is_interactive_user_authorized(
+            user_id, channel_id=channel_id, user_name=user_name, team_id=team_id
         ):
             logger.warning(
                 "[Slack] Unauthorized clarify click by %s (%s) - ignoring",
@@ -7388,8 +7406,9 @@ class SlackAdapter(BasePlatformAdapter):
 
         # Double-click guard — atomic pop; first caller gets False (proceed),
         # any later click gets the True default and bails (mirrors approval).
-        if self._clarify_resolved.pop(msg_ts, True):
+        if self._clarify_resolved.pop(clarify_key, True):
             return
+        self._clarify_requesters.pop(clarify_key, None)
 
         # Preserve the original question so the resolved message keeps context.
         original_text = ""

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -262,6 +262,16 @@ _slash_user_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     default=None,
 )
 
+# The Slack app can present replies from several isolated Hermes profiles while
+# keeping one Socket Mode connection.  This context is set only for an inbound
+# user turn (including a continued thread), so cron and other synthetic sends
+# retain the Slack app's normal identity.
+_profile_persona: contextvars.ContextVar[Optional[Dict[str, str]]] = (
+    contextvars.ContextVar("_profile_persona", default=None)
+)
+_PROFILE_PERSONA_METADATA_KEY = "_slack_profile_persona"
+_SLASH_USER_ID_METADATA_KEY = "_slack_slash_user_id"
+
 
 @dataclass
 class _ThreadContextCache:
@@ -1028,6 +1038,17 @@ class SlackAdapter(BasePlatformAdapter):
         # commands that arrived without a workspace id.
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, ...], Dict[str, Any]] = {}
+        # Durable Slack thread -> profile bindings for configured profile
+        # invocations. Values contain only public routing/display metadata;
+        # credentials never enter this store.
+        self._profile_thread_routes: Dict[str, Dict[str, str]] = {}
+        self._PROFILE_THREAD_ROUTES_MAX = 5000
+        # Capture the default gateway-owned path now. During a routed turn the
+        # process-wide HERMES_HOME scope temporarily points at the selected
+        # profile; recomputing then would split one Slack route store across
+        # multiple profile homes.
+        self._profile_route_store = self._profile_route_store_path()
+        self._load_profile_thread_routes()
         # Socket Mode resilience: track runtime connection state so we can
         # self-heal when Slack silently drops the websocket.
         self._app_token: Optional[str] = None
@@ -1528,6 +1549,186 @@ class SlackAdapter(BasePlatformAdapter):
             return self._slash_command_contexts.pop(key, None)
 
         return None
+
+    def _profile_invocation_specs(self) -> Dict[str, Dict[str, Any]]:
+        """Return configured Slack invocation aliases keyed by slash name.
+
+        Configuration lives under ``gateway.slack.profile_invocations`` and is
+        deliberately opt-in. Example::
+
+            profile_invocations:
+              - profile: nami
+                slash: nami
+                aliases: [nami, "나미"]
+                display_name: Nami
+                icon_emoji: ":hermes_nami:"
+        """
+        # Display customization is truthful only when the gateway will also
+        # honor source.profile for runtime/session selection. Fail closed on a
+        # single-profile gateway instead of showing "Nami" while running Luffy.
+        from agent.secret_scope import is_multiplex_active
+
+        if not is_multiplex_active():
+            return {}
+        raw = self.config.extra.get("profile_invocations", [])
+        if not isinstance(raw, list):
+            return {}
+        specs: Dict[str, Dict[str, Any]] = {}
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            profile = str(item.get("profile") or "").strip().lower()
+            slash = str(item.get("slash") or profile).strip().lower().lstrip("/")
+            if not profile or not slash or not re.fullmatch(r"[a-z0-9_-]{1,32}", slash):
+                continue
+            try:
+                from hermes_cli.profiles import profile_exists, validate_profile_name
+
+                validate_profile_name(profile)
+                if not profile_exists(profile):
+                    logger.error(
+                        "[Slack] Profile invocation /%s targets missing profile %s",
+                        slash,
+                        profile,
+                    )
+                    continue
+            except (ImportError, ValueError, OSError):
+                continue
+            aliases = item.get("aliases") or [profile]
+            if isinstance(aliases, str):
+                aliases = [aliases]
+            aliases = [
+                str(alias).strip().casefold()
+                for alias in aliases
+                if str(alias).strip()
+            ]
+            if profile.casefold() not in aliases:
+                aliases.append(profile.casefold())
+            icon = str(item.get("icon_emoji") or "").strip()
+            if icon and not (icon.startswith(":") and icon.endswith(":")):
+                icon = f":{icon.strip(':')}:"
+            specs[slash] = {
+                "profile": profile,
+                "slash": slash,
+                "aliases": aliases,
+                "display_name": str(item.get("display_name") or profile.title())[:80],
+                "icon_emoji": icon,
+            }
+        return specs
+
+    def _profile_route_store_path(self) -> _Path:
+        captured = getattr(self, "_profile_route_store", None)
+        if captured is not None:
+            return captured
+        configured = str(self.config.extra.get("profile_invocation_store") or "").strip()
+        if configured:
+            return _Path(configured).expanduser()
+        from hermes_constants import get_hermes_home
+
+        return _Path(get_hermes_home()) / "gateway" / "slack-profile-invocations.json"
+
+    def _load_profile_thread_routes(self) -> None:
+        try:
+            payload = json.loads(self._profile_route_store_path().read_text(encoding="utf-8"))
+            routes = payload.get("routes", {}) if isinstance(payload, dict) else {}
+            if isinstance(routes, dict):
+                self._profile_thread_routes = {
+                    str(key): value
+                    for key, value in routes.items()
+                    if isinstance(value, dict) and value.get("profile")
+                }
+        except FileNotFoundError:
+            return
+        except (OSError, ValueError, TypeError) as exc:
+            logger.warning("[Slack] Could not load profile thread routes: %s", exc)
+
+    def _save_profile_thread_routes(self) -> None:
+        path = self._profile_route_store_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(
+                json.dumps({"version": 1, "routes": self._profile_thread_routes}, sort_keys=True),
+                encoding="utf-8",
+            )
+            os.replace(tmp, path)
+        except OSError as exc:
+            logger.warning("[Slack] Could not persist profile thread routes: %s", exc)
+
+    @staticmethod
+    def _profile_thread_key(team_id: str, channel_id: str, thread_ts: str) -> str:
+        return "\x1f".join((str(team_id or ""), str(channel_id), str(thread_ts)))
+
+    def _bind_profile_thread(
+        self, team_id: str, channel_id: str, thread_ts: str, spec: Dict[str, Any]
+    ) -> None:
+        if not thread_ts:
+            return
+        key = self._profile_thread_key(team_id, channel_id, thread_ts)
+        self._profile_thread_routes[key] = {
+            "profile": str(spec["profile"]),
+            "display_name": str(spec.get("display_name") or ""),
+            "icon_emoji": str(spec.get("icon_emoji") or ""),
+        }
+        if len(self._profile_thread_routes) > self._PROFILE_THREAD_ROUTES_MAX:
+            excess = len(self._profile_thread_routes) - self._PROFILE_THREAD_ROUTES_MAX
+            for old_key in list(self._profile_thread_routes)[:excess]:
+                self._profile_thread_routes.pop(old_key, None)
+        self._save_profile_thread_routes()
+
+    def _continued_profile_spec(
+        self, team_id: str, channel_id: str, thread_ts: Optional[str]
+    ) -> Optional[Dict[str, str]]:
+        if not thread_ts:
+            return None
+        stored = self._profile_thread_routes.get(
+            self._profile_thread_key(team_id, channel_id, thread_ts)
+        )
+        if not stored:
+            return None
+        # Configuration is the authority. A stale/tampered route file must not
+        # keep invoking a profile that the operator removed from Slack.
+        configured = {
+            str(spec["profile"]): spec
+            for spec in self._profile_invocation_specs().values()
+        }
+        return configured.get(str(stored.get("profile") or ""))
+
+    def _match_profile_alias(
+        self, text: str
+    ) -> Tuple[Optional[Dict[str, Any]], str]:
+        stripped = str(text or "").lstrip()
+        folded = stripped.casefold()
+        for spec in self._profile_invocation_specs().values():
+            for alias in sorted(spec["aliases"], key=len, reverse=True):
+                if folded == alias:
+                    return spec, ""
+                if folded.startswith(alias) and len(stripped) > len(alias):
+                    boundary = stripped[len(alias)]
+                    if boundary.isspace() or boundary in ":：,-":
+                        return spec, stripped[len(alias) :].lstrip(" \t:：,-")
+        return None, text
+
+    def _profile_slash_source_allowed(self, source: Any) -> bool:
+        """Apply Slack's user/channel gates before a crew slash dispatch."""
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if source.user_id and callable(auth_fn) and not auth_fn(source):
+            logger.warning(
+                "[Slack] Early reject of unauthorized profile slash user %s in channel %s",
+                source.user_id,
+                source.chat_id,
+            )
+            return False
+        if source.chat_type != "dm":
+            allowed_channels = self._slack_allowed_channels()
+            if allowed_channels and source.chat_id not in allowed_channels:
+                logger.info(
+                    "[Slack] Ignoring profile slash in non-allowed channel %s",
+                    source.chat_id,
+                )
+                return False
+        return True
 
     async def _send_slash_ephemeral(
         self,
@@ -2066,6 +2267,8 @@ class SlackAdapter(BasePlatformAdapter):
             import re as _re
 
             _slash_names = [name for name, _d, _h in slack_native_slashes()]
+            _slash_names.extend(self._profile_invocation_specs())
+            _slash_names = list(dict.fromkeys(_slash_names))
             if _slash_names:
                 _slash_pattern = _re.compile(
                     r"^/(?:" + "|".join(_re.escape(n) for n in _slash_names) + r")$"
@@ -2076,10 +2279,16 @@ class SlackAdapter(BasePlatformAdapter):
             @self._app.command(_slash_pattern)
             async def handle_hermes_command(ack, command):
                 slash = (command.get("command") or "").lstrip("/")
-                await ack(
-                    response_type="ephemeral",
-                    text=f"Running `/{slash}`…",
-                )
+                if slash in self._profile_invocation_specs():
+                    # A profile slash produces one public customized response.
+                    # Acknowledge silently so Slack does not leave a stale
+                    # ephemeral "Running" placeholder behind.
+                    await ack()
+                else:
+                    await ack(
+                        response_type="ephemeral",
+                        text=f"Running `/{slash}`…",
+                    )
                 await self._handle_slash_command(command)
 
             # Register Block Kit action handlers for approval buttons
@@ -2447,6 +2656,31 @@ class SlackAdapter(BasePlatformAdapter):
         ignored = self._slack_ignored_channels()
         return "*" in ignored or parent_channel_id in ignored
 
+    async def _process_message_background(
+        self, event: MessageEvent, session_key: str
+    ) -> None:
+        """Restore the Slack persona carried by this queued event.
+
+        Context variables are copied when a task is created, but busy-session
+        follow-ups are drained by a task created from the previous turn.  Read
+        the event's own value here so a profile switch cannot inherit the
+        prior turn's display identity.  An absent value deliberately clears
+        the persona for ordinary slash commands and synthetic events.
+        """
+        persona = event.metadata.get(_PROFILE_PERSONA_METADATA_KEY)
+        persona_token = _profile_persona.set(
+            persona if isinstance(persona, dict) else None
+        )
+        slash_user_id = event.metadata.get(_SLASH_USER_ID_METADATA_KEY)
+        slash_token = _slash_user_id.set(
+            str(slash_user_id) if slash_user_id else None
+        )
+        try:
+            await super()._process_message_background(event, session_key)
+        finally:
+            _slash_user_id.reset(slash_token)
+            _profile_persona.reset(persona_token)
+
     async def send(
         self,
         chat_id: str,
@@ -2470,12 +2704,13 @@ class SlackAdapter(BasePlatformAdapter):
         thread_ts = None
         try:
             team_id = self._metadata_team_id(metadata)
+            persona = _profile_persona.get()
             # Check for a pending slash-command context.  When the user ran a
             # native slash command (e.g. /q, /stop, /model), the initial ack
             # already showed an ephemeral "Running /cmd…" message.  If we have
             # a stashed response_url for this channel, replace that ack with
             # the actual command reply ephemerally instead of posting publicly.
-            slash_ctx = self._pop_slash_context(chat_id, team_id)
+            slash_ctx = None if persona else self._pop_slash_context(chat_id, team_id)
             if slash_ctx:
                 ephemeral_result = await self._send_slash_ephemeral(
                     slash_ctx,
@@ -2562,6 +2797,11 @@ class SlackAdapter(BasePlatformAdapter):
                     # Only broadcast the first chunk of the first reply
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
+                if persona:
+                    if persona.get("display_name"):
+                        kwargs["username"] = persona["display_name"]
+                    if persona.get("icon_emoji"):
+                        kwargs["icon_emoji"] = persona["icon_emoji"]
 
                 try:
                     last_result = await self._get_client(
@@ -2589,6 +2829,13 @@ class SlackAdapter(BasePlatformAdapter):
             # replies without requiring @mention.
             sent_ts = last_result.get("ts") if last_result else None
             if sent_ts:
+                if persona:
+                    self._bind_profile_thread(
+                        team_id,
+                        chat_id,
+                        thread_ts or str(sent_ts),
+                        persona,
+                    )
                 self._bot_message_ts.add(
                     self._workspace_message_marker(team_id, sent_ts)
                 )
@@ -6319,6 +6566,24 @@ class SlackAdapter(BasePlatformAdapter):
             },
         )
 
+        # Resolve explicit ``@App <alias> ...`` invocations only after Slack's
+        # authorization/channel/mention gates above have accepted the event.
+        # A thread binding then keeps later unqualified replies on the same
+        # profile, including after a gateway restart.
+        profile_spec = None
+        if not is_command_text and (is_mentioned or is_one_to_one_dm):
+            profile_spec, routed_text = self._match_profile_alias(msg_event.text)
+            if profile_spec:
+                msg_event.text = routed_text or "/profile"
+        if profile_spec is None:
+            profile_spec = self._continued_profile_spec(team_id, channel_id, thread_ts)
+        if profile_spec:
+            source.profile = str(profile_spec["profile"])
+            if thread_ts:
+                self._bind_profile_thread(team_id, channel_id, thread_ts, profile_spec)
+        msg_event.metadata[_PROFILE_PERSONA_METADATA_KEY] = profile_spec
+        msg_event.metadata[_SLASH_USER_ID_METADATA_KEY] = None
+
         # Only react when bot is directly addressed (1:1 DM or @mention).
         # MPIMs are shared surfaces: reacting to every group-DM message (even
         # when unmentioned) is visible noise to the whole group, so they must
@@ -6362,7 +6627,11 @@ class SlackAdapter(BasePlatformAdapter):
                 )[-self._PROCESSED_MESSAGE_TS_MAX :]
                 self._processed_message_ts = dict(newest_items)
 
-        await self.handle_message(msg_event)
+        _profile_token = _profile_persona.set(profile_spec)
+        try:
+            await self.handle_message(msg_event)
+        finally:
+            _profile_persona.reset(_profile_token)
 
     # ----- Approval button support (Block Kit) -----
 
@@ -7669,12 +7938,37 @@ class SlackAdapter(BasePlatformAdapter):
         user_id = command.get("user_id", "")
         channel_id = command.get("channel_id", "")
         team_id = command.get("team_id", "")
+        profile_spec = self._profile_invocation_specs().get(slash_name)
+        profile_routed_text = None
+        if profile_spec is None and slash_name in {"hermes", ""}:
+            # Slack caps apps at 25 slash commands.  Long-lived Hermes apps
+            # may already be at that limit, so keep the single-entry-point
+            # form useful as a no-slot fallback: ``/hermes nami ...``.
+            profile_spec, profile_routed_text = self._match_profile_alias(raw_text)
+
+        # Crew slashes must obey the same hard channel kill switch as normal
+        # Slack messages. Stop before stamping source.profile or invoking the
+        # gateway so an ignored channel cannot consume another profile's turn.
+        if profile_spec and self._is_ignored_channel(channel_id):
+            logger.info(
+                "[Slack] Ignoring profile slash /%s in ignored channel %s",
+                slash_name,
+                channel_id,
+            )
+            return
 
         # Track which workspace owns this channel
         if team_id and channel_id:
             self._remember_channel_team(channel_id, team_id)
 
-        if slash_name in {"hermes", ""}:
+        if profile_spec:
+            # Crew/profile slashes are prompts, not gateway control commands.
+            # Their reply is public and uses the selected profile's display
+            # identity; ordinary native slashes keep the existing ephemeral
+            # response path.
+            routed = raw_text if profile_routed_text is None else profile_routed_text
+            text = routed.strip() or "/profile"
+        elif slash_name in {"hermes", ""}:
             # Legacy /hermes <subcommand> [args] routing + free-form questions.
             # Empty slash_name falls into this branch for backward compat
             # with any caller that didn't populate command["command"].
@@ -7749,6 +8043,12 @@ class SlackAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             scope_id=team_id or None,
         )
+        if profile_spec:
+            if not self._profile_slash_source_allowed(source):
+                return
+            source.profile = str(profile_spec["profile"])
+            if thread_id:
+                self._bind_profile_thread(team_id, channel_id, thread_id, profile_spec)
 
         event = MessageEvent(
             text=text,
@@ -7757,6 +8057,10 @@ class SlackAdapter(BasePlatformAdapter):
             ),
             source=source,
             raw_message=command,
+            metadata={
+                _PROFILE_PERSONA_METADATA_KEY: profile_spec,
+                _SLASH_USER_ID_METADATA_KEY: user_id or None,
+            },
         )
 
         # Stash the Slack response_url so the first reply for this
@@ -7766,7 +8070,13 @@ class SlackAdapter(BasePlatformAdapter):
         # questions via "/hermes <question>" must produce public replies so
         # the whole channel can see the agent's answer.
         response_url = command.get("response_url", "")
-        if response_url and user_id and channel_id and text.startswith("/"):
+        if (
+            not profile_spec
+            and response_url
+            and user_id
+            and channel_id
+            and text.startswith("/")
+        ):
             context_key = (
                 (str(team_id), str(channel_id), str(user_id))
                 if team_id
@@ -7804,9 +8114,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Set the ContextVar so send() can match the correct stashed
         # response_url even when multiple users slash concurrently.
         _slash_user_id_token = _slash_user_id.set(user_id or None)
+        _profile_token = _profile_persona.set(profile_spec)
         try:
             await self.handle_message(event)
         finally:
+            _profile_persona.reset(_profile_token)
             _slash_user_id.reset(_slash_user_id_token)
 
     def _build_thread_session_key(

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6571,12 +6571,17 @@ class SlackAdapter(BasePlatformAdapter):
         # A thread binding then keeps later unqualified replies on the same
         # profile, including after a gateway restart.
         profile_spec = None
-        if not is_command_text and (is_mentioned or is_one_to_one_dm):
+        continued_profile_spec = self._continued_profile_spec(
+            team_id, channel_id, thread_ts
+        )
+        if not is_command_text and (
+            is_mentioned or is_one_to_one_dm or continued_profile_spec is not None
+        ):
             profile_spec, routed_text = self._match_profile_alias(msg_event.text)
             if profile_spec:
                 msg_event.text = routed_text or "/profile"
         if profile_spec is None:
-            profile_spec = self._continued_profile_spec(team_id, channel_id, thread_ts)
+            profile_spec = continued_profile_spec
         if profile_spec:
             source.profile = str(profile_spec["profile"])
             if thread_ts:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1662,6 +1662,22 @@ class SlackAdapter(BasePlatformAdapter):
             }
         return specs
 
+    def profile_persona_for_name(self, profile_name: str) -> Optional[Dict[str, Any]]:
+        """Return the configured, validated Slack persona for a profile.
+
+        Outbound delegation transcripts use this public resolver instead of
+        trusting caller-supplied username/icon metadata.  That keeps visual
+        attribution limited to real multiplex profiles in the operator's
+        allowlist.
+        """
+        wanted = str(profile_name or "").strip().lower()
+        if not wanted:
+            return None
+        for spec in self._profile_invocation_specs().values():
+            if str(spec.get("profile") or "").lower() == wanted:
+                return dict(spec)
+        return None
+
     def _profile_route_store_path(self) -> _Path:
         captured = getattr(self, "_profile_route_store", None)
         if captured is not None:
@@ -2751,6 +2767,17 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             team_id = self._metadata_team_id(metadata)
             persona = _profile_persona.get()
+            metadata_persona = (
+                metadata.get(_PROFILE_PERSONA_METADATA_KEY)
+                if isinstance(metadata, dict)
+                else None
+            )
+            if isinstance(metadata_persona, dict):
+                resolved_persona = self.profile_persona_for_name(
+                    metadata_persona.get("profile")
+                )
+                if resolved_persona is not None:
+                    persona = resolved_persona
             # Check for a pending slash-command context.  When the user ran a
             # native slash command (e.g. /q, /stop, /model), the initial ack
             # already showed an ephemeral "Running /cmd…" message.  If we have

--- a/run_agent.py
+++ b/run_agent.py
@@ -7794,6 +7794,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            profile=function_args.get("profile"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/agent/test_subagent_progress.py
+++ b/tests/agent/test_subagent_progress.py
@@ -14,7 +14,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from agent.display import KawaiiSpinner
-from tools.delegate_tool import _build_child_progress_callback
+from tools.delegate_tool import _build_child_progress_callback, _build_child_system_prompt
 
 
 # =========================================================================
@@ -99,6 +99,31 @@ class TestBuildChildProgressCallback:
         summary_text = summary_call.kwargs.get("preview") or summary_call.args[2]
         assert "tool_0" in summary_text
         assert "tool_4" in summary_text
+
+    def test_profile_identity_is_relayed_on_every_child_event(self):
+        parent = MagicMock()
+        parent._delegate_spinner = None
+        parent.tool_progress_callback = MagicMock()
+
+        cb = _build_child_progress_callback(
+            0, "check numbers", parent, profile_name="nami"
+        )
+        cb("subagent.start", preview="check numbers")
+        cb("subagent.text", preview="answer")
+        cb("subagent.complete", status="completed", summary="answer")
+
+        assert [call.kwargs["profile_name"] for call in parent.tool_progress_callback.call_args_list] == [
+            "nami", "nami", "nami"
+        ]
+
+    def test_profile_soul_is_in_child_prompt(self):
+        prompt = _build_child_system_prompt(
+            "check numbers",
+            profile_name="nami",
+            profile_soul="You are the finance specialist.",
+        )
+        assert "configured Hermes profile 'nami'" in prompt
+        assert "You are the finance specialist." in prompt
 
 
     def test_parallel_callbacks_independent(self):
@@ -265,4 +290,3 @@ class TestBatchFlush:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3005,6 +3005,7 @@ class TestAssistantThreadLifecycle:
         assert runner._thread_metadata_for_source(msg_event.source) == {
             "thread_id": "171.111",
             "slack_team_id": "T_OTHER",
+            "slack_requester_user_id": "U_USER",
         }
 
     @pytest.mark.asyncio
@@ -4558,4 +4559,3 @@ class TestSlackUserAgent:
         """Module constant matches the HermesAgent/<version> convention used
         elsewhere in the codebase for platform-partner attribution."""
         assert _slack_mod._HERMES_SLACK_USER_AGENT_PREFIX.startswith("HermesAgent/")
-

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -291,6 +291,75 @@ class TestSlackApprovalAction:
         assert "1234.5678" not in adapter._approval_requesters
 
 
+class TestSlackClarifyAction:
+    @pytest.mark.asyncio
+    async def test_binds_prompt_to_authorized_requester(self):
+        adapter = _make_adapter()
+        adapter._team_clients["T1"].chat_postMessage = AsyncMock(
+            return_value={"ts": "1234.5678"}
+        )
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="Proceed?",
+            choices=["Yes", "No"],
+            clarify_id="clarify-1",
+            session_key="session-key",
+            metadata={"slack_team_id": "T1", "slack_requester_user_id": "U_OWNER"},
+        )
+
+        marker = ("T1", "1234.5678")
+        assert adapter._clarify_resolved[marker] is False
+        assert adapter._clarify_requesters[marker] == "U_OWNER"
+
+    @pytest.mark.asyncio
+    async def test_original_requester_can_answer_without_profile_stamp(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter, auth_fn=lambda _source: False)
+        marker = ("T1", "1234.5678")
+        adapter._clarify_resolved[marker] = False
+        adapter._clarify_requesters[marker] = "U_OWNER"
+        adapter._team_clients["T1"].chat_update = AsyncMock()
+
+        ack = AsyncMock()
+        body = {
+            "team": {"id": "T1"},
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {"action_id": "hermes_clarify_choice_0", "value": "clarify-1|0"}
+
+        with patch("tools.clarify_gateway.resolve_gateway_clarify", return_value=True) as resolve:
+            await adapter._handle_clarify_action(ack, body, action)
+
+        resolve.assert_called_once_with("clarify-1", "choice 1")
+        assert marker not in adapter._clarify_requesters
+
+    @pytest.mark.asyncio
+    async def test_different_user_cannot_answer_requester_bound_prompt(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter, auth_fn=lambda _source: False)
+        marker = ("T1", "1234.5678")
+        adapter._clarify_resolved[marker] = False
+        adapter._clarify_requesters[marker] = "U_OWNER"
+
+        ack = AsyncMock()
+        body = {
+            "team": {"id": "T1"},
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "mallory", "id": "U_ATTACKER"},
+        }
+        action = {"action_id": "hermes_clarify_choice_0", "value": "clarify-1|0"}
+
+        with patch("tools.clarify_gateway.resolve_gateway_clarify") as resolve:
+            await adapter._handle_clarify_action(ack, body, action)
+
+        resolve.assert_not_called()
+        assert adapter._clarify_requesters[marker] == "U_OWNER"
+
+
 class TestSlackInteractiveAuth:
     def test_delegates_to_gateway_runner_auth(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -122,6 +122,21 @@ class TestSlackExecApproval:
             assert e["value"] == "agent:main:slack:group:C1:1111"
 
     @pytest.mark.asyncio
+    async def test_binds_prompt_to_authorized_requester(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        await adapter.send_exec_approval(
+            chat_id="C1",
+            command="ps -p 123 -o pid=,command=",
+            session_key="session-key",
+            metadata={"slack_team_id": "T1", "slack_requester_user_id": "U_OWNER"},
+        )
+
+        assert adapter._approval_requesters[("T1", "1234.5678")] == "U_OWNER"
+
+    @pytest.mark.asyncio
     async def test_smart_deny_owner_override_hides_persistent_buttons(self):
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]
@@ -204,6 +219,76 @@ class TestSlackApprovalAction:
 
         ack.assert_called_once()
         mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_original_requester_can_click_without_profile_stamp(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter, auth_fn=lambda _source: False)
+        marker = ("T1", "1234.5678")
+        adapter._approval_resolved[marker] = False
+        adapter._approval_requesters[marker] = "U_OWNER"
+
+        ack = AsyncMock()
+        body = {
+            "team": {"id": "T1"},
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+        adapter._team_clients["T1"].chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        resolve.assert_called_once_with("session-key", "once")
+        assert marker not in adapter._approval_requesters
+
+    @pytest.mark.asyncio
+    async def test_different_user_cannot_use_requester_bound_button(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter, auth_fn=lambda _source: False)
+        marker = ("T1", "1234.5678")
+        adapter._approval_resolved[marker] = False
+        adapter._approval_requesters[marker] = "U_OWNER"
+
+        ack = AsyncMock()
+        body = {
+            "team": {"id": "T1"},
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "mallory", "id": "U_ATTACKER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+
+        with patch("tools.approval.resolve_gateway_approval") as resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        resolve.assert_not_called()
+        assert adapter._approval_requesters[marker] == "U_OWNER"
+
+    @pytest.mark.asyncio
+    async def test_requester_binding_supports_metadata_poor_prompt_key(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter, auth_fn=lambda _source: False)
+        adapter._approval_resolved["1234.5678"] = False
+        adapter._approval_requesters["1234.5678"] = "U_OWNER"
+
+        ack = AsyncMock()
+        body = {
+            "team": {"id": "T1"},
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "owner", "id": "U_OWNER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+        adapter._team_clients["T1"].chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        resolve.assert_called_once_with("session-key", "once")
+        assert "1234.5678" not in adapter._approval_requesters
 
 
 class TestSlackInteractiveAuth:
@@ -840,4 +925,3 @@ class TestSlackReactionAuthorizationGate:
         assert "U_RANDO" in runner.auth_checked
         assert runner.handled == []
         adapter.handle_message.assert_not_called()
-

--- a/tests/gateway/test_slack_delegation_transcript.py
+++ b/tests/gateway/test_slack_delegation_transcript.py
@@ -1,0 +1,63 @@
+"""Slack-visible specialist delegation transcript behavior."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from gateway.run import TurnRunner
+from gateway.turn_context import TurnContext
+
+
+def _runner():
+    source = SimpleNamespace(platform=SimpleNamespace(value="slack"), chat_id="C1")
+    ctx = TurnContext(
+        source=source,
+        _run_still_current=lambda: False,
+        delegation_progress_enabled=True,
+        delegation_lock=threading.Lock(),
+    )
+    owner = MagicMock()
+    runner = TurnRunner(owner, ctx)
+    runner._schedule_delegation_message = MagicMock()
+    return runner, ctx
+
+
+def test_profile_child_start_and_final_text_are_visible_after_parent_turn_ends():
+    runner, _ = _runner()
+
+    common = {
+        "profile_name": "nami",
+        "child_session_id": "child-1",
+    }
+    runner.progress_callback("subagent.start", preview="work", **common)
+    runner.progress_callback("subagent.text", preview="재고 ", **common)
+    runner.progress_callback("subagent.text", preview="확인 완료", **common)
+    runner.progress_callback(
+        "subagent.complete", status="completed", summary="ignored", **common
+    )
+
+    calls = runner._schedule_delegation_message.call_args_list
+    assert calls[0].args[0] == "nami"
+    assert "시작" in calls[0].args[1]
+    assert "work" in calls[0].args[1]
+    assert calls[1].args == ("nami", "재고 확인 완료")
+
+
+def test_failed_child_marks_streamed_text_as_partial_failure():
+    runner, _ = _runner()
+    common = {"profile_name": "chopper", "child_session_id": "child-2"}
+    runner.progress_callback("subagent.start", preview="verify", **common)
+    runner.progress_callback("subagent.text", preview="partial", **common)
+    runner.progress_callback("subagent.complete", status="failed", **common)
+    final = runner._schedule_delegation_message.call_args_list[-1].args[1]
+    assert final.startswith("⚠️")
+    assert "failed" in final
+    assert "partial" in final
+
+
+def test_unnamed_subagents_stay_hidden():
+    runner, _ = _runner()
+    runner.progress_callback("subagent.start", preview="anonymous")
+    runner.progress_callback("subagent.text", preview="secret scratch")
+    runner.progress_callback("subagent.complete", summary="done")
+    runner._schedule_delegation_message.assert_not_called()

--- a/tests/gateway/test_slack_profile_invocations.py
+++ b/tests/gateway/test_slack_profile_invocations.py
@@ -12,7 +12,7 @@ from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource, build_session_key
 from hermes_cli import slack_cli
 from plugins.platforms.slack import adapter as slack_adapter_module
-from plugins.platforms.slack.adapter import SlackAdapter
+from plugins.platforms.slack.adapter import SlackAdapter, _apply_yaml_config
 
 
 def _config(store, *, profile="nami"):
@@ -70,6 +70,28 @@ def test_profile_invocations_fail_closed_without_multiplex(tmp_path):
     with patch("agent.secret_scope.is_multiplex_active", return_value=False):
         assert adapter._profile_invocation_specs() == {}
         assert adapter._match_profile_alias("나미 재고 확인")[0] is None
+
+
+def test_yaml_bridge_preserves_structured_profile_invocations():
+    invocations = [
+        {
+            "profile": "nami",
+            "aliases": ["nami", "나미"],
+            "display_name": "Nami",
+            "icon_emoji": ":hermes_nami:",
+        }
+    ]
+
+    assert _apply_yaml_config(
+        {},
+        {
+            "profile_invocations": invocations,
+            "profile_invocation_store": "/tmp/routes.json",
+        },
+    ) == {
+        "profile_invocations": invocations,
+        "profile_invocation_store": "/tmp/routes.json",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack_profile_invocations.py
+++ b/tests/gateway/test_slack_profile_invocations.py
@@ -1,0 +1,408 @@
+"""Slack single-app profile invocation behavior."""
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+from hermes_cli import slack_cli
+from plugins.platforms.slack import adapter as slack_adapter_module
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+def _config(store, *, profile="nami"):
+    return PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={
+            "profile_invocation_store": str(store),
+            "profile_invocations": [
+                {
+                    "profile": profile,
+                    "slash": profile,
+                    "aliases": [profile, "나미"],
+                    "display_name": "Nami",
+                    "icon_emoji": "hermes_nami",
+                }
+            ],
+        },
+    )
+
+
+def _adapter(store, *, profile="nami"):
+    adapter = SlackAdapter(_config(store, profile=profile))
+    adapter._app = MagicMock()
+    client = AsyncMock()
+    client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "200.001"})
+    adapter._get_client = MagicMock(return_value=client)
+    adapter.stop_typing = AsyncMock()
+    return adapter, client
+
+
+def test_alias_parser_is_explicit_and_boundary_safe(tmp_path):
+    adapter, _ = _adapter(tmp_path / "routes.json")
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        spec, text = adapter._match_profile_alias("나미: 재고를 확인해줘")
+        assert spec["profile"] == "nami"
+        assert text == "재고를 확인해줘"
+        assert adapter._match_profile_alias("나미야 재고를 확인해줘")[0] is None
+
+
+def test_missing_profile_is_rejected(tmp_path):
+    adapter, _ = _adapter(tmp_path / "routes.json", profile="missing")
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=False),
+    ):
+        assert adapter._profile_invocation_specs() == {}
+
+
+def test_profile_invocations_fail_closed_without_multiplex(tmp_path):
+    adapter, _ = _adapter(tmp_path / "routes.json")
+    with patch("agent.secret_scope.is_multiplex_active", return_value=False):
+        assert adapter._profile_invocation_specs() == {}
+        assert adapter._match_profile_alias("나미 재고 확인")[0] is None
+
+
+@pytest.mark.asyncio
+async def test_profile_slash_is_public_customized_and_stamps_source(tmp_path):
+    store = tmp_path / "routes.json"
+    adapter, client = _adapter(store)
+    captured = []
+
+    async def handle(event):
+        captured.append(event)
+        await adapter.send(
+            event.source.chat_id,
+            "done",
+            metadata={"slack_team_id": event.source.scope_id},
+        )
+
+    adapter.handle_message = handle
+    command = {
+        "command": "/nami",
+        "text": "calculate coverage",
+        "user_id": "U1",
+        "channel_id": "C1",
+        "team_id": "T1",
+        "response_url": "https://example.invalid/ephemeral",
+    }
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        await adapter._handle_slash_command(command)
+
+    assert captured[0].source.profile == "nami"
+    assert captured[0].text == "calculate coverage"
+    assert adapter._slash_command_contexts == {}
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert kwargs["username"] == "Nami"
+    assert kwargs["icon_emoji"] == ":hermes_nami:"
+    assert json.loads(store.read_text())["routes"]["T1\u001fC1\u001f200.001"]["profile"] == "nami"
+
+
+@pytest.mark.asyncio
+async def test_legacy_hermes_slash_routes_profile_without_extra_command_slot(tmp_path):
+    adapter, client = _adapter(tmp_path / "routes.json")
+    captured = []
+
+    async def handle(event):
+        captured.append(event)
+        await adapter.send(
+            event.source.chat_id,
+            "done",
+            metadata={"slack_team_id": event.source.scope_id},
+        )
+
+    adapter.handle_message = handle
+    command = {
+        "command": "/hermes",
+        "text": "나미 calculate coverage",
+        "user_id": "U1",
+        "channel_id": "C1",
+        "team_id": "T1",
+        "response_url": "https://example.invalid/ephemeral",
+    }
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        await adapter._handle_slash_command(command)
+
+    assert captured[0].source.profile == "nami"
+    assert captured[0].text == "calculate coverage"
+    assert adapter._slash_command_contexts == {}
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert kwargs["username"] == "Nami"
+    assert kwargs["icon_emoji"] == ":hermes_nami:"
+
+
+@pytest.mark.asyncio
+async def test_normal_send_and_cron_path_keep_app_identity(tmp_path):
+    adapter, client = _adapter(tmp_path / "routes.json")
+    await adapter.send("C1", "scheduled report", metadata={"slack_team_id": "T1"})
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert "username" not in kwargs
+    assert "icon_emoji" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_queued_profile_switch_restores_event_persona(tmp_path):
+    adapter, client = _adapter(tmp_path / "routes.json")
+    adapter.config.typing_indicator = False
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="done"))
+    event = MessageEvent(
+        text="review this",
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C1",
+            chat_type="group",
+            user_id="U1",
+            scope_id="T1",
+            profile="chopper",
+        ),
+        metadata={
+            "_slack_profile_persona": {
+                "profile": "chopper",
+                "display_name": "Chopper",
+                "icon_emoji": ":hermes_chopper:",
+            }
+        },
+    )
+
+    stale = slack_adapter_module._profile_persona.set(
+        {"profile": "nami", "display_name": "Nami", "icon_emoji": ":hermes_nami:"}
+    )
+    try:
+        await adapter._process_message_background(event, build_session_key(event.source))
+    finally:
+        slack_adapter_module._profile_persona.reset(stale)
+
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert kwargs["username"] == "Chopper"
+    assert kwargs["icon_emoji"] == ":hermes_chopper:"
+
+
+@pytest.mark.asyncio
+async def test_queued_ordinary_slash_clears_stale_persona(tmp_path):
+    adapter, client = _adapter(tmp_path / "routes.json")
+    adapter.config.typing_indicator = False
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="status"))
+    adapter._send_slash_ephemeral = AsyncMock(
+        return_value=SendResult(success=True, message_id="ephemeral")
+    )
+    adapter._slash_command_contexts[("T1", "C1", "U2")] = {
+        "response_url": "https://example.invalid/ephemeral",
+        "user_id": "U2",
+        "ts": time.monotonic(),
+    }
+    event = MessageEvent(
+        text="/status",
+        message_type=MessageType.COMMAND,
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C1",
+            chat_type="group",
+            user_id="U2",
+            scope_id="T1",
+        ),
+        metadata={
+            "_slack_profile_persona": None,
+            "_slack_slash_user_id": "U2",
+        },
+    )
+
+    stale = slack_adapter_module._profile_persona.set(
+        {"profile": "nami", "display_name": "Nami", "icon_emoji": ":hermes_nami:"}
+    )
+    try:
+        await adapter._process_message_background(event, build_session_key(event.source))
+    finally:
+        slack_adapter_module._profile_persona.reset(stale)
+
+    adapter._send_slash_ephemeral.assert_awaited_once()
+    client.chat_postMessage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_profile_slash_is_blocked_before_dispatch_in_ignored_channel(tmp_path):
+    config = _config(tmp_path / "routes.json")
+    config.extra["ignored_channels"] = ["C_BLOCKED"]
+    adapter = SlackAdapter(config)
+    adapter.handle_message = AsyncMock()
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        await adapter._handle_slash_command(
+            {
+                "command": "/nami",
+                "text": "run",
+                "user_id": "U1",
+                "channel_id": "C_BLOCKED",
+                "team_id": "T1",
+            }
+        )
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_profile_slash_obeys_allowed_channels_before_dispatch(tmp_path):
+    config = _config(tmp_path / "routes.json")
+    config.extra["allowed_channels"] = ["C_ALLOWED"]
+    adapter = SlackAdapter(config)
+    adapter.handle_message = AsyncMock()
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        await adapter._handle_slash_command(
+            {
+                "command": "/nami",
+                "text": "run",
+                "user_id": "U1",
+                "channel_id": "C_OTHER",
+                "team_id": "T1",
+            }
+        )
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_profile_slash_obeys_user_authorization_before_dispatch(tmp_path):
+    adapter, _ = _adapter(tmp_path / "routes.json")
+    runner = MagicMock()
+    runner._is_user_authorized.return_value = False
+    adapter._message_handler = AsyncMock()
+    adapter._message_handler.__self__ = runner
+    adapter.handle_message = AsyncMock()
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        await adapter._handle_slash_command(
+            {
+                "command": "/nami",
+                "text": "run",
+                "user_id": "U_BAD",
+                "channel_id": "C_ALLOWED",
+                "team_id": "T1",
+            }
+        )
+    adapter.handle_message.assert_not_awaited()
+    runner._is_user_authorized.assert_called_once()
+
+
+def test_thread_binding_survives_adapter_restart(tmp_path):
+    store = tmp_path / "routes.json"
+    adapter, _ = _adapter(store)
+    spec = {
+        "profile": "nami",
+        "display_name": "Nami",
+        "icon_emoji": ":hermes_nami:",
+    }
+    adapter._bind_profile_thread("T1", "C1", "100.001", spec)
+
+    restarted, _ = _adapter(store)
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        restored = restarted._continued_profile_spec("T1", "C1", "100.001")
+        assert restored["profile"] == "nami"
+        assert restored["display_name"] == "Nami"
+        assert restarted._continued_profile_spec("T2", "C1", "100.001") is None
+
+
+def test_stale_thread_binding_cannot_bypass_current_config(tmp_path):
+    store = tmp_path / "routes.json"
+    adapter, _ = _adapter(store)
+    adapter._bind_profile_thread(
+        "T1",
+        "C1",
+        "100.001",
+        {"profile": "nami", "display_name": "Nami", "icon_emoji": ":hermes_nami:"},
+    )
+    adapter.config.extra["profile_invocations"] = []
+    assert adapter._continued_profile_spec("T1", "C1", "100.001") is None
+
+
+def test_manifest_pins_profile_slashes_and_customize_scope(monkeypatch):
+    monkeypatch.setattr(
+        slack_cli,
+        "_configured_profile_slashes",
+        lambda: [
+            {
+                "command": "/nami",
+                "description": "Run Nami",
+                "usage_hint": "[request]",
+                "should_escape": False,
+                "url": "https://hermes-agent.local/slack/commands",
+            }
+        ],
+    )
+    manifest = slack_cli._build_full_manifest("Luffy", "Crew gateway")
+    commands = [entry["command"] for entry in manifest["features"]["slash_commands"]]
+    assert commands[:2] == ["/hermes", "/nami"]
+    assert len(commands) <= 50
+    assert "chat:write.customize" in manifest["oauth_config"]["scopes"]["bot"]
+
+
+def test_configured_profile_slashes_reads_real_gateway_shape(monkeypatch):
+    slack = MagicMock()
+    slack.extra = {
+        "profile_invocations": [
+            {"profile": name, "display_name": name.title()}
+            for name in ("luffy", "nami", "chopper", "franky")
+        ]
+    }
+    gateway = MagicMock(multiplex_profiles=True, platforms={Platform.SLACK: slack})
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: gateway)
+    assert [entry["command"] for entry in slack_cli._configured_profile_slashes()] == [
+        "/luffy",
+        "/nami",
+        "/chopper",
+        "/franky",
+    ]
+
+
+def test_manifest_config_failure_is_not_silent(monkeypatch):
+    def fail():
+        raise ValueError("broken config")
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", fail)
+    with pytest.raises(RuntimeError, match="profile invocation configuration"):
+        slack_cli._configured_profile_slashes()
+
+
+def test_customize_scope_absent_without_profile_invocations(monkeypatch):
+    monkeypatch.setattr(slack_cli, "_configured_profile_slashes", lambda: [])
+    manifest = slack_cli._build_full_manifest("Luffy", "Gateway")
+    assert "chat:write.customize" not in manifest["oauth_config"]["scopes"]["bot"]
+
+
+def test_slashes_only_merge_also_pins_profile_commands(monkeypatch):
+    profile_entry = {
+        "command": "/nami",
+        "description": "Run Nami",
+        "usage_hint": "[request]",
+        "should_escape": False,
+        "url": "https://hermes-agent.local/slack/commands",
+    }
+    monkeypatch.setattr(slack_cli, "_configured_profile_slashes", lambda: [profile_entry])
+    base = [
+        {"command": "/hermes"},
+        *({"command": f"/cmd{i}"} for i in range(1, 50)),
+    ]
+    merged = slack_cli._merge_profile_slashes(base)
+    assert [entry["command"] for entry in merged[:2]] == ["/hermes", "/nami"]
+    assert len(merged) == 50

--- a/tests/gateway/test_slack_profile_invocations.py
+++ b/tests/gateway/test_slack_profile_invocations.py
@@ -358,6 +358,70 @@ def test_stale_thread_binding_cannot_bypass_current_config(tmp_path):
     assert adapter._continued_profile_spec("T1", "C1", "100.001") is None
 
 
+@pytest.mark.asyncio
+async def test_explicit_alias_switches_profile_in_bound_thread(tmp_path):
+    store = tmp_path / "routes.json"
+    adapter, _ = _adapter(store)
+    adapter.config.extra["profile_invocations"] = [
+        {
+            "profile": "nami",
+            "slash": "nami",
+            "aliases": ["nami", "나미"],
+            "display_name": "Nami",
+            "icon_emoji": ":hermes_nami:",
+        },
+        {
+            "profile": "chopper",
+            "slash": "chopper",
+            "aliases": ["chopper", "쵸파", "초파"],
+            "display_name": "Chopper",
+            "icon_emoji": ":hermes_chopper:",
+        },
+    ]
+    adapter._bot_user_id = "U_BOT"
+    adapter._running = True
+    adapter.handle_message = AsyncMock()
+    adapter._fetch_thread_context = AsyncMock(return_value="")
+    adapter._fetch_thread_parent_text = AsyncMock(return_value="root")
+    adapter._has_active_session_for_thread = MagicMock(return_value=False)
+    adapter._mentioned_threads.add("100.001")
+    adapter._bind_profile_thread(
+        "T1",
+        "C1",
+        "100.001",
+        {
+            "profile": "nami",
+            "display_name": "Nami",
+            "icon_emoji": ":hermes_nami:",
+        },
+    )
+
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        await adapter._handle_slack_message(
+            {
+                "type": "message",
+                "channel": "C1",
+                "channel_type": "channel",
+                "team": "T1",
+                "user": "U1",
+                "client_msg_id": "m1",
+                "text": "쵸파 프로필 이름을 알려줘",
+                "ts": "101.001",
+                "thread_ts": "100.001",
+            }
+        )
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.profile == "chopper"
+    assert event.text == "프로필 이름을 알려줘"
+    assert event.metadata["_slack_profile_persona"]["display_name"] == "Chopper"
+    persisted = json.loads(store.read_text())["routes"]["T1\u001fC1\u001f100.001"]
+    assert persisted["profile"] == "chopper"
+
+
 def test_manifest_pins_profile_slashes_and_customize_scope(monkeypatch):
     monkeypatch.setattr(
         slack_cli,

--- a/tests/gateway/test_slack_profile_invocations.py
+++ b/tests/gateway/test_slack_profile_invocations.py
@@ -133,6 +133,31 @@ async def test_profile_slash_is_public_customized_and_stamps_source(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_outbound_delegation_metadata_uses_validated_profile_persona(tmp_path):
+    adapter, client = _adapter(tmp_path / "routes.json")
+    with (
+        patch("agent.secret_scope.is_multiplex_active", return_value=True),
+        patch("hermes_cli.profiles.profile_exists", return_value=True),
+    ):
+        await adapter.send(
+            "C1",
+            "specialist answer",
+            metadata={
+                "slack_team_id": "T1",
+                "_slack_profile_persona": {
+                    "profile": "nami",
+                    "display_name": "forged",
+                    "icon_emoji": ":forged:",
+                },
+            },
+        )
+
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert kwargs["username"] == "Nami"
+    assert kwargs["icon_emoji"] == ":hermes_nami:"
+
+
+@pytest.mark.asyncio
 async def test_legacy_hermes_slash_routes_profile_without_extra_command_slot(tmp_path):
     adapter, client = _adapter(tmp_path / "routes.json")
     captured = []

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -275,8 +275,8 @@ class TestSocketModeRestart:
 
 
     @pytest.mark.asyncio
-    async def test_watchdog_restarts_when_transport_disconnected(self, adapter):
-        """A transport that reports itself down still triggers a reconnect."""
+    async def test_watchdog_restarts_when_disconnect_persists(self, adapter):
+        """A sustained disconnected transport still triggers a reconnect."""
         live_task = MagicMock()
         live_task.done.return_value = False
         adapter._socket_mode_task = live_task
@@ -291,7 +291,45 @@ class TestSocketModeRestart:
         adapter._restart_socket_mode = _fake_restart
         adapter._socket_transport_connected = AsyncMock(return_value=False)
         adapter._socket_watchdog_interval_s = 0.01
+        adapter._socket_reconnect_grace_s = 0.02
 
         await adapter._socket_watchdog_loop()
 
         assert reasons == ["transport disconnected"]
+
+    @pytest.mark.asyncio
+    async def test_watchdog_defers_to_native_transient_reconnect(self, adapter):
+        """One failed probe must not tear down an SDK reconnect in progress.
+
+        The production incident started with slack_sdk abandoning an old
+        websocket and establishing a replacement about one second later.  The
+        watchdog ran between those events, closed the shared aiohttp session,
+        and left the SDK retrying against that closed session forever.
+        """
+        live_task = MagicMock()
+        live_task.done.return_value = False
+        adapter._socket_mode_task = live_task
+        adapter._handler = MagicMock()
+
+        reasons: list[str] = []
+        probes = iter([False, True])
+
+        async def _probe():
+            connected = next(probes)
+            if connected:
+                adapter._running = False
+            return connected
+
+        async def _fake_restart(reason: str) -> None:
+            reasons.append(reason)
+            adapter._running = False
+
+        adapter._restart_socket_mode = _fake_restart
+        adapter._socket_transport_connected = _probe
+        adapter._socket_watchdog_interval_s = 0.01
+        adapter._socket_reconnect_grace_s = 1.0
+
+        await adapter._socket_watchdog_loop()
+
+        assert reasons == []
+        assert adapter._socket_unhealthy_since_monotonic is None

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1224,6 +1224,25 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 class TestDispatchDelegateTask(unittest.TestCase):
     """Tests for the _dispatch_delegate_task helper and full param forwarding."""
 
+    def test_profile_forwarded_to_delegate_task(self):
+        """The model-selected Hermes profile reaches the child dispatcher."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "check the numbers", "profile": "nami"},
+            )
+
+        self.assertEqual(captured["profile"], "nami")
+
     def test_model_acp_args_not_forwarded(self):
         """The live model dispatch path strips hidden ACP transport args."""
         import run_agent

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -905,6 +905,8 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    profile_name: Optional[str] = None,
+    profile_soul: Optional[str] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -919,6 +921,15 @@ def _build_child_system_prompt(
         "",
         f"YOUR TASK:\n{goal}",
     ]
+    if profile_name:
+        parts.insert(
+            1,
+            "\nSPECIALIST PROFILE:\n"
+            f"You are acting as the configured Hermes profile '{profile_name}'. "
+            "Keep that profile's identity and remit while completing only the delegated task.",
+        )
+    if profile_soul:
+        parts.insert(2, f"\nPROFILE IDENTITY:\n{profile_soul}")
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -973,6 +984,36 @@ def _build_child_system_prompt(
             f"is capped at max_spawn_depth={max_spawn_depth}. {child_note}"
         )
     return "\n".join(parts)
+
+
+def _resolve_delegated_profile(profile: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Validate a model-selected specialist profile and load its SOUL only.
+
+    Delegation remains a fresh, isolated child session.  Loading the target
+    profile's SOUL gives the child the durable specialist identity without
+    importing that profile's credentials, memory, or mutable runtime state.
+    """
+    if profile is None or not str(profile).strip():
+        return None, None
+    from hermes_cli.profiles import (
+        get_profile_dir,
+        normalize_profile_name,
+        profile_exists,
+        validate_profile_name,
+    )
+
+    canonical = normalize_profile_name(str(profile))
+    validate_profile_name(canonical)
+    if canonical == "default" or not profile_exists(canonical):
+        raise ValueError(f"Unknown delegated profile: {canonical}")
+    soul_path = get_profile_dir(canonical) / "SOUL.md"
+    try:
+        soul = soul_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        soul = ""
+    except OSError as exc:
+        raise ValueError(f"Could not read delegated profile {canonical}") from exc
+    return canonical, soul or None
 
 
 def _resolve_workspace_hint(parent_agent) -> Optional[str]:
@@ -1074,6 +1115,7 @@ def _build_child_progress_callback(
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     session_ref: Optional[Dict[str, Any]] = None,
+    profile_name: Optional[str] = None,
 ) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -1121,6 +1163,8 @@ def _build_child_progress_callback(
             kw["model"] = model
         if toolsets is not None:
             kw["toolsets"] = list(toolsets)
+        if profile_name is not None:
+            kw["profile_name"] = profile_name
         # The child's own session id — filled into the shared ref once the
         # child agent exists (the callback is built first), so every relayed
         # event lets UIs open/inspect the subagent's session directly.
@@ -1325,6 +1369,8 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    profile_name: Optional[str] = None,
+    profile_soul: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1434,6 +1480,8 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        profile_name=profile_name,
+        profile_soul=profile_soul,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -1458,6 +1506,7 @@ def _build_child_agent(
         model=effective_model_for_cb,
         toolsets=child_toolsets,
         session_ref=child_session_ref,
+        profile_name=profile_name,
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
@@ -1669,6 +1718,7 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    child._delegated_profile = profile_name
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
@@ -3128,6 +3178,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3226,7 +3277,12 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
+        single_task: Dict[str, Any] = {
+            "goal": goal,
+            "context": context,
+            "role": top_role,
+            "profile": profile,
+        }
         if output_schema is not None:
             single_task["output_schema"] = output_schema
         task_list = [single_task]
@@ -3237,6 +3293,7 @@ def delegate_task(
         return tool_error("No tasks provided.")
 
     # Validate each task has a goal
+    resolved_task_profiles: List[tuple[Optional[str], Optional[str]]] = []
     for i, task in enumerate(task_list):
         if not isinstance(task, dict):
             return tool_error(
@@ -3244,6 +3301,11 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+        try:
+            resolved_profile, profile_soul = _resolve_delegated_profile(task.get("profile"))
+        except ValueError as exc:
+            return tool_error(str(exc))
+        resolved_task_profiles.append((resolved_profile, profile_soul))
 
     # Batch-only quality gate: catch malformed fan-outs (placeholder goals,
     # unexpanded multi-word template markers, 1-task batches) before any
@@ -3322,6 +3384,7 @@ def delegate_task(
     # subagent-lifecycle API).
     children = []
     for i, t in enumerate(task_list):
+        resolved_profile, profile_soul = resolved_task_profiles[i]
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
         effective_role = _normalize_role(t.get("role") or top_role)
@@ -3353,6 +3416,8 @@ def delegate_task(
             override_acp_command=creds.get("command"),
             override_acp_args=creds.get("args"),
             role=effective_role,
+            profile_name=resolved_profile,
+            profile_soul=profile_soul,
         )
         # Attach the validated schema for the completion-side validation
         # hook in _run_single_child. Absent (None) on schema-less tasks.
@@ -4245,6 +4310,15 @@ DELEGATE_TASK_SCHEMA = {
                                 "require only fields you will actually read."
                             ),
                         },
+                        "profile": {
+                            "type": "string",
+                            "description": (
+                                "Existing Hermes specialist profile whose SOUL identity should be "
+                                "used and whose configured Slack persona should label the visible "
+                                "delegation transcript. The child remains an isolated delegated "
+                                "session and does not inherit that profile's credentials or memory."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -4264,6 +4338,14 @@ DELEGATE_TASK_SCHEMA = {
                     "Optional JSON Schema for the single-goal form — the "
                     "subagent's final answer must validate against it "
                     "(same semantics as tasks[].output_schema)."
+                ),
+            },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Existing Hermes specialist profile for this single delegated task. "
+                    "Uses its SOUL identity and Slack persona while keeping credentials and "
+                    "memory isolated."
                 ),
             },
             "background": {
@@ -4337,6 +4419,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        profile=args.get("profile"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
         parent_agent=kw.get("parent_agent"),


### PR DESCRIPTION
## Summary
- bind approval and clarification callbacks to the originating Slack requester
- allow delegate_task to select an existing Hermes profile without loading profile credentials or memory
- relay profiled child start/final messages into the originating Slack thread with that profile's configured persona
- preserve parent session and workspace isolation while hiding internal child tool/reasoning events

## Verification
- 278 focused delegation, async-delivery, profile-persona, and Slack adapter tests passed
- ruff passed on all changed runtime and test files
- live Slack smoke test: Luffy-only mention produced Nami and Chopper messages in the same thread with their configured names/icons