### PR TITLE
feat(tools): add native Cursor Agent delegation

### DIFF
--- a/tests/tools/test_cursor_agent_tool.py
+++ b/tests/tools/test_cursor_agent_tool.py
@@ -1145,3 +1145,42 @@ time.sleep(30)
             proc.wait(timeout=1)
         except Exception:
             pass
+def test_child_env_guarantees_home_and_local_bin(monkeypatch, tmp_path):
+    import os
+
+    from tools import cursor_agent_tool
+
+    captured = {}
+
+    class _EnvCapturePopen(_FakePopen):
+        def __init__(self, cmd, *, cwd=None, stdout=None, stderr=None, env=None, **kwargs):
+            super().__init__(cmd, cwd=cwd, stdout=stdout, stderr=stderr, **kwargs)
+            captured["env"] = env
+            self.stdout = _FakeStdoutWithEof(b"")
+
+        def poll(self):
+            if self.stdout.eof_reached.is_set():
+                return 0
+            return None
+
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _EnvCapturePopen)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    result = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(
+            task="x",
+            workdir=str(workdir.resolve()),
+        )
+    )
+
+    assert result["success"] is True
+    env = captured["env"]
+    assert env is not None
+    # HOME must be present and non-empty even though the caller env lacked it;
+    # the agent wrapper runs with `set -u` and dies on unbound $HOME.
+    assert env["HOME"] == str(Path.home())
+    # ~/.local/bin is prepended so binary resolution works under minimal PATH.
+    assert env["PATH"].split(os.pathsep)[0] == str(Path.home() / ".local" / "bin")

--- a/tests/tools/test_cursor_agent_tool.py
+++ b/tests/tools/test_cursor_agent_tool.py
@@ -883,16 +883,111 @@ def test_parse_non_hashable_values_do_not_crash():
         assert len(parsed["delegations"]) == 1
 
 
+def test_parse_distinct_scalar_call_ids():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    def _event(call_id):
+        return json.dumps(
+            {
+                "type": "tool_call",
+                "call_id": call_id,
+                "tool_call": {
+                    "taskToolCall": {
+                        "args": {
+                            "description": "scalar id",
+                            "subagentType": "explore",
+                            "model": "m",
+                        }
+                    }
+                },
+            }
+        )
+
+    log = "\n".join([_event(True), _event(1), _event(False), _event(0), _event(1.0)])
+    parsed = parse_cursor_agent_log(log)
+    assert len(parsed["delegations"]) == 5
+
+
+def test_parse_distinct_nested_scalar_call_ids():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    def _event(call_id):
+        return json.dumps(
+            {
+                "type": "tool_call",
+                "call_id": call_id,
+                "tool_call": {
+                    "taskToolCall": {
+                        "args": {
+                            "description": "nested scalar id",
+                            "subagentType": "explore",
+                            "model": "m",
+                        }
+                    }
+                },
+            }
+        )
+
+    log = "\n".join(
+        [
+            _event({"flag": True}),
+            _event({"flag": 1}),
+            _event({"flag": False}),
+            _event({"flag": 0}),
+            _event({"value": 1}),
+            _event({"value": 1.0}),
+        ]
+    )
+    parsed = parse_cursor_agent_log(log)
+    assert len(parsed["delegations"]) == 6
+
+
+def _kill_process_group_or_pid(pgid: int | None, pid: int | None) -> None:
+    import os
+    import signal
+
+    if pgid is not None:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+            return
+        except (OSError, ProcessLookupError):
+            pass
+    if pid is not None:
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+            return
+        except (OSError, ProcessLookupError):
+            pass
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            pass
+
+
 @pytest.mark.live_system_guard_bypass
 def test_incremental_stdout_updates_log_before_child_exit(monkeypatch, tmp_path):
     import os
-    import signal
+    import subprocess
     import sys
 
     from tools import cursor_agent_tool
 
     monkeypatch.setattr(cursor_agent_tool, "STALL_WATCHDOG_SECONDS", 5)
     monkeypatch.setattr(cursor_agent_tool, "_MONITOR_POLL_SECONDS", 0.05)
+
+    spawn_info: dict[str, int | None] = {"pid": None, "pgid": None}
+    real_popen = subprocess.Popen
+
+    def _capturing_popen(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        spawn_info["pid"] = proc.pid
+        try:
+            spawn_info["pgid"] = os.getpgid(proc.pid)
+        except (OSError, ProcessLookupError):
+            spawn_info["pgid"] = None
+        return proc
+
+    monkeypatch.setattr(cursor_agent_tool.subprocess, "Popen", _capturing_popen)
 
     child_script = (
         "import sys, time\n"
@@ -958,16 +1053,12 @@ def test_incremental_stdout_updates_log_before_child_exit(monkeypatch, tmp_path)
         assert "chunk2" in log_text
         assert returncode == 0
     finally:
-        if pgid is not None:
-            try:
-                os.killpg(pgid, signal.SIGKILL)
-            except (OSError, ProcessLookupError):
-                pass
-        elif child_pid is not None:
-            try:
-                os.kill(child_pid, signal.SIGKILL)
-            except (OSError, ProcessLookupError):
-                pass
+        cleanup_pgid = pgid if pgid is not None else spawn_info.get("pgid")
+        cleanup_pid = child_pid if child_pid is not None else spawn_info.get("pid")
+        _kill_process_group_or_pid(
+            cleanup_pgid if isinstance(cleanup_pgid, int) else None,
+            cleanup_pid if isinstance(cleanup_pid, int) else None,
+        )
         thread.join(timeout=10)
 
 
@@ -1036,9 +1127,18 @@ time.sleep(30)
                 os.killpg(pgid, signal.SIGKILL)
             except (OSError, ProcessLookupError):
                 pass
-        elif proc.poll() is None:
+        else:
             try:
-                proc.kill()
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (OSError, ProcessLookupError):
+                if proc.poll() is None:
+                    try:
+                        proc.kill()
+                    except (OSError, ProcessLookupError):
+                        pass
+        if desc_pid is not None:
+            try:
+                os.kill(desc_pid, signal.SIGKILL)
             except (OSError, ProcessLookupError):
                 pass
         try:

--- a/tests/tools/test_cursor_agent_tool.py
+++ b/tests/tools/test_cursor_agent_tool.py
@@ -1,0 +1,577 @@
+"""Behavior-contract tests for delegate_cursor_agent."""
+
+from __future__ import annotations
+
+import io
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+
+SAMPLE_STREAM_JSON = "\n".join(
+    [
+        json.dumps(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "sess-abc-123",
+            }
+        ),
+        json.dumps(
+            {
+                "type": "tool_call",
+                "tool_call": {
+                    "taskToolCall": {
+                        "args": {
+                            "description": "Review auth module",
+                            "subagentType": "explore",
+                            "model": "kimi-k3-high",
+                        }
+                    }
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "Partial progress update."}]
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "tool_call",
+                "tool_call": {
+                    "taskToolCall": {
+                        "args": {
+                            "description": "Implement fix",
+                            "subagent_type": "implementer",
+                            "model": "composer-2.5-fast",
+                        }
+                    }
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "Final implementation report."}]
+                },
+            }
+        ),
+    ]
+)
+
+
+class _FakeStdoutWithEof:
+    def __init__(self, data: bytes = b""):
+        self._stream = io.BytesIO(data)
+        self.eof_reached = threading.Event()
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._stream.read(4096 if size < 0 else size)
+        if not chunk:
+            self.eof_reached.set()
+        return chunk
+
+    def close(self):
+        self._stream.close()
+
+
+class _FakePopen:
+    instances: list["_FakePopen"] = []
+
+    def __init__(
+        self,
+        cmd,
+        *,
+        cwd=None,
+        stdout=None,
+        stderr=None,
+        stdin=None,
+        start_new_session=False,
+        **kwargs,
+    ):
+        del stderr, stdin, start_new_session, kwargs
+        self.cmd = cmd
+        self.cwd = cwd
+        self.stdout = stdout
+        self._returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+        self.pid = 4242 + len(_FakePopen.instances)
+        _FakePopen.instances.append(self)
+
+    def poll(self):
+        return self._returncode
+
+    def terminate(self):
+        self.terminated = True
+        self._returncode = -15
+
+    def kill(self):
+        self.killed = True
+        self._returncode = -9
+
+    def wait(self, timeout=None):
+        del timeout
+        if self._returncode is None:
+            self._returncode = 0
+        return self._returncode
+
+    def set_exit(self, code: int) -> None:
+        self._returncode = code
+
+
+class _StreamingFakePopen(_FakePopen):
+    """Popen that exposes canned stream-json on stdout and exits after EOF."""
+
+    def __init__(self, cmd, *, cwd=None, stdout=None, stderr=None, **kwargs):
+        super().__init__(cmd, cwd=cwd, stdout=stdout, stderr=stderr, **kwargs)
+        self.stdout = _FakeStdoutWithEof(SAMPLE_STREAM_JSON.encode("utf-8"))
+        self._returncode = None
+
+    def poll(self):
+        if self._returncode is not None:
+            return self._returncode
+        if isinstance(self.stdout, _FakeStdoutWithEof) and self.stdout.eof_reached.is_set():
+            self._returncode = 0
+        return self._returncode
+
+
+class _StalledFakePopen(_FakePopen):
+    """Never emits stdout bytes and never exits until terminated."""
+
+    def __init__(self, cmd, *, cwd=None, stdout=None, stderr=None, **kwargs):
+        super().__init__(cmd, cwd=cwd, stdout=stdout, stderr=stderr, **kwargs)
+        self.stdout = _FakeStdoutWithEof(b"")
+        self._returncode = None
+
+    def poll(self):
+        return None
+
+
+class _TimeoutFakePopen(_StalledFakePopen):
+    pass
+
+
+class _NonZeroExitPopen(_StreamingFakePopen):
+    def poll(self):
+        if self._returncode is not None:
+            return self._returncode
+        if isinstance(self.stdout, _FakeStdoutWithEof) and self.stdout.eof_reached.is_set():
+            self._returncode = 1
+        return self._returncode
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_popen():
+    _FakePopen.instances.clear()
+    yield
+    _FakePopen.instances.clear()
+
+
+def test_schema_registration():
+    import tools.cursor_agent_tool  # noqa: F401
+    from tools.registry import registry
+
+    entry = registry.get_entry("delegate_cursor_agent")
+    assert entry is not None
+    assert entry.toolset == "delegation"
+    assert entry.max_result_size_chars == 100_000
+
+    schema = entry.schema
+    required = set(schema["parameters"]["required"])
+    assert required == {"task", "workdir"}
+
+    props = schema["parameters"]["properties"]
+    assert props["model"]["default"] == "kimi-k3-high"
+    assert props["timeout_seconds"]["default"] == 900
+    assert props["force"]["default"] is True
+
+
+def test_check_fn_binary_found(monkeypatch):
+    from tools.cursor_agent_tool import check_cursor_agent_requirements
+
+    monkeypatch.setattr("tools.cursor_agent_tool.shutil.which", lambda name: "/usr/bin/agent")
+    assert check_cursor_agent_requirements() is True
+
+
+def test_check_fn_binary_missing(monkeypatch):
+    from tools.cursor_agent_tool import check_cursor_agent_requirements
+
+    monkeypatch.setattr("tools.cursor_agent_tool.shutil.which", lambda name: None)
+
+    class _MissingPath(Path):
+        def is_file(self):
+            return False
+
+    monkeypatch.setattr("tools.cursor_agent_tool._local_bin_agent_path", lambda: _MissingPath("/nope/agent"))
+    assert check_cursor_agent_requirements() is False
+
+
+def test_clamp_timeout_seconds():
+    from tools.cursor_agent_tool import (
+        DEFAULT_TIMEOUT_SECONDS,
+        MAX_TIMEOUT_SECONDS,
+        MIN_TIMEOUT_SECONDS,
+        _clamp_timeout_seconds,
+    )
+
+    assert _clamp_timeout_seconds(59) == MIN_TIMEOUT_SECONDS
+    assert _clamp_timeout_seconds(1801) == MAX_TIMEOUT_SECONDS
+    assert _clamp_timeout_seconds("garbage") == DEFAULT_TIMEOUT_SECONDS
+    assert _clamp_timeout_seconds(None) == DEFAULT_TIMEOUT_SECONDS
+
+
+def test_parse_stream_json_log():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    parsed = parse_cursor_agent_log(SAMPLE_STREAM_JSON)
+
+    assert parsed["session_id"] == "sess-abc-123"
+    assert parsed["final_report"] == "Final implementation report."
+    assert len(parsed["delegations"]) == 2
+    assert parsed["delegations"][0] == {
+        "description": "Review auth module",
+        "subagent_type": "explore",
+        "model": "kimi-k3-high",
+    }
+    assert parsed["delegations"][1] == {
+        "description": "Implement fix",
+        "subagent_type": "implementer",
+        "model": "composer-2.5-fast",
+    }
+
+
+def test_parse_dedupes_duplicate_delegations():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    duplicate = json.dumps(
+        {
+            "type": "tool_call",
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "Same task",
+                        "subagentType": "explore",
+                        "model": "kimi-k3-high",
+                    }
+                }
+            },
+        }
+    )
+    log = "\n".join([duplicate, duplicate])
+    parsed = parse_cursor_agent_log(log)
+    assert len(parsed["delegations"]) == 1
+
+
+def test_action_required_structured_event_only():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    log_line = json.dumps(
+        {
+            "type": "error",
+            "error_type": "ActionRequiredError",
+            "message": "Approve file write",
+        }
+    )
+    parsed = parse_cursor_agent_log(log_line + "\n")
+    assert parsed["action_required"] is not None
+    assert "Approve file write" in parsed["action_required"]["detail"]
+
+
+def test_action_required_not_triggered_by_assistant_mention():
+    from tools import cursor_agent_tool
+
+    log_text = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "session_id": "sess-1",
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "We saw an ActionRequiredError in docs but recovered.",
+                            }
+                        ]
+                    },
+                }
+            ),
+        ]
+    )
+
+    parsed = cursor_agent_tool.parse_cursor_agent_log(log_text)
+    assert parsed["action_required"] is None
+
+
+def test_action_required_error_handler(monkeypatch, tmp_path):
+    from tools import cursor_agent_tool
+
+    log_text = json.dumps(
+        {
+            "type": "error",
+            "error_type": "ActionRequiredError",
+            "message": "Needs approval",
+        }
+    )
+
+    class _ActionRequiredPopen(_FakePopen):
+        def __init__(self, cmd, *, cwd=None, stdout=None, stderr=None, **kwargs):
+            super().__init__(cmd, cwd=cwd, stdout=stdout, stderr=stderr, **kwargs)
+            self.stdout = _FakeStdoutWithEof((log_text + "\n").encode("utf-8"))
+
+        def poll(self):
+            if self.stdout.eof_reached.is_set():
+                return 0
+            return None
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _ActionRequiredPopen)
+    monkeypatch.setattr(cursor_agent_tool, "STALL_WATCHDOG_SECONDS", 60)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    result = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(
+            task="do something",
+            workdir=str(workdir.resolve()),
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "action_required"
+    assert result["error_type"] == "ActionRequiredError"
+    assert "Needs approval" in result["detail"]
+
+
+def test_validation_errors_use_full_result_shape(monkeypatch, tmp_path):
+    from tools import cursor_agent_tool
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+
+    empty = json.loads(cursor_agent_tool.delegate_cursor_agent(task="", workdir=str(tmp_path)))
+    assert empty["success"] is False
+    assert empty["error"]
+    assert empty["log_path"] is None
+    assert "final_report" in empty
+    assert "delegations" in empty
+
+    relative = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(task="x", workdir="relative/path")
+    )
+    assert relative["success"] is False
+    assert "absolute path" in relative["error"]
+
+    missing = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(
+            task="x",
+            workdir=str((tmp_path / "missing").resolve()),
+        )
+    )
+    assert missing["success"] is False
+    assert "does not exist" in missing["error"]
+
+
+def test_stall_path_terminates_process(monkeypatch, tmp_path):
+    from tools import cursor_agent_tool
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _StalledFakePopen)
+    monkeypatch.setattr(cursor_agent_tool, "STALL_WATCHDOG_SECONDS", 0.01)
+    monkeypatch.setattr(cursor_agent_tool, "_MONITOR_POLL_SECONDS", 0.005)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    result = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(
+            task="stall test",
+            workdir=str(workdir.resolve()),
+            timeout_seconds=900,
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "stalled"
+    assert _FakePopen.instances
+    proc = _FakePopen.instances[0]
+    assert proc.terminated or proc.killed
+
+
+def test_timeout_path_terminates_process(monkeypatch, tmp_path):
+    from tools import cursor_agent_tool
+
+    start = time.monotonic()
+    calls = {"n": 0}
+
+    def _fake_monotonic():
+        calls["n"] += 1
+        return start + calls["n"] * 40
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _TimeoutFakePopen)
+    monkeypatch.setattr("tools.cursor_agent_tool.time.monotonic", _fake_monotonic)
+    monkeypatch.setattr(cursor_agent_tool, "STALL_WATCHDOG_SECONDS", 9999)
+    monkeypatch.setattr(cursor_agent_tool, "_MONITOR_POLL_SECONDS", 0.001)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    result = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(
+            task="timeout test",
+            workdir=str(workdir.resolve()),
+            timeout_seconds=60,
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "timeout"
+    assert _FakePopen.instances
+    proc = _FakePopen.instances[0]
+    assert proc.terminated or proc.killed
+
+
+def test_interrupt_path_terminates_process(monkeypatch, tmp_path):
+    from tools import cursor_agent_tool
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _StalledFakePopen)
+    monkeypatch.setattr(cursor_agent_tool, "STALL_WATCHDOG_SECONDS", 9999)
+    monkeypatch.setattr(cursor_agent_tool, "_MONITOR_POLL_SECONDS", 0.001)
+    monkeypatch.setattr("tools.cursor_agent_tool._check_interrupted", lambda: True)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    result = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(
+            task="interrupt test",
+            workdir=str(workdir.resolve()),
+        )
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "interrupted"
+    proc = _FakePopen.instances[0]
+    assert proc.terminated or proc.killed
+
+
+def test_non_zero_exit_reports_failure(monkeypatch, tmp_path):
+    from tools import cursor_agent_tool
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _NonZeroExitPopen)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    result = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(
+            task="fail test",
+            workdir=str(workdir.resolve()),
+        )
+    )
+
+    assert result["success"] is False
+    assert "exited with code 1" in result["error"]
+
+
+def test_happy_path_e2e(monkeypatch, tmp_path):
+    from tools import cursor_agent_tool
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _StreamingFakePopen)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+
+    result = json.loads(
+        cursor_agent_tool.delegate_cursor_agent(
+            task="implement feature",
+            workdir=str(workdir.resolve()),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["final_report"] == "Final implementation report."
+    assert len(result["delegations"]) == 2
+    assert result["session_id"] == "sess-abc-123"
+    assert result["error"] is None
+    assert "cursor-runs" in result["log_path"]
+    assert Path(result["log_path"]).is_file()
+
+    proc = _FakePopen.instances[0]
+    assert proc.cmd == [
+        "/usr/bin/agent",
+        "-p",
+        "--trust",
+        "--force",
+        "--model",
+        "kimi-k3-high",
+        "--output-format",
+        "stream-json",
+        "implement feature",
+    ]
+    assert proc.cwd == str(workdir.resolve())
+
+
+@pytest.mark.parametrize(
+    "force_value,expect_force_flag",
+    [
+        (False, False),
+        ("false", False),
+        ("0", False),
+    ],
+)
+def test_force_coercion_omits_flag(monkeypatch, tmp_path, force_value, expect_force_flag):
+    from tools import cursor_agent_tool
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _StreamingFakePopen)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+
+    cursor_agent_tool.delegate_cursor_agent(
+        task="no force",
+        workdir=str(workdir.resolve()),
+        force=force_value,
+    )
+
+    proc = _FakePopen.instances[0]
+    has_force = "--force" in proc.cmd
+    assert has_force is expect_force_flag
+    if expect_force_flag:
+        assert proc.cmd.index("--force") == proc.cmd.index("--trust") + 1
+
+
+def test_handler_force_string_false(monkeypatch, tmp_path):
+    from tools.cursor_agent_tool import _handle_delegate_cursor_agent
+
+    monkeypatch.setattr("tools.cursor_agent_tool.resolve_cursor_agent_binary", lambda: "/usr/bin/agent")
+    monkeypatch.setattr("tools.cursor_agent_tool.subprocess.Popen", _StreamingFakePopen)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+
+    _handle_delegate_cursor_agent(
+        {
+            "task": "handler force",
+            "workdir": str(workdir.resolve()),
+            "force": "false",
+        }
+    )
+
+    proc = _FakePopen.instances[0]
+    assert "--force" not in proc.cmd

--- a/tests/tools/test_cursor_agent_tool.py
+++ b/tests/tools/test_cursor_agent_tool.py
@@ -79,6 +79,12 @@ class _FakeStdoutWithEof:
             self.eof_reached.set()
         return chunk
 
+    def read1(self, size: int = -1) -> bytes:
+        chunk = self._stream.read1(4096 if size < 0 else size)
+        if not chunk:
+            self.eof_reached.set()
+        return chunk
+
     def close(self):
         self._stream.close()
 
@@ -255,6 +261,7 @@ def test_parse_dedupes_duplicate_delegations():
     duplicate = json.dumps(
         {
             "type": "tool_call",
+            "call_id": "call-same-1",
             "tool_call": {
                 "taskToolCall": {
                     "args": {
@@ -268,6 +275,27 @@ def test_parse_dedupes_duplicate_delegations():
     )
     log = "\n".join([duplicate, duplicate])
     parsed = parse_cursor_agent_log(log)
+    assert len(parsed["delegations"]) == 1
+
+
+def test_parse_dedupes_duplicate_delegations_without_identity_keys():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    duplicate = json.dumps(
+        {
+            "type": "tool_call",
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "Same task",
+                        "subagentType": "explore",
+                        "model": "kimi-k3-high",
+                    }
+                }
+            },
+        }
+    )
+    parsed = parse_cursor_agent_log("\n".join([duplicate, duplicate]))
     assert len(parsed["delegations"]) == 1
 
 
@@ -575,3 +603,291 @@ def test_handler_force_string_false(monkeypatch, tmp_path):
 
     proc = _FakePopen.instances[0]
     assert "--force" not in proc.cmd
+
+
+def test_parse_distinct_call_ids_same_args_produce_two_records():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    def _tool_call(call_id: str) -> str:
+        return json.dumps(
+            {
+                "type": "tool_call",
+                "call_id": call_id,
+                "tool_call": {
+                    "taskToolCall": {
+                        "args": {
+                            "description": "Same task",
+                            "subagentType": "explore",
+                            "model": "kimi-k3-high",
+                        }
+                    }
+                },
+            }
+        )
+
+    log = "\n".join([_tool_call("call-a"), _tool_call("call-b")])
+    parsed = parse_cursor_agent_log(log)
+    assert len(parsed["delegations"]) == 2
+    assert parsed["delegations"][0] == parsed["delegations"][1]
+
+
+def test_parse_started_and_completed_same_call_id_one_record():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    started = json.dumps(
+        {
+            "type": "tool_call",
+            "call_id": "call-xyz",
+            "subtype": "started",
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "Review module",
+                        "subagentType": "explore",
+                        "model": "kimi-k3-high",
+                    }
+                }
+            },
+        }
+    )
+    completed = json.dumps(
+        {
+            "type": "tool_call",
+            "call_id": "call-xyz",
+            "subtype": "completed",
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "Review module",
+                        "subagentType": "explore",
+                        "model": "kimi-k3-high",
+                    }
+                }
+            },
+        }
+    )
+    parsed = parse_cursor_agent_log("\n".join([started, completed]))
+    assert len(parsed["delegations"]) == 1
+
+
+def test_parse_camel_and_snake_subagent_type_keys():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    camel = json.dumps(
+        {
+            "type": "tool_call",
+            "call_id": "call-camel",
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "Camel case",
+                        "subagentType": "explore",
+                        "model": "m1",
+                    }
+                }
+            },
+        }
+    )
+    snake = json.dumps(
+        {
+            "type": "tool_call",
+            "call_id": "call-snake",
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "Snake case",
+                        "subagent_type": "implementer",
+                        "model": "m2",
+                    }
+                }
+            },
+        }
+    )
+    parsed = parse_cursor_agent_log("\n".join([camel, snake]))
+    assert len(parsed["delegations"]) == 2
+    assert parsed["delegations"][0]["subagent_type"] == "explore"
+    assert parsed["delegations"][1]["subagent_type"] == "implementer"
+
+
+def test_action_required_plain_text_line():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    line = (
+        "ActionRequiredError: Named models unavailable Free plans can only use Auto. "
+        "Switch to Auto or upgrade plans to continue."
+    )
+    parsed = parse_cursor_agent_log(line)
+    assert parsed["action_required"] is not None
+    assert "Named models unavailable" in parsed["action_required"]["detail"]
+
+
+def test_action_required_json_string_line():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    line = (
+        "ActionRequiredError: Named models unavailable Free plans can only use Auto. "
+        "Switch to Auto or upgrade plans to continue."
+    )
+    parsed = parse_cursor_agent_log(json.dumps(line))
+    assert parsed["action_required"] is not None
+    assert "Named models unavailable" in parsed["action_required"]["detail"]
+
+
+def test_action_required_json_string_prose_mention_not_triggered():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    line = json.dumps("We saw an ActionRequiredError in docs but recovered.")
+    parsed = parse_cursor_agent_log(line)
+    assert parsed["action_required"] is None
+
+
+def test_action_required_malformed_lines_do_not_crash():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    log = "\n".join(['{"broken json', "random garbage", "Error: something else"])
+    parsed = parse_cursor_agent_log(log)
+    assert parsed["action_required"] is None
+
+
+@pytest.mark.live_system_guard_bypass
+def test_incremental_stdout_updates_log_before_child_exit(monkeypatch, tmp_path):
+    import os
+    import sys
+
+    from tools import cursor_agent_tool
+
+    monkeypatch.setattr(cursor_agent_tool, "STALL_WATCHDOG_SECONDS", 5)
+    monkeypatch.setattr(cursor_agent_tool, "_MONITOR_POLL_SECONDS", 0.05)
+
+    child_script = (
+        "import sys, time\n"
+        "sys.stdout.write('chunk1\\n')\n"
+        "sys.stdout.flush()\n"
+        "time.sleep(1.25)\n"
+        "sys.stdout.write('chunk2\\n')\n"
+        "sys.stdout.flush()\n"
+        "time.sleep(0.1)\n"
+    )
+    cmd = [sys.executable, "-c", child_script]
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    result_holder: dict = {}
+
+    def run() -> None:
+        result_holder["result"] = cursor_agent_tool._run_and_stream(
+            cmd,
+            workdir=str(tmp_path),
+            timeout_seconds=60,
+            log_dir=log_dir,
+            run_timestamp="test",
+        )
+
+    thread = threading.Thread(target=run)
+    thread.start()
+
+    found_chunk = False
+    child_pid: int | None = None
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        logs = list(log_dir.glob("*.jsonl"))
+        if logs and "chunk1" in logs[0].read_text(encoding="utf-8", errors="replace"):
+            found_chunk = True
+            assert thread.is_alive(), "run finished before chunk1 reached the log"
+            assert "result" not in result_holder, "run finished before chunk1 reached the log"
+            name_parts = logs[0].stem.rsplit("-", 1)
+            if len(name_parts) == 2 and name_parts[1].isdigit():
+                child_pid = int(name_parts[1])
+                os.kill(child_pid, 0)
+            break
+        time.sleep(0.05)
+
+    thread.join(timeout=10)
+    assert "result" in result_holder
+    error_code, _log_path, log_text, _duration, returncode = result_holder["result"]
+
+    assert found_chunk
+    if child_pid is not None:
+        with pytest.raises(ProcessLookupError):
+            os.kill(child_pid, 0)
+    assert error_code != "stalled"
+    assert "chunk1" in log_text
+    assert "chunk2" in log_text
+    assert returncode == 0
+
+
+@pytest.mark.live_system_guard_bypass
+def test_terminate_process_kills_sigterm_resistant_descendant(tmp_path, monkeypatch):
+    import os
+    import signal
+    import subprocess
+    import sys
+
+    from tools.cursor_agent_tool import _terminate_process
+
+    monkeypatch.setattr("tools.cursor_agent_tool._TERMINATE_GRACE_SECONDS", 0.5)
+
+    desc_pid_file = tmp_path / "desc.pid"
+    leader_script = f"""
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+desc_script = '''
+import signal
+import time
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+time.sleep(30)
+'''
+
+desc = subprocess.Popen([sys.executable, "-c", desc_script])
+Path({str(desc_pid_file)!r}).write_text(str(desc.pid))
+time.sleep(30)
+"""
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", leader_script],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    pgid: int | None = None
+    desc_pid: int | None = None
+    try:
+        for _ in range(100):
+            if desc_pid_file.is_file():
+                desc_pid = int(desc_pid_file.read_text(encoding="utf-8").strip())
+                break
+            time.sleep(0.05)
+        assert desc_pid is not None
+
+        try:
+            pgid = os.getpgid(proc.pid)
+        except (OSError, ProcessLookupError):
+            pgid = None
+
+        _terminate_process(proc, pgid)
+
+        assert proc.poll() is not None
+        assert proc.returncode == -signal.SIGTERM
+
+        with pytest.raises(ProcessLookupError):
+            os.kill(desc_pid, 0)
+    finally:
+        if pgid is not None:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except (OSError, ProcessLookupError):
+                pass
+        elif proc.poll() is None:
+            try:
+                proc.kill()
+            except (OSError, ProcessLookupError):
+                pass
+        try:
+            proc.wait(timeout=1)
+        except Exception:
+            pass

--- a/tests/tools/test_cursor_agent_tool.py
+++ b/tests/tools/test_cursor_agent_tool.py
@@ -749,9 +749,144 @@ def test_action_required_malformed_lines_do_not_crash():
     assert parsed["action_required"] is None
 
 
+def _task_call_event(**extra_fields) -> str:
+    base = {
+        "type": "tool_call",
+        "tool_call": {
+            "taskToolCall": {
+                "args": {
+                    "description": "Same task",
+                    "subagentType": "explore",
+                    "model": "kimi-k3-high",
+                }
+            }
+        },
+    }
+    base.update(extra_fields)
+    return json.dumps(base)
+
+
+def test_parse_dedupes_dict_valued_call_id():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    event = _task_call_event(call_id={"a": 1, "b": 2})
+    parsed = parse_cursor_agent_log("\n".join([event, event]))
+    assert len(parsed["delegations"]) == 1
+
+
+def test_parse_dedupes_list_valued_call_id():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    event = _task_call_event(call_id=["x", 1])
+    parsed = parse_cursor_agent_log("\n".join([event, event]))
+    assert len(parsed["delegations"]) == 1
+
+
+def test_parse_dedupes_dict_valued_call_id_key_order_stable():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    first = _task_call_event(call_id={"b": 2, "a": 1})
+    second = _task_call_event(call_id={"a": 1, "b": 2})
+    parsed = parse_cursor_agent_log("\n".join([first, second]))
+    assert len(parsed["delegations"]) == 1
+
+
+def test_parse_dedupes_nested_dict_list_identity_keys():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    tool_call_id = json.dumps(
+        {
+            "type": "tool_call",
+            "toolCallId": {"id": "nested", "seq": [1, 2]},
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "Nested id",
+                        "subagentType": "explore",
+                        "model": "m1",
+                    }
+                }
+            },
+        }
+    )
+    agent_id = json.dumps(
+        {
+            "type": "tool_call",
+            "agentId": ["agent", 42],
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "Agent id list",
+                        "subagentType": "explore",
+                        "model": "m2",
+                    }
+                }
+            },
+        }
+    )
+    parsed = parse_cursor_agent_log("\n".join([tool_call_id, tool_call_id, agent_id, agent_id]))
+    assert len(parsed["delegations"]) == 2
+
+
+def test_parse_dedupes_dict_list_content_fallback():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    duplicate = json.dumps(
+        {
+            "type": "tool_call",
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": {"goal": "review", "scope": ["auth"]},
+                        "subagentType": "explore",
+                        "model": ["kimi-k3-high"],
+                    }
+                }
+            },
+        }
+    )
+    parsed = parse_cursor_agent_log("\n".join([duplicate, duplicate]))
+    assert len(parsed["delegations"]) == 1
+
+
+def test_parse_non_hashable_values_do_not_crash():
+    from tools.cursor_agent_tool import parse_cursor_agent_log
+
+    samples = [
+        {
+            "type": "tool_call",
+            "call_id": {"b": 2, "a": 1},
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": "x",
+                        "model": "m",
+                    }
+                }
+            },
+        },
+        {
+            "type": "tool_call",
+            "call_id": ["x", 1],
+            "tool_call": {
+                "taskToolCall": {
+                    "args": {
+                        "description": {"x": 1},
+                        "model": ["m"],
+                    }
+                }
+            },
+        },
+    ]
+    for event in samples:
+        parsed = parse_cursor_agent_log(json.dumps(event))
+        assert len(parsed["delegations"]) == 1
+
+
 @pytest.mark.live_system_guard_bypass
 def test_incremental_stdout_updates_log_before_child_exit(monkeypatch, tmp_path):
     import os
+    import signal
     import sys
 
     from tools import cursor_agent_tool
@@ -786,34 +921,54 @@ def test_incremental_stdout_updates_log_before_child_exit(monkeypatch, tmp_path)
     thread = threading.Thread(target=run)
     thread.start()
 
-    found_chunk = False
     child_pid: int | None = None
-    deadline = time.monotonic() + 3.0
-    while time.monotonic() < deadline:
-        logs = list(log_dir.glob("*.jsonl"))
-        if logs and "chunk1" in logs[0].read_text(encoding="utf-8", errors="replace"):
-            found_chunk = True
-            assert thread.is_alive(), "run finished before chunk1 reached the log"
-            assert "result" not in result_holder, "run finished before chunk1 reached the log"
-            name_parts = logs[0].stem.rsplit("-", 1)
-            if len(name_parts) == 2 and name_parts[1].isdigit():
-                child_pid = int(name_parts[1])
+    pgid: int | None = None
+    try:
+        found_chunk = False
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            logs = list(log_dir.glob("*.jsonl"))
+            if logs:
+                name_parts = logs[0].stem.rsplit("-", 1)
+                if child_pid is None and len(name_parts) == 2 and name_parts[1].isdigit():
+                    child_pid = int(name_parts[1])
+                    try:
+                        pgid = os.getpgid(child_pid)
+                    except (OSError, ProcessLookupError):
+                        pgid = None
+                if "chunk1" in logs[0].read_text(encoding="utf-8", errors="replace"):
+                    found_chunk = True
+                    assert thread.is_alive(), "run finished before chunk1 reached the log"
+                    assert "result" not in result_holder, "run finished before chunk1 reached the log"
+                    if child_pid is not None:
+                        os.kill(child_pid, 0)
+                    break
+            time.sleep(0.05)
+
+        thread.join(timeout=10)
+        assert "result" in result_holder
+        error_code, _log_path, log_text, _duration, returncode = result_holder["result"]
+
+        assert found_chunk
+        if child_pid is not None:
+            with pytest.raises(ProcessLookupError):
                 os.kill(child_pid, 0)
-            break
-        time.sleep(0.05)
-
-    thread.join(timeout=10)
-    assert "result" in result_holder
-    error_code, _log_path, log_text, _duration, returncode = result_holder["result"]
-
-    assert found_chunk
-    if child_pid is not None:
-        with pytest.raises(ProcessLookupError):
-            os.kill(child_pid, 0)
-    assert error_code != "stalled"
-    assert "chunk1" in log_text
-    assert "chunk2" in log_text
-    assert returncode == 0
+        assert error_code != "stalled"
+        assert "chunk1" in log_text
+        assert "chunk2" in log_text
+        assert returncode == 0
+    finally:
+        if pgid is not None:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except (OSError, ProcessLookupError):
+                pass
+        elif child_pid is not None:
+            try:
+                os.kill(child_pid, signal.SIGKILL)
+            except (OSError, ProcessLookupError):
+                pass
+        thread.join(timeout=10)
 
 
 @pytest.mark.live_system_guard_bypass
@@ -854,7 +1009,11 @@ time.sleep(30)
         stderr=subprocess.DEVNULL,
     )
 
-    pgid: int | None = None
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (OSError, ProcessLookupError):
+        pgid = None
+
     desc_pid: int | None = None
     try:
         for _ in range(100):
@@ -863,11 +1022,6 @@ time.sleep(30)
                 break
             time.sleep(0.05)
         assert desc_pid is not None
-
-        try:
-            pgid = os.getpgid(proc.pid)
-        except (OSError, ProcessLookupError):
-            pgid = None
 
         _terminate_process(proc, pgid)
 

--- a/tools/cursor_agent_tool.py
+++ b/tools/cursor_agent_tool.py
@@ -169,8 +169,22 @@ def _delegation_key(record: Dict[str, Any]) -> Tuple[Any, Any, Any]:
 
 def _canonicalize_dedupe_token(value: Any) -> Any:
     """Convert a value into a deterministic hashable token for dedupe keys."""
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
+    if value is None:
+        return ("null", None)
+    if isinstance(value, bool):
+        return ("bool", value)
+    if isinstance(value, int):
+        return ("int", value)
+    if isinstance(value, float):
+        if value != value:
+            return ("float", "nan")
+        if value == float("inf"):
+            return ("float", "inf")
+        if value == float("-inf"):
+            return ("float", "-inf")
+        return ("float", value)
+    if isinstance(value, str):
+        return ("str", value)
     if isinstance(value, bytes):
         return ("bytes", value)
     try:
@@ -197,7 +211,11 @@ def _canonicalize_dedupe_token(value: Any) -> Any:
                     )
                 ),
             )
-        return json.dumps(value, sort_keys=True, default=str)
+        return ("json", json.dumps(value, sort_keys=True, default=str))
+    except Exception:
+        pass
+    try:
+        return ("json", json.dumps(value, sort_keys=True, default=str))
     except Exception:
         pass
     try:

--- a/tools/cursor_agent_tool.py
+++ b/tools/cursor_agent_tool.py
@@ -145,6 +145,20 @@ def _extract_action_required_detail(event: Dict[str, Any]) -> str:
     return "Action required"
 
 
+def _is_action_required_plain_text(text: str) -> bool:
+    stripped = text.strip()
+    return stripped == "ActionRequiredError" or stripped.startswith("ActionRequiredError:")
+
+
+def _extract_action_required_plain_detail(text: str) -> str:
+    stripped = text.strip()
+    if stripped == "ActionRequiredError":
+        return ""
+    if stripped.startswith("ActionRequiredError:"):
+        return stripped[len("ActionRequiredError:") :].strip()
+    return "Action required"
+
+
 def _delegation_key(record: Dict[str, Any]) -> Tuple[Any, Any, Any]:
     return (
         record.get("description"),
@@ -153,11 +167,31 @@ def _delegation_key(record: Dict[str, Any]) -> Tuple[Any, Any, Any]:
     )
 
 
+def _delegation_dedupe_key(
+    event: Dict[str, Any],
+    task_call: Dict[str, Any],
+    record: Dict[str, Any],
+) -> Tuple[Any, ...]:
+    call_id = event.get("call_id")
+    if call_id is not None:
+        return ("call_id", call_id)
+
+    for source in (event, task_call):
+        if not isinstance(source, dict):
+            continue
+        for key in ("toolCallId", "agentId"):
+            value = source.get(key)
+            if value is not None:
+                return (key, value)
+
+    return ("content",) + _delegation_key(record)
+
+
 def parse_cursor_agent_log(log_text: str) -> Dict[str, Any]:
     """Parse a stream-json log into structured fields."""
     session_id: Optional[str] = None
     delegations: List[Dict[str, Any]] = []
-    seen_delegations: Set[Tuple[Any, Any, Any]] = set()
+    seen_delegations: Set[Tuple[Any, ...]] = set()
     final_report = ""
     action_required: Optional[Dict[str, Any]] = None
 
@@ -168,6 +202,17 @@ def parse_cursor_agent_log(log_text: str) -> Dict[str, Any]:
         try:
             event = json.loads(raw_line)
         except json.JSONDecodeError:
+            if _is_action_required_plain_text(raw_line):
+                action_required = {
+                    "detail": _extract_action_required_plain_detail(raw_line),
+                }
+            continue
+
+        if isinstance(event, str):
+            if _is_action_required_plain_text(event):
+                action_required = {
+                    "detail": _extract_action_required_plain_detail(event),
+                }
             continue
 
         if not isinstance(event, dict):
@@ -195,7 +240,7 @@ def parse_cursor_agent_log(log_text: str) -> Dict[str, Any]:
                     "subagent_type": args.get("subagentType") or args.get("subagent_type"),
                     "model": args.get("model"),
                 }
-                key = _delegation_key(record)
+                key = _delegation_dedupe_key(event, task_call, record)
                 if key not in seen_delegations:
                     seen_delegations.add(key)
                     delegations.append(record)
@@ -242,8 +287,36 @@ def _signal_process_group(proc: subprocess.Popen, sig: signal.Signals) -> bool:
         return False
 
 
-def _terminate_process(proc: subprocess.Popen) -> None:
-    if not _signal_process_group(proc, signal.SIGTERM):
+def _signal_pgid(pgid: int, sig: signal.Signals) -> bool:
+    try:
+        os.killpg(pgid, sig)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def _wait_pgid_reap(pgid: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return
+        except OSError as exc:
+            if getattr(exc, "errno", None) == 3:
+                return
+            return
+        time.sleep(0.05)
+
+
+def _terminate_process(proc: subprocess.Popen, pgid: Optional[int] = None) -> None:
+    if pgid is not None:
+        if not _signal_pgid(pgid, signal.SIGTERM):
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+    elif not _signal_process_group(proc, signal.SIGTERM):
         try:
             proc.terminate()
         except Exception:
@@ -251,11 +324,13 @@ def _terminate_process(proc: subprocess.Popen) -> None:
 
     try:
         proc.wait(timeout=_TERMINATE_GRACE_SECONDS)
-        return
     except Exception:
         pass
 
-    if not _signal_process_group(proc, signal.SIGKILL):
+    if pgid is not None:
+        _signal_pgid(pgid, signal.SIGKILL)
+        _wait_pgid_reap(pgid, _TERMINATE_GRACE_SECONDS)
+    elif not _signal_process_group(proc, signal.SIGKILL):
         try:
             proc.kill()
         except Exception:
@@ -321,6 +396,11 @@ def _run_and_stream(
         start_new_session=True,
     )
 
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (OSError, ProcessLookupError):
+        pgid = None
+
     log_path = log_dir / f"{run_timestamp}-{proc.pid}.jsonl"
     reader_done = threading.Event()
 
@@ -330,10 +410,14 @@ def _run_and_stream(
             assert proc.stdout is not None
             with open(log_path, "wb") as log_file:
                 while True:
-                    chunk = proc.stdout.read(4096)
+                    try:
+                        chunk = proc.stdout.read1(4096)
+                    except (OSError, ValueError):
+                        break
                     if not chunk:
                         break
                     log_file.write(chunk)
+                    log_file.flush()
                     last_byte_mono = time.monotonic()
         finally:
             try:
@@ -363,13 +447,13 @@ def _run_and_stream(
         time.sleep(_MONITOR_POLL_SECONDS)
 
     if error_code is not None:
-        _terminate_process(proc)
+        _terminate_process(proc, pgid)
 
     reader_thread.join(timeout=_TERMINATE_GRACE_SECONDS + 1.0)
     duration = time.monotonic() - start_mono
 
     if reader_thread.is_alive():
-        _terminate_process(proc)
+        _terminate_process(proc, pgid)
         return (
             "incomplete_output",
             str(log_path),

--- a/tools/cursor_agent_tool.py
+++ b/tools/cursor_agent_tool.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Delegate dev tasks to the Cursor Agent CLI as a subprocess.
+
+Gating
+------
+The tool registers only when the Cursor Agent CLI binary is available on
+PATH (``agent``) or as an executable at ``~/.local/bin/agent``.
+
+Log format
+----------
+Stdout is streamed to ``<HERMES_HOME>/cursor-runs/<timestamp>-<pid>.jsonl``
+as newline-delimited JSON (stream-json). Each line is one event from the
+Cursor Agent run; the handler parses assistant text, delegation records,
+and session metadata from that log after a successful exit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+from utils import is_truthy_value
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CURSOR_AGENT_MODEL = "kimi-k3-high"
+DEFAULT_TIMEOUT_SECONDS = 900
+MIN_TIMEOUT_SECONDS = 60
+MAX_TIMEOUT_SECONDS = 1800
+STALL_WATCHDOG_SECONDS = 180
+
+_MONITOR_POLL_SECONDS = 0.1
+_TERMINATE_GRACE_SECONDS = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Binary resolution + gating
+# ---------------------------------------------------------------------------
+
+def _local_bin_agent_path() -> Path:
+    return Path.home() / ".local" / "bin" / "agent"
+
+
+def resolve_cursor_agent_binary() -> Optional[str]:
+    """Return the Cursor Agent CLI path, or None if not found."""
+    try:
+        found = shutil.which("agent")
+        if found:
+            return found
+        local = _local_bin_agent_path()
+        if local.is_file() and os.access(local, os.X_OK):
+            return str(local)
+    except Exception:
+        pass
+    return None
+
+
+def check_cursor_agent_requirements() -> bool:
+    """Return True when the Cursor Agent CLI binary is available."""
+    try:
+        return resolve_cursor_agent_binary() is not None
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Stream-json parsing
+# ---------------------------------------------------------------------------
+
+def _find_task_tool_calls(obj: Any) -> List[Dict[str, Any]]:
+    """Recursively collect dicts that look like taskToolCall payloads."""
+    found: List[Dict[str, Any]] = []
+    if isinstance(obj, dict):
+        if "taskToolCall" in obj and isinstance(obj["taskToolCall"], dict):
+            found.append(obj["taskToolCall"])
+        for value in obj.values():
+            found.extend(_find_task_tool_calls(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            found.extend(_find_task_tool_calls(item))
+    return found
+
+
+def _extract_assistant_text(event: Dict[str, Any]) -> str:
+    """Extract plain text from an assistant stream-json event."""
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return ""
+
+    content = message.get("content")
+    if isinstance(content, str):
+        return content.strip()
+
+    parts: List[str] = []
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") in {"text", "output_text"}:
+                text = str(block.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def _is_action_required_event(event: Dict[str, Any]) -> bool:
+    """Return True when a parsed JSON event structurally indicates action required."""
+    if event.get("error_type") == "ActionRequiredError":
+        return True
+
+    if event.get("type") != "error":
+        return False
+
+    for key in ("error_type", "name", "code"):
+        if event.get(key) == "ActionRequiredError":
+            return True
+
+    err = event.get("error")
+    if isinstance(err, dict):
+        for key in ("type", "name", "code", "error_type"):
+            if err.get(key) == "ActionRequiredError":
+                return True
+    elif isinstance(err, str) and err == "ActionRequiredError":
+        return True
+
+    return False
+
+
+def _extract_action_required_detail(event: Dict[str, Any]) -> str:
+    for key in ("message", "error", "detail", "description"):
+        value = event.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "Action required"
+
+
+def _delegation_key(record: Dict[str, Any]) -> Tuple[Any, Any, Any]:
+    return (
+        record.get("description"),
+        record.get("subagent_type"),
+        record.get("model"),
+    )
+
+
+def parse_cursor_agent_log(log_text: str) -> Dict[str, Any]:
+    """Parse a stream-json log into structured fields."""
+    session_id: Optional[str] = None
+    delegations: List[Dict[str, Any]] = []
+    seen_delegations: Set[Tuple[Any, Any, Any]] = set()
+    final_report = ""
+    action_required: Optional[Dict[str, Any]] = None
+
+    for raw_line in log_text.splitlines():
+        if not raw_line.strip():
+            continue
+
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+
+        if not isinstance(event, dict):
+            continue
+
+        if _is_action_required_event(event):
+            action_required = {
+                "detail": _extract_action_required_detail(event),
+            }
+
+        if (
+            session_id is None
+            and event.get("type") == "system"
+            and event.get("subtype") == "init"
+        ):
+            init_sid = event.get("session_id")
+            if isinstance(init_sid, str) and init_sid.strip():
+                session_id = init_sid.strip()
+
+        if event.get("type") == "tool_call":
+            for task_call in _find_task_tool_calls(event):
+                args = task_call.get("args") if isinstance(task_call.get("args"), dict) else {}
+                record = {
+                    "description": args.get("description"),
+                    "subagent_type": args.get("subagentType") or args.get("subagent_type"),
+                    "model": args.get("model"),
+                }
+                key = _delegation_key(record)
+                if key not in seen_delegations:
+                    seen_delegations.add(key)
+                    delegations.append(record)
+
+        if event.get("type") == "assistant":
+            text = _extract_assistant_text(event)
+            if text:
+                final_report = text
+
+    return {
+        "session_id": session_id,
+        "delegations": delegations,
+        "final_report": final_report,
+        "action_required": action_required,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+
+def _clamp_timeout_seconds(timeout_seconds: int) -> int:
+    try:
+        value = int(timeout_seconds)
+    except (TypeError, ValueError):
+        value = DEFAULT_TIMEOUT_SECONDS
+    return max(MIN_TIMEOUT_SECONDS, min(MAX_TIMEOUT_SECONDS, value))
+
+
+def _check_interrupted() -> bool:
+    try:
+        from tools.interrupt import is_interrupted
+
+        return is_interrupted()
+    except Exception:
+        return False
+
+
+def _signal_process_group(proc: subprocess.Popen, sig: signal.Signals) -> bool:
+    try:
+        os.killpg(os.getpgid(proc.pid), sig)
+        return True
+    except (OSError, ProcessLookupError, AttributeError):
+        return False
+
+
+def _terminate_process(proc: subprocess.Popen) -> None:
+    if not _signal_process_group(proc, signal.SIGTERM):
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+    try:
+        proc.wait(timeout=_TERMINATE_GRACE_SECONDS)
+        return
+    except Exception:
+        pass
+
+    if not _signal_process_group(proc, signal.SIGKILL):
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+    try:
+        proc.wait(timeout=_TERMINATE_GRACE_SECONDS)
+    except Exception:
+        pass
+
+
+def _make_result(
+    *,
+    success: bool,
+    final_report: str = "",
+    delegations: Optional[List[Dict[str, Any]]] = None,
+    duration_seconds: float = 0.0,
+    session_id: Optional[str] = None,
+    log_path: Optional[str] = None,
+    error: Optional[str] = None,
+    **extra: Any,
+) -> str:
+    payload: Dict[str, Any] = {
+        "success": success,
+        "final_report": final_report,
+        "delegations": delegations or [],
+        "duration_seconds": duration_seconds,
+        "session_id": session_id,
+        "log_path": log_path,
+        "error": error,
+    }
+    payload.update(extra)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _read_log_text(log_path: Path) -> str:
+    if not log_path.is_file():
+        return ""
+    return log_path.read_text(encoding="utf-8", errors="replace")
+
+
+def _run_and_stream(
+    cmd: List[str],
+    *,
+    workdir: str,
+    timeout_seconds: int,
+    log_dir: Path,
+    run_timestamp: str,
+) -> Tuple[Optional[str], str, str, float, Optional[int]]:
+    """Spawn the agent, stream stdout to a log file, enforce watchdogs.
+
+    Returns ``(error_code, log_path, log_text, duration_seconds, returncode)``.
+    """
+    start_mono = time.monotonic()
+    last_byte_mono = start_mono
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=workdir,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    log_path = log_dir / f"{run_timestamp}-{proc.pid}.jsonl"
+    reader_done = threading.Event()
+
+    def _reader() -> None:
+        nonlocal last_byte_mono
+        try:
+            assert proc.stdout is not None
+            with open(log_path, "wb") as log_file:
+                while True:
+                    chunk = proc.stdout.read(4096)
+                    if not chunk:
+                        break
+                    log_file.write(chunk)
+                    last_byte_mono = time.monotonic()
+        finally:
+            try:
+                if proc.stdout is not None:
+                    proc.stdout.close()
+            except Exception:
+                pass
+            reader_done.set()
+
+    reader_thread = threading.Thread(target=_reader, daemon=True)
+    reader_thread.start()
+
+    error_code: Optional[str] = None
+    while proc.poll() is None:
+        if _check_interrupted():
+            error_code = "interrupted"
+            break
+
+        now = time.monotonic()
+        elapsed = now - start_mono
+        if elapsed >= timeout_seconds:
+            error_code = "timeout"
+            break
+        if now - last_byte_mono >= STALL_WATCHDOG_SECONDS:
+            error_code = "stalled"
+            break
+        time.sleep(_MONITOR_POLL_SECONDS)
+
+    if error_code is not None:
+        _terminate_process(proc)
+
+    reader_thread.join(timeout=_TERMINATE_GRACE_SECONDS + 1.0)
+    duration = time.monotonic() - start_mono
+
+    if reader_thread.is_alive():
+        _terminate_process(proc)
+        return (
+            "incomplete_output",
+            str(log_path),
+            _read_log_text(log_path),
+            duration,
+            proc.poll() if proc.poll() is not None else -1,
+        )
+
+    log_text = _read_log_text(log_path)
+
+    returncode = proc.poll()
+    if returncode is None:
+        try:
+            returncode = proc.wait(timeout=_TERMINATE_GRACE_SECONDS)
+        except Exception:
+            returncode = -1
+
+    return error_code, str(log_path), log_text, duration, returncode
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+def delegate_cursor_agent(
+    task: str,
+    workdir: str,
+    model: str = DEFAULT_CURSOR_AGENT_MODEL,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    force: bool = True,
+    task_id: str | None = None,
+) -> str:
+    del task_id  # reserved for future correlation; not used yet
+
+    if not task or not str(task).strip():
+        return _make_result(
+            success=False,
+            error="task is required for delegate_cursor_agent",
+        )
+
+    workdir_path = Path(workdir)
+    if not workdir_path.is_absolute():
+        return _make_result(
+            success=False,
+            error="workdir must be an absolute path",
+        )
+    if not workdir_path.is_dir():
+        return _make_result(
+            success=False,
+            error=f"workdir does not exist or is not a directory: {workdir}",
+        )
+
+    binary = resolve_cursor_agent_binary()
+    if not binary:
+        return _make_result(
+            success=False,
+            error=(
+                "Cursor Agent CLI binary not found. Install the `agent` CLI and "
+                "ensure it is on PATH or at ~/.local/bin/agent."
+            ),
+        )
+
+    clamped_timeout = _clamp_timeout_seconds(timeout_seconds)
+    model_name = str(model or "").strip() or DEFAULT_CURSOR_AGENT_MODEL
+    force_enabled = is_truthy_value(force, default=True)
+
+    log_dir = get_hermes_home() / "cursor-runs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    run_timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+    cmd = [
+        binary,
+        "-p",
+        "--trust",
+    ]
+    if force_enabled:
+        cmd.append("--force")
+    cmd.extend(
+        [
+            "--model",
+            model_name,
+            "--output-format",
+            "stream-json",
+            str(task).strip(),
+        ]
+    )
+
+    try:
+        watchdog_error, log_path, log_text, duration, returncode = _run_and_stream(
+            cmd,
+            workdir=str(workdir_path),
+            timeout_seconds=clamped_timeout,
+            log_dir=log_dir,
+            run_timestamp=run_timestamp,
+        )
+    except Exception as exc:
+        logger.error("delegate_cursor_agent spawn failed: %s", exc, exc_info=True)
+        return _make_result(
+            success=False,
+            error=str(exc),
+            duration_seconds=0.0,
+        )
+
+    parsed = parse_cursor_agent_log(log_text)
+    base_fields = {
+        "final_report": parsed.get("final_report") or "",
+        "delegations": parsed.get("delegations") or [],
+        "duration_seconds": round(duration, 3),
+        "session_id": parsed.get("session_id"),
+        "log_path": log_path,
+    }
+
+    if parsed.get("action_required"):
+        detail = parsed["action_required"].get("detail", "")
+        return _make_result(
+            success=False,
+            error="action_required",
+            error_type="ActionRequiredError",
+            detail=detail,
+            **base_fields,
+        )
+
+    if watchdog_error:
+        return _make_result(
+            success=False,
+            error=watchdog_error,
+            **base_fields,
+        )
+
+    if returncode != 0:
+        tail = log_text.strip()[-2000:] if log_text.strip() else ""
+        return _make_result(
+            success=False,
+            error=f"Cursor Agent exited with code {returncode}" + (f": {tail}" if tail else ""),
+            **base_fields,
+        )
+
+    return _make_result(
+        success=True,
+        error=None,
+        **base_fields,
+    )
+
+
+CURSOR_AGENT_SCHEMA = {
+    "name": "delegate_cursor_agent",
+    "description": (
+        "Delegate a software development task to the Cursor Agent CLI running "
+        "as a local subprocess. The CLI performs code edits, terminal commands, "
+        "and multi-step dev work inside the specified repository directory. "
+        "Stdout is captured as stream-json in a log under the Hermes home "
+        "directory. Available only when the Cursor Agent CLI binary is installed."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "string",
+                "description": "The development task for Cursor Agent to perform.",
+            },
+            "workdir": {
+                "type": "string",
+                "description": "Absolute path to the target project directory.",
+            },
+            "model": {
+                "type": "string",
+                "description": "Cursor Agent model to use for the run.",
+                "default": DEFAULT_CURSOR_AGENT_MODEL,
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "description": (
+                    f"Maximum wall-clock seconds before the run is terminated "
+                    f"({MIN_TIMEOUT_SECONDS}–{MAX_TIMEOUT_SECONDS})."
+                ),
+                "default": DEFAULT_TIMEOUT_SECONDS,
+            },
+            "force": {
+                "type": "boolean",
+                "description": (
+                    "When true, pass --force so Cursor Agent may write files "
+                    "and run commands without interactive approval."
+                ),
+                "default": True,
+            },
+        },
+        "required": ["task", "workdir"],
+    },
+}
+
+
+def _handle_delegate_cursor_agent(args, **kw):
+    return delegate_cursor_agent(
+        task=args.get("task", ""),
+        workdir=args.get("workdir", ""),
+        model=args.get("model", DEFAULT_CURSOR_AGENT_MODEL),
+        timeout_seconds=args.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS),
+        force=is_truthy_value(args.get("force", True), default=True),
+        task_id=kw.get("task_id"),
+    )
+
+
+registry.register(
+    name="delegate_cursor_agent",
+    toolset="delegation",
+    schema=CURSOR_AGENT_SCHEMA,
+    handler=_handle_delegate_cursor_agent,
+    check_fn=check_cursor_agent_requirements,
+    emoji="🖥️",
+    max_result_size_chars=100_000,
+)

--- a/tools/cursor_agent_tool.py
+++ b/tools/cursor_agent_tool.py
@@ -446,6 +446,17 @@ def _run_and_stream(
     start_mono = time.monotonic()
     last_byte_mono = start_mono
 
+    # NOTE(future-me): the agent wrapper script runs with `set -u` and dies on
+    # unbound $HOME in bare environments (transient systemd units, cron). The
+    # gateway unit sets HOME, but guarantee it here so any sparse-env caller
+    # works. Also prepend ~/.local/bin so binary resolution stays consistent
+    # when PATH is minimal.
+    env = os.environ.copy()
+    if not env.get("HOME"):
+        env["HOME"] = str(Path.home())
+    local_bin = str(Path.home() / ".local" / "bin")
+    env["PATH"] = local_bin + os.pathsep + env.get("PATH", "")
+
     proc = subprocess.Popen(
         cmd,
         cwd=workdir,
@@ -453,6 +464,7 @@ def _run_and_stream(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         start_new_session=True,
+        env=env,
     )
 
     try:

--- a/tools/cursor_agent_tool.py
+++ b/tools/cursor_agent_tool.py
@@ -167,6 +167,45 @@ def _delegation_key(record: Dict[str, Any]) -> Tuple[Any, Any, Any]:
     )
 
 
+def _canonicalize_dedupe_token(value: Any) -> Any:
+    """Convert a value into a deterministic hashable token for dedupe keys."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return ("bytes", value)
+    try:
+        if isinstance(value, dict):
+            return (
+                "dict",
+                tuple(
+                    (_canonicalize_dedupe_token(k), _canonicalize_dedupe_token(v))
+                    for k, v in sorted(
+                        value.items(),
+                        key=lambda item: json.dumps(item[0], sort_keys=True, default=str),
+                    )
+                ),
+            )
+        if isinstance(value, (list, tuple)):
+            return ("list", tuple(_canonicalize_dedupe_token(item) for item in value))
+        if isinstance(value, set):
+            return (
+                "set",
+                tuple(
+                    sorted(
+                        json.dumps(_canonicalize_dedupe_token(item), sort_keys=True, default=str)
+                        for item in value
+                    )
+                ),
+            )
+        return json.dumps(value, sort_keys=True, default=str)
+    except Exception:
+        pass
+    try:
+        return ("repr", repr(value))
+    except Exception:
+        return ("type", type(value).__name__)
+
+
 def _delegation_dedupe_key(
     event: Dict[str, Any],
     task_call: Dict[str, Any],
@@ -174,7 +213,7 @@ def _delegation_dedupe_key(
 ) -> Tuple[Any, ...]:
     call_id = event.get("call_id")
     if call_id is not None:
-        return ("call_id", call_id)
+        return ("call_id", _canonicalize_dedupe_token(call_id))
 
     for source in (event, task_call):
         if not isinstance(source, dict):
@@ -182,9 +221,11 @@ def _delegation_dedupe_key(
         for key in ("toolCallId", "agentId"):
             value = source.get(key)
             if value is not None:
-                return (key, value)
+                return (key, _canonicalize_dedupe_token(value))
 
-    return ("content",) + _delegation_key(record)
+    return ("content",) + tuple(
+        _canonicalize_dedupe_token(part) for part in _delegation_key(record)
+    )
 
 
 def parse_cursor_agent_log(log_text: str) -> Dict[str, Any]:

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Cursor Agent CLI delegation (gated via check_fn on the agent binary)
+    "delegate_cursor_agent",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary

- add a native `delegate_cursor_agent` tool for delegating repository work through the Cursor Agent CLI
- expose the tool only when an executable Cursor `agent` binary is available
- return structured run evidence: final report, Cursor session ID, delegated subagents/models, duration, errors, and the incremental JSONL log path

## Motivation

Hermes can delegate to its own subagents, but Cursor Agent users currently need ad hoc terminal commands to run Cursor's parent/subagent workflow. This adds a structured native bridge with workspace validation, bounded execution, process cleanup, error parsing, and machine-readable evidence.

The capability is optional and service-gated, so installations without Cursor Agent do not expose its schema.

## Changes

- register `delegate_cursor_agent` in the `delegation` toolset with an executable availability check
- validate an absolute existing workdir and build argv without a shell
- run `agent -p --trust [--force] --model ... --output-format stream-json` in the target repository
- stream merged stdout/stderr incrementally to `$HERMES_HOME/cursor-runs/*.jsonl`
- enforce wall-clock and no-byte-stall timeouts while terminating the complete process group, including resistant descendants
- parse Cursor stream JSON for session ID, final report, real `taskToolCall` delegations, and `ActionRequiredError`
- deduplicate started/completed events by stable type-aware identity while preserving distinct calls
- guarantee `HOME` and `~/.local/bin` in sparse child environments such as cron or transient systemd units
- add behavior-level tests for validation, parsing, incremental pipes, failure modes, timeouts, and process-group cleanup

## Test Plan

- [x] CI-parity focused suite: `scripts/run_tests.sh tests/tools/test_cursor_agent_tool.py`
  - `38 tests passed, 0 failed`
- [x] Ruff: `python -m ruff check tools/cursor_agent_tool.py tests/tools/test_cursor_agent_tool.py toolsets.py`
  - `All checks passed!`
- [x] `git diff --check`
- [x] synthetic merge against current `origin/main` completed without conflicts
- [x] independent fresh-context verifier returned `PASS` with no unmet criteria
- [x] real native-tool smoke run using Cursor Agent:
  - Kimi K3 parent delegated implementation to Composer 2.5
  - delegated read-only adversarial review to Grok 4.5 High
  - routed the review finding back through Composer
  - produced and committed a hello-world HTTP server
  - independent curls returned exact `hello world` with HTTP 200 on localhost and LAN
  - server was stopped and its port verified free
- [x] repeated native smoke with caller `HOME` deliberately unset; run succeeded and returned structured delegation evidence

## Notes for Reviewers

This is intentionally service-gated because adding an unconditional core schema would impose recurring prompt cost on users without Cursor installed. The main review-sensitive areas are malformed stream-event identity handling, incremental reader races, and descendant cleanup on stall or timeout; the test suite includes real subprocess probes for those paths.
