### PR TITLE
fix(cli): catch httpx.ConnectError in xAI OAuth token refresh (#82204)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4853,16 +4853,24 @@ def refresh_xai_oauth_pure(
     # with a clear error so the user can re-run `hermes model` to refetch.
     _xai_validate_oauth_endpoint(endpoint, field="token_endpoint")
     timeout = httpx.Timeout(max(5.0, float(timeout_seconds)))
-    with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
-        response = client.post(
-            endpoint,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data={
-                "grant_type": "refresh_token",
-                "client_id": XAI_OAUTH_CLIENT_ID,
-                "refresh_token": refresh_token,
-            },
-        )
+    try:
+        with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}) as client:
+            response = client.post(
+                endpoint,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={
+                    "grant_type": "refresh_token",
+                    "client_id": XAI_OAUTH_CLIENT_ID,
+                    "refresh_token": refresh_token,
+                },
+            )
+    except httpx.HTTPError as exc:
+        raise AuthError(
+            f"xAI token refresh failed: {exc}",
+            provider="xai-oauth",
+            code="xai_refresh_network_error",
+            relogin_required=False,
+        ) from exc
     if response.status_code != 200:
         detail = response.text.strip()
         # ``403`` from xAI's token endpoint is almost always a tier /


### PR DESCRIPTION
## Problem

`hermes model` crashes with raw httpx traceback when xAI OAuth token refresh hits DNS failure:

```
httpx.ConnectError: [Errno -3] Temporary failure in name resolution
```

The `refresh_xai_oauth_pure()` function does not catch `httpx.HTTPError` from the `client.post()` call. When DNS resolution fails, the exception escapes through `resolve_xai_oauth_runtime_credentials` and `get_xai_oauth_auth_status` which only catches `AuthError`.

## Fix

Wrap the HTTP POST call in `refresh_xai_oauth_pure()` with `try/except httpx.HTTPError` and raise `AuthError` with `code=xai_refresh_network_error` so the caller catches it cleanly.

```python
try:
    with httpx.Client(...) as client:
        response = client.post(...)
except httpx.HTTPError as exc:
    raise AuthError(
        f"xAI token refresh failed: {exc}",
        provider="xai-oauth",
        code="xai_refresh_network_error",
        relogin_required=False,
    ) from exc
```

The `relogin_required=False` ensures the user is not prompted to re-authenticate for transient network errors.

## Testing

- Existing xAI OAuth tests pass
- Network errors now surface as clean AuthError instead of raw traceback

Fixes #82204
