### PR TITLE
fix(compression): stop the stale-replay prune anchoring on retry scaffolding

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -281,12 +281,23 @@ def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
     # Find the last real user message — everything after it is the active
     # turn.  Synthetic continuation rows and tool results never mark a turn
     # boundary.
+    # ``role == "user"`` alone does not mean a human spoke: the retry loop
+    # appends ephemeral scaffolding rows under that role *inside* a turn
+    # (the codex incomplete/ack nudges, the length-continuation and
+    # dropped-tool-call nudges, the todo/continuation markers). Anchoring on
+    # one splits the in-flight turn and strips the reasoning bridging its
+    # earlier function calls — the exact mid-chain loss the user boundary
+    # replaced the last-assistant boundary to avoid. Ask the classifier that
+    # already knows those rows.
     last_user_idx = -1
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
-        if isinstance(msg, dict) and msg.get("role") == "user":
-            last_user_idx = i
-            break
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        if ContextCompressor._is_synthetic_compression_user_turn(msg):
+            continue
+        last_user_idx = i
+        break
     if last_user_idx < 0:
         # No user boundary found — cannot distinguish the active turn, so
         # prune nothing (fail open toward correctness, not size).

--- a/tests/agent/test_stale_replay_prune.py
+++ b/tests/agent/test_stale_replay_prune.py
@@ -106,6 +106,59 @@ def test_no_user_boundary_prunes_nothing():
     assert messages[1]["codex_reasoning_items"]
 
 
+def test_retry_nudge_does_not_split_the_active_turn():
+    """The retry loop appends role="user" scaffolding *inside* a turn.
+
+    Anchoring the boundary on one of those rows makes the earlier half of the
+    in-flight turn look stale, so the reasoning bridging its function calls is
+    stripped — the mid-chain loss the user boundary exists to prevent.
+    """
+    from agent.context_compressor import ContextCompressor
+    from agent.conversation_loop import _CODEX_INCOMPLETE_NUDGE
+
+    nudge = {"role": "user", "content": _CODEX_INCOMPLETE_NUDGE}
+    assert ContextCompressor._is_synthetic_compression_user_turn(nudge)
+
+    messages = [
+        {"role": "user", "content": "audit the config"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "read_file"}}],
+            "codex_reasoning_items": [_reasoning("rs_a")],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "file body"},
+        {"role": "assistant", "content": "", "codex_reasoning_items": [_reasoning("rs_b")]},
+        nudge,
+        {"role": "assistant", "content": "done", "codex_reasoning_items": [_reasoning("rs_c")]},
+    ]
+
+    assert _prune_stale_reasoning_replay(messages) == 0
+    assert messages[1]["codex_reasoning_items"]
+    assert messages[3]["codex_reasoning_items"]
+    assert messages[5]["codex_reasoning_items"]
+
+
+def test_real_user_turn_before_a_retry_nudge_is_still_the_boundary():
+    """Skipping scaffolding must not disable pruning — it relocates it."""
+    from agent.conversation_loop import _CODEX_INCOMPLETE_NUDGE
+
+    messages = [
+        {"role": "user", "content": "turn 1"},
+        {"role": "assistant", "content": "a1", "codex_reasoning_items": [_reasoning("rs_a")]},
+        {"role": "user", "content": "turn 2"},
+        {"role": "assistant", "content": "a2", "codex_reasoning_items": [_reasoning("rs_b")]},
+        {"role": "user", "content": _CODEX_INCOMPLETE_NUDGE},
+        {"role": "assistant", "content": "a3", "codex_reasoning_items": [_reasoning("rs_c")]},
+    ]
+
+    # "turn 2" is the boundary, so only turn 1's reasoning is stale.
+    assert _prune_stale_reasoning_replay(messages) == 1
+    assert "codex_reasoning_items" not in messages[1]
+    assert messages[3]["codex_reasoning_items"]
+    assert messages[5]["codex_reasoning_items"]
+
+
 def test_non_codex_messages_untouched():
     messages = [
         {"role": "user", "content": "u1"},


### PR DESCRIPTION
## What

`_prune_stale_reasoning_replay` picks its turn boundary like this:

```python
# Find the last real user message — everything after it is the active
# turn.  Synthetic continuation rows and tool results never mark a turn
# boundary.
last_user_idx = -1
for i in range(len(messages) - 1, -1, -1):
    msg = messages[i]
    if isinstance(msg, dict) and msg.get("role") == "user":
        last_user_idx = i
        break
```

The comment states the rule; the scan below it does not implement the first half. `role == "user"` is not the same question as "a human spoke here".

`conversation_loop`'s retry loop appends `role="user"` scaffolding rows *inside* a turn: the codex incomplete and ack-continuation nudges, the three length-continuation variants, the dropped-tool-call nudge, the todo/continuation markers. Anchoring the boundary on one of those splits the in-flight turn in half. Every assistant message before the nudge is then treated as a prior turn and loses its `codex_reasoning_items` — the encrypted items that bridge that turn's function calls, which the Responses API requires replayed together.

That is precisely the failure the boundary exists to prevent. e00965a7e (2026-08-08, fix(compression): correct prune boundary + exempt native compaction checkpoints) moved the anchor from the last assistant message to the last user message because "a single Codex turn spans several assistant messages … the last-assistant boundary would strip reasoning mid-chain from the in-flight turn". A retry nudge reintroduces exactly that split through a different door.

The classifier for these rows already exists and already knows all of them. 45cd93fb5 (2026-08-08, fix(agent): recognize the retry loop's other synthetic nudges during compaction) extended `_is_synthetic_compression_user_turn` to cover the retry-loop nudges, for the same "ephemeral runtime scaffolding rather than a human turn" reason. The prune boundary never asks it.

Driving the real function over one Codex turn — `assistant+tool_calls → tool → assistant → nudge → assistant`, reasoning items A, B, C:

| transcript | messages pruned | reasoning surviving |
| --- | --- | --- |
| with the retry nudge | 2 | `C` |
| same turn, nudge removed | 0 | `A`, `B`, `C` |

The classifier answers `True` for that same nudge row. The presence of the scaffolding alone costs the turn two thirds of its replay chain.

## The fix

Skip rows `_is_synthetic_compression_user_turn` recognizes while scanning for the boundary, so the anchor lands on the last row a human actually sent.

Sharing that predicate rather than re-deriving the nudge set keeps the two from drifting — the same reason `merge_interim_reasoning_items` was extracted in e00965a7e.

Note this is deliberately conservative in one direction: a compaction summary handoff also classifies as synthetic, so when one is the newest user-role row the scan walks past it and, finding no human turn behind it, prunes nothing. That trades some token savings for never breaking a replay chain, which is the tradeoff the function's own no-boundary branch already takes ("fail open toward correctness, not size").

## Tests and results

Two cases added to `tests/agent/test_stale_replay_prune.py`:

- a retry nudge mid-turn no longer splits it — all three assistant messages keep their items, and the nudge is asserted to be one the classifier recognizes, so the test pins the real contract rather than a hand-made string
- skipping scaffolding relocates the boundary instead of disabling pruning: with a genuine second user turn present, turn 1's reasoning is still pruned and turns 2–3 are kept

Reverting only `agent/context_compressor.py` turns both red; the eleven pre-existing tests in that file stay green either way. 13 passed with the change.

`tests/agent -k "prune or compaction or compress"` — 514 passed, 4 skipped. Two failures in that selection (`test_compression_review_76354.py::TestF6ExecutorSaturation::test_cancelled_fence_skips_summary_work_before_start` and `test_curator_classification.py::test_report_md_splits_consolidated_and_pruned_sections`) reproduce identically with the change reverted, so they are pre-existing and unrelated.
