### PR TITLE
fix(tools): recognize `gh repo sync` as a self-repo mutation

### DIFF
--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -104,6 +104,20 @@ class TestBlocksMutationsInSourceRepo:
         hit, _ = _detect(command, repo, repo)
         assert hit is True
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh repo sync",
+            "hub repo sync",
+            "gh repo sync --force",
+            "gh repo sync --branch main",
+            "gh repo sync -b main --force",
+        ],
+    )
+    def test_repo_sync_without_destination_clients(self, repo, command):
+        hit, _ = _detect(command, repo, repo)
+        assert hit is True
+
     def test_explicit_work_tree_targeting_repo(self, repo, tmp_path):
         command = f"git --git-dir={repo / '.git'} --work-tree={repo} checkout main"
         hit, _ = _detect(command, tmp_path, repo)
@@ -209,6 +223,26 @@ class TestAllowsSafeCommands:
 
     def test_pr_checkout_words_in_other_gh_command_are_safe(self, repo):
         hit, _ = _detect("gh api /repos/example/pr/checkout", repo, repo)
+        assert hit is False
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh repo sync owner/repo",
+            "gh repo sync owner/repo --force",
+            "gh repo sync owner/repo --branch main",
+            "gh repo sync --source upstream/repo owner/repo",
+        ],
+    )
+    def test_repo_sync_with_explicit_destination_is_safe(self, repo, command):
+        """A destination-repository argument targets a *remote* repo via the
+        GitHub API and never touches this checkout — unlike bare `gh repo
+        sync`, which fast-forwards/resets the local repo in place."""
+        hit, _ = _detect(command, repo, repo)
+        assert hit is False
+
+    def test_repo_sync_words_in_other_gh_command_are_safe(self, repo):
+        hit, _ = _detect("gh api /repos/example/repo/sync", repo, repo)
         assert hit is False
 
     @pytest.mark.parametrize(

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -637,6 +637,19 @@ def _inspect_github_cli(
     index = _consume_options(args, 0, frozenset({"-R", "--repo", "--hostname"}))
     if args[index : index + 2] == ["pr", "checkout"]:
         return f"{name} pr checkout"
+    if args[index : index + 2] == ["repo", "sync"]:
+        # Without a destination-repository argument, `gh repo sync`
+        # fast-forwards (or, with --force, hard-resets) the LOCAL checkout
+        # to match its upstream — the same "module-version skew under the
+        # live interpreter" hazard `git pull`/`git reset --hard` are
+        # blocked for. `gh repo sync owner/repo` targets a *remote* repo
+        # via the API and never touches this checkout, so only the
+        # destination-omitted form is flagged.
+        sync_index = _consume_options(
+            args, index + 2, frozenset({"-b", "--branch", "-s", "--source"})
+        )
+        if sync_index >= len(args):
+            return f"{name} repo sync"
     return None
 
 


### PR DESCRIPTION
## What does this PR do?

`tools/self_repo_guard.py` exists to block git operations that could rewrite the checkout backing this running process — a mutation while the interpreter has this exact source loaded risks module-version skew. It already recognizes both the raw `git` mutating subcommands (`checkout`, `reset --hard`, `pull`, `rebase`, `bisect`, etc.) and the `gh`/`hub` CLI equivalent of one of them: `gh pr checkout` / `hub pr checkout` (`_inspect_github_cli()`).

It never checked `gh repo sync`. Per `gh repo sync --help`: *"Without an argument, the local repository is selected as the destination repository."* Run bare (or with `--force`) inside this checkout, it fast-forwards (or hard-resets) the local branch to match its upstream — the exact same "module-version skew under the live interpreter" hazard `git pull`/`git reset --hard` are already blocked for, just through a different door the existing `_inspect_github_cli()` function doesn't check.

## Fix

Extended `_inspect_github_cli()` with a check for `repo sync`: after consuming the command's own flags (`-b/--branch`, `-s/--source`, `--force`), if no positional destination-repository argument remains, flag it the same way `pr checkout` already is. `gh repo sync owner/repo` (an explicit destination) is left untouched — that targets a *remote* repository through the GitHub API and never touches the local checkout, so it's not a self-repo mutation.

## Testing

- New tests in `tests/tools/test_self_repo_guard.py`: 5 parametrized cases confirming `gh repo sync` / `hub repo sync` (bare, `--force`, `--branch`, combined) are blocked inside the source repo; 4 confirming an explicit destination argument (with any combination of flags) is left safe; 1 confirming the words "repo"/"sync" appearing in an unrelated `gh api` path don't false-positive (mirroring the existing `pr checkout` word-boundary test).
- Mutation-verified: reverted the fix and confirmed all 5 "should block" cases fail for the right reason (guard returns `False`) while the 5 "should stay safe" cases pass either way.
- Full `tests/tools/test_self_repo_guard.py`: 121 passed.
- `tests/tools/test_terminal_self_repo_guard.py` (the `terminal_tool.py` integration suite for this guard): 7 passed.
- `ruff check` clean on both changed files.

## Note

My own open PR #81702 (`fix/self-repo-guard-git-apply-am`) touches the same file (a different function — `_KNOWN_GIT_BUILTINS`/`_mutates_worktree`, for `git apply`/`git am`, not `_inspect_github_cli`). No functional overlap, but flagging it in case of a textual merge conflict depending on merge order.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate ("gh repo sync self repo", "self_repo_guard gh repo sync", "_inspect_github_cli", "self-repo guard github cli" — no matches)
- [x] My PR contains only changes related to this fix
- [x] Tests added, mutation-verified