### PR TITLE
fix(tools): resolve explicit Git -C targets without ambient-cwd fail-open

### DIFF
--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -5,11 +5,13 @@ from pathlib import Path
 
 import pytest
 
+from tools.approval import _deobfuscate_shell_word_for_detection
 from tools.self_repo_guard import (
     _explicit_git_path,
     _is_mangled_windows_drive,
     _normalize_git_path_operand,
     _path_aware_shell_word,
+    _shell_words_at,
     _strip_quotes_preserve_windows_path,
     _windows_git_bash_to_drive,
     detect_self_repo_git_mutation,
@@ -370,6 +372,10 @@ class TestExplicitGitTargetPaths:
         preserved = _strip_quotes_preserve_windows_path(raw)
         assert preserved == r"D:\work\hermes-agent"
         assert "\\" in preserved
+        # Path preserve applies in -C operand position via _shell_words_at,
+        # not to bare quoted Windows paths in arbitrary token slots.
+        words = _shell_words_at(f"git -C {raw} status", 0)
+        assert words[2] == r"D:\work\hermes-agent"
         assert _path_aware_shell_word(raw) == r"D:\work\hermes-agent"
         normalized = _normalize_git_path_operand(r"D:\work\hermes-agent")
         assert normalized == r"D:\work\hermes-agent"
@@ -451,11 +457,35 @@ class TestExplicitGitTargetPaths:
 
     def test_path_aware_word_recovers_quoted_windows_path(self):
         # Simulates the raw token _read_shell_word returns for a double-quoted
-        # Windows path; approval deobfuscation would mangle it.
-        from tools.approval import _deobfuscate_shell_word_for_detection
-
+        # Windows path; approval deobfuscation would mangle it. Recovery is
+        # via the path-operand helper / -C position — not every shell token.
         raw = r'"D:\work\hermes-agent"'
         mangled = _deobfuscate_shell_word_for_detection(raw)
         assert mangled == "D:workhermes-agent" or "\\" not in mangled
+        words = _shell_words_at(f"git -C {raw} checkout main", 0)
+        assert words[2] == r"D:\work\hermes-agent"
+        assert not _is_mangled_windows_drive(words[2])
         assert _path_aware_shell_word(raw) == r"D:\work\hermes-agent"
-        assert not _is_mangled_windows_drive(_path_aware_shell_word(raw))
+
+    def test_configured_alias_still_blocks_in_source_repo(self, repo):
+        """Regression: operand-only path-aware words must not break aliases."""
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "alias.co", "checkout"],
+            check=True,
+        )
+        hit, _ = _detect("git co main", repo, repo)
+        assert hit is True
+
+    def test_non_path_words_use_normal_deobfuscation(self):
+        """Path-aware preserve must not blanket every shell token."""
+        raw_path = r'"D:\work\hermes-agent"'
+        # Outside a Git path-operand position, the quoted Windows path is
+        # normal-deobfuscated (backslashes stripped as shell escapes).
+        words = _shell_words_at(f"echo {raw_path}", 0)
+        assert words[0] == "echo"
+        assert words[1] == _deobfuscate_shell_word_for_detection(raw_path)
+        assert "\\" not in words[1]
+        # Contrast: the same token after bare -C keeps separators.
+        git_words = _shell_words_at(f"git -C {raw_path} status", 0)
+        assert git_words[2] == r"D:\work\hermes-agent"
+        assert "\\" in git_words[2]

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -6,6 +6,12 @@ from pathlib import Path
 import pytest
 
 from tools.self_repo_guard import (
+    _explicit_git_path,
+    _is_mangled_windows_drive,
+    _normalize_git_path_operand,
+    _path_aware_shell_word,
+    _strip_quotes_preserve_windows_path,
+    _windows_git_bash_to_drive,
     detect_self_repo_git_mutation,
     get_running_source_root,
 )
@@ -354,3 +360,102 @@ class TestUnparseableCommands:
     def test_subshell_syntax_does_not_crash(self, repo):
         hit, _ = _detect("VAL=$(git rev-parse HEAD) git checkout main", repo, repo)
         assert hit is True
+
+
+class TestExplicitGitTargetPaths:
+    """Windows / Git-Bash explicit ``-C`` operands must not fail open."""
+
+    def test_preserves_windows_backslash_in_dash_c_operand(self):
+        raw = r'"D:\work\hermes-agent"'
+        preserved = _strip_quotes_preserve_windows_path(raw)
+        assert preserved == r"D:\work\hermes-agent"
+        assert "\\" in preserved
+        assert _path_aware_shell_word(raw) == r"D:\work\hermes-agent"
+        normalized = _normalize_git_path_operand(r"D:\work\hermes-agent")
+        assert normalized == r"D:\work\hermes-agent"
+        path = _explicit_git_path(r"D:\work\hermes-agent", Path("/tmp"))
+        assert "D:" in str(path).replace("\\", "/") or str(path).startswith("D:")
+        text = str(path).replace("\\", "/")
+        assert "work" in text and "hermes-agent" in text
+
+    def test_git_bash_drive_path_normalizes(self):
+        assert _windows_git_bash_to_drive("/d/work/hermes-agent") == "D:/work/hermes-agent"
+        assert _windows_git_bash_to_drive("/D/work/x") == "D:/work/x"
+        assert _windows_git_bash_to_drive("/c") == "C:/"
+        assert _normalize_git_path_operand("/d/work/hermes-agent") == "D:/work/hermes-agent"
+        path = _explicit_git_path("/d/work/hermes-agent", Path("/var/tmp"))
+        text = str(path).replace("\\", "/")
+        assert "D:" in text
+        assert "work/hermes-agent" in text
+        # Use non-escape string forms: "/tmp/..." embeds a TAB via \t in
+        # ordinary Python literals and would accidentally pass a looser regex.
+        assert _windows_git_bash_to_drive("/" + "tmp/foo") is None
+        assert _windows_git_bash_to_drive("/" + "dev/null") is None
+        assert _windows_git_bash_to_drive("/" + "Users/hermes") is None
+        assert _windows_git_bash_to_drive("/" + "etc/passwd") is None
+
+    def test_dash_c_windows_path_blocks_mutation_when_normalized_target_is_repo(
+        self, repo, tmp_path, monkeypatch
+    ):
+        import tools.self_repo_guard as mod
+
+        win_path = r"D:\work\hermes-agent"
+
+        def fake_explicit(path_str, base):
+            if path_str.replace("\\", "/") in {
+                win_path.replace("\\", "/"),
+                "D:/work/hermes-agent",
+            } or path_str == win_path:
+                return repo
+            return mod._resolve_git_target(
+                mod._normalize_git_path_operand(path_str), base
+            )
+
+        monkeypatch.setattr(mod, "_explicit_git_path", fake_explicit)
+        # Double-quoted native Windows path — path-aware word keep separators,
+        # then our stub maps the operand onto the real temp repo.
+        command = f'git -C "{win_path}" checkout main'
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_multiple_dash_c_fail_closed_when_first_is_repo(self, repo, tmp_path):
+        # Intermediate -C lands in the source root even though a later -C
+        # leaves it — conservative rule blocks the mutating subcommand.
+        hit, _ = _detect(
+            f"git -C {repo} -C {tmp_path} checkout main",
+            tmp_path,
+            repo,
+        )
+        assert hit is True
+
+    def test_multiple_dash_c_all_outside_still_allowed(self, repo, tmp_path):
+        outside_a = tmp_path / "outside-a"
+        outside_b = tmp_path / "outside-b"
+        outside_a.mkdir()
+        outside_b.mkdir()
+        hit, _ = _detect(
+            f"git -C {outside_a} -C {outside_b} checkout main",
+            tmp_path,
+            repo,
+        )
+        assert hit is False
+
+    def test_mangled_drive_path_operand_fail_closed(self, repo, tmp_path):
+        assert _is_mangled_windows_drive("D:workhermes")
+        assert not _is_mangled_windows_drive(r"D:\work\hermes")
+        assert not _is_mangled_windows_drive("D:/work/hermes")
+        # Escape-stripped drive form must fail closed for mutations regardless
+        # of ambient cwd (do not fall open to outside-the-repo ambient path).
+        hit, _ = _detect("git -C D:workhermes checkout main", tmp_path, repo)
+        assert hit is True
+
+    def test_path_aware_word_recovers_quoted_windows_path(self):
+        # Simulates the raw token _read_shell_word returns for a double-quoted
+        # Windows path; approval deobfuscation would mangle it.
+        from tools.approval import _deobfuscate_shell_word_for_detection
+
+        raw = r'"D:\work\hermes-agent"'
+        mangled = _deobfuscate_shell_word_for_detection(raw)
+        assert mangled == "D:workhermes-agent" or "\\" not in mangled
+        assert _path_aware_shell_word(raw) == r"D:\work\hermes-agent"
+        assert not _is_mangled_windows_drive(_path_aware_shell_word(raw))

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -197,25 +197,39 @@ def _strip_quotes_preserve_windows_path(raw_word: str) -> str:
     return _unquote_raw_preserve(raw_word)
 
 
+_GIT_PATH_OPTIONS_WITH_ARG = frozenset({
+    "-C",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+})
+_GIT_PATH_ENV_VARS = frozenset({"GIT_DIR", "GIT_WORK_TREE"})
+
+
 def _path_aware_shell_word(raw_word: str) -> str:
     """Deobfuscate a shell word, preserving native Windows path separators.
 
     approval.py's escape strip treats `\\` as a shell escape, which mangles
     quoted paths like ``"D:\\work\\hermes-agent"`` into ``D:workhermes-agent``.
     For explicit filesystem operands we keep those separators instead.
+
+    Callers must only invoke this for Git path-operand positions (see
+    ``_shell_words_at``); it is not safe to apply to every shell token.
     """
     assign = _ASSIGNMENT_RE.fullmatch(raw_word)
     if assign:
         name, _, value_raw = raw_word.partition("=")
-        if _raw_looks_like_windows_path(value_raw):
+        if name in _GIT_PATH_ENV_VARS and _raw_looks_like_windows_path(value_raw):
             return f"{name}={_strip_quotes_preserve_windows_path(value_raw)}"
         return _deobfuscate_shell_word_for_detection(raw_word)
 
-    if raw_word.startswith("--work-tree="):
-        value = raw_word[len("--work-tree=") :]
-        if _raw_looks_like_windows_path(value):
-            return "--work-tree=" + _strip_quotes_preserve_windows_path(value)
-        return _deobfuscate_shell_word_for_detection(raw_word)
+    for prefix in ("--work-tree=", "--git-dir="):
+        if raw_word.startswith(prefix):
+            value = raw_word[len(prefix) :]
+            if _raw_looks_like_windows_path(value):
+                return prefix + _strip_quotes_preserve_windows_path(value)
+            return _deobfuscate_shell_word_for_detection(raw_word)
 
     if (
         raw_word.startswith("-C")
@@ -230,6 +244,25 @@ def _path_aware_shell_word(raw_word: str) -> str:
     if _raw_looks_like_windows_path(raw_word):
         return _strip_quotes_preserve_windows_path(raw_word)
     return _deobfuscate_shell_word_for_detection(raw_word)
+
+
+def _is_glued_git_path_option(raw_word: str) -> bool:
+    """True for ``-Cpath`` / ``--git-dir=`` / ``--work-tree=`` glued forms."""
+    if raw_word.startswith("--work-tree=") or raw_word.startswith("--git-dir="):
+        return True
+    return (
+        raw_word.startswith("-C")
+        and len(raw_word) > 2
+        and not raw_word.startswith("--")
+    )
+
+
+def _is_git_path_env_assignment(raw_word: str) -> bool:
+    """True for ``GIT_DIR=...`` / ``GIT_WORK_TREE=...`` assignment words."""
+    if not _ASSIGNMENT_RE.fullmatch(raw_word):
+        return False
+    name, _, _ = raw_word.partition("=")
+    return name in _GIT_PATH_ENV_VARS
 
 
 def _windows_git_bash_to_drive(path: str) -> str | None:
@@ -286,15 +319,42 @@ def _executable_name(value: str) -> str:
 
 
 def _shell_words_at(command: str, start: int) -> list[str]:
+    """Tokenize a shell command start, path-preserving only Git path operands.
+
+    Windows backslash preservation applies solely to:
+    - the next word after bare ``-C`` / ``--git-dir`` / ``--work-tree`` /
+      ``--namespace`` / ``--exec-path``
+    - glued ``--work-tree=VALUE`` / ``--git-dir=VALUE`` / ``-CVALUE``
+    - ``GIT_DIR=`` / ``GIT_WORK_TREE=`` assignment values (when Windows-looking)
+
+    Every other token uses ``_deobfuscate_shell_word_for_detection`` unchanged
+    so non-path words (aliases, subcommands, ordinary args) are not rewritten.
+    """
     words: list[str] = []
     cursor = start
+    expect_path_operand = False
     for _ in range(64):
         word_start, word_end, raw_word = _read_shell_word(command, cursor)
         if word_start == word_end:
             break
         if words and "\n" in command[cursor:word_start]:
             break
-        words.append(_path_aware_shell_word(raw_word))
+
+        if (
+            expect_path_operand
+            or _is_glued_git_path_option(raw_word)
+            or _is_git_path_env_assignment(raw_word)
+        ):
+            word = _path_aware_shell_word(raw_word)
+        else:
+            word = _deobfuscate_shell_word_for_detection(raw_word)
+        words.append(word)
+
+        if expect_path_operand:
+            expect_path_operand = False
+        else:
+            expect_path_operand = word in _GIT_PATH_OPTIONS_WITH_ARG
+
         cursor = word_end
     return words
 

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -123,6 +123,17 @@ _WRAPPER_OPTIONS_WITH_ARG = {
 }
 _SIMPLE_WRAPPERS = frozenset({"builtin", "exec", "nohup", "setsid", "time"})
 _MAX_RECURSION = 4
+# Native Windows path: drive letter + separator. Used to avoid treating `\` as a
+# shell escape when the operand is clearly a filesystem path for Git.
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+# After approval.py's escape stripping, `D:\work\repo` becomes `D:workrepo` —
+# drive letter, colon, then a non-separator. Treat as untrusted (fail closed).
+_MANGLED_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[^\\/]")
+# Git-Bash / MSYS drive form: `/d/work/...` → `D:/work/...` (explicit Git
+# path operands only; always recognized so tests can pin behavior on POSIX).
+# Require a slash (or EOS) immediately after the single drive letter so
+# ordinary Unix paths like `/tmp/foo` and `/dev/null` never match.
+_GIT_BASH_DRIVE_RE = re.compile(r"^/([A-Za-z])(?:/(.*))?\Z")
 
 
 @dataclass
@@ -166,6 +177,110 @@ def _is_within(path: Path, root: Path) -> bool:
         return False
 
 
+def _unquote_raw_preserve(raw: str) -> str:
+    """Strip a single layer of matching quotes without interpreting escapes."""
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
+        return raw[1:-1]
+    return raw
+
+
+def _raw_looks_like_windows_path(raw: str) -> bool:
+    """True when *raw* (possibly quoted) is a native Windows drive path."""
+    inner = _unquote_raw_preserve(raw)
+    if _WINDOWS_DRIVE_PATH_RE.match(inner):
+        return True
+    return bool(re.match(r"^[A-Za-z]:", inner) and "\\" in inner)
+
+
+def _strip_quotes_preserve_windows_path(raw_word: str) -> str:
+    """Strip shell quotes but keep `\\` as path separators in Windows paths."""
+    return _unquote_raw_preserve(raw_word)
+
+
+def _path_aware_shell_word(raw_word: str) -> str:
+    """Deobfuscate a shell word, preserving native Windows path separators.
+
+    approval.py's escape strip treats `\\` as a shell escape, which mangles
+    quoted paths like ``"D:\\work\\hermes-agent"`` into ``D:workhermes-agent``.
+    For explicit filesystem operands we keep those separators instead.
+    """
+    assign = _ASSIGNMENT_RE.fullmatch(raw_word)
+    if assign:
+        name, _, value_raw = raw_word.partition("=")
+        if _raw_looks_like_windows_path(value_raw):
+            return f"{name}={_strip_quotes_preserve_windows_path(value_raw)}"
+        return _deobfuscate_shell_word_for_detection(raw_word)
+
+    if raw_word.startswith("--work-tree="):
+        value = raw_word[len("--work-tree=") :]
+        if _raw_looks_like_windows_path(value):
+            return "--work-tree=" + _strip_quotes_preserve_windows_path(value)
+        return _deobfuscate_shell_word_for_detection(raw_word)
+
+    if (
+        raw_word.startswith("-C")
+        and len(raw_word) > 2
+        and not raw_word.startswith("--")
+    ):
+        value = raw_word[2:]
+        if _raw_looks_like_windows_path(value):
+            return "-C" + _strip_quotes_preserve_windows_path(value)
+        return _deobfuscate_shell_word_for_detection(raw_word)
+
+    if _raw_looks_like_windows_path(raw_word):
+        return _strip_quotes_preserve_windows_path(raw_word)
+    return _deobfuscate_shell_word_for_detection(raw_word)
+
+
+def _windows_git_bash_to_drive(path: str) -> str | None:
+    """Translate Git-Bash ``/d/work/...`` to ``D:/work/...``, else None."""
+    match = _GIT_BASH_DRIVE_RE.fullmatch(path)
+    if not match:
+        return None
+    drive = match.group(1).upper()
+    rest = match.group(2)
+    if rest is None:
+        return f"{drive}:/"
+    return f"{drive}:/{rest}"
+
+
+def _is_mangled_windows_drive(path: str) -> bool:
+    """True when a drive path lost its separators (escape-strip artifact)."""
+    return bool(_MANGLED_WINDOWS_DRIVE_RE.match(path))
+
+
+def _normalize_git_path_operand(path: str) -> str:
+    """Normalize an explicit Git path operand for resolve/compare.
+
+    Preserves native Windows separators; maps Git-Bash drive form to
+    ``D:/...``. Does not require running on Windows.
+    """
+    git_bash = _windows_git_bash_to_drive(path)
+    if git_bash is not None:
+        return git_bash
+    return path
+
+
+def _explicit_git_path(path: str, base: Path) -> Path:
+    """Resolve an explicit Git ``-C`` / work-tree path operand."""
+    return _resolve_git_target(_normalize_git_path_operand(path), base)
+
+
+def _resolve_git_target(path_str: str, base: Path) -> Path:
+    """Resolve a Git path operand with Windows-aware absolute detection.
+
+    Drive-letter paths (``D:/...``, ``D:\\...``) are absolute for comparison
+    even when pathlib on POSIX would treat them as relative.
+    """
+    normalized = _normalize_git_path_operand(path_str)
+    expanded = os.path.expanduser(normalized)
+    if _WINDOWS_DRIVE_PATH_RE.match(expanded):
+        # Keep a stable absolute form without joining *base* (POSIX Path would
+        # otherwise treat ``D:/x`` as relative and prepend cwd/base).
+        return Path(expanded.replace("\\", "/"))
+    return _resolve(expanded, base)
+
+
 def _executable_name(value: str) -> str:
     return Path(value.replace("\\", "/")).name.removesuffix(".exe").lower()
 
@@ -179,7 +294,7 @@ def _shell_words_at(command: str, start: int) -> list[str]:
             break
         if words and "\n" in command[cursor:word_start]:
             break
-        words.append(_deobfuscate_shell_word_for_detection(raw_word))
+        words.append(_path_aware_shell_word(raw_word))
         cursor = word_end
     return words
 
@@ -457,11 +572,30 @@ def _git_target_and_subcommand(
     args: list[str],
     current_dir: Path,
     env: dict[str, str],
+    root: Path | None = None,
 ) -> tuple[Path, str | None, list[str], dict[str, str]]:
     target = current_dir
     work_tree: str | None = None
     aliases: dict[str, str] = {}
     index = 0
+    dash_c_count = 0
+    # Conservative multi -C rule: if any intermediate -C lands inside the
+    # source root, treat the effective target as the source root so mutating
+    # subcommands block — even when a later -C leaves the tree. Ambiguous /
+    # mangled Windows operands also fail closed (target := root) rather than
+    # falling back to ambient cwd.
+    any_dash_c_within_root = False
+    untrusted_path_operand = False
+
+    def _apply_explicit_path(path_str: str, base: Path) -> Path:
+        nonlocal any_dash_c_within_root, untrusted_path_operand
+        if _is_mangled_windows_drive(path_str):
+            untrusted_path_operand = True
+            return root if root is not None else base
+        resolved = _explicit_git_path(path_str, base)
+        if root is not None and _is_within(resolved, root):
+            any_dash_c_within_root = True
+        return resolved
 
     while index < len(args):
         arg = args[index]
@@ -469,11 +603,13 @@ def _git_target_and_subcommand(
             index += 1
             break
         if arg == "-C" and index + 1 < len(args):
-            target = _resolve(args[index + 1], target)
+            dash_c_count += 1
+            target = _apply_explicit_path(args[index + 1], target)
             index += 2
             continue
         if arg.startswith("-C") and len(arg) > 2:
-            target = _resolve(arg[2:], target)
+            dash_c_count += 1
+            target = _apply_explicit_path(arg[2:], target)
             index += 1
             continue
         if arg in {"--work-tree", "--git-dir", "--namespace", "--exec-path"}:
@@ -504,7 +640,14 @@ def _git_target_and_subcommand(
 
     explicit_work_tree = work_tree or env.get("GIT_WORK_TREE")
     if explicit_work_tree:
-        target = _resolve(explicit_work_tree, target)
+        target = _apply_explicit_path(explicit_work_tree, target)
+
+    if root is not None and (
+        untrusted_path_operand
+        or (dash_c_count > 1 and any_dash_c_within_root)
+    ):
+        target = root
+
     subcommand = args[index].lower() if index < len(args) else None
     return target, subcommand, args[index + 1 :], aliases
 
@@ -559,7 +702,7 @@ def _inspect_git_worktree(args: list[str], cwd: Path, root: Path) -> str | None:
     target_index = _next_positional(args, action_index + 1)
     if target_index >= len(args):
         return None
-    if _resolve(args[target_index], cwd) == root:
+    if _explicit_git_path(args[target_index], cwd) == root:
         return f"git worktree {action}"
     return None
 
@@ -588,7 +731,7 @@ def _inspect_git(
     depth: int,
 ) -> str | None:
     target, subcommand, sub_args, inline_aliases = _git_target_and_subcommand(
-        args, current_dir, env
+        args, current_dir, env, root=root
     )
     if subcommand is None:
         return None


### PR DESCRIPTION
## Problem

The live-source Git mutation guard (`tools/self_repo_guard.py`) can inspect the ambient shell directory instead of the repository explicitly targeted by `git -C`. On Windows, approval-style shell-word deobfuscation removes native path separators from quoted Windows path operands, and Git-Bash `/d/...` operands are resolved as ordinary root-relative paths. The guard then **fails open** for a mutation aimed at the running source checkout.

## Root cause

- `_shell_words_at` always ran words through `_deobfuscate_shell_word_for_detection` → `_strip_shell_word_syntax`, which treats backslash as a shell escape.
- Quoted Windows paths lost separators and resolved outside the real source root, so `_is_within(target, root)` was false and the mutation was allowed.

## Fix

- Path-preserving deobfuscation applies **only** to explicit Git path operand positions (`-C` / `--git-dir` / `--work-tree` / `GIT_DIR` / `GIT_WORK_TREE`) — not every shell token.
- Explicit Git path operands map Git-Bash `/d/...` → `D:/...` (single-letter drive form only; ordinary Unix paths are not rewritten).
- Mangled drive operands fail closed.
- Multiple `-C` options: if any intermediate target lands in the source root, mutating subcommands block even when a later `-C` leaves the tree.

## Why it matters

Agents on Windows can rewrite Hermes's live source checkout via `git -C <source> ...` while the guard believes the target is elsewhere.

## Test plan

```bash
python -m pytest tests/tools/test_self_repo_guard.py tests/tools/test_terminal_self_repo_guard.py -q
# Result at head f74372a6: 127 passed (macOS Mini)
```

## Status vs competing work (2026-08-11)

- [#83834](https://github.com/NousResearch/hermes-agent/pull/83834) (andrexibiza) is a **broader class-close** that includes this PR's fail-open coverage and credits Olympusbuildz via `Co-authored-by`.
- This PR is held as **draft** to avoid thrash on #82569. Prefer maintainer pick of #83834 once required CI is green; this branch remains if a smaller surgical surface is preferred.
- Earlier #82636 closed; delivery moved to #83834.

Fixes #82569
