### PR TITLE
fix(dashboard): scope credential pool to profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12756,34 +12756,38 @@ def _pool_entry_summary(entry: Any, index: int) -> Dict[str, Any]:
 
 
 @app.get("/api/credentials/pool")
-async def list_credential_pool():
+async def list_credential_pool(profile: Optional[str] = None):
     from agent.credential_pool import load_pool
     from hermes_cli.auth import read_credential_pool
 
     providers = []
-    # read_credential_pool(None) lists every provider that has pooled entries;
-    # load_pool() then gives us the rich PooledCredential objects per provider.
-    raw_pool = read_credential_pool()
-    for provider_id in sorted(raw_pool.keys()):
-        try:
-            pool = load_pool(provider_id)
-        except Exception:
-            _log.exception("load_pool(%s) failed", provider_id)
-            continue
-        entries = pool.entries()
-        if not entries:
-            continue
-        providers.append({
-            "provider": provider_id,
-            "entries": [
-                _pool_entry_summary(e, i) for i, e in enumerate(entries, start=1)
-            ],
-        })
+    with _config_profile_scope(profile):
+        # read_credential_pool(None) lists every provider that has pooled entries;
+        # load_pool() then gives us the rich PooledCredential objects per provider.
+        raw_pool = read_credential_pool()
+        for provider_id in sorted(raw_pool.keys()):
+            try:
+                pool = load_pool(provider_id)
+            except Exception:
+                _log.exception("load_pool(%s) failed", provider_id)
+                continue
+            entries = pool.entries()
+            if not entries:
+                continue
+            providers.append({
+                "provider": provider_id,
+                "entries": [
+                    _pool_entry_summary(e, i) for i, e in enumerate(entries, start=1)
+                ],
+            })
     return {"providers": providers}
 
 
 @app.post("/api/credentials/pool")
-async def add_credential_pool_entry(body: CredentialPoolAdd):
+async def add_credential_pool_entry(
+    body: CredentialPoolAdd,
+    profile: Optional[str] = None,
+):
     import uuid as _uuid
     from agent.credential_pool import (
         load_pool,
@@ -12799,33 +12803,34 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
         raise HTTPException(status_code=400, detail="provider and api_key are required")
 
     try:
-        pool = load_pool(provider)
-        label = (body.label or "").strip() or f"key #{len(pool.entries()) + 1}"
-        entry = PooledCredential(
-            provider=provider,
-            id=_uuid.uuid4().hex[:6],
-            label=label,
-            auth_type=AUTH_TYPE_API_KEY,
-            priority=0,
-            source=SOURCE_MANUAL,
-            access_token=api_key,
-        )
-        pool.add_entry(entry)
-        # Re-adding a credential is an explicit re-engagement signal: lift
-        # every suppression for this provider so a source deleted earlier
-        # (via DELETE below or `hermes auth remove`) can seed again.
-        # Mirrors the `hermes auth add` behaviour in auth_commands.py.
-        if not provider.startswith(CUSTOM_POOL_PREFIX):
-            try:
-                from hermes_cli.auth import (
-                    _load_auth_store,
-                    unsuppress_credential_source,
-                )
-                suppressed = _load_auth_store().get("suppressed_sources", {})
-                for src in list(suppressed.get(provider, []) or []):
-                    unsuppress_credential_source(provider, src)
-            except Exception:
-                _log.exception("unsuppress after pool add failed (non-fatal)")
+        with _config_profile_scope(profile):
+            pool = load_pool(provider)
+            label = (body.label or "").strip() or f"key #{len(pool.entries()) + 1}"
+            entry = PooledCredential(
+                provider=provider,
+                id=_uuid.uuid4().hex[:6],
+                label=label,
+                auth_type=AUTH_TYPE_API_KEY,
+                priority=0,
+                source=SOURCE_MANUAL,
+                access_token=api_key,
+            )
+            pool.add_entry(entry)
+            # Re-adding a credential is an explicit re-engagement signal: lift
+            # every suppression for this provider so a source deleted earlier
+            # (via DELETE below or `hermes auth remove`) can seed again.
+            # Mirrors the `hermes auth add` behaviour in auth_commands.py.
+            if not provider.startswith(CUSTOM_POOL_PREFIX):
+                try:
+                    from hermes_cli.auth import (
+                        _load_auth_store,
+                        unsuppress_credential_source,
+                    )
+                    suppressed = _load_auth_store().get("suppressed_sources", {})
+                    for src in list(suppressed.get(provider, []) or []):
+                        unsuppress_credential_source(provider, src)
+                except Exception:
+                    _log.exception("unsuppress after pool add failed (non-fatal)")
     except HTTPException:
         raise
     except Exception as exc:
@@ -12835,7 +12840,11 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
 
 
 @app.delete("/api/credentials/pool/{provider}/{index}")
-async def remove_credential_pool_entry(provider: str, index: int):
+async def remove_credential_pool_entry(
+    provider: str,
+    index: int,
+    profile: Optional[str] = None,
+):
     """Remove a pool entry.  ``index`` is 1-based (matches the list response).
 
     Removal must be sticky (#55217): ``load_pool()`` re-seeds entries from
@@ -12852,44 +12861,45 @@ async def remove_credential_pool_entry(provider: str, index: int):
     from hermes_cli.auth import suppress_credential_source
 
     provider = (provider or "").strip().lower()
-    try:
-        pool = load_pool(provider)
-        removed = pool.remove_index(index)
-    except Exception as exc:
-        _log.exception("DELETE /api/credentials/pool failed")
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if removed is None:
-        raise HTTPException(status_code=404, detail="No pool entry at that index")
-
-    cleaned: List[str] = []
-    hints: List[str] = []
-    step = find_removal_step(provider, removed.source or "")
-    if step is not None:
+    with _config_profile_scope(profile):
         try:
-            result = step.remove_fn(provider, removed)
-            cleaned = list(result.cleaned)
-            hints = list(result.hints)
-            if result.suppress:
-                suppress_credential_source(provider, removed.source)
-        except Exception:
-            # Cleanup is best-effort, but suppression is the actual bug fix —
-            # without it the entry resurrects on the next load_pool().  Apply
-            # it even when source-specific cleanup blew up.
-            _log.exception(
-                "credential source cleanup failed for %s/%s; suppressing anyway",
-                provider, removed.source,
-            )
+            pool = load_pool(provider)
+            removed = pool.remove_index(index)
+        except Exception as exc:
+            _log.exception("DELETE /api/credentials/pool failed")
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if removed is None:
+            raise HTTPException(status_code=404, detail="No pool entry at that index")
+
+        cleaned: List[str] = []
+        hints: List[str] = []
+        step = find_removal_step(provider, removed.source or "")
+        if step is not None:
             try:
-                suppress_credential_source(provider, removed.source)
+                result = step.remove_fn(provider, removed)
+                cleaned = list(result.cleaned)
+                hints = list(result.hints)
+                if result.suppress:
+                    suppress_credential_source(provider, removed.source)
             except Exception:
-                _log.exception("suppress_credential_source failed")
-    return {
-        "ok": True,
-        "provider": provider,
-        "count": len(pool.entries()),
-        "cleaned": cleaned,
-        "hints": hints,
-    }
+                # Cleanup is best-effort, but suppression is the actual bug fix —
+                # without it the entry resurrects on the next load_pool().  Apply
+                # it even when source-specific cleanup blew up.
+                _log.exception(
+                    "credential source cleanup failed for %s/%s; suppressing anyway",
+                    provider, removed.source,
+                )
+                try:
+                    suppress_credential_source(provider, removed.source)
+                except Exception:
+                    _log.exception("suppress_credential_source failed")
+        return {
+            "ok": True,
+            "provider": provider,
+            "count": len(pool.entries()),
+            "cleaned": cleaned,
+            "hints": hints,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -7,6 +7,8 @@ contract and the CLI-config parity (servers/keys written via the API are
 visible to the CLI data layer), not specific catalog values.
 """
 
+import json
+
 import pytest
 
 
@@ -208,6 +210,41 @@ class TestCredentialPoolEndpoints:
         save_env_value("OPENROUTER_API_KEY", fake_key)
         sources = sorted(e.source for e in load_pool("openrouter").entries())
         assert sources == ["env:OPENROUTER_API_KEY", "manual"]
+
+    def test_credential_pool_actions_are_scoped_to_selected_profile(self):
+        """Dashboard pool mutations must target the selected management profile."""
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        worker_home = hermes_home / "profiles" / "worker"
+        worker_home.mkdir(parents=True)
+
+        response = self.client.post(
+            "/api/credentials/pool?profile=worker",
+            json={
+                "provider": "openrouter",
+                "api_key": "sk-or-" + "w" * 20,
+                "label": "worker-key",
+            },
+        )
+        assert response.status_code == 200
+
+        worker_auth = json.loads((worker_home / "auth.json").read_text())
+        assert worker_auth["credential_pool"]["openrouter"][0]["label"] == "worker-key"
+        assert not (hermes_home / "auth.json").exists()
+
+        listed = self.client.get("/api/credentials/pool?profile=worker").json()
+        assert listed["providers"][0]["provider"] == "openrouter"
+        assert listed["providers"][0]["entries"][0]["label"] == "worker-key"
+
+        response = self.client.delete(
+            "/api/credentials/pool/openrouter/1?profile=worker"
+        )
+        assert response.status_code == 200
+
+        worker_auth = json.loads((worker_home / "auth.json").read_text())
+        assert worker_auth["credential_pool"]["openrouter"] == []
+        assert not (hermes_home / "auth.json").exists()
 
 
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api, fetchJSON } from "./api";
+import { api, fetchJSON, setManagementProfile } from "./api";
 
 const reloadMocks = vi.hoisted(() => ({
   attemptDashboardTokenReloadOnce: vi.fn(() => false),
@@ -33,6 +33,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setManagementProfile("");
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -115,6 +116,26 @@ describe("api.getModelOptions", () => {
       "/api/model/options?profile=default&refresh=1&include_unconfigured=1",
       expect.objectContaining({ credentials: "include" }),
     );
+  });
+});
+
+describe("api Credential Pool helpers", () => {
+  it("scopes credential pool requests to the selected management profile", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("coder");
+
+    const fetchMock = jsonFetchMock({ providers: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getCredentialPool();
+    await api.addCredentialPoolEntry("openrouter", "sk-or-test", "coder key");
+    await api.removeCredentialPoolEntry("openrouter", 1);
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "/api/credentials/pool?profile=coder",
+      "/api/credentials/pool?profile=coder",
+      "/api/credentials/pool/openrouter/1?profile=coder",
+    ]);
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -84,6 +84,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/auxiliary",
   "/api/model/moa",
   "/api/model/options",
+  "/api/credentials/pool",
   // A named profile keeps its own pairing whitelist, and its gateway only
   // consults that one — approving into the global store would grant access
   // the running gateway never sees.


### PR DESCRIPTION
Fixes NousResearch#82577

Dashboard Credential Pool actions were not scoped to the selected management profile.

The frontend profile switcher only appends ?profile=<selected> for paths in PROFILE_SCOPED_PREFIXES, but /api/credentials/pool was missing from that list. The backend Credential Pool handlers also did not accept a profile query parameter or enter the selected profile scope.

That meant listing, adding, and removing credential pool entries could operate on the dashboard launch/default profile while the UI showed another management profile as selected.

This patch:

Adds /api/credentials/pool to PROFILE_SCOPED_PREFIXES.
Adds profile support to GET /api/credentials/pool.
Adds profile support to POST /api/credentials/pool.
Adds profile support to DELETE /api/credentials/pool/{provider}/{index}.
Keeps delete cleanup and suppression inside the same selected profile scope.
Adds backend regression coverage using a real worker profile auth.json path.
Adds frontend regression coverage proving Credential Pool helpers append ?profile=coder.

Validation:

python3 -m py_compile hermes_cli/web_server.py
uv run --extra dev pytest tests/hermes_cli/test_dashboard_admin_endpoints.py -q
git diff --check

Result:

39 passed
git diff --check clean

Note:

I could not run the frontend vitest locally because this fresh worktree did not have vitest installed, and npm install timed out twice before completing. The frontend regression test is included for CI.