### PR TITLE
feat: add per-call model override to delegate_task

### DIFF
--- a/contributors/emails/dhruvkejri9@gmail.com
+++ b/contributors/emails/dhruvkejri9@gmail.com
@@ -1,0 +1,1 @@
+dhruvkej9

--- a/run_agent.py
+++ b/run_agent.py
@@ -7794,6 +7794,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            model=function_args.get("model"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -287,6 +287,43 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
 
+    def test_per_call_model_override(self):
+        """delegate_task(model=...) must override the delegation model for
+        the child without touching provider/base_url from config."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Test model override", model="kimi-k3", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "kimi-k3")
+
+    def test_no_model_override_keeps_configured_model(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok",
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Test default model", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            # With no override, the child inherits the parent's model.
+            self.assertEqual(kwargs["model"], parent.model)
+
     def test_nous_child_rederives_api_mode_from_model(self):
         """Portal is dual-wire — same provider + different model prefix must
         not inherit the parent's Messages/chat_completions mode verbatim."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3128,6 +3128,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    model: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3206,6 +3207,12 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Per-call model override: lets the caller pick a different model for
+    # this delegation without touching config.yaml. Provider/base_url stay
+    # from the delegation config (cliproxy by default).
+    if model:
+        creds["model"] = model
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -4215,6 +4222,15 @@ DELEGATE_TASK_SCHEMA = {
                     "Background information the subagent needs: file paths, "
                     "error messages, project structure, constraints. The more "
                     "specific you are, the better the subagent performs."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional model override for this delegation (e.g. "
+                    "'kimi-k3', 'gpt-5.6-luna'). Overrides the configured "
+                    "delegation model for all children in this call; "
+                    "provider/base_url stay from config."
                 ),
             },
             "tasks": {


### PR DESCRIPTION
## Summary
Expose a `model` parameter on the `delegate_task` tool so callers can pick a different model for a delegation without editing `config.yaml`.

- `tools/delegate_tool.py`: add `model: Optional[str] = None` to `delegate_task()`, override `creds["model"]` when set, and add the `model` property to `DELEGATE_TASK_SCHEMA`.
- `run_agent.py`: thread `model` through `_dispatch_delegate_task` (the single call site for all invocation paths).
- `tests/tools/test_delegate.py`: two tests — override reaches the child, and no-override keeps the configured model.

Provider/base_url/api_key stay from the delegation config; only the model string is overridden. The override reaches both child-build paths (single at `delegate_tool.py:3350`, batch at `:3745`).

## Test Plan
- `pytest tests/tools/test_delegate.py` — 65 passed
- Live E2E: `delegate_task(model="baseten-kimi-k3")` spawned a child on `provider=custom base_url=http://localhost:8317/v1 model=baseten-kimi-k3` and returned `ok`