### PR TITLE
feat(whatsapp): add explicit tested proxy routing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2984,6 +2984,10 @@ def cmd_whatsapp(args):
     print()
 
     try:
+        bridge_env = with_hermes_node_path()
+        proxy_url = get_env_value("WHATSAPP_PROXY_URL")
+        if proxy_url:
+            bridge_env["WHATSAPP_PROXY_URL"] = proxy_url
         subprocess.run(
             [
                 find_node_executable("node") or "node",
@@ -2993,7 +2997,7 @@ def cmd_whatsapp(args):
                 str(session_dir),
             ],
             cwd=str(bridge_dir),
-            env=with_hermes_node_path(),
+            env=bridge_env,
         )
     except KeyboardInterrupt:
         pass

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -64,6 +64,7 @@ from hermes_cli.config import (
     clear_model_endpoint_credentials,
     get_config_path,
     get_env_path,
+    get_env_value,
     get_hermes_home,
     get_process_hermes_home,
     load_config,
@@ -8666,6 +8667,9 @@ def _spawn_whatsapp_pairing_process(session_path: Path, mode: str) -> subprocess
     env = with_hermes_node_path()
     env["WHATSAPP_MODE"] = mode
     env["WHATSAPP_DM_POLICY"] = "pairing"
+    proxy_url = get_env_value("WHATSAPP_PROXY_URL")
+    if proxy_url:
+        env["WHATSAPP_PROXY_URL"] = proxy_url
     return subprocess.Popen(
         [
             node,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -355,6 +355,14 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+def _proxy_config_hash(proxy_url: str) -> str:
+    """Return a non-secret bridge configuration fingerprint."""
+    if not proxy_url:
+        return ""
+    import hashlib
+    return hashlib.sha256(proxy_url.encode("utf-8")).hexdigest()[:16]
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -428,6 +436,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
+        self._proxy_url = _wenv("WHATSAPP_PROXY_URL").strip()
         self._dm_policy = str(config.extra.get("dm_policy") or _wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         # Prefer config.extra, then the documented WHATSAPP_ALLOWED_USERS env
         # (setup wizard / pairing mirror). Select by key *presence* so an
@@ -638,7 +647,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
+                                running_proxy_hash = str(data.get("proxyHash") or "")
+                                config_matches = (
+                                    running_read_receipts == self._send_read_receipts
+                                    and running_proxy_hash == _proxy_config_hash(self._proxy_url)
+                                )
                                 if (
                                     running_hash
                                     and disk_hash
@@ -654,7 +667,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 stale_reason = (
                                     f"running={running_hash or 'unversioned'}, disk={disk_hash}"
                                     if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
+                                    else "bridge configuration changed"
                                 )
                                 print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
@@ -685,6 +698,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
             )
+            # Always replace the process-global value with the active profile's
+            # scoped secret. An empty value must not leak another profile's
+            # credential-bearing proxy URL into this bridge.
+            bridge_env.pop("WHATSAPP_PROXY_URL", None)
+            if self._proxy_url:
+                bridge_env["WHATSAPP_PROXY_URL"] = self._proxy_url
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env
             # vars.  Inject the resolved WHATSAPP_* values so the Node bridge

--- a/plugins/platforms/whatsapp/plugin.yaml
+++ b/plugins/platforms/whatsapp/plugin.yaml
@@ -31,3 +31,7 @@ optional_env:
     description: "Display name for the WhatsApp home channel"
     prompt: "Home channel display name"
     password: false
+  - name: WHATSAPP_PROXY_URL
+    description: "Optional HTTP(S) proxy URL for all WhatsApp bridge traffic"
+    prompt: "WhatsApp proxy URL (leave blank for direct networking)"
+    password: true

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -33,6 +33,7 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { installWhatsAppProxy } from './proxy.js';
 import {
   buildPollPayload,
   createReconnectScheduler,
@@ -60,6 +61,12 @@ const WHATSAPP_DEBUG =
   process.env &&
   typeof process.env.WHATSAPP_DEBUG === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
+
+const WHATSAPP_PROXY_URL = String(process.env.WHATSAPP_PROXY_URL || '').trim();
+const whatsappProxy = installWhatsAppProxy(WHATSAPP_PROXY_URL);
+const PROXY_HASH = WHATSAPP_PROXY_URL
+  ? createHash('sha256').update(WHATSAPP_PROXY_URL).digest('hex').slice(0, 16)
+  : '';
 
 // Opt-in: when true (and WHATSAPP_MODE === 'bot'), fromMe inbound messages
 // that are NOT echoes of our own /send or /send-media calls are forwarded
@@ -396,7 +403,9 @@ function emitPairEvent(event) {
 }
 
 const scheduleReconnect = createReconnectScheduler(() => startSocket());
-const getWAVersion = createVersionResolver(fetchLatestBaileysVersion);
+const getWAVersion = createVersionResolver(
+  () => fetchLatestBaileysVersion(whatsappProxy.versionFetchOptions),
+);
 
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
@@ -406,6 +415,8 @@ async function startSocket() {
     ...(version ? { version } : {}),
     auth: state,
     logger,
+    agent: whatsappProxy.httpAgent,
+    fetchAgent: whatsappProxy.httpAgent,
     printQRInTerminal: false,
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,
@@ -726,7 +737,7 @@ async function startSocket() {
         senderNumber,
         botIds,
         isGroup,
-        downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage }),
+        downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', whatsappProxy.mediaDownloadOptions, { logger, reuploadRequest: sock.updateMediaMessage }),
         cacheDirs: {
           image: IMAGE_CACHE_DIR,
           document: DOCUMENT_CACHE_DIR,
@@ -1111,6 +1122,7 @@ app.get('/health', (req, res) => {
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    proxyHash: PROXY_HASH,
   });
 });
 

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@whiskeysockets/baileys": "7.0.0-rc13",
         "express": "^4.21.0",
+        "https-proxy-agent": "^7.0.6",
         "pino": "^9.0.0",
-        "qrcode-terminal": "^0.12.0"
+        "qrcode-terminal": "^0.12.0",
+        "undici": "^6.28.0"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -806,6 +808,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1284,6 +1295,42 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -2105,6 +2152,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -5,13 +5,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bridge.js"
+    "start": "node bridge.js",
+    "test": "node --test *.test.mjs"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",
     "express": "^4.21.0",
+    "https-proxy-agent": "^7.0.6",
+    "pino": "^9.0.0",
     "qrcode-terminal": "^0.12.0",
-    "pino": "^9.0.0"
+    "undici": "^6.28.0"
   },
   "overrides": {
     "protobufjs": "^7.5.5"

--- a/scripts/whatsapp-bridge/proxy.js
+++ b/scripts/whatsapp-bridge/proxy.js
@@ -1,0 +1,46 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { ProxyAgent as UndiciProxyAgent, fetch as undiciFetch } from 'undici';
+
+const EMPTY_PROXY = Object.freeze({
+  enabled: false,
+  fetch: undefined,
+  httpAgent: undefined,
+  versionFetchOptions: Object.freeze({}),
+  mediaDownloadOptions: Object.freeze({}),
+});
+
+export function buildWhatsAppProxy(rawUrl) {
+  const value = String(rawUrl || '').trim();
+  if (!value) return EMPTY_PROXY;
+
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error('WHATSAPP_PROXY_URL must be a valid http:// or https:// URL');
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('WHATSAPP_PROXY_URL must use http:// or https://');
+  }
+
+  const httpAgent = new HttpsProxyAgent(parsed);
+  const dispatcher = new UndiciProxyAgent(parsed.toString());
+  return {
+    enabled: true,
+    fetch: undiciFetch,
+    httpAgent,
+    versionFetchOptions: { dispatcher },
+    mediaDownloadOptions: { options: { dispatcher } },
+  };
+}
+
+export function installWhatsAppProxy(rawUrl, target = globalThis) {
+  const proxy = buildWhatsAppProxy(rawUrl);
+  if (proxy.enabled) {
+    // Baileys' version and media downloads pass an Undici dispatcher. Node's
+    // bundled fetch may use a different Undici instance, so keep the fetch and
+    // dispatcher implementations paired.
+    target.fetch = proxy.fetch;
+  }
+  return proxy;
+}

--- a/scripts/whatsapp-bridge/proxy.test.mjs
+++ b/scripts/whatsapp-bridge/proxy.test.mjs
@@ -1,0 +1,38 @@
+import { strict as assert } from 'node:assert';
+
+import { buildWhatsAppProxy, installWhatsAppProxy } from './proxy.js';
+
+{
+  const target = { fetch: 'unchanged' };
+  const proxy = installWhatsAppProxy('', target);
+
+  assert.equal(proxy.enabled, false);
+  assert.equal(proxy.httpAgent, undefined);
+  assert.deepEqual(proxy.versionFetchOptions, {});
+  assert.deepEqual(proxy.mediaDownloadOptions, {});
+  assert.equal(target.fetch, 'unchanged');
+  console.log('  ✓ empty proxy configuration preserves direct networking');
+}
+
+{
+  const target = {};
+  const proxy = installWhatsAppProxy('http://user:pass@127.0.0.1:8080', target);
+
+  assert.equal(proxy.enabled, true);
+  assert.equal(typeof proxy.httpAgent.addRequest, 'function');
+  assert.equal(target.fetch, proxy.fetch);
+  assert.equal(
+    proxy.mediaDownloadOptions.options.dispatcher,
+    proxy.versionFetchOptions.dispatcher,
+  );
+  await proxy.versionFetchOptions.dispatcher.close();
+  console.log('  ✓ configured proxy shares one dispatcher across Baileys fetches');
+}
+
+for (const value of ['socks5://127.0.0.1:1080', 'not a URL']) {
+  assert.throws(
+    () => buildWhatsAppProxy(value),
+    /WHATSAPP_PROXY_URL must/,
+  );
+}
+console.log('  ✓ unsupported and invalid proxy URLs fail closed');

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -53,6 +53,7 @@ def _make_adapter():
     adapter._bridge_log = None
     adapter._bridge_process = None
     adapter._reply_prefix = None
+    adapter._proxy_url = ""
     adapter._send_read_receipts = False
     adapter._running = False
     adapter._message_handler = None

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -53,6 +53,7 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     adapter._bridge_log = None
     adapter._bridge_process = None
     adapter._reply_prefix = None
+    adapter._proxy_url = ""
     adapter._send_read_receipts = False
     adapter._running = False
     adapter._message_handler = None
@@ -151,6 +152,41 @@ class TestStaleBridgeHandshake:
 
         mock_popen.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_when_proxy_config_changed(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter._proxy_url = "http://new-proxy.invalid:8080"
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "sendReadReceipts": False,
+                "proxyHash": "old-configuration",
+            }
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+
 
 class TestDepRefreshStamp:
     @pytest.mark.asyncio
@@ -211,3 +247,28 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
         assert env["WHATSAPP_SEND_READ_RECEIPTS"] == "true"
+
+    @pytest.mark.asyncio
+    async def test_bridge_spawn_env_uses_scoped_proxy(self, tmp_path):
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter._proxy_url = "https://profile-proxy.invalid:8443"
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("plugins.platforms.whatsapp.adapter.with_hermes_node_path", return_value={"WHATSAPP_PROXY_URL": "foreign"}), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        assert mock_popen.call_args.kwargs["env"]["WHATSAPP_PROXY_URL"] == adapter._proxy_url

--- a/tests/hermes_cli/test_whatsapp_onboarding.py
+++ b/tests/hermes_cli/test_whatsapp_onboarding.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from unittest.mock import MagicMock
 
 
 class _FakeProc:
@@ -21,6 +22,30 @@ class _FakeProc:
 
     def kill(self):
         self.killed = True
+
+
+def test_pairing_process_receives_proxy_from_dotenv(monkeypatch, tmp_path):
+    from hermes_cli import web_server as ws
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "bridge.js").write_text("// bridge\n", encoding="utf-8")
+    proc = MagicMock()
+    monkeypatch.setattr(
+        "gateway.platforms.whatsapp_common.resolve_whatsapp_bridge_dir",
+        lambda: bridge_dir,
+    )
+    monkeypatch.setattr(ws, "_ensure_whatsapp_bridge_dependencies", lambda _path: None)
+    monkeypatch.setattr("hermes_constants.find_node_executable", lambda _name: "/node")
+    monkeypatch.setattr("hermes_constants.with_hermes_node_path", lambda: {"PATH": "/bin"})
+    monkeypatch.setattr(ws, "get_env_value", lambda key: "http://proxy.invalid:8080" if key == "WHATSAPP_PROXY_URL" else None)
+    monkeypatch.setattr(ws.subprocess, "Popen", MagicMock(return_value=proc))
+
+    result = ws._spawn_whatsapp_pairing_process(tmp_path / "session", "bot")
+
+    assert result is proc
+    env = ws.subprocess.Popen.call_args.kwargs["env"]
+    assert env["WHATSAPP_PROXY_URL"] == "http://proxy.invalid:8080"
 
 
 
@@ -113,7 +138,6 @@ def test_start_whatsapp_onboarding_existing_creds_returns_linked_account(monkeyp
     assert old_proc.terminated is True
     assert ws._whatsapp_onboarding_sessions["existing-creds"].account_phone == "15551234567"
     ws._whatsapp_onboarding_sessions.clear()
-
 
 
 

--- a/tests/hermes_cli/test_whatsapp_setup_ordering.py
+++ b/tests/hermes_cli/test_whatsapp_setup_ordering.py
@@ -138,3 +138,37 @@ def test_existing_pairing_skip_branch_enables_whatsapp(isolated_home, monkeypatc
 
     # The skip-rebar branch should have set the env var on its way out.
     assert _env_value(isolated_home, "WHATSAPP_ENABLED") == "true"
+
+
+def test_pairing_process_receives_proxy_from_dotenv(isolated_home, monkeypatch):
+    from hermes_cli.main import cmd_whatsapp
+
+    monkeypatch.setenv("WHATSAPP_MODE", "bot")
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "15551234567")
+    monkeypatch.setenv("WHATSAPP_PROXY_URL", "http://proxy.invalid:8080")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
+    monkeypatch.setattr("hermes_cli.main._require_tty", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "gateway.platforms.whatsapp_common.resolve_whatsapp_bridge_dir",
+        lambda: isolated_home / "bridge",
+    )
+    bridge_dir = isolated_home / "bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "bridge.js").write_text("// bridge\n", encoding="utf-8")
+    (bridge_dir / "node_modules").mkdir()
+    captured = {}
+
+    def fake_run(*_args, **kwargs):
+        captured.update(kwargs)
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "hermes_constants.with_hermes_node_path",
+        lambda: {"PATH": "/bin"},
+    )
+
+    with redirect_stdout(io.StringIO()):
+        cmd_whatsapp(MagicMock())
+
+    assert captured["env"]["WHATSAPP_PROXY_URL"] == "http://proxy.invalid:8080"

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -140,6 +140,20 @@ sudo hermes gateway install --system   # Linux only: boot-time system service
 
 The gateway starts the WhatsApp bridge automatically using the saved session.
 
+### HTTP proxy (optional)
+
+Networks that require an outbound HTTP proxy can route all Baileys traffic
+through it by adding the URL to `~/.hermes/.env`:
+
+```bash
+WHATSAPP_PROXY_URL=http://user:password@proxy.example.com:8080
+```
+
+Only `http://` and `https://` proxy URLs are accepted. The setting covers the
+WhatsApp Web socket, version checks, media uploads, and media downloads. Leave
+it unset for direct networking. Because the URL may contain credentials, keep
+it in `.env` rather than `config.yaml`.
+
 ---
 
 ## Session Persistence


### PR DESCRIPTION
## What does this PR do?

This is a current-main, tested alternative implementation of #12787.

It adds explicit opt-in proxy routing for the Baileys WhatsApp bridge through `WHATSAPP_PROXY_URL`. When set, the same proxy covers:

- the WhatsApp WebSocket,
- Baileys version lookup,
- media uploads,
- media downloads,
- terminal and dashboard QR-pairing processes.

When unset, networking remains direct.

## Why a separate alternative?

#12787 identifies the same real gap, but it is currently unmergeable and its automated review requested two changes that remain open: consistent credential redaction and focused proxy tests.

This implementation addresses those points by never logging the proxy URL at all and by putting construction/wiring in a pure tested helper. It also integrates the setting with Hermes' profile-scoped secret handling and bridge staleness handshake, so a different profile cannot inherit another profile's proxy and changing the proxy restarts an otherwise long-lived bridge.

The setting is deliberately WhatsApp-specific. It does **not** honor generic `HTTP_PROXY` / `HTTPS_PROXY`, so default/direct bridge egress remains compatible with the concern in #21627; proxy routing happens only when an operator explicitly sets `WHATSAPP_PROXY_URL`.

## Safety

- only `http://` and `https://` URLs are accepted; invalid schemes fail bridge startup,
- credential-bearing URLs stay in `.env`, are passed only in the child environment, and are never printed,
- the no-proxy path does not replace global fetch,
- the Python adapter overwrites/removes any process-global proxy value with the active profile's scoped value,
- the health endpoint exposes only a truncated SHA-256 configuration fingerprint, not the URL.

## Validation

- `npm test` in `scripts/whatsapp-bridge` — 23 tests passed
- focused Python matrix across bridge startup/staleness and both onboarding paths — 29 passed
- Ruff on changed Python files — clean
- `py_compile` — clean
- `git diff --check` — clean

The new tests cover direct-network invariance, valid and invalid proxy construction, one dispatcher shared by version/media fetches, profile-correct subprocess environment, bridge restart on proxy changes, and proxy propagation through terminal and dashboard pairing.

## Scope

This does not alter WhatsApp message policy, reconnect policy, generic process proxy behavior, or the Cloud API adapter.