### PR TITLE
fix(agent): preserve tel: links from phone-number redaction (#82405)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -403,8 +403,9 @@ _JWT_RE = re.compile(
 )
 
 # E.164 phone numbers: +<country><number>, 7-15 digits
-# Negative lookahead prevents matching hex strings or identifiers
-_SIGNAL_PHONE_RE = re.compile(r"(\+[1-9]\d{6,14})(?![A-Za-z0-9])")
+# Negative lookahead prevents matching hex strings or identifiers.
+# Negative lookbehind for tel: preserves clickable tel: links (#82405).
+_SIGNAL_PHONE_RE = re.compile(r"(?<!tel:)(\+[1-9]\d{6,14})(?![A-Za-z0-9])")
 
 # URLs containing query strings — matches `scheme://...?...[# or end]`.
 # Used to scan text for URLs whose query params may contain secrets.


### PR DESCRIPTION
## Problem

E.164 phone numbers inside tel: links are redacted, breaking clickable phone links in user-visible output.

Example: `tel:+15551234567` becomes `tel:+155****4567` which is not a valid callable link.

## Fix

Add negative lookbehind for `tel:` in `_SIGNAL_PHONE_RE` regex so phone numbers that are part of a tel: URI scheme are preserved.

```python
# Before
_SIGNAL_PHONE_RE = re.compile(r"(\+[1-9]\d{6,14})(?![A-Za-z0-9])")

# After
_SIGNAL_PHONE_RE = re.compile(r"(?<!tel:)(\+[1-9]\d{6,14})(?![A-Za-z0-9])")
```

## Testing

- 97 existing redact tests pass
- Phone numbers in tel: links are preserved
- Standalone phone numbers (not in tel: links) are still redacted

Fixes #82405
