### PR TITLE
fix(gateway): accept metadata kwarg in BasePlatformAdapter.edit_message (#82422)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3878,6 +3878,7 @@ class BasePlatformAdapter(ABC):
         content: str,
         *,
         finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
         Edit a previously sent message. Optional — platforms that don't


### PR DESCRIPTION
## Problem

FeishuAdapter.edit_message() raises TypeError when stream_consumer passes metadata kwarg.

The stream_consumer's _edit_message method checks if the adapter accepts metadata via inspect.signature, but BasePlatformAdapter.edit_message() did not include the parameter. Any adapter inheriting the base method (including FeishuAdapter) would fail with:



## Fix

Add metadata as an optional keyword argument to BasePlatformAdapter.edit_message(), matching the existing send() signature. The base implementation ignores it; adapters that need routing metadata can consume it in their override.

## Testing

- 89 gateway adapter tests pass (feishu, dingtalk, discord, etc.)
- No behavioral change for adapters that don't use metadata

Fixes #82422
