### PR TITLE
feat: add independent Kanban review templates

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -341,6 +341,28 @@ def decompose_task(
     if parsed is None:
         return DecomposeOutcome(task_id, False, "LLM returned malformed JSON")
 
+    # Template enforcement (task t_e36247bb): force a separate implementer +
+    # independent reviewer for council paths (SL analysis/editorial, SL web
+    # ship). Skipped silently when no template matches or the template names a
+    # profile that isn't installed, so non-templated work is unaffected.
+    try:
+        from hermes_cli.kanban_decompose_templates import (
+            _apply_to_plan,
+            load_templates,
+            select_template,
+        )
+        _tpls = load_templates(cfg)
+        _tpl = select_template(task.title or "", _tpls)
+        if _tpl is not None:
+            parsed, _tpl_changed = _apply_to_plan(task, parsed, _tpl, valid_names)
+            if _tpl_changed:
+                logger.info(
+                    "decompose: template %r enforced separate implementer+reviewer "
+                    "on %s", _tpl.get("name"), task_id,
+                )
+    except Exception as exc:  # never let template logic break decomposition
+        logger.warning("decompose: template step failed (skipped): %s", exc)
+
     fanout = bool(parsed.get("fanout"))
     audit_author = author or _profile_author()
 

--- a/hermes_cli/kanban_decompose_templates.py
+++ b/hermes_cli/kanban_decompose_templates.py
@@ -1,0 +1,274 @@
+"""Kanban decompose templates for an implementer/reviewer split.
+
+Templates are configured under ``kanban.decompose_templates``.  They match a
+triage title, require two installed and distinct profiles, and harden the LLM
+plan so implementation and independent review cannot collapse onto one owner.
+
+Example::
+
+    decompose_templates:
+      - name: sl_analysis_editorial
+        match_title_requires_any: [suomen liittokunta, sl, pohjolan ihme]
+        match_title_contains: [analysis, editorial, rothbard]
+        enforce_review_child: true
+        implementer: suomen-liittokunta
+        reviewer: academic
+        require_mention: true
+        credential_isolation: true
+
+``match_title_requires_any`` is the project/path anchor.  At least one anchor
+and one ``match_title_contains`` signal must match when both are configured.
+Single-word matching is boundary-aware, so the ``sl`` anchor does not match a
+word such as ``slack``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+_CREDENTIAL_POLICY = (
+    "Credential isolation: never read, reuse, request, or pass another "
+    "profile's secrets, tokens, auth files, or credentials. Each profile owns "
+    "its own credentials."
+)
+
+
+def load_templates(cfg: dict) -> list[dict]:
+    """Return the ``kanban.decompose_templates`` list, or [] if malformed."""
+    kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    templates = kanban_cfg.get("decompose_templates")
+    if not isinstance(templates, list):
+        return []
+    return [template for template in templates if isinstance(template, dict)]
+
+
+def _normalize_match_text(value: object) -> str:
+    text = str(value or "").casefold().replace("-", " ").replace("_", " ")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _matches_token(title: str, token: object) -> bool:
+    needle = _normalize_match_text(token)
+    if not needle:
+        return False
+    if " " in needle:
+        return needle in title
+    return re.search(rf"(?<!\w){re.escape(needle)}(?!\w)", title) is not None
+
+
+def select_template(title: str, templates: list[dict]) -> Optional[dict]:
+    """Return the most-specific title template.
+
+    If ``match_title_requires_any`` is present, at least one of those anchors
+    must match.  If ``match_title_contains`` is present, at least one of those
+    signals must also match.  Legacy templates without anchors retain their
+    old any-token behavior.
+    """
+    normalized_title = _normalize_match_text(title)
+    if not normalized_title:
+        return None
+
+    best: Optional[dict] = None
+    best_score = -1
+    for template in templates:
+        anchors = template.get("match_title_requires_any") or []
+        signals = template.get("match_title_contains") or []
+        if not isinstance(anchors, list) or not isinstance(signals, list):
+            continue
+        if not anchors and not signals:
+            continue
+
+        anchor_matches = sum(
+            1 for token in anchors if _matches_token(normalized_title, token)
+        )
+        signal_matches = sum(
+            1 for token in signals if _matches_token(normalized_title, token)
+        )
+        if anchors and anchor_matches == 0:
+            continue
+        if signals and signal_matches == 0:
+            continue
+
+        # Anchors dominate ties because they encode the project/path boundary.
+        score = anchor_matches * 100 + signal_matches
+        if score > best_score:
+            best_score = score
+            best = template
+    return best
+
+
+def _append_credential_policy(body: object) -> str:
+    text = body.strip() if isinstance(body, str) else ""
+    if _CREDENTIAL_POLICY in text:
+        return text
+    if text:
+        return f"{text}\n\n{_CREDENTIAL_POLICY}"
+    return _CREDENTIAL_POLICY
+
+
+def _review_body_for(template: dict, task, original_body: object = "") -> str:
+    """Build a reviewer body containing the hard policy boundaries."""
+    lines = [
+        "**Independent review required.** You are the review counterpart to the "
+        "implementation work on this task. Do NOT implement or modify the "
+        "artifact. Critique it, verify it against the acceptance criteria, and "
+        "gate completion.",
+        "require_mention is enforced: this assignment is the explicit request "
+        "for this specific review; do not act on other council/mention-gated "
+        "surfaces without a separate explicit request.",
+        _CREDENTIAL_POLICY,
+    ]
+
+    supplied = original_body.strip() if isinstance(original_body, str) else ""
+    if supplied:
+        lines.append("Review scope from the decomposer:\n" + supplied)
+
+    root_body = getattr(task, "body", "")
+    root_body = root_body.strip() if isinstance(root_body, str) else ""
+    if root_body:
+        lines.append("Original task acceptance context:\n" + _truncate(root_body, 4000))
+    return "\n\n".join(lines)
+
+
+def _is_reviewer_task(entry: dict) -> bool:
+    title = str(entry.get("title", "")).strip().casefold()
+    return title.startswith("review")
+
+
+def _apply_to_plan(
+    task,
+    parsed: dict,
+    template: dict,
+    valid_names: set[str],
+) -> tuple[dict, bool]:
+    """Force one installed implementer and an independent review gate.
+
+    Policy flags fail closed: a template is ignored unless
+    ``require_mention`` and ``credential_isolation`` are literally true.  A
+    fanout plan keeps supporting non-review children and routes every such
+    child to the configured implementer.  Every reviewer is routed
+    to the configured reviewer, receives the policy body, and depends on all
+    non-review children.
+    """
+    implementer = template.get("implementer")
+    reviewer = template.get("reviewer")
+    policy_enabled = (
+        template.get("require_mention") is True
+        and template.get("credential_isolation") is True
+    )
+    if (
+        template.get("enforce_review_child") is not True
+        or not policy_enabled
+        or not isinstance(implementer, str)
+        or not isinstance(reviewer, str)
+    ):
+        return parsed, False
+
+    implementer = implementer.strip()
+    reviewer = reviewer.strip()
+    if (
+        not implementer
+        or not reviewer
+        or implementer == reviewer
+        or implementer not in valid_names
+        or reviewer not in valid_names
+    ):
+        return parsed, False
+
+    if not bool(parsed.get("fanout")):
+        title = parsed.get("title") or getattr(task, "title", "") or "Implement work"
+        title = title.strip() if isinstance(title, str) else "Implement work"
+        implementation = {
+            "title": title,
+            "body": _append_credential_policy(parsed.get("body")),
+            "assignee": implementer,
+            "parents": [],
+        }
+        review = {
+            "title": "Review: " + _truncate(title, 60),
+            "body": _review_body_for(template, task),
+            "assignee": reviewer,
+            "parents": [0],
+        }
+        return {
+            "fanout": True,
+            "rationale": parsed.get("rationale")
+            or "template-enforced separate implementer and reviewer",
+            "tasks": [implementation, review],
+        }, True
+
+    raw_tasks = parsed.get("tasks")
+    tasks = [dict(entry) if isinstance(entry, dict) else entry for entry in (
+        raw_tasks if isinstance(raw_tasks, list) else []
+    )]
+
+    reviewer_indices: list[int] = []
+    implementation_indices: list[int] = []
+    for index, entry in enumerate(tasks):
+        if not isinstance(entry, dict):
+            continue
+        if _is_reviewer_task(entry):
+            entry["assignee"] = reviewer
+            entry["body"] = _review_body_for(template, task, entry.get("body"))
+            reviewer_indices.append(index)
+        else:
+            entry["body"] = _append_credential_policy(entry.get("body"))
+            implementation_indices.append(index)
+
+    if not implementation_indices:
+        implementation_index = len(tasks)
+        root_title = getattr(task, "title", "") or "work"
+        root_body = getattr(task, "body", "") or ""
+        tasks.append({
+            "title": "Implement: " + _truncate(str(root_title), 60),
+            "body": _append_credential_policy(root_body),
+            "assignee": implementer,
+            "parents": [],
+        })
+        implementation_indices.append(implementation_index)
+    else:
+        # All non-review children are part of the template's implementation
+        # lane. Routing every one prevents an artifact-producing child from
+        # retaining a generic or otherwise unintended owner.
+        for index in implementation_indices:
+            tasks[index]["assignee"] = implementer
+
+    # Review must remain a terminal gate. If the LLM made implementation
+    # depend on a reviewer, replacing only the reviewer's parents below would
+    # leave an implementer <-> reviewer cycle. Preserve unrelated work edges
+    # while removing every dependency on a review child.
+    reviewer_index_set = set(reviewer_indices)
+    if reviewer_index_set:
+        for index in implementation_indices:
+            parents = tasks[index].get("parents")
+            if isinstance(parents, list):
+                tasks[index]["parents"] = [
+                    parent for parent in parents
+                    if parent not in reviewer_index_set
+                ]
+
+    if reviewer_indices:
+        for index in reviewer_indices:
+            # Review is a terminal gate. Replacing LLM-provided review edges
+            # avoids self/cross-review cycles while covering every work child.
+            tasks[index]["parents"] = list(implementation_indices)
+    else:
+        tasks.append({
+            "title": "Review: " + _truncate(getattr(task, "title", "") or "work", 60),
+            "body": _review_body_for(template, task),
+            "assignee": reviewer,
+            "parents": list(implementation_indices),
+        })
+
+    result = dict(parsed)
+    result["fanout"] = True
+    result["tasks"] = tasks
+    return result, True
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -15,6 +15,7 @@ import pytest
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_decompose as decomp
+from hermes_cli import kanban_decompose_templates as templates
 
 
 @pytest.fixture
@@ -161,3 +162,430 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+# ---------------------------------------------------------------------------
+# Template enforcement (task t_e36247bb): SL paths must emit a separate
+# implementer + independent reviewer, never collapse review onto the
+# implementer. Coverage: fanout with no reviewer, fanout=false single task,
+# reviewer missing (skipped), and non-matching title (no template).
+# ---------------------------------------------------------------------------
+
+_SL_TEMPLATES = {
+    "kanban": {
+        "default_assignee": "academic",
+        "orchestrator_profile": "default",
+        "decompose_templates": [
+            {
+                "name": "sl_analysis_editorial",
+                "match_title_requires_any": [
+                    "suomen liittokunta", "sl", "pohjolan ihme",
+                ],
+                "match_title_contains": ["analysis", "editorial", "rothbard"],
+                "enforce_review_child": True,
+                "implementer": "suomen-liittokunta",
+                "reviewer": "academic",
+                "require_mention": True,
+                "credential_isolation": True,
+            },
+            {
+                "name": "sl_web_ship",
+                "match_title_requires_any": [
+                    "suomen liittokunta", "sl", "pohjolan ihme",
+                ],
+                "match_title_contains": ["website", "deploy", "ship", "vercel"],
+                "enforce_review_child": True,
+                "implementer": "websites",
+                "reviewer": "academic",
+                "require_mention": True,
+                "credential_isolation": True,
+            },
+        ],
+    }
+}
+
+
+def test_template_injects_reviewer_into_fanout(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="Suomen Liittokunta analysis on pensions", triage=True,
+        )
+    # LLM returns only a child under the wrong owner, forgetting the reviewer.
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "research then write",
+        "tasks": [
+            {"title": "Write analysis", "body": "do it",
+             "assignee": "default", "parents": []},
+        ],
+    })
+    patches = _patch_list_profiles(
+        ["default", "suomen-liittokunta", "academic", "websites"],
+    )
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=_SL_TEMPLATES,
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+    assert outcome.ok, outcome.reason
+    assert outcome.fanout is True
+    assert len(outcome.child_ids) == 2
+    with kb.connect() as conn:
+        c0 = kb.get_task(conn, outcome.child_ids[0])
+        c1 = kb.get_task(conn, outcome.child_ids[1])
+    # Implementer and reviewer are DISTINCT profiles.
+    assert c0.assignee == "suomen-liittokunta"
+    assert c1.assignee == "academic"
+    assert c1.title.lower().startswith("review")
+    assert "Credential isolation:" in c0.body
+    assert "require_mention is enforced" in c1.body
+    assert "Credential isolation:" in c1.body
+    # Reviewer depends on the implementer; implementer runs first.
+    assert c0.status == "ready"
+    assert c1.status == "todo"
+    assert c1.title.lower().startswith("review")
+
+
+def test_template_upgrades_single_task_to_implementer_reviewer(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="SL analysis: tighten editorial copy", triage=True,
+        )
+    # LLM returned fanout=false (single unit) -> must be split.
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Tightened editorial",
+        "body": "Write the copy.",
+    })
+    patches = _patch_list_profiles(
+        ["default", "suomen-liittokunta", "academic", "websites"],
+    )
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=_SL_TEMPLATES,
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+    assert outcome.ok, outcome.reason
+    assert outcome.fanout is True
+    assert len(outcome.child_ids) == 2
+    with kb.connect() as conn:
+        c0 = kb.get_task(conn, outcome.child_ids[0])
+        c1 = kb.get_task(conn, outcome.child_ids[1])
+    assert c0.assignee == "suomen-liittokunta"
+    assert c1.assignee == "academic"
+    assert c1.title.lower().startswith("review")
+
+
+def test_template_skipped_when_reviewer_profile_missing(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="Suomen Liittokunta analysis on pensions", triage=True,
+        )
+    # Only implementer installed; reviewer 'academic' is NOT in the roster,
+    # so the template must NOT fake a reviewer child.
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "research then write",
+        "tasks": [
+            {"title": "Write analysis", "body": "do it",
+             "assignee": "suomen-liittokunta", "parents": []},
+        ],
+    })
+    patches = _patch_list_profiles(["default", "suomen-liittokunta"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=_SL_TEMPLATES,
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+    assert outcome.ok, outcome.reason
+    assert len(outcome.child_ids) == 1
+    with kb.connect() as conn:
+        c0 = kb.get_task(conn, outcome.child_ids[0])
+    assert c0.assignee == "suomen-liittokunta"
+
+
+def test_template_no_match_for_non_sl_title(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="Deploy the finance website", triage=True,
+        )
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "two parts",
+        "tasks": [
+            {"title": "Write fix", "body": "a", "assignee": "engineer", "parents": []},
+            {"title": "Verify", "body": "b", "assignee": "engineer", "parents": [0]},
+        ],
+    })
+    patches = _patch_list_profiles(
+        ["default", "engineer", "suomen-liittokunta", "academic", "websites"],
+    )
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=_SL_TEMPLATES,
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+    assert outcome.ok, outcome.reason
+    # No template matched -> LLM plan untouched, both children to 'engineer'.
+    assert len(outcome.child_ids) == 2
+    with kb.connect() as conn:
+        for cid in outcome.child_ids:
+            assert kb.get_task(conn, cid).assignee == "engineer"
+
+
+def test_template_normalizes_existing_review_child_and_policy(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="SL website deploy",
+            body="Acceptance: deployment receipt and smoke test.",
+            triage=True,
+        )
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "build then review",
+        "tasks": [
+            {"title": "Deploy website", "body": "ship it",
+             "assignee": "websites", "parents": []},
+            {"title": "Review deployment", "body": "check smoke evidence",
+             "assignee": "websites", "parents": []},
+        ],
+    })
+    patches = _patch_list_profiles(
+        ["default", "suomen-liittokunta", "academic", "websites"],
+    )
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=_SL_TEMPLATES,
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert len(outcome.child_ids) == 2
+    with kb.connect() as conn:
+        implementation = kb.get_task(conn, outcome.child_ids[0])
+        review = kb.get_task(conn, outcome.child_ids[1])
+    assert implementation.assignee == "websites"
+    assert review.assignee == "academic"
+    assert review.status == "todo"
+    assert "check smoke evidence" in (review.body or "")
+    assert "Original task acceptance context" in (review.body or "")
+    assert "require_mention is enforced" in (review.body or "")
+    assert "Credential isolation:" in (review.body or "")
+
+
+def test_template_adds_implementer_when_llm_returns_only_review(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="SL analysis: review policy memo", triage=True,
+        )
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "bad review-only plan",
+        "tasks": [
+            {"title": "Review memo", "body": "review it",
+             "assignee": "academic", "parents": []},
+        ],
+    })
+    patches = _patch_list_profiles(
+        ["default", "suomen-liittokunta", "academic", "websites"],
+    )
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=_SL_TEMPLATES,
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect() as conn:
+        children = [kb.get_task(conn, cid) for cid in outcome.child_ids]
+    by_assignee = {child.assignee: child for child in children}
+    assert set(by_assignee) == {"suomen-liittokunta", "academic"}
+    assert by_assignee["suomen-liittokunta"].status == "ready"
+    assert by_assignee["academic"].status == "todo"
+
+
+def test_template_policy_flags_fail_closed():
+    template = dict(_SL_TEMPLATES["kanban"]["decompose_templates"][0])
+    template["require_mention"] = False
+    task = type("Task", (), {"title": "SL analysis", "body": ""})()
+    plan = {"fanout": False, "title": "Write analysis", "body": "do it"}
+
+    result, changed = templates._apply_to_plan(
+        task,
+        plan,
+        template,
+        {"suomen-liittokunta", "academic"},
+    )
+
+    assert changed is False
+    assert result is plan
+
+def test_template_breaks_implementer_reviewer_cycle():
+    template = _SL_TEMPLATES["kanban"]["decompose_templates"][0]
+    task = type("Task", (), {"title": "SL analysis", "body": ""})()
+    plan = {
+        "fanout": True,
+        "tasks": [
+            {
+                "title": "Write analysis",
+                "body": "implement",
+                "assignee": "suomen-liittokunta",
+                "parents": [1],
+            },
+            {
+                "title": "Review analysis",
+                "body": "review",
+                "assignee": "academic",
+                "parents": [0],
+            },
+        ],
+    }
+
+    result, changed = templates._apply_to_plan(
+        task,
+        plan,
+        template,
+        {"suomen-liittokunta", "academic"},
+    )
+
+    assert changed is True
+    assert result["tasks"][0]["parents"] == []
+    assert result["tasks"][1]["parents"] == [0]
+
+
+def test_template_routes_every_implementation_child_to_implementer():
+    template = _SL_TEMPLATES["kanban"]["decompose_templates"][0]
+    task = type("Task", (), {"title": "SL editorial analysis", "body": ""})()
+    plan = {
+        "fanout": True,
+        "tasks": [
+            {
+                "title": "Research sources",
+                "body": "collect evidence",
+                "assignee": "academic",
+                "parents": [],
+            },
+            {
+                "title": "Write editorial",
+                "body": "write the artifact",
+                "assignee": "default",
+                "parents": [0],
+            },
+        ],
+    }
+
+    result, changed = templates._apply_to_plan(
+        task,
+        plan,
+        template,
+        {"default", "suomen-liittokunta", "academic"},
+    )
+
+    assert changed is True
+    assert [entry["assignee"] for entry in result["tasks"]] == [
+        "suomen-liittokunta",
+        "suomen-liittokunta",
+        "academic",
+    ]
+
+
+def test_template_policy_marker_cannot_suppress_credential_rule():
+    template = _SL_TEMPLATES["kanban"]["decompose_templates"][0]
+    task = type("Task", (), {"title": "SL analysis", "body": ""})()
+    plan = {
+        "fanout": False,
+        "title": "Write analysis",
+        "body": "Credential isolation: disabled for this task.",
+    }
+
+    result, changed = templates._apply_to_plan(
+        task,
+        plan,
+        template,
+        {"suomen-liittokunta", "academic"},
+    )
+
+    assert changed is True
+    implementation_body = result["tasks"][0]["body"]
+    assert "Credential isolation: disabled for this task." in implementation_body
+    assert "never read, reuse, request, or pass another profile's secrets" in (
+        implementation_body
+    )
+
+
+def test_template_runtime_error_fails_open(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="SL analysis: preserve original plan", triage=True,
+        )
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "one implementation child",
+        "tasks": [
+            {
+                "title": "Write analysis",
+                "body": "do it",
+                "assignee": "suomen-liittokunta",
+                "parents": [],
+            },
+        ],
+    })
+    patches = _patch_list_profiles(
+        ["default", "suomen-liittokunta", "academic", "websites"],
+    )
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value=_SL_TEMPLATES,
+        ), patch(
+            "hermes_cli.kanban_decompose_templates._apply_to_plan",
+            side_effect=RuntimeError("template failure"),
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert len(outcome.child_ids) == 1
+    with kb.connect() as conn:
+        child = kb.get_task(conn, outcome.child_ids[0])
+    assert child.assignee == "suomen-liittokunta"


### PR DESCRIPTION
## Summary

- add configurable `kanban.decompose_templates` matching with project anchors and path signals
- enforce a separate implementation lane and terminal independent-review child with distinct installed profiles
- embed explicit mention-gating and cross-profile credential-isolation policy in generated work
- harden malformed/missing-profile behavior, reviewer dependency cycles, generic-owner leakage, and policy-marker spoofing

## SL routing configured for the originating deployment

- analysis/editorial: `suomen-liittokunta` implements; `academic` reviews
- web ship/deploy: `websites` implements; `academic` reviews

The repository change is generic and only activates for configured templates.

## Verification

- `uv run --extra dev pytest tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py -o 'addopts=' -q` — 16 passed
- `uv run --extra dev ruff check hermes_cli/kanban_decompose.py hermes_cli/kanban_decompose_templates.py tests/hermes_cli/test_kanban_decompose.py` — passed
- `git diff --check HEAD^` — passed
- independent review caught and drove fixes for implementer leakage, policy-marker spoofing, review cycles, and reviewer-assignee misclassification
