### PR TITLE
fix(desktop): avoid layered opaque windows on Windows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -225,6 +225,7 @@ import {
   MIN_HEIGHT as WINDOW_MIN_HEIGHT,
   MIN_WIDTH as WINDOW_MIN_WIDTH
 } from './window-state'
+import { initialWindowTranslucencyOptions, opacityForTranslucency } from './window-translucency'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 import {
   buildPathExtCandidates,
@@ -775,11 +776,14 @@ let translucencyIntensity = readPersistedTranslucency()
 // Map the 0–100 lever to a window opacity. Floor at 0.3 so the most see-through
 // setting is still usable rather than nearly invisible. 0 → fully opaque.
 function windowOpacity() {
-  return 1 - (translucencyIntensity / 100) * 0.7
+  return opacityForTranslucency(translucencyIntensity)
 }
 
 // Re-apply translucency to a live window (runtime toggle, no recreation).
 // `setOpacity` is a no-op on Linux, which is fine — it just stays opaque there.
+// On Windows, setting this back to 1 restores visual opacity but Electron keeps
+// the existing HWND layered until the window is recreated. Cold opaque starts
+// avoid that compositor path through initialWindowTranslucencyOptions().
 function applyWindowTranslucency(win) {
   if (!win || win.isDestroyed() || typeof win.setOpacity !== 'function') {
     return
@@ -8864,7 +8868,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     titleBarOverlay: getTitleBarOverlayOptions(),
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    ...initialWindowTranslucencyOptions(translucencyIntensity, IS_WINDOWS),
     icon,
     // Don't show until the renderer's first themed paint is ready. macOS
     // `vibrancy` ignores `backgroundColor` and paints a translucent OS
@@ -8946,7 +8950,7 @@ function createInstanceWindow() {
     titleBarOverlay: getTitleBarOverlayOptions(),
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    ...initialWindowTranslucencyOptions(translucencyIntensity, IS_WINDOWS),
     icon,
     show: false,
     backgroundColor: getWindowBackgroundColor(),
@@ -9716,7 +9720,7 @@ function createWindow() {
     titleBarOverlay: getTitleBarOverlayOptions(),
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    ...initialWindowTranslucencyOptions(translucencyIntensity, IS_WINDOWS),
     icon,
     // Hidden until the first themed paint so macOS `vibrancy` (which ignores
     // `backgroundColor` and follows the OS appearance) can't flash a light

--- a/apps/desktop/electron/window-translucency.test.ts
+++ b/apps/desktop/electron/window-translucency.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { initialWindowTranslucencyOptions, opacityForTranslucency } from './window-translucency'
+
+test('opacityForTranslucency maps the control range to usable opacity', () => {
+  assert.equal(opacityForTranslucency(0), 1)
+  assert.equal(opacityForTranslucency(50), 0.65)
+  assert.ok(Math.abs(opacityForTranslucency(100) - 0.3) < Number.EPSILON)
+})
+
+test('initialWindowTranslucencyOptions omits opacity for opaque Windows starts', () => {
+  const options = initialWindowTranslucencyOptions(0, true)
+
+  assert.deepEqual(options, {})
+  assert.equal(Object.hasOwn(options, 'opacity'), false)
+})
+
+test('initialWindowTranslucencyOptions retains opacity for translucent Windows starts', () => {
+  assert.deepEqual(initialWindowTranslucencyOptions(50, true), { opacity: 0.65 })
+  assert.ok(Math.abs(initialWindowTranslucencyOptions(100, true).opacity! - 0.3) < Number.EPSILON)
+})
+
+test('initialWindowTranslucencyOptions preserves non-Windows behavior', () => {
+  assert.deepEqual(initialWindowTranslucencyOptions(0, false), { opacity: 1 })
+})

--- a/apps/desktop/electron/window-translucency.ts
+++ b/apps/desktop/electron/window-translucency.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure helpers for native BrowserWindow translucency.
+ *
+ * Omitting the `opacity` option at zero is behaviorally important on Windows:
+ * Electron's SetOpacity path marks the HWND as layered even when the value is
+ * exactly 1, and that layered composition mode cannot be removed from the live
+ * window by calling setOpacity(1). A fully opaque cold start should therefore
+ * never enter that path.
+ */
+
+function opacityForTranslucency(intensity: number): number {
+  // Floor at 0.3 so the most translucent setting remains usable.
+  return 1 - (intensity / 100) * 0.7
+}
+
+function initialWindowTranslucencyOptions(intensity: number, isWindows: boolean): { opacity?: number } {
+  return isWindows && intensity === 0 ? {} : { opacity: opacityForTranslucency(intensity) }
+}
+
+export { initialWindowTranslucencyOptions, opacityForTranslucency }


### PR DESCRIPTION
## What does this PR do?

Keeps fully opaque Hermes windows off Windows' layered-window compositor path.

When Chat Window Translucency is 0, Hermes currently passes `opacity: 1` to every full `BrowserWindow`. Electron treats the presence of that option as a call to `SetOpacity`; on Windows, that permanently adds `WS_EX_LAYERED` to the HWND even though the window is visually opaque.

This PR omits the initial `opacity` property only on Windows at intensity 0. Non-zero translucency and non-Windows behavior are unchanged. The fix covers the primary window, peer instance windows, and standalone session windows.

## Related Issue

Fixes #82572

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a pure `window-translucency` policy helper.
- Omitted `opacity` for opaque Windows cold starts in all three full-window constructors.
- Preserved opacity mapping for non-zero translucency and all existing non-Windows behavior.
- Documented Electron's live-window limitation: `setOpacity(1)` restores visual opacity, but a new window/restart is required to remove the layered compositor path after translucency was previously enabled.
- Added behavior tests for property omission, opacity mapping, and cross-platform preservation.

## How to Test

1. Leave Chat Window Translucency at 0 and launch a packaged Windows build.
2. Inspect the main HWND with `GetWindowLongPtr(GWL_EXSTYLE)` and verify `WS_EX_LAYERED` is absent.
3. Set translucency above 0 and verify the native opacity behavior is unchanged.

Manual Windows 11 validation:

- Before (current 0.17.0): `ExStyle=0x280100`, `WS_EX_LAYERED=True`
- After (this PR): `ExStyle=0x200100`, `WS_EX_LAYERED=False`

Automated validation:

- `npm run test:desktop:platforms -- electron/window-translucency.test.ts` — 4/4 passed
- `npm run typecheck` — passed
- Focused ESLint and Prettier checks — passed
- `npm run test:desktop:all` — passed; Windows NSIS package built and validated
- Full Electron suite — 983 passed, 21 failed, 2 skipped. The same 21 unrelated POSIX/path/file-mode tests fail on untouched `origin/main` (targeted baseline: 21 failed, 132 passed, 1 skipped); none imports or exercises this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] N/A — desktop-only TypeScript change; the relevant desktop suites are listed above
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 (10.0.26200)

### Documentation & Housekeeping

- [x] N/A — implementation comments document the native lifecycle constraint
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow changes
- [x] Cross-platform behavior is explicitly preserved and tested
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

Native style probe from the packaged fixed build:

```text
Pid         : 70728
Hwnd        : 0x78197E
ExStyle     : 0x200100
WsExLayered : False
```