### PR TITLE
fix(web): validate MoA preset in /api/model/info and fall back to existing default when stale

### DIFF
--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -361,6 +361,8 @@ export interface ModelInfoResponse {
   effective_context_length?: number
   model: string
   provider: string
+  /** True when provider=moa and model.default referenced a deleted preset; model holds the fallback name. */
+  stale_default?: boolean
 }
 
 export interface ModelPricing {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6241,6 +6241,29 @@ def get_model_info(profile: Optional[str] = None):
         if not model_name:
             return dict(_EMPTY_MODEL_INFO, provider=provider)
 
+        # MoA is a virtual provider: ``model.default`` holds a preset name that
+        # must still exist under ``moa.presets``. If the user deleted the preset
+        # after pinning it as the global default, surface the first valid
+        # existing preset — the same fallback ``normalize_moa_config`` already
+        # applies to ``moa.default_preset`` — instead of handing new desktop
+        # sessions a dead model name. ``stale_default`` lets the frontend warn.
+        stale_default = False
+        if provider == "moa" and model_name:
+            try:
+                from agent.errors import MoAPresetNotFoundError
+                from hermes_cli.moa_config import normalize_moa_config, resolve_moa_preset
+
+                moa_cfg = cfg.get("moa") or {}
+                try:
+                    resolve_moa_preset(moa_cfg, model_name)
+                except MoAPresetNotFoundError:
+                    stale_default = True
+                    model_name = normalize_moa_config(moa_cfg)["default_preset"]
+            except Exception:
+                # Never fail the endpoint for a validation nicety; if MoA
+                # config itself is broken, keep reporting model.default as-is.
+                stale_default = False
+
         # Resolve auto-detected context length (pass config_ctx=None to get
         # purely auto-detected value, then separately report the override)
         try:
@@ -6285,6 +6308,7 @@ def get_model_info(profile: Optional[str] = None):
             "config_context_length": config_ctx_int,
             "effective_context_length": effective_ctx,
             "capabilities": caps,
+            "stale_default": stale_default,
         }
     except HTTPException:
         # Unknown/invalid profile must surface as 404, not degrade into a

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2709,6 +2709,68 @@ class TestModelInfoEndpoint:
         self.client = TestClient(app)
 
 
+    def test_model_info_moa_preset_valid(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {"default": "TOP", "provider": "moa"},
+            "moa": {
+                "default_preset": "TOP",
+                "presets": {
+                    "TOP": {"reference_models": [], "aggregator": {}},
+                    "日常": {"reference_models": [], "aggregator": {}},
+                },
+            },
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=0):
+            resp = self.client.get("/api/model/info")
+
+        data = resp.json()
+        assert data["model"] == "TOP"
+        assert data["provider"] == "moa"
+        assert data["stale_default"] is False
+
+    def test_model_info_moa_preset_deleted_falls_back(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {"default": "TOP", "provider": "moa"},
+            "moa": {
+                "default_preset": "TOP",
+                "presets": {
+                    "日常": {"reference_models": [], "aggregator": {}},
+                },
+            },
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=0):
+            resp = self.client.get("/api/model/info")
+
+        data = resp.json()
+        assert data["model"] == "日常"  # fell back to the first existing preset
+        assert data["provider"] == "moa"
+        assert data["stale_default"] is True
+
+    def test_model_info_moa_no_presets_uses_builtin_default(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {"default": "TOP", "provider": "moa"},
+            "moa": {"default_preset": "TOP", "presets": {}},
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=0):
+            resp = self.client.get("/api/model/info")
+
+        data = resp.json()
+        # normalize_moa_config guarantees a preset even with an empty presets
+        # dict (DEFAULT_MOA_PRESET_NAME); the endpoint must never leak the
+        # deleted name.
+        assert data["model"] != "TOP"
+        assert data["provider"] == "moa"
+        assert data["stale_default"] is True
+
     def test_model_info_with_dict_config(self, monkeypatch):
         import hermes_cli.web_server as ws
 


### PR DESCRIPTION
## Summary

`GET /api/model/info` returns `model.default` verbatim without checking that the
referenced MoA preset still exists in `moa.presets`. When a user deletes a
preset that was pinned as the global default (`model.default: <preset>` +
`provider: moa`), new desktop sessions seed the composer with the deleted name,
the picker menu shows no such model, and the first message crashes with
`MoAPresetNotFoundError`. #66331 only improved the error message; the stale
display and the crash remained.

This PR validates the preset at the API boundary and falls back to the first
valid existing preset — the same fallback `normalize_moa_config` already
applies to `moa.default_preset` — so the UI never presents a dead model.

## Changes

- `hermes_cli/web_server.py` — `get_model_info()`: when `provider == "moa"`
  and the preset is unresolvable (`MoAPresetNotFoundError`), fall back to
  `normalize_moa_config(cfg["moa"])["default_preset"]` and set
  `"stale_default": true` in the response. Validation failures degrade safely
  (endpoint keeps reporting `model.default` as-is, never 500s).
- `apps/desktop/src/types/hermes.ts` — add optional `stale_default?: boolean`
  to `ModelInfoResponse` (backward-compatible additive field).
- `tests/hermes_cli/test_web_server.py` — 3 new cases: valid preset (no
  behavior change), deleted preset (fallback + flag), empty `presets` dict
  (built-in default name, deleted name never leaks).

## Behavior Change

- New desktop sessions no longer display a deleted MoA preset; the model pill
  shows the first existing preset instead.
- Frontend can detect `stale_default` and surface a notice (optional follow-up).

## How to Test

1. Set `model.default: TOP` + `provider: moa`, define `moa.presets.TOP`,
   start the gateway.
2. Delete `TOP` from `moa.presets` (the config mtime cache invalidates
   automatically — no restart needed for the read path).
3. `GET /api/model/info` → returns an existing preset name with
   `"stale_default": true`.
4. Open a new desktop window → pill shows a valid preset; sending a message no
   longer raises `MoAPresetNotFoundError` on the info path.
5. Regression: with a valid preset the response is unchanged
   (`stale_default: false`).

## Checklist

- [x] `pytest tests/hermes_cli/test_web_server.py -k "model"` — 55 passed
- [x] `TestModelInfoEndpoint` — 10 passed (7 existing + 3 new)
- [x] No change to fail-closed semantics of `resolve_moa_preset` (explicit
      runtime selection still raises)

Closes #82613

Related: #65875 (same family: stale MoA state on desktop — new sessions hang
with MoAPresetNotFoundError and the model pill shows a stale model).
