### PR TITLE
fix(telegram): preserve text in composite rich replies

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9713,7 +9713,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
             block_type = block.get("type")
             if block_type == "list":
-                for item in block.get("items", []):
+                items = block.get("items")
+                if not isinstance(items, list):
+                    continue
+                for item in items:
                     if not isinstance(item, dict):
                         continue
                     item_text = cls._flatten_rich_blocks(item.get("blocks"))
@@ -9730,9 +9733,48 @@ class TelegramAdapter(BasePlatformAdapter):
                     lines.extend(item_lines[1:])
                 continue
 
-            text = cls._flatten_rich_inline_text(block.get("text"))
-            if text:
-                lines.extend(text.splitlines())
+            # Rich blocks are compositional: quotes, details, media groups,
+            # tables, and future block types can all contain nested plaintext.
+            # Walk content-bearing fields rather than keying behavior to the
+            # current set of Telegram block type names.
+            remaining = dict(block)
+            remaining.pop("type", None)
+            remaining.pop("label", None)
+            for key in (
+                "summary", "text", "expression", "children", "blocks", "items",
+                "rows", "cells", "content", "caption", "credit",
+            ):
+                if key not in remaining:
+                    continue
+                value = remaining.pop(key)
+                if key in {"summary", "text", "expression", "children", "caption", "credit"}:
+                    text = cls._flatten_rich_inline_text(value)
+                    if text:
+                        lines.extend(text.splitlines())
+                else:
+                    # Tables may encode cells as rows of inline mappings rather
+                    # than rich block mappings.  Flatten each row in stable
+                    # row-major order before falling back to block recursion.
+                    nested = ""
+                    if key == "cells" and isinstance(value, list):
+                        cell_lines = []
+                        for row in value:
+                            if not isinstance(row, list):
+                                continue
+                            for cell in row:
+                                if not isinstance(cell, dict):
+                                    continue
+                                cell_text = cls._flatten_rich_inline_text(cell.get("text"))
+                                if cell_text:
+                                    cell_lines.extend(cell_text.splitlines())
+                        nested = "\n".join(cell_lines)
+                    if not nested:
+                        nested = cls._flatten_rich_blocks(value)
+                    if nested:
+                        lines.extend(nested.splitlines())
+            nested = cls._flatten_rich_blocks(list(remaining.values()))
+            if nested:
+                lines.extend(nested.splitlines())
 
         return "\n".join(line.rstrip() for line in lines if line)
 

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -576,6 +576,95 @@ def _reply_message_with_rich_blocks(
     )
 
 
+def test_flatten_rich_blocks_preserves_composite_plaintext():
+    blocks = [
+        {"type": "blockquote", "blocks": [{"type": "paragraph", "text": "Block quote"}]},
+        {"type": "quote", "children": [{"type": "text", "text": "Inline quote"}]},
+        {
+            "type": "details",
+            "summary": [{"type": "text", "text": "Details summary"}],
+            "blocks": [{"type": "paragraph", "text": "Details body"}],
+        },
+        {
+            "type": "collage",
+            "items": [
+                {"caption": [{"type": "text", "text": "Collage caption"}]},
+                {"credit": "Collage credit"},
+            ],
+        },
+        {
+            "type": "slideshow",
+            "items": [
+                {"caption": "Slide one"},
+                {"caption": "Slide two", "credit": "Slide credit"},
+            ],
+        },
+        {
+            "type": "table",
+            "rows": [
+                {"cells": [{"text": "Name"}, {"text": "Value"}]},
+                {"cells": [{"text": "Alpha"}, {"text": "42"}]},
+            ],
+            "caption": "Table caption",
+        },
+        {
+            "type": "table",
+            "cells": [[{"text": "Direct A"}, {"text": "Direct B"}]],
+        },
+        {
+            "type": "mathematical_expression",
+            "expression": "x² + y²",
+            "caption": "Equation caption",
+        },
+        {"type": "image", "caption": "Image caption", "credit": "Image credit"},
+    ]
+
+    assert TelegramAdapter._flatten_rich_blocks(blocks) == (
+        "Block quote\nInline quote\nDetails summary\nDetails body\n"
+        "Collage caption\nCollage credit\nSlide one\nSlide two\nSlide credit\n"
+        "Name\nValue\nAlpha\n42\nTable caption\nDirect A\nDirect B\n"
+        "x² + y²\nEquation caption\n"
+        "Image caption\nImage credit"
+    )
+
+
+def test_flatten_rich_blocks_skips_malformed_nodes_without_losing_nested_text():
+    blocks = [
+        None,
+        "not a block",
+        {"type": "list", "items": None},
+        {"type": "details", "summary": 7, "blocks": "not a list"},
+        {
+            "type": "unknown-composite",
+            "content": [
+                {"type": "paragraph", "text": "Still readable"},
+                99,
+                {"wrapper": {"caption": "Nested caption"}},
+            ],
+        },
+        {"type": "table", "rows": [{"cells": None}, {"cells": [{"text": ["Valid ", 5, "text"]}]}]},
+    ]
+
+    assert TelegramAdapter._flatten_rich_blocks(blocks) == (
+        "Still readable\nNested caption\nValid text"
+    )
+
+
+def test_extract_rich_reply_text_preserves_composite_plaintext():
+    replied = SimpleNamespace(
+        api_kwargs={
+            "rich_message": {
+                "blocks": [
+                    {"type": "blockquote", "blocks": [{"type": "paragraph", "text": "Quoted"}]},
+                    {"type": "image", "caption": "Chart", "credit": "Analyst"},
+                ]
+            }
+        }
+    )
+
+    assert TelegramAdapter._extract_rich_reply_text(replied) == "Quoted\nChart\nAnalyst"
+
+
 @pytest.mark.asyncio
 async def test_rich_reply_records_and_recovers_text(monkeypatch, tmp_path):
     """A reply to a rich-sent message resolves the original text via the index."""


### PR DESCRIPTION
## Summary
- preserve plaintext when replies reference Telegram rich messages built from composite blocks
- recurse through quotes, details, media groups, tables, captions/credits, mathematical expressions, and unknown future containers
- tolerate malformed list/table nodes without dropping readable sibling content or raising

## Why
`_extract_rich_reply_text()` already exposes rich reply context to the agent, but `_flatten_rich_blocks()` only understood ordinary `text` and lists. Composite rich messages therefore arrived as incomplete or empty quoted context even though the Bot API payload still contained readable text.

The implementation is intentionally transport-only and best effort. It does not add inbound routing, persistence, configuration, or product-specific archive behavior.

## Tests
- RED before implementation: 3 focused tests failed
- `HERMES_PYTHON=/usr/local/lib/hermes-agent/venv/bin/python scripts/run_tests.sh tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_send_draft_format.py`
  - 72 passed
- independent neighboring verification:
  - `python -m pytest -q tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_send_draft_format.py tests/gateway/test_telegram_channel_posts.py`
  - 35 passed
- `git diff --check`
