### PR TITLE
fix(lsp): replace dead language-server clients instead of timing out diagnostics

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -919,6 +919,10 @@ class LSPClient:
         abs_path = os.path.abspath(path)
 
         while True:
+            if not self._connection_is_open():
+                raise LSPProtocolError(
+                    "server connection closed while waiting for diagnostics"
+                )
             remaining = deadline - asyncio.get_event_loop().time()
             if remaining <= 0:
                 return False

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -207,6 +207,7 @@ class LSPClient:
         self._proc: Optional[asyncio.subprocess.Process] = None
         self._stderr_task: Optional[asyncio.Task] = None
         self._reader_task: Optional[asyncio.Task] = None
+        self._cleanup_lock = asyncio.Lock()
 
         # Request/response correlation
         self._next_id: int = 0
@@ -255,7 +256,20 @@ class LSPClient:
 
     @property
     def is_running(self) -> bool:
-        return self._state == "running" and self._proc is not None and self._proc.returncode is None
+        return self._state == "running" and self._connection_is_open()
+
+    def _connection_is_open(self) -> bool:
+        proc = self._proc
+        reader = self._reader_task
+        return (
+            self._state in {"starting", "running"}
+            and proc is not None
+            and proc.returncode is None
+            and proc.stdin is not None
+            and not proc.stdin.is_closing()
+            and reader is not None
+            and not reader.done()
+        )
 
     @property
     def state(self) -> str:
@@ -274,6 +288,8 @@ class LSPClient:
         try:
             await self._spawn()
             await self._initialize()
+            if not self._connection_is_open():
+                raise LSPProtocolError("server connection closed during initialization")
             self._state = "running"
         except Exception:
             self._state = "error"
@@ -370,11 +386,16 @@ class LSPClient:
         except (asyncio.CancelledError, OSError):
             pass
         finally:
+            unexpected_close = not self._stopping and self._state in {"starting", "running"}
+            if unexpected_close:
+                self._state = "error"
             # Wake up any pending requests so they can fail fast.
             for fut in list(self._pending.values()):
                 if not fut.done():
                     fut.set_exception(LSPProtocolError("server connection closed"))
             self._pending.clear()
+            if unexpected_close:
+                await self._cleanup_process()
 
     async def _initialize(self) -> None:
         params = {
@@ -474,43 +495,54 @@ class LSPClient:
             await self._cleanup_process()
 
     async def _cleanup_process(self) -> None:
-        if self._reader_task is not None and not self._reader_task.done():
-            self._reader_task.cancel()
-            try:
-                await self._reader_task
-            except (asyncio.CancelledError, Exception):  # noqa: BLE001
-                pass
-        if self._stderr_task is not None and not self._stderr_task.done():
-            self._stderr_task.cancel()
-            try:
-                await self._stderr_task
-            except (asyncio.CancelledError, Exception):  # noqa: BLE001
-                pass
-        proc = self._proc
-        self._proc = None
-        if proc is None:
-            return
-        if proc.returncode is None:
-            try:
-                proc.terminate()
+        async with self._cleanup_lock:
+            current_task = asyncio.current_task()
+            reader_task = self._reader_task
+            self._reader_task = None
+            if (
+                reader_task is not None
+                and reader_task is not current_task
+                and not reader_task.done()
+            ):
+                reader_task.cancel()
                 try:
-                    await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                except asyncio.TimeoutError:
+                    await reader_task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            stderr_task = self._stderr_task
+            self._stderr_task = None
+            if stderr_task is not None and not stderr_task.done():
+                stderr_task.cancel()
+                try:
+                    await stderr_task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            proc = self._proc
+            self._proc = None
+            if proc is None:
+                return
+            if proc.returncode is None:
+                try:
+                    proc.terminate()
                     try:
-                        proc.kill()
-                        await proc.wait()
-                    except ProcessLookupError:
-                        pass
-            except ProcessLookupError:
-                pass
+                        await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+                    except asyncio.TimeoutError:
+                        try:
+                            proc.kill()
+                            await proc.wait()
+                        except ProcessLookupError:
+                            pass
+                except ProcessLookupError:
+                    pass
 
     # ------------------------------------------------------------------
     # request / notification plumbing
     # ------------------------------------------------------------------
 
     async def _send_request(self, method: str, params: Any) -> Any:
-        if self._proc is None or self._proc.stdin is None or self._proc.stdin.is_closing():
-            raise LSPProtocolError(f"cannot send {method!r}: stdin closed")
+        if not self._connection_is_open():
+            raise LSPProtocolError(f"cannot send {method!r}: server connection closed")
+        assert self._proc is not None and self._proc.stdin is not None
         loop = asyncio.get_running_loop()
         req_id = self._next_id
         self._next_id += 1
@@ -544,8 +576,9 @@ class LSPClient:
                 raise
 
     async def _send_notification(self, method: str, params: Any) -> None:
-        if self._proc is None or self._proc.stdin is None or self._proc.stdin.is_closing():
-            return
+        if not self._connection_is_open():
+            raise LSPProtocolError(f"cannot send {method!r}: server connection closed")
+        assert self._proc is not None and self._proc.stdin is not None
         try:
             self._proc.stdin.write(encode_message(make_notification(method, params)))
             await self._proc.stdin.drain()

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -25,6 +25,10 @@ Behaviour (all behaviours selectable via env var ``MOCK_LSP_SCRIPT``):
   ``didChange`` sleeps ``MOCK_LSP_PUSH_DELAY`` seconds (default 1.0)
   and then pushes EMPTY diagnostics.  Models a server that fixes
   the ghost if you actually wait for it.  Pull endpoint rejects.
+- ``"clean_eof"`` — closes stdout after ``didOpen`` but keeps the
+  process and stdin alive.
+- ``"malformed_frame"`` — writes an invalid frame after ``didOpen``,
+  then keeps the process and stdin alive.
 
 The script writes JSON-RPC framed messages to stdout and reads from
 stdin.  No third-party dependencies — uses only stdlib so it runs
@@ -105,6 +109,14 @@ def main():
             uri = td.get("uri", "")
             version = td.get("version", 0)
             is_change = msg.get("method") == "textDocument/didChange"
+            if not is_change and script in {"clean_eof", "malformed_frame"}:
+                if script == "malformed_frame":
+                    sys.stdout.buffer.write(b"Content-Length: invalid\r\n\r\n")
+                    sys.stdout.buffer.flush()
+                os.close(sys.stdout.fileno())
+                while read_message() is not None:
+                    pass
+                return 0
             error_diag = [
                 {
                     "range": {

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -107,11 +107,16 @@ async def test_reader_failure_retires_client_and_rejects_later_work(
     assert proc is not None
     assert reader_task is not None
     try:
-        await client.open_file(str(f), language_id="python")
+        version = await client.open_file(str(f), language_id="python")
         await asyncio.wait_for(asyncio.shield(reader_task), timeout=3.0)
 
         assert not client.is_running
         await asyncio.wait_for(proc.wait(), timeout=3.0)
+        with pytest.raises(LSPProtocolError):
+            await asyncio.wait_for(
+                client.wait_for_diagnostics(str(f), version, timeout=3.0),
+                timeout=0.5,
+            )
         with pytest.raises(LSPProtocolError):
             await asyncio.wait_for(
                 client.open_file(str(f), language_id="python"),

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from agent.lsp.client import LSPClient
+from agent.lsp.protocol import LSPProtocolError
 
 
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
@@ -72,9 +73,49 @@ async def test_client_receives_published_errors(tmp_path: Path):
         await client.shutdown()
 
 
+@pytest.mark.asyncio
+async def test_reader_exit_at_end_of_initialization_retires_client(tmp_path: Path):
+    client = _client(tmp_path, "crash")
+
+    try:
+        await client.start()
+    except LSPProtocolError:
+        pass
+    else:
+        reader_task = client._reader_task
+        if reader_task is not None:
+            await asyncio.wait_for(asyncio.shield(reader_task), timeout=3.0)
+
+    assert client.state == "error"
+    assert not client.is_running
+    assert client._proc is None
+    await client.shutdown()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("script", ["clean_eof", "malformed_frame"])
+async def test_reader_failure_retires_client_and_rejects_later_work(
+    tmp_path: Path, script: str
+):
+    f = tmp_path / "x.py"
+    f.write_text("print('hi')\n")
 
+    client = _client(tmp_path, script)
+    await client.start()
+    proc = client._proc
+    reader_task = client._reader_task
+    assert proc is not None
+    assert reader_task is not None
+    try:
+        await client.open_file(str(f), language_id="python")
+        await asyncio.wait_for(asyncio.shield(reader_task), timeout=3.0)
 
-
-
+        assert not client.is_running
+        await asyncio.wait_for(proc.wait(), timeout=3.0)
+        with pytest.raises(LSPProtocolError):
+            await asyncio.wait_for(
+                client.open_file(str(f), language_id="python"),
+                timeout=0.5,
+            )
+    finally:
+        await client.shutdown()

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -7,6 +7,7 @@ on.
 """
 from __future__ import annotations
 
+import asyncio
 import sys
 import time
 from pathlib import Path
@@ -25,7 +26,9 @@ from agent.lsp.servers import (
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
 
 
-def _install_mock_server(monkeypatch, script: str = "errors", server_id: str = "pyright"):
+def _install_mock_server(
+    monkeypatch, script: str | list[str] = "errors", server_id: str = "pyright"
+):
     """Replace one registered server with a wrapper that spawns the mock.
 
     We reuse ``pyright`` so .py files route to it.  This keeps the
@@ -33,9 +36,13 @@ def _install_mock_server(monkeypatch, script: str = "errors", server_id: str = "
     """
     target_index = next(i for i, s in enumerate(SERVERS) if s.server_id == server_id)
     original = SERVERS[target_index]
+    scripts = [script] if isinstance(script, str) else script
+    spawn_count = {"value": 0}
 
     def _spawn(root: str, ctx: ServerContext) -> SpawnSpec:
-        env = {"MOCK_LSP_SCRIPT": script}
+        index = min(spawn_count["value"], len(scripts) - 1)
+        spawn_count["value"] += 1
+        env = {"MOCK_LSP_SCRIPT": scripts[index]}
         return SpawnSpec(
             command=[sys.executable, MOCK_SERVER],
             workspace_root=root,
@@ -55,7 +62,7 @@ def _install_mock_server(monkeypatch, script: str = "errors", server_id: str = "
     # Patch the SERVERS list element directly + restore on teardown.
     SERVERS[target_index] = replacement
 
-    yield
+    yield spawn_count
 
     SERVERS[target_index] = original
 
@@ -102,6 +109,54 @@ def test_service_e2e_delta_filter(mock_pyright):
         assert new_diags == []
     finally:
         svc.shutdown()
+
+
+@pytest.mark.parametrize("failed_script", ["clean_eof", "malformed_frame"])
+def test_service_replaces_client_after_reader_failure(
+    tmp_path, monkeypatch, failed_script
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "pyproject.toml").write_text("")
+    source = repo / "x.py"
+    source.write_text("print('hi')\n")
+    monkeypatch.chdir(str(repo))
+    server = _install_mock_server(
+        monkeypatch, [failed_script, "clean"], "pyright"
+    )
+    spawn_count = next(server)
+
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=0.5,
+        install_strategy="manual",
+    )
+    try:
+        async def _break_first_client():
+            client = await svc._get_or_spawn(str(source))
+            assert client is not None
+            reader_task = client._reader_task
+            assert reader_task is not None
+            await client.open_file(str(source), language_id="python")
+            await asyncio.wait_for(asyncio.shield(reader_task), timeout=3.0)
+            return client
+
+        first = svc._loop.run(_break_first_client(), timeout=5.0)
+        replacement = svc._loop.run(svc._get_or_spawn(str(source)), timeout=5.0)
+
+        assert not first.is_running
+        assert replacement is not None
+        assert replacement is not first
+        assert replacement.is_running
+        assert spawn_count["value"] == 2
+    finally:
+        svc.shutdown()
+        try:
+            next(server)
+        except StopIteration:
+            pass
 
 
 def test_service_e2e_delta_filter_with_line_shift(mock_pyright):


### PR DESCRIPTION
## What does this PR do?

LSP diagnostics no longer hang until timeout or repeatedly reuse a dead cached connection when a language server closes stdout or sends a malformed JSON-RPC frame without exiting. The client now treats protocol-reader liveness as part of the connection invariant, rejects work promptly after transport death, retires the surviving child, and lets the service create a healthy replacement.

### Symptom

After the protocol reader exits, later diagnostics requests can still write to the server's open stdin but have no response dispatcher. The same stale cached client is reused on subsequent file accesses, so each operation waits until its outer timeout.

### Impact

Diagnostics and file-validation operations can repeatedly pay their full configured timeout and return no result. This affects language servers whose stdout transport closes or becomes malformed while the process remains alive; the broader frequency was not measured.

### Bug Cause

**Trigger:** `agent/lsp/client.py` / `LSPClient._reader_loop` when stdout reaches EOF, framing fails, or the stream raises while the child remains alive.

**Causal chain:**
1. The server's stdout transport ends while its process and stdin stay alive.
2. The reader exits and fails only requests already in `_pending`, but the client still reports running because lifecycle checks consider only state and process liveness.
3. `LSPService._get_or_spawn` reuses the cached client, and later requests or diagnostics waits have no reader to complete them.

**Why it is wrong:** A connection is usable only while both the child process and the protocol reader are alive. Process liveness alone is insufficient for JSON-RPC request completion.

**Working sibling / contrast:** Graceful shutdown marks the client stopped and cleans up the process, while a normal child exit changes the process return code. Neither path leaves the stale-reader state reproduced here.

**Ruled out:** A normal process crash was ruled out because the controllable child remained alive and kept stdin open after both clean stdout EOF and a malformed frame.

### Fix

- Require a live process, stdin stream, and reader task for an open connection.
- On unexpected reader termination, enter the error state, fail pending work, and run serialized cleanup that does not cancel or await the current reader task.
- Reject later requests, notifications, and diagnostics waits immediately after transport death.
- Reuse the manager's existing non-running-client replacement path to create a healthy server on the next access.

## Related Issue

Fixes #82602

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/lsp/client.py` - include reader liveness in the connection invariant and retire failed transports safely.
- `tests/agent/lsp/_mock_lsp_server.py` - add controllable clean-EOF and malformed-frame server behaviors.
- `tests/agent/lsp/test_client_e2e.py` - cover initialization-time and post-start reader failure, prompt later-work rejection, and child retirement.
- `tests/agent/lsp/test_service.py` - verify stale cached clients are replaced for both transport-failure variants.

## How to Test

1. Start the controllable LSP child with the clean-EOF behavior, open a file, and wait for the reader to exit.
2. Confirm the client becomes non-running, its child is retired, current and later diagnostics work fails promptly, and the next service lookup returns a healthy replacement.
3. Repeat with a malformed JSON-RPC frame and confirm the same lifecycle behavior.
4. Run the targeted LSP client and service tests:

```bash
scripts/run_tests.sh tests/agent/lsp/test_client_e2e.py tests/agent/lsp/test_service.py -v
```

Result: 11 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant LSP tests and all 11 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the behavior is internal and covered by lifecycle docstrings and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - subprocess and asyncio lifecycle behavior remains platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changed

## Screenshots / Logs

N/A - verified with real subprocess behavior tests and exact-tip runtime reproduction for clean stdout EOF, malformed framing, replacement-cache behavior, child retirement, immediate later-work rejection, and concurrent shutdown.
