### PR TITLE
fix(agent): stop a personality-pivot marker from becoming the session title

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -142,6 +142,17 @@ _MACHINE_PREFIXES = (
     # actual question. Keep in sync with
     # tui_gateway.server._MODEL_SWITCH_MARKER_PREFIX.
     "[System: The active model for this chat has changed to ",
+    # Personality-pivot markers from tui_gateway.server._apply_personality_to_session.
+    # Same role="user" persistence, same failure mode as the model-switch
+    # marker above: switching personality before the first real message
+    # titled the session after the marker instead of the user's actual
+    # question. Keep in sync with tui_gateway.server._PERSONALITY_SET_MARKER_PREFIX
+    # and tui_gateway.server._PERSONALITY_CLEARED_MARKER.
+    "[System: The user has changed the assistant's personality. "
+    "From this point forward, adopt the following persona and respond "
+    "accordingly: ",
+    "[System: The user has cleared the personality overlay. "
+    "From this point forward, respond in your normal default style.]",
 )
 
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -560,3 +560,86 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestPersonalityMarkersNotTitleable:
+    """Regression: a personality-pivot marker must never become the session
+    title, mirroring TestModelSwitchMarkerNotTitleable above.
+
+    ``_apply_personality_to_session`` (tui_gateway/server.py) persists its
+    pivot notice with ``role="user"`` for the same reason
+    ``_append_model_switch_marker`` does (#48338): strict OpenAI-compatible
+    providers reject a system message that is not first. Switching
+    personality before asking the first real question titled the session
+    "[System: The user has changed the assistant's personality…" instead of
+    the user's actual question — the exact bug class #65891 fixed for the
+    model-switch marker, left open here.
+    """
+
+    SET_MARKER = (
+        "[System: The user has changed the assistant's personality. "
+        "From this point forward, adopt the following persona and respond "
+        "accordingly: You are a pirate.]"
+    )
+    CLEARED_MARKER = (
+        "[System: The user has cleared the personality overlay. "
+        "From this point forward, respond in your normal default style.]"
+    )
+
+    def test_marker_prefixes_match_gateway_constants(self):
+        """The guard must stay in sync with the gateway's marker builders."""
+        from tui_gateway.server import (
+            _PERSONALITY_CLEARED_MARKER,
+            _PERSONALITY_SET_MARKER_PREFIX,
+        )
+        from agent.title_generator import _MACHINE_PREFIXES
+
+        assert _PERSONALITY_SET_MARKER_PREFIX in _MACHINE_PREFIXES
+        assert _PERSONALITY_CLEARED_MARKER in _MACHINE_PREFIXES
+        assert self.SET_MARKER.startswith(_PERSONALITY_SET_MARKER_PREFIX)
+        assert self.CLEARED_MARKER == _PERSONALITY_CLEARED_MARKER
+
+    def test_set_marker_is_not_titleable(self):
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message(self.SET_MARKER) is False
+
+    def test_cleared_marker_is_not_titleable(self):
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message(self.CLEARED_MARKER) is False
+
+    def test_set_marker_not_counted_as_a_real_user_turn(self):
+        from agent.title_generator import _is_real_user_turn
+
+        assert _is_real_user_turn({"role": "user", "content": self.SET_MARKER}) is False
+
+    def test_real_question_after_marker_still_titles(self):
+        """The marker must not consume the session's one titling opportunity,
+        mirroring the model-switch marker's equivalent regression test."""
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        db.get_session_title_source.return_value = None
+        history = [
+            {"role": "user", "content": self.SET_MARKER},
+            {"role": "user", "content": "南京市秦淮区 小时级天气预报"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            import threading
+
+            called = threading.Event()
+            mock_auto.side_effect = lambda *a, **k: called.set()
+            maybe_auto_title(db, "sess-1", "南京市秦淮区 小时级天气预报", history)
+            assert called.wait(timeout=10), "auto_title never ran after marker"
+
+    def test_instant_title_skips_marker_uses_real_message(self):
+        from agent.title_generator import apply_instant_title
+
+        db = MagicMock()
+        db.get_session_title_source.return_value = None
+
+        assert apply_instant_title(db, "sess-1", self.SET_MARKER) is None
+        assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
+            "南京市秦淮区 小时级天气预报"
+        )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3967,6 +3967,22 @@ def _is_model_switch_marker(entry: Any) -> bool:
     return isinstance(content, str) and content.startswith(_MODEL_SWITCH_MARKER_PREFIX)
 
 
+# Stable text of the two personality-pivot markers _apply_personality_to_session
+# injects, mirrored (not imported, to avoid a circular import) into
+# agent.title_generator._MACHINE_PREFIXES so switching personality before the
+# first real message never leaks a marker into the session title the same way
+# the model-switch marker did (#65891 / see _MODEL_SWITCH_MARKER_PREFIX above).
+_PERSONALITY_SET_MARKER_PREFIX = (
+    "[System: The user has changed the assistant's personality. "
+    "From this point forward, adopt the following persona and respond "
+    "accordingly: "
+)
+_PERSONALITY_CLEARED_MARKER = (
+    "[System: The user has cleared the personality overlay. "
+    "From this point forward, respond in your normal default style.]"
+)
+
+
 def _append_model_switch_marker(session: dict | None, *, model: str, provider: str) -> None:
     """Record a real system-history pivot after a live model switch.
 
@@ -6064,16 +6080,9 @@ def _apply_personality_to_session(
         # Inject a pivot marker into history so the model sees the change point.
         # This prevents it from pattern-matching its prior style.
         if new_prompt:
-            marker = (
-                "[System: The user has changed the assistant's personality. "
-                "From this point forward, adopt the following persona and respond "
-                f"accordingly: {new_prompt}]"
-            )
+            marker = f"{_PERSONALITY_SET_MARKER_PREFIX}{new_prompt}]"
         else:
-            marker = (
-                "[System: The user has cleared the personality overlay. "
-                "From this point forward, respond in your normal default style.]"
-            )
+            marker = _PERSONALITY_CLEARED_MARKER
         # Tagged like the model-switch marker (`_append_model_switch_marker`):
         # the marker rides as role=user so strict OpenAI-compatible providers
         # accept it mid-conversation, but `display_kind` keeps it out of the


### PR DESCRIPTION
## What does this PR do?

`_apply_personality_to_session()` (`tui_gateway/server.py`) persists its personality-pivot notice with `role="user"` — for the same reason `_append_model_switch_marker()` does (#48338): strict OpenAI-compatible providers reject a `system` message that isn't first in the conversation.

Today's `b684cbb094` taught `agent/title_generator.py::_MACHINE_PREFIXES` to recognize the model-switch marker after it leaked into session titles ("Switching models before sending the first real message titled the session '[System: The active model for this chat has changed to…' instead of the user's actual question"). The personality marker — same file, same `role="user"` persistence trick, same shape — was never added to the same guard.

Switching personality (`/personality <name>`) before sending the first real message in a session:
1. Is not recognized by `is_titleable_user_message()`, so it can be titled/formatted as if it were the user's real opening message instead of being skipped.
2. Is counted as a real user turn by `_is_real_user_turn()` (used to detect "is this the opening turn"), pushing the actual first question to what looks like turn 2 — exactly the double failure mode `b684cbb094`'s commit message describes for the model-switch marker ("wrong title" *and* "counted as a turn, session left untitled").

Verified directly against the live functions before writing the fix:
```
>>> is_titleable_user_message(PERSONALITY_SET_MARKER)
True   # should be False, same as the model-switch marker
>>> _is_real_user_turn({"role": "user", "content": PERSONALITY_SET_MARKER})
True   # should be False
```

## Fix

Extracted the marker text into two named constants in `tui_gateway/server.py` (`_PERSONALITY_SET_MARKER_PREFIX`, `_PERSONALITY_CLEARED_MARKER` — the "cleared" marker has no variable suffix, so it's an exact string rather than a prefix), mirroring the existing `_MODEL_SWITCH_MARKER_PREFIX` pattern, and added both to `_MACHINE_PREFIXES` (duplicated as literals with a "keep in sync" comment, not imported — same reasoning as the existing model-switch entry: importing `tui_gateway.server` into `agent/title_generator.py` risks a circular import). `_apply_personality_to_session` now builds its marker from the shared constants instead of inline literals, so the title-generator guard and the gateway's own marker text can't drift apart.

## Testing

- New `TestPersonalityMarkersNotTitleable` class in `tests/agent/test_title_generator.py` (7 tests), mirroring the existing `TestModelSwitchMarkerNotTitleable` class: constant sync, `is_titleable_user_message` for both marker variants, `_is_real_user_turn`, the "real question after marker still titles" regression, and `apply_instant_title` skipping the marker.
- Mutation-verified: reverted the fix and confirmed 5/6 new tests fail for the right reason (the 6th, `test_real_question_after_marker_still_titles`, passes either way in this specific two-message history shape — kept for parity with the model-switch test class, and the other 5 tests independently prove the fix).
- `tests/agent/test_title_generator.py` full suite: 39 passed.
- `tests/tui_gateway/test_personality_clobbers_system_prompt.py` + `tests/tui_gateway/test_make_agent_personality_prompt.py` + full `tests/test_tui_gateway_server.py`: 526 passed.
- `ruff check` clean on all changed files.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate ("personality marker title", "_apply_personality_to_session title", "MACHINE_PREFIXES personality", "personality overlay session title" — no matches)
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified