### PR TITLE
fix(acp): inherit profile tool capabilities

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -72,7 +72,12 @@ from acp_adapter.events import (
 )
 from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
-from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
+from acp_adapter.session import (
+    SessionManager,
+    SessionState,
+    _agent_acp_capability_policy,
+    _expand_acp_enabled_toolsets,
+)
 from acp_adapter.tools import build_tool_complete, build_tool_start
 from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
@@ -1024,27 +1029,23 @@ class HermesACPAgent(acp.Agent):
             return
 
         try:
-            from model_tools import get_tool_definitions
-            from agent.memory_manager import inject_memory_provider_tools
+            from tools.mcp_tool import refresh_agent_mcp_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
                 mcp_server_names=[server.name for server in accepted_servers],
             )
-            state.agent.enabled_toolsets = enabled_toolsets
             disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
-            state.agent.tools = get_tool_definitions(
-                enabled_toolsets=enabled_toolsets,
-                disabled_toolsets=disabled_toolsets,
+            refresh_agent_mcp_tools(
+                state.agent,
+                enabled_override=enabled_toolsets,
+                disabled_override=disabled_toolsets,
                 quiet_mode=True,
             )
-            state.agent.valid_tool_names = {
-                tool["function"]["name"] for tool in state.agent.tools or []
-            }
-            inject_memory_provider_tools(state.agent)
             invalidate = getattr(state.agent, "_invalidate_system_prompt", None)
             if callable(invalidate):
                 invalidate()
+            self.session_manager.save_session(state.session_id)
             logger.info(
                 "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
                 state.session_id,
@@ -2219,6 +2220,7 @@ class HermesACPAgent(acp.Agent):
 
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
+        capability_policy = _agent_acp_capability_policy(state.agent)
 
         state.model = new_model
         state.agent = self.session_manager._make_agent(
@@ -2226,6 +2228,7 @@ class HermesACPAgent(acp.Agent):
             cwd=state.cwd,
             model=new_model,
             requested_provider=target_provider,
+            capability_policy=capability_policy,
         )
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
@@ -2476,6 +2479,7 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
+            capability_policy = _agent_acp_capability_policy(state.agent)
             state.agent = self.session_manager._make_agent(
                 session_id=session_id,
                 cwd=state.cwd,
@@ -2483,6 +2487,7 @@ class HermesACPAgent(acp.Agent):
                 requested_provider=requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
+                capability_policy=capability_policy,
             )
             self.session_manager.save_session(session_id)
             logger.info(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -976,11 +976,30 @@ class HermesACPAgent(acp.Agent):
         if not mcp_servers:
             return
 
+        allowed_names = getattr(state.agent, "_acp_mcp_allowed_names", None)
+        if not isinstance(allowed_names, frozenset):
+            allowed_names = None
+        denied_names = getattr(state.agent, "_acp_mcp_denied_names", frozenset())
+        if not isinstance(denied_names, frozenset):
+            denied_names = frozenset()
+        accepted_servers = [
+            server
+            for server in mcp_servers
+            if server.name not in denied_names
+            and (allowed_names is None or server.name in allowed_names)
+        ]
+        if not accepted_servers:
+            logger.info(
+                "Session %s: ACP MCP registration denied by session policy",
+                state.session_id,
+            )
+            return
+
         try:
             from tools.mcp_tool import register_mcp_servers
 
             config_map: dict[str, dict] = {}
-            for server in mcp_servers:
+            for server in accepted_servers:
                 name = server.name
                 if isinstance(server, McpServerStdio):
                     config = {
@@ -1010,7 +1029,7 @@ class HermesACPAgent(acp.Agent):
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
-                mcp_server_names=[server.name for server in mcp_servers],
+                mcp_server_names=[server.name for server in accepted_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets
             disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
@@ -2222,7 +2241,11 @@ class HermesACPAgent(acp.Agent):
             toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
             )
-            tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
+            tools = get_tool_definitions(
+                enabled_toolsets=toolsets,
+                disabled_toolsets=getattr(state.agent, "disabled_toolsets", None),
+                quiet_mode=True,
+            )
             tool_view = SimpleNamespace(
                 tools=list(tools or []),
                 valid_tool_names={
@@ -2231,6 +2254,7 @@ class HermesACPAgent(acp.Agent):
                     if isinstance(tool, dict)
                 },
                 enabled_toolsets=toolsets,
+                disabled_toolsets=getattr(state.agent, "disabled_toolsets", None),
                 _memory_manager=getattr(state.agent, "_memory_manager", None),
             )
             inject_memory_provider_tools(tool_view)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -132,7 +132,8 @@ def _expand_acp_enabled_toolsets(
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    resolved_toolsets = ["hermes-acp"] if toolsets is None else toolsets
+    for name in list(resolved_toolsets):
         if name and name not in expanded:
             expanded.append(name)
 
@@ -142,6 +143,155 @@ def _expand_acp_enabled_toolsets(
             expanded.append(toolset_name)
 
     return expanded
+
+
+def _acp_native_toolset_names(plugin_toolsets: set[str]) -> set[str]:
+    """Return native names without treating live MCP aliases as native."""
+    from toolsets import TOOLSETS, _get_registry_toolset_aliases
+
+    native_names = set(TOOLSETS) | set(plugin_toolsets) | {"all", "*"}
+    native_names.update(
+        alias
+        for alias, canonical in _get_registry_toolset_aliases().items()
+        if canonical in native_names
+    )
+    return native_names
+
+
+def _disabled_acp_mcp_server_names(config: dict) -> frozenset[str]:
+    """Map global disabled toolset names back to raw MCP server names."""
+    disabled = {
+        str(name).strip()
+        for name in ((config.get("agent") or {}).get("disabled_toolsets") or [])
+        if str(name).strip()
+    }
+    return frozenset(
+        name.removeprefix("mcp-") if name.startswith("mcp-") else name
+        for name in disabled
+    )
+
+
+def _resolve_acp_platform_toolsets(
+    config: dict,
+    *,
+    mcp_server_names: List[str] | None = None,
+) -> List[str]:
+    """Resolve ACP-native toolsets without making session startup brittle."""
+    try:
+        # The platform resolver derives plugin toolsets from the live plugin
+        # registry. ACP reaches this path before AIAgent imports model_tools,
+        # so discover explicitly rather than relying on that later side effect.
+        from hermes_cli.plugins import discover_plugins
+        from hermes_cli.tools_config import (
+            _get_platform_tools,
+            _get_plugin_toolset_keys,
+            enabled_mcp_server_names,
+        )
+
+        discover_plugins()
+        plugin_toolsets = set(_get_plugin_toolset_keys())
+        native_names = _acp_native_toolset_names(plugin_toolsets)
+        enabled_mcp = set(enabled_mcp_server_names(config))
+        configured_mcp = {
+            str(name) for name in (config.get("mcp_servers") or {}).keys()
+        }
+        native_config = config
+        platform_toolsets = (config.get("platform_toolsets") or {}).get("acp")
+        if isinstance(platform_toolsets, list):
+            native_config = copy.deepcopy(config)
+            native_config["platform_toolsets"]["acp"] = [
+                str(name)
+                for name in platform_toolsets
+                if str(name) != "no_mcp"
+                and not (
+                    (
+                        str(name) in enabled_mcp
+                        and str(name) not in plugin_toolsets
+                    )
+                    or (
+                        str(name) in configured_mcp
+                        and str(name) not in native_names
+                    )
+                )
+            ]
+        native_toolsets = set(
+            _get_platform_tools(
+                native_config,
+                "acp",
+                include_default_mcp_servers=False,
+            )
+        )
+        native_toolsets.discard("hermes-acp")
+        native_toolsets.difference_update(enabled_mcp - native_names)
+        if isinstance(platform_toolsets, list):
+            selected = {str(name) for name in platform_toolsets}
+            native_toolsets.difference_update(
+                (selected & enabled_mcp) - plugin_toolsets
+            )
+        return [
+            "hermes-acp",
+            *sorted(native_toolsets),
+        ]
+    except Exception:
+        logger.debug("ACP: platform toolset resolution failed", exc_info=True)
+        # Plugin/platform configuration is optional. Keep the curated ACP
+        # baseline available so one broken plugin cannot remove file, terminal,
+        # memory, and skill tools from every session on the profile.
+        return ["hermes-acp"]
+
+
+def _resolve_acp_mcp_policy(
+    config: dict,
+) -> tuple[List[str], frozenset[str] | None]:
+    """Return initial MCP names and the durable per-session allowlist.
+
+    ``None`` means no per-platform restriction, while an empty frozenset is an
+    explicit deny-all policy. Unprefixed names shared by native and MCP
+    namespaces are denied rather than granting either capability.
+    """
+    try:
+        from hermes_cli.plugins import discover_plugins
+        from hermes_cli.tools_config import (
+            _get_plugin_toolset_keys,
+            enabled_mcp_server_names,
+        )
+
+        discover_plugins()
+        enabled = set(enabled_mcp_server_names(config))
+        enabled.difference_update(_disabled_acp_mcp_server_names(config))
+        platform_toolsets = (config.get("platform_toolsets") or {}).get("acp")
+        if not isinstance(platform_toolsets, list):
+            return sorted(enabled), None
+
+        selected = {str(name) for name in platform_toolsets}
+        if "no_mcp" in selected:
+            return [], frozenset()
+        configured = {
+            str(name) for name in (config.get("mcp_servers") or {}).keys()
+        }
+        selected_mcp = selected & configured
+        if selected_mcp:
+            # Unprefixed names shared with any native toolset are ambiguous.
+            # Grant neither side; unambiguous MCP names form the allowlist.
+            plugin_toolsets = set(_get_plugin_toolset_keys())
+            native_names = _acp_native_toolset_names(plugin_toolsets)
+            explicit_references = {
+                name
+                for name in selected_mcp
+                if name not in native_names
+            }
+            allowed = frozenset(explicit_references & enabled)
+            return sorted(allowed), allowed
+        return sorted(enabled), None
+    except Exception:
+        logger.debug("ACP: MCP server resolution failed", exc_info=True)
+        return [], frozenset()
+
+
+def _enabled_acp_mcp_server_names(config: dict) -> List[str]:
+    """Resolve MCP servers enabled when an ACP session is constructed."""
+    enabled, _allowed = _resolve_acp_mcp_policy(config)
+    return enabled
 
 
 def _clear_task_cwd(task_id: str) -> None:
@@ -615,18 +765,31 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        configured_mcp_servers = [
-            name
-            for name, cfg in (config.get("mcp_servers") or {}).items()
-            if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
+        configured_mcp_servers, allowed_mcp_servers = _resolve_acp_mcp_policy(config)
+        denied_mcp_servers = _disabled_acp_mcp_server_names(config)
+        disabled_toolsets = [
+            str(name)
+            for name in ((config.get("agent") or {}).get("disabled_toolsets") or [])
+            if str(name).strip()
         ]
+        configured_mcp_names = {
+            str(name) for name in (config.get("mcp_servers") or {}).keys()
+        }
+        for server_name in sorted(denied_mcp_servers & configured_mcp_names):
+            canonical = f"mcp-{server_name}"
+            if canonical not in disabled_toolsets:
+                disabled_toolsets.append(canonical)
 
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                _resolve_acp_platform_toolsets(
+                    config,
+                    mcp_server_names=configured_mcp_servers,
+                ),
                 mcp_server_names=configured_mcp_servers,
             ),
+            "disabled_toolsets": disabled_toolsets,
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),
@@ -674,6 +837,11 @@ class SessionManager:
             logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
 
         agent = AIAgent(**kwargs)
+        # Retain the initial MCP capability decision across ACP-client server
+        # registration and every later tool-surface refresh. ``None`` means the
+        # profile did not set a per-platform MCP restriction.
+        setattr(agent, "_acp_mcp_allowed_names", allowed_mcp_servers)
+        setattr(agent, "_acp_mcp_denied_names", denied_mcp_servers)
         # Codex app-server sessions are spawned lazily on the first turn. Stamp
         # the ACP workspace onto the agent so the Codex runtime starts from the
         # editor/session cwd instead of the Hermes daemon's process cwd.

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -240,14 +240,15 @@ def _resolve_acp_platform_toolsets(
         return ["hermes-acp"]
 
 
-def _resolve_acp_mcp_policy(
+def _resolve_acp_mcp_policy_details(
     config: dict,
-) -> tuple[List[str], frozenset[str] | None]:
+) -> tuple[List[str], frozenset[str] | None, frozenset[str]]:
     """Return initial MCP names and the durable per-session allowlist.
 
     ``None`` means no per-platform restriction, while an empty frozenset is an
-    explicit deny-all policy. Unprefixed names shared by native and MCP
-    namespaces are denied rather than granting either capability.
+    explicit deny-all policy. An ambiguous raw selection grants neither side,
+    but it cannot revoke a native capability granted independently by the
+    always-on ACP baseline or an explicitly enabled plugin toolset.
     """
     try:
         from hermes_cli.plugins import discover_plugins
@@ -261,11 +262,11 @@ def _resolve_acp_mcp_policy(
         enabled.difference_update(_disabled_acp_mcp_server_names(config))
         platform_toolsets = (config.get("platform_toolsets") or {}).get("acp")
         if not isinstance(platform_toolsets, list):
-            return sorted(enabled), None
+            return sorted(enabled), None, frozenset()
 
         selected = {str(name) for name in platform_toolsets}
         if "no_mcp" in selected:
-            return [], frozenset()
+            return [], frozenset(), frozenset()
         configured = {
             str(name) for name in (config.get("mcp_servers") or {}).keys()
         }
@@ -275,23 +276,199 @@ def _resolve_acp_mcp_policy(
             # Grant neither side; unambiguous MCP names form the allowlist.
             plugin_toolsets = set(_get_plugin_toolset_keys())
             native_names = _acp_native_toolset_names(plugin_toolsets)
+            collisions = frozenset(selected_mcp & enabled & native_names)
             explicit_references = {
                 name
                 for name in selected_mcp
                 if name not in native_names
             }
             allowed = frozenset(explicit_references & enabled)
-            return sorted(allowed), allowed
-        return sorted(enabled), None
+            return sorted(allowed), allowed, collisions
+        return sorted(enabled), None, frozenset()
     except Exception:
         logger.debug("ACP: MCP server resolution failed", exc_info=True)
-        return [], frozenset()
+        return [], frozenset(), frozenset()
+
+
+def _resolve_acp_mcp_policy(
+    config: dict,
+) -> tuple[List[str], frozenset[str] | None]:
+    """Return initial MCP names and the durable per-session allowlist."""
+    enabled, allowed, _collisions = _resolve_acp_mcp_policy_details(config)
+    return enabled, allowed
 
 
 def _enabled_acp_mcp_server_names(config: dict) -> List[str]:
     """Resolve MCP servers enabled when an ACP session is constructed."""
     enabled, _allowed = _resolve_acp_mcp_policy(config)
     return enabled
+
+
+def _agent_acp_capability_policy(agent) -> dict | None:
+    """Return the durable ACP capability policy attached to an agent."""
+    enabled = getattr(agent, "enabled_toolsets", None)
+    disabled = getattr(agent, "disabled_toolsets", None)
+    allowed = getattr(agent, "_acp_mcp_allowed_names", None)
+    denied = getattr(agent, "_acp_mcp_denied_names", frozenset())
+    if not isinstance(enabled, list) or not all(isinstance(v, str) for v in enabled):
+        return None
+    if disabled is not None and (
+        not isinstance(disabled, list)
+        or not all(isinstance(v, str) for v in disabled)
+    ):
+        return None
+    if allowed is not None and not isinstance(allowed, (set, frozenset)):
+        return None
+    if not isinstance(denied, (set, frozenset)):
+        return None
+    return {
+        "enabled_toolsets": list(dict.fromkeys(enabled)),
+        "disabled_toolsets": (
+            list(dict.fromkeys(disabled)) if disabled is not None else None
+        ),
+        "mcp_allowed_names": sorted(allowed) if allowed is not None else None,
+        "mcp_denied_names": sorted(denied),
+    }
+
+
+def _normalize_acp_capability_policy(policy: dict) -> dict:
+    """Validate a policy restored from durable session metadata."""
+    if not isinstance(policy, dict):
+        raise ValueError("ACP capability policy must be an object")
+    normalized = {}
+    for key in ("enabled_toolsets", "mcp_denied_names"):
+        value = policy.get(key)
+        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+            raise ValueError(f"ACP capability policy {key} must be a string list")
+        normalized[key] = list(dict.fromkeys(value))
+    for key in ("disabled_toolsets", "mcp_allowed_names"):
+        value = policy.get(key)
+        if value is not None and (
+            not isinstance(value, list)
+            or not all(isinstance(v, str) for v in value)
+        ):
+            raise ValueError(f"ACP capability policy {key} must be null or a string list")
+        normalized[key] = None if value is None else list(dict.fromkeys(value))
+    return normalized
+
+
+def _intersect_optional_names(
+    original: list[str] | None,
+    current: list[str] | None,
+) -> list[str] | None:
+    """Apply current tightening without widening an original optional allowlist."""
+    if original is None:
+        return current
+    if current is None:
+        return original
+    current_names = set(current)
+    return [name for name in original if name in current_names]
+
+
+def _merge_acp_capability_policy(original: dict, current: dict) -> dict:
+    """Preserve original grants while applying stricter current profile policy."""
+    original = _normalize_acp_capability_policy(original)
+    current = _normalize_acp_capability_policy(current)
+    current_enabled = set(current["enabled_toolsets"])
+    current_disabled = set(current["disabled_toolsets"] or [])
+    current_denied = set(current["mcp_denied_names"])
+    current_allowed = current["mcp_allowed_names"]
+
+    def remains_allowed(name: str) -> bool:
+        if name in current_enabled:
+            return True
+        if not name.startswith("mcp-") or name in current_disabled:
+            return False
+        server_name = name.removeprefix("mcp-")
+        if server_name in current_denied:
+            return False
+        return current_allowed is None or server_name in current_allowed
+
+    enabled = [
+        name for name in original["enabled_toolsets"] if remains_allowed(name)
+    ]
+    disabled = list(
+        dict.fromkeys(
+            (original["disabled_toolsets"] or [])
+            + (current["disabled_toolsets"] or [])
+        )
+    )
+    denied = sorted(
+        set(original["mcp_denied_names"]) | set(current["mcp_denied_names"])
+    )
+    return {
+        "enabled_toolsets": enabled,
+        "disabled_toolsets": disabled or None,
+        "mcp_allowed_names": _intersect_optional_names(
+            original["mcp_allowed_names"], current["mcp_allowed_names"]
+        ),
+        "mcp_denied_names": denied,
+    }
+
+
+def _current_acp_capability_policy(config: dict) -> dict:
+    """Resolve the current profile into a durable, monotonic ACP policy."""
+    (
+        configured_mcp_servers,
+        allowed_mcp_servers,
+        ambiguous_mcp_servers,
+    ) = _resolve_acp_mcp_policy_details(config)
+    globally_denied_mcp_servers = _disabled_acp_mcp_server_names(config)
+
+    # ACP clients can propose additional MCP servers after session creation.
+    # Reserve native/plugin names (including all/*) so an untrusted client
+    # cannot create a raw MCP alias in another capability namespace. Servers
+    # explicitly configured by the profile are already canonicalized to
+    # mcp-<name>; this registration denylist does not remove their tools.
+    plugin_toolsets: set[str] = set()
+    try:
+        from hermes_cli.plugins import discover_plugins
+        from hermes_cli.tools_config import _get_plugin_toolset_keys
+
+        discover_plugins()
+        plugin_toolsets = set(_get_plugin_toolset_keys())
+    except Exception:
+        logger.debug("ACP: plugin MCP-name reservation failed", exc_info=True)
+    try:
+        reserved_mcp_server_names = _acp_native_toolset_names(plugin_toolsets)
+    except Exception:
+        logger.debug("ACP: native MCP-name reservation failed", exc_info=True)
+        reserved_mcp_server_names = {"all", "*"}
+
+    disabled_toolsets = [
+        str(name)
+        for name in ((config.get("agent") or {}).get("disabled_toolsets") or [])
+        if str(name).strip()
+    ]
+    configured_mcp_names = {
+        str(name) for name in (config.get("mcp_servers") or {}).keys()
+    }
+    surface_denied_mcp_servers = (
+        globally_denied_mcp_servers | ambiguous_mcp_servers
+    )
+    for server_name in sorted(surface_denied_mcp_servers & configured_mcp_names):
+        canonical = f"mcp-{server_name}"
+        if canonical not in disabled_toolsets:
+            disabled_toolsets.append(canonical)
+
+    return {
+        "enabled_toolsets": _expand_acp_enabled_toolsets(
+            _resolve_acp_platform_toolsets(
+                config,
+                mcp_server_names=configured_mcp_servers,
+            ),
+            mcp_server_names=configured_mcp_servers,
+        ),
+        "disabled_toolsets": disabled_toolsets or None,
+        "mcp_allowed_names": (
+            sorted(allowed_mcp_servers)
+            if allowed_mcp_servers is not None
+            else None
+        ),
+        "mcp_denied_names": sorted(
+            globally_denied_mcp_servers | reserved_mcp_server_names
+        ),
+    }
 
 
 def _clear_task_cwd(task_id: str) -> None:
@@ -403,6 +580,7 @@ class SessionManager:
             session_id=new_id,
             cwd=cwd,
             model=original.model or None,
+            capability_policy=_agent_acp_capability_policy(original.agent),
         )
         state = SessionState(
             session_id=new_id,
@@ -571,7 +749,10 @@ class SessionManager:
 
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
-        session_meta = {"cwd": state.cwd}
+        session_meta: dict[str, Any] = {"cwd": state.cwd}
+        capability_policy = _agent_acp_capability_policy(state.agent)
+        if capability_policy is not None:
+            session_meta["acp_capability_policy"] = capability_policy
         provider = getattr(state.agent, "provider", None)
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
@@ -591,7 +772,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -671,6 +852,7 @@ class SessionManager:
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
+        capability_policy = None
         mc = row.get("model_config")
         if mc:
             try:
@@ -680,6 +862,16 @@ class SessionManager:
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
+                    if "acp_capability_policy" in meta:
+                        capability_policy = _normalize_acp_capability_policy(
+                            meta["acp_capability_policy"]
+                        )
+            except ValueError:
+                logger.warning(
+                    "Refusing to restore ACP session %s with malformed capability policy",
+                    session_id,
+                )
+                return None
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -706,6 +898,7 @@ class SessionManager:
                 requested_provider=requested_provider,
                 base_url=restored_base_url,
                 api_mode=restored_api_mode,
+                capability_policy=capability_policy,
             )
         except Exception:
             logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
@@ -747,6 +940,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        capability_policy: dict | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -765,31 +959,17 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        configured_mcp_servers, allowed_mcp_servers = _resolve_acp_mcp_policy(config)
-        denied_mcp_servers = _disabled_acp_mcp_server_names(config)
-        disabled_toolsets = [
-            str(name)
-            for name in ((config.get("agent") or {}).get("disabled_toolsets") or [])
-            if str(name).strip()
-        ]
-        configured_mcp_names = {
-            str(name) for name in (config.get("mcp_servers") or {}).keys()
-        }
-        for server_name in sorted(denied_mcp_servers & configured_mcp_names):
-            canonical = f"mcp-{server_name}"
-            if canonical not in disabled_toolsets:
-                disabled_toolsets.append(canonical)
+        current_policy = _current_acp_capability_policy(config)
+        effective_policy = (
+            _merge_acp_capability_policy(capability_policy, current_policy)
+            if capability_policy is not None
+            else current_policy
+        )
 
         kwargs = {
             "platform": "acp",
-            "enabled_toolsets": _expand_acp_enabled_toolsets(
-                _resolve_acp_platform_toolsets(
-                    config,
-                    mcp_server_names=configured_mcp_servers,
-                ),
-                mcp_server_names=configured_mcp_servers,
-            ),
-            "disabled_toolsets": disabled_toolsets,
+            "enabled_toolsets": effective_policy["enabled_toolsets"],
+            "disabled_toolsets": effective_policy["disabled_toolsets"],
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),
@@ -840,8 +1020,17 @@ class SessionManager:
         # Retain the initial MCP capability decision across ACP-client server
         # registration and every later tool-surface refresh. ``None`` means the
         # profile did not set a per-platform MCP restriction.
-        setattr(agent, "_acp_mcp_allowed_names", allowed_mcp_servers)
-        setattr(agent, "_acp_mcp_denied_names", denied_mcp_servers)
+        allowed_names = effective_policy["mcp_allowed_names"]
+        setattr(
+            agent,
+            "_acp_mcp_allowed_names",
+            frozenset(allowed_names) if allowed_names is not None else None,
+        )
+        setattr(
+            agent,
+            "_acp_mcp_denied_names",
+            frozenset(effective_policy["mcp_denied_names"]),
+        )
         # Codex app-server sessions are spawned lazily on the first turn. Stamp
         # the ACP workspace onto the agent so the Codex runtime starts from the
         # editor/session cwd instead of the Hermes daemon's process cwd.

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -503,6 +503,27 @@ class TestSlashCommands:
         result = agent._handle_slash_command("/model", state)
         assert "test-model" in result
 
+    def test_model_switch_preserves_session_capability_policy(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent.disabled_toolsets = ["mcp-blocked"]
+        state.agent._acp_mcp_allowed_names = frozenset()
+        state.agent._acp_mcp_denied_names = frozenset({"blocked"})
+
+        with patch.object(
+            mock_manager,
+            "_make_agent",
+            return_value=MagicMock(model="new-model", provider="openrouter"),
+        ) as make_agent:
+            agent._handle_slash_command("/model new-model", state)
+
+        assert make_agent.call_args.kwargs["capability_policy"] == {
+            "enabled_toolsets": ["hermes-acp"],
+            "disabled_toolsets": ["mcp-blocked"],
+            "mcp_allowed_names": [],
+            "mcp_denied_names": ["blocked"],
+        }
+
 
     def test_tools_listing_applies_disabled_toolsets(self, agent, mock_manager):
         state = self._make_state(mock_manager)
@@ -759,7 +780,7 @@ class TestRegisterSessionMcpServers:
 
     @pytest.mark.asyncio
     async def test_refreshes_agent_tool_surface(self, agent, mock_manager):
-        """After MCP registration, agent.tools and valid_tool_names are refreshed."""
+        """After registration, the shared policy-aware refresh path is used."""
         from acp.schema import McpServerStdio
 
         state = mock_manager.create_session(cwd="/tmp")
@@ -781,39 +802,53 @@ class TestRegisterSessionMcpServers:
             env=[],
         )
 
-        fake_tools = [
-            {"function": {"name": "mcp_srv_search"}},
-            {"function": {"name": "memory"}},
-            {"function": {"name": "terminal"}},
-        ]
+        def refresh(target, **kwargs):
+            target.enabled_toolsets = kwargs["enabled_override"]
+            target.tools = [{"function": {"name": "mcp_srv_search"}}]
+            target.valid_tool_names = {"mcp_srv_search"}
+            return {"mcp_srv_search"}
 
         with patch("tools.mcp_tool.register_mcp_servers", return_value=["mcp_srv_search"]), \
-             patch("model_tools.get_tool_definitions", return_value=fake_tools) as mock_defs:
+             patch("tools.mcp_tool.refresh_agent_mcp_tools", side_effect=refresh) as mock_refresh, \
+             patch.object(mock_manager, "save_session") as save_session:
             await agent._register_session_mcp_servers(state, [server])
 
-        mock_defs.assert_called_once_with(
-            enabled_toolsets=["hermes-acp", "mcp-srv"],
-            disabled_toolsets=None,
+        mock_refresh.assert_called_once_with(
+            state.agent,
+            enabled_override=["hermes-acp", "mcp-srv"],
+            disabled_override=None,
             quiet_mode=True,
         )
         assert state.agent.enabled_toolsets == ["hermes-acp", "mcp-srv"]
-        assert state.agent.tools is fake_tools
-        assert state.agent.tools[-1] == {
-            "type": "function",
-            "function": {
-                "name": "hindsight_recall",
-                "description": "Recall",
-                "parameters": {},
-            },
-        }
-        assert state.agent.valid_tool_names == {
-            "hindsight_recall",
-            "memory",
-            "mcp_srv_search",
-            "terminal",
-        }
+        assert state.agent.valid_tool_names == {"mcp_srv_search"}
+        save_session.assert_called_once_with(state.session_id)
         # _invalidate_system_prompt should have been called
         state.agent._invalidate_system_prompt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_acp_mcp_server_with_reserved_native_name(
+        self, agent, mock_manager
+    ):
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent.disabled_toolsets = None
+        state.agent._acp_mcp_allowed_names = None
+        state.agent._acp_mcp_denied_names = frozenset({"all", "*", "memory"})
+        reserved = McpServerStdio(
+            name="all", command="/bin/reserved", args=[], env=[]
+        )
+        safe = McpServerStdio(name="srv", command="/bin/safe", args=[], env=[])
+
+        with patch("tools.mcp_tool.register_mcp_servers") as register, patch(
+            "tools.mcp_tool.refresh_agent_mcp_tools"
+        ):
+            await agent._register_session_mcp_servers(state, [reserved, safe])
+
+        assert register.call_args.args[0] == {
+            "srv": {"command": "/bin/safe", "args": [], "env": {}}
+        }
 
     @pytest.mark.asyncio
     async def test_register_failure_logs_warning(self, agent, mock_manager):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -504,6 +504,39 @@ class TestSlashCommands:
         assert "test-model" in result
 
 
+    def test_tools_listing_applies_disabled_toolsets(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.agent.enabled_toolsets = ["hermes-acp", "mcp-notes"]
+        state.agent.disabled_toolsets = ["mcp-notes"]
+
+        with patch("model_tools.get_tool_definitions", return_value=[]) as definitions:
+            agent._handle_slash_command("/tools", state)
+
+        definitions.assert_called_once_with(
+            enabled_toolsets=["hermes-acp", "mcp-notes"],
+            disabled_toolsets=["mcp-notes"],
+            quiet_mode=True,
+        )
+
+
+    def test_tools_listing_does_not_reinject_disabled_memory_provider(
+        self, agent, mock_manager
+    ):
+        state = self._make_state(mock_manager)
+        state.agent.enabled_toolsets = ["hermes-acp", "memory"]
+        state.agent.disabled_toolsets = ["memory"]
+        state.agent._memory_manager = MagicMock()
+        state.agent._memory_manager.get_all_tool_schemas.return_value = [
+            {"name": "external_memory_search", "description": "search"}
+        ]
+
+        with patch("model_tools.get_tool_definitions", return_value=[]):
+            result = agent._handle_slash_command("/tools", state)
+
+        assert result == "No tools available."
+        state.agent._memory_manager.get_all_tool_schemas.assert_not_called()
+
+
 
 
 
@@ -650,6 +683,78 @@ class TestRegisterSessionMcpServers:
         assert cfg["command"] == "/usr/bin/test"
         assert cfg["args"] == ["--flag"]
         assert cfg["env"] == {"KEY": "val"}
+
+
+    @pytest.mark.asyncio
+    async def test_no_mcp_policy_rejects_client_provided_server(self, agent, mock_manager):
+        """Late ACP registration must retain the session's initial no_mcp policy."""
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent._acp_mcp_allowed_names = frozenset()
+        server = McpServerStdio(
+            name="blocked",
+            command="/bin/test",
+            args=[],
+            env=[],
+        )
+
+        with patch("tools.mcp_tool.register_mcp_servers") as register:
+            await agent._register_session_mcp_servers(state, [server])
+
+        register.assert_not_called()
+        assert state.agent.enabled_toolsets == ["hermes-acp"]
+
+
+    @pytest.mark.asyncio
+    async def test_disabled_mcp_name_rejects_client_provided_server(
+        self, agent, mock_manager
+    ):
+        """Late ACP registration must retain global MCP denials."""
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent._acp_mcp_allowed_names = None
+        state.agent._acp_mcp_denied_names = frozenset({"blocked"})
+        server = McpServerStdio(
+            name="blocked", command="/bin/test", args=[], env=[]
+        )
+
+        with patch("tools.mcp_tool.register_mcp_servers") as register:
+            await agent._register_session_mcp_servers(state, [server])
+
+        register.assert_not_called()
+
+
+    @pytest.mark.asyncio
+    async def test_mcp_allowlist_filters_client_provided_servers(self, agent, mock_manager):
+        """Late ACP registration may add only names allowed when the session was built."""
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent.disabled_toolsets = None
+        state.agent.tools = []
+        state.agent.valid_tool_names = set()
+        state.agent._acp_mcp_allowed_names = frozenset({"allowed"})
+        allowed = McpServerStdio(
+            name="allowed", command="/bin/allowed", args=[], env=[]
+        )
+        blocked = McpServerStdio(
+            name="blocked", command="/bin/blocked", args=[], env=[]
+        )
+        registered_config = {}
+
+        with patch(
+            "tools.mcp_tool.register_mcp_servers",
+            side_effect=lambda config: registered_config.update(config),
+        ), patch("model_tools.get_tool_definitions", return_value=[]):
+            await agent._register_session_mcp_servers(state, [allowed, blocked])
+
+        assert set(registered_config) == {"allowed"}
+        assert state.agent.enabled_toolsets == ["hermes-acp", "mcp-allowed"]
 
 
     @pytest.mark.asyncio

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -220,6 +220,95 @@ class TestListAndCleanup:
 class TestPersistence:
     """Verify that sessions are persisted to SessionDB and can be restored."""
 
+    def test_restore_preserves_original_acp_capability_policy(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        original_agent = SimpleNamespace(
+            model="test-model",
+            provider=None,
+            base_url=None,
+            api_mode=None,
+            enabled_toolsets=["hermes-acp", "mcp-notes"],
+            disabled_toolsets=["mcp-blocked"],
+            _acp_mcp_allowed_names=frozenset({"notes"}),
+            _acp_mcp_denied_names=frozenset({"blocked"}),
+        )
+        manager = SessionManager(agent_factory=lambda: original_agent, db=db)
+        state = manager.create_session(cwd="/tmp/project")
+        with manager._lock:
+            del manager._sessions[state.session_id]
+
+        restored_agent = SimpleNamespace(model="test-model")
+        restored_manager = SessionManager(db=db)
+        with patch.object(
+            restored_manager,
+            "_make_agent",
+            return_value=restored_agent,
+        ) as make_agent:
+            restored = restored_manager.get_session(state.session_id)
+
+        assert restored is not None
+        policy = make_agent.call_args.kwargs["capability_policy"]
+        assert policy == {
+            "enabled_toolsets": ["hermes-acp", "mcp-notes"],
+            "disabled_toolsets": ["mcp-blocked"],
+            "mcp_allowed_names": ["notes"],
+            "mcp_denied_names": ["blocked"],
+        }
+
+    def test_fork_copies_original_acp_capability_policy(self, manager):
+        original = manager.create_session(cwd="/tmp/base")
+        original.agent.enabled_toolsets = ["hermes-acp"]
+        original.agent.disabled_toolsets = ["mcp-blocked"]
+        original.agent._acp_mcp_allowed_names = frozenset()
+        original.agent._acp_mcp_denied_names = frozenset({"blocked"})
+
+        with patch.object(manager, "_make_agent", return_value=_mock_agent()) as make_agent:
+            forked = manager.fork_session(original.session_id, cwd="/tmp/fork")
+
+        assert forked is not None
+        assert make_agent.call_args.kwargs["capability_policy"] == {
+            "enabled_toolsets": ["hermes-acp"],
+            "disabled_toolsets": ["mcp-blocked"],
+            "mcp_allowed_names": [],
+            "mcp_denied_names": ["blocked"],
+        }
+
+    def test_policy_merge_preserves_client_mcp_when_current_policy_allows_it(self):
+        original = {
+            "enabled_toolsets": ["hermes-acp", "mcp-client"],
+            "disabled_toolsets": None,
+            "mcp_allowed_names": None,
+            "mcp_denied_names": [],
+        }
+        current = {
+            "enabled_toolsets": ["hermes-acp"],
+            "disabled_toolsets": None,
+            "mcp_allowed_names": None,
+            "mcp_denied_names": ["all", "*", "memory"],
+        }
+
+        merged = acp_session._merge_acp_capability_policy(original, current)
+
+        assert merged["enabled_toolsets"] == ["hermes-acp", "mcp-client"]
+
+    def test_policy_merge_drops_client_mcp_when_current_policy_tightens(self):
+        original = {
+            "enabled_toolsets": ["hermes-acp", "mcp-client"],
+            "disabled_toolsets": None,
+            "mcp_allowed_names": None,
+            "mcp_denied_names": [],
+        }
+        current = {
+            "enabled_toolsets": ["hermes-acp"],
+            "disabled_toolsets": None,
+            "mcp_allowed_names": [],
+            "mcp_denied_names": ["all", "*", "memory"],
+        }
+
+        merged = acp_session._merge_acp_capability_policy(original, current)
+
+        assert merged["enabled_toolsets"] == ["hermes-acp"]
+
 
 
 

--- a/tests/acp_adapter/test_acp_toolsets.py
+++ b/tests/acp_adapter/test_acp_toolsets.py
@@ -1,0 +1,501 @@
+"""Behavioral tests for ACP session toolset resolution."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from acp_adapter import session as session_mod
+
+
+class NoopDb:
+    pass
+
+
+def _module(name: str, **attrs) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+def test_make_agent_includes_platform_resolved_native_plugin_toolsets(monkeypatch):
+    """ACP sessions must include enabled native plugins, not only MCP tools."""
+    captured = {}
+    config = {
+        "model": {"default": "test-model"},
+        "agent": {"disabled_toolsets": ["browser"]},
+        "mcp_servers": {
+            "notes": {"enabled": True},
+            "disabled": {"enabled": "false"},
+        },
+    }
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.model = kwargs["model"]
+
+    def resolve_platform_toolsets(
+        resolved_config,
+        platform,
+        *,
+        include_default_mcp_servers=True,
+    ):
+        assert resolved_config is config
+        assert platform == "acp"
+        assert include_default_mcp_servers is False
+        # The canonical resolver can return an explicitly selected MCP server
+        # name even with default MCP expansion disabled. It must not cross the
+        # native-toolset namespace before ACP adds the canonical mcp- prefix.
+        return {"hermes-acp", "fbrk", "notes"}
+
+    monkeypatch.setitem(
+        sys.modules, "run_agent", _module("run_agent", AIAgent=FakeAgent)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        _module("hermes_cli.config", load_config=lambda: config),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        _module(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=resolve_platform_toolsets,
+            _get_plugin_toolset_keys=lambda: {"fbrk"},
+            enabled_mcp_server_names=lambda resolved_config: {"notes"},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.mcp_startup",
+        _module(
+            "hermes_cli.mcp_startup",
+            ensure_mcp_discovery_before_agent_build=lambda **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(session_mod, "_register_task_cwd", lambda *_args: None)
+
+    manager = session_mod.SessionManager(db=NoopDb())
+    manager._make_agent(session_id="acp-test", cwd=".")
+
+    assert set(captured["enabled_toolsets"]) == {
+        "hermes-acp",
+        "fbrk",
+        "mcp-notes",
+    }
+    assert captured["disabled_toolsets"] == ["browser"]
+
+
+def test_base_acp_toolset_includes_profile_skill_tools():
+    from toolsets import resolve_toolset
+
+    assert {"skills_list", "skill_view", "skill_manage"}.issubset(
+        resolve_toolset("hermes-acp")
+    )
+
+
+def test_platform_resolver_failure_preserves_base_acp_toolset(monkeypatch):
+    """A broken optional plugin must not remove Hermes' base ACP tools or skills."""
+
+    def fail_resolution(*_args, **_kwargs):
+        raise RuntimeError("plugin discovery failed")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=fail_resolution,
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: set(),
+        ),
+    )
+
+    resolved = session_mod._resolve_acp_platform_toolsets({})
+
+    assert resolved == ["hermes-acp"]
+    assert session_mod._expand_acp_enabled_toolsets(resolved) == ["hermes-acp"]
+
+
+def test_platform_resolver_discovers_plugins_before_resolving_toolsets(monkeypatch):
+    call_order = []
+
+    def discover_plugins():
+        call_order.append("discover")
+
+    def resolve_toolsets(_config, platform, **_kwargs):
+        call_order.append("resolve")
+        assert platform == "acp"
+        return {"hermes-acp", "fbrk"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=discover_plugins),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=resolve_toolsets,
+            _get_plugin_toolset_keys=lambda: {"fbrk"},
+            enabled_mcp_server_names=lambda _config: set(),
+        ),
+    )
+
+    assert session_mod._resolve_acp_platform_toolsets({}) == ["hermes-acp", "fbrk"]
+    assert call_order == ["discover", "resolve"]
+
+
+def test_mcp_selection_honors_acp_allowlist_and_no_mcp(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: {"notes", "calendar"},
+        ),
+    )
+
+    allowlisted = {
+        "mcp_servers": {
+            "notes": {"enabled": True},
+            "calendar": {"enabled": True},
+        },
+        "platform_toolsets": {"acp": ["hermes-acp", "notes"]},
+    }
+    opted_out = {
+        "mcp_servers": {
+            "notes": {"enabled": True},
+            "calendar": {"enabled": True},
+        },
+        "platform_toolsets": {"acp": ["hermes-acp", "no_mcp"]},
+    }
+
+    assert session_mod._enabled_acp_mcp_server_names(allowlisted) == ["notes"]
+    assert session_mod._enabled_acp_mcp_server_names(opted_out) == []
+
+
+def test_mcp_policy_is_stable_after_raw_name_alias_registration(monkeypatch):
+    """A live MCP alias must not be mistaken for a native toolset collision."""
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: {"notes"},
+        ),
+    )
+    monkeypatch.setattr(
+        "toolsets._get_registry_toolset_aliases",
+        lambda: {"notes": "mcp-notes"},
+    )
+    config = {
+        "mcp_servers": {"notes": {"enabled": True}},
+        "platform_toolsets": {"acp": ["hermes-acp", "notes"]},
+    }
+
+    assert session_mod._resolve_acp_mcp_policy(config) == (
+        ["notes"],
+        frozenset({"notes"}),
+    )
+
+
+def test_disabled_toolset_name_denies_canonical_mcp_toolset(monkeypatch):
+    """Global disabled_toolsets must survive ACP's mcp- namespace canonicalization."""
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: {"notes"},
+        ),
+    )
+    config = {
+        "agent": {"disabled_toolsets": ["notes"]},
+        "mcp_servers": {"notes": {"enabled": True}},
+    }
+
+    assert session_mod._resolve_acp_mcp_policy(config) == ([], None)
+    assert session_mod._disabled_acp_mcp_server_names(config) == frozenset(
+        {"notes"}
+    )
+
+
+def test_disabled_mcp_allowlist_entry_does_not_enable_other_servers(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: {"calendar"},
+        ),
+    )
+    config = {
+        "mcp_servers": {
+            "notes": {"enabled": False},
+            "calendar": {"enabled": True},
+        },
+        "platform_toolsets": {"acp": ["hermes-acp", "notes"]},
+    }
+
+    assert session_mod._enabled_acp_mcp_server_names(config) == []
+
+
+def test_native_plugin_survives_mcp_name_collision(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=lambda *_args, **_kwargs: {"hermes-acp", "notes"},
+            _get_plugin_toolset_keys=lambda: {"notes"},
+            enabled_mcp_server_names=lambda _config: set(),
+        ),
+    )
+
+    assert session_mod._resolve_acp_platform_toolsets(
+        {}, mcp_server_names=["notes"]
+    ) == ["hermes-acp", "notes"]
+    assert session_mod._expand_acp_enabled_toolsets(
+        ["hermes-acp", "notes"], mcp_server_names=["notes"]
+    ) == ["hermes-acp", "notes", "mcp-notes"]
+
+
+def test_explicit_known_plugin_survives_enabled_mcp_collision(monkeypatch):
+    """A selected plugin keeps its native tools while its colliding MCP is denied."""
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=lambda config, *_args, **_kwargs: {
+                "hermes-acp",
+                *(
+                    {"fbrk"}
+                    if "fbrk" in config["platform_toolsets"]["acp"]
+                    else set()
+                ),
+            },
+            _get_plugin_toolset_keys=lambda: {"fbrk"},
+            enabled_mcp_server_names=lambda _config: {"fbrk"},
+        ),
+    )
+    config = {
+        "mcp_servers": {"fbrk": {"enabled": True}},
+        "platform_toolsets": {"acp": ["hermes-acp", "fbrk"]},
+        "known_plugin_toolsets": {"acp": ["fbrk"]},
+    }
+
+    mcp_names = session_mod._enabled_acp_mcp_server_names(config)
+    native = session_mod._resolve_acp_platform_toolsets(
+        config, mcp_server_names=mcp_names
+    )
+
+    assert mcp_names == []
+    assert native == ["hermes-acp", "fbrk"]
+
+
+def test_builtin_toolset_survives_mcp_name_collision(monkeypatch):
+    """An MCP server named after a native toolset must not suppress native tools."""
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=lambda *_args, **_kwargs: {"hermes-acp", "memory"},
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: set(),
+        ),
+    )
+
+    resolved = session_mod._resolve_acp_platform_toolsets(
+        {}, mcp_server_names=["memory"]
+    )
+
+    assert resolved == ["hermes-acp", "memory"]
+    assert session_mod._expand_acp_enabled_toolsets(
+        resolved, mcp_server_names=["memory"]
+    ) == ["hermes-acp", "memory", "mcp-memory"]
+
+
+def test_explicit_builtin_mcp_collision_fails_closed(monkeypatch):
+    """An ambiguous explicit name must grant neither native nor MCP capability."""
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    def resolve_native(resolved_config, *_args, **_kwargs):
+        selected = set(resolved_config["platform_toolsets"]["acp"])
+        return {"hermes-acp", *(selected & {"cronjob"})}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=resolve_native,
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: {"cronjob"},
+        ),
+    )
+    config = {
+        "mcp_servers": {"cronjob": {"enabled": True}},
+        "platform_toolsets": {"acp": ["hermes-acp", "cronjob"]},
+    }
+
+    mcp_names = session_mod._enabled_acp_mcp_server_names(config)
+    native = session_mod._resolve_acp_platform_toolsets(
+        config, mcp_server_names=mcp_names
+    )
+
+    assert mcp_names == []
+    assert native == ["hermes-acp"]
+    assert session_mod._expand_acp_enabled_toolsets(
+        native, mcp_server_names=mcp_names
+    ) == ["hermes-acp"]
+
+
+def test_composite_mcp_collision_is_removed_before_native_resolution(monkeypatch):
+    """An MCP named ``all`` must not expand into every native capability."""
+    resolved_platform_toolsets = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+
+    def resolve_native(resolved_config, *_args, **_kwargs):
+        resolved_platform_toolsets.extend(resolved_config["platform_toolsets"]["acp"])
+        return {"hermes-acp"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=resolve_native,
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: {"all"},
+        ),
+    )
+    config = {
+        "mcp_servers": {"all": {"enabled": True}},
+        "platform_toolsets": {"acp": ["hermes-acp", "all"]},
+    }
+
+    mcp_names = session_mod._enabled_acp_mcp_server_names(config)
+
+    assert mcp_names == []
+    assert session_mod._resolve_acp_platform_toolsets(
+        config, mcp_server_names=mcp_names
+    ) == ["hermes-acp"]
+    assert resolved_platform_toolsets == ["hermes-acp"]
+
+
+def test_disabled_mcp_collision_does_not_suppress_native_toolset(monkeypatch):
+    """A disabled MCP entry must not affect an independently selected native toolset."""
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=lambda *_args, **_kwargs: {"hermes-acp", "memory"},
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: set(),
+        ),
+    )
+    config = {
+        "mcp_servers": {"memory": {"enabled": False}},
+        "platform_toolsets": {"acp": ["hermes-acp", "memory"]},
+    }
+
+    assert session_mod._enabled_acp_mcp_server_names(config) == []
+    assert session_mod._resolve_acp_platform_toolsets(
+        config, mcp_server_names=[]
+    ) == ["hermes-acp", "memory"]
+
+
+def test_native_plugin_collision_does_not_widen_mcp_allowlist(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_plugin_toolset_keys=lambda: {"notes"},
+            enabled_mcp_server_names=lambda _config: {"notes", "calendar"},
+        ),
+    )
+    config = {
+        "mcp_servers": {
+            "notes": {"enabled": True},
+            "calendar": {"enabled": True},
+        },
+        "platform_toolsets": {
+            "acp": ["hermes-acp", "notes", "calendar"],
+        },
+    }
+
+    assert session_mod._enabled_acp_mcp_server_names(config) == ["calendar"]

--- a/tests/acp_adapter/test_acp_toolsets.py
+++ b/tests/acp_adapter/test_acp_toolsets.py
@@ -370,6 +370,43 @@ def test_builtin_toolset_survives_mcp_name_collision(monkeypatch):
     ) == ["hermes-acp", "memory", "mcp-memory"]
 
 
+def test_current_policy_reserves_native_names_from_acp_client_mcp_registration():
+    policy = session_mod._current_acp_capability_policy({})
+
+    assert {"all", "*", "memory", "coding"}.issubset(
+        set(policy["mcp_denied_names"])
+    )
+
+
+def test_current_policy_reserves_static_native_names_when_plugin_discovery_fails(
+    monkeypatch,
+):
+    def fail_discovery():
+        raise RuntimeError("broken plugin")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=fail_discovery),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=lambda *_args, **_kwargs: {"hermes-acp"},
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: set(),
+        ),
+    )
+
+    policy = session_mod._current_acp_capability_policy({})
+
+    assert {"all", "*", "memory", "coding"}.issubset(
+        set(policy["mcp_denied_names"])
+    )
+
+
 def test_explicit_builtin_mcp_collision_fails_closed(monkeypatch):
     """An ambiguous explicit name must grant neither native nor MCP capability."""
     monkeypatch.setitem(
@@ -406,6 +443,152 @@ def test_explicit_builtin_mcp_collision_fails_closed(monkeypatch):
     assert session_mod._expand_acp_enabled_toolsets(
         native, mcp_server_names=mcp_names
     ) == ["hermes-acp"]
+
+
+def test_explicit_builtin_mcp_collision_preserves_baseline_native_tools(monkeypatch):
+    """A colliding MCP name cannot revoke a separately granted ACP baseline."""
+    captured = {}
+    config = {
+        "model": {"default": "test-model"},
+        "mcp_servers": {"memory": {"enabled": True}},
+        "platform_toolsets": {"acp": ["hermes-acp", "memory"]},
+    }
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.model = kwargs["model"]
+            self.tools = [
+                {"type": "function", "function": {"name": "memory"}},
+                {"type": "function", "function": {"name": "read_file"}},
+            ]
+            self.valid_tool_names = {"memory", "read_file"}
+
+    monkeypatch.setitem(
+        sys.modules, "run_agent", _module("run_agent", AIAgent=FakeAgent)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        _module("hermes_cli.config", load_config=lambda: config),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        _module(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=lambda *_args, **_kwargs: {
+                "hermes-acp",
+                "memory",
+            },
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: {"memory"},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.mcp_startup",
+        _module(
+            "hermes_cli.mcp_startup",
+            ensure_mcp_discovery_before_agent_build=lambda **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(session_mod, "_register_task_cwd", lambda *_args: None)
+
+    manager = session_mod.SessionManager(db=NoopDb())
+    agent = manager._make_agent(session_id="acp-test", cwd=".")
+
+    assert captured["enabled_toolsets"] == ["hermes-acp"]
+    assert set(captured["disabled_toolsets"]) == {"mcp-memory"}
+    assert agent.valid_tool_names == {"memory", "read_file"}
+    assert [tool["function"]["name"] for tool in agent.tools] == [
+        "memory",
+        "read_file",
+    ]
+    assert agent._acp_mcp_allowed_names == frozenset()
+
+
+def test_explicit_bundle_mcp_collision_preserves_independent_baseline(monkeypatch):
+    config = {
+        "model": {"default": "test-model"},
+        "mcp_servers": {"hermes-acp": {"enabled": True}},
+        "platform_toolsets": {"acp": ["hermes-acp"]},
+    }
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.model = kwargs["model"]
+            self.tools = [
+                {"type": "function", "function": {"name": "read_file"}},
+                {"type": "function", "function": {"name": "terminal"}},
+                {"type": "function", "function": {"name": "memory_search"}},
+            ]
+            self.valid_tool_names = {"read_file", "terminal", "memory_search"}
+
+    monkeypatch.setitem(
+        sys.modules, "run_agent", _module("run_agent", AIAgent=FakeAgent)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        _module("hermes_cli.config", load_config=lambda: config),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        _module(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        _module("hermes_cli.plugins", discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        _module(
+            "hermes_cli.tools_config",
+            _get_platform_tools=lambda *_args, **_kwargs: {"hermes-acp"},
+            _get_plugin_toolset_keys=lambda: set(),
+            enabled_mcp_server_names=lambda _config: {"hermes-acp"},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.mcp_startup",
+        _module(
+            "hermes_cli.mcp_startup",
+            ensure_mcp_discovery_before_agent_build=lambda **_kwargs: None,
+        ),
+    )
+    monkeypatch.setattr(session_mod, "_register_task_cwd", lambda *_args: None)
+
+    manager = session_mod.SessionManager(db=NoopDb())
+    agent = manager._make_agent(session_id="bundle-collision", cwd=".")
+
+    assert [tool["function"]["name"] for tool in agent.tools] == [
+        "read_file",
+        "terminal",
+        "memory_search",
+    ]
+    assert agent.valid_tool_names == {"read_file", "terminal", "memory_search"}
+    assert agent._acp_mcp_allowed_names == frozenset()
 
 
 def test_composite_mcp_collision_is_removed_before_native_resolution(monkeypatch):

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -23,7 +23,12 @@ conversation transport.
 
 ## What Hermes exposes in ACP mode
 
-Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. It includes:
+Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. It also
+loads the native plugin toolsets enabled for the active Hermes profile, so an ACP host
+such as Buzz sees the same profile-specific plugin capabilities as a native Hermes
+session. Disabled plugins remain unavailable, and profiles do not share plugin settings.
+
+The base ACP toolset includes:
 
 - file tools: `read_file`, `write_file`, `patch`, `search_files`
 - terminal tools: `terminal`, `process`

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -40,6 +40,18 @@ The base ACP toolset includes:
 
 It intentionally excludes things that do not fit typical editor UX, such as messaging delivery and cronjob management.
 
+ACP resolves native/plugin toolsets and MCP servers as separate capability
+namespaces. MCP servers are exposed under canonical `mcp-<server>` toolsets. If
+an unprefixed platform selection is ambiguous because the same name identifies
+both a native toolset and an MCP server, that selection does not grant either
+meaning. Capabilities granted independently by the curated `hermes-acp`
+baseline or an explicitly enabled native plugin remain available; an ambiguous
+MCP name cannot revoke them.
+
+The resolved capability policy is stored with the ACP session and copied across
+restore, fork, and model-switch operations. Later profile changes may tighten
+an existing session, but cannot silently widen its original tool or MCP access.
+
 ## Installation
 
 Install Hermes normally, then add the ACP extra from the install checkout:


### PR DESCRIPTION
## Summary
- resolve ACP native and plugin toolsets through the canonical platform configuration
- enforce durable MCP allow/deny policy across initial and late session registration
- preserve namespace boundaries, disabled toolsets, and `/tools` parity
- document ACP toolset behavior and add collision/lifecycle regressions

## Verification
- `.venv/bin/python -m pytest -q tests/acp_adapter tests/acp tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_mcp_tools_config.py tests/hermes_cli/test_toolset_validation.py tests/test_toolsets.py tests/test_toolset_distributions.py tests/providers/test_plugin_discovery.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_runtime_disable_gate.py tests/hermes_cli/test_startup_plugin_gating.py` — 274 passed
- `.venv/bin/ruff check acp_adapter/session.py acp_adapter/server.py tests/acp_adapter/test_acp_toolsets.py tests/acp/test_server.py`
- `git diff --check`
- independent staged-diff review passed with no security concerns or logic errors