### PR TITLE
fix(state): Propagate schema reconciliation failures

### DIFF
--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -394,13 +394,12 @@ class SessionSchemaMixin:
         """
         expected = self._parse_schema_columns(SCHEMA_SQL)
         for table_name, declared_cols in expected.items():
-            # Get current columns from the live table
-            try:
-                rows = cursor.execute(
-                    f'PRAGMA table_info("{table_name}")'
-                ).fetchall()
-            except sqlite3.OperationalError:
-                continue  # Table doesn't exist yet (shouldn't happen after executescript)
+            # Get current columns from the live table. Inspection failures must
+            # reach SessionDB's open retry/error path; a missing table simply
+            # returns no rows.
+            rows = cursor.execute(
+                f'PRAGMA table_info("{table_name}")'
+            ).fetchall()
             live_cols = set()
             for row in rows:
                 # PRAGMA table_info returns (cid, name, type, notnull, dflt_value, pk)
@@ -415,10 +414,11 @@ class SessionSchemaMixin:
                             f'ALTER TABLE "{table_name}" ADD COLUMN "{safe_name}" {col_type}'
                         )
                     except sqlite3.OperationalError as exc:
-                        # Expected: "duplicate column name" from a race or
-                        # re-run.  Unexpected: "Cannot add a NOT NULL column
-                        # with default value NULL" from a schema mistake.
-                        # Log at DEBUG so it's visible in agent.log.
+                        # A concurrent migrator may add the column after
+                        # ``live_cols`` is read. Only that race is benign;
+                        # every other failure must remain visible (#79531).
+                        if "duplicate column name" not in str(exc).lower():
+                            raise
                         logger.debug(
                             "reconcile %s.%s: %s", table_name, col_name, exc,
                         )

--- a/tests/test_schema_reconciliation.py
+++ b/tests/test_schema_reconciliation.py
@@ -1,0 +1,61 @@
+"""Schema reconciliation must surface migration failures to its retry owner."""
+
+import sqlite3
+from typing import cast
+
+import pytest
+
+from hermes_state_schema import SessionSchemaMixin
+
+
+class _SingleColumnSchema(SessionSchemaMixin):
+    @staticmethod
+    def _parse_schema_columns(schema_sql):
+        del schema_sql
+        return {"sessions": {"missing_column": "TEXT"}}
+
+
+class _ReconcileCursor:
+    def __init__(self, *, probe_error=None, alter_error=None):
+        self.probe_error = probe_error
+        self.alter_error = alter_error
+
+    def execute(self, statement):
+        if statement.startswith("PRAGMA table_info"):
+            if self.probe_error:
+                raise self.probe_error
+            return self
+        if statement.startswith("ALTER TABLE"):
+            if self.alter_error:
+                raise self.alter_error
+            return self
+        raise AssertionError(f"unexpected statement: {statement}")
+
+    def fetchall(self):
+        return [(0, "id", "TEXT", 0, None, 1)]
+
+
+def test_reconcile_propagates_schema_probe_lock():
+    cursor = _ReconcileCursor(
+        probe_error=sqlite3.OperationalError("database is locked")
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        _SingleColumnSchema()._reconcile_columns(cast(sqlite3.Cursor, cursor))
+
+
+def test_reconcile_propagates_database_lock():
+    cursor = _ReconcileCursor(
+        alter_error=sqlite3.OperationalError("database is locked")
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        _SingleColumnSchema()._reconcile_columns(cast(sqlite3.Cursor, cursor))
+
+
+def test_reconcile_tolerates_duplicate_column_race():
+    cursor = _ReconcileCursor(
+        alter_error=sqlite3.OperationalError("duplicate column name: missing_column")
+    )
+
+    _SingleColumnSchema()._reconcile_columns(cast(sqlite3.Cursor, cursor))


### PR DESCRIPTION
## What does this PR do?

Stops schema reconciliation from silently swallowing SQLite lock and migration errors. Only the benign concurrent `duplicate column name` race is ignored, allowing `SessionDB`'s existing open retry path to handle transient contention.

## Related Issue

Fixes #79531

This complements #80797: that PR fixes stale-schema detection on read-only opens; this PR fixes the independent writable-reconciliation path that swallowed migration lock and other operational errors. #80030 was an earlier draft of the #80797 approach.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- Propagate schema-probe and non-duplicate `ALTER TABLE` failures.
- Add regressions for probe locks, `ALTER TABLE` locks, and duplicate-column races.

## How to Test

```bash
scripts/run_tests.sh tests/test_schema_reconciliation.py tests/test_schema_read_probe.py tests/state/test_write_lock_patience.py -q
scripts/run_tests.sh tests/test_hermes_state.py -k TestSchemaInit -q
```

Results: 14 passed; 3 passed. Ruff and Python compile checks pass.

## Checklist

- [x] Read contributing guide and searched for duplicate PRs
- [x] Focused diff with regression tests
- [x] Considered cross-platform behavior
- [x] Documentation/config/tool schemas: N/A
