### PR TITLE
fix(desktop): map SSH profile aliases in REST paths

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -338,6 +338,28 @@ test('pathWithGlobalRemoteProfile skips local and per-profile remote override pa
   )
 })
 
+test('pathWithGlobalRemoteProfile translates a desktop SSH alias in an explicit profile query', () => {
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/cron/jobs?profile=mara', 'mara', {
+      globalRemote: false,
+      profileRemoteOverride: true,
+      backendProfile: 'default'
+    }),
+    '/api/cron/jobs?profile=default'
+  )
+})
+
+test('pathWithGlobalRemoteProfile preserves cross-profile selectors when translating an SSH alias', () => {
+  const opts = {
+    globalRemote: false,
+    profileRemoteOverride: true,
+    backendProfile: 'default'
+  }
+
+  assert.equal(pathWithGlobalRemoteProfile('/api/cron/jobs?profile=all', 'mara', opts), '/api/cron/jobs?profile=all')
+  assert.equal(pathWithGlobalRemoteProfile('/api/cron/jobs?profile=worker', 'mara', opts), '/api/cron/jobs?profile=worker')
+})
+
 test('pathWithGlobalRemoteProfile skips empty profile/path safely', () => {
   assert.equal(
     pathWithGlobalRemoteProfile('/api/model/info', '', {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -374,6 +374,9 @@ function profileRemoteOverride(config, profile) {
 }
 
 export interface ProfileRouteOptions {
+  /** Profile name on a separately-scoped backend when it differs from the
+   * desktop's local routing label (managed SSH `remoteProfile`). */
+  backendProfile?: null | string
   globalRemote?: boolean
   primaryProfile?: null | string
   profileRemoteOverride?: boolean
@@ -428,16 +431,16 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
 }
 
 /**
- * Add renderer-side `request.profile` to a REST path when the route says the
- * serving backend is not already scoped to that profile.
+ * Reconcile the renderer's desktop-facing profile label with the backend's
+ * profile namespace, then add `request.profile` when a shared backend needs it.
+ *
+ * A managed SSH override can deliberately map local `mara` to remote `default`.
+ * Endpoint-level filters (cron list / blueprint instantiate) arrive as an
+ * explicit `?profile=mara`; translate only that self-scope. Cross-profile
+ * selectors such as `all` or another concrete profile retain their meaning.
  */
 function pathWithGlobalRemoteProfile(path, profile, opts: ProfileRouteOptions = {}) {
   const scopedProfile = connectionScopeKey(profile)
-
-  if (!resolveProfileBackendRoute(profile, opts).scopePath) {
-    return path
-  }
-
   const rawPath = String(path || '')
 
   if (!rawPath) {
@@ -449,6 +452,19 @@ function pathWithGlobalRemoteProfile(path, profile, opts: ProfileRouteOptions = 
   try {
     parsed = new URL(rawPath, 'http://hermes.local')
   } catch {
+    return path
+  }
+
+  const backendProfile = connectionScopeKey(opts.backendProfile)
+  const explicitProfile = connectionScopeKey(parsed.searchParams.get('profile'))
+
+  if (backendProfile && backendProfile !== scopedProfile && explicitProfile === scopedProfile) {
+    parsed.searchParams.set('profile', backendProfile)
+
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  }
+
+  if (!resolveProfileBackendRoute(profile, opts).scopePath) {
     return path
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8087,10 +8087,16 @@ function primaryProfileKey() {
 
 // Options describing the current connection setup for `resolveProfileBackendRoute`.
 function profileRouteOptions(profile) {
+  const config = readDesktopConnectionConfig()
+  const sshOverride = profileSshOverride(config, profile)
+
   return {
+    // A desktop profile can be only a client-side routing alias. Keep backend
+    // endpoint filters in the SSH target's namespace (e.g. mara → default).
+    backendProfile: sshOverride?.remoteProfile,
     globalRemote: globalRemoteActive(),
     primaryProfile: primaryProfileKey(),
-    profileRemoteOverride: Boolean(profileHasRemoteOverride(profile))
+    profileRemoteOverride: Boolean(profileRemoteOverride(config, profile) || sshOverride)
   }
 }
 


### PR DESCRIPTION
## Summary

- translate endpoint-level self-profile filters from a Desktop SSH alias to the configured remote Hermes profile
- keep `request.profile` as the Desktop routing key so Electron still selects the correct managed SSH backend
- preserve cross-profile selectors such as `profile=all` and other explicit profiles

## Problem

A Desktop profile can be a client-side routing label rather than the profile name on its managed SSH host. With local `mara` mapped to remote `default`, the Cron modal routed to the correct remote backend but requested:

```text
/api/cron/jobs?profile=mara
```

The remote backend has no `mara` profile, so the Cron view failed to load.

## Approach

The Electron REST boundary now carries the managed SSH connection's `remoteProfile` into the existing path resolver. The resolver rewrites an explicit profile query only when it targets the Desktop alias itself:

```text
?profile=mara → ?profile=default
```

It leaves `all` and unrelated concrete profile selectors unchanged. Because this is handled at the REST routing boundary, the fix also covers sibling endpoint-filtered calls such as Cron blueprint instantiation.

## Verification

- [x] Regression test failed against the pre-fix resolver and passes with the change
- [x] `npx vitest run --project electron electron/connection-config.test.ts` — 77 passed
- [x] `npm run check` — passed (typecheck, lint with no errors, UI tests, Electron tests, desktop artifact tests, production build, macOS packaging)
- [x] Static security scan — no findings
- [x] Independent code review — passed with no blocking security or logic findings

## Related work

PR #79025 adds broader profile-alias support for URL remotes and WebSocket RPC routing. It does not currently propagate the existing managed SSH `remoteProfile` mapping into Electron REST path routing; this PR is the focused SSH/Cron gap reported here. The overlapping path-resolver changes may be combined during review if #79025 lands first.

Closes #82530
