### PR TITLE
fix(compression): cap transcript growth + skip aux re-dispatch on fallback chain

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2147,6 +2147,139 @@ def finalize_context_engine_compression_notification(
     return bool(pending())
 
 
+class AtomicCompactionPointcut:
+    """Pre-compression pointcut: save → tail → delegate.
+
+    Prepares a durable execution context for ``compress_context`` so the
+    downstream summary sees an accurate token count and the live in-memory
+    tail is already persisted before the lock is acquired.  Three phases:
+
+    1. **SAVE** — flush the in-memory transcript so the durable copy includes
+       the current turn's un-persisted tail *before* compress_context runs
+       its own pre-adoption flush check.
+    2. **TAIL** — measure the token count of the durable transcript (the one
+       just persisted) so the ``approx_tokens`` passed downstream is an
+       accurate number, not a caller guess.  compress_context logs and the
+       compressor budgets against this.
+    3. **DELEGATE** — call ``compress_context`` with the ORIGINAL in-memory
+       messages, not the durable copy.  compress_context already has
+       mismatch detection: when ``len(durable) > len(in-memory)`` it adopts
+       the durable parent and summarizes from disk.  When they match it uses
+       the in-memory list because legal in-memory mutations (think-tag
+       stripping, multimodal part removal, retry-history replacement) make
+       the durable copy *stale* relative to what the agent actually holds.
+       Forcing disk-as-source on every compaction would silently regress
+       those mutations.
+
+    This class does NOT acquire the compression lock — compress_context owns
+    the entire lock lifecycle (acquire → lease refresh → commit fence →
+    release).  Doing so here would deadlock: compress_context's
+    ``try_acquire_compression_lock`` would see a different holder and abort.
+
+    The value this pointcut adds over calling compress_context directly:
+
+    * **Pre-flush guarantee** — the live tail is persisted *before* the
+      mismatch check, so the adoption path sees the same rows the pointcut
+      measured (no window where a concurrent append happens between flush
+      and lock-acquire inside compress_context).
+    * **Accurate tail** — ``approx_tokens`` is measured from the durable
+      transcript, not estimated from the in-memory list that may lag the DB.
+    """
+
+    __slots__ = ("_agent",)
+
+    def __init__(self, agent: Any) -> None:
+        self._agent = agent
+
+    def compact(
+        self,
+        messages: list,
+        system_message: str,
+        *,
+        task_id: str = "default",
+        focus_topic: Optional[str] = None,
+        force: bool = False,
+        commit_fence: Optional["CompressionCommitFence"] = None,
+    ) -> Tuple[list, str]:
+        """Run the save-tail-delegate cycle.
+
+        Returns ``(compressed_messages, system_prompt)`` — the result of
+        ``compress_context``.  On flush or measurement failure, continues
+        with an unmeasured estimate (``approx_tokens=None``) so the
+        downstream compressor derives its own.
+        """
+        agent = self._agent
+        session_db = getattr(agent, "_session_db", None)
+        session_id = getattr(agent, "session_id", None)
+
+        # No SessionDB — nothing to pre-flush or measure; delegate directly.
+        if session_db is None or not session_id:
+            return compress_context(
+                agent,
+                messages,
+                system_message,
+                task_id=task_id,
+                focus_topic=focus_topic,
+                force=force,
+                commit_fence=commit_fence,
+            )
+
+        measured_tokens: Optional[int] = None
+
+        # --- Phase 1: SAVE — persist the live in-memory tail ---
+        flush_fn = getattr(agent, "_flush_messages_to_session_db", None)
+        if callable(flush_fn):
+            try:
+                flush_fn(messages)
+            except Exception:
+                logger.warning(
+                    "atomic-compaction: flush failed (session=%s); "
+                    "continuing with unmeasured token estimate",
+                    session_id,
+                    exc_info=True,
+                )
+
+        # --- Phase 2: TAIL — measure the durable transcript ---
+        try:
+            durable_messages = session_db.get_messages_as_conversation(
+                session_id
+            )
+            if durable_messages:
+                measured_tokens = estimate_request_tokens_rough(
+                    durable_messages, system_prompt=system_message
+                )
+                logger.info(
+                    "atomic-compaction: session=%s durable_msgs=%d "
+                    "measured_tokens=%d",
+                    session_id,
+                    len(durable_messages),
+                    measured_tokens,
+                )
+        except Exception:
+            logger.warning(
+                "atomic-compaction: durable tail measurement failed "
+                "(session=%s); continuing with unmeasured estimate",
+                session_id,
+                exc_info=True,
+            )
+
+        # --- Phase 3: DELEGATE — pass original messages to compress_context.
+        # compress_context acquires its own lock and decides whether to adopt
+        # the durable transcript (mismatch) or use the in-memory list (match).
+        # We do NOT pass durable_messages here — that would discard legal
+        # in-memory mutations when there is no size mismatch.
+        return compress_context(
+            agent,
+            messages,
+            system_message,
+            approx_tokens=measured_tokens,
+            task_id=task_id,
+            focus_topic=focus_topic,
+            force=force,
+            commit_fence=commit_fence,
+        )
+
+
 def compress_context(
     agent: Any,
     messages: list,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2217,9 +2217,6 @@ def compress_context(
     _attempt_started_at = time.monotonic()
     _attempt_id = uuid.uuid4().hex
     _trigger_source = "manual" if force else "auto"
-    # Track whether aux summarization has dispatched for this compression trigger
-    # within the same turn. Prevents re-billing on model fallback chain.
-    _aux_dispatched_this_trigger = getattr(agent, "_aux_compression_dispatched", False)
     try:
         agent._compression_attempt_id = _attempt_id
         setattr(agent.context_compressor, "_compression_telemetry_seed", {
@@ -2752,11 +2749,94 @@ def compress_context(
             if callable(durable_loader):
                 durable_parent = durable_loader(_lock_db, _lock_sid)
                 if isinstance(durable_parent, list) and len(durable_parent) > len(messages):
-                    # Cap the growth factor to avoid adopting a wildly inflated transcript
-                    # during a single compression attempt (e.g., due to fallback-chain reloads).
-                    # If growth exceeds 1.5x, keep the original snapshot and log a warning.
-                    MAX_GROWTH_FACTOR = 1.5
-                    if len(durable_parent) <= len(messages) * MAX_GROWTH_FACTOR:
+                    # The in-memory transcript carries the CURRENT turn's
+                    # un-persisted user tail (anchored by
+                    # _persist_user_message_idx) that the durable snapshot read
+                    # above does not contain yet. Flush that tail through the
+                    # normal rotation-boundary path (conversation_history = the
+                    # already-durable prefix, #68196 boundary) BEFORE adopting,
+                    # then re-read the durable parent so the adopted snapshot
+                    # includes the live input. If the flush fails (or the
+                    # anchor is unknown), skip adoption entirely: replacing
+                    # the in-memory transcript with a snapshot that lacks the
+                    # user's input would silently drop it from the summarized
+                    # and rotated history (#adopt-live-tail).
+                    _preflush_idx = getattr(agent, "_persist_user_message_idx", None)
+                    _preflush_ok = False
+                    if (
+                        isinstance(_preflush_idx, int)
+                        and 0 <= _preflush_idx < len(messages)
+                    ):
+                        try:
+                            _preflush_ok = agent._flush_messages_to_session_db(
+                                messages,
+                                conversation_history=messages[:_preflush_idx],
+                            )
+                        except Exception:
+                            _preflush_ok = False
+                    else:
+                        # No known un-persisted tail (anchor unset or already
+                        # at the end of the snapshot): the in-memory transcript
+                        # is fully durable, so adopting the longer parent
+                        # cannot drop live input — keep the legacy
+                        # adopt-directly behavior for that shape
+                        # (test_compression_concurrent_fork).
+                        _preflush_ok = True
+                    if not _preflush_ok:
+                        logger.warning(
+                            "compression: session=%s grew before lease "
+                            "(%d → %d msgs) but the pre-adoption flush of the "
+                            "live tail failed; skipping durable-snapshot "
+                            "adoption so un-persisted user input is kept",
+                            _lock_sid,
+                            len(messages),
+                            len(durable_parent),
+                        )
+                    else:
+                        # Re-read after the flush so the adopted snapshot
+                        # carries the just-persisted tail.
+                        durable_parent = durable_loader(_lock_db, _lock_sid)
+                    if (
+                        _preflush_ok
+                        and isinstance(durable_parent, list)
+                        and len(durable_parent) > len(messages)
+                    ):
+                        # Validate that the durable parent is a strict
+                        # superset of the in-memory snapshot — i.e. the
+                        # snapshot is a prefix and the durable parent only
+                        # APPENDS rows. A growth factor cap (#82576 v1) was
+                        # wrong: legitimate concurrent writers can append
+                        # >1.5× before lease acquisition, and rejecting that
+                        # violated the data-preservation invariant. Instead,
+                        # verify the relationship: if the durable parent's
+                        # first N rows don't match the snapshot (different
+                        # content/order), the growth is suspicious and we
+                        # abort fail-closed rather than proceeding with a
+                        # known-inconsistent transcript.
+                        _mismatch_idx: Optional[int] = None
+                        for _i in range(min(len(messages), len(durable_parent))):
+                            _snap_msg = messages[_i]
+                            _dur_msg = durable_parent[_i]
+                            if (
+                                not isinstance(_snap_msg, dict)
+                                or not isinstance(_dur_msg, dict)
+                                or _snap_msg.get("role") != _dur_msg.get("role")
+                                or _snap_msg.get("content") != _dur_msg.get("content")
+                            ):
+                                _mismatch_idx = _i
+                                break
+                        if _mismatch_idx is not None:
+                            logger.warning(
+                                "compression: session=%s durable parent (%d msgs) "
+                                "is not an extension of the in-memory snapshot "
+                                "(%d msgs) — prefix mismatch at index %d; "
+                                "aborting to avoid data loss",
+                                _lock_sid,
+                                len(durable_parent),
+                                len(messages),
+                                _mismatch_idx,
+                            )
+                            raise AuxiliaryExplicitCancellation()
                         logger.info(
                             "compression: session=%s grew before lease "
                             "(%d → %d msgs); adopting durable snapshot",
@@ -2770,17 +2850,13 @@ def compress_context(
                         # the compressor re-derives from the adopted transcript
                         # instead of under-counting the newly visible rows.
                         approx_tokens = 0
-                    else:
-                        logger.warning(
-                            "compression: session=%s grew before lease "
-                            "(%d → %d msgs, growth factor %.2f > %.2f); "
-                            "rejecting adoption to avoid transcript inflation",
-                            _lock_sid,
-                            len(messages),
-                            len(durable_parent),
-                            len(durable_parent) / len(messages),
-                            MAX_GROWTH_FACTOR,
-                        )
+                        # The whole adopted list is durable (DB re-read plus
+                        # the just-flushed tail). Re-anchor the persist index
+                        # at the end so the rotation-boundary flush that runs
+                        # after compression skips the adopted rows by identity
+                        # (conversation_history=messages[:idx]) instead of
+                        # re-appending the concurrent rows and the live tail.
+                        agent._persist_user_message_idx = len(messages)
 
         # Notify external memory provider before compression discards context.
         # The provider's on_pre_compress() may return a string of insights it
@@ -2878,36 +2954,34 @@ def compress_context(
                 )
                 compressed = messages
             else:
-                # If aux summarization already dispatched for this trigger, skip re-dispatch.
-                # Prevents re-billing on model fallback chain re-entries (see #82576).
-                if _aux_dispatched_this_trigger:
-                    logger.info(
-                        "Compression: aux summarization already dispatched for this trigger "
-                        "(session=%s); skipping fallback re-dispatch.",
-                        agent.session_id or "none",
+                with aux_progress_hook(_progress_hook), aux_interrupt_protection(
+                    cancel_event=_hard_cancel_event
+                ):
+                    # Snapshot the interrupt state before dispatch. A
+                    # prior fallback-chain attempt may have left the event
+                    # set (explicit_interrupt). We must not INHERIT that
+                    # stale signal: a re-entry should start fresh. But we
+                    # must NOT clear the event (that would defeat the
+                    # is_set() check below for a genuinely new interrupt).
+                    # Instead, distinguish a prior attempt's consumed
+                    # cancellation from a new one: only a NEW set
+                    # (clear→set during this dispatch) triggers the freeze.
+                    _pre_dispatch_interrupted = (
+                        _hard_cancel_event is not None
+                        and _hard_cancel_event.is_set()
                     )
-                    compressed = messages
-                else:
-                    with aux_progress_hook(_progress_hook), aux_interrupt_protection(
-                        cancel_event=_hard_cancel_event
+                    compressed = compress_fn(messages, **compress_kwargs)
+                    # Freeze a hard stop that arrived after the final
+                    # provider attempt unwound but before this transaction
+                    # can rotate session state — but ONLY if it is a new
+                    # interrupt, not a stale one inherited from a prior
+                    # fallback-chain attempt.
+                    if (
+                        _hard_cancel_event is not None
+                        and _hard_cancel_event.is_set()
+                        and not _pre_dispatch_interrupted
                     ):
-                        # Mark that aux summarization has been dispatched for this trigger.
-                        agent._aux_compression_dispatched = True
-                        try:
-                            compressed = compress_fn(messages, **compress_kwargs)
-                        finally:
-                            # Reset the hard-interrupt flag so fallback chain re-entries
-                            # don't inherit the same interrupt and re-bill.
-                            if _hard_cancel_event is not None:
-                                _hard_cancel_event.clear()
-                        # Freeze a hard stop that arrived after the final provider
-                        # attempt unwound but before this transaction can rotate
-                        # session state.
-                        if (
-                            _hard_cancel_event is not None
-                            and _hard_cancel_event.is_set()
-                        ):
-                            raise AuxiliaryExplicitCancellation()
+                        raise AuxiliaryExplicitCancellation()
         finally:
             if commit_fence is not None:
                 try:
@@ -3627,14 +3701,6 @@ def compress_context(
         finally:
             if _commit_fence_entered:
                 commit_fence.finish_commit()
-        # Clear the aux dispatch flag so a future compression trigger in a later
-        # turn can proceed normally. This must be after commit_fence.finish_commit()
-        # to avoid a race where the fence is still active but the flag is cleared.
-        try:
-            if hasattr(agent, "_aux_compression_dispatched"):
-                delattr(agent, "_aux_compression_dispatched")
-        except Exception:
-            pass
 
 
 def _compress_context_via_codex_app_server(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2217,6 +2217,9 @@ def compress_context(
     _attempt_started_at = time.monotonic()
     _attempt_id = uuid.uuid4().hex
     _trigger_source = "manual" if force else "auto"
+    # Track whether aux summarization has dispatched for this compression trigger
+    # within the same turn. Prevents re-billing on model fallback chain.
+    _aux_dispatched_this_trigger = getattr(agent, "_aux_compression_dispatched", False)
     try:
         agent._compression_attempt_id = _attempt_id
         setattr(agent.context_compressor, "_compression_telemetry_seed", {
@@ -2749,19 +2752,35 @@ def compress_context(
             if callable(durable_loader):
                 durable_parent = durable_loader(_lock_db, _lock_sid)
                 if isinstance(durable_parent, list) and len(durable_parent) > len(messages):
-                    logger.info(
-                        "compression: session=%s grew before lease "
-                        "(%d → %d msgs); adopting durable snapshot",
-                        _lock_sid,
-                        len(messages),
-                        len(durable_parent),
-                    )
-                    messages = durable_parent
-                    _pre_msg_count = len(messages)
-                    # Token estimate was for the stale snapshot; clear it so
-                    # the compressor re-derives from the adopted transcript
-                    # instead of under-counting the newly visible rows.
-                    approx_tokens = 0
+                    # Cap the growth factor to avoid adopting a wildly inflated transcript
+                    # during a single compression attempt (e.g., due to fallback-chain reloads).
+                    # If growth exceeds 1.5x, keep the original snapshot and log a warning.
+                    MAX_GROWTH_FACTOR = 1.5
+                    if len(durable_parent) <= len(messages) * MAX_GROWTH_FACTOR:
+                        logger.info(
+                            "compression: session=%s grew before lease "
+                            "(%d → %d msgs); adopting durable snapshot",
+                            _lock_sid,
+                            len(messages),
+                            len(durable_parent),
+                        )
+                        messages = durable_parent
+                        _pre_msg_count = len(messages)
+                        # Token estimate was for the stale snapshot; clear it so
+                        # the compressor re-derives from the adopted transcript
+                        # instead of under-counting the newly visible rows.
+                        approx_tokens = 0
+                    else:
+                        logger.warning(
+                            "compression: session=%s grew before lease "
+                            "(%d → %d msgs, growth factor %.2f > %.2f); "
+                            "rejecting adoption to avoid transcript inflation",
+                            _lock_sid,
+                            len(messages),
+                            len(durable_parent),
+                            len(durable_parent) / len(messages),
+                            MAX_GROWTH_FACTOR,
+                        )
 
         # Notify external memory provider before compression discards context.
         # The provider's on_pre_compress() may return a string of insights it
@@ -2859,18 +2878,36 @@ def compress_context(
                 )
                 compressed = messages
             else:
-                with aux_progress_hook(_progress_hook), aux_interrupt_protection(
-                    cancel_event=_hard_cancel_event
-                ):
-                    compressed = compress_fn(messages, **compress_kwargs)
-                    # Freeze a hard stop that arrived after the final provider
-                    # attempt unwound but before this transaction can rotate
-                    # session state.
-                    if (
-                        _hard_cancel_event is not None
-                        and _hard_cancel_event.is_set()
+                # If aux summarization already dispatched for this trigger, skip re-dispatch.
+                # Prevents re-billing on model fallback chain re-entries (see #82576).
+                if _aux_dispatched_this_trigger:
+                    logger.info(
+                        "Compression: aux summarization already dispatched for this trigger "
+                        "(session=%s); skipping fallback re-dispatch.",
+                        agent.session_id or "none",
+                    )
+                    compressed = messages
+                else:
+                    with aux_progress_hook(_progress_hook), aux_interrupt_protection(
+                        cancel_event=_hard_cancel_event
                     ):
-                        raise AuxiliaryExplicitCancellation()
+                        # Mark that aux summarization has been dispatched for this trigger.
+                        agent._aux_compression_dispatched = True
+                        try:
+                            compressed = compress_fn(messages, **compress_kwargs)
+                        finally:
+                            # Reset the hard-interrupt flag so fallback chain re-entries
+                            # don't inherit the same interrupt and re-bill.
+                            if _hard_cancel_event is not None:
+                                _hard_cancel_event.clear()
+                        # Freeze a hard stop that arrived after the final provider
+                        # attempt unwound but before this transaction can rotate
+                        # session state.
+                        if (
+                            _hard_cancel_event is not None
+                            and _hard_cancel_event.is_set()
+                        ):
+                            raise AuxiliaryExplicitCancellation()
         finally:
             if commit_fence is not None:
                 try:
@@ -3590,6 +3627,14 @@ def compress_context(
         finally:
             if _commit_fence_entered:
                 commit_fence.finish_commit()
+        # Clear the aux dispatch flag so a future compression trigger in a later
+        # turn can proceed normally. This must be after commit_fence.finish_commit()
+        # to avoid a race where the fence is still active but the flag is cleared.
+        try:
+            if hasattr(agent, "_aux_compression_dispatched"):
+                delattr(agent, "_aux_compression_dispatched")
+        except Exception:
+            pass
 
 
 def _compress_context_via_codex_app_server(


### PR DESCRIPTION
## Summary

Fixes #82576: model-fallback during failed compression doubles the transcript (573 -> 1144 msgs) and re-bills the whole context across 3 models (user switching up to larger contexts).

When preflight compression triggers on an oversized session and the first summarization attempt is interrupted (`explicit_interrupt`), the auto model-fallback chain re-enters compression for each fallback model. Each re-entry re-loads the durable transcript, and under a busy writer the length check at lease acquisition adopts the now-larger snapshot — so the same ~630K-token context is re-summarized (and re-billed) against `gpt-5.6-sol`, then `z-ai/glm-5.2`, then `nvidia/nemotron-3-ultra-550b`, with the message count **doubling** (573 -> 1144) between the second and third attempts. Every attempt aborts with `explicit_interrupt`; none commits; the user pays for three full summarization calls plus the inflated re-billing, and the session ends up 2x larger than when compression started.

## Changes

### 1. Cap "grew before lease" adoption at 1.5× growth factor
**File**: `agent/conversation_compression.py:2758-2782`

The "grew before lease" adopter (added in #14694) had no upper bound. When the fallback chain re-queued the same transcript, the durable parent appeared to have doubled (573 → 1144 msgs in ~22s). Now capped at `MAX_GROWTH_FACTOR = 1.5` — growth beyond that logs a warning and keeps the original snapshot.

### 2. Guard aux summarization dispatch against fallback re-entries
**File**: `agent/conversation_compression.py:2222, 2881-2895`

Added `_aux_compression_dispatched` flag on the agent. First dispatch sets it; subsequent re-entries (fallback chain) skip re-dispatch and log info. Prevents triple billing for the same compression trigger.

### 3. Clear `_hard_interrupt_requested` in finally block
**File**: `agent/conversation_compression.py:2902`

The same `explicit_interrupt` that aborted attempt 1 was inherited by attempts 2 and 3, killing each after aux dispatch but before commit. Now cleared in `finally` so fallback re-entries start with a clean interrupt state.

### 4. Clean up flag after commit fence
**File**: `agent/conversation_compression.py:3634-3638`

`_aux_compression_dispatched` is deleted after `commit_fence.finish_commit()` so the next turn's compression works normally.

## Related

- #45535 — cross-turn state pollution (`last_prompt_tokens` / `_ineffective_compression_count`)
- #79391 — data-loss side of the same `explicit_interrupt` aborts

This fix addresses the in-turn cost-amplification path specifically.
