### PR TITLE
fix(desktop): scope sidebar data to active profile

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -161,7 +161,7 @@ import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
-import { fetchPrimaryProfileSessions } from './profile-session-routing'
+import { fetchPrimaryProfileSessions, sidebarSessionSliceParams } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
@@ -10606,36 +10606,7 @@ async function interceptSessionRequestForRemote(request) {
       return undefined // local fast path → batched endpoint's single DB open
     }
 
-    const recentsProfile = (searchParams.get('recents_profile') || 'all').trim() || 'all'
-
-    const sliceParams = (limitKey, defaultLimit, extra) => {
-      const sp = new URLSearchParams({
-        limit: searchParams.get(limitKey) || defaultLimit,
-        offset: '0',
-        min_messages: '1',
-        archived: 'exclude',
-        order: 'recent',
-        ...extra
-      })
-
-      return sp
-    }
-
-    const recentsSp = sliceParams('recents_limit', '20', { profile: recentsProfile })
-    const recentsExclude = searchParams.get('recents_exclude')
-
-    if (recentsExclude) {
-      recentsSp.set('exclude_sources', recentsExclude)
-    }
-
-    const cronSp = sliceParams('cron_limit', '50', { profile: 'all', source: 'cron' })
-
-    const messagingSp = sliceParams('messaging_limit', '100', { profile: 'all' })
-    const messagingExclude = searchParams.get('messaging_exclude')
-
-    if (messagingExclude) {
-      messagingSp.set('exclude_sources', messagingExclude)
-    }
+    const { recents: recentsSp, cron: cronSp, messaging: messagingSp } = sidebarSessionSliceParams(searchParams)
 
     const [recents, cron, messaging] = await Promise.all([
       fetchProfilesSessionSlice(recentsSp, remoteProfiles),

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -2,7 +2,32 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { fetchPrimaryProfileSessions } from './profile-session-routing'
+import { fetchPrimaryProfileSessions, sidebarSessionSliceParams } from './profile-session-routing'
+
+test('sidebar slice fan-out keeps every slice on the requested profile', () => {
+  const slices = sidebarSessionSliceParams(
+    new URLSearchParams({
+      recents_profile: 'work',
+      recents_limit: '30',
+      cron_limit: '50',
+      messaging_limit: '100',
+      recents_exclude: 'cron,tool',
+      messaging_exclude: 'cron,desktop'
+    })
+  )
+
+  assert.equal(slices.recents.get('profile'), 'work')
+  assert.equal(slices.cron.get('profile'), 'work')
+  assert.equal(slices.messaging.get('profile'), 'work')
+})
+
+test('sidebar slice fan-out preserves the explicit all-profiles scope', () => {
+  const slices = sidebarSessionSliceParams(new URLSearchParams({ recents_profile: 'all' }))
+
+  assert.equal(slices.recents.get('profile'), 'all')
+  assert.equal(slices.cron.get('profile'), 'all')
+  assert.equal(slices.messaging.get('profile'), 'all')
+})
 
 test('primary session reads use the profile-aware request path', async () => {
   const calls: Array<{ profile: string | null; path: string }> = []

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -7,6 +7,45 @@ export interface ProfileSessionsResponse {
 
 type FetchJsonForProfile = (profile: string | null, path: string) => Promise<unknown>
 
+export function sidebarSessionSliceParams(searchParams: URLSearchParams): {
+  recents: URLSearchParams
+  cron: URLSearchParams
+  messaging: URLSearchParams
+} {
+  const profile = (searchParams.get('recents_profile') || 'all').trim() || 'all'
+
+  const slice = (limitKey: string, defaultLimit: string, extra: Record<string, string> = {}) =>
+    new URLSearchParams({
+      limit: searchParams.get(limitKey) || defaultLimit,
+      offset: '0',
+      min_messages: '1',
+      archived: 'exclude',
+      order: 'recent',
+      profile,
+      ...extra
+    })
+
+  const recents = slice('recents_limit', '20')
+  const recentsExclude = searchParams.get('recents_exclude')
+
+  if (recentsExclude) {
+    recents.set('exclude_sources', recentsExclude)
+  }
+
+  const messaging = slice('messaging_limit', '100')
+  const messagingExclude = searchParams.get('messaging_exclude')
+
+  if (messagingExclude) {
+    messaging.set('exclude_sources', messagingExclude)
+  }
+
+  return {
+    recents,
+    cron: slice('cron_limit', '50', { source: 'cron' }),
+    messaging
+  }
+}
+
 export async function fetchPrimaryProfileSessions(
   searchParams: URLSearchParams,
   fetchJsonForProfile: FetchJsonForProfile

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -2,16 +2,23 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
+import { $cronJobs, setCronJobs } from '@/store/cron'
+import { ALL_PROFILES } from '@/store/profile'
 import {
   $cronSessions,
+  $messagingPlatformTotals,
   $messagingSessions,
+  $messagingTruncated,
   $sessions,
   $sessionsLoading,
   setCronSessions,
+  setMessagingPlatformTotals,
   setMessagingSessions,
+  setMessagingTruncated,
   setSessions,
   setSessionsLoading
 } from '@/store/session'
+import type { CronJob } from '@/types/hermes'
 
 import { useSessionListActions } from './use-session-list-actions'
 
@@ -38,6 +45,8 @@ const row = (id: string, over: Partial<SessionInfo> = {}): SessionInfo =>
     ...over
   }) as SessionInfo
 
+const job = (id: string): CronJob => ({ enabled: true, id })
+
 // Batched sidebar response builder. `refreshSessions` now makes ONE
 // listSidebarSessions call that returns all three slices, replacing the three
 // separate listAllProfileSessions calls (each of which reopened every profile
@@ -54,10 +63,21 @@ const sidebar = (
 
 const listSidebarSessions = vi.fn()
 const listAllProfileSessions = vi.fn()
+const getCronJobs = vi.fn()
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
 
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  getCronJobs: vi.fn(async () => []),
+  getCronJobs: (...args: unknown[]) => getCronJobs(...args),
   listAllProfileSessions: (...args: unknown[]) => listAllProfileSessions(...args),
   listSidebarSessions: (...args: unknown[]) => listSidebarSessions(...args)
 }))
@@ -73,17 +93,25 @@ vi.mock('@/store/projects', () => ({
 beforeEach(() => {
   listSidebarSessions.mockReset()
   listAllProfileSessions.mockReset()
+  getCronJobs.mockReset()
+  getCronJobs.mockResolvedValue([])
   removed.ids = new Set()
   setSessions([])
   setCronSessions([])
+  setCronJobs([])
   setMessagingSessions([])
+  setMessagingPlatformTotals({})
+  setMessagingTruncated(false)
   setSessionsLoading(false)
 })
 
 afterEach(() => {
   setSessions([])
   setCronSessions([])
+  setCronJobs([])
   setMessagingSessions([])
+  setMessagingPlatformTotals({})
+  setMessagingTruncated(false)
   setSessionsLoading(false)
 })
 
@@ -229,7 +257,6 @@ describe('refreshSessions batches slices into one request', () => {
   })
 
   it('scopes the cron-jobs fetch to the active profile (all → unified view)', async () => {
-    const { getCronJobs } = await import('@/hermes')
     listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
 
     const scoped = renderHook(() => useSessionListActions({ profileScope: 'work' }))
@@ -247,5 +274,415 @@ describe('refreshSessions batches slices into one request', () => {
     })
 
     expect(getCronJobs).toHaveBeenLastCalledWith('all')
+  })
+})
+
+describe('profile scope re-home boundary', () => {
+  it('clears every profile-scoped secondary store in the scope-change commit', () => {
+    const { rerender } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    setCronSessions([row('cron-work', { profile: 'work', source: 'cron' })])
+    setCronJobs([job('job-work')])
+    setMessagingSessions([row('message-work', { profile: 'work', source: 'telegram' })])
+    setMessagingTruncated(true)
+    setMessagingPlatformTotals({ telegram: 42 })
+
+    rerender({ profileScope: 'personal' })
+
+    expect($cronSessions.get()).toEqual([])
+    expect($cronJobs.get()).toEqual([])
+    expect($messagingSessions.get()).toEqual([])
+    expect($messagingTruncated.get()).toBe(false)
+    expect($messagingPlatformTotals.get()).toEqual({})
+  })
+
+  it('rejects a stale batched refresh after the scope changes', async () => {
+    const workRequest = deferred<SidebarSessionsResponse>()
+    listSidebarSessions.mockReturnValueOnce(workRequest.promise)
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    let refresh!: Promise<void>
+
+    await act(async () => {
+      refresh = result.current.refreshSessions()
+      await Promise.resolve()
+    })
+
+    rerender({ profileScope: 'personal' })
+    setCronSessions([row('cron-personal', { profile: 'personal', source: 'cron' })])
+    setMessagingSessions([row('message-personal', { profile: 'personal', source: 'telegram' })])
+
+    await act(async () => {
+      workRequest.resolve(
+        sidebar(
+          { sessions: [row('recent-work', { profile: 'work' })] },
+          [row('cron-work', { profile: 'work', source: 'cron' })],
+          [row('message-work', { profile: 'work', source: 'telegram' })]
+        )
+      )
+      await refresh
+    })
+
+    expect($cronSessions.get().map(session => session.id)).toEqual(['cron-personal'])
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['message-personal'])
+    expect(getCronJobs).not.toHaveBeenCalled()
+  })
+
+  it('does not let an older batch overwrite a newer dedicated messaging refresh', async () => {
+    const batchRequest = deferred<SidebarSessionsResponse>()
+    const messagingRequest = deferred<{ sessions: SessionInfo[] }>()
+    listSidebarSessions.mockReturnValueOnce(batchRequest.promise)
+    listAllProfileSessions.mockReturnValueOnce(messagingRequest.promise)
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+
+    let batchRefresh!: Promise<void>
+    let messagingRefresh!: Promise<void>
+
+    await act(async () => {
+      batchRefresh = result.current.refreshSessions()
+      messagingRefresh = result.current.refreshMessagingSessions()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      messagingRequest.resolve({ sessions: [row('message-newer', { profile: 'work', source: 'telegram' })] })
+      await messagingRefresh
+    })
+
+    await act(async () => {
+      batchRequest.resolve(
+        sidebar(
+          { sessions: [row('recent-work', { profile: 'work' })] },
+          [],
+          [row('message-older', { profile: 'work', source: 'telegram' })]
+        )
+      )
+      await batchRefresh
+    })
+
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['message-newer'])
+  })
+
+  it('rejects stale and out-of-order cron jobs refreshes', async () => {
+    const staleWorkRequest = deferred<CronJob[]>()
+    const olderPersonalRequest = deferred<CronJob[]>()
+    const newerPersonalRequest = deferred<CronJob[]>()
+    getCronJobs
+      .mockReturnValueOnce(staleWorkRequest.promise)
+      .mockReturnValueOnce(olderPersonalRequest.promise)
+      .mockReturnValueOnce(newerPersonalRequest.promise)
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    let staleWorkRefresh!: Promise<void>
+    let olderPersonalRefresh!: Promise<void>
+    let newerPersonalRefresh!: Promise<void>
+
+    await act(async () => {
+      staleWorkRefresh = result.current.refreshCronJobs()
+      await Promise.resolve()
+    })
+
+    rerender({ profileScope: 'personal' })
+
+    await act(async () => {
+      olderPersonalRefresh = result.current.refreshCronJobs()
+      newerPersonalRefresh = result.current.refreshCronJobs()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      newerPersonalRequest.resolve([job('job-personal-newer')])
+      await newerPersonalRefresh
+      olderPersonalRequest.resolve([job('job-personal-older')])
+      await olderPersonalRefresh
+      staleWorkRequest.resolve([job('job-work')])
+      await staleWorkRefresh
+    })
+
+    expect($cronJobs.get().map(job => job.id)).toEqual(['job-personal-newer'])
+  })
+
+  it('rejects an old A batch after an A to B to A transition', async () => {
+    const oldWorkRequest = deferred<SidebarSessionsResponse>()
+    listSidebarSessions.mockReturnValueOnce(oldWorkRequest.promise)
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    let oldWorkRefresh!: Promise<void>
+
+    await act(async () => {
+      oldWorkRefresh = result.current.refreshSessions()
+      await Promise.resolve()
+    })
+
+    rerender({ profileScope: 'personal' })
+    rerender({ profileScope: 'work' })
+    setCronSessions([row('cron-current-work', { profile: 'work', source: 'cron' })])
+    setMessagingSessions([row('message-current-work', { profile: 'work', source: 'telegram' })])
+
+    await act(async () => {
+      oldWorkRequest.resolve(
+        sidebar(
+          { sessions: [row('recent-old-work', { profile: 'work' })] },
+          [row('cron-old-work', { profile: 'work', source: 'cron' })],
+          [row('message-old-work', { profile: 'work', source: 'telegram' })]
+        )
+      )
+      await oldWorkRefresh
+    })
+
+    expect($cronSessions.get().map(session => session.id)).toEqual(['cron-current-work'])
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['message-current-work'])
+    expect(getCronJobs).not.toHaveBeenCalled()
+  })
+
+  it('preserves ALL_PROFILES as a real scope while re-homing its secondary stores', async () => {
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    setCronSessions([row('cron-work', { profile: 'work', source: 'cron' })])
+    rerender({ profileScope: ALL_PROFILES })
+
+    expect($cronSessions.get()).toEqual([])
+
+    await act(async () => {
+      await result.current.refreshSessions()
+      await result.current.refreshCronJobs()
+    })
+
+    expect(listSidebarSessions).toHaveBeenLastCalledWith(expect.objectContaining({ recentsProfile: 'all' }))
+    expect(getCronJobs).toHaveBeenLastCalledWith('all')
+  })
+})
+
+describe('messaging session profile scope', () => {
+  it('keeps the newest messaging refresh when requests resolve out of order', async () => {
+    const olderRequest = deferred<{ sessions: SessionInfo[] }>()
+    const newerRequest = deferred<{ sessions: SessionInfo[] }>()
+    listAllProfileSessions.mockReturnValueOnce(olderRequest.promise).mockReturnValueOnce(newerRequest.promise)
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+
+    let olderRefresh!: Promise<void>
+    let newerRefresh!: Promise<void>
+
+    await act(async () => {
+      olderRefresh = result.current.refreshMessagingSessions()
+      newerRefresh = result.current.refreshMessagingSessions()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      newerRequest.resolve({ sessions: [row('newer', { profile: 'work', source: 'telegram' })] })
+      await newerRefresh
+    })
+
+    await act(async () => {
+      olderRequest.resolve({ sessions: [row('older', { profile: 'work', source: 'telegram' })] })
+      await olderRefresh
+    })
+
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['newer'])
+  })
+
+  it('keeps the newest same-platform page when requests resolve out of order', async () => {
+    const olderRequest = deferred<{ sessions: SessionInfo[]; total: number }>()
+    const newerRequest = deferred<{ sessions: SessionInfo[]; total: number }>()
+    listAllProfileSessions.mockReturnValueOnce(olderRequest.promise).mockReturnValueOnce(newerRequest.promise)
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
+
+    let olderLoadMore!: Promise<void>
+    let newerLoadMore!: Promise<void>
+
+    await act(async () => {
+      olderLoadMore = result.current.loadMoreMessagingForPlatform('telegram')
+      newerLoadMore = result.current.loadMoreMessagingForPlatform('telegram')
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      newerRequest.resolve({
+        sessions: [row('newer', { profile: 'work', source: 'telegram' })],
+        total: 1
+      })
+      await newerLoadMore
+    })
+
+    await act(async () => {
+      olderRequest.resolve({
+        sessions: [row('older', { profile: 'work', source: 'telegram' })],
+        total: 1
+      })
+      await olderLoadMore
+    })
+
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['newer'])
+    expect($messagingPlatformTotals.get()).toEqual({ telegram: 1 })
+  })
+
+  it('does not publish a refresh that resolves after the profile scope changes', async () => {
+    const workRequest = deferred<{ sessions: SessionInfo[] }>()
+    listAllProfileSessions.mockReturnValueOnce(workRequest.promise)
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    let refresh!: Promise<void>
+
+    await act(async () => {
+      refresh = result.current.refreshMessagingSessions()
+      await Promise.resolve()
+    })
+
+    rerender({ profileScope: 'personal' })
+    setMessagingSessions([row('personal-row', { profile: 'personal', source: 'telegram' })])
+
+    await act(async () => {
+      workRequest.resolve({ sessions: [row('work-row', { profile: 'work', source: 'telegram' })] })
+      await refresh
+    })
+
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['personal-row'])
+  })
+
+  it('does not publish a platform page that resolves after the profile scope changes', async () => {
+    setMessagingSessions([row('work-seed', { profile: 'work', source: 'telegram' })])
+    const workRequest = deferred<{ sessions: SessionInfo[]; total: number }>()
+    listAllProfileSessions.mockReturnValueOnce(workRequest.promise)
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    let loadMore!: Promise<void>
+
+    await act(async () => {
+      loadMore = result.current.loadMoreMessagingForPlatform('telegram')
+      await Promise.resolve()
+    })
+
+    rerender({ profileScope: 'personal' })
+    setMessagingSessions([row('personal-row', { profile: 'personal', source: 'telegram' })])
+
+    await act(async () => {
+      workRequest.resolve({
+        sessions: [row('work-row', { profile: 'work', source: 'telegram' })],
+        total: 2
+      })
+      await loadMore
+    })
+
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['personal-row'])
+    expect($messagingPlatformTotals.get()).toEqual({})
+  })
+
+  it('resets exact platform totals when the profile scope changes, including ALL_PROFILES', () => {
+    const { rerender } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    setMessagingPlatformTotals({ telegram: 42 })
+
+    rerender({ profileScope: ALL_PROFILES })
+
+    expect($messagingPlatformTotals.get()).toEqual({})
+  })
+
+  it('refreshes messaging sessions for the concrete profile and maps ALL_PROFILES to all', async () => {
+    listAllProfileSessions.mockResolvedValue({ sessions: [] })
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    await act(async () => {
+      await result.current.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessions).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'work',
+      expect.any(Object)
+    )
+
+    rerender({ profileScope: ALL_PROFILES })
+
+    await act(async () => {
+      await result.current.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessions).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'all',
+      expect.any(Object)
+    )
+  })
+
+  it('loads more messaging sessions for the concrete profile and maps ALL_PROFILES to all', async () => {
+    listAllProfileSessions.mockResolvedValue({ sessions: [], total: 0 })
+
+    const { rerender, result } = renderHook(
+      ({ profileScope }) => useSessionListActions({ profileScope }),
+      { initialProps: { profileScope: 'work' } }
+    )
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('telegram')
+    })
+
+    expect(listAllProfileSessions).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'work',
+      expect.objectContaining({ source: 'telegram' })
+    )
+
+    rerender({ profileScope: ALL_PROFILES })
+
+    await act(async () => {
+      await result.current.loadMoreMessagingForPlatform('telegram')
+    })
+
+    expect(listAllProfileSessions).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      1,
+      'exclude',
+      'recent',
+      'all',
+      expect.objectContaining({ source: 'telegram' })
+    )
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 
 import { getCronJobs, listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
 import { sameCronSignature } from '@/lib/session-signatures'
@@ -78,21 +78,74 @@ interface UseSessionListActionsArgs {
   profileScope: string
 }
 
+interface ProfileScopeToken {
+  generation: number
+  identity: string
+}
+
+function matchesScope(current: ProfileScopeToken, identity: string, generation: number): boolean {
+  return current.identity === identity && current.generation === generation
+}
+
 /** Owns the sidebar's session-list fetching + paging: recents, cron runs/jobs,
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
+  const scopeRef = useRef({ generation: 0, identity: profileScope })
+  const messagingRequestSequenceRef = useRef(0)
+  const latestMessagingWholeRequestRef = useRef(0)
+  const latestMessagingMutationRef = useRef(0)
+  const messagingPlatformRequestRefs = useRef(new Map<string, number>())
+  const refreshCronJobsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
+
+  // These stores are global renderer caches but their contents belong to one
+  // profile scope. Re-home them in the scope-change commit, before the browser
+  // can paint the new scope with rows from the old one. Replacing the token
+  // invalidates every outstanding publisher even for A -> B -> A transitions.
+  useLayoutEffect(() => {
+    if (scopeRef.current.identity === profileScope) {
+      return
+    }
+
+    scopeRef.current = {
+      generation: scopeRef.current.generation + 1,
+      identity: profileScope
+    }
+    messagingPlatformRequestRefs.current.clear()
+    setCronSessions([])
+    setCronJobs([])
+    setMessagingSessions([])
+    setMessagingTruncated(false)
+    setMessagingPlatformTotals({})
+  }, [profileScope])
 
   // Messaging-platform sessions as their own slice, fetched separately from
   // local recents so each platform renders a self-managed section and never
   // competes with local chats for the recents page budget. One combined fetch
   // seeds every platform; the sidebar splits the rows per source.
   const refreshMessagingSessions = useCallback(async () => {
+    const requestId = messagingRequestSequenceRef.current + 1
+    messagingRequestSequenceRef.current = requestId
+    latestMessagingWholeRequestRef.current = requestId
+    latestMessagingMutationRef.current = requestId
+    const requestScopeGeneration = scopeRef.current.generation
+    const requestScopeIdentity = profileScope
+
     try {
-      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
+      const messagingProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+
+      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', messagingProfile, {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
       })
+
+      if (
+        !matchesScope(scopeRef.current, requestScopeIdentity, requestScopeGeneration) ||
+        latestMessagingWholeRequestRef.current !== requestId ||
+        latestMessagingMutationRef.current !== requestId
+      ) {
+        return
+      }
 
       // Drop any non-messaging source the broad exclude didn't catch (custom
       // sources) — those stay in local recents, not a platform section.
@@ -105,18 +158,38 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }
-  }, [])
+  }, [profileScope])
 
   // Page a single platform's section independently (mirrors the per-profile
   // pager): fetch that source's next window and merge it back in place, leaving
   // every other platform's rows untouched. Resolves the platform's exact total.
   const loadMoreMessagingForPlatform = useCallback(async (platform: string) => {
+    const requestId = messagingRequestSequenceRef.current + 1
+    messagingRequestSequenceRef.current = requestId
+    latestMessagingMutationRef.current = requestId
+    messagingPlatformRequestRefs.current.set(platform, requestId)
+    const requestScopeGeneration = scopeRef.current.generation
+    const requestScopeIdentity = profileScope
     const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
     const loaded = $messagingSessions.get().filter(inPlatform).length
+    const messagingProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
 
-    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', 'all', {
-      source: platform
-    })
+    const result = await listAllProfileSessions(
+      loaded + SIDEBAR_SESSIONS_PAGE_SIZE,
+      1,
+      'exclude',
+      'recent',
+      messagingProfile,
+      { source: platform }
+    )
+
+    if (
+      !matchesScope(scopeRef.current, requestScopeIdentity, requestScopeGeneration) ||
+      messagingPlatformRequestRefs.current.get(platform) !== requestId ||
+      latestMessagingWholeRequestRef.current > requestId
+    ) {
+      return
+    }
 
     const incoming = result.sessions.filter(s => normalizeSessionSource(s.source) === platform)
 
@@ -127,7 +200,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
     const total = result.total ?? incoming.length
     setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
-  }, [])
+  }, [profileScope])
 
   // Cron *jobs* drive the sidebar "Cron jobs" section. Jobs are created
   // synchronously (agent tool call or the cron UI), so refreshing here right
@@ -137,8 +210,20 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // fetch to the sidebar's profile scope — a concrete profile sees only its
   // own jobs; ALL_PROFILES keeps the unified view.
   const refreshCronJobs = useCallback(async () => {
+    const requestId = refreshCronJobsRequestRef.current + 1
+    refreshCronJobsRequestRef.current = requestId
+    const requestScopeGeneration = scopeRef.current.generation
+    const requestScopeIdentity = profileScope
+
     try {
       const jobs = await getCronJobs(profileScope === ALL_PROFILES ? 'all' : profileScope)
+
+      if (
+        !matchesScope(scopeRef.current, requestScopeIdentity, requestScopeGeneration) ||
+        refreshCronJobsRequestRef.current !== requestId
+      ) {
+        return
+      }
 
       setCronJobs(jobs)
     } catch {
@@ -149,6 +234,12 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   const refreshSessions = useCallback(async () => {
     const requestId = refreshSessionsRequestRef.current + 1
     refreshSessionsRequestRef.current = requestId
+    const messagingRequestId = messagingRequestSequenceRef.current + 1
+    messagingRequestSequenceRef.current = messagingRequestId
+    latestMessagingWholeRequestRef.current = messagingRequestId
+    latestMessagingMutationRef.current = messagingRequestId
+    const requestScopeGeneration = scopeRef.current.generation
+    const requestScopeIdentity = profileScope
     // The loading flag exists to drive the initial skeletons (they only render
     // while the list is empty). Turn-complete / reconnect refreshes over a
     // populated list used to flip it true→false anyway, churning every
@@ -171,7 +262,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // Scope recents to the active profile (not always 'all') so a profile
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page — the empty-history-on-profile-switch bug. Cron + messaging
-      // stay cross-profile.
+      // use the same selected-profile scope so no sidebar slice leaks profiles.
       const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
 
       // Batched: one request opens each profile DB once and returns all three
@@ -186,7 +277,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         messagingExclude: MESSAGING_EXCLUDED_SOURCES
       })
 
-      if (refreshSessionsRequestRef.current === requestId) {
+      if (
+        matchesScope(scopeRef.current, requestScopeIdentity, requestScopeGeneration) &&
+        refreshSessionsRequestRef.current === requestId
+      ) {
         const recents = result.recents
 
         // Drop rows the user just deleted/archived: a refresh can race an
@@ -228,23 +322,37 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         // resolves via sessionByAnyId), signature-gated like above.
         setCronSessions(prev => (sameCronSignature(prev, result.cron.sessions) ? prev : result.cron.sessions))
 
-        // Messaging sections: drop any non-messaging source the broad exclude
-        // didn't catch (custom sources stay in local recents), then split per
-        // platform in the UI.
-        const messagingRows = result.messaging.sessions.filter(s => isMessagingSource(s.source))
+        if (
+          latestMessagingWholeRequestRef.current === messagingRequestId &&
+          latestMessagingMutationRef.current === messagingRequestId
+        ) {
+          // Messaging sections: drop any non-messaging source the broad exclude
+          // didn't catch (custom sources stay in local recents), then split per
+          // platform in the UI.
+          const messagingRows = result.messaging.sessions.filter(s => isMessagingSource(s.source))
 
-        setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
-        // Hit the cap → at least one platform may have more on disk than loaded.
-        setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+          setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
+          // Hit the cap → at least one platform may have more on disk than loaded.
+          setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+        }
       }
     } finally {
-      if (showLoading && refreshSessionsRequestRef.current === requestId) {
+      if (
+        showLoading &&
+        matchesScope(scopeRef.current, requestScopeIdentity, requestScopeGeneration) &&
+        refreshSessionsRequestRef.current === requestId
+      ) {
         setSessionsLoading(false)
       }
     }
 
     // Cron *jobs* are a distinct API (getCronJobs), not a session slice.
-    void refreshCronJobs()
+    if (
+      matchesScope(scopeRef.current, requestScopeIdentity, requestScopeGeneration) &&
+      refreshSessionsRequestRef.current === requestId
+    ) {
+      void refreshCronJobs()
+    }
   }, [profileScope, refreshCronJobs])
 
   const loadMoreSessions = useCallback(async () => {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -151,7 +151,7 @@ describe('Hermes REST helpers', () => {
     })
 
     // Slices reassembled from the legacy per-slice route with the same
-    // scoping: recents on the caller's profile, cron + messaging cross-profile.
+    // caller-selected profile scope for recents, cron, and messaging.
     expect(result.recents.sessions.map(s => s.id)).toEqual(['recent-1'])
     // One row back against a 30-row window: the profile is fully loaded, so
     // the legacy path must not claim there's another page.
@@ -160,9 +160,10 @@ describe('Hermes REST helpers', () => {
     expect(result.messaging.sessions.map(s => s.id)).toEqual(['msg-1'])
 
     const paths = api.mock.calls.map(call => (call[0] as { path: string }).path)
+    const legacyPaths = paths.filter(p => p.startsWith('/api/profiles/sessions?'))
     expect(paths.filter(p => p.startsWith('/api/profiles/sessions/sidebar'))).toHaveLength(1)
-    expect(paths.filter(p => p.startsWith('/api/profiles/sessions?'))).toHaveLength(3)
-    expect(paths).toContainEqual(expect.stringContaining('profile=work'))
+    expect(legacyPaths).toHaveLength(3)
+    expect(legacyPaths.filter(p => p.includes('profile=work'))).toHaveLength(3)
     expect(paths).toContainEqual(expect.stringContaining('source=cron'))
     expect(paths).toContainEqual(expect.stringContaining('exclude_sources=cron%2Ctool'))
   })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -452,8 +452,8 @@ export async function listAllProfileSessions(
   }
 }
 
-// Batched sidebar slices in one request: recents (scoped to the active profile),
-// cron, and messaging. The backend opens each profile's state.db once and runs
+// Batched sidebar slices in one request: recents, cron, and messaging, all
+// scoped to the requested profile. The backend opens each profile's state.db once and runs
 // all three filtered queries, replacing three separate listAllProfileSessions
 // calls that each reopened + re-counted every profile DB per refresh. Electron
 // splices remote profiles per slice (see interceptSessionRequestForRemote).
@@ -535,15 +535,15 @@ function isEndpointMissingError(err: unknown): boolean {
 // Compatibility fallback: reassemble the three sidebar slices from the
 // per-slice endpoint, mirroring the batched route's semantics (min_messages=1,
 // archived excluded, recency order; recents scoped to the caller's profile,
-// cron + messaging cross-profile). Rides the same Electron remote-splice
+// cron + messaging scoped to that same profile). Rides the same Electron remote-splice
 // interception as the pre-batching desktop, so remote profiles stay correct.
 async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<SidebarSessionsResponse> {
   const [recents, cron, messaging] = await Promise.all([
     listAllProfileSessions(req.recentsLimit, 1, 'exclude', 'recent', req.recentsProfile, {
       excludeSources: req.recentsExclude
     }),
-    listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', 'all', { source: 'cron' }),
-    listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', 'all', {
+    listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', req.recentsProfile, { source: 'cron' }),
+    listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', req.recentsProfile, {
       excludeSources: req.messagingExclude
     })
   ])

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -241,8 +241,8 @@ def get_profiles_sessions_sidebar(
     """Batched sidebar session slices — one profile-DB open per refresh.
 
     The desktop sidebar needs three source-scoped windows per refresh: recents
-    (local chats, scoped to the active profile), cron sessions (all profiles),
-    and messaging-platform sessions (all profiles). Served as three separate
+    (local chats), cron sessions, and messaging-platform sessions, all scoped
+    to the requested profile. Served as three separate
     ``/api/profiles/sessions`` calls they reopened every profile's ``state.db``
     three times and re-counted each refresh. This opens each DB once and runs
     the three filtered queries together, returning the three windows in one
@@ -257,8 +257,8 @@ def get_profiles_sessions_sidebar(
     """
     from hermes_cli import profiles as profiles_mod
 
-    # cron + messaging are cross-profile; recents is scoped to recents_profile.
-    # Scan every profile once regardless (each DB opened a single time).
+    # All slices share recents_profile; the explicit "all" scope retains the
+    # unified cross-profile view. Each selected DB is opened a single time.
     try:
         infos = profiles_mod.list_profiles()
         targets: List[Tuple[str, Path]] = [(info.name, info.path) for info in infos]
@@ -314,6 +314,8 @@ def get_profiles_sessions_sidebar(
         )
 
     for name, home in targets:
+        if recents_scope != "all" and name != recents_scope:
+            continue
         db_path = Path(home) / "state.db"
         if not db_path.exists():
             continue
@@ -327,16 +329,15 @@ def get_profiles_sessions_sidebar(
             errors.append({"profile": name, "error": str(exc)})
             continue
         try:
-            if recents_scope == "all" or name == recents_scope:
-                profile_rows = _slice(db, exclude=recents_exclude_list, cap=recents_cap)
-                # A full window means more rows remain on disk. That is all the
-                # sidebar's "load more" needs, and unlike an exact COUNT(*) per
-                # profile per refresh it costs nothing beyond the rows already
-                # read. Discount pinned back-fills — they arrive past the LIMIT
-                # and would otherwise fake a full page on a short list.
-                unpinned_count = sum(1 for s in profile_rows if not s.get("pinned"))
-                recents_truncated[name] = unpinned_count >= recents_cap
-                recents_rows.extend(_tag(profile_rows, name))
+            profile_rows = _slice(db, exclude=recents_exclude_list, cap=recents_cap)
+            # A full window means more rows remain on disk. That is all the
+            # sidebar's "load more" needs, and unlike an exact COUNT(*) per
+            # profile per refresh it costs nothing beyond the rows already
+            # read. Discount pinned back-fills — they arrive past the LIMIT
+            # and would otherwise fake a full page on a short list.
+            unpinned_count = sum(1 for s in profile_rows if not s.get("pinned"))
+            recents_truncated[name] = unpinned_count >= recents_cap
+            recents_rows.extend(_tag(profile_rows, name))
             cron_rows.extend(_tag(_slice(db, source="cron", cap=cron_cap), name))
             messaging_rows.extend(
                 _tag(_slice(db, exclude=messaging_exclude_list, cap=messaging_cap), name)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -476,6 +476,84 @@ class TestWebServerEndpoints:
             "sidebar-stale"
         ]
 
+    def test_profiles_sidebar_scopes_every_slice_to_selected_profile(self):
+        from hermes_cli.profiles import create_profile
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        work_home = create_profile("work", no_alias=True, no_skills=True)
+
+        def seed(home, prefix):
+            db = SessionDB(db_path=Path(home) / "state.db")
+            try:
+                for suffix, source in (
+                    ("recent", "desktop"),
+                    ("cron", "cron"),
+                    ("message", "telegram"),
+                ):
+                    session_id = f"{prefix}-{suffix}"
+                    db.create_session(session_id, source=source)
+                    db.append_message(session_id, "user", "hello")
+            finally:
+                db.close()
+
+        seed(get_hermes_home(), "default")
+        seed(work_home, "work")
+
+        response = self.client.get(
+            "/api/profiles/sessions/sidebar"
+            "?recents_profile=work"
+            "&recents_exclude=cron,telegram"
+            "&messaging_exclude=cron,desktop"
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert [row["id"] for row in payload["recents"]["sessions"]] == [
+            "work-recent"
+        ]
+        assert [row["id"] for row in payload["cron"]["sessions"]] == [
+            "work-cron"
+        ]
+        assert [row["id"] for row in payload["messaging"]["sessions"]] == [
+            "work-message"
+        ]
+
+        default_payload = self.client.get(
+            "/api/profiles/sessions/sidebar"
+            "?recents_profile=default"
+            "&recents_exclude=cron,telegram"
+            "&messaging_exclude=cron,desktop"
+        ).json()
+        assert [row["id"] for row in default_payload["recents"]["sessions"]] == [
+            "default-recent"
+        ]
+        assert [row["id"] for row in default_payload["cron"]["sessions"]] == [
+            "default-cron"
+        ]
+        assert [row["id"] for row in default_payload["messaging"]["sessions"]] == [
+            "default-message"
+        ]
+
+        all_payload = self.client.get(
+            "/api/profiles/sessions/sidebar"
+            "?recents_profile=all"
+            "&recents_exclude=cron,telegram"
+            "&messaging_exclude=cron,desktop"
+        ).json()
+        assert {row["id"] for row in all_payload["recents"]["sessions"]} == {
+            "default-recent",
+            "work-recent",
+        }
+        assert {row["id"] for row in all_payload["cron"]["sessions"]} == {
+            "default-cron",
+            "work-cron",
+        }
+        assert {row["id"] for row in all_payload["messaging"]["sessions"]} == {
+            "default-message",
+            "work-message",
+        }
+
     def test_heal_gives_up_when_reconcile_cannot_fix_the_store(self, monkeypatch):
         """A probe failure reconciliation can't cure must not retry forever.
 


### PR DESCRIPTION
## Summary
- scope recents, cron sessions/jobs, and messaging sections to the selected Desktop profile
- preserve the explicit all-profiles view
- apply the same scope through batched, legacy fallback, and remote-profile request paths
- prevent stale/out-of-order async responses from republishing another profile after a live profile switch
- clear profile-scoped secondary sidebar stores before paint during re-home

## Tests run
- `pytest tests/hermes_cli/test_web_server.py -q -p no:cacheprovider` (145 passed; one existing Starlette deprecation warning)
- `npm --prefix apps/desktop run test:ui` (3642 passed)
- `npm --prefix apps/desktop run test:desktop:platforms` (1002 passed, 2 skipped)
- `npm --prefix apps/desktop run typecheck`
- focused ESLint on all changed Desktop files (zero warnings)
- `git diff --check`

## Motivation
The profile rail visually communicates a scoped workspace, but messaging and cron sidebar slices were aggregated across every profile. Besides confusing users, globally cached async results could reappear after a profile switch. This makes the sidebar follow the selected profile consistently while keeping the explicit all-profiles mode available.