### PR TITLE
Fix idle delivery of terminal watch-pattern events

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11753,10 +11753,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # turn so the agent kicks off the new chat.
         self._spawn_supervised(self._handoff_watcher, "handoff_watcher")
 
-        # Start background async-delegation watcher — drains completion events
-        # from delegate_task(background=true) subagents and injects each
-        # result back into its originating session as a new turn, covering the
-        # idle case where the subagent finishes with no agent turn running.
+        # Start the background completion-event watcher. It injects async
+        # delegation results and terminal watch-pattern events into their
+        # originating sessions while the gateway is idle.
         self._spawn_supervised(self._async_delegation_watcher, "async_delegation_watcher")
 
         # Start the scale-to-zero idle watcher ONLY when this instance is opted
@@ -22814,41 +22813,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             evt["thread_id"] = parsed["thread_id"]
 
     async def _async_delegation_watcher(self, interval: float = 2.0) -> None:
-        """Drain async-delegation completions and inject them as new turns.
+        """Drain idle gateway events and inject them as new turns.
 
         Background subagents (``delegate_task(background=true)``) run on the
         async-delegation daemon executor — they have no per-process watcher
         task, so their completion events would only be seen by the post-turn
-        queue drain. This watcher covers the IDLE case: when a background
-        subagent finishes while no agent turn is running, its result still
-        re-enters the originating session promptly.
+        queue drain. Terminal watch-pattern events also need an idle consumer;
+        otherwise, they remain queued until the next foreground turn.
 
         Mirrors the CLI's idle ``process_loop`` drain. Stays silent when the
-        queue has nothing for us; ignores non-async event types (those are
-        handled by ``_run_process_watcher`` / the post-turn drain).
+        queue has nothing for us. Process completions remain owned by
+        ``_run_process_watcher`` tasks. Unknown event types are discarded so
+        they cannot cycle through this queue forever.
         """
         await asyncio.sleep(3)  # let platforms finish connecting
         from tools.process_registry import process_registry as _pr
         while self._running:
             try:
-                # Peek the queue for async-delegation events. We must NOT
-                # consume watch/completion events here (other drains own them),
-                # so requeue anything that isn't ours.
+                # Detach one queue snapshot before requeueing events owned by
+                # another consumer. This avoids consuming the same foreign
+                # event repeatedly in one iteration.
                 requeue = []
-                async_events = []
+                idle_events = []
                 while not _pr.completion_queue.empty():
                     try:
                         evt = _pr.completion_queue.get_nowait()
                     except Exception:
                         break
-                    if evt.get("type") == "async_delegation":
-                        async_events.append(evt)
-                    else:
+                    evt_type = evt.get("type", "completion")
+                    if evt_type in {
+                        "async_delegation", "watch_match", "watch_disabled",
+                    }:
+                        idle_events.append(evt)
+                    elif evt_type == "completion":
                         requeue.append(evt)
                 for evt in requeue:
                     _pr.completion_queue.put(evt)
-                for evt in async_events:
-                    self._enrich_async_delegation_routing(evt)
+                for evt in idle_events:
+                    if evt.get("type") == "async_delegation":
+                        self._enrich_async_delegation_routing(evt)
                     synth_text = _format_gateway_process_notification(evt)
                     if not synth_text:
                         continue
@@ -22858,9 +22861,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _pr.completion_queue.put(evt)
                     except Exception as e:
                         _pr.completion_queue.put(evt)
-                        logger.error("Async delegation injection error: %s", e)
+                        logger.error("Idle completion-event injection error: %s", e)
             except Exception as e:
-                logger.debug("Async delegation watcher error: %s", e)
+                logger.debug("Idle completion-event watcher error: %s", e)
             await asyncio.sleep(interval)
 
     async def _run_process_watcher(self, watcher: dict) -> None:

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import Platform
-from gateway.run import GatewayRunner
+from gateway.run import GatewayRunner, _drain_gateway_watch_events
 from gateway.session import SessionSource
 from tools.process_registry import ProcessRegistry, ProcessSession
 
@@ -84,6 +84,26 @@ def _completion_event(*, started_at, session_id="proc_reused"):
     }
 
 
+def _watch_event(*, event_type="watch_match", session_id="proc_watch"):
+    event = {
+        "type": event_type,
+        "session_id": session_id,
+        "session_key": "agent:main:telegram:dm:12345:678",
+        "platform": "telegram",
+        "chat_id": "12345",
+        "thread_id": "678",
+        "user_id": "owner-7",
+        "user_name": "Owner",
+        "message_id": "message-9",
+        "command": "claude",
+    }
+    if event_type == "watch_match":
+        event.update(pattern="Approve?", output="Approve? [y/N]", suppressed=0)
+    else:
+        event["message"] = "Watch patterns disabled"
+    return event
+
+
 def _stop_after_sleeps(monkeypatch, runner, count):
     sleep_calls = 0
 
@@ -110,6 +130,117 @@ def test_duplicate_async_queue_replay_injects_once(monkeypatch, isolated_registr
     asyncio.run(runner._async_delegation_watcher(interval=0))
 
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.parametrize("event_type", ["watch_match", "watch_disabled"])
+def test_idle_watch_event_wakes_exact_route_once(
+    monkeypatch, isolated_registry, event_type,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    isolated.put(_watch_event(event_type=event_type))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+    delivered = adapter.handle_message.await_args.args[0]
+    assert delivered.internal is True
+    assert delivered.message_id == "message-9"
+    assert delivered.source == SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id="678",
+        user_id="owner-7",
+        user_name="Owner",
+    )
+    assert isolated.empty()
+    assert _drain_gateway_watch_events(isolated) == []
+
+
+def test_failed_idle_watch_injection_is_requeued_and_retried(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    isolated.put(_watch_event())
+
+    adapter = SimpleNamespace(
+        handle_message=AsyncMock(side_effect=[RuntimeError("temporary"), None])
+    )
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=3)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    assert adapter.handle_message.await_count == 2
+    assert isolated.empty()
+
+
+def test_idle_watch_and_async_delegation_events_coexist(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    isolated.put(_watch_event())
+    isolated.put(_async_event("deleg_coexists"))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    assert adapter.handle_message.await_count == 2
+    delivered_texts = [call.args[0].text for call in adapter.handle_message.await_args_list]
+    assert any("matched watch pattern" in text for text in delivered_texts)
+    assert any("Investigate flaky test" in text for text in delivered_texts)
+    assert isolated.empty()
+
+
+def test_idle_watcher_preserves_process_completion_and_drops_unknown_events(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    completion = _completion_event(started_at=10.0)
+    isolated.put(completion)
+    isolated.put({"type": "unsupported"})
+    isolated.put(_watch_event(session_id="proc_after_unknown"))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+    assert isolated.qsize() == 1
+    assert isolated.get_nowait() is completion
+
+
+def test_unroutable_idle_watch_does_not_block_routable_event(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    unroutable = _watch_event(session_id="proc_unroutable")
+    unroutable.update(session_key="", platform="", chat_id="", thread_id="")
+    isolated.put(unroutable)
+    isolated.put(_watch_event(session_id="proc_routable"))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+    assert isolated.empty()
 
 
 def test_unroutable_async_event_is_not_requeued_forever(


### PR DESCRIPTION
## Summary

Fix terminal `watch_patterns` notifications that are detected while a gateway session is idle but are not delivered until the user sends another message.

- Let the existing idle completion-event watcher consume `watch_match` and `watch_disabled` events.
- Reuse the existing formatting, routing, retry, and internal-turn delivery path.
- Keep process completion events owned by their per-process watchers.
- Preserve async delegation behavior.
- Drop unsupported queue events instead of cycling them forever.

## Root cause

`ProcessRegistry._check_watch_patterns()` queues terminal watch events immediately. The gateway only consumed those events in the post-turn drain. The idle watcher consumed only `async_delegation` events and requeued everything else.

A background process could therefore match a blocker while no agent turn was running, but the owning session would not wake. The queued alert appeared only after the user sent a new message and caused the post-turn drain to run.

## Reproduction

1. Start a background terminal process with a rare `watch_patterns` marker.
2. Let the initiating gateway turn finish.
3. Have the process print the marker while the gateway session is idle.
4. Before this patch, no new internal turn starts.
5. Send any user message. The old watch event is then delivered.

## Tests

Added focused regressions for:

- idle `watch_match` delivery;
- idle `watch_disabled` delivery;
- exact stored route and reply-anchor preservation;
- failed delivery retry;
- no duplicate post-turn delivery after success;
- coexistence with async delegation events;
- preservation of process completion events;
- unroutable and unsupported event handling.

Verified locally on macOS:

```text
uv run --extra dev pytest -q tests/gateway/test_completion_delivery.py tests/tools/test_watch_patterns.py
31 passed in 0.99s

uv run --extra dev ruff check gateway/run.py tests/gateway/test_completion_delivery.py
All checks passed!

git diff --check
passed
```

The implementation adds no model tool, system-prompt text, configuration key, environment variable, dependency, or provider-specific behavior.
