### PR TITLE
feat(kanban): gate dependencies on structured outcomes

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -550,6 +550,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_link = sub.add_parser("link", help="Add a parent->child dependency")
     p_link.add_argument("parent_id")
     p_link.add_argument("child_id")
+    p_link.add_argument(
+        "--accept-outcome", action="append", dest="accepted_outcome_codes",
+        choices=sorted(kb.VALID_COMPLETION_OUTCOME_CODES),
+        help="Accepted parent outcome code (repeatable)",
+    )
+    p_link.add_argument("--subject-sha", help="Required exact parent subject SHA")
     p_unlink = sub.add_parser("unlink", help="Remove a parent->child dependency")
     p_unlink.add_argument("parent_id")
     p_unlink.add_argument("child_id")
@@ -600,6 +606,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_complete.add_argument("--metadata", default=None,
                             help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                                  '"tests_run": 12}\'). Stored on the closing run.')
+    p_complete.add_argument(
+        "--outcome-code", choices=sorted(kb.VALID_COMPLETION_OUTCOME_CODES),
+        help="Structured completion outcome for conditional dependencies",
+    )
+    p_complete.add_argument(
+        "--subject-sha", help="Exact lowercase 40-hex Git SHA reviewed",
+    )
 
     p_edit = sub.add_parser(
         "edit",
@@ -1633,6 +1646,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         events = kb.list_events(conn, args.task_id)
         parents = kb.parent_ids(conn, args.task_id)
         children = kb.child_ids(conn, args.task_id)
+        dependency_edges = kb.list_dependency_edges(conn, args.task_id)
         runs = kb.list_runs(conn, args.task_id, **rsk)
         # Workers hand off via ``task_runs.summary``; ``tasks.result`` is left NULL unless the caller explicitly passed
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
@@ -1645,6 +1659,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
             "latest_summary": latest_summary,
             "parents": parents,
             "children": children,
+            "dependency_edges": dependency_edges,
             "comments": [
                 {"author": c.author, "body": c.body, "created_at": c.created_at}
                 for c in comments
@@ -1665,6 +1680,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
                     "step_key": r.step_key,
                     "status": r.status,
                     "outcome": r.outcome,
+                    "outcome_code": r.outcome_code,
+                    "subject_sha": r.subject_sha,
                     "summary": r.summary,
                     "error": r.error,
                     "metadata": r.metadata,
@@ -1995,7 +2012,13 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
 def _cmd_link(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
-        kb.link_tasks(conn, args.parent_id, args.child_id)
+        kb.link_tasks(
+            conn,
+            args.parent_id,
+            args.child_id,
+            accepted_outcome_codes=getattr(args, "accepted_outcome_codes", None),
+            subject_sha=getattr(args, "subject_sha", None),
+        )
     print(f"Linked {args.parent_id} -> {args.child_id}")
     return 0
 
@@ -2146,12 +2169,14 @@ def _cmd_complete(args: argparse.Namespace) -> int:
         return 1
     summary = getattr(args, "summary", None)
     raw_meta = getattr(args, "metadata", None)
+    outcome_code = getattr(args, "outcome_code", None)
+    subject_sha = getattr(args, "subject_sha", None)
     # Guard: structured handoff fields are per-run, so they'd be
     # copy-pasted identically across N runs — almost always a footgun.
     # Refuse instead of silently doing the wrong thing.
-    if len(ids) > 1 and (summary or raw_meta):
+    if len(ids) > 1 and (summary or raw_meta or outcome_code or subject_sha):
         print(
-            "kanban: --summary / --metadata are per-task and can't be used "
+            "kanban: structured handoff/evidence flags are per-task and can't be used "
             "with multiple ids (would apply the same handoff to every task). "
             "Complete tasks one at a time, or drop the flags for the bulk close.",
             file=sys.stderr,
@@ -2219,6 +2244,8 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 summary=summary,
                 metadata=metadata,
                 expected_run_id=_worker_run_id_for(tid),
+                outcome_code=getattr(args, "outcome_code", None),
+                subject_sha=getattr(args, "subject_sha", None),
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
@@ -2827,6 +2854,7 @@ def _cmd_runs(args: argparse.Namespace) -> int:
             {
                 "id": r.id, "profile": r.profile, "status": r.status,
                 "outcome": r.outcome, "started_at": r.started_at,
+                "outcome_code": r.outcome_code, "subject_sha": r.subject_sha,
                 "ended_at": r.ended_at, "summary": r.summary,
                 "error": r.error, "metadata": r.metadata,
                 "worker_pid": r.worker_pid, "step_key": r.step_key,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,6 +101,8 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+VALID_COMPLETION_OUTCOME_CODES = {"APPROVED", "REJECT"}
+_FULL_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -1114,6 +1116,8 @@ class Run:
     started_at: int
     ended_at: Optional[int]
     outcome: Optional[str]
+    outcome_code: Optional[str]
+    subject_sha: Optional[str]
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
@@ -1138,6 +1142,8 @@ class Run:
             started_at=int(row["started_at"]),
             ended_at=(int(row["ended_at"]) if row["ended_at"] is not None else None),
             outcome=row["outcome"],
+            outcome_code=(row["outcome_code"] if "outcome_code" in row.keys() else None),
+            subject_sha=(row["subject_sha"] if "subject_sha" in row.keys() else None),
             summary=row["summary"],
             metadata=meta,
             error=row["error"],
@@ -1280,6 +1286,8 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
+    accepted_outcome_codes TEXT,
+    subject_sha TEXT,
     PRIMARY KEY (parent_id, child_id)
 );
 
@@ -1324,6 +1332,8 @@ CREATE TABLE IF NOT EXISTS task_runs (
     outcome             TEXT,
     -- outcome: completed | blocked | crashed | timed_out | spawn_failed |
     --          gave_up | reclaimed | (null while still running)
+    outcome_code        TEXT,
+    subject_sha         TEXT,
     summary             TEXT,
     metadata            TEXT,
     error               TEXT
@@ -2474,6 +2484,27 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    link_cols = {
+        row["name"] for row in conn.execute("PRAGMA table_info(task_links)")
+    }
+    if link_cols and "accepted_outcome_codes" not in link_cols:
+        _add_column_if_missing(
+            conn,
+            "task_links",
+            "accepted_outcome_codes",
+            "accepted_outcome_codes TEXT",
+        )
+    if link_cols and "subject_sha" not in link_cols:
+        _add_column_if_missing(conn, "task_links", "subject_sha", "subject_sha TEXT")
+
+    run_cols = {
+        row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+    }
+    if run_cols and "outcome_code" not in run_cols:
+        _add_column_if_missing(conn, "task_runs", "outcome_code", "outcome_code TEXT")
+    if run_cols and "subject_sha" not in run_cols:
+        _add_column_if_missing(conn, "task_runs", "subject_sha", "subject_sha TEXT")
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2634,7 +2665,8 @@ _REBUILD_SPECS = {
         " status TEXT NOT NULL, claim_lock TEXT, claim_expires INTEGER,"
         " worker_pid INTEGER, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
-        " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
+        " ended_at INTEGER, outcome TEXT, outcome_code TEXT, subject_sha TEXT,"
+        " summary TEXT, metadata TEXT,"
         " error TEXT)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",
@@ -3405,6 +3437,32 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
+def list_dependency_edges(
+    conn: sqlite3.Connection, task_id: str
+) -> list[dict[str, Any]]:
+    """Return dependency edges touching ``task_id`` with condition metadata."""
+    rows = conn.execute(
+        "SELECT parent_id, child_id, accepted_outcome_codes, subject_sha "
+        "FROM task_links WHERE parent_id = ? OR child_id = ? "
+        "ORDER BY parent_id, child_id",
+        (task_id, task_id),
+    ).fetchall()
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        codes_raw = row["accepted_outcome_codes"]
+        try:
+            codes = json.loads(codes_raw) if codes_raw is not None else None
+        except (TypeError, json.JSONDecodeError):
+            codes = codes_raw
+        result.append({
+            "parent_id": row["parent_id"],
+            "child_id": row["child_id"],
+            "accepted_outcome_codes": codes,
+            "subject_sha": row["subject_sha"],
+        })
+    return result
+
+
 def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
     """Assign or reassign a task.  Returns True on success.
 
@@ -3525,7 +3583,44 @@ def set_reasoning_effort(
 # Links
 # ---------------------------------------------------------------------------
 
-def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+def _normalize_dependency_condition(
+    accepted_outcome_codes: Optional[Iterable[str]],
+    subject_sha: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Validate and canonicalise an opt-in dependency condition."""
+    if accepted_outcome_codes is None and subject_sha is None:
+        return None, None
+    if accepted_outcome_codes is None or subject_sha is None:
+        raise ValueError(
+            "accepted_outcome_codes and subject_sha must be provided together"
+        )
+    if isinstance(accepted_outcome_codes, str):
+        accepted_outcome_codes = [accepted_outcome_codes]
+    raw_codes = list(accepted_outcome_codes)
+    if any(not isinstance(code, str) for code in raw_codes):
+        raise ValueError("accepted_outcome_codes must contain strings only")
+    codes = sorted(set(raw_codes))
+    if not codes:
+        raise ValueError("accepted_outcome_codes must not be empty")
+    unknown = [code for code in codes if code not in VALID_COMPLETION_OUTCOME_CODES]
+    if unknown:
+        raise ValueError(f"unknown outcome code(s): {', '.join(unknown)}")
+    if not isinstance(subject_sha, str) or not _FULL_GIT_SHA_RE.fullmatch(subject_sha):
+        raise ValueError("subject_sha must be a lowercase full 40-hex Git SHA")
+    return json.dumps(codes, separators=(",", ":")), subject_sha
+
+
+def link_tasks(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    accepted_outcome_codes: Optional[Iterable[str]] = None,
+    subject_sha: Optional[str] = None,
+) -> None:
+    codes_json, expected_sha = _normalize_dependency_condition(
+        accepted_outcome_codes, subject_sha
+    )
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
     with write_txn(conn):
@@ -3536,22 +3631,35 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             raise ValueError(
                 f"linking {parent_id} -> {child_id} would create a cycle"
             )
-        conn.execute(
-            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-            (parent_id, child_id),
-        )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        if codes_json is None:
+            conn.execute(
+                "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                (parent_id, child_id),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO task_links "
+                "(parent_id, child_id, accepted_outcome_codes, subject_sha) "
+                "VALUES (?, ?, ?, ?) ON CONFLICT(parent_id, child_id) DO UPDATE SET "
+                "accepted_outcome_codes = excluded.accepted_outcome_codes, "
+                "subject_sha = excluded.subject_sha",
+                (parent_id, child_id, codes_json, expected_sha),
+            )
+        if dependency_blockers(conn, child_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
             )
         _append_event(
             conn, child_id, "linked",
-            {"parent": parent_id, "child": child_id},
+            {
+                "parent": parent_id,
+                "child": child_id,
+                "accepted_outcome_codes": (
+                    json.loads(codes_json) if codes_json is not None else None
+                ),
+                "subject_sha": expected_sha,
+            },
         )
         _inherit_notify_subs(conn, child_id, (parent_id,))
 
@@ -3984,6 +4092,8 @@ def _end_run(
     error: Optional[str] = None,
     metadata: Optional[dict] = None,
     status: Optional[str] = None,
+    outcome_code: Optional[str] = None,
+    subject_sha: Optional[str] = None,
 ) -> Optional[int]:
     """Close the currently-active run for ``task_id`` and clear the pointer.
 
@@ -4006,6 +4116,8 @@ def _end_run(
         UPDATE task_runs
            SET status        = ?,
                outcome       = ?,
+               outcome_code  = ?,
+               subject_sha   = ?,
                summary       = ?,
                error         = ?,
                metadata      = ?,
@@ -4019,6 +4131,8 @@ def _end_run(
         (
             status or outcome,
             outcome,
+            outcome_code,
+            subject_sha,
             summary,
             error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
@@ -4047,6 +4161,8 @@ def _synthesize_ended_run(
     summary: Optional[str] = None,
     error: Optional[str] = None,
     metadata: Optional[dict] = None,
+    outcome_code: Optional[str] = None,
+    subject_sha: Optional[str] = None,
 ) -> int:
     """Insert a zero-duration, already-closed run row.
 
@@ -4074,14 +4190,15 @@ def _synthesize_ended_run(
         """
         INSERT INTO task_runs (
             task_id, profile, step_key,
-            status, outcome,
+            status, outcome, outcome_code, subject_sha,
             summary, error, metadata,
             started_at, ended_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             task_id, profile, step_key,
             outcome, outcome,
+            outcome_code, subject_sha,
             summary, error,
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
             now, now,
@@ -4093,6 +4210,104 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
+
+def dependency_blockers(
+    conn: sqlite3.Connection, child_id: str
+) -> list[dict[str, Any]]:
+    """Return every unsatisfied dependency, failing closed for conditions."""
+    edges = conn.execute(
+        "SELECT l.parent_id, l.accepted_outcome_codes, l.subject_sha, p.status "
+        "FROM task_links l LEFT JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? ORDER BY l.parent_id",
+        (child_id,),
+    ).fetchall()
+    blockers: list[dict[str, Any]] = []
+    for edge in edges:
+        parent_id = edge["parent_id"]
+        codes_raw = edge["accepted_outcome_codes"]
+        expected_sha = edge["subject_sha"]
+        conditional = codes_raw is not None or expected_sha is not None
+        if not conditional:
+            if edge["status"] not in ("done", "archived"):
+                blockers.append(
+                    {"parent_id": parent_id, "conditional": False, "reason": "parent_not_done"}
+                )
+            continue
+
+        reason = None
+        try:
+            codes = json.loads(codes_raw) if isinstance(codes_raw, str) else None
+        except (TypeError, json.JSONDecodeError):
+            codes = None
+        if (
+            not isinstance(codes, list)
+            or not codes
+            or any(
+                not isinstance(code, str)
+                or code not in VALID_COMPLETION_OUTCOME_CODES
+                for code in codes
+            )
+            or len(set(codes)) != len(codes)
+            or not isinstance(expected_sha, str)
+            or not _FULL_GIT_SHA_RE.fullmatch(expected_sha)
+        ):
+            reason = "malformed_condition"
+        elif edge["status"] not in ("done", "archived"):
+            reason = "parent_not_done"
+        else:
+            evidence = conn.execute(
+                "SELECT id, outcome_code, subject_sha FROM task_runs "
+                "WHERE task_id = ? AND outcome = 'completed' AND ended_at IS NOT NULL "
+                "ORDER BY ended_at DESC, id DESC LIMIT 1",
+                (parent_id,),
+            ).fetchone()
+            if evidence is None:
+                reason = "missing_evidence"
+            elif evidence["outcome_code"] not in VALID_COMPLETION_OUTCOME_CODES:
+                reason = "invalid_outcome"
+            elif evidence["outcome_code"] not in codes:
+                reason = "outcome_not_accepted"
+            elif (
+                not isinstance(evidence["subject_sha"], str)
+                or not _FULL_GIT_SHA_RE.fullmatch(evidence["subject_sha"])
+            ):
+                reason = "invalid_subject_sha"
+            elif evidence["subject_sha"] != expected_sha:
+                reason = "subject_sha_mismatch"
+            else:
+                completion_event = conn.execute(
+                    "SELECT id FROM task_events WHERE task_id = ? AND run_id = ? "
+                    "AND kind = 'completed' ORDER BY id DESC LIMIT 1",
+                    (parent_id, evidence["id"]),
+                ).fetchone()
+                if completion_event is None:
+                    reason = "missing_completion_event"
+                else:
+                    later_status_events = conn.execute(
+                        "SELECT payload FROM task_events WHERE task_id = ? "
+                        "AND id > ? AND kind = 'status' ORDER BY id",
+                        (parent_id, completion_event["id"]),
+                    ).fetchall()
+                    for status_event in later_status_events:
+                        try:
+                            status_payload = json.loads(status_event["payload"] or "{}")
+                        except (TypeError, json.JSONDecodeError):
+                            reason = "malformed_reopen_event"
+                            break
+                        if status_payload.get("status") not in ("done", "archived"):
+                            reason = "stale_evidence_after_reopen"
+                            break
+        if reason:
+            blockers.append(
+                {"parent_id": parent_id, "conditional": True, "reason": reason}
+            )
+    return blockers
+
+
+def _dependency_requeue_status(conn: sqlite3.Connection, task_id: str) -> str:
+    """Choose the only safe inactive status for a task being requeued."""
+    return "todo" if dependency_blockers(conn, task_id) else "ready"
+
 
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return True when ``task_id`` is sticky-blocked by an explicit
@@ -4180,13 +4395,7 @@ def recompute_ready(
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
                 continue
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if not dependency_blockers(conn, task_id):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this
@@ -4247,13 +4456,8 @@ def claim_task(
         # 'todo' here — recompute_ready will re-promote when the parents
         # actually finish. See RCA at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        if undone:
+        blockers = dependency_blockers(conn, task_id)
+        if blockers:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",
@@ -4261,7 +4465,7 @@ def claim_task(
             )
             _append_event(
                 conn, task_id, "claim_rejected",
-                {"reason": "parents_not_done"},
+                {"reason": "dependencies_unsatisfied", "blockers": blockers},
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -4357,9 +4561,9 @@ def claim_review_task(
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``review`` status).
 
-    Unlike ``claim_task`` (which handles ``ready -> running``), this
-    does NOT check parent dependencies — the task already passed that
-    gate on its original ``todo -> ready -> running`` transition.
+    Like ``claim_task``, this rechecks parent dependencies transactionally.
+    Review status can outlive the evidence that originally satisfied the
+    task, so stale approval must not grant a new worker lease.
 
     Creates a new run entry so the review agent's lifecycle is tracked
     independently from the original worker run.
@@ -4368,6 +4572,19 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        blockers = dependency_blockers(conn, task_id)
+        if blockers:
+            _append_event(
+                conn,
+                task_id,
+                "claim_rejected",
+                {
+                    "reason": "dependencies_unsatisfied",
+                    "source_status": "review",
+                    "blockers": blockers,
+                },
+            )
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -4557,12 +4774,13 @@ def release_stale_claims(
             )
             continue
         with write_txn(conn):
+            requeue_status = _dependency_requeue_status(conn, row["id"])
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
-                (row["id"], row["claim_lock"], now),
+                (requeue_status, row["id"], row["claim_lock"], now),
             )
             if cur.rowcount != 1:
                 continue
@@ -4629,12 +4847,13 @@ def reclaim_task(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
     with write_txn(conn):
+        requeue_status = _dependency_requeue_status(conn, task_id)
         cur = conn.execute(
-            "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+            "UPDATE tasks SET status = ?, claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
             "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
             "AND claim_lock IS ?",
-            (task_id, prev_lock),
+            (requeue_status, task_id, prev_lock),
         )
         if cur.rowcount != 1:
             return False
@@ -4842,6 +5061,8 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    outcome_code: Optional[str] = None,
+    subject_sha: Optional[str] = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4872,6 +5093,14 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+    if outcome_code is None and subject_sha is None:
+        pass
+    elif outcome_code is None or subject_sha is None:
+        raise ValueError("outcome_code and subject_sha must be provided together")
+    elif outcome_code not in VALID_COMPLETION_OUTCOME_CODES:
+        raise ValueError(f"unknown outcome_code: {outcome_code!r}")
+    elif not isinstance(subject_sha, str) or not _FULL_GIT_SHA_RE.fullmatch(subject_sha):
+        raise ValueError("subject_sha must be a lowercase full 40-hex Git SHA")
 
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
@@ -4958,17 +5187,21 @@ def complete_task(
             outcome="completed", status="done",
             summary=summary if summary is not None else result,
             metadata=metadata,
+            outcome_code=outcome_code,
+            subject_sha=subject_sha,
         )
         # If complete_task was called on a never-claimed task (ready or
         # blocked → done with no run in flight), synthesize a
         # zero-duration run so the handoff fields are persisted in
         # attempt history instead of silently lost.
-        if run_id is None and (summary or metadata or result):
+        if run_id is None and (summary or metadata or result or outcome_code):
             run_id = _synthesize_ended_run(
                 conn, task_id,
                 outcome="completed",
                 summary=summary if summary is not None else result,
                 metadata=metadata,
+                outcome_code=outcome_code,
+                subject_sha=subject_sha,
             )
         # Carry the handoff summary in the event payload so gateway
         # notifiers and dashboard WS consumers can render it without a
@@ -5860,17 +6093,15 @@ def promote_task(
             f"'todo' or 'blocked'"
         )
 
+    blockers = dependency_blockers(conn, task_id)
+    conditional_blockers = [b for b in blockers if b["conditional"]]
+    if conditional_blockers:
+        return False, (
+            "unsatisfied conditional dependencies: "
+            + ", ".join(b["parent_id"] for b in conditional_blockers)
+        )
     if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
-            (task_id,),
-        ).fetchall()
-        unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
-        ]
+        unsatisfied = [b["parent_id"] for b in blockers]
         if unsatisfied:
             return False, (
                 f"unsatisfied parent dependencies: "
@@ -5881,6 +6112,22 @@ def promote_task(
         return True, None
 
     with write_txn(conn):
+        # Re-evaluate under the same IMMEDIATE transaction as the status
+        # mutation. Parent completion evidence cannot change between this
+        # check and the UPDATE.
+        blockers = dependency_blockers(conn, task_id)
+        conditional_blockers = [b for b in blockers if b["conditional"]]
+        if conditional_blockers:
+            return False, (
+                "unsatisfied conditional dependencies: "
+                + ", ".join(b["parent_id"] for b in conditional_blockers)
+            )
+        if not force and blockers:
+            return False, (
+                "unsatisfied parent dependencies: "
+                + ", ".join(b["parent_id"] for b in blockers)
+                + " (use --force to override)"
+            )
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
             "WHERE id = ? AND status IN ('todo', 'blocked')",
@@ -5932,13 +6179,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # if parents are still in progress the task must wait in 'todo'
         # until recompute_ready picks it up. RCA: Bug 2 at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone_parents = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        new_status = "todo" if undone_parents else "ready"
+        new_status = "todo" if dependency_blockers(conn, task_id) else "ready"
         # NOTE: deliberately does NOT touch ``block_recurrences`` or
         # ``block_kind``. Resetting the recurrence counter on unblock is exactly
         # the amnesia that let a cron unblock → worker re-block loop run
@@ -7260,13 +7501,14 @@ def enforce_max_runtime(
                     pass
 
         with write_txn(conn):
+            requeue_status = _dependency_requeue_status(conn, tid)
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
-                (tid, pid, row["claim_lock"]),
+                (requeue_status, tid, pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
                 payload = {
@@ -7385,13 +7627,14 @@ def detect_stale_running(
             continue
 
         with write_txn(conn):
+            requeue_status = _dependency_requeue_status(conn, tid)
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ?",
-                (tid, row["claim_lock"]),
+                (requeue_status, tid, row["claim_lock"]),
             )
             if cur.rowcount != 1:
                 continue
@@ -7480,13 +7723,14 @@ def reconcile_orphaned_running(
             )
             continue
         with write_txn(conn):
+            requeue_status = _dependency_requeue_status(conn, tid)
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ? AND claim_expires IS ?",
-                (tid, row["claim_lock"], row["claim_expires"]),
+                (requeue_status, tid, row["claim_lock"], row["claim_expires"]),
             )
             if cur.rowcount != 1:
                 continue
@@ -7733,12 +7977,13 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
+            requeue_status = _dependency_requeue_status(conn, row["id"])
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
-                (row["id"], pid, row["claim_lock"]),
+                (requeue_status, row["id"], pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
                 # Rate-limited requeues are a clean release, not a crash —
@@ -8010,12 +8255,13 @@ def _record_task_failure(
             # Below threshold.
             if release_claim:
                 # Spawn path: transition running → ready + clear claim.
+                requeue_status = _dependency_requeue_status(conn, task_id)
                 conn.execute(
-                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
-                    (failures, error[:500], task_id),
+                    (requeue_status, failures, error[:500], task_id),
                 )
             else:
                 # Timeout/crash path: task is already at ``ready`` via
@@ -10106,15 +10352,23 @@ def rewind_notify_cursor(
 def gc_events(
     conn: sqlite3.Connection, *, older_than_seconds: int = 30 * 24 * 3600,
 ) -> int:
-    """Delete task_events rows older than ``older_than_seconds`` for tasks
-    in a terminal state (``done`` or ``archived``). Returns the number of
-    rows deleted. Running / ready / blocked tasks keep their full event
-    history."""
+    """Delete old terminal-task events while preserving approval provenance.
+
+    Structured completion events and later status changes for conditional
+    parents are part of the durable fail-closed evidence chain, not disposable
+    activity history. Running / ready / blocked tasks keep all events.
+    """
     cutoff = int(time.time()) - int(older_than_seconds)
     with write_txn(conn):
         cur = conn.execute(
             "DELETE FROM task_events WHERE created_at < ? AND task_id IN "
-            "(SELECT id FROM tasks WHERE status IN ('done', 'archived'))",
+            "(SELECT id FROM tasks WHERE status IN ('done', 'archived')) "
+            "AND NOT (kind = 'completed' AND run_id IN "
+            "  (SELECT id FROM task_runs WHERE outcome_code IS NOT NULL "
+            "   AND subject_sha IS NOT NULL)) "
+            "AND NOT (kind = 'status' AND task_id IN "
+            "  (SELECT parent_id FROM task_links "
+            "   WHERE accepted_outcome_codes IS NOT NULL OR subject_sha IS NOT NULL))",
             (cutoff,),
         )
     return int(cur.rowcount or 0)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -42,7 +42,7 @@ import sqlite3
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
 from fastapi.responses import FileResponse
@@ -228,6 +228,8 @@ def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
         "started_at": r.started_at,
         "ended_at": r.ended_at,
         "outcome": r.outcome,
+        "outcome_code": r.outcome_code,
+        "subject_sha": r.subject_sha,
         "summary": r.summary,
         "metadata": r.metadata,
         "error": r.error,
@@ -352,8 +354,8 @@ def _warnings_summary_from_diagnostics(
     }
 
 
-def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, list[str]]:
-    """Return {'parents': [...], 'children': [...]} for a task."""
+def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, Any]:
+    """Return linked ids and inspectable edge conditions for a task."""
     parents = [
         r["parent_id"]
         for r in conn.execute(
@@ -368,7 +370,11 @@ def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, list[str]]:
             (task_id,),
         )
     ]
-    return {"parents": parents, "children": children}
+    return {
+        "parents": parents,
+        "children": children,
+        "edges": kanban_db.list_dependency_edges(conn, task_id),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -836,6 +842,8 @@ class UpdateTaskBody(BaseModel):
     # complete --summary ... --metadata ...``.
     summary: Optional[str] = None
     metadata: Optional[dict] = None
+    outcome_code: Optional[Literal["APPROVED", "REJECT"]] = None
+    subject_sha: Optional[str] = Field(None, pattern=r"^[0-9a-f]{40}$")
     # Per-task model/provider override (the board's model dropdown).
     # ``model_override=""`` clears both. ``clear_model_override=True`` is
     # the explicit clear signal — needed because Optional[str]=None means
@@ -876,12 +884,17 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             s = payload.status
             ok = True
             if s == "done":
-                ok = kanban_db.complete_task(
-                    conn, task_id,
-                    result=payload.result,
-                    summary=payload.summary,
-                    metadata=payload.metadata,
-                )
+                try:
+                    ok = kanban_db.complete_task(
+                        conn, task_id,
+                        result=payload.result,
+                        summary=payload.summary,
+                        metadata=payload.metadata,
+                        outcome_code=payload.outcome_code,
+                        subject_sha=payload.subject_sha,
+                    )
+                except ValueError as exc:
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
             elif s == "blocked":
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
             elif s == "scheduled":
@@ -892,8 +905,9 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 if current and current.status in ("blocked", "scheduled"):
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
-                    # Direct status write for drag-drop (todo -> ready etc).
-                    ok = _set_status_direct(conn, task_id, "ready")
+                    ok, _error = kanban_db.promote_task(
+                        conn, task_id, actor="dashboard", force=False,
+                    )
             elif s == "archived":
                 ok = kanban_db.archive_task(conn, task_id)
             elif s == "running":
@@ -1027,16 +1041,21 @@ def _parents_blocking_ready(
     no-op.  Returns ``[]`` when nothing blocks the transition (e.g. no
     parents, or all parents already done).
     """
-    rows = conn.execute(
-        "SELECT t.id, t.title, t.status FROM tasks t "
-        "JOIN task_links l ON l.parent_id = t.id "
-        "WHERE l.child_id = ? AND t.status != 'done'",
-        (task_id,),
-    ).fetchall()
-    return [
-        {"id": r["id"], "title": r["title"], "status": r["status"]}
-        for r in rows
-    ]
+    blockers = kanban_db.dependency_blockers(conn, task_id)
+    result: list[dict[str, Any]] = []
+    for blocker in blockers:
+        row = conn.execute(
+            "SELECT title, status FROM tasks WHERE id = ?",
+            (blocker["parent_id"],),
+        ).fetchone()
+        result.append({
+            "id": blocker["parent_id"],
+            "title": row["title"] if row else None,
+            "status": row["status"] if row else None,
+            "reason": blocker["reason"],
+            "conditional": blocker["conditional"],
+        })
+    return result
 
 
 def _set_status_direct(
@@ -1065,15 +1084,7 @@ def _set_status_direct(
         # Prevents the dispatcher from spawning a child whose upstream work
         # hasn't completed (e.g. T4 dispatched while T3 is still blocked).
         if new_status == "ready":
-            parent_statuses = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if parent_statuses and not all(
-                p["status"] == "done" for p in parent_statuses
-            ):
+            if kanban_db.dependency_blockers(conn, task_id):
                 return False
 
         was_running = prev["status"] == "running"
@@ -1174,6 +1185,8 @@ def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query
 class LinkBody(BaseModel):
     parent_id: str
     child_id: str
+    accepted_outcome_codes: Optional[list[Literal["APPROVED", "REJECT"]]] = None
+    subject_sha: Optional[str] = Field(None, pattern=r"^[0-9a-f]{40}$")
 
 
 @router.post("/links")
@@ -1181,7 +1194,13 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        kanban_db.link_tasks(conn, payload.parent_id, payload.child_id)
+        kanban_db.link_tasks(
+            conn,
+            payload.parent_id,
+            payload.child_id,
+            accepted_outcome_codes=payload.accepted_outcome_codes,
+            subject_sha=payload.subject_sha,
+        )
         return {"ok": True}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,29 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_completion_and_link_condition_flags_round_trip(kanban_home):
+    sha = "a" * 40
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="review", assignee="reviewer")
+        child = kb.create_task(conn, title="release", assignee="release")
+
+    completed = kc.run_slash(
+        f"complete {parent} --summary reviewed --outcome-code APPROVED "
+        f"--subject-sha {sha}"
+    )
+    linked = kc.run_slash(
+        f"link {parent} {child} --accept-outcome APPROVED --subject-sha {sha}"
+    )
+
+    assert f"Completed {parent}" in completed
+    assert f"Linked {parent} -> {child}" in linked
+    with kb.connect() as conn:
+        run = kb.latest_run(conn, parent)
+        assert run.outcome_code == "APPROVED"
+        assert run.subject_sha == sha
+        assert kb.get_task(conn, child).status == "ready"
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")

--- a/tests/hermes_cli/test_kanban_outcome_dependencies.py
+++ b/tests/hermes_cli/test_kanban_outcome_dependencies.py
@@ -1,0 +1,285 @@
+"""Outcome-conditional dependency regression tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+APPROVED_SHA = "a" * 40
+OTHER_SHA = "b" * 40
+
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    with kb.connect() as connection:
+        yield connection
+
+
+def _complete_review(conn, *, outcome_code: str, subject_sha: str) -> str:
+    parent = kb.create_task(conn, title="review", assignee="reviewer")
+    assert kb.complete_task(
+        conn,
+        parent,
+        summary=f"review returned {outcome_code}",
+        outcome_code=outcome_code,
+        subject_sha=subject_sha,
+    )
+    return parent
+
+
+def _conditional_child(conn, parent: str, *, subject_sha: str = APPROVED_SHA) -> str:
+    child = kb.create_task(conn, title="release", assignee="release")
+    kb.link_tasks(
+        conn,
+        parent,
+        child,
+        accepted_outcome_codes=["APPROVED"],
+        subject_sha=subject_sha,
+    )
+    return child
+
+
+def test_reject_is_normal_completion_but_does_not_satisfy_release(conn):
+    parent = _complete_review(conn, outcome_code="REJECT", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+
+    review = kb.get_task(conn, parent)
+    run = kb.latest_run(conn, parent)
+    assert review.status == "done"
+    assert run.outcome == "completed"
+    assert run.outcome_code == "REJECT"
+    assert run.subject_sha == APPROVED_SHA
+    assert kb.get_task(conn, child).status == "todo"
+    assert kb.recompute_ready(conn) == 0
+    assert kb.claim_task(conn, child) is None
+
+
+def test_approved_exact_sha_promotes_and_is_claimable(conn):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+
+    assert kb.get_task(conn, child).status == "ready"
+    claimed = kb.claim_task(conn, child)
+    assert claimed is not None
+    assert claimed.status == "running"
+
+
+@pytest.mark.parametrize(
+    ("outcome_code", "subject_sha"),
+    [
+        (None, APPROVED_SHA),
+        ("UNKNOWN", APPROVED_SHA),
+        ("APPROVED", None),
+        ("APPROVED", "a" * 12),
+        ("APPROVED", "A" * 40),
+        ("APPROVED", OTHER_SHA),
+    ],
+)
+def test_malformed_or_mismatched_evidence_fails_closed(
+    conn, outcome_code, subject_sha
+):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    run = kb.latest_run(conn, parent)
+    conn.execute(
+        "UPDATE task_runs SET outcome_code = ?, subject_sha = ? WHERE id = ?",
+        (outcome_code, subject_sha, run.id),
+    )
+    child = _conditional_child(conn, parent)
+
+    assert kb.get_task(conn, child).status == "todo"
+    blockers = kb.dependency_blockers(conn, child)
+    assert [blocker["parent_id"] for blocker in blockers] == [parent]
+
+
+def test_legacy_unconditional_edge_keeps_completion_only_behavior(conn):
+    parent = kb.create_task(conn, title="legacy parent")
+    child = kb.create_task(conn, title="legacy child", parents=[parent])
+
+    assert kb.complete_task(conn, parent, result="done")
+    assert kb.get_task(conn, child).status == "ready"
+    assert kb.claim_task(conn, child) is not None
+
+
+def test_claim_rechecks_evidence_and_demotes_stale_ready_child(conn):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+    assert kb.get_task(conn, child).status == "ready"
+
+    run = kb.latest_run(conn, parent)
+    conn.execute("UPDATE task_runs SET outcome_code = 'REJECT' WHERE id = ?", (run.id,))
+
+    assert kb.claim_task(conn, child) is None
+    assert kb.get_task(conn, child).status == "todo"
+    event = kb.list_events(conn, child)[-1]
+    assert event.kind == "claim_rejected"
+    assert event.payload["reason"] == "dependencies_unsatisfied"
+
+
+def test_candidate_revision_change_invalidates_stale_ready_child(conn):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+    assert kb.get_task(conn, child).status == "ready"
+
+    conn.execute(
+        "UPDATE task_links SET subject_sha = ? WHERE parent_id = ? AND child_id = ?",
+        (OTHER_SHA, parent, child),
+    )
+
+    assert kb.claim_task(conn, child) is None
+    assert kb.get_task(conn, child).status == "todo"
+    assert kb.dependency_blockers(conn, child)[0]["reason"] == "subject_sha_mismatch"
+
+
+def test_reopen_then_archive_does_not_reuse_stale_approval(conn):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+    assert kb.get_task(conn, child).status == "ready"
+
+    conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (parent,))
+    kb._append_event(conn, parent, "status", {"status": "todo"})
+    assert kb.archive_task(conn, parent)
+    conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (child,))
+
+    assert kb.recompute_ready(conn) == 0
+    blockers = kb.dependency_blockers(conn, child)
+    assert blockers[0]["reason"] == "stale_evidence_after_reopen"
+
+
+def test_event_gc_preserves_conditional_approval_provenance(conn):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+    conn.execute("UPDATE task_events SET created_at = 0 WHERE task_id = ?", (parent,))
+
+    kb.gc_events(conn, older_than_seconds=1)
+
+    assert kb.dependency_blockers(conn, child) == []
+    assert kb.get_task(conn, child).status == "ready"
+
+
+def test_review_claim_rechecks_conditional_dependencies(conn):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+    conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (child,))
+    run = kb.latest_run(conn, parent)
+    conn.execute("UPDATE task_runs SET outcome_code = 'REJECT' WHERE id = ?", (run.id,))
+
+    assert kb.claim_review_task(conn, child, claimer="reviewer") is None
+    assert kb.get_task(conn, child).status == "review"
+    event = kb.list_events(conn, child)[-1]
+    assert event.kind == "claim_rejected"
+    assert event.payload["source_status"] == "review"
+
+
+def test_linking_unsatisfied_condition_demotes_ready_child(conn):
+    parent = _complete_review(conn, outcome_code="REJECT", subject_sha=APPROVED_SHA)
+    child = kb.create_task(conn, title="release")
+    assert kb.get_task(conn, child).status == "ready"
+
+    kb.link_tasks(
+        conn,
+        parent,
+        child,
+        accepted_outcome_codes=["APPROVED"],
+        subject_sha=APPROVED_SHA,
+    )
+
+    assert kb.get_task(conn, child).status == "todo"
+
+
+def test_force_promotion_cannot_bypass_conditional_dependency(conn):
+    parent = _complete_review(conn, outcome_code="REJECT", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+
+    ok, error = kb.promote_task(conn, child, actor="operator", force=True)
+
+    assert ok is False
+    assert "conditional" in error
+    assert kb.get_task(conn, child).status == "todo"
+
+
+def test_manual_promotion_rechecks_evidence_inside_write_transaction(
+    conn, monkeypatch
+):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+    conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (child,))
+    run = kb.latest_run(conn, parent)
+    original = kb.dependency_blockers
+    calls = 0
+
+    def mutate_after_first_check(connection, child_id):
+        nonlocal calls
+        blockers = original(connection, child_id)
+        calls += 1
+        if calls == 1:
+            connection.execute(
+                "UPDATE task_runs SET outcome_code = 'REJECT' WHERE id = ?", (run.id,)
+            )
+        return blockers
+
+    monkeypatch.setattr(kb, "dependency_blockers", mutate_after_first_check)
+
+    ok, error = kb.promote_task(conn, child, actor="operator")
+
+    assert ok is False
+    assert "conditional" in error
+    assert calls == 2
+    assert kb.get_task(conn, child).status == "todo"
+
+
+def test_edge_condition_round_trips_as_canonical_json(conn):
+    parent = _complete_review(conn, outcome_code="APPROVED", subject_sha=APPROVED_SHA)
+    child = _conditional_child(conn, parent)
+
+    row = conn.execute(
+        "SELECT accepted_outcome_codes, subject_sha FROM task_links "
+        "WHERE parent_id = ? AND child_id = ?",
+        (parent, child),
+    ).fetchone()
+    assert json.loads(row["accepted_outcome_codes"]) == ["APPROVED"]
+    assert row["subject_sha"] == APPROVED_SHA
+
+
+def test_existing_board_adds_nullable_condition_and_evidence_columns(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    legacy = sqlite3.connect(db_path)
+    legacy.executescript(kb.SCHEMA_SQL)
+    legacy.execute("ALTER TABLE task_links DROP COLUMN accepted_outcome_codes")
+    legacy.execute("ALTER TABLE task_links DROP COLUMN subject_sha")
+    legacy.execute("ALTER TABLE task_runs DROP COLUMN outcome_code")
+    legacy.execute("ALTER TABLE task_runs DROP COLUMN subject_sha")
+    legacy.commit()
+    legacy.close()
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    with kb.connect() as migrated:
+        link_cols = {
+            row["name"] for row in migrated.execute("PRAGMA table_info(task_links)")
+        }
+        run_cols = {
+            row["name"] for row in migrated.execute("PRAGMA table_info(task_runs)")
+        }
+    assert {"accepted_outcome_codes", "subject_sha"} <= link_cols
+    assert {"outcome_code", "subject_sha"} <= run_cols

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -219,6 +219,69 @@ def test_task_detail_includes_links_and_events(client):
     assert len(data["events"]) >= 1
 
 
+def test_dashboard_round_trips_outcome_condition_and_blocks_reject(client):
+    sha = "a" * 40
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "review"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "release"},
+    ).json()["task"]
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={
+            "status": "done",
+            "summary": "rejected exact candidate",
+            "outcome_code": "REJECT",
+            "subject_sha": sha,
+        },
+    )
+    assert response.status_code == 200, response.text
+    response = client.post(
+        "/api/plugins/kanban/links",
+        json={
+            "parent_id": parent["id"],
+            "child_id": child["id"],
+            "accepted_outcome_codes": ["APPROVED"],
+            "subject_sha": sha,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    detail = client.get(
+        f"/api/plugins/kanban/tasks/{parent['id']}"
+    ).json()
+    assert detail["runs"][-1]["outcome_code"] == "REJECT"
+    assert detail["runs"][-1]["subject_sha"] == sha
+    child_detail = client.get(
+        f"/api/plugins/kanban/tasks/{child['id']}"
+    ).json()
+    assert child_detail["task"]["status"] == "todo"
+
+
+def test_dashboard_rejects_partial_or_unknown_completion_evidence(client):
+    task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "review"},
+    ).json()["task"]
+
+    partial = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"status": "done", "outcome_code": "APPROVED"},
+    )
+    unknown = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={
+            "status": "done",
+            "outcome_code": "MAYBE",
+            "subject_sha": "a" * 40,
+        },
+    )
+
+    assert partial.status_code == 400
+    assert unknown.status_code == 422
+
+
 # ---------------------------------------------------------------------------
 # PATCH /tasks/:id — status transitions
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -132,6 +132,38 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_and_link_support_structured_outcome_condition(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    sha = "a" * 40
+    completed = json.loads(kt._handle_complete({
+        "summary": "approved exact candidate",
+        "outcome_code": "APPROVED",
+        "subject_sha": sha,
+    }))
+    assert completed["ok"] is True
+
+    with kb.connect() as conn:
+        child = kb.create_task(conn, title="release", assignee="release")
+    linked = json.loads(kt._handle_link({
+        "parent_id": worker_env,
+        "child_id": child,
+        "accepted_outcome_codes": ["APPROVED"],
+        "subject_sha": sha,
+    }))
+    assert linked["ok"] is True
+
+    with kb.connect() as conn:
+        run = kb.latest_run(conn, worker_env)
+        assert run.outcome_code == "APPROVED"
+        assert run.subject_sha == sha
+        assert kb.get_task(conn, child).status == "ready"
+
+    assert "outcome_code" in kt.KANBAN_COMPLETE_SCHEMA["parameters"]["properties"]
+    assert "accepted_outcome_codes" in kt.KANBAN_LINK_SCHEMA["parameters"]["properties"]
+
+
 def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -512,6 +512,7 @@ def _handle_show(args: dict, **kw) -> str:
             runs = kb.list_runs(conn, tid)
             parents = kb.parent_ids(conn, tid)
             children = kb.child_ids(conn, tid)
+            dependency_edges = kb.list_dependency_edges(conn, tid)
 
             def _task_dict(t):
                 return {
@@ -533,6 +534,8 @@ def _handle_show(args: dict, **kw) -> str:
                 return {
                     "id": r.id, "profile": r.profile,
                     "status": r.status, "outcome": r.outcome,
+                    "outcome_code": r.outcome_code,
+                    "subject_sha": r.subject_sha,
                     "summary": r.summary, "error": r.error,
                     "metadata": r.metadata,
                     "started_at": r.started_at, "ended_at": r.ended_at,
@@ -542,6 +545,7 @@ def _handle_show(args: dict, **kw) -> str:
                 "task": _task_dict(task),
                 "parents": parents,
                 "children": children,
+                "dependency_edges": dependency_edges,
                 "comments": [
                     {"author": c.author, "body": c.body,
                      "created_at": c.created_at}
@@ -766,6 +770,8 @@ def _handle_complete(args: dict, **kw) -> str:
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
+                    outcome_code=args.get("outcome_code"),
+                    subject_sha=args.get("subject_sha"),
                 )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(
@@ -1519,7 +1525,13 @@ def _handle_link(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            kb.link_tasks(conn, parent_id=parent_id, child_id=child_id)
+            kb.link_tasks(
+                conn,
+                parent_id=parent_id,
+                child_id=child_id,
+                accepted_outcome_codes=args.get("accepted_outcome_codes"),
+                subject_sha=args.get("subject_sha"),
+            )
             return _ok(parent_id=parent_id, child_id=child_id)
         finally:
             conn.close()
@@ -1714,6 +1726,16 @@ KANBAN_COMPLETE_SCHEMA = {
                     "cleanup; a missing declared scratch artifact keeps the "
                     "task in-flight so you can fix the path and retry."
                 ),
+            },
+            "outcome_code": {
+                "type": "string",
+                "enum": ["APPROVED", "REJECT"],
+                "description": "Structured completion outcome for conditional dependencies.",
+            },
+            "subject_sha": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{40}$",
+                "description": "Exact lowercase full Git SHA reviewed.",
             },
             "board": _board_schema_prop(),
         },
@@ -2130,6 +2152,18 @@ KANBAN_LINK_SCHEMA = {
         "properties": {
             "parent_id": {"type": "string", "description": "Parent task id."},
             "child_id":  {"type": "string", "description": "Child task id."},
+            "accepted_outcome_codes": {
+                "type": "array",
+                "items": {"type": "string", "enum": ["APPROVED", "REJECT"]},
+                "minItems": 1,
+                "uniqueItems": True,
+                "description": "Accepted structured parent outcomes.",
+            },
+            "subject_sha": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{40}$",
+                "description": "Exact parent subject SHA required by the child.",
+            },
             "board": _board_schema_prop(),
         },
         "required": ["parent_id", "child_id"],


### PR DESCRIPTION
## Summary

- persist structured reviewer completion evidence with `outcome_code` and an exact full `subject_sha`
- add opt-in conditional dependency edges with accepted outcome codes and an expected subject SHA
- enforce one fail-closed dependency predicate across linking, recompute, manual promotion, unblock, claim/review-claim, and requeue paths
- preserve legacy unconditional completion-only dependencies and add additive database migration/read compatibility
- expose the structured contract through the CLI, worker tools, dashboard API, and inspectable task/run models

## Contract

- Contract ID: `hermes-agent:outcome-conditional-dependencies-core`
- Contract revision: `1`
- Coder task: `t_9778888d`
- Independent Reviewer task: `t_966be34f`
- Release Gate task: `t_6c375364`
- Exact reviewed head: `2d3fce3d4e86ca012d27e56fb8eb066e1b27988f`
- Reviewed base: `2446c8bb6755ff5e6feff4d26e425661edd4019b`

## Acceptance coverage

- `APPROVED` with the matching full SHA satisfies a conditional edge and permits claim.
- `REJECT`, missing/unknown outcome, missing/malformed/abbreviated SHA, and SHA mismatch fail closed.
- Link-time promotion, automatic recompute, manual promotion (including `--force`), unblock, normal claim, review claim, and stale/reclaimed requeue paths share the same satisfaction rule.
- A stale-ready child is demoted and cannot be claimed after evidence changes.
- `REJECT` remains a normal successful review completion rather than a blocked or failed worker run.
- Existing unconditional dependency edges retain their prior completion-only behavior.
- Existing boards receive nullable additive columns; structured run and edge fields round-trip through canonical DB/API surfaces.
- Free text is never used as release authority.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_outcome_dependencies.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_promote.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py`
  - 5 files, 75 tests passed, 0 failed
- broader Kanban suite independently reviewed: 45 files, 281 tests passed, 0 failed
- independent temporary-database verifier passed REJECT, exact-SHA APPROVED, missing/unknown/malformed/mismatched evidence, legacy-edge, stale-ready claim, forced-promotion, and canonical edge round-trip scenarios
- Ruff passed on all eight changed Python files
- `git diff --check upstream/main...HEAD` passed
- complete diff: 8 files changed, 843 insertions, 105 deletions; no `project-truth.json`

## Independent review

Reviewer verdict: `APPROVED`

- `outcome_code`: `APPROVED`
- `subject_sha`: `2d3fce3d4e86ca012d27e56fb8eb066e1b27988f`
- findings: none
- scope drift: false

## Overlap check

Current open overlap was rechecked before publication. PR #74598 concerns transient runtime outcomes and does not implement conditional dependency evidence. PR #68981 derives acceptance from task-body prose and changes legacy dependency behavior, and PR #67405 lacks exact reviewed-subject SHA binding; neither satisfies this contract's complete fail-closed, exact-SHA, backward-compatible acceptance criteria.

This PR is intentionally open and unmerged. No deployment or runtime activation is part of this contract.
