### PR TITLE
fix(desktop): Linux HUD permanently click-through — ignore-mouse is a one-way door on X11

### DIFF
--- a/apps/desktop/electron/hud-input-policy.test.ts
+++ b/apps/desktop/electron/hud-input-policy.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the HUD input policy. The point of these is the split: the
+ * solid fallback has to reach the X11 windows where the input region never
+ * comes back, and has to leave every other backend on the click-through path
+ * it works fine on.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { hudInputPolicy } from './hud-input-policy'
+
+const X11_SESSION = { DISPLAY: ':0', XDG_SESSION_TYPE: 'x11' }
+const WAYLAND_SESSION = { WAYLAND_DISPLAY: 'wayland-0', XDG_SESSION_TYPE: 'wayland' }
+// A Wayland login with an X server behind it, which is what an XWayland client
+// sees.
+const XWAYLAND_SESSION = { DISPLAY: ':0', WAYLAND_DISPLAY: 'wayland-0', XDG_SESSION_TYPE: 'wayland' }
+
+test('the click-through design is kept everywhere it works', () => {
+  for (const platform of ['darwin', 'win32']) {
+    assert.equal(hudInputPolicy(platform, {}, []), 'click-through')
+    // Stray Linux session variables do not make a Mac an X11 box.
+    assert.equal(hudInputPolicy(platform, X11_SESSION, []), 'click-through')
+  }
+})
+
+test('an X11 session gets the solid HUD', () => {
+  assert.equal(hudInputPolicy('linux', X11_SESSION, []), 'solid')
+})
+
+test('a Wayland session gets the solid HUD too, because Electron is on XWayland there', () => {
+  // Nothing appends an --ozone-platform switch, so Electron takes its default
+  // X11 backend and the window is an X11 window whatever the session says.
+  // This is the KDE-Plasma-and-GNOME-alike case from the reports.
+  assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, []), 'solid')
+  assert.equal(hudInputPolicy('linux', XWAYLAND_SESSION, []), 'solid')
+})
+
+test('asking for a native Wayland surface keeps the click-through path', () => {
+  for (const argv of [['--ozone-platform=wayland'], ['--ozone-platform-hint=wayland']]) {
+    assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, argv), 'click-through')
+  }
+
+  assert.equal(
+    hudInputPolicy('linux', { ...WAYLAND_SESSION, ELECTRON_OZONE_PLATFORM_HINT: 'wayland' }, []),
+    'click-through'
+  )
+})
+
+test('an auto hint follows the session', () => {
+  assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, ['--ozone-platform-hint=auto']), 'click-through')
+  assert.equal(hudInputPolicy('linux', X11_SESSION, ['--ozone-platform-hint=auto']), 'solid')
+  // Both displays present means an X server is there to fall back to, so auto
+  // resolving to Wayland is the session's call, not ours.
+  assert.equal(hudInputPolicy('linux', XWAYLAND_SESSION, ['--ozone-platform-hint=auto']), 'click-through')
+})
+
+test('asking for X11 on a Wayland session gets the solid HUD', () => {
+  assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, ['--ozone-platform=x11']), 'solid')
+})
+
+test('the explicit switch beats the hint, and the last switch wins', () => {
+  assert.equal(
+    hudInputPolicy('linux', WAYLAND_SESSION, ['--ozone-platform-hint=auto', '--ozone-platform=x11']),
+    'solid'
+  )
+  assert.equal(
+    hudInputPolicy('linux', X11_SESSION, ['--ozone-platform=x11', '--ozone-platform=wayland']),
+    'click-through'
+  )
+})
+
+test('a backend nobody recognises falls back to X11, the Linux default', () => {
+  assert.equal(hudInputPolicy('linux', X11_SESSION, ['--ozone-platform=headless']), 'solid')
+  assert.equal(hudInputPolicy('linux', {}, []), 'solid')
+})

--- a/apps/desktop/electron/hud-input-policy.ts
+++ b/apps/desktop/electron/hud-input-policy.ts
@@ -1,0 +1,114 @@
+/**
+ * Which input model the HUD can safely use on this system.
+ *
+ * The HUD's default is per-element click-through: the window ignores the mouse
+ * and turns solid only where the renderer's hit test finds a control under the
+ * cursor. That design rests on `setIgnoreMouseEvents(false)` actually handing
+ * the input region back. On X11 it does not — once a window has ignored the
+ * mouse the X server keeps hit-testing straight through it, and no later call
+ * restores it (the live diagnosis is in `startHudCursorFeed`). It is a one-way
+ * door, so the only policy that works there is never to walk through it: keep
+ * the HUD a normal solid window for its whole life.
+ *
+ * That trade is a real loss — a solid HUD swallows clicks in the faded band
+ * above the composer that would otherwise reach the app underneath — so it is
+ * scoped to the backend where the restore is known to be broken instead of
+ * being applied to every Linux desktop.
+ *
+ * The windowing backend, not the session type, is what decides this. Electron
+ * reaches the display server through Ozone, and this app appends no
+ * `--ozone-platform` switch, so on Linux it takes Electron's default X11
+ * backend — including on a Wayland session, where it runs as an XWayland client
+ * and is an X11 window like any other. That is why the affected reports span
+ * GNOME/ARM64 and KDE Plasma/x86_64 alike: both are X11 windows. A native
+ * Wayland surface happens only when someone asks for one explicitly, the
+ * one-way door has never been observed there, and so that case keeps the
+ * existing click-through path.
+ */
+
+/**
+ * `solid` keeps the HUD a normal window that never ignores the mouse.
+ * `click-through` is the per-element design: ignore by default, solid under the
+ * cursor.
+ */
+export type HudInputPolicy = 'click-through' | 'solid'
+
+/** The Ozone backend Electron talks to the display server through. */
+type Backend = 'wayland' | 'x11'
+
+/**
+ * The Ozone platform this process was asked for, or null when nothing asked.
+ *
+ * `--ozone-platform` names a backend outright and `--ozone-platform-hint`
+ * (equivalently `ELECTRON_OZONE_PLATFORM_HINT`) asks for one, with `auto`
+ * meaning "Wayland if the session is Wayland". The explicit switch wins over
+ * the hint, and a repeated switch resolves last-one-wins, both matching
+ * Chromium's own handling.
+ */
+function requestedOzonePlatform(env: NodeJS.ProcessEnv, argv: readonly string[]): null | string {
+  let explicit: null | string = null
+  let hint: null | string = null
+
+  for (const arg of argv) {
+    const match = /^--ozone-platform(-hint)?=(.+)$/.exec(arg)
+
+    if (!match) {
+      continue
+    }
+
+    if (match[1]) {
+      hint = match[2].toLowerCase()
+    } else {
+      explicit = match[2].toLowerCase()
+    }
+  }
+
+  return explicit ?? hint ?? env.ELECTRON_OZONE_PLATFORM_HINT?.toLowerCase() ?? null
+}
+
+/**
+ * Whether the session itself is Wayland.
+ *
+ * Matches the reading already used for window enumeration in `window-below.ts`:
+ * a session advertising `WAYLAND_DISPLAY` without a `DISPLAY` is Wayland with
+ * no X server to fall back to.
+ */
+function sessionIsWayland(env: NodeJS.ProcessEnv): boolean {
+  return env.XDG_SESSION_TYPE === 'wayland' || (Boolean(env.WAYLAND_DISPLAY) && !env.DISPLAY)
+}
+
+/**
+ * The backend Electron will actually use on Linux.
+ *
+ * Absent any request this is X11 — Electron's Linux default — which is why a
+ * Wayland session still lands here as an XWayland client unless it opted in.
+ */
+function linuxBackend(env: NodeJS.ProcessEnv, argv: readonly string[]): Backend {
+  const requested = requestedOzonePlatform(env, argv)
+
+  if (requested === 'wayland') {
+    return 'wayland'
+  }
+
+  if (requested === 'auto') {
+    return sessionIsWayland(env) ? 'wayland' : 'x11'
+  }
+
+  return 'x11'
+}
+
+/**
+ * The input model the HUD should use.
+ *
+ * macOS and Windows keep the click-through design: `setIgnoreMouseEvents(true,
+ * { forward: true })` is `@platform darwin,win32`, so the renderer goes on
+ * seeing the cursor while the window ignores it and can re-arm whenever the
+ * pointer comes back to the bar.
+ */
+export function hudInputPolicy(platform: string, env: NodeJS.ProcessEnv, argv: readonly string[]): HudInputPolicy {
+  if (platform !== 'linux') {
+    return 'click-through'
+  }
+
+  return linuxBackend(env, argv) === 'x11' ? 'solid' : 'click-through'
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -137,6 +137,7 @@ import {
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
 import { cursorPointInWindow } from './hud-cursor'
+import { hudInputPolicy } from './hud-input-policy'
 import { buildHudWindowUrl } from './hud-url'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
@@ -9231,35 +9232,39 @@ function startHudCursorFeed(win: BrowserWindow) {
     return
   }
 
-  // CDX local fix (X11/GNOME/ARM64, Electron 40): setIgnoreMouseEvents(false)
-  // does NOT restore the input region once a window has ignored the mouse —
-  // verified live: with main forcing false every poll tick and the cursor
-  // parked on the bar, the X server still hit-tested the window behind the
-  // HUD, permanently. Since ignore is a one-way door on this stack, the HUD
-  // must never walk through it: the window stays solid for its whole life
-  // (see the companion veto in the hermes:hud:ignore-mouse handler). The
-  // faded band above the composer eats clicks inside the HUD rect — coarser
-  // than upstream's per-element click-through, but every control works and
-  // the bar stays draggable.
-  rememberLog('[hud-cursor] feed armed (solid-HUD mode: ignore-mouse disabled on this platform)')
-  try {
-    win.setIgnoreMouseEvents(false)
-  } catch {
-    // best effort
+  // On an X11 window `setIgnoreMouseEvents(false)` does not restore the input
+  // region once the window has ignored the mouse — verified live: with main
+  // forcing false every poll tick and the cursor parked on the bar, the X
+  // server still hit-tested the window behind the HUD, permanently. Ignore is
+  // a one-way door there, so the HUD must never walk through it and is held
+  // solid for its whole life instead (the companion veto is in the
+  // hermes:hud:ignore-mouse handler). The cursor feed keeps running either
+  // way: it is what the renderer's hit test reads, and it is correct on the
+  // backends where the door swings both ways.
+  if (hudInputPolicy(process.platform, process.env, process.argv) === 'solid') {
+    rememberLog('[hud-cursor] feed armed (solid HUD: ignore-mouse vetoed on this backend)')
+
+    try {
+      win.setIgnoreMouseEvents(false)
+    } catch {
+      // best effort
+    }
   }
 
   let last: string | null = null
 
   const timer = setInterval(() => {
-    if (win.isDestroyed()) {
+    if (win.isDestroyed() || !win.isVisible()) {
       return
     }
 
     let point: { x: number; y: number } | null = null
+
     try {
       point = cursorPointInWindow(screen.getCursorScreenPoint(), win.getBounds(), win.webContents.getZoomFactor())
     } catch (err) {
       rememberLog(`[hud-cursor] poll failed: ${(err as Error)?.message || err}`)
+
       return
     }
 
@@ -9278,11 +9283,6 @@ function startHudCursorFeed(win: BrowserWindow) {
 
   win.on('closed', () => clearInterval(timer))
 }
-
-// Whether main's cursor poll currently sees the pointer inside the HUD rect
-// (Linux only). While true, renderer requests to IGNORE the mouse are vetoed
-// — they are based on a cursor point the renderer never received.
-let hudCursorInside = false
 
 function hudBounds() {
   // Remembered spot first — validated against the LIVE displays so a HUD
@@ -10218,13 +10218,14 @@ ipcMain.handle('hermes:hud:vibrancy', (_event, on) => {
 // reaches the bar.
 ipcMain.on('hermes:hud:ignore-mouse', (_event, ignore) => {
   if (hudWindow && !hudWindow.isDestroyed()) {
-    // CDX local fix (Linux): ignore-mouse is a ONE-WAY DOOR on this
-    // X11/Electron stack — setIgnoreMouseEvents(false) cannot restore the
-    // input region afterwards (verified live; see startHudCursorFeed). Veto
-    // every ignore request so the HUD stays a normal solid window.
-    if (process.platform === 'linux' && Boolean(ignore)) {
+    // On X11 ignore-mouse is a one-way door: setIgnoreMouseEvents(false)
+    // cannot restore the input region afterwards (verified live; see
+    // startHudCursorFeed). Veto the request there so the HUD stays a normal
+    // solid window. Every other backend keeps the per-element behaviour.
+    if (Boolean(ignore) && hudInputPolicy(process.platform, process.env, process.argv) === 'solid') {
       return
     }
+
     hudWindow.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
   }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9231,14 +9231,37 @@ function startHudCursorFeed(win: BrowserWindow) {
     return
   }
 
+  // CDX local fix (X11/GNOME/ARM64, Electron 40): setIgnoreMouseEvents(false)
+  // does NOT restore the input region once a window has ignored the mouse —
+  // verified live: with main forcing false every poll tick and the cursor
+  // parked on the bar, the X server still hit-tested the window behind the
+  // HUD, permanently. Since ignore is a one-way door on this stack, the HUD
+  // must never walk through it: the window stays solid for its whole life
+  // (see the companion veto in the hermes:hud:ignore-mouse handler). The
+  // faded band above the composer eats clicks inside the HUD rect — coarser
+  // than upstream's per-element click-through, but every control works and
+  // the bar stays draggable.
+  rememberLog('[hud-cursor] feed armed (solid-HUD mode: ignore-mouse disabled on this platform)')
+  try {
+    win.setIgnoreMouseEvents(false)
+  } catch {
+    // best effort
+  }
+
   let last: string | null = null
 
   const timer = setInterval(() => {
-    if (win.isDestroyed() || !win.isVisible()) {
+    if (win.isDestroyed()) {
       return
     }
 
-    const point = cursorPointInWindow(screen.getCursorScreenPoint(), win.getBounds(), win.webContents.getZoomFactor())
+    let point: { x: number; y: number } | null = null
+    try {
+      point = cursorPointInWindow(screen.getCursorScreenPoint(), win.getBounds(), win.webContents.getZoomFactor())
+    } catch (err) {
+      rememberLog(`[hud-cursor] poll failed: ${(err as Error)?.message || err}`)
+      return
+    }
 
     // Off-window is a real answer (it is what hands the mouse back), so it is
     // sent — once. Only an unchanged answer is dropped, to keep an idle cursor
@@ -9255,6 +9278,11 @@ function startHudCursorFeed(win: BrowserWindow) {
 
   win.on('closed', () => clearInterval(timer))
 }
+
+// Whether main's cursor poll currently sees the pointer inside the HUD rect
+// (Linux only). While true, renderer requests to IGNORE the mouse are vetoed
+// — they are based on a cursor point the renderer never received.
+let hudCursorInside = false
 
 function hudBounds() {
   // Remembered spot first — validated against the LIVE displays so a HUD
@@ -10190,6 +10218,13 @@ ipcMain.handle('hermes:hud:vibrancy', (_event, on) => {
 // reaches the bar.
 ipcMain.on('hermes:hud:ignore-mouse', (_event, ignore) => {
   if (hudWindow && !hudWindow.isDestroyed()) {
+    // CDX local fix (Linux): ignore-mouse is a ONE-WAY DOOR on this
+    // X11/Electron stack — setIgnoreMouseEvents(false) cannot restore the
+    // input region afterwards (verified live; see startHudCursorFeed). Veto
+    // every ignore request so the HUD stays a normal solid window.
+    if (process.platform === 'linux' && Boolean(ignore)) {
+      return
+    }
     hudWindow.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
   }
 })


### PR DESCRIPTION
## Symptom

On Linux/X11, toggling HUD mode produces the floating bar but it is **100% click-through**: it cannot be clicked, focused, or dragged. Quitting exits HUD mode (main window returns), so the only escape is never using the HUD. Reproduced consistently on Ubuntu 24.04 / GNOME / X11 / ARM64 (NVIDIA DGX Spark, GB10) with Electron 40.10.2, both with and without `--disable-gpu`. This matches several user reports of broken/untouchable HUD windows on Linux and Windows.

## Diagnosis (live, X-server-level)

Two independent failures in the Linux click-through design (`startHudCursorFeed` + `useHudClickThrough`):

1. **The pushed cursor feed never reaches the renderer.** With a CDP counter subscribed to `hermesDesktop.hud.onCursor` and the pointer wiggled across the bar via xdotool, **zero events arrived over 5s** — while main-process instrumentation confirmed the poll interval was armed, ticking, and computing correct in-window points. The renderer's hit test therefore always runs on a null point and decides `ignore=true` forever.

2. **`setIgnoreMouseEvents(false)` cannot restore the input region once the window has ignored the mouse.** We patched main to call `win.setIgnoreMouseEvents(point === null)` on every 60ms poll tick. With the cursor parked on the bar (point non-null → `false` asserted 16×/sec), `xdotool getmouselocation` still reported the window *behind* the HUD as containing the pointer, indefinitely, and clicks kept landing there. Forcing `setIgnoreMouse(false)` via the renderer IPC in a session where ignore had *not yet stuck* did make the window clickable — the API only fails after the ignore state has been entered. It is a one-way door on this stack.

Because of (2), no cursor-feed fix can rescue the window after its first `setIgnoreMouse(true)`.

## Fix

On Linux, never enter ignore state: the HUD stays a normal solid always-on-top window.

- `startHudCursorFeed`: clear ignore once at feed start; keep pushing cursor points (harmless, and correct on stacks where delivery works)
- `hermes:hud:ignore-mouse` handler: veto `ignore=true` on Linux

Trade-off: the faded band above the composer now swallows clicks inside the HUD rect (620×320 default) instead of passing them through. Coarser than the per-element design, but every control is clickable and the long-press composer drag works — verified by click tests (bar click activates the HUD; click outside the rect reaches the app behind) and manual drag.

A finer follow-up could shrink the window to the composer band on Linux, restoring most of the pass-through area without touching the broken API.

## Notes

- Related: #82233 (composer containment) — present in this build; orthogonal to this input-region issue.
- Happy to add logs/repro scripts (CDP cursor-event counter, X input probes) if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)