### PR TITLE
fix(email): reply to all original recipients instead of only the sender

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -33,7 +33,7 @@ from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
-from email.utils import formatdate
+from email.utils import formatdate, getaddresses
 from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -326,6 +326,44 @@ def _extract_email_address(raw: str) -> str:
     if match:
         return match.group(1).strip().lower()
     return raw.strip().lower()
+
+
+def _reply_all_recipients(
+    to_header: str,
+    cc_header: str,
+    sender_addr: str,
+    agent_addr: str,
+) -> Dict[str, str]:
+    """Build Reply-All recipient headers from an inbound message's To/Cc.
+
+    The direct sender is promoted to the front of To, the remaining original
+    To recipients stay in To, Cc recipients stay in Cc, and the agent's own
+    address is dropped from both (it should never mail itself). Addresses are
+    deduplicated case-insensitively while retaining first-seen order and are
+    returned as comma-joined bare addresses.
+    """
+    agent = agent_addr.strip().lower()
+    seen = set()
+    to_addresses: List[str] = []
+    cc_addresses: List[str] = []
+
+    def add(target: List[str], address: str) -> None:
+        normalized = address.strip().lower()
+        if not normalized or normalized == agent or normalized in seen:
+            return
+        seen.add(normalized)
+        target.append(address.strip())
+
+    add(to_addresses, sender_addr)
+    for _name, address in getaddresses([to_header or ""]):
+        add(to_addresses, address)
+    for _name, address in getaddresses([cc_header or ""]):
+        add(cc_addresses, address)
+
+    return {
+        "to": ", ".join(to_addresses) or sender_addr,
+        "cc": ", ".join(cc_addresses),
+    }
 
 
 def _domain_of(address: str) -> str:
@@ -812,6 +850,8 @@ class EmailAdapter(BasePlatformAdapter):
                         "uid": uid,
                         "sender_addr": sender_addr,
                         "sender_name": sender_name,
+                        "to_header": msg.get("To", ""),
+                        "cc_header": msg.get("Cc", ""),
                         "subject": subject,
                         "message_id": message_id,
                         "in_reply_to": in_reply_to,
@@ -948,10 +988,18 @@ class EmailAdapter(BasePlatformAdapter):
                 # only classification that surfaces both.
                 msg_type = MessageType.DOCUMENT
 
-        # Store thread context for reply threading
+        # Store thread context for reply threading. Besides the subject and
+        # Message-ID, keep the original To/Cc recipients so a reply goes to
+        # the whole thread (Reply All) instead of forking it into a 1:1.
         self._thread_context[sender_addr] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            **_reply_all_recipients(
+                msg_data.get("to_header", ""),
+                msg_data.get("cc_header", ""),
+                sender_addr,
+                self._address,
+            ),
         }
 
         source = self.build_source(
@@ -1012,10 +1060,14 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
 
-        # Thread context for reply
+        # Thread context for reply. Restore the original thread's To/Cc
+        # recipients (Reply All); smtplib.send_message derives the SMTP
+        # envelope from these headers, so Cc recipients are delivered too.
         ctx = self._thread_context.get(to_addr, {})
+        msg["To"] = ctx.get("to") or to_addr
+        if ctx.get("cc"):
+            msg["Cc"] = ctx["cc"]
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -1127,9 +1179,11 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
+        msg["To"] = ctx.get("to") or to_addr
+        if ctx.get("cc"):
+            msg["Cc"] = ctx["cc"]
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -1207,9 +1261,11 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
+        msg["To"] = ctx.get("to") or to_addr
+        if ctx.get("cc"):
+            msg["Cc"] = ctx["cc"]
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -360,6 +360,38 @@ class TestThreadContext(unittest.TestCase):
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
+    def test_thread_context_stored_after_dispatch(self):
+        """Dispatch stores subject, message id, and Reply-All recipients."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        async def noop_handle(event):
+            pass
+
+        adapter.handle_message = noop_handle
+
+        msg_data = {
+            "uid": b"10",
+            "sender_addr": "alice@test.com",
+            "sender_name": "Alice",
+            "to_header": "Agent <hermes@test.com>, Bob <bob@test.com>",
+            "cc_header": "Carol <carol@test.com>",
+            "subject": "Project question",
+            "message_id": "<original@test.com>",
+            "in_reply_to": "",
+            "body": "Hello",
+            "attachments": [],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+        ctx = adapter._thread_context.get("alice@test.com")
+        self.assertIsNotNone(ctx)
+        assert ctx is not None
+        self.assertEqual(ctx["subject"], "Project question")
+        self.assertEqual(ctx["message_id"], "<original@test.com>")
+        self.assertEqual(ctx["to"], "alice@test.com, bob@test.com")
+        self.assertEqual(ctx["cc"], "carol@test.com")
 
     def test_reply_uses_re_prefix(self):
         """Reply subject should have Re: prefix."""
@@ -381,6 +413,55 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["In-Reply-To"], "<original@test.com>")
             self.assertEqual(send_call["References"], "<original@test.com>")
             self.assertIn("Date", send_call)
+
+    def test_reply_all_preserves_to_and_cc_recipients(self):
+        """A reply keeps all original To/Cc recipients of the thread."""
+        adapter = self._make_adapter()
+        adapter._thread_context["alice@test.com"] = {
+            "subject": "Group planning",
+            "message_id": "<original@test.com>",
+            "to": "alice@test.com, bob@test.com",
+            "cc": "carol@test.com",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("alice@test.com", "Both recipients are included.", None)
+
+            sent = mock_server.send_message.call_args[0][0]
+            self.assertEqual(sent["To"], "alice@test.com, bob@test.com")
+            self.assertEqual(sent["Cc"], "carol@test.com")
+
+    def test_reply_without_cc_context_sets_no_cc_header(self):
+        """Without stored recipients, replies go only to the sender."""
+        adapter = self._make_adapter()
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("alice@test.com", "Just you and me.", None)
+
+            sent = mock_server.send_message.call_args[0][0]
+            self.assertEqual(sent["To"], "alice@test.com")
+            self.assertIsNone(sent["Cc"])
+
+    def test_reply_all_recipients_excludes_agent_address(self):
+        """The agent's own address never appears in To or Cc, and duplicate
+        addresses are removed case-insensitively (first-seen wins)."""
+        from plugins.platforms.email.adapter import _reply_all_recipients
+
+        result = _reply_all_recipients(
+            to_header="Agent <hermes@test.com>, Bob <bob@test.com>, ALICE@test.com",
+            cc_header="hermes@test.com, Carol <carol@test.com>, bob@test.com",
+            sender_addr="alice@test.com",
+            agent_addr="hermes@test.com",
+        )
+
+        self.assertEqual(result["to"], "alice@test.com, bob@test.com")
+        self.assertEqual(result["cc"], "carol@test.com")
 
 
 class TestSendMethods(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

Makes email replies behave like **Reply All**. Today the email adapter's IMAP
fetch path never captures the inbound message's `To`/`Cc` headers, and
`_thread_context` stores only `{subject, message_id}` — so a reply to a
multi-recipient thread *structurally cannot* include the other recipients.
Every group email thread is silently forked into a 1:1 with the direct
sender: the other participants never see the agent's replies, and follow-ups
splinter the conversation.

Fix: capture `To`/`Cc` at fetch time, compute safe Reply-All recipients at
dispatch, and restore them on the three send paths. The direct sender is
promoted to the front of `To`, original `To` recipients stay in `To`, `Cc`
recipients stay in `Cc`, the agent's own address is dropped from both, and
addresses are deduplicated case-insensitively in first-seen order (parsed
with `email.utils.getaddresses`, joined as bare comma-separated addresses —
bare on purpose: it avoids re-emitting RFC 2047-encoded or otherwise odd
display names into outbound headers).

Delivery is correct end-to-end because the adapter sends with
`smtplib.send_message(msg)`, which derives the SMTP envelope recipients from
the `To`/`Cc` headers — so Cc'd recipients actually receive the mail, not
just appear in the header.

Behavior is unchanged for 1:1 threads: with no stored recipients the reply
still goes only to the sender and no `Cc` header is added. Unsolicited sends
(no thread context) are also unchanged.

## Related Issue

No existing issue found — see the duplicate search at the bottom.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/email/adapter.py`
  - New module-level helper `_reply_all_recipients(to_header, cc_header,
    sender_addr, agent_addr)` returning `{"to": ..., "cc": ...}` with the
    semantics described above.
  - `_fetch_new_messages`: msg_data now includes `"to_header"` and
    `"cc_header"` (raw `To`/`Cc` headers of the inbound message).
  - `_dispatch_message`: merges the helper's `{to, cc}` into
    `self._thread_context[sender_addr]` alongside `subject`/`message_id`.
  - `_send_email`, `_send_email_with_attachments`,
    `_send_email_with_attachment`: set `msg["To"]` from the stored context
    (falling back to the sender address as before) and add `msg["Cc"]` when
    the context carries Cc recipients.
- `tests/gateway/test_email.py` — four new tests in `TestThreadContext`:
  - `test_thread_context_stored_after_dispatch` — dispatch stores subject,
    message id, and Reply-All `to`/`cc` (agent's own address excluded).
  - `test_reply_all_preserves_to_and_cc_recipients` — `_send_email` emits the
    stored `To` and `Cc` headers on the outgoing message.
  - `test_reply_without_cc_context_sets_no_cc_header` — regression guard: no
    context ⇒ To = sender only, no `Cc` header.
  - `test_reply_all_recipients_excludes_agent_address` — helper drops the
    agent address from both fields and dedups case-insensitively.
  - (No separate envelope-recipient test needed: the adapter uses
    `send_message`, which derives the envelope from these same headers.)

## How to Test

1. `pytest tests/gateway/test_email.py -q` → 36 passed.
   Broader sweep: `pytest tests/gateway/ -q -k email` → 74 passed, 2 skipped.
2. Manual repro: configure the email platform, then from account A send a
   mail to the agent with another account B in `To` and account C in `Cc`.
3. Before this patch: the agent's reply has `To: <A>` only — B and C are
   dropped from the thread. After: the reply has `To: A, B` and `Cc: C`, the
   agent's own address appears in neither, and B/C receive the message
   (envelope derived from headers via `smtplib.send_message`).
4. Send a plain 1:1 mail to the agent and confirm the reply still goes only
   to the sender with no `Cc` header.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (except two pre-existing failures in `tests/run_agent/test_switch_model_reasoning_override.py` that also fail on a clean `main` checkout — unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3 (Darwin 25.3.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings/comments in the adapter; no user-facing config change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure stdlib `email`/`smtplib`, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema change)

## Screenshots / Logs

```
$ pytest tests/gateway/test_email.py -q
36 passed in 1.46s

$ pytest tests/gateway/ -q -k email
74 passed, 2 skipped, 5031 deselected in 9.93s

$ uvx ruff@0.15.10 check plugins/ tests/
All checks passed!
```

---

### Duplicate search (2026-08-09)

- `gh search prs --repo NousResearch/hermes-agent "email reply"` — closest:
  #55841 (open, "Fix email reply References threading" — References header
  chain, not recipients), #11422 (session keying by Gmail thread id), #45600
  (subject-based thread isolation). None touch reply recipients.
- `gh search prs --repo NousResearch/hermes-agent "reply all"` — no email
  hits (Slack/Telegram reply-mode PRs only).
- `gh search issues` for both queries — no matching issue; closest are HTML
  email support (#11941) and subject-based session isolation (#26277).

No existing PR or issue covers preserving To/Cc recipients on email replies.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
