### PR TITLE
docs(whatsapp): add italic row to markdown table + caveat reply-context for uncaptioned media quotes

### DIFF
--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -244,7 +244,7 @@ You can have **both** the Baileys (`whatsapp`) and Cloud (`whatsapp_cloud`) adap
 - **Voice notes** — auto-downloaded as `.ogg`, transcribed via your configured STT provider (local faster-whisper, OpenAI/Nous, Groq, etc.), then handed to the agent as text.
 - **Documents** — auto-downloaded. Small text-readable files (`.txt`, `.md`, `.json`, `.py`, `.csv`, etc.) up to 100KB get inlined into the agent's input so it can read them without a tool call. Larger files are cached locally for the agent's other tools to access.
 - **Button taps** — when the user taps a button the bot sent earlier (clarify choice, command approval, slash-command confirm), the tap is routed directly to the right handler. Stale taps fall back to being treated as regular text input.
-- **Reply context** — when the user replies to a previous bot message, the agent sees the original message as context.
+- **Reply context** — when the user replies to a previous bot message, the agent sees the original message as context. This applies to **text** messages (and captioned media, whose caption is used). Note: for **uncaptioned media quotes** (e.g. replying to a plain photo with no text), the original media body is empty and the reply arrives without quote text — so the agent receives no "Replying to…" context for that message.
 
 ### Outbound
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -201,6 +201,7 @@ Standard Markdown in AI responses is automatically converted to WhatsApp's nativ
 
 | Markdown | WhatsApp | Renders as |
 |----------|----------|------------|
+| `*italic*` | `_italic_` | *italic* |
 | `**bold**` | `*bold*` | **bold** |
 | `~~strikethrough~~` | `~strikethrough~` | ~~strikethrough~~ |
 | `# Heading` | `*Heading*` | Bold text (no native headings) |


### PR DESCRIPTION
Fixes #80067

## What
1. **whatsapp.md:204-208** — the markdown→WhatsApp conversion table listed bold/strikethrough/heading/link but omitted **italic**. The code already converts `*text*` → `_text_` (`whatsapp_common.py:465-471`), so the docs now match the implementation.
2. **whatsapp-cloud.md:247** — the Reply-context claim said the agent always sees the original message. It's true for text and captioned media, but **uncaptioned media quotes** have an empty body and arrive without quote text — the agent gets no `[Replying to: ...]` context. Added the caveat.

## Verification
- Confirmed italic conversion exists in code (`(?<!\*)\*(?!\s|\*)([^*\n]*?\S[^*\n]*?)\*(?!\*)` → `_\1_`).
- Confirmed docs table lacks the italic row.
- Confirmed rich_sent_store only records TEXT bodies (`if body:`) — uncaptioned media is never recorded, so quote context is lost for media (same class as #74380).

Docs-only change, no runtime impact.