### PR TITLE
fix(agent): persist completed text turns before the loop exits (#81641)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7613,25 +7613,23 @@ def run_conversation(
                     continue
 
                 messages.append(final_msg)
-                # Make the completed answer durable before leaving the loop.
-                # The text already reached the user through the streaming /
-                # interim display path, which is display-only and never writes
-                # to state.db; the next durable write would otherwise be
-                # finalize_turn's _persist_session, behind post-turn work that
-                # can include micro-compaction's aux-LLM call. A session torn
-                # down inside that window (ws_orphan_reap after a remote 1006
-                # close, container stop) lost a reply the user had already
-                # seen (#81641). Same contract the tool-call exit gets from
-                # #49045 and the verify-on-stop exits above; the
-                # _DB_PERSISTED_MARKER dedup keeps _persist_session idempotent.
-                #
-                # Unlike the tool-call exit, a failed flush must NOT abort the
-                # turn: no side effect runs after this point, the answer is
-                # already produced, and _persist_session retries the write.
+                # Make the completed answer durable before leaving the loop —
+                # a session torn down before finalize_turn's _persist_session
+                # otherwise loses a reply the user already saw (#81641). Same
+                # contract as the tool-call exit (#49045) and the verify exits
+                # above; _DB_PERSISTED_MARKER keeps _persist_session idempotent.
+                # Unlike the tool-call exit, failure must NOT abort the turn:
+                # no side effect follows and _persist_session retries the write.
+                # Full incident narrative: tests/run_agent/test_81641_*.py.
                 try:
                     agent._flush_messages_to_session_db(messages, conversation_history)
                 except Exception:
-                    logger.debug("final text-turn flush failed", exc_info=True)
+                    logger.warning(
+                        "final text-turn flush failed (session=%s) — reply is "
+                        "not yet durable; relying on finalize_turn retry",
+                        getattr(agent, "session_id", None) or "none",
+                        exc_info=True,
+                    )
 
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7613,7 +7613,26 @@ def run_conversation(
                     continue
 
                 messages.append(final_msg)
-                
+                # Make the completed answer durable before leaving the loop.
+                # The text already reached the user through the streaming /
+                # interim display path, which is display-only and never writes
+                # to state.db; the next durable write would otherwise be
+                # finalize_turn's _persist_session, behind post-turn work that
+                # can include micro-compaction's aux-LLM call. A session torn
+                # down inside that window (ws_orphan_reap after a remote 1006
+                # close, container stop) lost a reply the user had already
+                # seen (#81641). Same contract the tool-call exit gets from
+                # #49045 and the verify-on-stop exits above; the
+                # _DB_PERSISTED_MARKER dedup keeps _persist_session idempotent.
+                #
+                # Unlike the tool-call exit, a failed flush must NOT abort the
+                # turn: no side effect runs after this point, the answer is
+                # already produced, and _persist_session retries the write.
+                try:
+                    agent._flush_messages_to_session_db(messages, conversation_history)
+                except Exception:
+                    logger.debug("final text-turn flush failed", exc_info=True)
+
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")

--- a/tests/run_agent/test_81641_text_turn_incremental_persistence.py
+++ b/tests/run_agent/test_81641_text_turn_incremental_persistence.py
@@ -138,9 +138,14 @@ class TestCompletedTextTurnIncrementalPersistence:
             f"transcript tail; observed events: {events!r}"
         )
 
-        final_persist = max(
+        persist_indices = [
             i for i, (kind, _) in enumerate(events) if kind == "persist_session"
+        ]
+        assert persist_indices, (
+            "finalize_turn must call _persist_session after the loop exits; "
+            f"observed events: {events!r}"
         )
+        final_persist = persist_indices[-1]
         assert answer_flushes[0] < final_persist, (
             "The assistant row must be durable BEFORE post-loop finalization, "
             f"but the answer flush at index {answer_flushes[0]} did not precede "

--- a/tests/run_agent/test_81641_text_turn_incremental_persistence.py
+++ b/tests/run_agent/test_81641_text_turn_incremental_persistence.py
@@ -1,0 +1,170 @@
+"""Behavior contract: a completed pure-text assistant turn is durable before
+the conversation loop yields control (#81641).
+
+Neighbouring turn exits already carry this guarantee. The tool-call exit
+flushes the assistant(tool_calls) block before handing control to
+``_execute_tool_calls`` (#49045), and the verify-on-stop / pre_verify exits
+flush ``final_msg`` before appending their nudge (#65919 §7). The ordinary
+``finish_reason=stop`` exit — the common case — did not.
+
+Its only durable write was ``finalize_turn`` -> ``_persist_session``, which
+runs after the loop exits and after post-turn work (interrupt tail repair,
+persist-override rewrite, micro-compaction — which can issue its own aux-LLM
+call). Anything that ended the process or tore the session down inside that
+window lost a reply the user had already been shown: the text reaches the UI
+through the streaming/interim display path, which is display-only and never
+writes to ``state.db``.
+
+Reported against v0.20.0 on a remote (non-loopback) backend, where WS ``1006``
+closures drive ``ws_orphan_reap`` teardown and widen that window: affected
+sessions held user rows with zero assistant rows in ``state.db``.
+
+These tests pin the fix:
+
+1. The completed assistant row is flushed to the session DB *before* the
+   turn's post-loop finalization runs.
+2. A failing flush must not abort the turn — the answer is already produced
+   and delivered, so ``_persist_session`` stays the retry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent with a mocked OpenAI client (mirrors test_run_agent's fixture)."""
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+
+def _run_text_turn(agent, answer: str, *, flush_side_effect=None):
+    """Drive one clean finish_reason=stop turn, recording persistence calls.
+
+    Returns ``(result, events)`` where ``events`` is the ordered log of
+    persistence calls. Flush entries carry a snapshot of the transcript taken
+    *at call time*, so the assertion cannot be satisfied by a later mutation
+    of the same live list.
+    """
+    from tests.run_agent.test_run_agent import _mock_response
+
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=answer, finish_reason="stop"),
+    ]
+
+    events: list[tuple[str, object]] = []
+
+    def _record_flush(messages, conversation_history=None):
+        events.append((
+            "flush",
+            [
+                (m.get("role"), m.get("content"))
+                for m in messages
+                if isinstance(m, dict)
+            ],
+        ))
+        if flush_side_effect is not None:
+            raise flush_side_effect
+        return True
+
+    def _record_persist(messages, conversation_history=None):
+        events.append(("persist_session", None))
+
+    with (
+        patch.object(
+            agent, "_flush_messages_to_session_db", side_effect=_record_flush
+        ),
+        patch.object(agent, "_persist_session", side_effect=_record_persist),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("what is 2 + 2?")
+
+    return result, events
+
+
+class TestCompletedTextTurnIncrementalPersistence:
+    def test_completed_text_turn_is_flushed_before_finalization(self, loop_agent):
+        """The assistant row must reach the session DB before the loop exits.
+
+        Asserting on the snapshot taken at flush time (not on the final list)
+        is what makes this mutation-survivable: removing the production flush
+        leaves ``finalize_turn``'s ``_persist_session`` as the first
+        persistence event and the test fails.
+        """
+        answer = "2 + 2 is 4."
+        result, events = _run_text_turn(loop_agent, answer)
+
+        assert result["final_response"] == answer
+
+        # The turn-start crash-resilience write of the user message is itself a
+        # _persist_session call, so "first event" is not the contract. The
+        # contract is that a flush carrying the assistant answer lands before
+        # the FINAL persist_session — the one finalize_turn issues after the
+        # loop exits and after post-turn work.
+        assert any(kind == "flush" for kind, _ in events), (
+            "A completed text turn must flush the assistant row to the session "
+            "DB; no _flush_messages_to_session_db call was observed."
+        )
+
+        answer_flushes = [
+            i
+            for i, (kind, snapshot) in enumerate(events)
+            if kind == "flush" and snapshot and snapshot[-1] == ("assistant", answer)
+        ]
+        assert answer_flushes, (
+            "A flush must carry the completed assistant answer as its "
+            f"transcript tail; observed events: {events!r}"
+        )
+
+        final_persist = max(
+            i for i, (kind, _) in enumerate(events) if kind == "persist_session"
+        )
+        assert answer_flushes[0] < final_persist, (
+            "The assistant row must be durable BEFORE post-loop finalization, "
+            f"but the answer flush at index {answer_flushes[0]} did not precede "
+            f"finalize_turn's _persist_session at index {final_persist}."
+        )
+
+    def test_flush_failure_does_not_abort_the_completed_turn(self, loop_agent):
+        """A transient SQLite failure must not swallow a produced answer.
+
+        The tool-call exit treats a failed flush as fatal because side-effecting
+        tools must not run on state that exists only in this process. Here the
+        turn is already over and the text already delivered, so the turn must
+        still return its answer and still reach ``_persist_session``, which
+        retries the write.
+        """
+        answer = "Still answered."
+        result, events = _run_text_turn(
+            loop_agent, answer, flush_side_effect=RuntimeError("database is locked")
+        )
+
+        assert result["final_response"] == answer, (
+            "A failed incremental flush must not discard the produced answer."
+        )
+        assert ("persist_session", None) in events, (
+            "finalize_turn's _persist_session must still run so the failed "
+            "flush gets retried."
+        )


### PR DESCRIPTION
## Summary

A completed pure-text assistant turn is now durable before the conversation loop exits — a session torn down before `finalize_turn`'s `_persist_session` (ws_orphan_reap after a remote WS 1006 close, container stop) no longer loses a reply the user already saw.

Fixes #81641. Salvages #81692 by @JoaoMarcos44 onto current main (his commit cherry-picked, authorship preserved).

Root cause: `run_conversation` has four terminal exits; three already flush the assistant row before yielding control (tool-call exit #49045, verify-on-stop and pre_verify exits #65919 §7). The ordinary `finish_reason=stop` exit — the common case — did not: its text reached the user via the display-only streaming path, and the first durable write was `_persist_session`, behind post-turn work (including micro-compaction's aux-LLM call). Reporter's affected sessions held user rows and zero assistant rows in `state.db`.

## Changes

- `agent/conversation_loop.py`: apply the existing flush idiom at the ordinary text exit. `_DB_PERSISTED_MARKER` dedup keeps the later `_persist_session` idempotent (no duplicate rows — E2E-verified against a real SQLite store). Failure is non-fatal (no side effect follows; `_persist_session` retries) but logs at `warning` with the session id, since a failure here reopens the reported data-loss window.
- `tests/run_agent/test_81641_text_turn_incremental_persistence.py`: two behavior contracts — (1) the assistant row is flushed before post-loop finalization (mutation-verified: removing the production flush fails the test), (2) a failing flush does not discard the produced answer.

Follow-up commit (reviewer): warning-level flush-failure log, trimmed flush-site comment to sibling proportion, guarded the test's persist-index lookup so a wiring change fails with a clean assertion instead of `ValueError`.

Sibling audit: the kanban stop-guard exit intentionally has no flush — its `final_msg` is `_kanban_stop_synthetic`, which `_is_ephemeral_scaffolding` excludes from persistence by design (runtime-verified: flushing such a pair writes 0 rows).

## Validation

| | Result |
|---|---|
| New tests | 2 passed |
| Neighboring suite (`test_run_agent.py`) | 243 passed |
| Persistence suites (tool-call incremental, identity flush, compression persistence, in-place compaction) | 39 passed |
| E2E (real SQLite, real `_flush_messages_to_session_db`/`_persist_session`) | flush writes row once; two later `_persist_session` calls write zero extra rows |
| Mutation check | removing the flush fails the guard test; restoring passes |
| ruff / py_compile | clean |

## Credit

Fix authored by @JoaoMarcos44 in #81692 — excellent root-cause analysis mapping all four loop exits and matching the established idiom exactly.
