### PR TITLE
fix(acp): handle empty final response after cancellation

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2002,7 +2002,10 @@ class HermesACPAgent(acp.Agent):
                     exc_info=True,
                 )
 
-        final_response = result.get("final_response", "")
+        final_response = result.get("final_response")
+        if final_response is None:
+            # Interrupted turns can legitimately complete without assistant text.
+            final_response = ""
         cancelled = bool(state.cancel_event and state.cancel_event.is_set())
         interrupted = bool(result.get("interrupted")) or cancelled
         # Hermes' local "waiting for model response" interrupt status is metadata,

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -1,4 +1,6 @@
+import asyncio
 import sys
+import threading
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -162,6 +164,33 @@ async def test_acp_cancel_publishes_hard_stop_while_holding_runtime_lock():
     assert state.cancel_event.is_set()
     assert state.interrupted_prompt_text == "original request"
 
+
+@pytest.mark.asyncio
+async def test_acp_cancel_returns_cancelled_when_core_final_response_is_none():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    started = threading.Event()
+    interrupted = threading.Event()
+
+    def run_conversation(**_kwargs):
+        started.set()
+        assert interrupted.wait(timeout=5)
+        return {"final_response": None, "messages": [], "interrupted": True}
+
+    fake.run_conversation = run_conversation
+    fake.interrupt = interrupted.set
+
+    prompt_task = asyncio.create_task(
+        acp_agent.prompt(
+            session_id=state.session_id,
+            prompt=[TextContentBlock(type="text", text="run until cancelled")],
+        )
+    )
+    assert await asyncio.wait_for(asyncio.to_thread(started.wait, 5), timeout=6)
+
+    await acp_agent.cancel(state.session_id)
+    response = await asyncio.wait_for(prompt_task, timeout=6)
+
+    assert response.stop_reason == "cancelled"
 
 
 


### PR DESCRIPTION
## Summary

- normalize a `None` final response before ACP's interrupt-sentinel check
- add a concurrent prompt/cancel regression requiring `stop_reason="cancelled"`

## Problem

An interrupted core turn can legitimately return `final_response=None`. The ACP
adapter calls `.startswith(...)` on that value before constructing its prompt
response, so a correctly delivered `session/cancel` becomes JSON-RPC `-32603`
instead of returning `stop_reason="cancelled"`.

The regression test starts a real adapter prompt, waits until synchronous core
work is active, sends `cancel`, releases the work through the normal interrupt
path, and returns the interrupted result shape. It fails on current main at the
string operation before the fix.

## Fix

Normalize only `None` to an empty string before the existing response-filtering
logic. Non-empty responses and the cancellation contract are otherwise
unchanged.

## Verification

- `scripts/run_tests.sh tests/acp_adapter/test_acp_commands.py -q`
- `scripts/run_tests.sh tests/acp tests/acp_adapter -q`
- Ruff and Windows-footgun checks on the two changed files

Tested on macOS with Python 3.11. The focused file passes 4 tests; the ACP and
ACP-adapter suites pass 142 tests across 19 files without retries.
