### PR TITLE
fix(agent): stop interrupt-scaffold ghost rows from self-replicating

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -220,14 +220,13 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
     ``[This response was interrupted by a user correction.]`` and its
     ``Visible response before the interruption:`` header exist so the MODEL
     understands its own reply was cut off. They are not prose the user wrote
-    or the agent said. Persisting them into ``content`` painted the raw
-    machinery as an assistant bubble on every reload (and merged it into the
-    preceding tool-call bubble), which is what made a steered transcript
-    unreadable. Carry the scaffolded form in the ``api_content`` sidecar --
-    the exact bytes replayed to the provider -- and keep ``content`` clean.
-    When nothing was on screen there is no clean form at all, so the row is
-    marked ``display_kind="hidden"``: still replayed to the model, dropped by
-    every transcript surface (desktop, TUI, CLI resume), exactly like the
+    or the agent said. Persisting them into an assistant row's ``content`` or
+    ``api_content`` made the model treat the scaffold as *its own previous
+    reply*, echo it, and self-replicate ghost rows across turns (#81841).
+    Carry the scaffolded form only in the *user correction's* ``api_content``
+    sidecar — never on the placeholder assistant row. When nothing was on
+    screen the placeholder is marked ``display_kind="hidden"`` (empty
+    content) so every transcript surface drops it, exactly like
     compaction-reference rows.
     """
     visible = agent._strip_think_blocks(
@@ -240,34 +239,37 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
             ["Visible response before the interruption:", visible]
         )
     checkpoint = "\n\n".join(checkpoint_parts)
+    correction = (
+        "[Context from the interrupted assistant response]\n"
+        f"{checkpoint}\n\n"
+        f"{text}"
+    )
 
-    # The normal live tail is user or tool, so an assistant checkpoint followed
-    # by the correction preserves strict alternation. If a transport already
-    # committed an assistant item, attribute the checkpoint inside the user
-    # correction instead of creating assistant→assistant.
+    # The normal live tail is user or tool, so an assistant placeholder
+    # followed by the correction preserves strict alternation. If a transport
+    # already committed an assistant item, attribute the checkpoint inside the
+    # user correction instead of creating assistant→assistant.
     if messages and messages[-1].get("role") == "assistant":
-        correction = (
-            "[Context from the interrupted assistant response]\n"
-            f"{checkpoint}\n\n"
-            f"{text}"
-        )
         # Transcript shows the user's own words; the provider replays the
         # scaffolded form so it still sees the interrupted context.
         messages.append(
             {"role": "user", "content": text, "api_content": correction}
         )
     else:
-        entry: Dict[str, Any] = {
+        # Placeholder preserves role alternation only. Scaffold bytes must
+        # never land here — the API replay path substitutes api_content back
+        # into content, and a scaffold-as-assistant-reply is what the model
+        # then echoes (#81841 / incomplete #73146 else branch).
+        placeholder: Dict[str, Any] = {
             "role": "assistant",
-            "content": visible or checkpoint,
-            "api_content": checkpoint,
+            "content": visible or "",
         }
         if not visible:
-            # Nothing reached the screen — this row carries no assistant prose
-            # at all, only the cut-off notice for the model.
-            entry["display_kind"] = "hidden"
-        messages.append(entry)
-        messages.append({"role": "user", "content": text})
+            placeholder["display_kind"] = "hidden"
+        messages.append(placeholder)
+        messages.append(
+            {"role": "user", "content": text, "api_content": correction}
+        )
 
     agent._current_streamed_assistant_text = ""
     agent._stream_needs_break = True

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -98,6 +98,11 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 
+# Scaffold marker used by _apply_active_turn_redirect and the ghost-row filter
+# in the api_messages loop. Module-level so both sites can never drift.
+_INTERRUPT_SCAFFOLD_MARKER = "[This response was interrupted by a user correction.]"
+
+
 def _restore_user_after_reference_handoff(
     messages: List[Dict[str, Any]], user_message: Any
 ) -> bool:
@@ -233,7 +238,7 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
         getattr(agent, "_current_streamed_assistant_text", "") or ""
     ).strip()
 
-    checkpoint_parts = ["[This response was interrupted by a user correction.]"]
+    checkpoint_parts = [_INTERRUPT_SCAFFOLD_MARKER]
     if visible:
         checkpoint_parts.extend(
             ["Visible response before the interruption:", visible]
@@ -1779,6 +1784,30 @@ def run_conversation(
                 agent.session_id or "-",
             )
 
+        # Drop legacy ghost rows from the incomplete #73146 else branch BEFORE
+        # the alternation repair below: a hidden assistant placeholder whose
+        # content/api_content is the raw interrupt scaffold. Replaying that as
+        # an assistant message makes the model echo it and self-replicate
+        # (#81841). Dropping before repair lets repair_message_sequence fix
+        # any user→user adjacency the filter creates.
+        messages = [
+            msg for msg in messages
+            if not (
+                msg.get("display_kind") == "hidden"
+                and msg.get("role") == "assistant"
+                and (
+                    (
+                        isinstance(msg.get("content"), str)
+                        and msg["content"].strip() == _INTERRUPT_SCAFFOLD_MARKER
+                    )
+                    or (
+                        isinstance(msg.get("api_content"), str)
+                        and msg["api_content"].strip() == _INTERRUPT_SCAFFOLD_MARKER
+                    )
+                )
+            )
+        ]
+
         # Defensive: repair malformed role-alternation before API call.
         # Catches cases where the history got wedged into a
         # ``tool → user`` or ``user → user`` tail (e.g. after empty-
@@ -1799,32 +1828,7 @@ def run_conversation(
             )
 
         api_messages = []
-        _interrupt_scaffold = (
-            "[This response was interrupted by a user correction.]"
-        )
         for idx, msg in enumerate(messages):
-            # Legacy ghost rows from the incomplete #73146 else branch: a
-            # hidden assistant placeholder whose content/api_content is the
-            # raw interrupt scaffold. Replaying that as an assistant message
-            # makes the model echo it and self-replicate (#81841). Drop them
-            # so pre-fix session history cannot keep poisoning new turns.
-            _ghost_content = msg.get("content")
-            _ghost_api = msg.get("api_content")
-            if (
-                msg.get("display_kind") == "hidden"
-                and msg.get("role") == "assistant"
-                and (
-                    (
-                        isinstance(_ghost_content, str)
-                        and _ghost_content.strip() == _interrupt_scaffold
-                    )
-                    or (
-                        isinstance(_ghost_api, str)
-                        and _ghost_api.strip() == _interrupt_scaffold
-                    )
-                )
-            ):
-                continue
 
             # Structural clone, NOT msg.copy(): every in-place transform
             # below (canonicalize/repair, surrogate + non-ASCII sanitizers,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1799,7 +1799,33 @@ def run_conversation(
             )
 
         api_messages = []
+        _interrupt_scaffold = (
+            "[This response was interrupted by a user correction.]"
+        )
         for idx, msg in enumerate(messages):
+            # Legacy ghost rows from the incomplete #73146 else branch: a
+            # hidden assistant placeholder whose content/api_content is the
+            # raw interrupt scaffold. Replaying that as an assistant message
+            # makes the model echo it and self-replicate (#81841). Drop them
+            # so pre-fix session history cannot keep poisoning new turns.
+            _ghost_content = msg.get("content")
+            _ghost_api = msg.get("api_content")
+            if (
+                msg.get("display_kind") == "hidden"
+                and msg.get("role") == "assistant"
+                and (
+                    (
+                        isinstance(_ghost_content, str)
+                        and _ghost_content.strip() == _interrupt_scaffold
+                    )
+                    or (
+                        isinstance(_ghost_api, str)
+                        and _ghost_api.strip() == _interrupt_scaffold
+                    )
+                )
+            ):
+                continue
+
             # Structural clone, NOT msg.copy(): every in-place transform
             # below (canonicalize/repair, surrogate + non-ASCII sanitizers,
             # cache decoration) must be unable to reach the persisted

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3542,14 +3542,18 @@ class TestRunConversation:
             "assistant",
             "user",
         ]
-        checkpoint = replay[-2]["content"]
-        assert "interrupted by a user correction" in checkpoint
+        # Scaffold rides on the user correction (api_content → content), never
+        # as the assistant placeholder's own reply (#81841).
+        placeholder = replay[-2]["content"]
+        correction = replay[-1]["content"]
+        assert "interrupted by a user correction" not in (placeholder or "")
+        assert "interrupted by a user correction" in correction
+        assert correction.endswith("No, use Postgres instead.")
         # Displayed chain-of-thought must NOT be replayed: an assistant turn
         # inlining its own reasoning trips Anthropic's output classifier and
         # bricks the session with deterministic empty responses (July 2026).
-        assert "I should implement this with SQLite." not in checkpoint
-        assert "Reasoning shown before the interruption" not in checkpoint
-        assert replay[-1]["content"] == "No, use Postgres instead."
+        assert "I should implement this with SQLite." not in correction
+        assert "Reasoning shown before the interruption" not in correction
         assert agent._pending_redirect is None
         assert any(
             snapshot[-1].get("content") == "No, use Postgres instead."
@@ -3629,14 +3633,21 @@ class TestRunConversation:
         assert calls == 2
         assert results["result"]["completed"] is True
         assert results["result"]["final_response"] == "Corrected answer."
-        checkpoint = results["result"]["messages"][-3]
-        assert "interrupted by a user correction" in checkpoint["content"]
+        placeholder = results["result"]["messages"][-3]
+        correction = results["result"]["messages"][-2]
+        assert placeholder["role"] == "assistant"
+        assert "interrupted by a user correction" not in (
+            placeholder.get("content") or ""
+        )
+        assert "interrupted by a user correction" in (
+            correction.get("api_content") or ""
+        )
         # Displayed reasoning is display-only — replaying it as assistant
         # content trips Anthropic's output classifier (July 2026 brickings).
-        assert "Following the original approach." not in checkpoint["content"]
-        assert results["result"]["messages"][-2]["content"] == (
-            "Use the corrected approach."
+        assert "Following the original approach." not in (
+            correction.get("api_content") or ""
         )
+        assert correction["content"] == "Use the corrected approach."
 
 
     def test_nous_401_refreshes_after_remint_and_retries(self, agent):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3691,8 +3691,12 @@ class TestRunConversation:
             if m.get("role") == "assistant"
         )
         # Real history around the ghost still reaches the provider.
+        # The two consecutive user messages ("first" + "real follow-up")
+        # may be merged by repair_message_sequence, so check for the
+        # content as a substring rather than exact match.
         assert any(
-            m.get("role") == "user" and m.get("content") == "real follow-up"
+            m.get("role") == "user"
+            and "real follow-up" in str(m.get("content", ""))
             for m in replayed
         )
         assert any(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3649,6 +3649,56 @@ class TestRunConversation:
         )
         assert correction["content"] == "Use the corrected approach."
 
+    def test_legacy_interrupt_scaffold_ghost_dropped_from_api_replay(self, agent):
+        """Pre-#81841 hidden assistant rows with the interrupt scaffold must
+        not be replayed to the provider — that is what made the model echo
+        them into a self-replicating ghost loop."""
+        self._setup_agent(agent)
+        scaffold = "[This response was interrupted by a user correction.]"
+        history = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": scaffold,
+                "api_content": scaffold,
+                "display_kind": "hidden",
+            },
+            {"role": "user", "content": "real follow-up"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        requests = []
+
+        def _fake_api_call(api_kwargs):
+            requests.append(api_kwargs)
+            return _mock_response(content="done", finish_reason="stop")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "next turn", conversation_history=history
+            )
+
+        assert result["completed"] is True
+        assert len(requests) == 1
+        replayed = requests[0]["messages"]
+        assert not any(
+            isinstance(m.get("content"), str) and m["content"].strip() == scaffold
+            for m in replayed
+            if m.get("role") == "assistant"
+        )
+        # Real history around the ghost still reaches the provider.
+        assert any(
+            m.get("role") == "user" and m.get("content") == "real follow-up"
+            for m in replayed
+        )
+        assert any(
+            m.get("role") == "assistant" and m.get("content") == "ok"
+            for m in replayed
+        )
 
     def test_nous_401_refreshes_after_remint_and_retries(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -217,10 +217,10 @@ class TestActiveTurnRedirectCheckpoint:
         """The checkpoint machinery is for the MODEL, not the transcript.
 
         Persisting ``[This response was interrupted by a user correction.]``
-        into ``content`` painted raw scaffolding as an assistant bubble on
-        every reload. It must ride in ``api_content`` (replayed to the
-        provider) while ``content`` stays clean, or be marked
-        ``display_kind="hidden"`` when there is no clean form at all.
+        into an assistant row's ``content`` or ``api_content`` painted raw
+        scaffolding as the model's own prior reply (#81841). Scaffold bytes
+        ride only in the *user correction's* ``api_content``; assistant
+        placeholders stay clean (or ``display_kind="hidden"`` when empty).
         """
         from agent.conversation_loop import _apply_active_turn_redirect
 
@@ -248,6 +248,20 @@ class TestActiveTurnRedirectCheckpoint:
                 _apply_active_turn_redirect(agent, messages, "New direction.")
 
                 for msg in messages:
+                    if msg.get("role") == "assistant":
+                        # Scaffold must never live on an assistant row at all
+                        # — content OR api_content (API replay substitutes the
+                        # sidecar back into content).
+                        blob = (
+                            str(msg.get("content") or "")
+                            + str(msg.get("api_content") or "")
+                        )
+                        for marker in scaffolding:
+                            assert marker not in blob, (
+                                f"scaffolding leaked into assistant row "
+                                f"(tail={tail_role}, streamed={bool(streamed)}): "
+                                f"{blob!r}"
+                            )
                     if msg.get("display_kind") == "hidden":
                         continue  # dropped by every transcript surface
                     content = str(msg.get("content", ""))
@@ -259,10 +273,9 @@ class TestActiveTurnRedirectCheckpoint:
 
                 # The user's correction is always shown verbatim.
                 assert messages[-1]["content"] == "New direction."
-                # ...and the model still receives the interrupted context.
-                replayed = "".join(
-                    str(m.get("api_content") or m.get("content", "")) for m in messages
-                )
+                # ...and the model still receives the interrupted context,
+                # but only via the user correction's api_content sidecar.
+                replayed = messages[-1].get("api_content") or ""
                 assert "[This response was interrupted by a user correction.]" in replayed
                 if streamed:
                     assert streamed in replayed
@@ -307,15 +320,46 @@ class TestActiveTurnRedirectCheckpoint:
 
         _apply_active_turn_redirect(agent, messages, "New direction.")
 
-        checkpoint_row = messages[-2]
-        # Nothing was on screen, so the row exists only for the model: hidden
-        # from every transcript surface, scaffolding replayed via the sidecar.
-        assert checkpoint_row["display_kind"] == "hidden"
+        placeholder = messages[-2]
+        correction = messages[-1]
+        # Nothing was on screen: empty hidden placeholder for alternation;
+        # scaffold rides only on the user correction's api_content.
+        assert placeholder["role"] == "assistant"
+        assert placeholder["display_kind"] == "hidden"
+        assert placeholder.get("content") == ""
+        assert not placeholder.get("api_content")
+        assert correction["content"] == "New direction."
         assert (
-            checkpoint_row["api_content"]
-            == "[This response was interrupted by a user correction.]"
+            "[This response was interrupted by a user correction.]"
+            in correction["api_content"]
         )
-        assert messages[-1]["content"] == "New direction."
+
+    def test_tool_tail_scaffold_never_on_assistant_api_content(self):
+        """#81841: mid-tool steer must not put the interrupt scaffold on the
+        placeholder assistant row (that is what the model echoed)."""
+        from agent.conversation_loop import _apply_active_turn_redirect
+
+        agent = _bare_agent()
+        messages = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "tool_calls": [{"id": "a"}]},
+            {"role": "tool", "content": "out", "tool_call_id": "a"},
+        ]
+
+        _apply_active_turn_redirect(agent, messages, "Stop and do X instead.")
+
+        placeholder = messages[-2]
+        correction = messages[-1]
+        assert placeholder["role"] == "assistant"
+        assert placeholder.get("display_kind") == "hidden"
+        assert placeholder.get("content") == ""
+        assert not placeholder.get("api_content")
+        assert correction["role"] == "user"
+        assert correction["content"] == "Stop and do X instead."
+        assert correction["api_content"].startswith(
+            "[Context from the interrupted assistant response]\n"
+            "[This response was interrupted by a user correction.]"
+        )
 
 
 class TestSteerInjection:


### PR DESCRIPTION
## Summary

Moves the interrupt-scaffold text off the assistant placeholder row and onto the user correction's `api_content` only, preventing the model from seeing it as its own prior reply and echoing it into a self-replicating ghost loop. Also drops legacy ghost rows from pre-fix sessions during API message building.

Salvage of #81862 by @HexLab98 — cherry-picked with authorship preserved, plus two follow-up fixes.

## What it solves

When a mid-turn correction arrived while the message tail was tool/user (the else branch of `_apply_active_turn_redirect`), the scaffold text `[This response was interrupted by a user correction.]` was written to the assistant placeholder's `content` AND `api_content`. The API replay path substitutes `api_content` back into `content`, so the model saw the scaffold as its own prior reply and echoed it, creating self-replicating ghost rows across turns (#81841, incomplete fix from #73146).

## Changes

- **`agent/conversation_loop.py`**: Restructures `_apply_active_turn_redirect`'s else branch to keep scaffold off the assistant placeholder entirely (scaffold rides only on the user correction's `api_content`). Adds a ghost-row filter for legacy sessions. Filter runs BEFORE `repair_message_sequence_with_cursor` so any alternation violation from dropping a ghost row is repaired.
- **`tests/run_agent/test_run_agent.py`**: Updates existing redirect tests + adds ghost-row regression test.
- **`tests/run_agent/test_steer.py`**: Updates scaffold tests + adds tool-tail test.

## Salvage notes

- Cherry-picked @HexLab98's 2 commits with authorship preserved (rebase-merge).
- **Fixed alternation risk**: Moved the ghost-row filter from inside the `api_messages` loop to BEFORE `repair_message_sequence_with_cursor`. Previously, dropping a ghost assistant row between two user messages created `user→user` that the repair already missed. Now repair sees and fixes it.
- **Promoted scaffold string**: `[This response was interrupted by a user correction.]` was duplicated as a local in the api_messages loop and an inline literal in `_apply_active_turn_redirect`. Promoted to module-level `_INTERRUPT_SCAFFOLD_MARKER` constant.
- Updated ghost-row test to check for merged user content as substring (repair now merges consecutive user messages after ghost drop).

## Validation

| | Before | After |
|---|---|---|
| Steer + run_agent targeted tests | 18 passed | 18 passed |
| Ruff | clean | clean |
| Alternation repair | ghost drop AFTER repair (could miss user→user) | ghost drop BEFORE repair (fixed) |

Closes #81841
Closes #81862
