### PR TITLE
fix(gateway,acp): bound two runaway-transcript sites the resume-safety guard missed

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -541,9 +541,34 @@ class SessionManager:
         # otherwise re-fire the pre-request defensive repair on every request
         # for the rest of the session (see hermes_state.get_messages_as_conversation).
         try:
+            from hermes_state import SessionResumeTooLargeError
+
+            safety_check = getattr(db, "assert_resume_safe", None)
+            if callable(safety_check):
+                safety_check(session_id)
             history = db.get_messages_as_conversation(
                 session_id, repair_alternation=True
             )
+        except SessionResumeTooLargeError:
+            # Fail closed like the CLI/TUI resume guards this mirrors
+            # (hermes_cli/cli_agent_setup_mixin.py, tui_gateway/methods_session.py):
+            # a transcript this large would otherwise be fully materialized
+            # into memory here and then replayed message-by-message over the
+            # ACP connection on every reconnect, with no guard at all. None
+            # falls through the same "restore failed" path a genuine DB
+            # error already takes below — every caller (get_session,
+            # update_cwd, resume_session, load_session) treats it as "not
+            # found" and starts a fresh session, so an oversized session
+            # degrades the same way a corrupted one does instead of OOMing
+            # the ACP server.
+            logger.error(
+                "ACP session %s transcript too large to restore safely; "
+                "starting a fresh session instead. Raise "
+                "sessions.max_resume_messages in config.yaml (or set it to "
+                "0 to disable the guard) to restore it.",
+                session_id,
+            )
+            return None
         except Exception:
             logger.warning("Failed to load messages for ACP session %s", session_id, exc_info=True)
             history = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16059,6 +16059,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
+        from hermes_state import SessionResumeTooLargeError
+
         try:
             try:
                 _agent_result = await self._handle_message_with_agent(
@@ -16079,6 +16081,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "⏳ Another turn is still running on this session. To "
                     "protect the transcript, this message was not processed. "
                     "Wait for the active turn to finish, then resend it."
+                )
+            except SessionResumeTooLargeError as exc:
+                # Same rejection shape as TurnLeaseTimeoutError just above:
+                # the transcript load was never attempted, so nothing here
+                # needs the /goal judge or a resend notice beyond this text.
+                logger.error(
+                    "Rejecting turn for routing key %s: %s", _quick_key, exc
+                )
+                return (
+                    "⚠️ This session's transcript has grown too large to "
+                    "process safely. Use /compact to compress the "
+                    "conversation, or /reset to start fresh."
                 )
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
@@ -17069,9 +17083,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # began processing if the gateway died while it was still waiting.
         await self._mark_durable_active_turn(event, session_entry.session_key)
 
-        # Load conversation history from transcript
+        # Load conversation history from transcript. Bound the load first —
+        # this hot path runs on EVERY message for a live session and, unlike
+        # the CLI/TUI resume paths (hermes_cli/cli_agent_setup_mixin.py,
+        # tui_gateway/methods_session.py) and session.history
+        # (tui_gateway/methods_session.py), it never got the
+        # assert_resume_safe() guard added this week to stop a runaway
+        # lineage from exhausting memory. A session that keeps growing while
+        # staying live in _sessions would otherwise re-materialize its full
+        # (unbounded) transcript on every single incoming message, before
+        # the hygiene auto-compress below even gets a chance to shrink it.
+        from hermes_state import SessionResumeTooLargeError
+
+        try:
+            _resume_guard = getattr(self._session_db, "assert_resume_safe", None)
+            if callable(_resume_guard):
+                await _resume_guard(session_entry.session_id)
+        except SessionResumeTooLargeError:
+            # Fail closed, matching the turn-lease-timeout early exit just
+            # above: restore the tokens before propagating, or this early
+            # exit leaks task-local identity (the broad session-context
+            # cleanup finally later in this method never runs).
+            self._clear_session_env(_session_env_tokens)
+            raise
+        except Exception:
+            # Fail OPEN on a transient guard failure (locked DB, schema skew
+            # on an old test/adaptor DB) — same posture as the resume guards
+            # this mirrors.
+            logger.debug(
+                "Resume-size guard failed for session %s; proceeding unguarded",
+                session_entry.session_id,
+                exc_info=True,
+            )
         history = await self.async_session_store.load_transcript(session_entry.session_id)
-        
+
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
         #

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -241,6 +241,58 @@ class TestPersistence:
         # Should not be found via ACP SessionManager.
         assert manager.get_session("cli-session-123") is None
 
+    def test_restore_rejects_oversized_transcript(self, manager, monkeypatch):
+        """A transcript over sessions.max_resume_messages must not be
+        materialized on ACP restore — get_session falls back to None (the
+        same "not found" shape a genuine DB error already takes), instead
+        of unconditionally loading the full lineage into memory and
+        replaying it over the connection, mirroring the CLI/TUI resume
+        guards."""
+        from hermes_state import SessionResumeTooLargeError
+
+        state = manager.create_session()
+        state.history.append({"role": "user", "content": "hi"})
+        manager.save_session(state.session_id)
+
+        with manager._lock:
+            del manager._sessions[state.session_id]
+
+        db = manager._get_db()
+        load_calls = []
+        real_get_messages = db.get_messages_as_conversation
+
+        def spy_get_messages(*args, **kwargs):
+            load_calls.append((args, kwargs))
+            return real_get_messages(*args, **kwargs)
+
+        monkeypatch.setattr(db, "get_messages_as_conversation", spy_get_messages)
+        monkeypatch.setattr(
+            db,
+            "assert_resume_safe",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                SessionResumeTooLargeError(20_001, 20_000)
+            ),
+        )
+
+        restored = manager.get_session(state.session_id)
+
+        assert restored is None
+        assert load_calls == []
+
+    def test_restore_proceeds_when_transcript_is_within_the_limit(self, manager):
+        """The new guard must not regress the ordinary restore path."""
+        state = manager.create_session()
+        state.history.append({"role": "user", "content": "hi"})
+        manager.save_session(state.session_id)
+
+        with manager._lock:
+            del manager._sessions[state.session_id]
+
+        restored = manager.get_session(state.session_id)
+
+        assert restored is not None
+        assert restored.history[-1]["content"] == "hi"
+
     def test_sessions_searchable_via_fts(self, manager):
         """ACP sessions stored in SessionDB are searchable via FTS5."""
         state = manager.create_session()

--- a/tests/gateway/test_transcript_resume_guard.py
+++ b/tests/gateway/test_transcript_resume_guard.py
@@ -1,0 +1,165 @@
+"""Tests for the resume-size guard on the gateway's per-message transcript load.
+
+``gateway/run.py::_handle_message_with_agent`` calls
+``self.async_session_store.load_transcript()`` on EVERY incoming message for a
+live session — unlike the CLI/TUI resume paths, it never checked
+``assert_resume_safe()`` (added this week to stop a runaway lineage from
+exhausting memory on resume/export). A session that keeps growing while
+staying live in ``_sessions`` would otherwise re-materialize its full,
+unbounded transcript on every single message.
+"""
+
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+from hermes_state import SessionResumeTooLargeError
+
+
+def _bootstrap(monkeypatch, tmp_path):
+    """Minimal GatewayRunner setup, mirroring test_42039_duplicate_user_message."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    config = GatewayConfig()
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:12345",
+        session_id="sess-guard",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.has_platform_message_id.return_value = False
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+def _event():
+    return MessageEvent(
+        text="hello world",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            user_id="12345",
+        ),
+        message_id="msg-guard",
+    )
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_path_rejects_oversized_transcript_before_loading(
+    monkeypatch, tmp_path
+):
+    """A runaway lineage must abort before the unbounded load, not after."""
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._session_db.assert_resume_safe = AsyncMock(
+        side_effect=SessionResumeTooLargeError(20_001, 20_000)
+    )
+    runner.session_store.load_transcript.side_effect = AssertionError(
+        "transcript must not load once the session is over the resume limit"
+    )
+    runner._run_agent = pytest.fail
+
+    with pytest.raises(SessionResumeTooLargeError):
+        await runner._handle_message_with_agent(
+            _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+        )
+
+    runner.session_store.load_transcript.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_dispatch_rejects_oversized_transcript_with_bounded_notice(
+    monkeypatch, tmp_path
+):
+    """The outer dispatch turns the guard's error into a bounded chat reply,
+    cleans up the session-env tokens, and never runs the /goal hook — the
+    same shape as the existing turn-lease-timeout rejection."""
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._session_db.assert_resume_safe = AsyncMock(
+        side_effect=SessionResumeTooLargeError(20_001, 20_000)
+    )
+    runner.session_store.load_transcript.side_effect = AssertionError(
+        "transcript must not load once the session is over the resume limit"
+    )
+    runner._run_agent = pytest.fail
+    session_env_tokens = object()
+    runner._set_session_env = MagicMock(return_value=session_env_tokens)
+    runner._clear_session_env = MagicMock()
+    runner._post_turn_goal_continuation = AsyncMock()
+
+    response = await runner._handle_message(_event())
+
+    assert isinstance(response, str)
+    assert "too large" in response.lower()
+    runner.session_store.load_transcript.assert_not_called()
+    runner._clear_session_env.assert_called_once_with(session_env_tokens)
+    runner._post_turn_goal_continuation.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_path_still_loads_transcript_within_the_limit(
+    monkeypatch, tmp_path
+):
+    """The new guard must not regress the ordinary (within-limit) path."""
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._session_db.assert_resume_safe = AsyncMock(return_value=3)
+    runner._run_agent = AsyncMock(
+        return_value={"final_response": "", "failed": True}
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    runner.session_store.load_transcript.assert_called_once_with("sess-guard")


### PR DESCRIPTION
## What does this PR do?

This week's transcript-safety series (`f0794640f6`/`c750d5354a`, salvaged as #81283) added `SessionDB.assert_resume_safe()` / `resolved_max_resume_messages()` (config-gated, default 20000) specifically "to prevent oversized transcripts from exhausting memory" on resume. It was wired into CLI resume (`hermes_cli/cli_agent_setup_mixin.py`), CLI/dashboard export (`console_engine.py`, `web_routers/sessions.py`), and TUI `session.resume` (`tui_gateway/methods_session.py`) — plus a 4th sibling, `tui_gateway`'s `session.history` RPC, in our own already-open #81690.

Two more sites still call `SessionDB.get_messages_as_conversation()` unconditionally, with no size check at all:

1. **`gateway/run.py::_handle_message_with_agent`** — loads the transcript on **every incoming message** for a live session, before the "Session hygiene: auto-compress pathologically large transcripts" step even runs. This is the highest-value gap: a session that keeps growing (e.g. because hygiene/compression itself starts failing) while staying live in `_sessions` re-materializes its full, unbounded lineage into memory on every single message, not just on an explicit resume action.
2. **`acp_adapter/session.py::SessionManager._restore`** — ACP's own independent `session/load` / `session/resume` restore path (used by Zed, JetBrains Junie, etc.). Confirmed via `gh pr diff` on #81283 that it never touched `acp_adapter/`. An oversized session restored here is not just materialized in memory but then replayed message-by-message over the ACP connection.

## Fix

Both sites now call `assert_resume_safe()` before the load, mirroring the exact fail-closed/fail-open posture already established by the other guarded sites:

- **`gateway/run.py`**: guard right before the transcript load in `_handle_message_with_agent`. On `SessionResumeTooLargeError`, clears `_session_env_tokens` (matching the existing `TurnLeaseTimeoutError` early-exit just above it, since the broader session-context cleanup `finally` hasn't started yet at this point) and re-raises; `_handle_message`'s outer dispatch catches it and returns a bounded chat notice, the same shape as its existing turn-lease-timeout rejection. Any other guard error fails open (logs and proceeds), matching the established posture.
- **`acp_adapter/session.py`**: guard right before the load in `_restore`. On `SessionResumeTooLargeError`, logs an actionable error and returns `None` — the exact same "not found -> fresh session" fallback every caller (`get_session`/`update_cwd`/`resume_session`/`load_session`) already takes on a genuine DB error a few lines below, so an oversized session degrades the same way a corrupted one does instead of OOMing the ACP server.

## Testing

- New `tests/gateway/test_transcript_resume_guard.py` (3 tests): the guard rejects before `load_transcript` is ever called and propagates `SessionResumeTooLargeError` from the agent path; the full `_handle_message` dispatch turns it into a bounded notice, clears the session-env tokens, and skips the `/goal` continuation hook (mirroring the existing turn-lease-timeout test in `tests/gateway/test_turn_lease.py`); the guard does not regress the ordinary within-limit path.
- New tests in `tests/acp/test_session.py` (2 tests): an oversized transcript is rejected without ever calling `get_messages_as_conversation`; an ordinary session still restores normally.
- Mutation-verified: reverted each fix in isolation and confirmed the corresponding new tests fail for the right reason (transcript loads / restore succeeds when it shouldn't).
- `tests/acp/test_session.py` full suite: 17 passed.
- `tests/gateway/` full suite (excluding pre-existing `aiohttp.test_utils` import-time collection errors — `aiohttp` lives behind optional platform extras not installed under `--extra dev`, unrelated to this change): 4830 passed, 9 failed. Re-ran all 9 failing tests in isolation both with and without this fix — identical 4-failed/5-passed result either way (systemd socket, subprocess-forensics, and a `defusedxml`-dependent WeCom XML parser are pre-existing environment gaps; the other 5 pass in isolation and only fail under the full 4800+ test run, a pre-existing test-order-pollution artifact unrelated to this change).
- `ruff check` clean on all changed/added files.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate (searched "transcript memory resume gateway", "load_transcript", "acp session restore memory", "assert_resume_safe" — no open/merged PR targets `gateway/run.py`'s per-message load or `acp_adapter/session.py`'s restore path specifically; our own #81690 guards a different call site, `tui_gateway`'s `session.history` RPC)
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified