### PR TITLE
fix(cli): propagate MCP test failures

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11222,7 +11222,7 @@ def cmd_plugins(args):
 def cmd_mcp(args):
     from hermes_cli.mcp_config import mcp_command
 
-    mcp_command(args)
+    return mcp_command(args)
 
 
 def cmd_claw(args):

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -721,7 +721,7 @@ def cmd_mcp_list(args=None):
 # ─── hermes mcp test ──────────────────────────────────────────────────────────
 
 def cmd_mcp_test(args):
-    """Test connection to an MCP server."""
+    """Test connection to an MCP server and return a process-style status."""
     name = args.name
     servers = _get_mcp_servers()
 
@@ -730,7 +730,7 @@ def cmd_mcp_test(args):
         available = list(servers.keys())
         if available:
             _info(f"Available: {', '.join(available)}")
-        return
+        return 1
 
     cfg = servers[name]
     print()
@@ -769,7 +769,7 @@ def cmd_mcp_test(args):
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
         _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
-        return
+        return 1
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")
     _success(f"Tools discovered: {len(tools)}")
@@ -780,6 +780,7 @@ def cmd_mcp_test(args):
             short = desc[:55] + "..." if len(desc) > 55 else desc
             print(f"    {color(tool_name, Colors.GREEN):36s} {short}")
     print()
+    return 0
 
 
 # ─── hermes mcp login ────────────────────────────────────────────────────────
@@ -1112,7 +1113,7 @@ def mcp_command(args):
 
     handler = handlers.get(action)
     if handler:
-        handler(args)
+        return handler(args)
     else:
         # No subcommand — drop the user into the catalog picker. This is the
         # "try enabling and it flows you into setup" UX matching `hermes plugin`.

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -297,10 +297,35 @@ class TestMcpTest:
         )
         from hermes_cli.mcp_config import cmd_mcp_test
 
-        cmd_mcp_test(_make_args(name="ink"))
+        exit_code = cmd_mcp_test(_make_args(name="ink"))
         out = capsys.readouterr().out
+        assert exit_code == 0
         assert "Connected" in out
         assert "Tools discovered: 2" in out
+
+    def test_unknown_server_returns_nonzero(self, tmp_path, capsys):
+        _seed_config(tmp_path, {})
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        exit_code = cmd_mcp_test(_make_args(name="missing"))
+
+        assert exit_code == 1
+        assert "not found" in capsys.readouterr().out
+
+    def test_probe_exception_returns_nonzero(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "ink": {"url": "https://mcp.ml.ink/mcp"},
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("probe failed")),
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        exit_code = cmd_mcp_test(_make_args(name="ink"))
+
+        assert exit_code == 1
+        assert "Connection failed" in capsys.readouterr().out
 
     def test_probe_uses_configured_connect_timeout(self, monkeypatch):
         """OAuth-capable probes must not hard-code a short 30s timeout."""
@@ -676,6 +701,21 @@ class TestDispatcher:
         mcp_command(_make_args(mcp_action=None))
         out = capsys.readouterr().out
         assert "Commands:" in out or "No MCP servers" in out
+
+    def test_test_action_propagates_handler_exit_code(self, monkeypatch):
+        from hermes_cli import mcp_config
+
+        monkeypatch.setattr(mcp_config, "cmd_mcp_test", lambda _args: 7)
+
+        assert mcp_config.mcp_command(_make_args(mcp_action="test")) == 7
+
+    def test_top_level_mcp_wrapper_propagates_dispatcher_exit_code(self, monkeypatch):
+        from hermes_cli import mcp_config
+        from hermes_cli.main import cmd_mcp
+
+        monkeypatch.setattr(mcp_config, "mcp_command", lambda _args: 9)
+
+        assert cmd_mcp(_make_args(mcp_action="test")) == 9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- return nonzero status when `hermes mcp test` targets an unknown server or the probe fails
- propagate MCP handler statuses through both CLI dispatch layers
- keep successful probes at status 0

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py` (42 passed)