### PR TITLE
feat(google-workspace): gmail reply defaults to Reply All with --to/--cc/--no-reply-all

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -189,9 +189,17 @@ $GAPI gmail send --to user@example.com --subject "Hello" --body "Message text"
 $GAPI gmail send --to user@example.com --subject "Report" --body "<h1>Q4</h1><p>Details...</p>" --html
 $GAPI gmail send --to user@example.com --subject "Hello" --from '"Research Agent" <user@example.com>' --body "Message text"
 
-# Reply (automatically threads and sets In-Reply-To)
+# Reply (automatically threads and sets In-Reply-To).
+# Reply All is the default: the original sender goes on To, everyone else on
+# the original To stays on To and the original Cc stays on Cc (your own
+# address is dropped, duplicates removed).
 $GAPI gmail reply MESSAGE_ID --body "Thanks, that works for me."
 $GAPI gmail reply MESSAGE_ID --from '"Support Bot" <user@example.com>' --body "Thanks"
+# Add extra recipients on top of Reply All
+$GAPI gmail reply MESSAGE_ID --body "Looping in Dana." --cc dana@example.com
+$GAPI gmail reply MESSAGE_ID --body "Adding Sam." --to sam@example.com
+# Reply to the sender only (drop the other To/Cc recipients)
+$GAPI gmail reply MESSAGE_ID --no-reply-all --body "Just between us."
 
 # Labels
 $GAPI gmail labels

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -9,7 +9,7 @@ Usage:
   python google_api.py gmail search "is:unread" [--max 10]
   python google_api.py gmail get MESSAGE_ID
   python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
-  python google_api.py gmail reply MESSAGE_ID --body "Thanks"
+  python google_api.py gmail reply MESSAGE_ID --body "Thanks"  # Reply All by default: keeps original To/Cc (minus your own address); --no-reply-all for sender-only
   python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
   python google_api.py drive search "budget report" [--max 10]
@@ -29,6 +29,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
+from email.utils import getaddresses
 from pathlib import Path
 
 # Ensure sibling modules (_hermes_home) are importable when run standalone.
@@ -134,6 +135,39 @@ def _headers_dict(msg: dict) -> dict[str, str]:
         for h in msg.get("payload", {}).get("headers", [])
         if h.get("name")
     }
+
+
+def _reply_all_recipients(headers, self_address, extra_to="", extra_cc="", reply_all=True):
+    """Compute (To, Cc) header strings for a reply.
+
+    With reply_all=True (the default) every recipient of the original message
+    is kept: the original sender is promoted onto To, everyone already on To
+    stays on To, and everyone on Cc stays on Cc. Your own address is dropped
+    (case-insensitively) so you never reply to yourself, and addresses are
+    de-duplicated first-seen. extra_to/extra_cc are appended on top. With
+    reply_all=False only the original sender is used (extras still apply).
+    """
+    self_norm = (self_address or "").strip().lower()
+    seen = set()
+    to_list = []
+    cc_list = []
+
+    def add(target, raw):
+        for _name, addr in getaddresses([raw or ""]):
+            norm = addr.strip().lower()
+            if not norm or norm == self_norm or norm in seen:
+                continue
+            seen.add(norm)
+            target.append(addr.strip())
+
+    add(to_list, headers.get("from", ""))
+    if reply_all:
+        add(to_list, headers.get("to", ""))
+    add(to_list, extra_to)
+    if reply_all:
+        add(cc_list, headers.get("cc", ""))
+    add(cc_list, extra_cc)
+    return ", ".join(to_list), ", ".join(cc_list)
 
 
 def _extract_message_body(msg: dict) -> str:
@@ -359,6 +393,13 @@ def gmail_send(args):
 
 
 def gmail_reply(args):
+    # Reply All by default so recipients already on the thread are never
+    # silently dropped; --no-reply-all falls back to sender-only.
+    reply_all = not getattr(args, "no_reply_all", False)
+    extra_to = getattr(args, "to", "") or ""
+    extra_cc = getattr(args, "cc", "") or ""
+    meta_headers = ["From", "To", "Cc", "Subject", "Message-ID"]
+
     if _gws_binary():
         original = _run_gws(
             ["gmail", "users", "messages", "get"],
@@ -366,17 +407,29 @@ def gmail_reply(args):
                 "userId": "me",
                 "id": args.message_id,
                 "format": "metadata",
-                "metadataHeaders": ["From", "Subject", "Message-ID"],
+                "metadataHeaders": meta_headers,
             },
         )
         headers = _headers_dict(original)
+        # Best-effort: our own address, so Reply All never echoes back to us.
+        try:
+            self_address = _run_gws(
+                ["gmail", "users", "getProfile"], params={"userId": "me"}
+            ).get("emailAddress", "")
+        except Exception:
+            self_address = ""
 
         subject = headers.get("subject", "")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
 
+        to_hdr, cc_hdr = _reply_all_recipients(
+            headers, self_address, extra_to, extra_cc, reply_all
+        )
         message = MIMEText(args.body)
-        message["To"] = headers.get("from", "")
+        message["To"] = to_hdr
+        if cc_hdr:
+            message["Cc"] = cc_hdr
         message["Subject"] = subject
         if args.from_header:
             message["From"] = args.from_header
@@ -390,22 +443,32 @@ def gmail_reply(args):
             params={"userId": "me"},
             body={"raw": raw, "threadId": original["threadId"]},
         )
-        print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
+        print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", ""), "to": to_hdr, "cc": cc_hdr}, indent=2))
         return
 
     service = build_service("gmail", "v1")
     original = service.users().messages().get(
         userId="me", id=args.message_id, format="metadata",
-        metadataHeaders=["From", "Subject", "Message-ID"],
+        metadataHeaders=meta_headers,
     ).execute()
     headers = _headers_dict(original)
+    # Best-effort: our own address, so Reply All never echoes back to us.
+    try:
+        self_address = service.users().getProfile(userId="me").execute().get("emailAddress", "")
+    except Exception:
+        self_address = ""
 
     subject = headers.get("subject", "")
     if not subject.startswith("Re:"):
         subject = f"Re: {subject}"
 
+    to_hdr, cc_hdr = _reply_all_recipients(
+        headers, self_address, extra_to, extra_cc, reply_all
+    )
     message = MIMEText(args.body)
-    message["To"] = headers.get("from", "")
+    message["To"] = to_hdr
+    if cc_hdr:
+        message["Cc"] = cc_hdr
     message["Subject"] = subject
     if args.from_header:
         message["From"] = args.from_header
@@ -417,7 +480,7 @@ def gmail_reply(args):
     body = {"raw": raw, "threadId": original["threadId"]}
 
     result = service.users().messages().send(userId="me", body=body).execute()
-    print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
+    print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", ""), "to": to_hdr, "cc": cc_hdr}, indent=2))
 
 
 
@@ -1082,6 +1145,9 @@ def main():
     p.add_argument("message_id", help="Message ID to reply to")
     p.add_argument("--body", required=True)
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
+    p.add_argument("--to", default="", help="Extra To recipients (comma-separated), added on top of Reply All")
+    p.add_argument("--cc", default="", help="Extra Cc recipients (comma-separated), added on top of Reply All")
+    p.add_argument("--no-reply-all", action="store_true", help="Reply to the original sender only; do NOT keep the other To/Cc recipients")
     p.set_defaults(func=gmail_reply)
 
     p = gmail_sub.add_parser("labels")

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -1,5 +1,7 @@
 """Tests for Google Workspace gws bridge and CLI wrapper."""
 
+import base64
+import email
 import importlib.util
 import json
 import subprocess
@@ -144,6 +146,123 @@ def test_api_calendar_list_uses_events_list(api_module):
 
 
 
+
+
+def test_reply_all_promotes_sender_and_keeps_to_cc(api_module):
+    headers = {
+        "from": "Alice <alice@example.com>",
+        "to": "me@example.com, Bob <bob@example.com>",
+        "cc": "Carol <carol@example.com>",
+    }
+    to, cc = api_module._reply_all_recipients(headers, "me@example.com")
+    assert to == "alice@example.com, bob@example.com"
+    assert cc == "carol@example.com"
+
+
+def test_reply_all_drops_self_case_insensitively(api_module):
+    headers = {
+        "from": "alice@example.com",
+        "to": "ME@Example.COM, bob@example.com",
+        "cc": "Me@example.com",
+    }
+    to, cc = api_module._reply_all_recipients(headers, "me@example.com")
+    assert to == "alice@example.com, bob@example.com"
+    assert cc == ""
+
+
+def test_reply_all_dedupes_first_seen(api_module):
+    headers = {
+        "from": "Alice <alice@example.com>",
+        "to": "ALICE@example.com, bob@example.com",
+        "cc": "Bob <BOB@Example.com>, carol@example.com",
+    }
+    to, cc = api_module._reply_all_recipients(headers, "me@example.com")
+    assert to == "alice@example.com, bob@example.com"
+    assert cc == "carol@example.com"
+
+
+def test_reply_all_false_is_sender_only(api_module):
+    headers = {
+        "from": "alice@example.com",
+        "to": "bob@example.com",
+        "cc": "carol@example.com",
+    }
+    to, cc = api_module._reply_all_recipients(headers, "me@example.com", reply_all=False)
+    assert to == "alice@example.com"
+    assert cc == ""
+
+
+def test_reply_all_extra_to_cc_are_additive(api_module):
+    headers = {
+        "from": "alice@example.com",
+        "to": "bob@example.com",
+        "cc": "carol@example.com",
+    }
+    to, cc = api_module._reply_all_recipients(
+        headers, "me@example.com", extra_to="dave@example.com", extra_cc="erin@example.com"
+    )
+    assert to == "alice@example.com, bob@example.com, dave@example.com"
+    assert cc == "carol@example.com, erin@example.com"
+
+    # Extras still apply with --no-reply-all (sender-only base).
+    to, cc = api_module._reply_all_recipients(
+        headers, "me@example.com", extra_to="dave@example.com",
+        extra_cc="erin@example.com", reply_all=False,
+    )
+    assert to == "alice@example.com, dave@example.com"
+    assert cc == "erin@example.com"
+
+
+def test_api_gmail_reply_sends_reply_all_mime(api_module, monkeypatch, capsys):
+    """gmail_reply (API path) sends a threaded MIME reply carrying To + Cc."""
+    original = {
+        "threadId": "thread-1",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "Alice <alice@example.com>"},
+                {"name": "To", "value": "me@example.com, Bob <bob@example.com>"},
+                {"name": "Cc", "value": "carol@example.com"},
+                {"name": "Subject", "value": "Plans"},
+                {"name": "Message-ID", "value": "<orig@id>"},
+            ]
+        },
+    }
+
+    service = MagicMock()
+    users = service.users.return_value
+    users.messages.return_value.get.return_value.execute.return_value = original
+    users.getProfile.return_value.execute.return_value = {"emailAddress": "me@example.com"}
+    users.messages.return_value.send.return_value.execute.return_value = {
+        "id": "sent-1",
+        "threadId": "thread-1",
+    }
+
+    # Force the Python SDK path (the fixture pins _gws_binary to a fake path).
+    monkeypatch.setattr(api_module, "_gws_binary", lambda: None)
+    monkeypatch.setattr(api_module, "build_service", lambda api, version: service)
+
+    args = api_module.argparse.Namespace(
+        message_id="msg-1", body="Sounds good.", from_header="",
+        to="", cc="", no_reply_all=False,
+    )
+    api_module.gmail_reply(args)
+
+    get_kwargs = users.messages.return_value.get.call_args.kwargs
+    assert get_kwargs["metadataHeaders"] == ["From", "To", "Cc", "Subject", "Message-ID"]
+
+    send_body = users.messages.return_value.send.call_args.kwargs["body"]
+    assert send_body["threadId"] == "thread-1"
+
+    mime = email.message_from_bytes(base64.urlsafe_b64decode(send_body["raw"]))
+    assert mime["To"] == "alice@example.com, bob@example.com"
+    assert mime["Cc"] == "carol@example.com"
+    assert mime["Subject"] == "Re: Plans"
+    assert mime["In-Reply-To"] == "<orig@id>"
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "sent"
+    assert out["to"] == "alice@example.com, bob@example.com"
+    assert out["cc"] == "carol@example.com"
 
 
 def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`gmail reply` fetched only `From`/`Subject`/`Message-ID` from the original message and hardcoded `To=<original sender>` with no `Cc`. On any group thread, the reply silently dropped every other recipient — the classic "replied to one person, forked the thread" failure, and the sender has no indication it happened (the result JSON reported only `id`/`threadId`).

This PR makes `gmail reply` behave like a mail client's **Reply All by default**:

- The original sender is promoted onto `To`, everyone else on the original `To` stays on `To`, and the original `Cc` stays on `Cc`.
- The account's own address is dropped (case-insensitively) so the reply never echoes back to the sender, and addresses are de-duplicated first-seen (via `email.utils.getaddresses`, so display names and address lists parse correctly).
- `--to` / `--cc` append extra recipients on top of either mode; `--no-reply-all` restores the old sender-only behavior.
- The printed result JSON now includes the final `"to"` / `"cc"` so callers (and the agent) can see exactly who the reply went to.
- Both code paths are updated symmetrically: the `gws` binary path and the `googleapiclient` fallback each widen `metadataHeaders` to `From/To/Cc/Subject/Message-ID` and resolve the account's own address best-effort via `users.getProfile` (wrapped in try/except — if the profile call fails, the reply still sends; the own address just isn't filtered).

Reply All is the right default for an agent: dropping recipients loses information silently, while keeping them is visible and reversible (`--no-reply-all`).

## Related Issue

No existing issue for recipient-dropping on group threads. Adjacent (not duplicates, see duplicate search below):

- PR #74676 / issue #74675 — fixes *which single recipient* is targeted (Reply-To preference, own-message case, non-ASCII headers); still sender-only, no Cc preservation.
- PR #35894 / issue #34806 — reports the `gws` binary path may not honor `metadataHeaders` inside `--params` JSON. This PR keeps the two paths symmetric; if #35894 lands first, its removal of the params key composes cleanly (the helper degrades gracefully when `To`/`Cc` headers come back empty — it falls back to sender-only output).

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `skills/productivity/google-workspace/scripts/google_api.py`
  - New module-level helper `_reply_all_recipients(headers, self_address, extra_to, extra_cc, reply_all)` (next to `_headers_dict`) computing the `(To, Cc)` header strings.
  - `gmail_reply`: both the `_run_gws` and `build_service` paths widen `metadataHeaders`, resolve the own address via `getProfile` (best-effort), set `To`/`Cc` from the helper (the `Cc` header is omitted when empty), and report `to`/`cc` in the result JSON.
  - `gmail reply` argparse: new `--to`, `--cc`, `--no-reply-all` flags.
  - Usage docstring updated for the new default.
- `skills/productivity/google-workspace/SKILL.md` — Gmail reply section documents the Reply All default and the three new flags with examples.
- `tests/skills/test_google_workspace_api.py` — five pure-function tests for `_reply_all_recipients` (sender promotion, self-exclusion, case-insensitive dedupe, `reply_all=False` sender-only, additive `--to`/`--cc` in both modes) plus a mocked-service test asserting the sent MIME carries the merged `To` + `Cc`, `Re:` subject, `In-Reply-To`, and the original `threadId`, and that the printed JSON reports `to`/`cc`.

## How to Test

1. `pytest tests/skills/test_google_workspace_api.py -q` — 10 tests pass (5 pure-function, 1 mocked end-to-end reply, plus the 4 pre-existing tests). `pytest tests/skills/ -q` is fully green (1512 passed).
2. `uvx ruff@0.15.10 check skills/ tests/` — clean.
3. Live smoke test (Python client path, requires an authenticated `~/.hermes/google_token.json`):
   ```bash
   GAPI="python skills/productivity/google-workspace/scripts/google_api.py"
   # Pick a message on a thread with multiple To/Cc recipients:
   $GAPI gmail search "cc:*" --max 5
   $GAPI gmail reply MESSAGE_ID --body "Test reply"
   # → result JSON's "to" lists the original sender + other To recipients
   #   (minus your own address), "cc" mirrors the original Cc.
   $GAPI gmail reply MESSAGE_ID --no-reply-all --body "Test"   # sender-only
   $GAPI gmail reply MESSAGE_ID --cc extra@example.com --body "Test"  # additive Cc
   ```
4. **Note on the `gws` binary path:** it was implemented symmetrically with the API path but is exercised manually — CI has no `gws` binary installed (the test fixture pins `_gws_binary` to a fake path only for calls that never shell out, and the reply test forces the Python client path). Manual test: with `gws` on `PATH` (or `HERMES_GWS_BIN` set), repeat step 3; verified that `gmail users messages get` returns the widened header set, `gmail users getProfile` supplies the own address (and that a failing profile call degrades to an unfiltered Reply All rather than an error), and the sent message threads correctly with the merged `To`/`Cc`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(google-workspace):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.3 (Tahoe)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (SKILL.md + module usage docstring)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact considered — pure-Python stdlib (`email.utils`), no platform-specific code
- [x] Tool descriptions/schemas — N/A (skill script CLI, documented in SKILL.md)

## Duplicate search

```
gh search prs --repo NousResearch/hermes-agent "gmail reply"
gh search prs --repo NousResearch/hermes-agent "reply all"
gh search issues --repo NousResearch/hermes-agent "gmail reply"
gh search issues --repo NousResearch/hermes-agent "reply all"
```

(`--state all` is not a valid `gh search` value; the default search covers all states.) No PR or issue implements Reply All / Cc preservation for `gmail reply`. Closest matches, both distinct:

- **#74676** (open) "correct gmail reply recipient and non-ASCII address headers" — chooses a better *single* recipient (Reply-To, own-message fallback); does not preserve To/Cc or add flags.
- **#35894** (open) "remove unsupported metadataHeaders from gws binary path in gmail_reply" — orthogonal transport fix on the gws path; composes with this change (see Related Issue).
- **#20947**, **#43373**, **#77067** — other gmail send/reply fixes, unrelated to recipient sets.

## Screenshots / Logs

Result JSON after this change (mocked-service test output shape):

```json
{
  "status": "sent",
  "id": "sent-1",
  "threadId": "thread-1",
  "to": "alice@example.com, bob@example.com",
  "cc": "carol@example.com"
}
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
