### PR TITLE
fix(tools): isolate subprocess Python environments (#74817)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2360,12 +2360,30 @@ def resolve_profile_env(profile_name: str) -> str:
 
     Called early in the CLI entry point, before any hermes modules
     are imported, to set the HERMES_HOME environment variable.
+
+    When HERMES_HOME is already set, the configured spelling IS the
+    launch root (it may be a junction/symlink alias of the platform
+    default).  Keep that spelling so profile re-home does not destroy
+    the launcher's lexical provenance -- the subprocess sanitizer needs
+    it to match Hermes-owned PYTHONPATH entries written in the same
+    spelling (#82581 junction follow-up).  Physically the paths are
+    identical (junction-transparent); only the spelling is preserved.
     """
     canon = normalize_profile_name(profile_name)
     validate_profile_name(canon)
-    profile_dir = get_profile_dir(canon)
+    env_home = os.environ.get("HERMES_HOME", "").strip()
+    if env_home:
+        env_path = Path(env_home)
+        # A profile-shaped env value means the root is the grandparent
+        # (mirrors get_default_hermes_root()).
+        root = env_path.parent.parent if env_path.parent.name == "profiles" else env_path
+    else:
+        root = _get_default_hermes_home()
+    if canon == "default":
+        return str(root)
+    profile_dir = root / "profiles" / canon
 
-    if canon != "default" and not profile_dir.is_dir():
+    if not profile_dir.is_dir():
         raise FileNotFoundError(
             f"Profile '{canon}' does not exist. "
             f"Create it with: hermes profile create {canon}"

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -938,3 +938,63 @@ class TestProfilesToServe:
 
 
 
+        assert set(serve) == {"default", "worker"}
+        assert serve["worker"] == get_profile_dir("worker")
+
+
+# ---------------------------------------------------------------------------
+# resolve_profile_env spelling preservation (#82581 junction follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProfileEnvSpelling:
+    """resolve_profile_env() keeps the configured HERMES_HOME spelling as
+
+    the launch root (junction installs) while preserving the pre-existing
+    profile-path handling and existence/validation semantics.
+    """
+
+    @staticmethod
+    def _resolve(monkeypatch, env_home, profile):
+        monkeypatch.setenv("HERMES_HOME", str(env_home))
+        return Path(resolve_profile_env(profile))
+
+    def test_root_env_named_profile(self, monkeypatch, tmp_path):
+        # HERMES_HOME=<root> + --profile coder -> <root>/profiles/coder
+        root = tmp_path / "configured-root"
+        (root / "profiles" / "coder").mkdir(parents=True)
+        assert self._resolve(monkeypatch, root, "coder") == root / "profiles" / "coder"
+
+    def test_profile_shaped_env_named_profile_no_nesting(self, monkeypatch, tmp_path):
+        # HERMES_HOME=<root>/profiles/alpha + --profile beta
+        # -> <root>/profiles/beta (never <root>/profiles/alpha/profiles/beta)
+        root = tmp_path / "configured-root"
+        (root / "profiles" / "beta").mkdir(parents=True)
+        env_home = root / "profiles" / "alpha"
+        assert self._resolve(monkeypatch, env_home, "beta") == root / "profiles" / "beta"
+
+    def test_profile_shaped_env_default_returns_root(self, monkeypatch, tmp_path):
+        # HERMES_HOME=<root>/profiles/alpha + --profile default -> <root>
+        root = tmp_path / "configured-root"
+        (root / "profiles" / "alpha").mkdir(parents=True)
+        assert self._resolve(monkeypatch, root / "profiles" / "alpha", "default") == root
+
+    def test_custom_root_does_not_fall_back_to_platform_default(self, monkeypatch, tmp_path):
+        # HERMES_HOME=X:\custom-hermes + --profile beta stays under the
+        # custom root; it must never silently fall back to the platform default.
+        root = tmp_path / "custom-hermes"
+        (root / "profiles" / "beta").mkdir(parents=True)
+        assert self._resolve(monkeypatch, root, "beta") == root / "profiles" / "beta"
+
+    def test_missing_named_profile_still_raises(self, monkeypatch, tmp_path):
+        root = tmp_path / "configured-root"
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        with pytest.raises(FileNotFoundError):
+            resolve_profile_env("nope")
+
+    def test_unset_env_falls_back_to_default_root(self, monkeypatch):
+        # No HERMES_HOME: the platform default root applies (existing contract).
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        assert Path(resolve_profile_env("default")) == _get_default_hermes_home()
+
+

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -954,37 +954,26 @@ class TestResolveProfileEnvSpelling:
     profile-path handling and existence/validation semantics.
     """
 
-    @staticmethod
-    def _resolve(monkeypatch, env_home, profile):
-        monkeypatch.setenv("HERMES_HOME", str(env_home))
-        return Path(resolve_profile_env(profile))
-
-    def test_root_env_named_profile(self, monkeypatch, tmp_path):
-        # HERMES_HOME=<root> + --profile coder -> <root>/profiles/coder
+    def test_resolution_matrix_preserves_configured_spelling(self, monkeypatch, tmp_path):
+        """Resolution matrix over the four pre-existing invariants: root env
+        -> <root>/profiles/<name>; profile-shaped env -> <root>/profiles/<name>
+        with no nesting; profile-shaped env + default -> <root>; custom roots
+        never fall back to the platform default.
+        """
         root = tmp_path / "configured-root"
+        (root / "profiles" / "beta").mkdir(parents=True)
         (root / "profiles" / "coder").mkdir(parents=True)
-        assert self._resolve(monkeypatch, root, "coder") == root / "profiles" / "coder"
-
-    def test_profile_shaped_env_named_profile_no_nesting(self, monkeypatch, tmp_path):
-        # HERMES_HOME=<root>/profiles/alpha + --profile beta
-        # -> <root>/profiles/beta (never <root>/profiles/alpha/profiles/beta)
-        root = tmp_path / "configured-root"
-        (root / "profiles" / "beta").mkdir(parents=True)
-        env_home = root / "profiles" / "alpha"
-        assert self._resolve(monkeypatch, env_home, "beta") == root / "profiles" / "beta"
-
-    def test_profile_shaped_env_default_returns_root(self, monkeypatch, tmp_path):
-        # HERMES_HOME=<root>/profiles/alpha + --profile default -> <root>
-        root = tmp_path / "configured-root"
-        (root / "profiles" / "alpha").mkdir(parents=True)
-        assert self._resolve(monkeypatch, root / "profiles" / "alpha", "default") == root
-
-    def test_custom_root_does_not_fall_back_to_platform_default(self, monkeypatch, tmp_path):
-        # HERMES_HOME=X:\custom-hermes + --profile beta stays under the
-        # custom root; it must never silently fall back to the platform default.
-        root = tmp_path / "custom-hermes"
-        (root / "profiles" / "beta").mkdir(parents=True)
-        assert self._resolve(monkeypatch, root, "beta") == root / "profiles" / "beta"
+        custom = tmp_path / "custom-hermes"
+        (custom / "profiles" / "beta").mkdir(parents=True)
+        cases = [
+            (root, "coder", root / "profiles" / "coder"),
+            (root / "profiles" / "alpha", "beta", root / "profiles" / "beta"),
+            (root / "profiles" / "alpha", "default", root),
+            (custom, "beta", custom / "profiles" / "beta"),
+        ]
+        for env_home, profile, expected in cases:
+            monkeypatch.setenv("HERMES_HOME", str(env_home))
+            assert Path(resolve_profile_env(profile)) == expected
 
     def test_missing_named_profile_still_raises(self, monkeypatch, tmp_path):
         root = tmp_path / "configured-root"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -560,6 +560,52 @@ class TestPythonpathSelectiveStrip:
         assert real_repo_root not in entries
         assert "/home/user/my-lib" in entries
 
+    def test_repo_root_direct_child_stripped(self):
+        """A direct child of the repo root (depth=1) is stripped.
+
+        Check 3's depth rule is ``depth <= 1``: the repo root itself is
+        depth=0 (covered above), and a top-level package directory like
+        ``<repo>/tools`` is depth=1.  Both are stripped because Electron
+        prepends exactly these shallow paths so ``import tools`` works in
+        the backend, and they shadow user packages of the same name.
+        """
+        from tools.environments.local import _strip_mismatched_site_packages
+
+        local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
+        real_repo_root = local_file.parents[2]
+        direct_child = str(real_repo_root / "tools")
+
+        env = {
+            "PYTHONPATH": os.pathsep.join([direct_child, "/home/user/my-lib"]),
+        }
+        _strip_mismatched_site_packages(env)
+        pp = env.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert direct_child not in entries
+        assert "/home/user/my-lib" in entries
+
+    def test_deep_path_under_repo_root_preserved(self):
+        """A deeper path under the repo root (depth=2) is preserved.
+
+        ``<repo>/tools/environments`` is depth=2, past the ``depth <= 1``
+        cutoff.  Such a path is not something Electron injects and may be
+        a legitimate user library path, so it must survive Check 3.
+        """
+        from tools.environments.local import _strip_mismatched_site_packages
+
+        local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
+        real_repo_root = local_file.parents[2]
+        deep_path = str(real_repo_root / "tools" / "environments")
+
+        env = {
+            "PYTHONPATH": os.pathsep.join([deep_path, "/home/user/my-lib"]),
+        }
+        _strip_mismatched_site_packages(env)
+        pp = env.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert deep_path in entries
+        assert "/home/user/my-lib" in entries
+
 
 class TestProfileScopedPassthrough:
     def test_make_run_env_uses_active_profile_for_passthrough(self, monkeypatch):

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -9,6 +9,7 @@ See: https://github.com/NousResearch/hermes-agent/issues/1264
 """
 
 import os
+import sys
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -321,7 +322,7 @@ class TestPythonpathSelectiveStrip:
     venv's site-packages (Python 3.11) into PYTHONPATH.  When this leaks
     into subprocesses running a different Python (e.g. 3.13), 3.11 C
     extensions appear on sys.path and crash with ImportError.
-    ``_strip_mismatched_site_packages`` surgically removes only the
+    ``_strip_hermes_owned_pythonpath`` surgically removes only the
     entries Hermes itself owns (repo root, own venv site-packages),
     preserving user paths — including user paths whose names merely
     contain another Python version.
@@ -329,7 +330,7 @@ class TestPythonpathSelectiveStrip:
 
     def test_hermes_venv_site_packages_stripped(self):
         """A site-packages entry under the Hermes venv is removed."""
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         import sys
 
         # Construct a path that looks like the Hermes venv site-packages.
@@ -342,7 +343,7 @@ class TestPythonpathSelectiveStrip:
         env = {
             "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
         }
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         assert "PYTHONPATH" in env
         entries = env["PYTHONPATH"].split(os.pathsep)
         assert venv_sp not in entries
@@ -350,10 +351,10 @@ class TestPythonpathSelectiveStrip:
 
     def test_user_pythonpath_preserved(self):
         """User PYTHONPATH entries pass through untouched."""
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         user_pp = os.pathsep.join(["/opt/my-lib", "/another/path"])
         env = {"PYTHONPATH": user_pp}
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         assert env.get("PYTHONPATH") == user_pp
 
     def test_other_version_site_packages_preserved(self):
@@ -365,7 +366,7 @@ class TestPythonpathSelectiveStrip:
         judged against the BACKEND's interpreter version (P2, #74817
         follow-up).  Regression: prior Check 1 stripped these.
         """
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         import sys
 
         # Use a version different from the running interpreter.
@@ -378,7 +379,7 @@ class TestPythonpathSelectiveStrip:
         env = {
             "PYTHONPATH": os.pathsep.join([other_sp, "/home/user/my-lib"]),
         }
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         assert "PYTHONPATH" in env
         entries = env["PYTHONPATH"].split(os.pathsep)
         assert other_sp in entries
@@ -388,11 +389,11 @@ class TestPythonpathSelectiveStrip:
         """A user's python2.7/site-packages entry is preserved — path
         ownership, not version, decides stripping (P2, #74817 follow-up).
         """
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         env = {
             "PYTHONPATH": "/old/lib/python2.7/site-packages:/home/user/lib",
         }
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         assert "PYTHONPATH" in env
         entries = env["PYTHONPATH"].split(os.pathsep)
         assert "/old/lib/python2.7/site-packages" in entries
@@ -403,14 +404,14 @@ class TestPythonpathSelectiveStrip:
         must never be stripped (P1, #74817 follow-up).  Regression: prior
         Check 1 deleted these because it keyed on the version component alone.
         """
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         user_pp = os.pathsep.join([
             "/opt/tools/python3.13/bin",
             "/opt/downloads/python3.13",
             "/custom/python3.13",
         ])
         env = {"PYTHONPATH": user_pp}
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         assert env.get("PYTHONPATH") == user_pp
 
     def test_windows_backslash_paths(self):
@@ -423,9 +424,10 @@ class TestPythonpathSelectiveStrip:
         (including site-packages paths for another Python version) are
         never destroyed.  On a real Windows host, Path splits on
         backslashes and Hermes venv site-packages entries are stripped
-        by the same Hermes-owned check.
+        by the same Hermes-owned check (covered by the Windows-only test
+        below).
         """
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         import sys
 
         pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
@@ -436,7 +438,7 @@ class TestPythonpathSelectiveStrip:
         }
         # Mock os.pathsep to ';' (Windows) just for the strip call.
         with patch("os.pathsep", ";"):
-            _strip_mismatched_site_packages(env)
+            _strip_hermes_owned_pythonpath(env)
         assert "PYTHONPATH" in env
         entries = env["PYTHONPATH"].split(";")
         # Both survive on POSIX: user paths must always be preserved, and
@@ -444,26 +446,106 @@ class TestPythonpathSelectiveStrip:
         assert hermes_win in entries
         assert user_win in entries
 
+    @pytest.mark.windows_only
+    def test_windows_hermes_owned_paths_stripped(self):
+        """On Windows, a Hermes venv site-packages entry written with
+        backslashes is stripped by the same Hermes-owned check, while a
+        user Windows path is preserved.  Windows-only: POSIX ``Path`` does
+        not split on backslashes, so this cannot be meaningfully simulated
+        on a POSIX host."""
+        from tools.environments.local import _strip_hermes_owned_pythonpath
+        import sys
+
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "Lib" / "site-packages"
+        )
+        # Windows form: C:\...\venv\Lib\site-packages (backslashes)
+        hermes_win = venv_sp.replace("\\", "\\\\").replace("/", "\\\\")
+        user_win = "D:\\\\user\\\\lib"
+        env = {
+            "PYTHONPATH": ";".join([hermes_win, user_win]),
+        }
+        _strip_hermes_owned_pythonpath(env)
+        entries = env["PYTHONPATH"].split(";")
+        assert hermes_win not in entries
+        assert user_win in entries
+
     def test_empty_pythonpath_unchanged(self):
         """An empty PYTHONPATH is a no-op (falsy -> early return)."""
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         env = {"PYTHONPATH": ""}
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         # Empty string is falsy, so the function returns early without
         # modifying the dict.  The key stays as-is (empty string).
         assert env.get("PYTHONPATH") == ""
 
+    def test_mixed_ordering_user_and_hermes_preserves_user_order(self):
+        """Mixed user/Hermes/user entries: user entries survive in their
+        original relative order after Hermes-owned entries are removed."""
+        from tools.environments.local import _strip_hermes_owned_pythonpath
+        import sys
+
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
+        )
+        local_file = Path(
+            __import__("tools.environments.local", fromlist=["__file__"]).__file__
+        ).resolve()
+        repo_root = str(local_file.parents[2])
+        env = {
+            "PYTHONPATH": os.pathsep.join([
+                "/first/user/lib",
+                repo_root,
+                "/second/user/lib",
+                venv_sp,
+                "/third/user/lib",
+            ]),
+        }
+        _strip_hermes_owned_pythonpath(env)
+        pp = env.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert entries == ["/first/user/lib", "/second/user/lib", "/third/user/lib"]
+
+    def test_duplicate_hermes_entries_all_stripped(self):
+        """Every duplicate Hermes-owned entry is removed; user duplicates
+        follow the existing contract (no unrelated dedup)."""
+        from tools.environments.local import _strip_hermes_owned_pythonpath
+        import sys
+
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
+        )
+        local_file = Path(
+            __import__("tools.environments.local", fromlist=["__file__"]).__file__
+        ).resolve()
+        repo_root = str(local_file.parents[2])
+        env = {
+            "PYTHONPATH": os.pathsep.join([
+                venv_sp,
+                "/user/lib",
+                venv_sp,  # duplicate Hermes entry
+                "/user/lib",  # duplicate user entry — preserved as-is
+            ]),
+        }
+        _strip_hermes_owned_pythonpath(env)
+        pp = env.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert entries == ["/user/lib", "/user/lib"]
+
     def test_no_pythonpath_key(self):
         """Missing PYTHONPATH key is a no-op."""
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         env = {"PATH": "/usr/bin"}
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         assert "PYTHONPATH" not in env
 
     def test_all_entries_stripped_removes_key(self):
         """If all entries are Hermes-owned and stripped, PYTHONPATH key is
         removed entirely."""
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         import sys
 
         pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
@@ -472,7 +554,7 @@ class TestPythonpathSelectiveStrip:
         )
 
         env = {"PYTHONPATH": venv_sp}
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         assert "PYTHONPATH" not in env
 
     def test_make_run_env_strips_hermes_venv_pythonpath(self):
@@ -537,11 +619,11 @@ class TestPythonpathSelectiveStrip:
     def test_scrub_child_env_strips_hermes_venv_pythonpath(self):
         """execute_code's _scrub_child_env path: after scrubbing, Hermes venv
         site-packages entries should be stripped when
-        _strip_mismatched_site_packages is applied (as the spawn path does),
+        _strip_hermes_owned_pythonpath is applied (as the spawn path does),
         while user entries (even for another Python version) are preserved.
         """
         from tools.code_execution_tool import _scrub_child_env
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
         import sys
 
         pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
@@ -558,7 +640,7 @@ class TestPythonpathSelectiveStrip:
         # The scrubber passes PYTHONPATH through (it's in _SAFE_ENV_PREFIXES).
         assert "PYTHONPATH" in scrubbed
         # Now apply the selective strip (as the spawn path does).
-        _strip_mismatched_site_packages(scrubbed)
+        _strip_hermes_owned_pythonpath(scrubbed)
         pp = scrubbed.get("PYTHONPATH", "")
         entries = pp.split(os.pathsep) if pp else []
         assert venv_sp not in entries
@@ -577,7 +659,7 @@ class TestPythonpathSelectiveStrip:
         (e.g. ``parents[1]`` resolving to ``tools/``) would cause this test
         to fail instead of silently passing.
         """
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
 
         # Independently compute the real repo root: local.py lives at
         # tools/environments/local.py, so the repo root is parents[2].
@@ -587,22 +669,25 @@ class TestPythonpathSelectiveStrip:
         env = {
             "PYTHONPATH": os.pathsep.join([real_repo_root, "/home/user/my-lib"]),
         }
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         pp = env.get("PYTHONPATH", "")
         entries = pp.split(os.pathsep) if pp else []
         assert real_repo_root not in entries
         assert "/home/user/my-lib" in entries
 
-    def test_repo_root_direct_child_stripped(self):
-        """A direct child of the repo root (depth=1) is stripped.
+    def test_repo_root_direct_child_preserved(self):
+        """A direct child of the repo root (depth=1) is PRESERVED.
 
-        Check 3's depth rule is ``depth <= 1``: the repo root itself is
-        depth=0 (covered above), and a top-level package directory like
-        ``<repo>/tools`` is depth=1.  Both are stripped because Electron
-        prepends exactly these shallow paths so ``import tools`` works in
-        the backend, and they shadow user packages of the same name.
+        Independent audit of every real launcher producer (Electron
+        ``electron-main.mjs``, ``gateway/run.py::_ensure_windows_gateway_venv_imports``,
+        ``cron/scheduler.py::_windows_cron_python_invocation``,
+        ``tui_gateway/host_supervisor.py``) shows they all inject the exact
+        repo root and/or the venv site-packages — none injects
+        ``<repo>/tools`` or another direct child as an independent
+        PYTHONPATH entry.  A user path that merely happens to live under
+        the repo directory must therefore be preserved.
         """
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
 
         local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
         real_repo_root = local_file.parents[2]
@@ -611,20 +696,63 @@ class TestPythonpathSelectiveStrip:
         env = {
             "PYTHONPATH": os.pathsep.join([direct_child, "/home/user/my-lib"]),
         }
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         pp = env.get("PYTHONPATH", "")
         entries = pp.split(os.pathsep) if pp else []
-        assert direct_child not in entries
+        assert direct_child in entries
         assert "/home/user/my-lib" in entries
+
+    def test_repo_root_junction_alias_stripped(self):
+        """A PYTHONPATH entry using the unresolved (HERMES_HOME/junction)
+        spelling of the repo root is stripped.
+
+        On Windows the gateway launcher renders Hermes-owned paths under the
+        configured HERMES_HOME spelling, which may be a symlink/junction to
+        another drive (``_preserve_hermes_home_path`` in
+        ``hermes_cli/gateway_windows.py``).  ``_hermes_repo_root`` is the
+        RESOLVED physical path, so the launcher's spelling differs lexically;
+        the alias set must still recognize it as Hermes-owned.  This test
+        monkeypatches the aliases to a pair whose lexical forms differ, the
+        way a junction would, and verifies the launcher's spelling is
+        stripped while a nested user path under the same prefix is not.
+        """
+        from tools.environments.local import (
+            _strip_hermes_owned_pythonpath,
+            _hermes_repo_root_aliases,
+        )
+        from pathlib import Path as _Path
+
+        resolved_root = _Path("/data/hermes/hermes-agent")
+        junction_root = _Path("/home/u/AppData/Local/hermes/hermes-agent")
+        with patch(
+            "tools.environments.local._hermes_repo_root_aliases",
+            (resolved_root, junction_root),
+        ):
+            # Launcher spelling (junction form) of the exact repo root.
+            env = {"PYTHONPATH": str(junction_root)}
+            _strip_hermes_owned_pythonpath(env)
+            assert "PYTHONPATH" not in env
+
+            # Nested user path under the same junction prefix survives.
+            env = {"PYTHONPATH": os.pathsep.join([
+                str(junction_root / "user-data"),
+                "/home/user/my-lib",
+            ])}
+            _strip_hermes_owned_pythonpath(env)
+            pp = env.get("PYTHONPATH", "")
+            entries = pp.split(os.pathsep) if pp else []
+            assert str(junction_root / "user-data") in entries
+            assert "/home/user/my-lib" in entries
 
     def test_deep_path_under_repo_root_preserved(self):
         """A deeper path under the repo root (depth=2) is preserved.
 
         ``<repo>/tools/environments`` is depth=2, past the ``depth <= 1``
         cutoff.  Such a path is not something Electron injects and may be
-        a legitimate user library path, so it must survive Check 3.
+        a legitimate user library path, so it must survive the repo-root
+        ownership check.
         """
-        from tools.environments.local import _strip_mismatched_site_packages
+        from tools.environments.local import _strip_hermes_owned_pythonpath
 
         local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
         real_repo_root = local_file.parents[2]
@@ -633,7 +761,7 @@ class TestPythonpathSelectiveStrip:
         env = {
             "PYTHONPATH": os.pathsep.join([deep_path, "/home/user/my-lib"]),
         }
-        _strip_mismatched_site_packages(env)
+        _strip_hermes_owned_pythonpath(env)
         pp = env.get("PYTHONPATH", "")
         entries = pp.split(os.pathsep) if pp else []
         assert deep_path in entries
@@ -695,6 +823,28 @@ class TestPythonhomeSanitized:
         that iterate it drop the variable."""
         from tools.environments.local import _ACTIVE_VENV_MARKER_VARS
         assert "PYTHONHOME" in _ACTIVE_VENV_MARKER_VARS
+
+    def test_build_subprocess_env_no_scrub_preserves_pythonhome(self):
+        """``build_subprocess_env(scrub_secrets=False)`` is the documented
+        byte-for-byte escape hatch: no key is removed, so PYTHONHOME (and
+        everything else) survives there by contract, not by omission.
+
+        Callers that explicitly opt out of scrubbing (git credential flows,
+        secret CLIs) must not have their environment silently altered — this
+        test pins that exception as intentional.
+        """
+        from tools.environments.local import build_subprocess_env
+        base = {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "PYTHONHOME": "/opt/hermes-venv",
+            "VIRTUAL_ENV": "/opt/hermes-venv",
+            "SERVICE_TOKEN": "s3cr3t",
+        }
+        result = build_subprocess_env(base, scrub_secrets=False)
+        assert result.get("PYTHONHOME") == "/opt/hermes-venv"
+        assert result.get("VIRTUAL_ENV") == "/opt/hermes-venv"
+        assert result.get("SERVICE_TOKEN") == "s3cr3t"
 
 
 class TestProfileScopedPassthrough:

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -9,6 +9,7 @@ See: https://github.com/NousResearch/hermes-agent/issues/1264
 """
 
 import os
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -323,6 +324,33 @@ class TestActiveVenvMarkerStripping:
         assert "CONDA_PREFIX" in _ACTIVE_VENV_MARKER_VARS
 
 
+def _make_directory_link(link: Path, target: Path) -> None:
+    """Create a directory link without requiring symlink privileges.
+
+    POSIX: Path.symlink_to.  Windows: try symlink_to first (works with
+    Developer Mode enabled), then fall back to an unprivileged directory
+    junction via `cmd /c mklink /J` -- junctions do not require the
+    SeCreateSymbolicLinkPrivilege.  Raises the original error when no
+    mechanism is available so callers can skip with a clear reason.
+    """
+    try:
+        link.symlink_to(target, target_is_directory=True)
+        return
+    except OSError:
+        if sys.platform != "win32":
+            raise
+    # Binary capture: on a localized Windows the junction message is in the
+    # console code page (e.g. GBK), which would raise UnicodeDecodeError in
+    # the reader thread under UTF-8 mode.  Only the exit code matters.
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise OSError(detail or f"mklink /J failed: {result.returncode}")
+
+
 class TestPythonpathSelectiveStrip:
     """PYTHONPATH Hermes-owned entry stripping (#74817).
 
@@ -418,7 +446,10 @@ class TestPythonpathSelectiveStrip:
         """
         from tools.environments.local import _strip_hermes_owned_pythonpath
         env = {
-            "PYTHONPATH": "/old/lib/python2.7/site-packages:/home/user/lib",
+            "PYTHONPATH": os.pathsep.join([
+                "/old/lib/python2.7/site-packages",
+                "/home/user/lib",
+            ]),
         }
         _strip_hermes_owned_pythonpath(env)
         assert "PYTHONPATH" in env
@@ -865,7 +896,10 @@ class TestPythonpathSelectiveStrip:
         physical_root = physical_home / "hermes-agent"
         physical_root.mkdir(parents=True)
         configured_home = tmp_path / "configured-home"
-        configured_home.symlink_to(physical_home, target_is_directory=True)
+        try:
+            _make_directory_link(configured_home, physical_home)
+        except OSError as exc:
+            pytest.skip(f"directory link unavailable on this host: {exc}")
         monkeypatch.setenv("HERMES_HOME", str(configured_home))
 
         launcher_entry = Path(_preserve_hermes_home_path(physical_root))
@@ -1217,25 +1251,42 @@ class TestSanePathIncludesHomebrew:
         assert "/opt/homebrew/bin" in _SANE_PATH
 
 
-    def test_make_run_env_appends_homebrew_on_minimal_path(self):
-        """When PATH is minimal, _make_run_env appends missing sane entries."""
+    def test_make_run_env_appends_homebrew_on_minimal_path(self, monkeypatch):
+        """When PATH is minimal, _make_run_env appends missing sane entries.
+
+        POSIX: the sane-path merge appends the Homebrew dirs.  Windows:
+        _append_missing_sane_path_entries is a documented passthrough (the
+        native PATH must not be touched), so the assertion is the unchanged
+        input.  Git Bash dir prepending is neutralised so the merged PATH
+        layout is deterministic on every host.
+        """
+        from tools.environments import local as local_mod
         from tools.environments.local import _SANE_PATH, _make_run_env
+        monkeypatch.setattr(local_mod, "_git_bash_bin_dirs", lambda: [])
         minimal_env = {"PATH": "/some/custom/bin"}
         with patch.dict(os.environ, minimal_env, clear=True):
             result = _make_run_env({})
-        path_entries = result["PATH"].split(":")
+        path_entries = result["PATH"].split(os.pathsep)
         assert path_entries[0] == "/some/custom/bin"
-        for entry in _SANE_PATH.split(":"):
-            assert entry in path_entries
+        if sys.platform == "win32":
+            assert result["PATH"] == "/some/custom/bin"
+        else:
+            for entry in _SANE_PATH.split(os.pathsep):
+                assert entry in path_entries
 
 
+    @pytest.mark.macos_only
     def test_make_run_env_real_launchd_path_gains_homebrew(self):
-        """The literal macOS launchd PATH is the production trigger for #35613."""
+        """The literal macOS launchd PATH is the production trigger for #35613.
+
+        macOS-only: the regression is the launchd environment on macOS, and
+        the sane-path merge is a documented passthrough on Windows.
+        """
         from tools.environments.local import _make_run_env
-        launchd_env = {"PATH": "/usr/bin:/bin:/usr/sbin:/sbin"}
+        launchd_env = {"PATH": os.pathsep.join(["/usr/bin", "/bin", "/usr/sbin", "/sbin"])}
         with patch.dict(os.environ, launchd_env, clear=True):
             result = _make_run_env({})
-        path_entries = result["PATH"].split(":")
+        path_entries = result["PATH"].split(os.pathsep)
         assert "/opt/homebrew/bin" in path_entries
         assert "/opt/homebrew/sbin" in path_entries
         # Original entries keep their leading precedence.
@@ -1298,7 +1349,11 @@ class TestHermesBinDirOnPath:
         from tools.environments.local import _make_run_env
         self._reset_cache()
         local_mod._HERMES_BIN_DIR = "/opt/hermes/bin"
-        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=True):
+        with patch.dict(
+            os.environ,
+            {"PATH": os.pathsep.join(["/usr/bin", "/bin"])},
+            clear=True,
+        ):
             result = _make_run_env({})
         entries = result["PATH"].split(os.pathsep)
         assert entries[0] == "/opt/hermes/bin"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -640,6 +640,63 @@ class TestPythonpathSelectiveStrip:
         assert "/home/user/my-lib" in entries
 
 
+class TestPythonhomeSanitized:
+    """PYTHONHOME must not leak from the Hermes runtime into subprocesses.
+
+    The gateway inherits/sets PYTHONHOME in its process environment; a child
+    interpreter (system Python, another venv, cron no_agent scripts) that
+    inherits it redirects its stdlib search to the Hermes venv and crashes
+    with version-mismatch errors before importing anything (#75018).
+    """
+
+    def test_make_run_env_strips_pythonhome(self):
+        from tools.environments.local import _make_run_env
+        with patch.dict(os.environ, {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "PYTHONHOME": "/opt/hermes-venv",
+        }, clear=True):
+            run_env = _make_run_env({})
+        assert "PYTHONHOME" not in run_env
+
+    def test_sanitize_subprocess_env_strips_pythonhome(self):
+        from tools.environments.local import _sanitize_subprocess_env
+        result = _sanitize_subprocess_env({
+            "PATH": "/usr/bin",
+            "HOME": "/home/user",
+            "PYTHONHOME": "/opt/hermes-venv",
+        })
+        assert "PYTHONHOME" not in result
+
+    def test_hermes_subprocess_env_strips_pythonhome(self):
+        from tools.environments.local import hermes_subprocess_env
+        with patch.dict(os.environ, {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "PYTHONHOME": "/opt/hermes-venv",
+        }, clear=True):
+            result = hermes_subprocess_env()
+        assert "PYTHONHOME" not in result
+
+    def test_build_subprocess_env_strips_pythonhome(self):
+        """cron no_agent children go through build_subprocess_env; the
+        gateway's PYTHONHOME must not reach them (#75018)."""
+        from tools.environments.local import build_subprocess_env
+        with patch.dict(os.environ, {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "PYTHONHOME": "/opt/hermes-venv",
+        }, clear=True):
+            result = build_subprocess_env()
+        assert "PYTHONHOME" not in result
+
+    def test_pythonhome_removed_from_active_venv_markers(self):
+        """PYTHONHOME is part of _ACTIVE_VENV_MARKER_VARS so all builders
+        that iterate it drop the variable."""
+        from tools.environments.local import _ACTIVE_VENV_MARKER_VARS
+        assert "PYTHONHOME" in _ACTIVE_VENV_MARKER_VARS
+
+
 class TestProfileScopedPassthrough:
     def test_make_run_env_uses_active_profile_for_passthrough(self, monkeypatch):
         """Allowlisted values must come from the routed profile, not os.environ."""

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -928,6 +928,52 @@ class TestPythonpathSelectiveStrip:
             "/home/user/my-lib",
         ]
 
+    def test_profile_rehome_keeps_junction_lexical_alias(self, tmp_path, monkeypatch):
+        """Profile re-home must not lose the launcher's lexical repo-root spelling.
+
+        The desktop/CLI spawn children with HERMES_HOME and PYTHONPATH in the
+        configured (junction) spelling, but --profile / sticky active_profile
+        re-home HERMES_HOME through resolve_profile_env() before the
+        sanitizer loads.  Regression (junction + profile re-home): the alias
+        builder must still recover the lexical root so the inherited lexical
+        repo-root entry is stripped.
+        """
+        import tools.environments.local as local
+        from hermes_cli.profiles import resolve_profile_env
+
+        physical_home = tmp_path / "physical-home"
+        physical_root = physical_home / "hermes-agent"
+        physical_root.mkdir(parents=True)
+        (physical_home / "profiles" / "coder").mkdir(parents=True)
+        configured_home = tmp_path / "configured-home"
+        try:
+            _make_directory_link(configured_home, physical_home)
+        except OSError as exc:
+            pytest.skip(f"directory link unavailable on this host: {exc}")
+
+        # Launcher contract: the configured spelling is the env and the root.
+        monkeypatch.setenv("HERMES_HOME", str(configured_home))
+        lexical_root = configured_home / "hermes-agent"
+
+        # Profile re-home keeps the configured spelling (physically identical
+        # through the link; lexically the launcher spelling is preserved).
+        assert Path(resolve_profile_env("default")) == configured_home
+        assert Path(resolve_profile_env("coder")) == configured_home / "profiles" / "coder"
+
+        # The sanitizer now runs under the re-homed (profile) HERMES_HOME.
+        aliases = local._build_hermes_repo_root_aliases(
+            physical_root.resolve(),
+            physical_root,
+            configured_home / "profiles" / "coder",
+        )
+        assert any(local._same_path(a, lexical_root) for a in aliases)
+
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
+        env = {"PYTHONPATH": os.pathsep.join([str(lexical_root), "/home/user/my-lib"])}
+        local._strip_hermes_owned_pythonpath(env)
+        assert env["PYTHONPATH"].split(os.pathsep) == ["/home/user/my-lib"]
+
+
     def test_deep_path_under_repo_root_preserved(self):
         """A deeper path under the repo root (depth=2) is preserved.
 

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -23,6 +23,14 @@ from tools.environments.local import (
 )
 
 
+def _running_venv_site_packages() -> Path:
+    """Independently construct the host-native venv site-packages path."""
+    if sys.platform == "win32":
+        return Path(sys.prefix) / "Lib" / "site-packages"
+    pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+    return Path(sys.prefix) / "lib" / pyver / "site-packages"
+
+
 def _make_fake_popen(captured: dict):
     """Return a fake Popen constructor that records the env kwarg."""
     def fake_popen(cmd, **kwargs):
@@ -331,15 +339,11 @@ class TestPythonpathSelectiveStrip:
     def test_hermes_venv_site_packages_stripped(self):
         """A site-packages entry under the Hermes venv is removed."""
         from tools.environments.local import _strip_hermes_owned_pythonpath
-        import sys
 
         # Construct a path that looks like the Hermes venv site-packages.
         # Use the running interpreter's version so it hits the Hermes-venv
         # ownership check, not a user-path case.
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
-        )
+        venv_sp = str(_running_venv_site_packages())
         env = {
             "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
         }
@@ -349,6 +353,18 @@ class TestPythonpathSelectiveStrip:
         assert venv_sp not in entries
         assert "/home/user/my-lib" in entries
 
+    def test_hermes_site_packages_descendant_preserved(self):
+        """Only the exact producer entry is owned; descendants are user paths."""
+        from tools.environments.local import _strip_hermes_owned_pythonpath
+
+        venv_sp = _running_venv_site_packages()
+        descendant = str(venv_sp / "some-user-path")
+        env = {"PYTHONPATH": os.pathsep.join([descendant, "/home/user/my-lib"])}
+
+        _strip_hermes_owned_pythonpath(env)
+
+        assert env["PYTHONPATH"].split(os.pathsep) == [descendant, "/home/user/my-lib"]
+
     def test_user_pythonpath_preserved(self):
         """User PYTHONPATH entries pass through untouched."""
         from tools.environments.local import _strip_hermes_owned_pythonpath
@@ -356,6 +372,17 @@ class TestPythonpathSelectiveStrip:
         env = {"PYTHONPATH": user_pp}
         _strip_hermes_owned_pythonpath(env)
         assert env.get("PYTHONPATH") == user_pp
+
+    def test_nix_store_path_without_provenance_preserved(self):
+        """Path shape alone cannot distinguish a Nix user path from Hermes."""
+        from tools.environments.local import _strip_hermes_owned_pythonpath
+
+        nix_path = "/nix/store/abc123-user-plugin/lib/python3.12/site-packages"
+        env = {"PYTHONPATH": nix_path}
+
+        _strip_hermes_owned_pythonpath(env)
+
+        assert env["PYTHONPATH"] == nix_path
 
     def test_other_version_site_packages_preserved(self):
         """A user's pythonX.Y/site-packages entry is preserved even when its
@@ -419,7 +446,7 @@ class TestPythonpathSelectiveStrip:
 
         On Windows, os.pathsep is ';'.  We mock it so the test runs
         correctly on POSIX CI.  On a POSIX host a backslash path is a
-        single path component, so _is_path_under cannot identify it as
+        single path component, so ``Path`` cannot identify it as
         Hermes-owned — the critical invariant is that user Windows paths
         (including site-packages paths for another Python version) are
         never destroyed.  On a real Windows host, Path splits on
@@ -454,14 +481,10 @@ class TestPythonpathSelectiveStrip:
         not split on backslashes, so this cannot be meaningfully simulated
         on a POSIX host."""
         from tools.environments.local import _strip_hermes_owned_pythonpath
-        import sys
 
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "Lib" / "site-packages"
-        )
+        venv_sp = str(_running_venv_site_packages())
         # Windows form: C:\...\venv\Lib\site-packages (backslashes)
-        hermes_win = venv_sp.replace("\\", "\\\\").replace("/", "\\\\")
+        hermes_win = venv_sp
         user_win = "D:\\\\user\\\\lib"
         env = {
             "PYTHONPATH": ";".join([hermes_win, user_win]),
@@ -480,16 +503,39 @@ class TestPythonpathSelectiveStrip:
         # modifying the dict.  The key stays as-is (empty string).
         assert env.get("PYTHONPATH") == ""
 
-    def test_mixed_ordering_user_and_hermes_preserves_user_order(self):
-        """Mixed user/Hermes/user entries: user entries survive in their
-        original relative order after Hermes-owned entries are removed."""
+    def test_empty_component_preserved(self):
+        """An empty component means cwd and must survive unchanged."""
         from tools.environments.local import _strip_hermes_owned_pythonpath
-        import sys
 
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
-        )
+        user_pp = os.pathsep.join(["/foo", "", "/bar"])
+        env = {"PYTHONPATH": user_pp}
+
+        _strip_hermes_owned_pythonpath(env)
+
+        assert env["PYTHONPATH"] == user_pp
+
+    def test_raw_user_spelling_preserved(self):
+        """The sanitizer does not trim, normalize, or deduplicate user entries."""
+        from tools.environments.local import _strip_hermes_owned_pythonpath
+
+        user_pp = os.pathsep.join([
+            " /opt/user-lib ",
+            "relative/../lib",
+            "",
+            "/opt/user-lib",
+            "/opt/user-lib",
+        ])
+        env = {"PYTHONPATH": user_pp}
+
+        _strip_hermes_owned_pythonpath(env)
+
+        assert env["PYTHONPATH"] == user_pp
+
+    def test_mixed_ordering_user_and_hermes_preserves_user_order(self):
+        """Mixed entries retain raw user order, including an empty component."""
+        from tools.environments.local import _strip_hermes_owned_pythonpath
+
+        venv_sp = str(_running_venv_site_packages())
         local_file = Path(
             __import__("tools.environments.local", fromlist=["__file__"]).__file__
         ).resolve()
@@ -498,26 +544,81 @@ class TestPythonpathSelectiveStrip:
             "PYTHONPATH": os.pathsep.join([
                 "/first/user/lib",
                 repo_root,
-                "/second/user/lib",
+                "",
                 venv_sp,
-                "/third/user/lib",
+                "/second/user/lib",
             ]),
         }
         _strip_hermes_owned_pythonpath(env)
-        pp = env.get("PYTHONPATH", "")
-        entries = pp.split(os.pathsep) if pp else []
-        assert entries == ["/first/user/lib", "/second/user/lib", "/third/user/lib"]
+        assert env["PYTHONPATH"].split(os.pathsep) == [
+            "/first/user/lib",
+            "",
+            "/second/user/lib",
+        ]
+
+    def test_base_python_sanitizer_uses_validated_separate_runtime_venv(self, tmp_path, monkeypatch):
+        """A base interpreter strips the exact Windows runtime site-packages.
+
+        This deliberately uses a synthetic Hermes venv separate from the test
+        runner: sys.prefix represents base Python, while validated VIRTUAL_ENV
+        identifies ``<repo>/venv`` as the Hermes runtime producer contract.
+        """
+        import tools.environments.local as local
+
+        repo_root = tmp_path / "hermes-agent"
+        runtime_venv = repo_root / "venv"
+        runtime_sp = runtime_venv / "Lib" / "site-packages"
+        runtime_sp.mkdir(parents=True)
+        (runtime_venv / "pyvenv.cfg").write_text("version = 3.11\n", encoding="utf-8")
+        base_prefix = tmp_path / "base-python"
+        unrelated = "/custom/lib/python3.13/site-packages"
+
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", (repo_root,))
+        monkeypatch.setattr(local, "_in_venv", False)
+        monkeypatch.setattr(local, "_hermes_site_packages", None)
+        monkeypatch.setattr(local.sys, "prefix", str(base_prefix))
+        monkeypatch.setattr(local.sys, "base_prefix", str(base_prefix))
+
+        env = {
+            "VIRTUAL_ENV": str(runtime_venv),
+            "PYTHONPATH": os.pathsep.join([str(runtime_sp), unrelated]),
+        }
+        result = local._sanitize_subprocess_env(env)
+
+        assert Path(local.sys.prefix) == base_prefix
+        assert runtime_venv != Path(local.sys.prefix)
+        assert result["PYTHONPATH"] == unrelated
+        assert "VIRTUAL_ENV" not in result
+
+    def test_unrelated_virtual_env_is_not_runtime_provenance(self, tmp_path, monkeypatch):
+        """An arbitrary inherited VIRTUAL_ENV cannot claim PYTHONPATH ownership."""
+        import tools.environments.local as local
+
+        repo_root = tmp_path / "hermes-agent"
+        repo_root.mkdir()
+        unrelated_venv = tmp_path / "user-venv"
+        unrelated_sp = unrelated_venv / "Lib" / "site-packages"
+        unrelated_sp.mkdir(parents=True)
+        (unrelated_venv / "pyvenv.cfg").write_text("version = 3.13\n", encoding="utf-8")
+
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", (repo_root,))
+        monkeypatch.setattr(local, "_in_venv", False)
+        monkeypatch.setattr(local, "_hermes_site_packages", None)
+
+        env = {
+            "VIRTUAL_ENV": str(unrelated_venv),
+            "PYTHONPATH": str(unrelated_sp),
+        }
+        local._strip_hermes_owned_pythonpath(env)
+
+        assert env["PYTHONPATH"] == str(unrelated_sp)
 
     def test_duplicate_hermes_entries_all_stripped(self):
         """Every duplicate Hermes-owned entry is removed; user duplicates
         follow the existing contract (no unrelated dedup)."""
         from tools.environments.local import _strip_hermes_owned_pythonpath
-        import sys
 
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
-        )
+        venv_sp = str(_running_venv_site_packages())
         local_file = Path(
             __import__("tools.environments.local", fromlist=["__file__"]).__file__
         ).resolve()
@@ -546,12 +647,8 @@ class TestPythonpathSelectiveStrip:
         """If all entries are Hermes-owned and stripped, PYTHONPATH key is
         removed entirely."""
         from tools.environments.local import _strip_hermes_owned_pythonpath
-        import sys
 
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
-        )
+        venv_sp = str(_running_venv_site_packages())
 
         env = {"PYTHONPATH": venv_sp}
         _strip_hermes_owned_pythonpath(env)
@@ -560,12 +657,8 @@ class TestPythonpathSelectiveStrip:
     def test_make_run_env_strips_hermes_venv_pythonpath(self):
         """_make_run_env strips Hermes venv site-packages from PYTHONPATH."""
         from tools.environments.local import _make_run_env
-        import sys
 
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
-        )
+        venv_sp = str(_running_venv_site_packages())
         with patch.dict(os.environ, {
             "PATH": "/usr/bin:/bin",
             "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
@@ -579,12 +672,8 @@ class TestPythonpathSelectiveStrip:
     def test_sanitize_subprocess_env_strips_hermes_venv_pythonpath(self):
         """_sanitize_subprocess_env strips Hermes venv site-packages."""
         from tools.environments.local import _sanitize_subprocess_env
-        import sys
 
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
-        )
+        venv_sp = str(_running_venv_site_packages())
         base = {
             "PATH": "/usr/bin",
             "HOME": "/home/user",
@@ -599,12 +688,8 @@ class TestPythonpathSelectiveStrip:
     def test_hermes_subprocess_env_strips_hermes_venv_pythonpath(self):
         """hermes_subprocess_env strips Hermes venv site-packages."""
         from tools.environments.local import hermes_subprocess_env
-        import sys
 
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
-        )
+        venv_sp = str(_running_venv_site_packages())
         with patch.dict(os.environ, {
             "PATH": "/usr/bin:/bin",
             "HOME": "/home/user",
@@ -624,12 +709,8 @@ class TestPythonpathSelectiveStrip:
         """
         from tools.code_execution_tool import _scrub_child_env
         from tools.environments.local import _strip_hermes_owned_pythonpath
-        import sys
 
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        venv_sp = str(
-            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
-        )
+        venv_sp = str(_running_venv_site_packages())
         other_sp = "/opt/other-venv/lib/python3.99/site-packages"
         source = {
             "PATH": "/usr/bin",
@@ -679,7 +760,8 @@ class TestPythonpathSelectiveStrip:
         """A direct child of the repo root (depth=1) is PRESERVED.
 
         Independent audit of every real launcher producer (Electron
-        ``electron-main.mjs``, ``gateway/run.py::_ensure_windows_gateway_venv_imports``,
+        ``apps/desktop/electron/main.ts``,
+        ``gateway/run.py::_ensure_windows_gateway_venv_imports``,
         ``cron/scheduler.py::_windows_cron_python_invocation``,
         ``tui_gateway/host_supervisor.py``) shows they all inject the exact
         repo root and/or the venv site-packages — none injects
@@ -702,47 +784,43 @@ class TestPythonpathSelectiveStrip:
         assert direct_child in entries
         assert "/home/user/my-lib" in entries
 
-    def test_repo_root_junction_alias_stripped(self):
-        """A PYTHONPATH entry using the unresolved (HERMES_HOME/junction)
-        spelling of the repo root is stripped.
+    def test_configured_home_alias_matches_launcher_output(self, tmp_path, monkeypatch):
+        """The real producer spelling is derived and consumed end to end."""
+        import tools.environments.local as local
+        from hermes_cli.gateway_windows import _preserve_hermes_home_path
 
-        On Windows the gateway launcher renders Hermes-owned paths under the
-        configured HERMES_HOME spelling, which may be a symlink/junction to
-        another drive (``_preserve_hermes_home_path`` in
-        ``hermes_cli/gateway_windows.py``).  ``_hermes_repo_root`` is the
-        RESOLVED physical path, so the launcher's spelling differs lexically;
-        the alias set must still recognize it as Hermes-owned.  This test
-        monkeypatches the aliases to a pair whose lexical forms differ, the
-        way a junction would, and verifies the launcher's spelling is
-        stripped while a nested user path under the same prefix is not.
-        """
-        from tools.environments.local import (
-            _strip_hermes_owned_pythonpath,
-            _hermes_repo_root_aliases,
+        physical_home = tmp_path / "physical-home"
+        physical_root = physical_home / "hermes-agent"
+        physical_root.mkdir(parents=True)
+        configured_home = tmp_path / "configured-home"
+        configured_home.symlink_to(physical_home, target_is_directory=True)
+        monkeypatch.setenv("HERMES_HOME", str(configured_home))
+
+        launcher_entry = Path(_preserve_hermes_home_path(physical_root))
+        aliases = local._build_hermes_repo_root_aliases(
+            physical_root.resolve(),
+            physical_root,
+            configured_home,
         )
-        from pathlib import Path as _Path
 
-        resolved_root = _Path("/data/hermes/hermes-agent")
-        junction_root = _Path("/home/u/AppData/Local/hermes/hermes-agent")
-        with patch(
-            "tools.environments.local._hermes_repo_root_aliases",
-            (resolved_root, junction_root),
-        ):
-            # Launcher spelling (junction form) of the exact repo root.
-            env = {"PYTHONPATH": str(junction_root)}
-            _strip_hermes_owned_pythonpath(env)
-            assert "PYTHONPATH" not in env
+        assert launcher_entry == configured_home / "hermes-agent"
+        assert launcher_entry in aliases
 
-            # Nested user path under the same junction prefix survives.
-            env = {"PYTHONPATH": os.pathsep.join([
-                str(junction_root / "user-data"),
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
+        nested_user_path = launcher_entry / "user-data"
+        env = {
+            "PYTHONPATH": os.pathsep.join([
+                str(launcher_entry),
+                str(nested_user_path),
                 "/home/user/my-lib",
-            ])}
-            _strip_hermes_owned_pythonpath(env)
-            pp = env.get("PYTHONPATH", "")
-            entries = pp.split(os.pathsep) if pp else []
-            assert str(junction_root / "user-data") in entries
-            assert "/home/user/my-lib" in entries
+            ])
+        }
+        local._strip_hermes_owned_pythonpath(env)
+
+        assert env["PYTHONPATH"].split(os.pathsep) == [
+            str(nested_user_path),
+            "/home/user/my-lib",
+        ]
 
     def test_deep_path_under_repo_root_preserved(self):
         """A deeper path under the repo root (depth=2) is preserved.

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -313,6 +313,238 @@ class TestActiveVenvMarkerStripping:
         assert "CONDA_PREFIX" in _ACTIVE_VENV_MARKER_VARS
 
 
+class TestPythonpathSelectiveStrip:
+    """PYTHONPATH site-packages stripping for cross-version ABI safety (#74817).
+
+    The Desktop Electron app injects the Hermes venv's site-packages
+    (Python 3.11) into PYTHONPATH.  When this leaks into subprocesses
+    running a different Python (e.g. 3.13), 3.11 C extensions appear on
+    sys.path and crash with ImportError.  ``_strip_mismatched_site_packages``
+    surgically removes only the dangerous entries, preserving user paths.
+    """
+
+    def test_hermes_venv_site_packages_stripped(self):
+        """A site-packages entry under the Hermes venv is removed."""
+        from tools.environments.local import _strip_mismatched_site_packages
+        import sys
+
+        # Construct a path that looks like the Hermes venv site-packages.
+        # Use the running interpreter's version so it hits the "under Hermes
+        # venv" check (check 2), not the cross-version check (check 1).
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
+        )
+        env = {
+            "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
+        }
+        _strip_mismatched_site_packages(env)
+        assert "PYTHONPATH" in env
+        entries = env["PYTHONPATH"].split(os.pathsep)
+        assert venv_sp not in entries
+        assert "/home/user/my-lib" in entries
+
+    def test_user_pythonpath_preserved(self):
+        """User PYTHONPATH entries pass through untouched."""
+        from tools.environments.local import _strip_mismatched_site_packages
+        user_pp = os.pathsep.join(["/opt/my-lib", "/another/path"])
+        env = {"PYTHONPATH": user_pp}
+        _strip_mismatched_site_packages(env)
+        assert env.get("PYTHONPATH") == user_pp
+
+    def test_cross_version_site_packages_stripped(self):
+        """A python3.12/site-packages entry is stripped even if NOT under the
+        Hermes venv path - simulates a leak from systemd or another source."""
+        from tools.environments.local import _strip_mismatched_site_packages
+        import sys
+
+        # Use a version different from the running interpreter.
+        running_major = sys.version_info[0]
+        running_minor = sys.version_info[1]
+        # Pick a guaranteed-different version.
+        other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
+        other_ver = f"python{running_major}.{other_minor}"
+
+        mismatched_sp = f"/opt/other-venv/lib/{other_ver}/site-packages"
+        env = {
+            "PYTHONPATH": os.pathsep.join([mismatched_sp, "/home/user/my-lib"]),
+        }
+        _strip_mismatched_site_packages(env)
+        assert "PYTHONPATH" in env
+        entries = env["PYTHONPATH"].split(os.pathsep)
+        assert mismatched_sp not in entries
+        assert "/home/user/my-lib" in entries
+
+    def test_cross_major_version_stripped(self):
+        """A python2.7/site-packages entry is always stripped."""
+        from tools.environments.local import _strip_mismatched_site_packages
+        env = {
+            "PYTHONPATH": "/old/lib/python2.7/site-packages:/home/user/lib",
+        }
+        _strip_mismatched_site_packages(env)
+        entries = env["PYTHONPATH"].split(os.pathsep)
+        assert "/old/lib/python2.7/site-packages" not in entries
+        assert "/home/user/lib" in entries
+
+    def test_windows_backslash_paths(self):
+        """Windows-style backslash paths with site-packages are handled.
+
+        On Windows, os.pathsep is ';'.  We mock it so the test runs
+        correctly on POSIX CI."""
+        from tools.environments.local import _strip_mismatched_site_packages
+        import sys
+
+        # Construct a Windows-style path with a different Python version.
+        running_major = sys.version_info[0]
+        running_minor = sys.version_info[1]
+        other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
+        other_ver = f"python{running_major}.{other_minor}"
+
+        mismatched_win = f"C:\\venv\\lib\\{other_ver}\\site-packages"
+        user_win = "D:\\user\\lib"
+        env = {
+            "PYTHONPATH": ";".join([mismatched_win, user_win]),
+        }
+        # Mock os.pathsep to ';' (Windows) just for the strip call.
+        with patch("os.pathsep", ";"):
+            _strip_mismatched_site_packages(env)
+        assert "PYTHONPATH" in env
+        entries = env["PYTHONPATH"].split(";")
+        assert mismatched_win not in entries
+        assert user_win in entries
+
+    def test_empty_pythonpath_unchanged(self):
+        """An empty PYTHONPATH is a no-op (falsy -> early return)."""
+        from tools.environments.local import _strip_mismatched_site_packages
+        env = {"PYTHONPATH": ""}
+        _strip_mismatched_site_packages(env)
+        # Empty string is falsy, so the function returns early without
+        # modifying the dict.  The key stays as-is (empty string).
+        assert env.get("PYTHONPATH") == ""
+
+    def test_no_pythonpath_key(self):
+        """Missing PYTHONPATH key is a no-op."""
+        from tools.environments.local import _strip_mismatched_site_packages
+        env = {"PATH": "/usr/bin"}
+        _strip_mismatched_site_packages(env)
+        assert "PYTHONPATH" not in env
+
+    def test_all_entries_stripped_removes_key(self):
+        """If all entries are stripped, PYTHONPATH key is removed entirely."""
+        from tools.environments.local import _strip_mismatched_site_packages
+        import sys
+
+        running_major = sys.version_info[0]
+        running_minor = sys.version_info[1]
+        other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
+        other_ver = f"python{running_major}.{other_minor}"
+
+        env = {"PYTHONPATH": f"/a/lib/{other_ver}/site-packages"}
+        _strip_mismatched_site_packages(env)
+        assert "PYTHONPATH" not in env
+
+    def test_make_run_env_strips_hermes_venv_pythonpath(self):
+        """_make_run_env strips Hermes venv site-packages from PYTHONPATH."""
+        from tools.environments.local import _make_run_env
+        import sys
+
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
+        )
+        with patch.dict(os.environ, {
+            "PATH": "/usr/bin:/bin",
+            "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
+        }, clear=True):
+            run_env = _make_run_env({})
+        pp = run_env.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert venv_sp not in entries
+        assert "/home/user/my-lib" in entries
+
+    def test_sanitize_subprocess_env_strips_hermes_venv_pythonpath(self):
+        """_sanitize_subprocess_env strips Hermes venv site-packages."""
+        from tools.environments.local import _sanitize_subprocess_env
+        import sys
+
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
+        )
+        base = {
+            "PATH": "/usr/bin",
+            "HOME": "/home/user",
+            "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
+        }
+        result = _sanitize_subprocess_env(base)
+        pp = result.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert venv_sp not in entries
+        assert "/home/user/my-lib" in entries
+
+    def test_hermes_subprocess_env_strips_hermes_venv_pythonpath(self):
+        """hermes_subprocess_env strips Hermes venv site-packages."""
+        from tools.environments.local import hermes_subprocess_env
+        import sys
+
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
+        )
+        with patch.dict(os.environ, {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
+        }, clear=True):
+            result = hermes_subprocess_env()
+        pp = result.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert venv_sp not in entries
+        assert "/home/user/my-lib" in entries
+
+    def test_scrub_child_env_strips_mismatched_pythonpath(self):
+        """execute_code's _scrub_child_env path: after scrubbing, mismatched
+        site-packages entries should be stripped when _strip_mismatched_site_packages
+        is applied (as the spawn path does)."""
+        from tools.code_execution_tool import _scrub_child_env
+        from tools.environments.local import _strip_mismatched_site_packages
+        import sys
+
+        running_major = sys.version_info[0]
+        running_minor = sys.version_info[1]
+        other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
+        other_ver = f"python{running_major}.{other_minor}"
+
+        mismatched_sp = f"/opt/other-venv/lib/{other_ver}/site-packages"
+        source = {
+            "PATH": "/usr/bin",
+            "HOME": "/home/user",
+            "PYTHONPATH": os.pathsep.join([mismatched_sp, "/home/user/my-lib"]),
+        }
+        scrubbed = _scrub_child_env(source)
+        # The scrubber passes PYTHONPATH through (it's in _SAFE_ENV_PREFIXES).
+        assert "PYTHONPATH" in scrubbed
+        # Now apply the selective strip (as the spawn path does).
+        _strip_mismatched_site_packages(scrubbed)
+        pp = scrubbed.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert mismatched_sp not in entries
+        assert "/home/user/my-lib" in entries
+
+    def test_repo_root_stripped(self):
+        """The Hermes repo root entry is stripped from PYTHONPATH."""
+        from tools.environments.local import _strip_mismatched_site_packages, _hermes_repo_root
+        repo_root = str(_hermes_repo_root)
+        env = {
+            "PYTHONPATH": os.pathsep.join([repo_root, "/home/user/my-lib"]),
+        }
+        _strip_mismatched_site_packages(env)
+        pp = env.get("PYTHONPATH", "")
+        entries = pp.split(os.pathsep) if pp else []
+        assert repo_root not in entries
+        assert "/home/user/my-lib" in entries
+
+
 class TestProfileScopedPassthrough:
     def test_make_run_env_uses_active_profile_for_passthrough(self, monkeypatch):
         """Allowlisted values must come from the routed profile, not os.environ."""

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -315,13 +315,16 @@ class TestActiveVenvMarkerStripping:
 
 
 class TestPythonpathSelectiveStrip:
-    """PYTHONPATH site-packages stripping for cross-version ABI safety (#74817).
+    """PYTHONPATH Hermes-owned entry stripping (#74817).
 
-    The Desktop Electron app injects the Hermes venv's site-packages
-    (Python 3.11) into PYTHONPATH.  When this leaks into subprocesses
-    running a different Python (e.g. 3.13), 3.11 C extensions appear on
-    sys.path and crash with ImportError.  ``_strip_mismatched_site_packages``
-    surgically removes only the dangerous entries, preserving user paths.
+    The Desktop Electron app injects the Hermes repo root and the Hermes
+    venv's site-packages (Python 3.11) into PYTHONPATH.  When this leaks
+    into subprocesses running a different Python (e.g. 3.13), 3.11 C
+    extensions appear on sys.path and crash with ImportError.
+    ``_strip_mismatched_site_packages`` surgically removes only the
+    entries Hermes itself owns (repo root, own venv site-packages),
+    preserving user paths — including user paths whose names merely
+    contain another Python version.
     """
 
     def test_hermes_venv_site_packages_stripped(self):
@@ -330,8 +333,8 @@ class TestPythonpathSelectiveStrip:
         import sys
 
         # Construct a path that looks like the Hermes venv site-packages.
-        # Use the running interpreter's version so it hits the "under Hermes
-        # venv" check (check 2), not the cross-version check (check 1).
+        # Use the running interpreter's version so it hits the Hermes-venv
+        # ownership check, not a user-path case.
         pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
         venv_sp = str(
             __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
@@ -353,65 +356,92 @@ class TestPythonpathSelectiveStrip:
         _strip_mismatched_site_packages(env)
         assert env.get("PYTHONPATH") == user_pp
 
-    def test_cross_version_site_packages_stripped(self):
-        """A python3.12/site-packages entry is stripped even if NOT under the
-        Hermes venv path - simulates a leak from systemd or another source."""
+    def test_other_version_site_packages_preserved(self):
+        """A user's pythonX.Y/site-packages entry is preserved even when its
+        version differs from the Hermes backend interpreter.
+
+        The env builder cannot know which Python the child will run, so a
+        user path intended for a child of another version must never be
+        judged against the BACKEND's interpreter version (P2, #74817
+        follow-up).  Regression: prior Check 1 stripped these.
+        """
         from tools.environments.local import _strip_mismatched_site_packages
         import sys
 
         # Use a version different from the running interpreter.
         running_major = sys.version_info[0]
         running_minor = sys.version_info[1]
-        # Pick a guaranteed-different version.
         other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
         other_ver = f"python{running_major}.{other_minor}"
 
-        mismatched_sp = f"/opt/other-venv/lib/{other_ver}/site-packages"
+        other_sp = f"/opt/other-venv/lib/{other_ver}/site-packages"
         env = {
-            "PYTHONPATH": os.pathsep.join([mismatched_sp, "/home/user/my-lib"]),
+            "PYTHONPATH": os.pathsep.join([other_sp, "/home/user/my-lib"]),
         }
         _strip_mismatched_site_packages(env)
         assert "PYTHONPATH" in env
         entries = env["PYTHONPATH"].split(os.pathsep)
-        assert mismatched_sp not in entries
+        assert other_sp in entries
         assert "/home/user/my-lib" in entries
 
-    def test_cross_major_version_stripped(self):
-        """A python2.7/site-packages entry is always stripped."""
+    def test_other_major_version_site_packages_preserved(self):
+        """A user's python2.7/site-packages entry is preserved — path
+        ownership, not version, decides stripping (P2, #74817 follow-up).
+        """
         from tools.environments.local import _strip_mismatched_site_packages
         env = {
             "PYTHONPATH": "/old/lib/python2.7/site-packages:/home/user/lib",
         }
         _strip_mismatched_site_packages(env)
+        assert "PYTHONPATH" in env
         entries = env["PYTHONPATH"].split(os.pathsep)
-        assert "/old/lib/python2.7/site-packages" not in entries
+        assert "/old/lib/python2.7/site-packages" in entries
         assert "/home/user/lib" in entries
 
+    def test_non_site_packages_python_version_paths_preserved(self):
+        """Paths merely CONTAINING a pythonX.Y component (not site-packages)
+        must never be stripped (P1, #74817 follow-up).  Regression: prior
+        Check 1 deleted these because it keyed on the version component alone.
+        """
+        from tools.environments.local import _strip_mismatched_site_packages
+        user_pp = os.pathsep.join([
+            "/opt/tools/python3.13/bin",
+            "/opt/downloads/python3.13",
+            "/custom/python3.13",
+        ])
+        env = {"PYTHONPATH": user_pp}
+        _strip_mismatched_site_packages(env)
+        assert env.get("PYTHONPATH") == user_pp
+
     def test_windows_backslash_paths(self):
-        """Windows-style backslash paths with site-packages are handled.
+        """Windows-style backslash paths are handled for Hermes-owned entries.
 
         On Windows, os.pathsep is ';'.  We mock it so the test runs
-        correctly on POSIX CI."""
+        correctly on POSIX CI.  On a POSIX host a backslash path is a
+        single path component, so _is_path_under cannot identify it as
+        Hermes-owned — the critical invariant is that user Windows paths
+        (including site-packages paths for another Python version) are
+        never destroyed.  On a real Windows host, Path splits on
+        backslashes and Hermes venv site-packages entries are stripped
+        by the same Hermes-owned check.
+        """
         from tools.environments.local import _strip_mismatched_site_packages
         import sys
 
-        # Construct a Windows-style path with a different Python version.
-        running_major = sys.version_info[0]
-        running_minor = sys.version_info[1]
-        other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
-        other_ver = f"python{running_major}.{other_minor}"
-
-        mismatched_win = f"C:\\venv\\lib\\{other_ver}\\site-packages"
-        user_win = "D:\\user\\lib"
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        hermes_win = f"C:\\\\Users\\\\u\\\\.hermes\\\\hermes-agent\\\\venv\\\\lib\\\\{pyver}\\\\site-packages"
+        user_win = "D:\\\\user\\\\lib"
         env = {
-            "PYTHONPATH": ";".join([mismatched_win, user_win]),
+            "PYTHONPATH": ";".join([hermes_win, user_win]),
         }
         # Mock os.pathsep to ';' (Windows) just for the strip call.
         with patch("os.pathsep", ";"):
             _strip_mismatched_site_packages(env)
         assert "PYTHONPATH" in env
         entries = env["PYTHONPATH"].split(";")
-        assert mismatched_win not in entries
+        # Both survive on POSIX: user paths must always be preserved, and
+        # the Hermes-owned check cannot match a backslash path here.
+        assert hermes_win in entries
         assert user_win in entries
 
     def test_empty_pythonpath_unchanged(self):
@@ -431,16 +461,17 @@ class TestPythonpathSelectiveStrip:
         assert "PYTHONPATH" not in env
 
     def test_all_entries_stripped_removes_key(self):
-        """If all entries are stripped, PYTHONPATH key is removed entirely."""
+        """If all entries are Hermes-owned and stripped, PYTHONPATH key is
+        removed entirely."""
         from tools.environments.local import _strip_mismatched_site_packages
         import sys
 
-        running_major = sys.version_info[0]
-        running_minor = sys.version_info[1]
-        other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
-        other_ver = f"python{running_major}.{other_minor}"
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
+        )
 
-        env = {"PYTHONPATH": f"/a/lib/{other_ver}/site-packages"}
+        env = {"PYTHONPATH": venv_sp}
         _strip_mismatched_site_packages(env)
         assert "PYTHONPATH" not in env
 
@@ -503,24 +534,25 @@ class TestPythonpathSelectiveStrip:
         assert venv_sp not in entries
         assert "/home/user/my-lib" in entries
 
-    def test_scrub_child_env_strips_mismatched_pythonpath(self):
-        """execute_code's _scrub_child_env path: after scrubbing, mismatched
-        site-packages entries should be stripped when _strip_mismatched_site_packages
-        is applied (as the spawn path does)."""
+    def test_scrub_child_env_strips_hermes_venv_pythonpath(self):
+        """execute_code's _scrub_child_env path: after scrubbing, Hermes venv
+        site-packages entries should be stripped when
+        _strip_mismatched_site_packages is applied (as the spawn path does),
+        while user entries (even for another Python version) are preserved.
+        """
         from tools.code_execution_tool import _scrub_child_env
         from tools.environments.local import _strip_mismatched_site_packages
         import sys
 
-        running_major = sys.version_info[0]
-        running_minor = sys.version_info[1]
-        other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
-        other_ver = f"python{running_major}.{other_minor}"
-
-        mismatched_sp = f"/opt/other-venv/lib/{other_ver}/site-packages"
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        venv_sp = str(
+            __import__("pathlib").Path(sys.prefix) / "lib" / pyver / "site-packages"
+        )
+        other_sp = "/opt/other-venv/lib/python3.99/site-packages"
         source = {
             "PATH": "/usr/bin",
             "HOME": "/home/user",
-            "PYTHONPATH": os.pathsep.join([mismatched_sp, "/home/user/my-lib"]),
+            "PYTHONPATH": os.pathsep.join([venv_sp, other_sp, "/home/user/my-lib"]),
         }
         scrubbed = _scrub_child_env(source)
         # The scrubber passes PYTHONPATH through (it's in _SAFE_ENV_PREFIXES).
@@ -529,7 +561,8 @@ class TestPythonpathSelectiveStrip:
         _strip_mismatched_site_packages(scrubbed)
         pp = scrubbed.get("PYTHONPATH", "")
         entries = pp.split(os.pathsep) if pp else []
-        assert mismatched_sp not in entries
+        assert venv_sp not in entries
+        assert other_sp in entries
         assert "/home/user/my-lib" in entries
 
     def test_repo_root_stripped(self):

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -814,21 +814,33 @@ class TestPythonpathSelectiveStrip:
         assert "PYTHONPATH" in captured["env"], \
             "execute_code never reached Popen"
         parts = captured["env"]["PYTHONPATH"].split(os.pathsep)
-        assert parts[0] == captured["staging"], \
+        # Windows path comparison is case-insensitive: the inherited entries
+        # and the re-added repo root can carry a different case than the
+        # resolve()/abspath()-derived spellings used in this test (e.g. a
+        # launcher-written lowercase PYTHONPATH).  Normalize with
+        # os.path.normcase so a case-only difference never fails the
+        # composition contract (identity on POSIX).
+        norm_parts = [os.path.normcase(p) for p in parts]
+        norm_staging = os.path.normcase(captured["staging"])
+        norm_root = os.path.normcase(hermes_root)
+        norm_venv = os.path.normcase(venv_sp)
+        norm_user_a = os.path.normcase(user_a)
+        norm_user_b = os.path.normcase(user_b)
+        assert norm_parts[0] == norm_staging, \
             "staging tmpdir must be the first PYTHONPATH entry"
-        assert venv_sp not in parts, \
+        assert norm_venv not in norm_parts, \
             "inherited Hermes venv site-packages must be stripped"
-        assert user_a in parts and user_b in parts, \
+        assert norm_user_a in norm_parts and norm_user_b in norm_parts, \
             "user PYTHONPATH entries must survive"
-        assert parts.index(user_a) > parts.index(captured["staging"]), \
+        assert norm_parts.index(norm_user_a) > norm_parts.index(norm_staging), \
             "user entries must come after the staging tmpdir"
         if same_env:
-            assert parts.count(hermes_root) == 1, \
+            assert norm_parts.count(norm_root) == 1, \
                 "repo root must be re-added exactly once for a same-env child"
-            assert parts.index(user_a) > parts.index(hermes_root), \
+            assert norm_parts.index(norm_user_a) > norm_parts.index(norm_root), \
                 "user entries must come after the re-added repo root"
         else:
-            assert hermes_root not in parts, \
+            assert norm_root not in norm_parts, \
                 "repo root must stay absent for an external-env child"
 
     def test_repo_root_stripped(self):
@@ -972,6 +984,166 @@ class TestPythonpathSelectiveStrip:
         env = {"PYTHONPATH": os.pathsep.join([str(lexical_root), "/home/user/my-lib"])}
         local._strip_hermes_owned_pythonpath(env)
         assert env["PYTHONPATH"].split(os.pathsep) == ["/home/user/my-lib"]
+
+
+    def test_repo_level_junction_recovers_lexical_alias(self, tmp_path, monkeypatch):
+        """The repo itself may be a junction under the configured root
+        (e.g. D:\\hermes\\hermes-agent -> C:\\...\\hermes-agent) while the
+        editable import spelling resolves to the physical location.  The
+        alias builder must recover the lexical spelling via exact-identity
+        proof (strict resolve), not a name-based guess.
+        """
+        import tools.environments.local as local
+
+        physical_home = tmp_path / "physical-home"
+        physical_root = physical_home / "hermes-agent"
+        physical_root.mkdir(parents=True)
+        configured_home = tmp_path / "configured-home"
+        configured_home.mkdir()
+        # repo-level link: <configured-home>/hermes-agent -> physical repo
+        try:
+            _make_directory_link(configured_home / "hermes-agent", physical_root)
+        except OSError as exc:
+            pytest.skip(f"directory link unavailable on this host: {exc}")
+
+        lexical_root = configured_home / "hermes-agent"
+        aliases = local._build_hermes_repo_root_aliases(
+            physical_root.resolve(),
+            physical_root,
+            configured_home,
+        )
+        assert any(local._same_path(a, lexical_root) for a in aliases)
+
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
+        env = {"PYTHONPATH": os.pathsep.join([str(lexical_root), "/home/user/my-lib"])}
+        local._strip_hermes_owned_pythonpath(env)
+        assert env["PYTHONPATH"].split(os.pathsep) == ["/home/user/my-lib"]
+
+    def test_repo_level_junction_negative_control(self, tmp_path, monkeypatch):
+        """A same-named REAL directory under the configured root (not a link
+        to the known physical repo) must never become an alias or be
+        stripped -- exact filesystem identity decides, not the name.
+        """
+        import tools.environments.local as local
+
+        physical_home = tmp_path / "physical-home"
+        physical_root = physical_home / "hermes-agent"
+        physical_root.mkdir(parents=True)
+        configured_home = tmp_path / "configured-home"
+        (configured_home / "hermes-agent").mkdir(parents=True)
+
+        aliases = local._build_hermes_repo_root_aliases(
+            physical_root.resolve(),
+            physical_root,
+            configured_home,
+        )
+        lookalike = configured_home / "hermes-agent"
+        assert not any(local._same_path(a, lookalike) for a in aliases)
+
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
+        env = {"PYTHONPATH": os.pathsep.join([str(lookalike), "/home/user/my-lib"])}
+        local._strip_hermes_owned_pythonpath(env)
+        assert env["PYTHONPATH"].split(os.pathsep) == [str(lookalike), "/home/user/my-lib"]
+
+    def test_profile_home_with_repo_level_junction(self, tmp_path, monkeypatch):
+        """Profile re-home + repo-level junction together: the configured home
+        is <root>/profiles/<name> while the repo is a link at <root>/hermes-agent.
+        The root spelling must be derived (profiles -> grandparent) and then
+        the lexical repo alias recovered from it.
+        """
+        import tools.environments.local as local
+
+        physical_home = tmp_path / "physical-home"
+        physical_root = physical_home / "hermes-agent"
+        physical_root.mkdir(parents=True)
+        configured_root = tmp_path / "configured-root"
+        (configured_root / "profiles" / "coder").mkdir(parents=True)
+        try:
+            _make_directory_link(configured_root / "hermes-agent", physical_root)
+        except OSError as exc:
+            pytest.skip(f"directory link unavailable on this host: {exc}")
+
+        configured_home = configured_root / "profiles" / "coder"
+        lexical_root = configured_root / "hermes-agent"
+        aliases = local._build_hermes_repo_root_aliases(
+            physical_root.resolve(),
+            physical_root,
+            configured_home,
+        )
+        assert any(local._same_path(a, lexical_root) for a in aliases)
+        assert not any(local._same_path(a, configured_home / "hermes-agent") for a in aliases)
+
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
+        env = {"PYTHONPATH": os.pathsep.join([str(lexical_root), "/home/user/my-lib"])}
+        local._strip_hermes_owned_pythonpath(env)
+        assert env["PYTHONPATH"].split(os.pathsep) == ["/home/user/my-lib"]
+
+    def test_validated_runtime_venv_lexical_after_repo_recovery(self, tmp_path, monkeypatch):
+        """uv-base gateway: once the lexical repo alias is recovered, a lexical
+        VIRTUAL_ENV (<lexical repo>/venv) validates and its site-packages is
+        stripped together with the repo root, while user entries survive.
+        """
+        import tools.environments.local as local
+
+        physical_home = tmp_path / "physical-home"
+        physical_root = physical_home / "hermes-agent"
+        venv_dir = physical_root / "venv"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "pyvenv.cfg").write_text("home = x\n", encoding="utf-8")
+        configured_home = tmp_path / "configured-home"
+        configured_home.mkdir()
+        try:
+            _make_directory_link(configured_home / "hermes-agent", physical_root)
+        except OSError as exc:
+            pytest.skip(f"directory link unavailable on this host: {exc}")
+
+        lexical_root = configured_home / "hermes-agent"
+        aliases = local._build_hermes_repo_root_aliases(
+            physical_root.resolve(),
+            physical_root,
+            configured_home,
+        )
+        assert any(local._same_path(a, lexical_root) for a in aliases)
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
+
+        lexical_venv = lexical_root / "venv"
+        validated = local._validated_runtime_venv({"VIRTUAL_ENV": str(lexical_venv)})
+        assert validated is not None
+        assert local._same_path(validated, lexical_venv)
+
+        local._hermes_site_packages = None
+        env = {"PYTHONPATH": os.pathsep.join([
+            str(lexical_root),
+            str(lexical_venv / "Lib" / "site-packages"),
+            "/home/user/my-lib",
+        ]), "VIRTUAL_ENV": str(lexical_venv)}
+        local._strip_hermes_owned_pythonpath(env)
+        assert env["PYTHONPATH"].split(os.pathsep) == ["/home/user/my-lib"]
+
+    def test_lookalike_user_path_without_provenance_preserved(self, tmp_path, monkeypatch):
+        """A user PYTHONPATH entry that merely looks like a Hermes path
+        (repo-named directory, no link to the known physical repo) must be
+        preserved -- no ownership provenance, no strip.
+        """
+        import tools.environments.local as local
+
+        physical_home = tmp_path / "physical-home"
+        physical_root = physical_home / "hermes-agent"
+        physical_root.mkdir(parents=True)
+        unrelated = tmp_path / "user-tools" / "hermes-agent"
+        unrelated.mkdir(parents=True)
+
+        aliases = local._build_hermes_repo_root_aliases(
+            physical_root.resolve(),
+            physical_root,
+            tmp_path / "configured-home",
+        )
+        assert not any(local._same_path(a, unrelated) for a in aliases)
+
+        monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
+        env = {"PYTHONPATH": os.pathsep.join([str(unrelated), "/home/user/my-lib"])}
+        local._strip_hermes_owned_pythonpath(env)
+        assert env["PYTHONPATH"].split(os.pathsep) == [str(unrelated), "/home/user/my-lib"]
 
 
     def test_deep_path_under_repo_root_preserved(self):

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -10,6 +10,7 @@ See: https://github.com/NousResearch/hermes-agent/issues/1264
 
 import os
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -532,16 +533,31 @@ class TestPythonpathSelectiveStrip:
         assert "/home/user/my-lib" in entries
 
     def test_repo_root_stripped(self):
-        """The Hermes repo root entry is stripped from PYTHONPATH."""
-        from tools.environments.local import _strip_mismatched_site_packages, _hermes_repo_root
-        repo_root = str(_hermes_repo_root)
+        """The Hermes repo root entry is stripped from PYTHONPATH.
+
+        Electron prepends the *actual* repository root (the directory
+        containing ``tools/``, ``hermes_cli/``, etc.) to PYTHONPATH so the
+        backend can ``import tools``.  This test independently computes that
+        real repo root from the source-file location - three levels up from
+        ``tools/environments/local.py`` - rather than reusing the module
+        constant under test.  That way an off-by-one in ``_hermes_repo_root``
+        (e.g. ``parents[1]`` resolving to ``tools/``) would cause this test
+        to fail instead of silently passing.
+        """
+        from tools.environments.local import _strip_mismatched_site_packages
+
+        # Independently compute the real repo root: local.py lives at
+        # tools/environments/local.py, so the repo root is parents[2].
+        local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
+        real_repo_root = str(local_file.parents[2])
+
         env = {
-            "PYTHONPATH": os.pathsep.join([repo_root, "/home/user/my-lib"]),
+            "PYTHONPATH": os.pathsep.join([real_repo_root, "/home/user/my-lib"]),
         }
         _strip_mismatched_site_packages(env)
         pp = env.get("PYTHONPATH", "")
         entries = pp.split(os.pathsep) if pp else []
-        assert repo_root not in entries
+        assert real_repo_root not in entries
         assert "/home/user/my-lib" in entries
 
 

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -728,6 +728,78 @@ class TestPythonpathSelectiveStrip:
         assert other_sp in entries
         assert "/home/user/my-lib" in entries
 
+    @pytest.mark.parametrize("same_env", [True, False])
+    def test_execute_code_composition_strips_inherited_hermes_entries(self, same_env):
+        """Integration: execute_code's real spawn path composes a clean PYTHONPATH.
+
+        Seeds a contaminated inherited PYTHONPATH (Hermes repo root + Hermes
+        venv site-packages + user entries) through os.environ and drives
+        execute_code all the way to Popen.  Proves the #84500 conditional
+        composition and the #82581 selective strip compose correctly:
+
+        * inherited Hermes venv site-packages never survive into the sandbox;
+        * the staging tmpdir stays the first entry;
+        * the repo root is deliberately re-added exactly once for a same-env
+          child (the single occurrence proves the inherited copy was stripped
+          first) and stays absent for an external-environment child;
+        * user entries survive after the controlled entries.
+        """
+        import tools.code_execution_tool as cet
+        from tools.code_execution_tool import execute_code
+
+        def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+            return '{"output": "mock", "exit_code": 0}'
+
+        hermes_root = str(Path(cet.__file__).resolve().parents[1])
+        venv_sp = str(_running_venv_site_packages())
+        user_a = "/home/user/my-lib"
+        user_b = "/opt/project/lib"
+        captured = {}
+
+        def _fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+            captured["staging"] = os.path.dirname(cmd[1])
+            proc = MagicMock()
+            proc.stdout.read.return_value = b""
+            proc.stderr.read.return_value = b""
+            proc.wait.return_value = 0
+            proc.returncode = 0
+            proc.poll.return_value = 0
+            return proc
+
+        with patch("tools.code_execution_tool._load_config",
+                   return_value={"mode": "strict"}), \
+             patch("model_tools.handle_function_call",
+                   side_effect=_mock_handle_function_call), \
+             patch("tools.code_execution_tool._uses_hermes_python_environment",
+                   return_value=same_env), \
+             patch("subprocess.Popen", side_effect=_fake_popen), \
+             patch.dict(os.environ, {
+                 "PYTHONPATH": os.pathsep.join(
+                     [hermes_root, venv_sp, user_a, user_b]),
+             }):
+            execute_code(code="pass", task_id="test-int", enabled_tools=[])
+
+        assert "PYTHONPATH" in captured["env"], \
+            "execute_code never reached Popen"
+        parts = captured["env"]["PYTHONPATH"].split(os.pathsep)
+        assert parts[0] == captured["staging"], \
+            "staging tmpdir must be the first PYTHONPATH entry"
+        assert venv_sp not in parts, \
+            "inherited Hermes venv site-packages must be stripped"
+        assert user_a in parts and user_b in parts, \
+            "user PYTHONPATH entries must survive"
+        assert parts.index(user_a) > parts.index(captured["staging"]), \
+            "user entries must come after the staging tmpdir"
+        if same_env:
+            assert parts.count(hermes_root) == 1, \
+                "repo root must be re-added exactly once for a same-env child"
+            assert parts.index(user_a) > parts.index(hermes_root), \
+                "user entries must come after the re-added repo root"
+        else:
+            assert hermes_root not in parts, \
+                "repo root must stay absent for an external-env child"
+
     def test_repo_root_stripped(self):
         """The Hermes repo root entry is stripped from PYTHONPATH.
 

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -351,6 +351,13 @@ def _make_directory_link(link: Path, target: Path) -> None:
         raise OSError(detail or f"mklink /J failed: {result.returncode}")
 
 
+def _physical_repo_root(tmp_path: Path) -> Path:
+    """Create the physical repo checkout directory for junction tests."""
+    physical_root = tmp_path / "physical-home" / "hermes-agent"
+    physical_root.mkdir(parents=True)
+    return physical_root
+
+
 class TestPythonpathSelectiveStrip:
     """PYTHONPATH Hermes-owned entry stripping (#74817).
 
@@ -364,113 +371,90 @@ class TestPythonpathSelectiveStrip:
     contain another Python version.
     """
 
-    def test_hermes_venv_site_packages_stripped(self):
-        """A site-packages entry under the Hermes venv is removed."""
+    def test_owned_entries_stripped_matrix(self):
+        """Exact Hermes-owned entries are removed; everything else survives
+        verbatim (ordering, duplicates, empty components).
+
+        Covers: the running venv's site-packages, the repo root (computed
+        independently via parents[2] so an off-by-one in _hermes_repo_root
+        cannot silently pass), duplicate Hermes entries, all-owned input
+        (PYTHONPATH key removed), and mixed user/Hermes ordering with an
+        empty component preserved.
+        """
         from tools.environments.local import _strip_hermes_owned_pythonpath
 
-        # Construct a path that looks like the Hermes venv site-packages.
-        # Use the running interpreter's version so it hits the Hermes-venv
-        # ownership check, not a user-path case.
         venv_sp = str(_running_venv_site_packages())
-        env = {
-            "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
-        }
-        _strip_hermes_owned_pythonpath(env)
-        assert "PYTHONPATH" in env
-        entries = env["PYTHONPATH"].split(os.pathsep)
-        assert venv_sp not in entries
-        assert "/home/user/my-lib" in entries
+        local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
+        repo_root = str(local_file.parents[2])
+        cases = [
+            ([venv_sp, "/home/user/my-lib"], ["/home/user/my-lib"]),
+            ([repo_root, "/home/user/my-lib"], ["/home/user/my-lib"]),
+            ([venv_sp, "/user/lib", venv_sp, "/user/lib"], ["/user/lib", "/user/lib"]),
+            ([venv_sp], None),  # all owned -> PYTHONPATH key removed
+            (["/first/user/lib", repo_root, "", venv_sp, "/second/user/lib"],
+             ["/first/user/lib", "", "/second/user/lib"]),
+        ]
+        for input_entries, expected in cases:
+            env = {"PYTHONPATH": os.pathsep.join(input_entries)}
+            _strip_hermes_owned_pythonpath(env)
+            if expected is None:
+                assert "PYTHONPATH" not in env
+            else:
+                assert env["PYTHONPATH"].split(os.pathsep) == expected
 
-    def test_hermes_site_packages_descendant_preserved(self):
-        """Only the exact producer entry is owned; descendants are user paths."""
+    @pytest.mark.parametrize("user_pp", [
+        os.pathsep.join(["/opt/my-lib", "/another/path"]),
+        "/nix/store/abc123-user-plugin/lib/python3.12/site-packages",
+        os.pathsep.join(["/old/lib/python2.7/site-packages", "/home/user/lib"]),
+        os.pathsep.join(["/opt/tools/python3.13/bin", "/opt/downloads/python3.13", "/custom/python3.13"]),
+        os.pathsep.join([" /opt/user-lib ", "relative/../lib", "", "/opt/user-lib", "/opt/user-lib"]),
+        os.pathsep.join(["/foo", "", "/bar"]),
+        "",
+    ])
+    def test_non_owned_entries_preserved(self, user_pp):
+        """Anything not proven Hermes-owned is preserved byte-for-byte.
+
+        One invariant, one matrix: ordinary user paths, Nix store paths,
+        other-major/minor-version site-packages, paths merely containing a
+        pythonX.Y component, raw spellings (whitespace, relative segments,
+        duplicates), empty components, and an empty PYTHONPATH all reduce to
+        the same contract -- ownership is decided by provenance, never by
+        path shape or version (P1/P2, #74817 follow-ups).
+        """
         from tools.environments.local import _strip_hermes_owned_pythonpath
-
-        venv_sp = _running_venv_site_packages()
-        descendant = str(venv_sp / "some-user-path")
-        env = {"PYTHONPATH": os.pathsep.join([descendant, "/home/user/my-lib"])}
-
-        _strip_hermes_owned_pythonpath(env)
-
-        assert env["PYTHONPATH"].split(os.pathsep) == [descendant, "/home/user/my-lib"]
-
-    def test_user_pythonpath_preserved(self):
-        """User PYTHONPATH entries pass through untouched."""
-        from tools.environments.local import _strip_hermes_owned_pythonpath
-        user_pp = os.pathsep.join(["/opt/my-lib", "/another/path"])
         env = {"PYTHONPATH": user_pp}
         _strip_hermes_owned_pythonpath(env)
         assert env.get("PYTHONPATH") == user_pp
 
-    def test_nix_store_path_without_provenance_preserved(self):
-        """Path shape alone cannot distinguish a Nix user path from Hermes."""
-        from tools.environments.local import _strip_hermes_owned_pythonpath
-
-        nix_path = "/nix/store/abc123-user-plugin/lib/python3.12/site-packages"
-        env = {"PYTHONPATH": nix_path}
-
-        _strip_hermes_owned_pythonpath(env)
-
-        assert env["PYTHONPATH"] == nix_path
-
-    def test_other_version_site_packages_preserved(self):
-        """A user's pythonX.Y/site-packages entry is preserved even when its
-        version differs from the Hermes backend interpreter.
-
-        The env builder cannot know which Python the child will run, so a
-        user path intended for a child of another version must never be
-        judged against the BACKEND's interpreter version (P2, #74817
-        follow-up).  Regression: prior Check 1 stripped these.
+    def test_non_owned_runtime_shaped_entries_preserved(self):
+        """Runtime-derived user spellings are preserved: site-packages for a
+        different interpreter version, a descendant of the Hermes venv
+        site-packages, and direct/deeper children of the repo root.  The
+        repo root is computed independently (parents[2] of this file) so an
+        off-by-one in _hermes_repo_root cannot silently pass; no launcher
+        injects a direct child as a standalone entry, so such paths are user
+        paths by contract.
         """
         from tools.environments.local import _strip_hermes_owned_pythonpath
         import sys
 
-        # Use a version different from the running interpreter.
-        running_major = sys.version_info[0]
         running_minor = sys.version_info[1]
         other_minor = running_minor + 1 if running_minor < 20 else running_minor - 1
-        other_ver = f"python{running_major}.{other_minor}"
-
-        other_sp = f"/opt/other-venv/lib/{other_ver}/site-packages"
-        env = {
-            "PYTHONPATH": os.pathsep.join([other_sp, "/home/user/my-lib"]),
-        }
-        _strip_hermes_owned_pythonpath(env)
-        assert "PYTHONPATH" in env
-        entries = env["PYTHONPATH"].split(os.pathsep)
-        assert other_sp in entries
-        assert "/home/user/my-lib" in entries
-
-    def test_other_major_version_site_packages_preserved(self):
-        """A user's python2.7/site-packages entry is preserved — path
-        ownership, not version, decides stripping (P2, #74817 follow-up).
-        """
-        from tools.environments.local import _strip_hermes_owned_pythonpath
-        env = {
-            "PYTHONPATH": os.pathsep.join([
-                "/old/lib/python2.7/site-packages",
-                "/home/user/lib",
+        local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
+        real_repo_root = local_file.parents[2]
+        inputs = [
+            os.pathsep.join([
+                f"/opt/other-venv/lib/python{sys.version_info[0]}.{other_minor}/site-packages",
+                "/home/user/my-lib",
             ]),
-        }
-        _strip_hermes_owned_pythonpath(env)
-        assert "PYTHONPATH" in env
-        entries = env["PYTHONPATH"].split(os.pathsep)
-        assert "/old/lib/python2.7/site-packages" in entries
-        assert "/home/user/lib" in entries
-
-    def test_non_site_packages_python_version_paths_preserved(self):
-        """Paths merely CONTAINING a pythonX.Y component (not site-packages)
-        must never be stripped (P1, #74817 follow-up).  Regression: prior
-        Check 1 deleted these because it keyed on the version component alone.
-        """
-        from tools.environments.local import _strip_hermes_owned_pythonpath
-        user_pp = os.pathsep.join([
-            "/opt/tools/python3.13/bin",
-            "/opt/downloads/python3.13",
-            "/custom/python3.13",
-        ])
-        env = {"PYTHONPATH": user_pp}
-        _strip_hermes_owned_pythonpath(env)
-        assert env.get("PYTHONPATH") == user_pp
+            os.pathsep.join([str(_running_venv_site_packages() / "some-user-path"), "/home/user/my-lib"]),
+            os.pathsep.join([str(real_repo_root / "tools"), "/home/user/my-lib"]),
+            os.pathsep.join([str(real_repo_root / "tools" / "environments"), "/home/user/my-lib"]),
+        ]
+        for user_pp in inputs:
+            env = {"PYTHONPATH": user_pp}
+            _strip_hermes_owned_pythonpath(env)
+            assert env["PYTHONPATH"] == user_pp
 
     def test_windows_backslash_paths(self):
         """Windows-style backslash paths are handled for Hermes-owned entries.
@@ -562,30 +546,6 @@ class TestPythonpathSelectiveStrip:
 
         assert env["PYTHONPATH"] == user_pp
 
-    def test_mixed_ordering_user_and_hermes_preserves_user_order(self):
-        """Mixed entries retain raw user order, including an empty component."""
-        from tools.environments.local import _strip_hermes_owned_pythonpath
-
-        venv_sp = str(_running_venv_site_packages())
-        local_file = Path(
-            __import__("tools.environments.local", fromlist=["__file__"]).__file__
-        ).resolve()
-        repo_root = str(local_file.parents[2])
-        env = {
-            "PYTHONPATH": os.pathsep.join([
-                "/first/user/lib",
-                repo_root,
-                "",
-                venv_sp,
-                "/second/user/lib",
-            ]),
-        }
-        _strip_hermes_owned_pythonpath(env)
-        assert env["PYTHONPATH"].split(os.pathsep) == [
-            "/first/user/lib",
-            "",
-            "/second/user/lib",
-        ]
 
     def test_base_python_sanitizer_uses_validated_separate_runtime_venv(self, tmp_path, monkeypatch):
         """A base interpreter strips the exact Windows runtime site-packages.
@@ -644,28 +604,6 @@ class TestPythonpathSelectiveStrip:
 
         assert env["PYTHONPATH"] == str(unrelated_sp)
 
-    def test_duplicate_hermes_entries_all_stripped(self):
-        """Every duplicate Hermes-owned entry is removed; user duplicates
-        follow the existing contract (no unrelated dedup)."""
-        from tools.environments.local import _strip_hermes_owned_pythonpath
-
-        venv_sp = str(_running_venv_site_packages())
-        local_file = Path(
-            __import__("tools.environments.local", fromlist=["__file__"]).__file__
-        ).resolve()
-        repo_root = str(local_file.parents[2])
-        env = {
-            "PYTHONPATH": os.pathsep.join([
-                venv_sp,
-                "/user/lib",
-                venv_sp,  # duplicate Hermes entry
-                "/user/lib",  # duplicate user entry — preserved as-is
-            ]),
-        }
-        _strip_hermes_owned_pythonpath(env)
-        pp = env.get("PYTHONPATH", "")
-        entries = pp.split(os.pathsep) if pp else []
-        assert entries == ["/user/lib", "/user/lib"]
 
     def test_no_pythonpath_key(self):
         """Missing PYTHONPATH key is a no-op."""
@@ -674,59 +612,31 @@ class TestPythonpathSelectiveStrip:
         _strip_hermes_owned_pythonpath(env)
         assert "PYTHONPATH" not in env
 
-    def test_all_entries_stripped_removes_key(self):
-        """If all entries are Hermes-owned and stripped, PYTHONPATH key is
-        removed entirely."""
-        from tools.environments.local import _strip_hermes_owned_pythonpath
+
+    @pytest.mark.parametrize("builder", [
+        "_make_run_env",
+        "_sanitize_subprocess_env",
+        "hermes_subprocess_env",
+    ])
+    def test_builders_strip_hermes_venv_pythonpath(self, builder):
+        """Every subprocess env builder applies the same sanitation contract:
+        Hermes venv site-packages is stripped, user entries survive.
+        """
+        from tools.environments import local as local_mod
 
         venv_sp = str(_running_venv_site_packages())
-
-        env = {"PYTHONPATH": venv_sp}
-        _strip_hermes_owned_pythonpath(env)
-        assert "PYTHONPATH" not in env
-
-    def test_make_run_env_strips_hermes_venv_pythonpath(self):
-        """_make_run_env strips Hermes venv site-packages from PYTHONPATH."""
-        from tools.environments.local import _make_run_env
-
-        venv_sp = str(_running_venv_site_packages())
-        with patch.dict(os.environ, {
+        seed = {
             "PATH": "/usr/bin:/bin",
-            "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
-        }, clear=True):
-            run_env = _make_run_env({})
-        pp = run_env.get("PYTHONPATH", "")
-        entries = pp.split(os.pathsep) if pp else []
-        assert venv_sp not in entries
-        assert "/home/user/my-lib" in entries
-
-    def test_sanitize_subprocess_env_strips_hermes_venv_pythonpath(self):
-        """_sanitize_subprocess_env strips Hermes venv site-packages."""
-        from tools.environments.local import _sanitize_subprocess_env
-
-        venv_sp = str(_running_venv_site_packages())
-        base = {
-            "PATH": "/usr/bin",
             "HOME": "/home/user",
             "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
         }
-        result = _sanitize_subprocess_env(base)
-        pp = result.get("PYTHONPATH", "")
-        entries = pp.split(os.pathsep) if pp else []
-        assert venv_sp not in entries
-        assert "/home/user/my-lib" in entries
-
-    def test_hermes_subprocess_env_strips_hermes_venv_pythonpath(self):
-        """hermes_subprocess_env strips Hermes venv site-packages."""
-        from tools.environments.local import hermes_subprocess_env
-
-        venv_sp = str(_running_venv_site_packages())
-        with patch.dict(os.environ, {
-            "PATH": "/usr/bin:/bin",
-            "HOME": "/home/user",
-            "PYTHONPATH": os.pathsep.join([venv_sp, "/home/user/my-lib"]),
-        }, clear=True):
-            result = hermes_subprocess_env()
+        with patch.dict(os.environ, seed, clear=True):
+            if builder == "_make_run_env":
+                result = local_mod._make_run_env({})
+            elif builder == "_sanitize_subprocess_env":
+                result = local_mod._sanitize_subprocess_env(dict(os.environ))
+            else:
+                result = local_mod.hermes_subprocess_env()
         pp = result.get("PYTHONPATH", "")
         entries = pp.split(os.pathsep) if pp else []
         assert venv_sp not in entries
@@ -843,33 +753,6 @@ class TestPythonpathSelectiveStrip:
             assert norm_root not in norm_parts, \
                 "repo root must stay absent for an external-env child"
 
-    def test_repo_root_stripped(self):
-        """The Hermes repo root entry is stripped from PYTHONPATH.
-
-        Electron prepends the *actual* repository root (the directory
-        containing ``tools/``, ``hermes_cli/``, etc.) to PYTHONPATH so the
-        backend can ``import tools``.  This test independently computes that
-        real repo root from the source-file location - three levels up from
-        ``tools/environments/local.py`` - rather than reusing the module
-        constant under test.  That way an off-by-one in ``_hermes_repo_root``
-        (e.g. ``parents[1]`` resolving to ``tools/``) would cause this test
-        to fail instead of silently passing.
-        """
-        from tools.environments.local import _strip_hermes_owned_pythonpath
-
-        # Independently compute the real repo root: local.py lives at
-        # tools/environments/local.py, so the repo root is parents[2].
-        local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
-        real_repo_root = str(local_file.parents[2])
-
-        env = {
-            "PYTHONPATH": os.pathsep.join([real_repo_root, "/home/user/my-lib"]),
-        }
-        _strip_hermes_owned_pythonpath(env)
-        pp = env.get("PYTHONPATH", "")
-        entries = pp.split(os.pathsep) if pp else []
-        assert real_repo_root not in entries
-        assert "/home/user/my-lib" in entries
 
     def test_repo_root_direct_child_preserved(self):
         """A direct child of the repo root (depth=1) is PRESERVED.
@@ -905,8 +788,7 @@ class TestPythonpathSelectiveStrip:
         from hermes_cli.gateway_windows import _preserve_hermes_home_path
 
         physical_home = tmp_path / "physical-home"
-        physical_root = physical_home / "hermes-agent"
-        physical_root.mkdir(parents=True)
+        physical_root = _physical_repo_root(tmp_path)
         configured_home = tmp_path / "configured-home"
         try:
             _make_directory_link(configured_home, physical_home)
@@ -995,9 +877,7 @@ class TestPythonpathSelectiveStrip:
         """
         import tools.environments.local as local
 
-        physical_home = tmp_path / "physical-home"
-        physical_root = physical_home / "hermes-agent"
-        physical_root.mkdir(parents=True)
+        physical_root = _physical_repo_root(tmp_path)
         configured_home = tmp_path / "configured-home"
         configured_home.mkdir()
         # repo-level link: <configured-home>/hermes-agent -> physical repo
@@ -1019,31 +899,33 @@ class TestPythonpathSelectiveStrip:
         local._strip_hermes_owned_pythonpath(env)
         assert env["PYTHONPATH"].split(os.pathsep) == ["/home/user/my-lib"]
 
-    def test_repo_level_junction_negative_control(self, tmp_path, monkeypatch):
-        """A same-named REAL directory under the configured root (not a link
-        to the known physical repo) must never become an alias or be
-        stripped -- exact filesystem identity decides, not the name.
+    def test_same_named_non_owned_directories_preserved(self, tmp_path, monkeypatch):
+        """Negative controls: a directory that merely shares the repo's name
+        -- whether under the configured root or in an unrelated location --
+        is never aliased or stripped.  Exact filesystem identity decides,
+        not the name; no ownership provenance means no strip.
         """
         import tools.environments.local as local
 
-        physical_home = tmp_path / "physical-home"
-        physical_root = physical_home / "hermes-agent"
-        physical_root.mkdir(parents=True)
+        physical_root = _physical_repo_root(tmp_path)
         configured_home = tmp_path / "configured-home"
         (configured_home / "hermes-agent").mkdir(parents=True)
+        unrelated = tmp_path / "user-tools" / "hermes-agent"
+        unrelated.mkdir(parents=True)
 
         aliases = local._build_hermes_repo_root_aliases(
             physical_root.resolve(),
             physical_root,
             configured_home,
         )
-        lookalike = configured_home / "hermes-agent"
-        assert not any(local._same_path(a, lookalike) for a in aliases)
+        for lookalike in (configured_home / "hermes-agent", unrelated):
+            assert not any(local._same_path(a, lookalike) for a in aliases)
 
         monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
-        env = {"PYTHONPATH": os.pathsep.join([str(lookalike), "/home/user/my-lib"])}
-        local._strip_hermes_owned_pythonpath(env)
-        assert env["PYTHONPATH"].split(os.pathsep) == [str(lookalike), "/home/user/my-lib"]
+        for lookalike in (configured_home / "hermes-agent", unrelated):
+            env = {"PYTHONPATH": os.pathsep.join([str(lookalike), "/home/user/my-lib"])}
+            local._strip_hermes_owned_pythonpath(env)
+            assert env["PYTHONPATH"].split(os.pathsep) == [str(lookalike), "/home/user/my-lib"]
 
     def test_profile_home_with_repo_level_junction(self, tmp_path, monkeypatch):
         """Profile re-home + repo-level junction together: the configured home
@@ -1053,9 +935,7 @@ class TestPythonpathSelectiveStrip:
         """
         import tools.environments.local as local
 
-        physical_home = tmp_path / "physical-home"
-        physical_root = physical_home / "hermes-agent"
-        physical_root.mkdir(parents=True)
+        physical_root = _physical_repo_root(tmp_path)
         configured_root = tmp_path / "configured-root"
         (configured_root / "profiles" / "coder").mkdir(parents=True)
         try:
@@ -1085,8 +965,7 @@ class TestPythonpathSelectiveStrip:
         """
         import tools.environments.local as local
 
-        physical_home = tmp_path / "physical-home"
-        physical_root = physical_home / "hermes-agent"
+        physical_root = _physical_repo_root(tmp_path)
         venv_dir = physical_root / "venv"
         venv_dir.mkdir(parents=True)
         (venv_dir / "pyvenv.cfg").write_text("home = x\n", encoding="utf-8")
@@ -1120,54 +999,8 @@ class TestPythonpathSelectiveStrip:
         local._strip_hermes_owned_pythonpath(env)
         assert env["PYTHONPATH"].split(os.pathsep) == ["/home/user/my-lib"]
 
-    def test_lookalike_user_path_without_provenance_preserved(self, tmp_path, monkeypatch):
-        """A user PYTHONPATH entry that merely looks like a Hermes path
-        (repo-named directory, no link to the known physical repo) must be
-        preserved -- no ownership provenance, no strip.
-        """
-        import tools.environments.local as local
-
-        physical_home = tmp_path / "physical-home"
-        physical_root = physical_home / "hermes-agent"
-        physical_root.mkdir(parents=True)
-        unrelated = tmp_path / "user-tools" / "hermes-agent"
-        unrelated.mkdir(parents=True)
-
-        aliases = local._build_hermes_repo_root_aliases(
-            physical_root.resolve(),
-            physical_root,
-            tmp_path / "configured-home",
-        )
-        assert not any(local._same_path(a, unrelated) for a in aliases)
-
-        monkeypatch.setattr(local, "_hermes_repo_root_aliases", aliases)
-        env = {"PYTHONPATH": os.pathsep.join([str(unrelated), "/home/user/my-lib"])}
-        local._strip_hermes_owned_pythonpath(env)
-        assert env["PYTHONPATH"].split(os.pathsep) == [str(unrelated), "/home/user/my-lib"]
 
 
-    def test_deep_path_under_repo_root_preserved(self):
-        """A deeper path under the repo root (depth=2) is preserved.
-
-        ``<repo>/tools/environments`` is depth=2, past the ``depth <= 1``
-        cutoff.  Such a path is not something Electron injects and may be
-        a legitimate user library path, so it must survive the repo-root
-        ownership check.
-        """
-        from tools.environments.local import _strip_hermes_owned_pythonpath
-
-        local_file = Path(__import__("tools.environments.local", fromlist=["__file__"]).__file__).resolve()
-        real_repo_root = local_file.parents[2]
-        deep_path = str(real_repo_root / "tools" / "environments")
-
-        env = {
-            "PYTHONPATH": os.pathsep.join([deep_path, "/home/user/my-lib"]),
-        }
-        _strip_hermes_owned_pythonpath(env)
-        pp = env.get("PYTHONPATH", "")
-        entries = pp.split(os.pathsep) if pp else []
-        assert deep_path in entries
-        assert "/home/user/my-lib" in entries
 
 
 class TestPythonhomeSanitized:
@@ -1179,45 +1012,33 @@ class TestPythonhomeSanitized:
     with version-mismatch errors before importing anything (#75018).
     """
 
-    def test_make_run_env_strips_pythonhome(self):
-        from tools.environments.local import _make_run_env
-        with patch.dict(os.environ, {
+    @pytest.mark.parametrize("builder", [
+        "_make_run_env",
+        "_sanitize_subprocess_env",
+        "hermes_subprocess_env",
+        "build_subprocess_env",
+    ])
+    def test_builders_strip_pythonhome(self, builder):
+        """The gateway's inherited PYTHONHOME must not reach any subprocess
+        builder -- terminal, background/PTY, cron no_agent scripts, and
+        execute_code children (#75018).
+        """
+        from tools.environments import local as local_mod
+
+        seed = {
             "PATH": "/usr/bin:/bin",
             "HOME": "/home/user",
             "PYTHONHOME": "/opt/hermes-venv",
-        }, clear=True):
-            run_env = _make_run_env({})
-        assert "PYTHONHOME" not in run_env
-
-    def test_sanitize_subprocess_env_strips_pythonhome(self):
-        from tools.environments.local import _sanitize_subprocess_env
-        result = _sanitize_subprocess_env({
-            "PATH": "/usr/bin",
-            "HOME": "/home/user",
-            "PYTHONHOME": "/opt/hermes-venv",
-        })
-        assert "PYTHONHOME" not in result
-
-    def test_hermes_subprocess_env_strips_pythonhome(self):
-        from tools.environments.local import hermes_subprocess_env
-        with patch.dict(os.environ, {
-            "PATH": "/usr/bin:/bin",
-            "HOME": "/home/user",
-            "PYTHONHOME": "/opt/hermes-venv",
-        }, clear=True):
-            result = hermes_subprocess_env()
-        assert "PYTHONHOME" not in result
-
-    def test_build_subprocess_env_strips_pythonhome(self):
-        """cron no_agent children go through build_subprocess_env; the
-        gateway's PYTHONHOME must not reach them (#75018)."""
-        from tools.environments.local import build_subprocess_env
-        with patch.dict(os.environ, {
-            "PATH": "/usr/bin:/bin",
-            "HOME": "/home/user",
-            "PYTHONHOME": "/opt/hermes-venv",
-        }, clear=True):
-            result = build_subprocess_env()
+        }
+        with patch.dict(os.environ, seed, clear=True):
+            if builder == "_make_run_env":
+                result = local_mod._make_run_env({})
+            elif builder == "_sanitize_subprocess_env":
+                result = local_mod._sanitize_subprocess_env(dict(os.environ))
+            elif builder == "hermes_subprocess_env":
+                result = local_mod.hermes_subprocess_env()
+            else:
+                result = local_mod.build_subprocess_env()
         assert "PYTHONHOME" not in result
 
     def test_pythonhome_removed_from_active_venv_markers(self):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1486,10 +1486,10 @@ def execute_code(
         #
         # Before re-injecting PYTHONPATH, strip Hermes-owned entries that
         # leaked through _scrub_child_env (PYTHONPATH is in _SAFE_ENV_PREFIXES
-        # so it passes the scrub).  The sandbox runs the SAME Python as
-        # Hermes, so the Hermes venv entries are redundant — and if they
-        # came from a different Hermes venv they would poison the sandbox's
-        # sys.path with ABI-incompatible C extensions (#74817).
+        # so it passes the scrub).  They are redundant for same-Hermes-
+        # environment children and may be incompatible with external
+        # interpreters (project mode can select a different venv), so they
+        # must not shadow or poison the child's sys.path (#74817).
         from tools.environments.local import _strip_hermes_owned_pythonpath
         _strip_hermes_owned_pythonpath(child_env)
         _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1484,15 +1484,14 @@ def execute_code(
         # can mix incompatible compiled extensions (for example, Python 3.12
         # NumPy with a Python 3.9 project interpreter).
         #
-        # Before re-injecting PYTHONPATH, strip any mismatched site-packages
-        # entries that leaked through _scrub_child_env (PYTHONPATH is in
-        # _SAFE_ENV_PREFIXES so it passes the scrub).  The sandbox runs the
-        # SAME Python as Hermes, so same-version Hermes venv entries are
-        # harmless - but cross-version entries (e.g. python3.11 from a
-        # different venv injected by systemd/Electron) would poison the
-        # sandbox's sys.path with ABI-incompatible C extensions (#74817).
-        from tools.environments.local import _strip_mismatched_site_packages
-        _strip_mismatched_site_packages(child_env)
+        # Before re-injecting PYTHONPATH, strip Hermes-owned entries that
+        # leaked through _scrub_child_env (PYTHONPATH is in _SAFE_ENV_PREFIXES
+        # so it passes the scrub).  The sandbox runs the SAME Python as
+        # Hermes, so the Hermes venv entries are redundant — and if they
+        # came from a different Hermes venv they would poison the sandbox's
+        # sys.path with ABI-incompatible C extensions (#74817).
+        from tools.environments.local import _strip_hermes_owned_pythonpath
+        _strip_hermes_owned_pythonpath(child_env)
         _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         _existing_pp = child_env.get("PYTHONPATH", "")
         _pp_parts = [tmpdir]

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1483,6 +1483,16 @@ def execute_code(
         # external venv; exposing Hermes's site-packages to that interpreter
         # can mix incompatible compiled extensions (for example, Python 3.12
         # NumPy with a Python 3.9 project interpreter).
+        #
+        # Before re-injecting PYTHONPATH, strip any mismatched site-packages
+        # entries that leaked through _scrub_child_env (PYTHONPATH is in
+        # _SAFE_ENV_PREFIXES so it passes the scrub).  The sandbox runs the
+        # SAME Python as Hermes, so same-version Hermes venv entries are
+        # harmless - but cross-version entries (e.g. python3.11 from a
+        # different venv injected by systemd/Electron) would poison the
+        # sandbox's sys.path with ABI-incompatible C extensions (#74817).
+        from tools.environments.local import _strip_mismatched_site_packages
+        _strip_mismatched_site_packages(child_env)
         _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         _existing_pp = child_env.get("PYTHONPATH", "")
         _pp_parts = [tmpdir]

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -346,6 +346,10 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # to a different Python version overwrites it and breaks the gateway). The
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
+#
+# PYTHONPATH is NOT included here — it's handled by
+# _strip_mismatched_site_packages() which surgically removes only site-packages
+# paths that don't match the current Python ABI, preserving user-set entries.
 _ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
 
 
@@ -506,6 +510,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         sanitized.pop(_marker, None)
 
+    _strip_mismatched_site_packages(sanitized)
+
     _apply_windows_msys_bash_env_defaults(sanitized)
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)
@@ -634,6 +640,8 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     # Active-venv markers must not clobber another project's environment.
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         env.pop(_marker, None)
+
+    _strip_mismatched_site_packages(env)
 
     _apply_windows_msys_bash_env_defaults(env)
 
@@ -1321,11 +1329,229 @@ def _make_run_env(env: dict) -> dict:
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         run_env.pop(_marker, None)
 
+    _strip_mismatched_site_packages(run_env)
+
     _apply_windows_msys_bash_env_defaults(run_env)
 
     run_env = _scrub_delegated_child_kanban_env(run_env)
 
     return run_env
+
+
+def _is_path_under(child: Path, parent: Path) -> bool:
+    """Return True if *child* is the same as or under *parent*.
+
+    Uses ``os.path.normcase`` so the comparison is case-insensitive on
+    Windows (NTFS is case-insensitive by default) and case-sensitive on
+    POSIX, matching filesystem semantics.  Paths are NOT resolved against
+    disk (no ``.resolve()``) so non-existent paths - common in test mocks
+    and in PYTHONPATH entries pointing at yet-to-be-created dirs - work
+    correctly.  ``Path.resolve(strict=False)`` would also touch the
+    filesystem to resolve symlinks, which we deliberately avoid.
+    """
+    c_parts = [os.path.normcase(p) for p in child.parts]
+    p_parts = [os.path.normcase(p) for p in parent.parts]
+    if len(c_parts) < len(p_parts):
+        return False
+    return c_parts[: len(p_parts)] == p_parts
+
+
+# --- Hermes venv / repo-root detection (module-level, computed once) ---
+
+#: The running interpreter's own venv root.  On a venv Python ``sys.prefix``
+#: points at the venv root (e.g. ``.../venv``); on a system Python it points
+#: at ``/usr`` or similar.  We only strip site-packages under this path when
+#: the interpreter is actually inside a venv (``sys.prefix != sys.base_prefix``).
+_hermes_venv_root: Path = Path(sys.prefix)
+
+#: The Hermes repository root - two levels up from this file
+#: (``tools/environments/local.py`` -> ``tools/`` -> repo root).  This is the
+#: directory the Electron app prepends to PYTHONPATH so the backend can do
+#: ``import tools``, ``import hermes_cli``, etc.  Subprocesses that are NOT
+#: the Hermes backend don't need it and it can shadow local packages.
+_hermes_repo_root: Path = Path(__file__).resolve().parents[1]
+
+#: Whether the current interpreter is running inside a venv.  On Python 3.3+
+#: ``sys.base_prefix != sys.prefix`` indicates a venv (or virtualenv).
+#: ``sys.real_prefix`` is the old virtualenv (<20) marker.
+_in_venv: bool = (
+    getattr(sys, "base_prefix", sys.prefix) != sys.prefix
+    or hasattr(sys, "real_prefix")
+)
+
+#: Cached set of site-packages directories that belong to the running
+#: interpreter's own venv.  Computed lazily (once) because ``site`` import
+#: and path construction are not free and this function is called on every
+#: subprocess spawn.
+_hermes_site_packages: list[Path] | None = None
+
+
+def _get_hermes_site_packages() -> list[Path]:
+    """Return the site-packages dirs of the running interpreter's venv.
+
+    Uses ``site.getsitepackages()`` when available for robustness (it respects
+    ``.pth`` rewrites and platform conventions), with a manual fallback that
+    constructs the canonical path from ``sys.prefix`` for POSIX and Windows.
+    """
+    global _hermes_site_packages
+    if _hermes_site_packages is not None:
+        return _hermes_site_packages
+
+    result: list[Path] = []
+    try:
+        import site
+        for sp in site.getsitepackages():
+            result.append(Path(sp))
+    except Exception:
+        pass
+
+    # Fallback: construct manually.  On POSIX:
+    #   sys.prefix / lib / python{X.Y} / site-packages
+    # On Windows:
+    #   sys.prefix / Lib / site-packages
+    if not result:
+        if _IS_WINDOWS:
+            result.append(Path(sys.prefix) / "Lib" / "site-packages")
+        else:
+            pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+            result.append(Path(sys.prefix) / "lib" / pyver / "site-packages")
+
+    _hermes_site_packages = result
+    return result
+
+
+# Regex to extract a Python version marker (e.g. ``python3.11``) from a path.
+# Matches ``python3.11``, ``python3.13``, etc. as a path component - i.e.
+# preceded by a path separator (``/`` or ``\``) or string start, and followed
+# by a separator or string end.  This is cross-platform: it works with both
+# POSIX forward-slash paths and Windows backslash paths regardless of the
+# host OS, so a POSIX host correctly detects version markers in Windows-style
+# paths (important for testing and for edge cases like WSL).
+_PYVER_IN_PATH_RE = re.compile(r"(?:^|[\\/])python(\d+)\.(\d+)(?:[\\/]|$)")
+
+# Regex to detect ``site-packages`` as a path component (not a substring of
+# a longer directory name).  Same cross-platform separator handling.
+_SITE_PACKAGES_RE = re.compile(r"(?:^|[\\/])site-packages(?:[\\/]|$)")
+
+
+def _strip_mismatched_site_packages(env: dict) -> None:
+    """Remove mismatched site-packages paths from PYTHONPATH.
+
+    The Desktop Electron process (and systemd units, gateway VBS launchers,
+    etc.) inject the Hermes venv's site-packages path (e.g.
+    ``.../venv/lib/python3.11/site-packages``) into ``PYTHONPATH`` so the
+    Hermes backend can import its packages.  When this ``PYTHONPATH`` leaks
+    into subprocesses running a **different** Python version (e.g. 3.13),
+    the 3.11 C extensions appear on ``sys.path`` ahead of the correct 3.13
+    versions and crash with ``ImportError`` (``PIL._imaging``,
+    ``cryptography``, etc.).
+
+    Rather than stripping ``PYTHONPATH`` entirely - which would discard
+    legitimate user entries (Nix uses ``PYTHONPATH`` for plugin discovery,
+    users set it for custom library paths) - this function surgically
+    removes only the dangerous entries:
+
+    1. **Cross-version site-packages** - any entry whose path contains a
+       ``python{X.Y}/site-packages`` component where ``{X.Y}`` differs from
+       the running interpreter's version.  This catches ALL leak sources
+       (Electron, systemd, gateway scripts) with a single version check,
+       regardless of the venv path.
+
+    2. **Hermes venv site-packages** (no version marker or same-version) -
+       entries that live under the running interpreter's own venv
+       site-packages directory.  These are redundant for subprocesses: the
+       Hermes backend discovers its packages via ``sys.path``, not via an
+       inherited env var.  Only checked when running inside a venv.
+
+    3. **Hermes repo root** - the Electron app prepends the repo root
+       (parent of ``tools/``) to ``PYTHONPATH``.  Subprocesses don't need
+       it and it can shadow local packages.
+
+    User ``PYTHONPATH`` entries (``/opt/my-lib``, Nix plugin paths, etc.)
+    are always preserved.
+    """
+    pp = env.get("PYTHONPATH")
+    if not pp:
+        return
+
+    hermes_site_packages = _get_hermes_site_packages() if _in_venv else []
+    running_major = sys.version_info[0]
+    running_minor = sys.version_info[1]
+
+    kept: list[str] = []
+    stripped: list[str] = []
+
+    for entry in pp.split(os.pathsep):
+        entry = entry.strip()
+        if not entry:
+            continue
+
+        entry_path = Path(entry)
+        should_strip = False
+
+        # --- Check 1: cross-version site-packages ---
+        # Look for a ``python{X.Y}`` path component and compare its version
+        # against the running interpreter.  If they differ, the entry's
+        # C extensions are ABI-incompatible - strip unconditionally.
+        # We search the full entry string (not ``entry_path.parts``) because
+        # ``Path.parts`` only splits on the host OS separator, so a Windows
+        # backslash path on a POSIX host would be a single un-split part.
+        m = _PYVER_IN_PATH_RE.search(entry)
+        if m:
+            entry_major = int(m.group(1))
+            entry_minor = int(m.group(2))
+            if (entry_major, entry_minor) != (running_major, running_minor):
+                should_strip = True
+        if should_strip:
+            stripped.append(entry)
+            continue
+
+        # --- Check 2: under Hermes venv site-packages ---
+        # The entry lives under the running interpreter's own venv
+        # site-packages.  Redundant for subprocesses (they get their packages
+        # via sys.path, not PYTHONPATH) and a common leak vector.
+        # Use the regex (not ``entry_path.parts``) for cross-platform detection
+        # so Windows backslash paths are caught on a POSIX host.
+        if not should_strip and _SITE_PACKAGES_RE.search(entry):
+            for sp in hermes_site_packages:
+                if _is_path_under(entry_path, sp):
+                    should_strip = True
+                    break
+        if should_strip:
+            stripped.append(entry)
+            continue
+
+        # --- Check 3: Hermes repo root ---
+        # The Electron app prepends the repo root so ``import tools`` works
+        # in the backend.  Subprocesses don't need it and it can shadow
+        # local packages of the same name.
+        if not should_strip and _is_path_under(entry_path, _hermes_repo_root):
+            # Only strip if the entry IS the repo root or a direct package
+            # dir under it (e.g. ``.../hermes-agent/tools``).  Don't strip
+            # arbitrary user paths that happen to be nested deeper.
+            rel = entry_path.resolve() if entry_path.exists() else entry_path
+            try:
+                depth = len(rel.relative_to(_hermes_repo_root).parts)
+            except (ValueError, OSError):
+                depth = -1
+            if depth <= 1:
+                should_strip = True
+
+        if should_strip:
+            stripped.append(entry)
+        else:
+            kept.append(entry)
+
+    if kept:
+        env["PYTHONPATH"] = os.pathsep.join(kept)
+    else:
+        env.pop("PYTHONPATH", None)
+
+    if stripped:
+        logger.debug(
+            "Stripped mismatched/Hermes-venv site-packages from PYTHONPATH: %s",
+            stripped,
+        )
 
 
 def _read_terminal_shell_init_config() -> tuple[list[str], bool]:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1364,12 +1364,13 @@ def _is_path_under(child: Path, parent: Path) -> bool:
 #: the interpreter is actually inside a venv (``sys.prefix != sys.base_prefix``).
 _hermes_venv_root: Path = Path(sys.prefix)
 
-#: The Hermes repository root - two levels up from this file
-#: (``tools/environments/local.py`` -> ``tools/`` -> repo root).  This is the
-#: directory the Electron app prepends to PYTHONPATH so the backend can do
-#: ``import tools``, ``import hermes_cli``, etc.  Subprocesses that are NOT
-#: the Hermes backend don't need it and it can shadow local packages.
-_hermes_repo_root: Path = Path(__file__).resolve().parents[1]
+#: The Hermes repository root - three levels up from this file
+#: (``tools/environments/local.py`` -> ``tools/environments`` -> ``tools``
+#: -> repo root).  This is the directory the Electron app prepends to
+#: PYTHONPATH so the backend can do ``import tools``, ``import hermes_cli``,
+#: etc.  Subprocesses that are NOT the Hermes backend don't need it and it
+#: can shadow local packages.
+_hermes_repo_root: Path = Path(__file__).resolve().parents[2]
 
 #: Whether the current interpreter is running inside a venv.  On Python 3.3+
 #: ``sys.base_prefix != sys.prefix`` indicates a venv (or virtualenv).

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1380,15 +1380,28 @@ def _build_hermes_repo_root_aliases(
     add(resolved_root)
     add(lexical_root)
 
-    try:
-        resolved_home = configured_home.resolve()
-        home_key = os.path.normcase(str(resolved_home))
-        root_key = os.path.normcase(str(resolved_root))
-        if os.path.commonpath([home_key, root_key]) == home_key:
-            relative_root = os.path.relpath(str(resolved_root), str(resolved_home))
-            add(configured_home / relative_root)
-    except (OSError, ValueError):
-        pass
+    # Profile re-home: with --profile / sticky active_profile the configured
+    # home becomes <root>/profiles/<name>.  The repo root then lives beside
+    # the profiles directory (not under the profile home), so the home-
+    # relative mapping below cannot reach it.  Derive the root spelling
+    # lexically the same way get_default_hermes_root() does (parent of a
+    # "profiles" component) and run the same exact-ownership mapping against
+    # it -- this recovers the launcher's lexical root under profile re-home
+    # while still never matching arbitrary descendants of HERMES_HOME.
+    home_candidates = [configured_home]
+    if configured_home.parent.name == "profiles":
+        home_candidates.append(configured_home.parent.parent)
+
+    for home in home_candidates:
+        try:
+            resolved_home = home.resolve()
+            home_key = os.path.normcase(str(resolved_home))
+            root_key = os.path.normcase(str(resolved_root))
+            if os.path.commonpath([home_key, root_key]) == home_key:
+                relative_root = os.path.relpath(str(resolved_root), str(resolved_home))
+                add(home / relative_root)
+        except (OSError, ValueError):
+            pass
 
     return tuple(aliases)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1370,6 +1370,10 @@ def _build_hermes_repo_root_aliases(
     the resolved HERMES_HOME back onto the configured HERMES_HOME spelling.
     Mirror that producer contract here so a junction-backed install is matched
     without treating arbitrary descendants of HERMES_HOME as Hermes-owned.
+    Additionally, when the repo itself is a junction under the configured root
+    (repo-level junction, possibly cross-drive), the single deterministic
+    candidate <root>/<repo dirname> is accepted only when strict resolve
+    proves it is the exact physical repo root.
     """
     aliases: list[Path] = []
 
@@ -1401,6 +1405,24 @@ def _build_hermes_repo_root_aliases(
                 relative_root = os.path.relpath(str(resolved_root), str(resolved_home))
                 add(home / relative_root)
         except (OSError, ValueError):
+            pass
+
+    # Repo-level junction recovery: the repository itself may be a
+    # junction/symlink under the configured root (e.g. D:\hermes\hermes-agent
+    # -> C:\...\hermes-agent) while the import spelling (editable install)
+    # resolves to the physical location.  The home-relative mapping above
+    # cannot express a cross-drive link (commonpath raises on different
+    # drives), so prove the EXACT filesystem identity of the single
+    # deterministic candidate -- <lexical root>/<repo dirname> -- with a
+    # strict resolve before accepting it as Hermes-owned.  Fail-closed: a
+    # missing path (strict resolve raises), a real directory that is not the
+    # known physical root, or any unrelated spelling never becomes an alias.
+    for home in home_candidates:
+        repo_candidate = home / resolved_root.name
+        try:
+            if repo_candidate.resolve(strict=True) == resolved_root.resolve(strict=True):
+                add(repo_candidate)
+        except OSError:
             pass
 
     return tuple(aliases)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -521,10 +521,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # can run the gateway under a base interpreter while VIRTUAL_ENV identifies
     # the separate Hermes runtime venv.  The filter validates that relationship
     # against the repo layout before trusting it.
-    _strip_hermes_owned_pythonpath(sanitized)
-
-    for _marker in _ACTIVE_VENV_MARKER_VARS:
-        sanitized.pop(_marker, None)
+    _strip_hermes_owned_pythonpath_and_runtime_markers(sanitized)
 
     _apply_windows_msys_bash_env_defaults(sanitized)
 
@@ -651,11 +648,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(env)
 
-    _strip_hermes_owned_pythonpath(env)
-
-    # Active-venv markers must not clobber another project's environment.
-    for _marker in _ACTIVE_VENV_MARKER_VARS:
-        env.pop(_marker, None)
+    _strip_hermes_owned_pythonpath_and_runtime_markers(env)
 
     _apply_windows_msys_bash_env_defaults(env)
 
@@ -1340,10 +1333,7 @@ def _make_run_env(env: dict) -> dict:
     # engaged so a sibling session's os.environ mirror can't leak in).
     _inject_session_context_env(run_env)
 
-    _strip_hermes_owned_pythonpath(run_env)
-
-    for _marker in _ACTIVE_VENV_MARKER_VARS:
-        run_env.pop(_marker, None)
+    _strip_hermes_owned_pythonpath_and_runtime_markers(run_env)
 
     _apply_windows_msys_bash_env_defaults(run_env)
 
@@ -1534,6 +1524,18 @@ def _get_hermes_site_packages(env: dict) -> list[Path]:
             result.append(runtime_site_packages)
 
     return result
+
+
+def _strip_hermes_owned_pythonpath_and_runtime_markers(env: dict) -> None:
+    """Strip Hermes-owned PYTHONPATH entries, then the runtime marker vars.
+
+    Ordering is load-bearing: PYTHONPATH filtering must run BEFORE the
+    markers are removed so a validated Windows base-interpreter launch
+    (VIRTUAL_ENV -> <repo>/venv) can still prove ownership.
+    """
+    _strip_hermes_owned_pythonpath(env)
+    for _marker in _ACTIVE_VENV_MARKER_VARS:
+        env.pop(_marker, None)
 
 
 def _strip_hermes_owned_pythonpath(env: dict) -> None:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -357,7 +357,7 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # child can set it explicitly in the command.
 #
 # PYTHONPATH is NOT included here — it's handled by
-# _strip_mismatched_site_packages() which removes only Hermes-owned entries,
+# _strip_hermes_owned_pythonpath() which removes only Hermes-owned entries,
 # preserving user-set paths.
 _ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "PYTHONHOME")
 
@@ -519,7 +519,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         sanitized.pop(_marker, None)
 
-    _strip_mismatched_site_packages(sanitized)
+    _strip_hermes_owned_pythonpath(sanitized)
 
     _apply_windows_msys_bash_env_defaults(sanitized)
 
@@ -650,7 +650,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         env.pop(_marker, None)
 
-    _strip_mismatched_site_packages(env)
+    _strip_hermes_owned_pythonpath(env)
 
     _apply_windows_msys_bash_env_defaults(env)
 
@@ -1338,7 +1338,7 @@ def _make_run_env(env: dict) -> dict:
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         run_env.pop(_marker, None)
 
-    _strip_mismatched_site_packages(run_env)
+    _strip_hermes_owned_pythonpath(run_env)
 
     _apply_windows_msys_bash_env_defaults(run_env)
 
@@ -1380,6 +1380,19 @@ _hermes_venv_root: Path = Path(sys.prefix)
 #: etc.  Subprocesses that are NOT the Hermes backend don't need it and it
 #: can shadow local packages.
 _hermes_repo_root: Path = Path(__file__).resolve().parents[2]
+
+#: Alternate spellings of the repo root that Hermes launchers may emit.
+#: ``Path(__file__).resolve()`` canonicalizes symlinks/junctions, but the
+#: Windows gateway launcher deliberately renders Hermes-owned paths under
+#: the configured HERMES_HOME spelling (which may be a junction to another
+#: drive — see ``hermes_cli/gateway_windows.py::_preserve_hermes_home_path``).
+#: ``Path(__file__)`` (unresolved) keeps that spelling, so a PYTHONPATH
+#: entry written by the launcher still matches even though it differs
+#: lexically from the resolved root.
+_hermes_repo_root_aliases: tuple[Path, ...] = (
+    _hermes_repo_root,
+    Path(__file__).parents[2],
+)
 
 #: Whether the current interpreter is running inside a venv.  On Python 3.3+
 #: ``sys.base_prefix != sys.prefix`` indicates a venv (or virtualenv).
@@ -1435,7 +1448,7 @@ def _get_hermes_site_packages() -> list[Path]:
 _SITE_PACKAGES_RE = re.compile(r"(?:^|[\\/])site-packages(?:[\\/]|$)")
 
 
-def _strip_mismatched_site_packages(env: dict) -> None:
+def _strip_hermes_owned_pythonpath(env: dict) -> None:
     """Remove Hermes-owned PYTHONPATH entries from subprocess environments.
 
     The Desktop Electron process (and other Hermes launchers) prepend the
@@ -1454,7 +1467,9 @@ def _strip_mismatched_site_packages(env: dict) -> None:
 
     1. **Hermes repo root** - the path the Electron app prepends so the
        backend can ``import tools``.  Subprocesses don't need it and it can
-       shadow local packages of the same name.
+       shadow local packages of the same name.  Only the exact root is
+       stripped; direct children (``<repo>/tools`` etc.) are never injected
+       by any launcher and are treated as user paths.
 
     2. **Hermes venv site-packages** - entries under the running
        interpreter's own venv site-packages directory.  Redundant for
@@ -1506,18 +1521,20 @@ def _strip_mismatched_site_packages(env: dict) -> None:
         # --- Check 2: Hermes repo root ---
         # The Electron app prepends the repo root so ``import tools`` works
         # in the backend.  Subprocesses don't need it and it can shadow
-        # local packages of the same name.
-        if not should_strip and _is_path_under(entry_path, _hermes_repo_root):
-            # Only strip if the entry IS the repo root or a direct package
-            # dir under it (e.g. ``.../hermes-agent/tools``).  Don't strip
-            # arbitrary user paths that happen to be nested deeper.
-            rel = entry_path.resolve() if entry_path.exists() else entry_path
-            try:
-                depth = len(rel.relative_to(_hermes_repo_root).parts)
-            except (ValueError, OSError):
-                depth = -1
-            if depth <= 1:
-                should_strip = True
+        # local packages of the same name.  Only the EXACT root is stripped:
+        # no launcher injects a direct child (``<repo>/tools`` etc.) as an
+        # independent PYTHONPATH entry, and user paths that merely happen to
+        # live under the repo directory must be preserved.  Both the
+        # resolved and unresolved (HERMES_HOME/junction) spellings count as
+        # Hermes-owned.
+        if not should_strip:
+            for repo_root in _hermes_repo_root_aliases:
+                if _is_path_under(entry_path, repo_root):
+                    # Exact root only (same path), not children.
+                    rel = entry_path.relative_to(repo_root)
+                    if len(rel.parts) == 0:
+                        should_strip = True
+                    break
 
         if should_strip:
             stripped.append(entry)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1421,63 +1421,52 @@ def _get_hermes_site_packages() -> list[Path]:
     return result
 
 
-# Regex to extract a Python version marker (e.g. ``python3.11``) from a path.
-# Matches ``python3.11``, ``python3.13``, etc. as a path component - i.e.
-# preceded by a path separator (``/`` or ``\``) or string start, and followed
-# by a separator or string end.  This is cross-platform: it works with both
-# POSIX forward-slash paths and Windows backslash paths regardless of the
-# host OS, so a POSIX host correctly detects version markers in Windows-style
-# paths (important for testing and for edge cases like WSL).
-_PYVER_IN_PATH_RE = re.compile(r"(?:^|[\\/])python(\d+)\.(\d+)(?:[\\/]|$)")
-
 # Regex to detect ``site-packages`` as a path component (not a substring of
 # a longer directory name).  Same cross-platform separator handling.
 _SITE_PACKAGES_RE = re.compile(r"(?:^|[\\/])site-packages(?:[\\/]|$)")
 
 
 def _strip_mismatched_site_packages(env: dict) -> None:
-    """Remove mismatched site-packages paths from PYTHONPATH.
+    """Remove Hermes-owned PYTHONPATH entries from subprocess environments.
 
-    The Desktop Electron process (and systemd units, gateway VBS launchers,
-    etc.) inject the Hermes venv's site-packages path (e.g.
-    ``.../venv/lib/python3.11/site-packages``) into ``PYTHONPATH`` so the
-    Hermes backend can import its packages.  When this ``PYTHONPATH`` leaks
-    into subprocesses running a **different** Python version (e.g. 3.13),
-    the 3.11 C extensions appear on ``sys.path`` ahead of the correct 3.13
-    versions and crash with ``ImportError`` (``PIL._imaging``,
-    ``cryptography``, etc.).
+    The Desktop Electron process (and other Hermes launchers) prepend the
+    Hermes repo root and the Hermes venv's ``site-packages`` to ``PYTHONPATH``
+    so the backend can ``import tools`` / ``import hermes_cli``.  When that
+    ``PYTHONPATH`` leaks into subprocesses, a child Python of a DIFFERENT
+    version (e.g. 3.13 vs the backend's 3.11) picks up the 3.11 C extensions
+    from ``sys.path`` ahead of its own and crashes with ``ImportError``
+    (``PIL._imaging``, ``cryptography``, ``numpy._core._multiarray_umath``,
+    etc.).
 
     Rather than stripping ``PYTHONPATH`` entirely - which would discard
     legitimate user entries (Nix uses ``PYTHONPATH`` for plugin discovery,
     users set it for custom library paths) - this function surgically
-    removes only the dangerous entries:
+    removes only the entries Hermes itself owns:
 
-    1. **Cross-version site-packages** - any entry whose path contains a
-       ``python{X.Y}/site-packages`` component where ``{X.Y}`` differs from
-       the running interpreter's version.  This catches ALL leak sources
-       (Electron, systemd, gateway scripts) with a single version check,
-       regardless of the venv path.
+    1. **Hermes repo root** - the path the Electron app prepends so the
+       backend can ``import tools``.  Subprocesses don't need it and it can
+       shadow local packages of the same name.
 
-    2. **Hermes venv site-packages** (no version marker or same-version) -
-       entries that live under the running interpreter's own venv
-       site-packages directory.  These are redundant for subprocesses: the
-       Hermes backend discovers its packages via ``sys.path``, not via an
-       inherited env var.  Only checked when running inside a venv.
+    2. **Hermes venv site-packages** - entries under the running
+       interpreter's own venv site-packages directory.  Redundant for
+       subprocesses (they get their packages via ``sys.path``, not an
+       inherited env var) and a common leak vector.  Only checked when
+       running inside a venv.
 
-    3. **Hermes repo root** - the Electron app prepends the repo root
-       (parent of ``tools/``) to ``PYTHONPATH``.  Subprocesses don't need
-       it and it can shadow local packages.
-
-    User ``PYTHONPATH`` entries (``/opt/my-lib``, Nix plugin paths, etc.)
-    are always preserved.
+    User ``PYTHONPATH`` entries (``/opt/my-lib``, Nix plugin paths, a
+    ``/custom/lib/python3.13/site-packages`` intended for a child Python 3.13)
+    are always preserved.  In particular we deliberately do NOT apply a
+    cross-version heuristic here: the subprocess env builder cannot know
+    which Python version the child will ultimately run, so judging a user
+    path against the BACKEND's interpreter version would delete legitimate
+    user entries meant for a different child Python (#74817 follow-up).
+    Hermes-owned entries are identified by path ownership, not by version.
     """
     pp = env.get("PYTHONPATH")
     if not pp:
         return
 
     hermes_site_packages = _get_hermes_site_packages() if _in_venv else []
-    running_major = sys.version_info[0]
-    running_minor = sys.version_info[1]
 
     kept: list[str] = []
     stripped: list[str] = []
@@ -1490,30 +1479,13 @@ def _strip_mismatched_site_packages(env: dict) -> None:
         entry_path = Path(entry)
         should_strip = False
 
-        # --- Check 1: cross-version site-packages ---
-        # Look for a ``python{X.Y}`` path component and compare its version
-        # against the running interpreter.  If they differ, the entry's
-        # C extensions are ABI-incompatible - strip unconditionally.
-        # We search the full entry string (not ``entry_path.parts``) because
-        # ``Path.parts`` only splits on the host OS separator, so a Windows
-        # backslash path on a POSIX host would be a single un-split part.
-        m = _PYVER_IN_PATH_RE.search(entry)
-        if m:
-            entry_major = int(m.group(1))
-            entry_minor = int(m.group(2))
-            if (entry_major, entry_minor) != (running_major, running_minor):
-                should_strip = True
-        if should_strip:
-            stripped.append(entry)
-            continue
-
-        # --- Check 2: under Hermes venv site-packages ---
+        # --- Check 1: Hermes venv site-packages ---
         # The entry lives under the running interpreter's own venv
         # site-packages.  Redundant for subprocesses (they get their packages
         # via sys.path, not PYTHONPATH) and a common leak vector.
         # Use the regex (not ``entry_path.parts``) for cross-platform detection
         # so Windows backslash paths are caught on a POSIX host.
-        if not should_strip and _SITE_PACKAGES_RE.search(entry):
+        if _SITE_PACKAGES_RE.search(entry):
             for sp in hermes_site_packages:
                 if _is_path_under(entry_path, sp):
                     should_strip = True
@@ -1522,7 +1494,7 @@ def _strip_mismatched_site_packages(env: dict) -> None:
             stripped.append(entry)
             continue
 
-        # --- Check 3: Hermes repo root ---
+        # --- Check 2: Hermes repo root ---
         # The Electron app prepends the repo root so ``import tools`` works
         # in the backend.  Subprocesses don't need it and it can shadow
         # local packages of the same name.
@@ -1550,7 +1522,7 @@ def _strip_mismatched_site_packages(env: dict) -> None:
 
     if stripped:
         logger.debug(
-            "Stripped mismatched/Hermes-venv site-packages from PYTHONPATH: %s",
+            "Stripped Hermes-owned entries from PYTHONPATH: %s",
             stripped,
         )
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -347,10 +347,19 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 # Hermes venv stays reachable via PATH (its bin dir is first), so stripping
 # these markers is safe and only prevents the cross-project clobber (#23473).
 #
+# PYTHONHOME is included because a gateway-inherited value redirects the
+# standard-library search of ANY child interpreter — including unrelated
+# system/venv Pythons — to the Hermes venv's stdlib, which crashes with
+# version-mismatch errors before a child script even imports a package
+# (#75018). Hermes itself treats PYTHONHOME as contamination in its own
+# child processes (managed_uv.py, sqlite_runtime.py), so stripping it from
+# subprocess envs is consistent. Users who need PYTHONHOME for a specific
+# child can set it explicitly in the command.
+#
 # PYTHONPATH is NOT included here — it's handled by
-# _strip_mismatched_site_packages() which surgically removes only site-packages
-# paths that don't match the current Python ABI, preserving user-set entries.
-_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX")
+# _strip_mismatched_site_packages() which removes only Hermes-owned entries,
+# preserving user-set paths.
+_ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "PYTHONHOME")
 
 
 def _is_hermes_internal_secret(key: str) -> bool:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -14,6 +14,7 @@ import time
 from collections.abc import Mapping
 from pathlib import Path
 
+from hermes_constants import get_process_hermes_home
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -516,10 +517,14 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # spawn path (process_registry.spawn_local builds env via this function).
     _inject_session_context_env(sanitized)
 
+    # Filter PYTHONPATH before removing VIRTUAL_ENV: legacy Windows launchers
+    # can run the gateway under a base interpreter while VIRTUAL_ENV identifies
+    # the separate Hermes runtime venv.  The filter validates that relationship
+    # against the repo layout before trusting it.
+    _strip_hermes_owned_pythonpath(sanitized)
+
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         sanitized.pop(_marker, None)
-
-    _strip_hermes_owned_pythonpath(sanitized)
 
     _apply_windows_msys_bash_env_defaults(sanitized)
 
@@ -646,11 +651,11 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     from hermes_constants import apply_subprocess_home_env
     apply_subprocess_home_env(env)
 
+    _strip_hermes_owned_pythonpath(env)
+
     # Active-venv markers must not clobber another project's environment.
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         env.pop(_marker, None)
-
-    _strip_hermes_owned_pythonpath(env)
 
     _apply_windows_msys_bash_env_defaults(env)
 
@@ -1335,10 +1340,10 @@ def _make_run_env(env: dict) -> dict:
     # engaged so a sibling session's os.environ mirror can't leak in).
     _inject_session_context_env(run_env)
 
+    _strip_hermes_owned_pythonpath(run_env)
+
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         run_env.pop(_marker, None)
-
-    _strip_hermes_owned_pythonpath(run_env)
 
     _apply_windows_msys_bash_env_defaults(run_env)
 
@@ -1347,31 +1352,48 @@ def _make_run_env(env: dict) -> dict:
     return run_env
 
 
-def _is_path_under(child: Path, parent: Path) -> bool:
-    """Return True if *child* is the same as or under *parent*.
+def _same_path(left: Path, right: Path) -> bool:
+    """Compare path spellings with host filesystem case semantics."""
+    left_parts = [os.path.normcase(part) for part in left.parts]
+    right_parts = [os.path.normcase(part) for part in right.parts]
+    return left_parts == right_parts
 
-    Uses ``os.path.normcase`` so the comparison is case-insensitive on
-    Windows (NTFS is case-insensitive by default) and case-sensitive on
-    POSIX, matching filesystem semantics.  Paths are NOT resolved against
-    disk (no ``.resolve()``) so non-existent paths - common in test mocks
-    and in PYTHONPATH entries pointing at yet-to-be-created dirs - work
-    correctly.  ``Path.resolve(strict=False)`` would also touch the
-    filesystem to resolve symlinks, which we deliberately avoid.
+
+def _build_hermes_repo_root_aliases(
+    resolved_root: Path,
+    lexical_root: Path,
+    configured_home: Path,
+) -> tuple[Path, ...]:
+    """Return exact repo-root spellings emitted by Hermes launchers.
+
+    ``gateway_windows._preserve_hermes_home_path`` maps a physical path under
+    the resolved HERMES_HOME back onto the configured HERMES_HOME spelling.
+    Mirror that producer contract here so a junction-backed install is matched
+    without treating arbitrary descendants of HERMES_HOME as Hermes-owned.
     """
-    c_parts = [os.path.normcase(p) for p in child.parts]
-    p_parts = [os.path.normcase(p) for p in parent.parts]
-    if len(c_parts) < len(p_parts):
-        return False
-    return c_parts[: len(p_parts)] == p_parts
+    aliases: list[Path] = []
+
+    def add(candidate: Path) -> None:
+        if not any(_same_path(candidate, existing) for existing in aliases):
+            aliases.append(candidate)
+
+    add(resolved_root)
+    add(lexical_root)
+
+    try:
+        resolved_home = configured_home.resolve()
+        home_key = os.path.normcase(str(resolved_home))
+        root_key = os.path.normcase(str(resolved_root))
+        if os.path.commonpath([home_key, root_key]) == home_key:
+            relative_root = os.path.relpath(str(resolved_root), str(resolved_home))
+            add(configured_home / relative_root)
+    except (OSError, ValueError):
+        pass
+
+    return tuple(aliases)
 
 
 # --- Hermes venv / repo-root detection (module-level, computed once) ---
-
-#: The running interpreter's own venv root.  On a venv Python ``sys.prefix``
-#: points at the venv root (e.g. ``.../venv``); on a system Python it points
-#: at ``/usr`` or similar.  We only strip site-packages under this path when
-#: the interpreter is actually inside a venv (``sys.prefix != sys.base_prefix``).
-_hermes_venv_root: Path = Path(sys.prefix)
 
 #: The Hermes repository root - three levels up from this file
 #: (``tools/environments/local.py`` -> ``tools/environments`` -> ``tools``
@@ -1389,9 +1411,10 @@ _hermes_repo_root: Path = Path(__file__).resolve().parents[2]
 #: ``Path(__file__)`` (unresolved) keeps that spelling, so a PYTHONPATH
 #: entry written by the launcher still matches even though it differs
 #: lexically from the resolved root.
-_hermes_repo_root_aliases: tuple[Path, ...] = (
+_hermes_repo_root_aliases: tuple[Path, ...] = _build_hermes_repo_root_aliases(
     _hermes_repo_root,
-    Path(__file__).parents[2],
+    Path(__file__).absolute().parents[2],
+    get_process_hermes_home(),
 )
 
 #: Whether the current interpreter is running inside a venv.  On Python 3.3+
@@ -1409,43 +1432,73 @@ _in_venv: bool = (
 _hermes_site_packages: list[Path] | None = None
 
 
-def _get_hermes_site_packages() -> list[Path]:
-    """Return the site-packages dirs of the running interpreter's venv.
+def _validated_runtime_venv(env: dict) -> Path | None:
+    """Return a producer-owned runtime venv identified by VIRTUAL_ENV.
+
+    A user may carry an unrelated VIRTUAL_ENV, so the variable alone is not
+    provenance.  The legacy Windows base-Python gateway producer uses the exact
+    ``<Hermes repo>/venv`` layout and a real venv marker; require both before
+    accepting its separate runtime venv.
+    """
+    value = env.get("VIRTUAL_ENV")
+    if not value:
+        return None
+
+    candidate = Path(value)
+    if not any(_same_path(candidate, repo_root / "venv") for repo_root in _hermes_repo_root_aliases):
+        return None
+
+    try:
+        if not (candidate / "pyvenv.cfg").is_file():
+            return None
+    except OSError:
+        return None
+
+    return candidate
+
+
+def _get_hermes_site_packages(env: dict) -> list[Path]:
+    """Return exact site-packages dirs owned by the Hermes runtime.
 
     Uses ``site.getsitepackages()`` when available for robustness (it respects
     ``.pth`` rewrites and platform conventions), with a manual fallback that
     constructs the canonical path from ``sys.prefix`` for POSIX and Windows.
+    A validated Windows base-interpreter launch contributes its separate
+    ``VIRTUAL_ENV/Lib/site-packages`` directory as an additional exact entry.
     """
     global _hermes_site_packages
     if _hermes_site_packages is not None:
-        return _hermes_site_packages
+        result = list(_hermes_site_packages)
+    else:
+        result = []
+        if _in_venv:
+            try:
+                import site
+                for sp in site.getsitepackages():
+                    result.append(Path(sp))
+            except Exception:
+                pass
 
-    result: list[Path] = []
-    try:
-        import site
-        for sp in site.getsitepackages():
-            result.append(Path(sp))
-    except Exception:
-        pass
+            # Fallback: construct manually.  On POSIX:
+            #   sys.prefix / lib / python{X.Y} / site-packages
+            # On Windows:
+            #   sys.prefix / Lib / site-packages
+            if not result:
+                if _IS_WINDOWS:
+                    result.append(Path(sys.prefix) / "Lib" / "site-packages")
+                else:
+                    pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+                    result.append(Path(sys.prefix) / "lib" / pyver / "site-packages")
 
-    # Fallback: construct manually.  On POSIX:
-    #   sys.prefix / lib / python{X.Y} / site-packages
-    # On Windows:
-    #   sys.prefix / Lib / site-packages
-    if not result:
-        if _IS_WINDOWS:
-            result.append(Path(sys.prefix) / "Lib" / "site-packages")
-        else:
-            pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-            result.append(Path(sys.prefix) / "lib" / pyver / "site-packages")
+        _hermes_site_packages = list(result)
 
-    _hermes_site_packages = result
+    runtime_venv = _validated_runtime_venv(env)
+    if runtime_venv is not None:
+        runtime_site_packages = runtime_venv / "Lib" / "site-packages"
+        if not any(_same_path(runtime_site_packages, existing) for existing in result):
+            result.append(runtime_site_packages)
+
     return result
-
-
-# Regex to detect ``site-packages`` as a path component (not a substring of
-# a longer directory name).  Same cross-platform separator handling.
-_SITE_PACKAGES_RE = re.compile(r"(?:^|[\\/])site-packages(?:[\\/]|$)")
 
 
 def _strip_hermes_owned_pythonpath(env: dict) -> None:
@@ -1471,11 +1524,12 @@ def _strip_hermes_owned_pythonpath(env: dict) -> None:
        stripped; direct children (``<repo>/tools`` etc.) are never injected
        by any launcher and are treated as user paths.
 
-    2. **Hermes venv site-packages** - entries under the running
-       interpreter's own venv site-packages directory.  Redundant for
+    2. **Hermes venv site-packages** - the exact directories owned by the
+       running interpreter's venv, or by a separately validated Windows
+       base-Python gateway runtime venv.  Redundant for
        subprocesses (they get their packages via ``sys.path``, not an
-       inherited env var) and a common leak vector.  Only checked when
-       running inside a venv.
+       inherited env var) and a common leak vector.  Descendants are not
+       producer-owned entries and are preserved.
 
     User ``PYTHONPATH`` entries (``/opt/my-lib``, Nix plugin paths, a
     ``/custom/lib/python3.13/site-packages`` intended for a child Python 3.13)
@@ -1490,30 +1544,29 @@ def _strip_hermes_owned_pythonpath(env: dict) -> None:
     if not pp:
         return
 
-    hermes_site_packages = _get_hermes_site_packages() if _in_venv else []
+    hermes_site_packages = _get_hermes_site_packages(env)
 
     kept: list[str] = []
     stripped: list[str] = []
 
     for entry in pp.split(os.pathsep):
-        entry = entry.strip()
-        if not entry:
+        # Empty and non-normalized components are user-owned semantics.  In
+        # particular, an empty component means the current working directory.
+        # Preserve raw spelling unless the exact component is Hermes-owned.
+        if entry == "":
+            kept.append(entry)
             continue
 
         entry_path = Path(entry)
         should_strip = False
 
         # --- Check 1: Hermes venv site-packages ---
-        # The entry lives under the running interpreter's own venv
-        # site-packages.  Redundant for subprocesses (they get their packages
-        # via sys.path, not PYTHONPATH) and a common leak vector.
-        # Use the regex (not ``entry_path.parts``) for cross-platform detection
-        # so Windows backslash paths are caught on a POSIX host.
-        if _SITE_PACKAGES_RE.search(entry):
-            for sp in hermes_site_packages:
-                if _is_path_under(entry_path, sp):
-                    should_strip = True
-                    break
+        # Producers inject the exact directory, never a descendant.  Exact
+        # matching avoids deleting a user path nested below site-packages.
+        for sp in hermes_site_packages:
+            if _same_path(entry_path, sp):
+                should_strip = True
+                break
         if should_strip:
             stripped.append(entry)
             continue
@@ -1528,13 +1581,10 @@ def _strip_hermes_owned_pythonpath(env: dict) -> None:
         # resolved and unresolved (HERMES_HOME/junction) spellings count as
         # Hermes-owned.
         if not should_strip:
-            for repo_root in _hermes_repo_root_aliases:
-                if _is_path_under(entry_path, repo_root):
-                    # Exact root only (same path), not children.
-                    rel = entry_path.relative_to(repo_root)
-                    if len(rel.parts) == 0:
-                        should_strip = True
-                    break
+            should_strip = any(
+                _same_path(entry_path, repo_root)
+                for repo_root in _hermes_repo_root_aliases
+            )
 
         if should_strip:
             stripped.append(entry)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1541,41 +1541,23 @@ def _strip_hermes_owned_pythonpath_and_runtime_markers(env: dict) -> None:
 def _strip_hermes_owned_pythonpath(env: dict) -> None:
     """Remove Hermes-owned PYTHONPATH entries from subprocess environments.
 
-    The Desktop Electron process (and other Hermes launchers) prepend the
-    Hermes repo root and the Hermes venv's ``site-packages`` to ``PYTHONPATH``
-    so the backend can ``import tools`` / ``import hermes_cli``.  When that
-    ``PYTHONPATH`` leaks into subprocesses, a child Python of a DIFFERENT
-    version (e.g. 3.13 vs the backend's 3.11) picks up the 3.11 C extensions
-    from ``sys.path`` ahead of its own and crashes with ``ImportError``
-    (``PIL._imaging``, ``cryptography``, ``numpy._core._multiarray_umath``,
-    etc.).
+    Launchers prepend the Hermes repo root and the Hermes venv's
+    site-packages so the backend can ``import tools``; leaking those into a
+    child Python of a DIFFERENT version makes it load the backend's C
+    extensions and crash (``numpy._core._multiarray_umath``, ``PIL._imaging``,
+    ``cryptography``).  Blanket-removing PYTHONPATH would discard legitimate
+    user entries, so only entries proven Hermes-owned are removed:
 
-    Rather than stripping ``PYTHONPATH`` entirely - which would discard
-    legitimate user entries (Nix uses ``PYTHONPATH`` for plugin discovery,
-    users set it for custom library paths) - this function surgically
-    removes only the entries Hermes itself owns:
+    1. The exact repo root (never direct children -- no launcher injects
+       one, and user paths under the repo must survive).
+    2. The exact runtime site-packages dirs (running interpreter's venv or
+       a validated Windows base-Python runtime venv; descendants are user
+       paths).
 
-    1. **Hermes repo root** - the path the Electron app prepends so the
-       backend can ``import tools``.  Subprocesses don't need it and it can
-       shadow local packages of the same name.  Only the exact root is
-       stripped; direct children (``<repo>/tools`` etc.) are never injected
-       by any launcher and are treated as user paths.
-
-    2. **Hermes venv site-packages** - the exact directories owned by the
-       running interpreter's venv, or by a separately validated Windows
-       base-Python gateway runtime venv.  Redundant for
-       subprocesses (they get their packages via ``sys.path``, not an
-       inherited env var) and a common leak vector.  Descendants are not
-       producer-owned entries and are preserved.
-
-    User ``PYTHONPATH`` entries (``/opt/my-lib``, Nix plugin paths, a
-    ``/custom/lib/python3.13/site-packages`` intended for a child Python 3.13)
-    are always preserved.  In particular we deliberately do NOT apply a
-    cross-version heuristic here: the subprocess env builder cannot know
-    which Python version the child will ultimately run, so judging a user
-    path against the BACKEND's interpreter version would delete legitimate
-    user entries meant for a different child Python (#74817 follow-up).
-    Hermes-owned entries are identified by path ownership, not by version.
+    Everything else -- user libs, Nix plugin paths, a pythonX.Y/site-packages
+    entry meant for a DIFFERENT child version -- is preserved byte-for-byte:
+    ownership is decided by path provenance, never by a cross-version
+    heuristic (#74817 follow-up).
     """
     pp = env.get("PYTHONPATH")
     if not pp:


### PR DESCRIPTION
## Summary

Remove Hermes-owned runtime contamination from subprocess environments while preserving user-owned `PYTHONPATH` semantics byte-for-byte. Consolidates and builds on #78917, incorporates the follow-up correctness work from Yiipu/hermes-agent#1, and rebases the complete attributed history onto main at `f4c2c263f` (reconciled with #84500's `execute_code` PYTHONPATH composition, which is preserved unmodified).

## Reproduction / root cause

Hermes launchers prepend the Hermes repository root and the Hermes venv's `site-packages` to `PYTHONPATH` so the backend can `import tools`. When that `PYTHONPATH` leaks into an unrelated child interpreter of a different version, the child resolves Hermes' C extensions from the 3.11 tree and crashes:

```text
ModuleNotFoundError: No module named 'numpy._core._multiarray_umath'
_multiarray_umath.cpython-311-darwin.so
```

The same contamination class affects Pillow, cryptography, and other ABI-sensitive packages, and reaches non-agent cron/script subprocesses through the shared environment builders. Blanket removal of `PYTHONPATH` would fix the crash but destroy legitimate user configuration; comparing path-shaped versions against the backend interpreter is unsound because the builder cannot know which interpreter a child will run.

## Ownership model / design

`PYTHONPATH` entries are removed only when they are **proven Hermes-owned**; everything else is preserved verbatim (spelling, duplicates, empty components, ordering):

- Strip only the exact Hermes repository root and the exact Hermes runtime `site-packages` directories. Direct/deeper repo children and `site-packages` descendants are user paths by contract (no launcher injects them as standalone entries).
- No cross-version, path-shape, or `/nix/store` heuristics: a user `pythonX.Y/site-packages` entry meant for a different child version is preserved.
- Site-packages ownership comes from the running interpreter's venv plus a validated `VIRTUAL_ENV` (exact `<Hermes repo>/venv` layout with a real `pyvenv.cfg`; an unrelated inherited `VIRTUAL_ENV` is not trusted).
- Sanitize `PYTHONPATH` before removing runtime marker vars so a validated Windows base-interpreter launch can still prove ownership.
- The `build_subprocess_env(scrub_secrets=False)` no-scrub escape hatch is unchanged.
- Inherited `PYTHONHOME` is removed on normal sanitized paths (#75018) so it cannot redirect a child interpreter's stdlib search.

## Changes

- Apply the selective filter across terminal/background, shared subprocess, cron/script, and execute-code environment construction (#84500 composition: staging first, repo root re-added exactly once for same-env children, absent for external interpreters).
- `resolve_profile_env()` keeps the configured `HERMES_HOME` spelling as the launch root through profile re-home (junction-transparent; physically identical directories), so `--profile` / sticky `active_profile` cannot destroy the launcher's lexical provenance.
- The alias builder recovers launcher lexical repo-root spellings from three trusted sources, all fail-closed exact ownership: configured-home-relative mapping, profile-root derivation (parent of a `profiles` component), and a single deterministic repo-level candidate (`<root>/<repo dirname>`) accepted only when strict `resolve()` proves it is the exact physical repo root.
- Behavioral regression coverage for exact ownership, raw `PYTHONPATH` semantics, junction aliases (home-level and repo-level, including cross-drive), profile interaction, validated `VIRTUAL_ENV`, and `PYTHONHOME`.

## Windows runtime + junction handling

Supported real topologies, each with dedicated regressions (verified on native Windows 11 with real directory junctions):

- **Base/uv gateway with a separate Hermes `VIRTUAL_ENV`**: the runtime venv is validated against the repo layout and its exact `Lib/site-packages` is stripped; an unrelated `VIRTUAL_ENV` is not provenance.
- **Home-level junction** (`D:\hermes` -> physical `%LOCALAPPDATA%\hermes`): the configured-home spelling maps back onto the lexical repo root.
- **Profile re-home**: `--profile <name>` / `default` and sticky `active_profile` keep the configured lexical spelling and recover the root from the profile path.
- **Repo-level junction / cross-drive** (`D:\hermes` real dir, `D:\hermes\hermes-agent` junction -> physical repo): the single deterministic candidate is accepted only on exact filesystem identity; a same-named real directory is never aliased or stripped.
- Restoring the lexical repo alias also re-enables `VIRTUAL_ENV` validation for lexical venv spellings, so the uv-base gateway's venv site-packages cleanup follows the repo alias.

**Independent real-Windows validation by @vollegrewar**: on a Windows 11 desktop build (junction install, Hermes backend Python 3.11, external project venv Python 3.14), `main` reproducibly crashes the Python 3.14 child with the cp311 NumPy `_multiarray_umath` failure; this PR fixes the ABI isolation (`OK numpy 2.5.2` from the project venv). His subsequent real junction topology reports drove the alias-handling convergence above.

## Validation

- Native Windows 11 (isolated temp checkout at the exact PR head): `tests/tools/test_local_env_blocklist.py` — 78 passed, 1 skipped (`macos_only`), including the home-level / repo-level / profile / negative-control / uv-base `VIRTUAL_ENV` junction regressions; real cross-drive junction experiment strips the lexical root and venv site-packages with user entries preserved.
- macOS: blocklist + profiles + apply-profile-override — 132 passed, 4 skipped; related subprocess suites (`test_code_execution_modes.py`, `test_code_execution.py`, `test_code_execution_windows_env.py`, `test_build_subprocess_env.py`, `test_hermes_subprocess_env.py`) — 121 passed, 3 skipped.
- macOS arm64 real E2E: contaminated environment makes independent Python 3.13 load the Hermes Python 3.11 NumPy tree and fail; sanitized environment preserves `/custom/lib/python3.13/site-packages` and Python 3.13 imports NumPy and Pillow from its own conda environment.
- `ruff` / `py_compile` / `git diff --check` on changed files — passed.

## Known residual limitations

- Nix `extraPythonPackages` may append runtime plugin paths outside the repo/venv ownership boundary; a `/nix/store` path is not sufficient provenance, so those entries are deliberately preserved. A producer-side provenance contract is a separate discussion.
- `HostSupervisor` has an independent internal-child environment overwrite pattern; it does not block the user-facing #74817 subprocess path and is intentionally left for a separate issue/PR.
- Other exotic path topologies (UNC, `subst`, nested junctions) are not enumerated; the exact-ownership model is fail-closed by construction.

## Lineage / related work

Git history preserves original authorship: `mcjoys` (initial selective stripping, #61028/#78917 lineage), `Yiipu` (repo-root correction and boundary tests), `Xinyu Du` / `Starfie1d1272` (macOS reproduction, removal of the cross-version heuristic, user `PYTHONPATH` preservation, `PYTHONHOME`, junction/profile provenance handling, current-main integration, regression/E2E validation). Targets #74817 and the inherited-`PYTHONHOME` portion of #75018; related context #65909, #57467.

