### PR TITLE
fix(agent): recognize kanban stop nudge as synthetic during compaction (#82445)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4606,6 +4606,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             _LENGTH_CONTINUATION_NETWORK_STUB,
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
         )
+        from agent.kanban_stop import KANBAN_STOP_NUDGE_PREFIX
 
         return text in {
             COMPRESSION_CONTINUATION_USER_CONTENT,
@@ -4621,6 +4622,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             TODO_INJECTION_HEADER + "\n"
         ) or text.startswith(
             _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX
+        ) or text.startswith(
+            KANBAN_STOP_NUDGE_PREFIX
         )
 
     @staticmethod

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -21,6 +21,12 @@ _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 
+# Stable prefix for the kanban stop nudge message.  Used by
+# ``ContextCompressor._is_synthetic_compression_user_turn`` to recognize
+# the nudge after SessionDB projection drops the ``_kanban_stop_synthetic``
+# metadata flag (#82445).
+KANBAN_STOP_NUDGE_PREFIX = "[System: You are a Hermes kanban worker."
+
 
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
@@ -87,7 +93,7 @@ def build_kanban_stop_nudge(
 
     tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"
     return (
-        "[System: You are a Hermes kanban worker. A plain-text reply is NOT a "
+        KANBAN_STOP_NUDGE_PREFIX + " A plain-text reply is NOT a "
         "terminal state for the board.\n\n"
         f"Task `{tid}` is still `running`. Ending now without a board tool "
         "causes a protocol violation (clean exit with no "
@@ -102,6 +108,7 @@ def build_kanban_stop_nudge(
 
 
 __all__ = [
+    "KANBAN_STOP_NUDGE_PREFIX",
     "build_kanban_stop_nudge",
     "kanban_stop_nudge_enabled",
     "session_called_kanban_terminal",


### PR DESCRIPTION
## Summary

After SessionDB projection drops the `_kanban_stop_synthetic` metadata flag, the kanban stop nudge becomes a plain `role="user"` row that can be selected as the compaction anchor instead of the real task.

Adds `KANBAN_STOP_NUDGE_PREFIX` constant to `agent/kanban_stop.py` and uses it in `_is_synthetic_compression_user_turn` via `startswith()` matching.

## Root Cause

`build_kanban_stop_nudge()` returns a message tagged with `_kanban_stop_synthetic: True` metadata. But SessionDB preserves only `role` and `content` — not underscore-prefixed metadata. After a crash/interrupt persists the nudge mid-retry, it becomes a plain `role="user"` row without its metadata flag, and can be selected as the compaction anchor instead of the real task.

## Changes

- `agent/kanban_stop.py`: Added `KANBAN_STOP_NUDGE_PREFIX = "[System: You are a Hermes kanban worker."` constant. Updated `build_kanban_stop_nudge()` to use it instead of a hardcoded string.
- `agent/context_compressor.py`: Added `startswith(KANBAN_STOP_NUDGE_PREFIX)` check in `_is_synthetic_compression_user_turn`.

## Scope

This fixes the kanban stop nudge half of #82445. The pre-verify nudge (`get_pre_verify_continue_message()`) has dynamic content from hooks and no stable prefix — it requires a different approach (metadata persistence or content tagging).

## Test Plan

- [ ] Existing tests pass
- [ ] Verify kanban stop nudge content is recognized as synthetic after metadata stripping

Partially fixes #82445