### PR TITLE
feat(xai): add xai_code_interpreter server-side sandbox tool

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2968,6 +2968,15 @@ DEFAULT_CONFIG = {
         "retries": 2,
     },
 
+    # xAI Code Interpreter — server-side Python sandbox via Responses
+    # API code_interpreter. Separate from local execute_code. Enable in
+    # `hermes tools` → xAI Code Interpreter.
+    "xai_code_interpreter": {
+        "model": "grok-4.5",
+        "timeout_seconds": 180,
+        "retries": 2,
+    },
+
     # =========================================================================
     # External secret sources
     # =========================================================================

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -105,6 +105,7 @@ CONFIGURABLE_TOOLSETS = [
     ("video_gen",       "🎬 Video Generation",          "video_generate (text/image/reference)"),
     ("bfl",             "🎬 BFL FLUX 3 Video",          "bfl_flux3_*"),
     ("x_search",        "🐦 X (Twitter) Search",        "x_search (requires xAI OAuth or XAI_API_KEY)"),
+    ("xai_code_interpreter", "🧮 xAI Code Interpreter", "xai_code_interpreter (server-side Python sandbox)"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("stt",             "🎙️ Speech-to-Text",           "voice transcription (gateway voice messages + voice mode)"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
@@ -153,7 +154,19 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a"}
+# xai_code_interpreter stays default-off: server-side billing + distinct
+# from local execute_code; enable explicitly in hermes tools.
+_DEFAULT_OFF_TOOLSETS = {
+    "homeassistant",
+    "spotify",
+    "discord",
+    "discord_admin",
+    "video",
+    "video_gen",
+    "x_search",
+    "xai_code_interpreter",
+    "a2a",
+}
 
 
 # Config-only capabilities: they appear in `hermes tools` for provider/API-key
@@ -580,6 +593,38 @@ TOOL_CATEGORIES = {
             "(uses your subscription quota instead of API spend)."
         ),
         "icon": "🐦",
+        "providers": [
+            {
+                "name": "xAI Grok OAuth (SuperGrok / Premium+)",
+                "badge": "subscription",
+                "tag": "Browser login at accounts.x.ai — no API key required",
+                "env_vars": [],
+                "post_setup": "xai_grok",
+            },
+            {
+                "name": "xAI API key",
+                "badge": "paid",
+                "tag": "Direct xAI API billing via XAI_API_KEY",
+                "env_vars": [
+                    {
+                        "key": "XAI_API_KEY",
+                        "prompt": "xAI API key",
+                        "url": "https://console.x.ai/",
+                    },
+                ],
+            },
+        ],
+    },
+    "xai_code_interpreter": {
+        "name": "xAI Code Interpreter",
+        "setup_title": "Select xAI Credential Source",
+        "setup_note": (
+            "Runs Python in xAI's hosted code_interpreter sandbox via the "
+            "Responses API. This is separate from local execute_code — no "
+            "host filesystem or Hermes tools. SuperGrok OAuth is preferred "
+            "when both credential sources are set."
+        ),
+        "icon": "🧮",
         "providers": [
             {
                 "name": "xAI Grok OAuth (SuperGrok / Premium+)",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -80,6 +80,15 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
 
 
 
+def test_configurable_toolsets_include_xai_code_interpreter_default_off():
+    assert any(
+        ts_key == "xai_code_interpreter"
+        for ts_key, _, _ in CONFIGURABLE_TOOLSETS
+    )
+    assert "xai_code_interpreter" in _DEFAULT_OFF_TOOLSETS
+    assert "xai_code_interpreter" in TOOL_CATEGORIES
+
+
 def test_get_platform_tools_homeassistant_toolset_enabled_for_cron_when_hass_token_set(monkeypatch):
     """HA toolset is runtime-gated by check_fn (requires HASS_TOKEN).
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -40,6 +40,14 @@ class TestGetToolset:
         assert "xurl" in description
         assert "authenticated" in description
 
+    def test_xai_code_interpreter_toolset(self):
+        ts = get_toolset("xai_code_interpreter")
+        assert ts is not None
+        assert ts["tools"] == ["xai_code_interpreter"]
+        description = ts["description"].lower()
+        assert "code_interpreter" in description or "sandbox" in description
+        assert "execute_code" in description
+
     def test_merges_registry_tools_into_builtin_toolset(self, monkeypatch):
         reg = ToolRegistry()
         reg.register(

--- a/tests/tools/test_xai_code_interpreter_tool.py
+++ b/tests/tools/test_xai_code_interpreter_tool.py
@@ -1,0 +1,351 @@
+"""Tests for xAI Code Interpreter via the Responses API code_interpreter tool."""
+
+import json
+
+import requests
+
+
+class _FakeResponse:
+    def __init__(self, payload, *, status_code=200, text=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text if text is not None else json.dumps(payload)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            err = requests.HTTPError(f"{self.status_code} Error")
+            err.response = self
+            raise err
+
+    def json(self):
+        return self._payload
+
+
+def _fake_credentials(monkeypatch, *, provider="xai", api_key="xai-test-key"):
+    monkeypatch.setattr(
+        "tools.xai_code_interpreter_tool.resolve_xai_http_credentials",
+        lambda: {
+            "provider": provider,
+            "api_key": api_key,
+            "base_url": "https://api.x.ai/v1",
+        },
+    )
+
+
+def _no_xai_env(monkeypatch):
+    for var in ("XAI_API_KEY", "XAI_BASE_URL", "HERMES_XAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_xai_code_interpreter_posts_responses_request(monkeypatch):
+    from hermes_cli import __version__
+    from tools.xai_code_interpreter_tool import xai_code_interpreter_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "output_text": "Compound interest is $16288.95.",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "code_execution",
+                            "arguments": '{"code":"print(10000*(1.05)**10)"}',
+                        },
+                    }
+                ],
+                "server_side_tool_usage": {
+                    "SERVER_SIDE_TOOL_CODE_EXECUTION": 1,
+                },
+                "usage": {"input_tokens": 20, "output_tokens": 15},
+            }
+        )
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        xai_code_interpreter_tool(
+            task="Calculate compound interest for $10000 at 5% for 10 years"
+        )
+    )
+
+    tool_def = captured["json"]["tools"][0]
+    assert captured["url"] == "https://api.x.ai/v1/responses"
+    assert captured["headers"]["Authorization"] == "Bearer xai-test-key"
+    assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["json"]["model"] == "grok-4.5"
+    assert captured["json"]["store"] is False
+    assert captured["json"]["input"][0]["content"] == (
+        "Calculate compound interest for $10000 at 5% for 10 years"
+    )
+    assert captured["timeout"] == 180
+    assert tool_def == {"type": "code_interpreter"}
+    assert result["success"] is True
+    assert result["tool"] == "xai_code_interpreter"
+    assert result["xai_tool"] == "code_interpreter"
+    assert result["xai_sdk_tool"] == "code_execution"
+    assert result["answer"] == "Compound interest is $16288.95."
+    assert result["tool_calls"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "code_execution",
+                "arguments": '{"code":"print(10000*(1.05)**10)"}',
+            },
+        }
+    ]
+    assert result["server_side_tool_usage"] == {
+        "SERVER_SIDE_TOOL_CODE_EXECUTION": 1,
+    }
+    assert result["usage"] == {"input_tokens": 20, "output_tokens": 15}
+
+
+def test_xai_code_interpreter_extracts_output_and_calls(monkeypatch):
+    from tools.xai_code_interpreter_tool import xai_code_interpreter_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output": [
+                    {
+                        "type": "code_interpreter_call",
+                        "id": "ci_1",
+                        "status": "completed",
+                        "code": "print(2 + 2)",
+                    },
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "The result is 4.",
+                            }
+                        ],
+                    },
+                ]
+            }
+        )
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_code_interpreter_tool(task="What is 2+2?"))
+
+    assert result["success"] is True
+    assert result["answer"] == "The result is 4."
+    assert result["code_interpreter_calls"] == [
+        {
+            "type": "code_interpreter_call",
+            "id": "ci_1",
+            "status": "completed",
+            "code": "print(2 + 2)",
+        }
+    ]
+
+
+def test_xai_code_interpreter_empty_task_returns_tool_error(monkeypatch):
+    from tools.xai_code_interpreter_tool import xai_code_interpreter_tool
+
+    _fake_credentials(monkeypatch)
+
+    result = json.loads(xai_code_interpreter_tool(task="  "))
+
+    assert result["error"] == "task is required for xai_code_interpreter"
+
+
+def test_xai_code_interpreter_returns_structured_http_error(monkeypatch):
+    from tools.xai_code_interpreter_tool import xai_code_interpreter_tool
+
+    class _FailingResponse:
+        status_code = 403
+        text = '{"code":"forbidden","error":"code_interpreter is not enabled"}'
+
+        def json(self):
+            return {
+                "code": "forbidden",
+                "error": "code_interpreter is not enabled",
+            }
+
+        def raise_for_status(self):
+            err = requests.HTTPError("403 Client Error: Forbidden")
+            err.response = self
+            raise err
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(xai_code_interpreter_tool(task="Compute something"))
+
+    assert result["success"] is False
+    assert result["provider"] == "xai"
+    assert result["tool"] == "xai_code_interpreter"
+    assert result["xai_tool"] == "code_interpreter"
+    assert result["error_type"] == "HTTPError"
+    assert result["error"] == "forbidden: code_interpreter is not enabled"
+
+
+def test_xai_code_interpreter_http_error_supports_nested_error(monkeypatch):
+    from tools.xai_code_interpreter_tool import xai_code_interpreter_tool
+
+    class _FailingResponse:
+        status_code = 400
+        text = '{"error":{"message":"bad request"}}'
+
+        def json(self):
+            return {"error": {"message": "bad request"}}
+
+        def raise_for_status(self):
+            err = requests.HTTPError("400 Client Error: Bad Request")
+            err.response = self
+            raise err
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(xai_code_interpreter_tool(task="Compute something"))
+
+    assert result["success"] is False
+    assert result["error"] == "bad request"
+
+
+def test_xai_code_interpreter_retries_timeout_then_succeeds(monkeypatch):
+    from tools.xai_code_interpreter_tool import xai_code_interpreter_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise requests.ReadTimeout("timed out")
+        return _FakeResponse({"output_text": "Recovered after retry."})
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.xai_code_interpreter_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(xai_code_interpreter_tool(task="Compute something"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after retry."
+
+
+def test_xai_code_interpreter_retries_5xx_then_succeeds(monkeypatch):
+    from tools.xai_code_interpreter_tool import xai_code_interpreter_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _FakeResponse(
+                {"code": "server_error", "error": "temporary failure"},
+                status_code=500,
+            )
+        return _FakeResponse({"output_text": "Recovered after 5xx retry."})
+
+    _fake_credentials(monkeypatch)
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.xai_code_interpreter_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(xai_code_interpreter_tool(task="Compute something"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after 5xx retry."
+
+
+def test_xai_code_interpreter_uses_xai_oauth_when_available(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from tools.xai_code_interpreter_tool import (
+        check_xai_code_interpreter_requirements,
+        xai_code_interpreter_tool,
+    )
+
+    _no_xai_env(monkeypatch)
+    _fake_credentials(monkeypatch, provider="xai-oauth", api_key="oauth-token")
+    invalidate_check_fn_cache()
+
+    assert check_xai_code_interpreter_requirements() is True
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["headers"] = headers
+        return _FakeResponse({"output_text": "OAuth worked."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_code_interpreter_tool(task="Compute something"))
+
+    assert result["success"] is True
+    assert result["credential_source"] == "xai-oauth"
+    assert captured["headers"]["Authorization"] == "Bearer oauth-token"
+
+
+def test_xai_code_interpreter_returns_tool_error_when_no_credentials(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from tools.xai_code_interpreter_tool import (
+        check_xai_code_interpreter_requirements,
+        xai_code_interpreter_tool,
+    )
+
+    _no_xai_env(monkeypatch)
+    _fake_credentials(monkeypatch, api_key="")
+    invalidate_check_fn_cache()
+
+    assert check_xai_code_interpreter_requirements() is False
+
+    result = xai_code_interpreter_tool(task="Compute something")
+
+    assert "No xAI credentials available" in result
+    assert "hermes auth add xai-oauth" in result
+
+
+def test_xai_code_interpreter_honors_config_model_timeout_and_retries(monkeypatch):
+    from tools.xai_code_interpreter_tool import xai_code_interpreter_tool
+
+    monkeypatch.setattr(
+        "tools.xai_code_interpreter_tool._load_xai_code_interpreter_config",
+        lambda: {
+            "model": "grok-custom-test",
+            "timeout_seconds": 45,
+            "retries": 0,
+        },
+    )
+    _fake_credentials(monkeypatch)
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["model"] = json["model"]
+        captured["timeout"] = timeout
+        return _FakeResponse({"output_text": "Custom config OK."})
+
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(xai_code_interpreter_tool(task="Compute something"))
+
+    assert result["success"] is True
+    assert captured["model"] == "grok-custom-test"
+    assert captured["timeout"] == 45
+
+
+def test_xai_code_interpreter_registered_in_registry_with_check_fn():
+    import tools.xai_code_interpreter_tool  # noqa: F401 - ensures registration runs
+    from tools.registry import registry
+
+    entry = registry.get_entry("xai_code_interpreter")
+    assert entry is not None
+    assert entry.toolset == "xai_code_interpreter"
+    assert entry.check_fn is not None
+    assert entry.check_fn.__name__ == "check_xai_code_interpreter_requirements"
+    assert "XAI_API_KEY" in entry.requires_env
+    assert entry.emoji == "🧮"

--- a/tools/xai_code_interpreter_tool.py
+++ b/tools/xai_code_interpreter_tool.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""xAI Code Interpreter via the Responses API ``code_interpreter`` tool.
+
+Runs Python in xAI's hosted sandbox (NumPy/Pandas/SciPy-class libs). Stateless
+single-shot Responses call — no local filesystem, no Hermes tool whitelist.
+
+This is intentionally separate from local ``execute_code``:
+local project scripts and tool orchestration stay on ``execute_code``;
+server-side math/data work that should not touch the host goes here.
+
+Auth: SuperGrok OAuth preferred, then ``XAI_API_KEY`` — same resolver as
+``x_search`` / ``tools.xai_http.resolve_xai_http_credentials``.
+
+Docs: https://docs.x.ai/developers/tools/code-execution
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent, resolve_xai_http_credentials
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_XAI_CODE_INTERPRETER_MODEL = "grok-4.5"
+DEFAULT_XAI_CODE_INTERPRETER_TIMEOUT_SECONDS = 180
+DEFAULT_XAI_CODE_INTERPRETER_RETRIES = 2
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_xai_code_interpreter_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("xai_code_interpreter", {}) or {}
+    except Exception:
+        return {}
+
+
+def _get_xai_code_interpreter_model() -> str:
+    cfg = _load_xai_code_interpreter_config()
+    return (
+        str(cfg.get("model") or "").strip()
+        or DEFAULT_XAI_CODE_INTERPRETER_MODEL
+    )
+
+
+def _get_xai_code_interpreter_timeout_seconds() -> int:
+    cfg = _load_xai_code_interpreter_config()
+    raw_value = cfg.get(
+        "timeout_seconds",
+        DEFAULT_XAI_CODE_INTERPRETER_TIMEOUT_SECONDS,
+    )
+    try:
+        return max(30, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_CODE_INTERPRETER_TIMEOUT_SECONDS
+
+
+def _get_xai_code_interpreter_retries() -> int:
+    cfg = _load_xai_code_interpreter_config()
+    raw_value = cfg.get("retries", DEFAULT_XAI_CODE_INTERPRETER_RETRIES)
+    try:
+        return max(0, int(raw_value))
+    except Exception:
+        return DEFAULT_XAI_CODE_INTERPRETER_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_xai_bearer() -> Tuple[str, str, str]:
+    """Return ``(api_key, base_url, source)`` or raise on missing credentials."""
+    creds = resolve_xai_http_credentials()
+    api_key = str(creds.get("api_key") or "").strip()
+    if not api_key:
+        raise RuntimeError(
+            "No xAI credentials available. Run `hermes auth add xai-oauth` "
+            "to sign in with your SuperGrok subscription, or set XAI_API_KEY."
+        )
+    base_url = str(creds.get("base_url") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+    source = str(creds.get("provider") or "xai")
+    return api_key, base_url, source
+
+
+def check_xai_code_interpreter_requirements() -> bool:
+    """Return True when xAI credentials are available and non-empty."""
+    try:
+        creds = resolve_xai_http_credentials()
+        return bool(str(creds.get("api_key") or "").strip())
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _extract_response_text(payload: Dict[str, Any]) -> str:
+    output_text = str(payload.get("output_text") or "").strip()
+    if output_text:
+        return output_text
+
+    parts: List[str] = []
+    for item in payload.get("output", []) or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            if not isinstance(content, dict):
+                continue
+            ctype = content.get("type")
+            if ctype in ("output_text", "text"):
+                text = str(content.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
+def _extract_code_interpreter_calls(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    calls: List[Dict[str, Any]] = []
+    for item in payload.get("output", []) or []:
+        if not isinstance(item, dict):
+            continue
+        item_type = str(item.get("type") or "")
+        if item_type in ("code_interpreter_call", "code_execution_call"):
+            calls.append(item)
+    return calls
+
+
+def _extract_tool_calls(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw_calls = payload.get("tool_calls") or []
+    if isinstance(raw_calls, dict):
+        return [raw_calls]
+    if isinstance(raw_calls, list):
+        return [call for call in raw_calls if isinstance(call, dict)]
+    return []
+
+
+def _http_error_message(exc: requests.HTTPError) -> str:
+    response = getattr(exc, "response", None)
+    if response is None:
+        return str(exc)
+
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+
+    if isinstance(payload, dict):
+        code = str(payload.get("code") or "").strip()
+        error_value = payload.get("error")
+        if isinstance(error_value, dict):
+            error = str(error_value.get("message") or "").strip()
+        else:
+            error = str(error_value or "").strip()
+        message = error or str(payload)
+        if code and code not in message:
+            message = f"{code}: {message}"
+        return message or str(exc)
+
+    text = str(getattr(response, "text", "") or "").strip()
+    if text:
+        return text[:500]
+    return str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+def xai_code_interpreter_tool(task: str) -> str:
+    if not task or not str(task).strip():
+        return tool_error("task is required for xai_code_interpreter")
+
+    try:
+        api_key, base_url, source = _resolve_xai_bearer()
+    except RuntimeError as exc:
+        return tool_error(str(exc))
+
+    try:
+        tool_def = {"type": "code_interpreter"}
+        payload = {
+            "model": _get_xai_code_interpreter_model(),
+            "input": [
+                {
+                    "role": "user",
+                    "content": str(task).strip(),
+                }
+            ],
+            "tools": [tool_def],
+            "store": False,
+        }
+
+        timeout_seconds = _get_xai_code_interpreter_timeout_seconds()
+        max_retries = _get_xai_code_interpreter_retries()
+        response: Optional[requests.Response] = None
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.post(
+                    f"{base_url}/responses",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                        "User-Agent": hermes_xai_user_agent(),
+                    },
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+                response.raise_for_status()
+                break
+            except requests.HTTPError as e:
+                status_code = getattr(getattr(e, "response", None), "status_code", None)
+                if status_code is None or status_code < 500 or attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "xai_code_interpreter upstream failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    _http_error_message(e),
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+            except (requests.ReadTimeout, requests.ConnectionError) as e:
+                if attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "xai_code_interpreter transient failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    e,
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+
+        if response is None:
+            raise RuntimeError("xai_code_interpreter request did not return a response")
+
+        data = response.json()
+        answer = _extract_response_text(data)
+
+        return json.dumps(
+            {
+                "success": True,
+                "provider": "xai",
+                "credential_source": source,
+                "tool": "xai_code_interpreter",
+                "xai_tool": "code_interpreter",
+                "xai_sdk_tool": "code_execution",
+                "model": payload["model"],
+                "task": str(task).strip(),
+                "answer": answer,
+                "citations": list(data.get("citations") or []),
+                "tool_calls": _extract_tool_calls(data),
+                "code_interpreter_calls": _extract_code_interpreter_calls(data),
+                "server_side_tool_usage": data.get("server_side_tool_usage") or {},
+                "usage": data.get("usage") or {},
+            },
+            ensure_ascii=False,
+        )
+    except requests.HTTPError as e:
+        logger.error("xai_code_interpreter failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_code_interpreter",
+                "xai_tool": "code_interpreter",
+                "error": _http_error_message(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except requests.ReadTimeout as e:
+        logger.error("xai_code_interpreter timed out: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_code_interpreter",
+                "xai_tool": "code_interpreter",
+                "error": (
+                    "xAI code interpreter timed out after "
+                    f"{_get_xai_code_interpreter_timeout_seconds()} seconds"
+                ),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error("xai_code_interpreter failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "xai_code_interpreter",
+                "xai_tool": "code_interpreter",
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+
+
+XAI_CODE_INTERPRETER_SCHEMA = {
+    "name": "xai_code_interpreter",
+    "description": (
+        "Run Python in xAI's hosted code_interpreter sandbox "
+        "(NumPy/Pandas/SciPy-class libs). Stateless, no local filesystem or "
+        "Hermes tools. Prefer execute_code for local project code and tool "
+        "orchestration. Requires xAI credentials (SuperGrok OAuth or XAI_API_KEY)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "string",
+                "description": (
+                    "Natural-language task or precise computation request. "
+                    "Grok writes and runs the code server-side."
+                ),
+            },
+        },
+        "required": ["task"],
+    },
+}
+
+
+def _handle_xai_code_interpreter(args, **kw):
+    if not isinstance(args, dict):
+        args = {}
+    return xai_code_interpreter_tool(task=args.get("task", ""))
+
+
+registry.register(
+    name="xai_code_interpreter",
+    toolset="xai_code_interpreter",
+    schema=XAI_CODE_INTERPRETER_SCHEMA,
+    handler=_handle_xai_code_interpreter,
+    check_fn=check_xai_code_interpreter_requirements,
+    requires_env=["XAI_API_KEY"],
+    emoji="🧮",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -126,6 +126,18 @@ TOOLSETS = {
         "tools": ["x_search"],
         "includes": []
     },
+
+    "xai_code_interpreter": {
+        "description": (
+            "Run Python in xAI's hosted code_interpreter sandbox via the "
+            "Responses API. Stateless server-side execution (NumPy/Pandas/"
+            "SciPy-class libs) — not a replacement for local execute_code. "
+            "Requires xAI credentials. Off by default; enable in "
+            "`hermes tools` → xAI Code Interpreter."
+        ),
+        "tools": ["xai_code_interpreter"],
+        "includes": []
+    },
     
     "vision": {
         "description": "Image analysis and vision tools",


### PR DESCRIPTION
## Summary

Opt-in `xai_code_interpreter` toolset for Python in xAI's **hosted** sandbox.

- Responses API `tools: [{ "type": "code_interpreter" }]`
- xAI SDK name: `code_execution`
- Stateless single-shot call (`store: false`)
- **Not** a replacement for local `execute_code` (no host FS / Hermes tools)
- Credentials: SuperGrok OAuth preferred, else `XAI_API_KEY`
- Default-off in `hermes tools` → 🧮 xAI Code Interpreter
- Model default `grok-4.5`

## Why

Official xAI surface still missing as a first-class Hermes tool. Pattern matches `x_search` / `xai_collections_search`: gated toolset, Responses POST, unit-tested request shape.

Local `execute_code` stays untouched for project scripts and tool orchestration.

Docs: https://docs.x.ai/developers/tools/code-execution

## Config

```yaml
xai_code_interpreter:
  model: grok-4.5
  timeout_seconds: 180
  retries: 2
```

Enable: `hermes tools` → 🧮 xAI Code Interpreter

## Test plan

- [x] `uv run --extra dev pytest tests/tools/test_xai_code_interpreter_tool.py tests/test_toolsets.py::TestGetToolset::test_xai_code_interpreter_toolset tests/hermes_cli/test_tools_config.py::test_configurable_toolsets_include_xai_code_interpreter_default_off -q` → **13 passed**
- [ ] Optional live smoke with XAI credentials

## Scope discipline

Server-side code_interpreter toolset only. No `execute_code` backend switch, no chat-native injection, no multi-turn sandbox state.
