### PR TITLE
fix(gateway): expand ${env:VAR} references in _load_gateway_config (#82399)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3265,6 +3265,15 @@ def _load_gateway_config() -> dict:
         raw = _normalize_root_model_keys(raw)
     except Exception:
         pass
+    # Expand ${VAR} / ${env:VAR} references so every caller — including
+    # _resolve_gateway_model and slash-commands — sees resolved values.
+    # Without this, model: "${env:MODEL_NAME}" stays literal in the gateway
+    # while the TUI expands it correctly (#82399).
+    try:
+        from hermes_cli.config import _expand_env_vars
+        raw = _expand_env_vars(raw) if isinstance(raw, dict) else raw
+    except Exception:
+        pass
     return raw
 
 


### PR DESCRIPTION
## Summary

`_load_gateway_config()` returned raw YAML without calling `_expand_env_vars()`, so `model: "${env:MODEL_NAME}"` stayed as a literal string in the gateway while the TUI expanded it correctly.

Every caller of `_load_gateway_config()` — including `_resolve_gateway_model()` and slash-commands — now receives expanded environment variable references.

## Root Cause

The gateway has its own config loader (`_load_gateway_config()`) that reads raw YAML for speed, bypassing `load_config()`. This loader replayed several normalizations from `load_config()` (managed scope overlay, model key canonicalization) but missed `_expand_env_vars()`. The TUI uses `_expand_env_vars()` explicitly in its config path, which is why it worked there.

## Changes

- Added `_expand_env_vars()` call at the end of `_load_gateway_config()`, after model key normalization and before returning. Wrapped in try/except for fail-open consistency with the rest of the function.

## Test Plan

- [ ] Set `MODEL_NAME=provider/model` in `~/.hermes/.env`
- [ ] Set `model: { default: "${env:MODEL_NAME}" }` in `~/.hermes/config.yaml`
- [ ] Start gateway and verify the model resolves correctly (not the literal string)
- [ ] Existing tests pass

Fixes #82399