### PR TITLE
feat(agent): add attach-only image input mode

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -12,9 +12,16 @@ Two modes:
             it only sees a lossy text summary. This is the pre-existing
             behaviour and still the right choice for non-vision models.
 
+  attach  — do not pre-analyze at all. The cached local image path is exposed
+            as plain text so the agent can call ``vision_analyze`` itself
+            when it needs to inspect the image.  No extra LLM call is spent
+            on auto-summarization; the agent decides when (and whether) to
+            look at the image.  Useful for gateway platforms where an image
+            arrives without text and the user wants zero-cost intake.
+
 The decision is made once per message turn by :func:`decide_image_input_mode`.
 It reads ``agent.image_input_mode`` from config.yaml (``auto`` | ``native``
-| ``text``, default ``auto``) and the active model's capability metadata.
+| ``text`` | ``attach``, default ``auto``) and the active model's capability metadata.
 
 In ``auto`` mode:
   - If the active model reports ``supports_vision=True`` (via config
@@ -49,7 +56,7 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
-_VALID_MODES = frozenset({"auto", "native", "text"})
+_VALID_MODES = frozenset({"auto", "native", "text", "attach"})
 
 
 # Image extensions used by extract_image_refs(). Kept tight on purpose — we
@@ -483,6 +490,8 @@ def decide_image_input_mode(
         return "native"
     if mode_cfg == "text":
         return "text"
+    if mode_cfg == "attach":
+        return "attach"
 
     # auto: prefer native vision when the main model supports it. An
     # explicit auxiliary.vision config acts as a *fallback* for text-only

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16288,6 +16288,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Image routing: native (model supports vision). %d image(s) will be attached inline.",
                         len(image_paths),
                     )
+                elif _img_mode == "attach":
+                    # Attach-only: do NOT auto-summarize via vision_analyze.
+                    # Expose the cached image paths as text so the agent can
+                    # inspect them on demand with the vision_analyze tool.
+                    logger.info(
+                        "Image routing: attach (no auto-summary). %d image(s) exposed as paths.",
+                        len(image_paths),
+                    )
+                    _attach_parts = [
+                        f"[The user sent an image: {p}]"
+                        f"[Inspect it on demand with vision_analyze(image_url: {p})]"
+                        for p in image_paths
+                    ]
+                    message_text = (
+                        "\n\n".join(_attach_parts) + "\n\n" + message_text
+                        if message_text.strip()
+                        else "\n\n".join(_attach_parts)
+                    )
                 else:
                     logger.info(
                         "Image routing: text (mode=%s). Pre-analyzing %d image(s) via vision_analyze.",
@@ -20076,6 +20094,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
             enriched_prompt = prompt
+            img_mode = str(
+                (user_config.get("agent") or {}).get("image_input_mode") or "auto"
+            ).strip().lower()
             if media_urls:
                 image_paths = []
                 for i, path in enumerate(media_urls):
@@ -20083,12 +20104,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if mtype.startswith("image/"):
                         image_paths.append(path)
                 if image_paths:
-                    try:
-                        enriched_prompt = await self._enrich_message_with_vision(
-                            prompt, image_paths,
+                    if img_mode == "attach":
+                        # Attach-only: no auto-summary; expose cached paths as
+                        # text so the background agent can call vision_analyze
+                        # on demand (same as the main flow).
+                        _attach_parts = [
+                            f"[The user sent an image: {p}]"
+                            f"[Inspect it on demand with vision_analyze(image_url: {p})]"
+                            for p in image_paths
+                        ]
+                        enriched_prompt = (
+                            "\n\n".join(_attach_parts) + "\n\n" + prompt
+                            if prompt.strip()
+                            else "\n\n".join(_attach_parts)
                         )
-                    except Exception as e:
-                        logger.warning("Background task vision enrichment failed: %s", e)
+                    else:
+                        try:
+                            enriched_prompt = await self._enrich_message_with_vision(
+                                prompt, image_paths,
+                            )
+                        except Exception as e:
+                            logger.warning("Background task vision enrichment failed: %s", e)
 
             def run_sync():
                 agent = AIAgent(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -262,6 +262,10 @@ DEFAULT_CONFIG = {
         #              (see run_agent._prepare_messages_for_api).
         #   "text"   — always pre-analyze with vision_analyze and prepend the
         #              description as text; the main model never sees pixels.
+        #   "attach" — do not pre-analyze; expose the cached local image path
+        #              as text so the agent can call vision_analyze itself
+        #              when it needs to inspect the image.  No extra LLM call
+        #              is spent on auto-summarization.
         # Affects gateway platforms, the TUI, and CLI /attach.  vision_analyze
         # remains available as a tool regardless of this setting — the routing
         # only controls how inbound user images are presented.

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -78,6 +78,22 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", None) == "native"
 
+    def test_attach_mode_returns_attach_regardless_of_vision_capability(self):
+        """attach mode short-circuits before capability lookup: no auto-summary."""
+        cfg = {"agent": {"image_input_mode": "attach"}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "attach"
+
+    def test_attach_mode_with_text_only_model(self):
+        """attach is a valid explicit choice for non-vision main models too."""
+        cfg = {"agent": {"image_input_mode": "attach"}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=False):
+            assert decide_image_input_mode("deepseek", "deepseek-v4-flash", cfg) == "attach"
+
+    def test_attach_is_valid_coerced_mode(self):
+        assert _coerce_mode("attach") == "attach"
+        assert _coerce_mode("ATTACH") == "attach"
+
 
 
 


### PR DESCRIPTION
## Summary

- Add a fourth `agent.image_input_mode` value: **`attach`** — inbound user images are exposed as cached local paths in the message text, with **no auto-summarization** through the vision enrichment pipeline.
- The agent decides when (and whether) to inspect an image by calling `vision_analyze(image_url=<path>)` itself.
- Gateway intake costs **zero extra LLM calls** for images (the current `text` mode always spends one `vision_analyze` call per image up-front).

## Motivation

For messaging-gateway platforms (e.g. QQ Bot) with a **text-only main model**, the existing modes are both suboptimal:

- `native` — attaches pixels directly; text-only models can't see them, and some providers 400.
- `text` — always pre-analyzes every image via the auxiliary vision backend and injects `[The user sent an image~ Here's what I can see: ...]` into the message. This spends an LLM call on **every** image, even when the user never asks about it, and the injected summary format can be ignored by the model (#25993, #25900).

`attach` fills the gap: the image path is handed to the agent as text (like `_build_media_placeholder` already does for media-only events), and `vision_analyze` stays available as a tool for on-demand inspection.

There is no existing upstream issue requesting this exact mode; the closest related work is #15288 / #16862 (native passthrough) and #23503 (opt-in path hints, native-only). This PR targets the text-only-model gateway scenario those don't cover.

## Changes

- `agent/image_routing.py`
  - `_VALID_MODES` now includes `attach`
  - `decide_image_input_mode()` short-circuits to `"attach"` before the capability lookup, so it works for vision-capable and text-only models alike
  - Module docstring updated
- `gateway/run.py`
  - Main message preprocessing path: `attach` mode skips `_enrich_message_with_vision()` and injects `[The user sent an image: <path>] [Inspect it on demand with vision_analyze(image_url: <path>)]` per image
  - Background task path: same handling, reads `agent.image_input_mode` from config
- `hermes_cli/config_defaults.py` — document the new mode
- `tests/agent/test_image_routing.py` — unit tests for attach routing (valid mode, works with and without vision capability)

## Test Plan

- [x] `pytest tests/agent/test_image_routing.py` — 8 passed (3 new attach tests)
- [ ] Manual: gateway platform with `agent.image_input_mode: attach`, send an image, verify the agent receives the path text without an auto-summary LLM call, and can call `vision_analyze` on demand

## Notes for Reviewers

- The path-exposure direction has a known tension with #41564 (hide full local paths from the model). If maintainers prefer, `attach` could emit a sanitized/relative path instead — happy to adjust.
- `vision_analyze` remains in the toolset in attach mode (the agent opts in per-use), which is the opposite of #43951/#44029 (auto-disable vision tools for text-only models) — but those target the `text` auto-summary scenario, so no conflict.
