### PR TITLE
fix(signal): stage attachments for sidecar daemons

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -266,6 +266,10 @@ class SignalAdapter(BasePlatformAdapter):
         self.http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
         self.account = extra.get("account", "")
         self.ignore_stories = extra.get("ignore_stories", True)
+        staging_dir = str(extra.get("attachment_staging_dir", "") or "").strip()
+        self.attachment_staging_dir = (
+            Path(staging_dir).expanduser() if staging_dir else None
+        )
 
         # Parse allowlists — group policy is derived from presence of group allowlist
         group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
@@ -1050,6 +1054,77 @@ class SignalAdapter(BasePlatformAdapter):
     # Sending
     # ------------------------------------------------------------------
 
+    def _stage_outbound_attachment(
+        self,
+        file_path: str,
+    ) -> Tuple[str, Optional[Path]]:
+        """Copy an attachment into a signal-cli-readable shared directory."""
+        stage_dir = self.attachment_staging_dir
+        if stage_dir is None:
+            return file_path, None
+
+        source = Path(file_path)
+        try:
+            resolved_source = source.resolve()
+            resolved_source.relative_to(stage_dir.resolve())
+            return str(resolved_source), None
+        except ValueError:
+            pass
+
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        fd, staged_name = tempfile.mkstemp(
+            prefix="hermes-signal-",
+            suffix=source.suffix[:16],
+            dir=stage_dir,
+        )
+        staged_path = Path(staged_name)
+        try:
+            os.fchmod(fd, 0o644)
+            with os.fdopen(fd, "wb") as target, source.open("rb") as source_file:
+                shutil.copyfileobj(source_file, target)
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            staged_path.unlink(missing_ok=True)
+            raise
+        return str(staged_path), staged_path
+
+    async def _rpc_send_attachments(
+        self,
+        params: Dict[str, Any],
+        **rpc_kwargs: Any,
+    ) -> Any:
+        """Send attachment params after staging paths for a sidecar daemon."""
+        staged_paths: List[str] = []
+        cleanup_paths: List[Path] = []
+        try:
+            for file_path in params.get("attachments", []):
+                staged_path, cleanup_path = self._stage_outbound_attachment(file_path)
+                staged_paths.append(staged_path)
+                if cleanup_path is not None:
+                    cleanup_paths.append(cleanup_path)
+        except OSError as exc:
+            logger.warning("Signal: failed to stage outbound attachment: %s", exc)
+            for cleanup_path in cleanup_paths:
+                cleanup_path.unlink(missing_ok=True)
+            return None
+
+        staged_params = dict(params, attachments=staged_paths)
+        try:
+            return await self._rpc("send", staged_params, **rpc_kwargs)
+        finally:
+            for cleanup_path in cleanup_paths:
+                try:
+                    cleanup_path.unlink(missing_ok=True)
+                except OSError as exc:
+                    logger.warning(
+                        "Signal: failed to remove staged attachment %s: %s",
+                        cleanup_path,
+                        exc,
+                    )
+
     async def send(
         self,
         chat_id: str,
@@ -1276,8 +1351,8 @@ class SignalAdapter(BasePlatformAdapter):
                 await scheduler.acquire(n)
                 try:
                     _rpc_t0 = time.monotonic()
-                    result = await self._rpc(
-                        "send", params, raise_on_rate_limit=True, timeout=send_timeout,
+                    result = await self._rpc_send_attachments(
+                        params, raise_on_rate_limit=True, timeout=send_timeout,
                     )
                     _rpc_duration = time.monotonic() - _rpc_t0
                     if result is not None:
@@ -1404,7 +1479,7 @@ class SignalAdapter(BasePlatformAdapter):
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
 
-        result = await self._rpc("send", params)
+        result = await self._rpc_send_attachments(params)
         if result is not None:
             success, err_msg = self._validate_send_result(result)
             if not success:
@@ -1446,7 +1521,7 @@ class SignalAdapter(BasePlatformAdapter):
         else:
             params["recipient"] = [await self._resolve_recipient(chat_id)]
 
-        result = await self._rpc("send", params)
+        result = await self._rpc_send_attachments(params)
         if result is not None:
             success, err_msg = self._validate_send_result(result)
             if not success:

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -385,6 +385,93 @@ class TestSignalSendImageFile:
         # Timestamp must be tracked for echo-back prevention
         assert 1234567890 in adapter._recent_sent_timestamps
 
+    @pytest.mark.asyncio
+    async def test_send_image_file_stages_for_sidecar_and_cleans_up(
+        self, monkeypatch, tmp_path
+    ):
+        staging_dir = tmp_path / "shared" / "signal"
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            attachment_staging_dir=str(staging_dir),
+        )
+        adapter._stop_typing_indicator = AsyncMock()
+        source = tmp_path / "private" / "chart.png"
+        source.parent.mkdir()
+        source.write_bytes(b"private image bytes")
+        captured_path = None
+
+        async def rpc(method, params, rpc_id=None):
+            nonlocal captured_path
+            captured_path = Path(params["attachments"][0])
+            assert captured_path.parent == staging_dir
+            assert captured_path.read_bytes() == source.read_bytes()
+            assert captured_path.stat().st_mode & 0o777 == 0o644
+            return {"timestamp": 1234567890}
+
+        adapter._rpc = rpc
+
+        result = await adapter.send_image_file(
+            chat_id="+155****4567",
+            image_path=str(source),
+        )
+
+        assert result.success is True
+        assert captured_path is not None
+        assert not captured_path.exists()
+        assert source.exists()
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_keeps_already_shared_path(
+        self, monkeypatch, tmp_path
+    ):
+        staging_dir = tmp_path / "shared" / "signal"
+        staging_dir.mkdir(parents=True)
+        source = staging_dir / "chart.png"
+        source.write_bytes(b"shared image bytes")
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            attachment_staging_dir=str(staging_dir),
+        )
+        adapter._stop_typing_indicator = AsyncMock()
+        mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
+        adapter._rpc = mock_rpc
+
+        result = await adapter.send_image_file(
+            chat_id="+155****4567",
+            image_path=str(source),
+        )
+
+        assert result.success is True
+        assert captured[0]["params"]["attachments"] == [str(source)]
+        assert source.read_bytes() == b"shared image bytes"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_fails_before_rpc_when_staging_fails(
+        self, monkeypatch, tmp_path
+    ):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            attachment_staging_dir=str(tmp_path / "shared"),
+        )
+        adapter._stop_typing_indicator = AsyncMock()
+        adapter._rpc = AsyncMock()
+        monkeypatch.setattr(
+            adapter,
+            "_stage_outbound_attachment",
+            MagicMock(side_effect=PermissionError("read-only mount")),
+        )
+        source = tmp_path / "chart.png"
+        source.write_bytes(b"image bytes")
+
+        result = await adapter.send_image_file(
+            chat_id="+155****4567",
+            image_path=str(source),
+        )
+
+        assert result.success is False
+        assert "rpc send image failed" in result.error.lower()
+        adapter._rpc.assert_not_awaited()
+
 
     @pytest.mark.asyncio
     async def test_send_image_file_too_large(self, monkeypatch, tmp_path):
@@ -1070,6 +1157,34 @@ class TestSignalSendMultipleImages:
         assert len(params["attachments"]) == 5
         # raise_on_rate_limit must be opted into so the retry loop sees 429s
         assert captured[0]["kwargs"].get("raise_on_rate_limit") is True
+
+    @pytest.mark.asyncio
+    async def test_batch_stages_all_paths_through_rpc_then_cleans_up(
+        self, monkeypatch, tmp_path
+    ):
+        staging_dir = tmp_path / "shared" / "signal"
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            attachment_staging_dir=str(staging_dir),
+        )
+        adapter._stop_typing_indicator = AsyncMock()
+        captured_paths = []
+
+        async def rpc(method, params, rpc_id=None, **kwargs):
+            captured_paths.extend(Path(path) for path in params["attachments"])
+            assert all(path.exists() for path in captured_paths)
+            assert all(path.parent == staging_dir for path in captured_paths)
+            return {"timestamp": 1}
+
+        adapter._rpc = rpc
+
+        await adapter.send_multiple_images(
+            chat_id="+155****4567",
+            images=_make_image_files(tmp_path, 3),
+        )
+
+        assert len(captured_paths) == 3
+        assert all(not path.exists() for path in captured_paths)
 
 
     @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -166,6 +166,20 @@ The agent can send media files via `MEDIA:` tags in responses. The following del
 
 All outgoing media goes through Signal's standard attachment API. Unlike some platforms, Signal does not distinguish between voice messages and file attachments at the protocol level.
 
+If Hermes and signal-cli run in separate containers, mount a directory at the
+same path in both containers and configure it in `~/.hermes/config.yaml`:
+
+```yaml
+platforms:
+  signal:
+    extra:
+      attachment_staging_dir: /shared/signal-attachments
+```
+
+Hermes copies outbound files from private paths into that directory for the
+duration of the signal-cli RPC, then removes the temporary copy. Files already
+inside the configured directory are used in place and are never removed.
+
 Attachment size limit: **100 MB** (both directions).
 :::warning
 **Signal servers will rate-limit attachment uploads**, the adapter uses a scheduler for multiple image sending that batches images in groups of 32 and throttles uploads to match the Signal server policy.


### PR DESCRIPTION
## What does this PR do?

Signal attachment RPCs currently pass the gateway's local file path straight to `signal-cli`. That works when both processes share a filesystem namespace, but fails when `signal-cli` runs as a sidecar service/container that can only read an explicitly shared directory.

This adds an opt-in `platforms.signal.extra.attachment_staging_dir` setting. When configured, the adapter:

- copies outbound attachments into that shared directory before the RPC,
- uses a same-suffix temporary name and mode `0644`,
- reuses files that are already inside the shared directory,
- removes only adapter-created staging files in `finally`, including RPC failures,
- applies the same behavior to single attachments, native images, and attachment batches.

When the setting is absent, the existing path and behavior are unchanged.

## Root cause and impact

The gateway validated that a file existed in its own namespace, but the actual reader is the independent `signal-cli` daemon. A valid local path could therefore produce a remote attachment failure even though the file was present. Staging at the adapter boundary gives both processes one explicit shared path without making all Hermes media globally world-readable or persistent.

## Configuration

```yaml
platforms:
  signal:
    extra:
      attachment_staging_dir: /path/shared/with/signal-cli
```

The directory must already be mounted where both Hermes and `signal-cli` see the same absolute path.

## Validation

- `scripts/run_tests.sh tests/gateway/test_signal.py -q` — 56 passed
- Ruff on changed Python files — clean
- `py_compile` — clean
- `git diff --check` — clean

New tests cover staging lifetime and mode, already-shared files, pre-RPC staging failure, batch staging, and cleanup after the RPC boundary.

## Scope

This PR changes only Signal attachment path handoff. It does not alter Signal text delivery, daemon lifecycle, general cache permissions, or non-Signal adapters.