### PR TITLE
fix: preserve macOS TCC identity for managed Python

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -44,6 +44,7 @@ _RUNTIME_DIR_NAME = ".hermes-runtime"
 _VENV_NAME = "venv"
 _ALT_VENV_NAME = ".venv"
 _REPAIR_LOCK_NAME = "runtime-repair.lock"
+_MACOS_MANAGED_PYTHON_IDENTIFIER = "com.nousresearch.hermes.managed-python"
 
 # ---------------------------------------------------------------------------
 # Public helpers
@@ -114,6 +115,79 @@ def managed_python_env(
         "UV_PYTHON_INSTALL_REGISTRY": "0",
     })
     return env
+
+
+def _macos_sign_managed_python(python: Path) -> bool:
+    """Give a newly downloaded managed Python a stable macOS code identity.
+
+    python-build-standalone binaries are ad-hoc signed, which leaves macOS
+    TCC with a cdhash-only identity that changes whenever Hermes provisions a
+    new runtime generation.  An identifier-pinned designated requirement
+    gives those generations a stable identity even when no Developer ID
+    certificate is available locally.
+
+    Signing is deliberately best effort.  Runtime repair exists to remove a
+    security vulnerability, so an unavailable or incompatible ``codesign``
+    must not prevent the fixed interpreter from being installed.
+    """
+    if platform.system() != "Darwin":
+        return False
+
+    codesign = shutil.which("codesign")
+    if not codesign:
+        logger.info(
+            "macOS codesign is unavailable; using the downloaded Python signature"
+        )
+        return False
+
+    requirement = (
+        "=designated => identifier "
+        f'"{_MACOS_MANAGED_PYTHON_IDENTIFIER}"'
+    )
+    try:
+        signed = subprocess.run(
+            [
+                codesign,
+                "--force",
+                "--deep",
+                "--sign",
+                "-",
+                "--timestamp=none",
+                "--identifier",
+                _MACOS_MANAGED_PYTHON_IDENTIFIER,
+                "--requirements",
+                requirement,
+                str(python),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if signed.returncode != 0:
+            logger.warning(
+                "could not stably sign managed Python %s: %s",
+                python,
+                (signed.stderr or signed.stdout or "codesign failed").strip(),
+            )
+            return False
+
+        verified = subprocess.run(
+            [codesign, "--verify", "--deep", "--strict", str(python)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if verified.returncode != 0:
+            logger.warning(
+                "macOS signature verification failed for managed Python %s: %s",
+                python,
+                (verified.stderr or verified.stdout or "verification failed").strip(),
+            )
+            return False
+        return True
+    except Exception as exc:
+        logger.warning("could not sign managed Python %s: %s", python, exc)
+        return False
 
 
 @dataclass(frozen=True)
@@ -587,6 +661,12 @@ def _attempt_install_generation(
         logger.warning("uv resolved Python outside the Hermes generation: %s", python)
         _remove_tree(generation, boundary=python_root)
         return None
+
+    # Do this before the candidate is probed or promoted.  On macOS, the
+    # stable identifier prevents each immutable generation from looking like
+    # a new TCC principal.  Failure is non-fatal: the SQLite repair must still
+    # proceed when codesign is unavailable or rejects a particular artifact.
+    _macos_sign_managed_python(python)
 
     candidate = probe_sqlite_runtime(python)
     if candidate is None:

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -81,6 +81,74 @@ class TestManagedUvPath:
             assert managed_uv_path() == tmp_path / "bin" / "uv"
 
 
+class TestMacOSManagedPythonSigning:
+    def test_signs_with_stable_identifier_and_verifies(self, tmp_path, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        python = tmp_path / "generation" / "bin" / "python3.11"
+        python.parent.mkdir(parents=True)
+        python.touch()
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(managed_uv.shutil, "which", lambda name: "/usr/bin/codesign")
+        monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+
+        assert managed_uv._macos_sign_managed_python(python) is True
+        assert calls[0][0] == [
+            "/usr/bin/codesign",
+            "--force",
+            "--deep",
+            "--sign",
+            "-",
+            "--timestamp=none",
+            "--identifier",
+            "com.nousresearch.hermes.managed-python",
+            "--requirements",
+            '=designated => identifier "com.nousresearch.hermes.managed-python"',
+            str(python),
+        ]
+        assert calls[1][0] == [
+            "/usr/bin/codesign",
+            "--verify",
+            "--deep",
+            "--strict",
+            str(python),
+        ]
+
+    def test_is_non_blocking_when_signing_fails(self, tmp_path, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        python = tmp_path / "python3.11"
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(managed_uv.shutil, "which", lambda name: "/usr/bin/codesign")
+        monkeypatch.setattr(
+            managed_uv.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=1, stdout="", stderr="not signable"
+            ),
+        )
+
+        assert managed_uv._macos_sign_managed_python(python) is False
+
+    def test_skips_non_macos(self, tmp_path, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            managed_uv.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("codesign must not run on Linux"),
+        )
+
+        assert managed_uv._macos_sign_managed_python(tmp_path / "python") is False
+
+
 # ---------------------------------------------------------------------------
 # resolve_uv
 # ---------------------------------------------------------------------------
@@ -1099,4 +1167,3 @@ class TestVenvPythonUpdateBoundary:
         assert _venv_python(Path("/opt/hermes/venv")) == Path(
             "/opt/hermes/venv/bin/python"
         )
-


### PR DESCRIPTION
## What does this PR do?

  Fixes macOS TCC/Full Disk Access grants being lost when Hermes rotates its managed Python runtime during SQLite security repairs.

  Each new runtime generation previously contained a different ad-hoc-signed CPython binary, causing macOS to treat it as a new TCC identity. This PR signs newly provisioned
  runtimes with a stable identifier-based designated requirement before promotion.

  ## Related Issue

  Fixes #82427

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [x] 🔒 Security fix

  ## Changes Made

  - Added Darwin-only managed Python signing in hermes_cli/managed_uv.py.
  - Uses stable identifier com.nousresearch.hermes.managed-python.
  - Signs nested runtime code with codesign --deep.
  - Verifies the resulting signature before continuing.
  - Keeps signing best-effort so SQLite vulnerability repair is never blocked.
  - Added regression tests covering:
      - Stable identifier signing.
      - Signature verification.
      - Non-macOS behavior.
      - Signing failures remaining non-blocking.

  ## How to Test

  1. Run the targeted tests:

     pytest tests/hermes_cli/test_managed_uv.py -q

  2. On macOS, trigger a managed-runtime repair and verify the new interpreter:

     codesign -dv --verbose=4 <runtime-generation>/cpython-*/bin/python3.11
     codesign --verify --deep --strict <runtime-generation>/cpython-*/bin/python3.11

  3. Confirm the signature reports the stable identifier:

     Identifier=com.nousresearch.hermes.managed-python

  Validation completed:

  - Python compilation passed.
  - Direct managed-Python signing smoke test passed.
  - git diff --check passed.
  - Full targeted pytest execution was attempted but the environment lacked the project’s pyyaml dependency, so tests failed during shared fixture import before reaching test
    execution.

  ## Checklist

  ### Code

  - [x] Commit message follows Conventional Commits.
  - [x] PR contains only changes related to this fix.
  - [ ] I've run pytest tests/ -q and all tests pass — blocked by missing pyyaml.
  - [x] I've added tests for the fix.
  - [ ] I've tested on macOS directly.

  ### Documentation & Housekeeping

  - [x] Documentation update not required.
  - [x] No config keys changed.
  - [x] Cross-platform impact considered; signing is Darwin-only.
  - [x] No tool schemas changed.

  ## Screenshots / Logs

  Not applicable.