### PR TITLE
fix(api): interrupt session agent on SSE disconnect

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3836,6 +3836,9 @@ class APIServerAdapter(BasePlatformAdapter):
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
         message_id = f"msg_{uuid.uuid4().hex}"
         run_id = f"run_{uuid.uuid4().hex}"
+        # The SSE writer needs the live agent so a disconnected client can
+        # cooperatively stop provider/tool work running in the executor.
+        agent_ref: list = [None]
         seq = 0
 
         def _event_payload(name: str, payload: Dict[str, Any]) -> tuple[str, Dict[str, Any]]:
@@ -3893,6 +3896,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     requested_runtime=runtime_request.get("requested") or {},
                     route_source=runtime_request.get("route_source") or "global",
                     confirmed_runtime_lock=lock_active,
+                    agent_ref=agent_ref,
                     **agent_overrides,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
@@ -3968,7 +3972,23 @@ class APIServerAdapter(BasePlatformAdapter):
                     break
                 name, payload = item
                 await response.write(_sse_frame(payload, event=name, ensure_ascii=False))
-        except (asyncio.CancelledError, ConnectionResetError):
+        except (
+            asyncio.CancelledError,
+            ConnectionResetError,
+            ConnectionAbortedError,
+            BrokenPipeError,
+            OSError,
+        ):
+            agent = agent_ref[0]
+            if agent is not None:
+                try:
+                    request_hard_interrupt(agent, "Session SSE client disconnected")
+                except Exception:
+                    logger.debug(
+                        "[api_server] failed to interrupt disconnected session agent",
+                        exc_info=True,
+                    )
+                _reap_disconnected_agent_processes(agent)
             task.cancel()
             raise
         except Exception as exc:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3976,9 +3976,10 @@ class APIServerAdapter(BasePlatformAdapter):
             asyncio.CancelledError,
             ConnectionResetError,
             ConnectionAbortedError,
+            ConnectionError,
             BrokenPipeError,
             OSError,
-        ):
+        ) as disconnect_exc:
             agent = agent_ref[0]
             if agent is not None:
                 try:
@@ -3990,7 +3991,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 _reap_disconnected_agent_processes(agent)
             task.cancel()
-            raise
+            if isinstance(disconnect_exc, asyncio.CancelledError):
+                raise
         except Exception as exc:
             logger.debug("[api_server] session SSE stream error: %s", exc)
         return response

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1052,6 +1052,8 @@ class TestChatCompletionsEndpoint:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+        assert isinstance(kwargs["agent_ref"], list)
+        assert len(kwargs["agent_ref"]) == 1
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- pass an `agent_ref` through the native session-chat SSE endpoint
- hard-interrupt provider/tool work when the SSE client disconnects
- reap turn-owned background processes and handle all common disconnect exceptions

## Why
`/api/sessions/{session_id}/chat/stream` previously cancelled only the asyncio wrapper. `_run_agent` executes `run_conversation` in a thread, so provider and tool work could continue after the client disconnected. Other streaming API surfaces already retain an agent reference for this purpose.

## Verification
- `tests/gateway/test_api_server.py`: 99 passed
- `tests/gateway/test_session_api.py`: 16 passed
- added a regression assertion that the session stream passes a mutable `agent_ref` into `_run_agent`