### PR TITLE
Agent/turn lease fail open safe

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17058,15 +17058,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # to outer dispatch, or this early exit leaks task-local identity.
                 self._clear_session_env(_session_env_tokens)
                 raise
-            # A fail-open/legacy registry may return a degraded token after
-            # timing out. It does not own the registry lock and must never
-            # overwrite the held turn's token in shared session state.
-            if _lease_token is not None and not getattr(
-                _lease_token, "degraded", False
-            ):
-                _lease_state = self._session_state(_quick_key).turn
-                _lease_state.lease_token = _lease_token
-                _lease_state.lease_generation = run_generation
+            self._record_turn_lease(_quick_key, _lease_token, run_generation)
 
         # A turn only becomes durable recovery work after it owns (or has
         # explicitly degraded past) the per-session lease.  Marking before the
@@ -23458,6 +23450,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("Failed to release turn lease", exc_info=True)
             return False
+
+    def _record_turn_lease(
+        self, session_key: str, token: object, run_generation: int
+    ) -> bool:
+        """Record only a token that actually owns the registry lease.
+
+        A fail-open/legacy registry may return a degraded token after timing
+        out. It does not own the registry lock and must never overwrite the
+        held turn's token in shared session state.
+        """
+        if token is None or getattr(token, "degraded", False):
+            return False
+        lease_state = self._session_state(session_key).turn
+        lease_state.lease_token = token
+        lease_state.lease_generation = run_generation
+        return True
 
     def _rebind_turn_lease(
         self, session_key: str, run_generation: int, new_session_id: str

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17058,7 +17058,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # to outer dispatch, or this early exit leaks task-local identity.
                 self._clear_session_env(_session_env_tokens)
                 raise
-            if _lease_token is not None:
+            # A fail-open/legacy registry may return a degraded token after
+            # timing out. It does not own the registry lock and must never
+            # overwrite the held turn's token in shared session state.
+            if _lease_token is not None and not getattr(
+                _lease_token, "degraded", False
+            ):
                 _lease_state = self._session_state(_quick_key).turn
                 _lease_state.lease_token = _lease_token
                 _lease_state.lease_generation = run_generation

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -20,6 +20,7 @@ Covers:
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -478,3 +479,24 @@ def test_runner_release_turn_lease_is_token_scoped_and_bare_safe():
         assert runner._release_turn_lease("", 1) is False
 
     _run(scenario())
+
+
+def test_runner_does_not_record_degraded_turn_lease():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    held_token = object()
+    state = SimpleNamespace(
+        turn=SimpleNamespace(lease_token=held_token, lease_generation=1)
+    )
+    runner._session_state = MagicMock(return_value=state)
+    degraded_token = SimpleNamespace(degraded=True)
+
+    assert runner._record_turn_lease("key-a", degraded_token, 2) is False
+    assert state.turn.lease_token is held_token
+    assert state.turn.lease_generation == 1
+    runner._session_state.assert_not_called()
+
+    assert runner._record_turn_lease("key-a", held_token, 2) is True
+    assert state.turn.lease_token is held_token
+    assert state.turn.lease_generation == 2


### PR DESCRIPTION
## What does this PR do?

  Prevents degraded turn-lease tokens from overwriting the active holder’s lease state.

  A failed-open waiter does not own the registry lock. If its degraded token is stored in shared session state, it can
  replace the real holder’s token and prevent the holder from releasing the lock, wedging the session until gateway
  restart.

  The current `main` path fails closed on timeout, but this defensive check protects compatibility with legacy/fail-open
  registry behavior and prevents future regressions.

  ## Related Issue

  Fixes #82349 

  ## Type of Change

  - [x] 🐛 Bug fix
  - [x] ✅ Tests

  ## Changes Made

  - Updated `gateway/run.py` to record only non-degraded lease tokens.
  - Added `_record_turn_lease()` to centralize and document the ownership check.
  - Added regression coverage in `tests/gateway/test_turn_lease.py`.
  - Preserved the existing fail-closed timeout behavior.

  ## How to Test

  1. Run the focused lease tests:

     ```bash
     pytest tests/gateway/test_turn_lease.py -q

  2. Confirm the result:

     13 passed

  3. The regression test verifies that a degraded token cannot overwrite an existing holder token or generation.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide.
  - [x] Commit messages follow Conventional Commits.
  - [x] I searched for existing PRs to make sure this isn't a duplicate.
  - [x] My PR contains only changes related to this fix.
  - [ ] I've run `pytest tests/ -q` and all tests pass — full-suite collection is blocked by optional dependencies and
  integration requirements. The focused lease suite passes: 13 passed.

  - [x] I've added tests for this bug fix.
  - [x] I've considered cross-platform impact; this change is platform-independent.

  ### Documentation & Housekeeping

  - [x] Documentation update not required.
  - [x] No configuration keys changed.
  - [x] No architecture or workflow changes.
  - [x] No tool descriptions or schemas changed.

  ## Screenshots / Logs

  Not applicable.