### PR TITLE
fix(cron): guard against PyPI utils package shadowing local utils.py

### DIFF
--- a/contributors/emails/bot@blut-agent.dev
+++ b/contributors/emails/bot@blut-agent.dev
@@ -1,0 +1,1 @@
+blut-agent

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -38,6 +38,22 @@ from typing import Optional, Dict, List, Any, Set, Tuple, Union, Collection
 
 logger = logging.getLogger(__name__)
 
+# When a PyPI ``utils`` package is installed in the same venv (webui Docker
+# setup), ``from utils import ...`` resolves to that package and fails.  If
+# the ``utils`` entry in ``sys.modules`` is *not* the hermes local module,
+# remove it so the next import finds our ``utils.py`` on the filesystem.
+import sys as _sys
+_hermes_root = Path(__file__).resolve().parent.parent
+_hermes_root_str = str(_hermes_root)
+if _hermes_root_str not in _sys.path:
+    _sys.path.insert(0, _hermes_root_str)
+_utils_mod = _sys.modules.get("utils")
+if _utils_mod is not None:
+    _mod_file = getattr(_utils_mod, "__file__", None)
+    if _mod_file is None or not str(_mod_file).startswith(_hermes_root_str):
+        del _sys.modules["utils"]
+del _hermes_root, _hermes_root_str  # cleanup
+
 from hermes_time import now as _hermes_now
 from utils import atomic_replace, atomic_write_text
 

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -38,6 +38,21 @@ from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
+
+# When a PyPI ``utils`` package shadows our local ``utils.py`` (webui Docker),
+# remove the shadowed entry so the regular import finds our module.
+import sys as _sys
+_hermes_root = Path(__file__).resolve().parent.parent
+_hermes_root_str = str(_hermes_root)
+if _hermes_root_str not in _sys.path:
+    _sys.path.insert(0, _hermes_root_str)
+_utils_mod = _sys.modules.get("utils")
+if _utils_mod is not None:
+    _mod_file = getattr(_utils_mod, "__file__", None)
+    if _mod_file is None or not str(_mod_file).startswith(_hermes_root_str):
+        del _sys.modules["utils"]
+del _hermes_root, _hermes_root_str  # cleanup
+
 from utils import atomic_replace
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Problem

When the PyPI `utils` package is installed in the same venv (common in the webui Docker setup), `from utils import atomic_write_text` in `cron/jobs.py` and `from utils import atomic_replace` in `cron/suggestions.py` resolve to the PyPI package instead of the local `utils.py`, causing:

```
ImportError: cannot import name 'atomic_write_text' from 'utils' (/app/venv/lib/python3.12/site-packages/utils.py)
```

This breaks the `/api/crons` endpoint in the webui Docker setup.

## Fix

Before each bare `from utils import ...` statement in both files:
1. Ensure the hermes root directory is on `sys.path` so our local `utils.py` is first in the search path
2. Remove any existing `utils` entry from `sys.modules` that is not the hermes local module, allowing the next import to find our version

This is a targeted fix for the two files in the cron module — neither is part of the hot path and both are only loaded on demand.

## Test Plan

- [x] Verified both files load successfully when a mock PyPI `utils` is pre-loaded in `sys.modules`
- [x] Verified both files load successfully in the normal case (no PyPI utils installed)
- [x] Lint passes (pyright clean)

Closes NousResearch/hermes-agent#82069
