### PR TITLE
fix(tools): resolve explicit Git targets without alias regression

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# PR #82496 attribution enabler (canonical identity)

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -5,7 +5,15 @@ from pathlib import Path
 
 import pytest
 
+from tools.approval import _deobfuscate_shell_word_for_detection
 from tools.self_repo_guard import (
+    _explicit_git_path,
+    _is_mangled_windows_drive,
+    _normalize_git_path_operand,
+    _path_aware_shell_word,
+    _shell_words_at,
+    _strip_quotes_preserve_windows_path,
+    _windows_git_bash_to_drive,
     detect_self_repo_git_mutation,
     get_running_source_root,
 )
@@ -395,10 +403,12 @@ class TestSourceRootResolution:
 
         root = tmp_path / "wt"
         root.mkdir()
-        (root / ".git").write_text("gitdir: /somewhere/.git/worktrees/wt\n")
+        (root / ".git").write_text(
+            "gitdir: /somewhere/.git/worktrees/wt\n", encoding="utf-8"
+        )
         (root / "tools").mkdir()
         fake_file = root / "tools" / "self_repo_guard.py"
-        fake_file.write_text("")
+        fake_file.write_text("", encoding="utf-8")
         monkeypatch.setattr(mod, "__file__", str(fake_file))
         assert mod.get_running_source_root() == root.resolve()
 
@@ -411,3 +421,340 @@ class TestUnparseableCommands:
     def test_subshell_syntax_does_not_crash(self, repo):
         hit, _ = _detect("VAL=$(git rev-parse HEAD) git checkout main", repo, repo)
         assert hit is True
+
+
+class TestGitDirAndEnvTargeting:
+    """Explicit git-dir selectors must resolve to the worktree they govern.
+
+    Covers the residual fail-open sinks shared by main/#82586/#82636:
+    ``--git-dir`` (bare and glued) and ``GIT_DIR`` never resolved into the
+    effective target, so ``git --git-dir <src>/.git checkout`` switched the
+    source branch with rc=0 from any directory.
+    """
+
+    def test_git_dir_bare_operand_targeting_repo(self, repo, tmp_path):
+        command = f"git --git-dir {repo / '.git'} checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_git_dir_glued_operand_targeting_repo(self, repo, tmp_path):
+        command = f"git --git-dir={repo / '.git'} checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_git_dir_glued_git_bash_form_targeting_repo(self, repo, tmp_path):
+        target, cwd, source_root = _explicit_target_operands(
+            repo, "git_bash", tmp_path
+        )
+        command = f"git --git-dir={target}/.git checkout main"
+        hit, _ = _detect(command, cwd, source_root)
+        assert hit is True
+
+    def test_git_dir_env_targeting_repo(self, repo, tmp_path):
+        command = f"GIT_DIR={repo / '.git'} git checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_git_work_tree_env_targeting_repo(self, repo, tmp_path):
+        command = f"GIT_WORK_TREE={repo} git checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_git_dir_and_work_tree_env_targeting_repo(self, repo, tmp_path):
+        command = f"GIT_DIR={repo / '.git'} GIT_WORK_TREE={repo} git checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_git_dir_other_repo_mutation_allowed(self, repo, tmp_path):
+        other = tmp_path / "other-project"
+        other.mkdir()
+        (other / ".git").mkdir()
+        command = f"git --git-dir {other / '.git'} checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is False
+
+    def test_git_dir_safe_read_in_repo_allowed(self, repo, tmp_path):
+        command = f"git --git-dir {repo / '.git'} status"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is False
+
+    def test_git_dir_bare_repo_mutation_fail_closed(self, repo, tmp_path):
+        command = f"git --git-dir {tmp_path / 'bare-repo.git'} checkout main"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+
+class TestExplicitTargetSinkClosure:
+    """Operand forms that must not fail open (glued, single-quoted, mangled)."""
+
+    def test_glued_dash_c_native_blocks(self, repo, tmp_path):
+        command = f"git -C{repo} checkout pr-51020"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_glued_work_tree_native_blocks(self, repo, tmp_path):
+        command = f"git --work-tree={repo} checkout pr-51020"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_single_quoted_dash_c_native_blocks(self, repo, tmp_path):
+        command = f"git -C '{repo}' checkout pr-51020"
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_mangled_drive_operand_fail_closed(self, repo, tmp_path):
+        hit, _ = _detect("git -C D:workhermes checkout main", tmp_path, repo)
+        assert hit is True
+
+    def test_glued_mangled_drive_fail_closed(self, repo, tmp_path):
+        hit, _ = _detect("git -CD:workhermes checkout main", tmp_path, repo)
+        assert hit is True
+
+    def test_chained_dash_c_all_outside_status_allowed(self, repo, tmp_path):
+        outside_a = tmp_path / "outside-a"
+        outside_b = tmp_path / "outside-b"
+        outside_a.mkdir()
+        outside_b.mkdir()
+        hit, _ = _detect(
+            f"git -C {outside_a} -C {outside_b} status", tmp_path, repo
+        )
+        assert hit is False
+
+    def test_chained_dash_c_all_outside_checkout_allowed(self, repo, tmp_path):
+        outside_a = tmp_path / "outside-a"
+        outside_b = tmp_path / "outside-b"
+        outside_a.mkdir()
+        outside_b.mkdir()
+        hit, _ = _detect(
+            f"git -C {outside_a} -C {outside_b} checkout main", tmp_path, repo
+        )
+        assert hit is False
+
+    def test_chained_dash_c_in_root_safe_read_allowed(self, repo, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        hit, _ = _detect(f"git -C {repo} -C {outside} status", tmp_path, repo)
+        assert hit is False
+
+
+class TestExplicitGitTargetPaths:
+    """Windows / Git-Bash explicit ``-C`` operands must not fail open.
+
+    Salvaged from #82586 (olympusbuildz): operand-only path-aware words that
+    keep native separators, normalize Git-Bash drive spellings, and never
+    rewrite non-path tokens.
+    """
+
+    def test_preserves_windows_backslash_in_dash_c_operand(self):
+        raw = r'"D:\work\hermes-agent"'
+        preserved = _strip_quotes_preserve_windows_path(raw)
+        assert preserved == r"D:\work\hermes-agent"
+        assert "\\" in preserved
+        # Path preserve applies in -C operand position via _shell_words_at,
+        # not to bare quoted Windows paths in arbitrary token slots.
+        words = _shell_words_at(f"git -C {raw} status", 0)
+        assert words[2] == r"D:\work\hermes-agent"
+        assert _path_aware_shell_word(raw) == r"D:\work\hermes-agent"
+        normalized = _normalize_git_path_operand(r"D:\work\hermes-agent")
+        assert normalized == r"D:\work\hermes-agent"
+        path = _explicit_git_path(r"D:\work\hermes-agent", Path("/tmp"))
+        assert "D:" in str(path).replace("\\", "/") or str(path).startswith("D:")
+        text = str(path).replace("\\", "/")
+        assert "work" in text and "hermes-agent" in text
+
+    def test_git_bash_drive_path_normalizes(self):
+        assert _windows_git_bash_to_drive("/d/work/hermes-agent") == "D:/work/hermes-agent"
+        assert _windows_git_bash_to_drive("/D/work/x") == "D:/work/x"
+        assert _windows_git_bash_to_drive("/c") == "C:/"
+        assert _normalize_git_path_operand("/d/work/hermes-agent") == "D:/work/hermes-agent"
+        path = _explicit_git_path("/d/work/hermes-agent", Path("/var/tmp"))
+        text = str(path).replace("\\", "/")
+        assert "D:" in text
+        assert "work/hermes-agent" in text
+        # Use non-escape string forms: "/tmp/..." embeds a TAB via \t in
+        # ordinary Python literals and would accidentally pass a looser regex.
+        assert _windows_git_bash_to_drive("/" + "tmp/foo") is None
+        assert _windows_git_bash_to_drive("/" + "dev/null") is None
+        assert _windows_git_bash_to_drive("/" + "Users/hermes") is None
+        assert _windows_git_bash_to_drive("/" + "etc/passwd") is None
+
+    def test_dash_c_windows_path_blocks_mutation_when_normalized_target_is_repo(
+        self, repo, tmp_path, monkeypatch
+    ):
+        import tools.self_repo_guard as mod
+
+        win_path = r"D:\work\hermes-agent"
+
+        def fake_explicit(path_str, base):
+            if path_str.replace("\\", "/") in {
+                win_path.replace("\\", "/"),
+                "D:/work/hermes-agent",
+            } or path_str == win_path:
+                return repo
+            return mod._resolve_git_target(
+                mod._normalize_git_path_operand(path_str), base
+            )
+
+        monkeypatch.setattr(mod, "_explicit_git_path", fake_explicit)
+        # Double-quoted native Windows path — path-aware word keep separators,
+        # then our stub maps the operand onto the real temp repo.
+        command = f'git -C "{win_path}" checkout main'
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_multiple_dash_c_fail_closed_when_first_is_repo(self, repo, tmp_path):
+        # Intermediate -C lands in the source root even though a later -C
+        # leaves it — conservative rule blocks the mutating subcommand.
+        hit, _ = _detect(
+            f"git -C {repo} -C {tmp_path} checkout main",
+            tmp_path,
+            repo,
+        )
+        assert hit is True
+
+    def test_multiple_dash_c_all_outside_still_allowed(self, repo, tmp_path):
+        outside_a = tmp_path / "outside-a"
+        outside_b = tmp_path / "outside-b"
+        outside_a.mkdir()
+        outside_b.mkdir()
+        hit, _ = _detect(
+            f"git -C {outside_a} -C {outside_b} checkout main",
+            tmp_path,
+            repo,
+        )
+        assert hit is False
+
+    def test_mangled_drive_path_operand_fail_closed(self, repo, tmp_path):
+        assert _is_mangled_windows_drive("D:workhermes")
+        assert not _is_mangled_windows_drive(r"D:\work\hermes")
+        assert not _is_mangled_windows_drive("D:/work/hermes")
+        # Escape-stripped drive form must fail closed for mutations regardless
+        # of ambient cwd (do not fall open to outside-the-repo ambient path).
+        hit, _ = _detect("git -C D:workhermes checkout main", tmp_path, repo)
+        assert hit is True
+
+    def test_path_aware_word_recovers_quoted_windows_path(self):
+        # Simulates the raw token _read_shell_word returns for a double-quoted
+        # Windows path; approval deobfuscation would mangle it. Recovery is
+        # via the path-operand helper / -C position — not every shell token.
+        raw = r'"D:\work\hermes-agent"'
+        mangled = _deobfuscate_shell_word_for_detection(raw)
+        assert mangled == "D:workhermes-agent" or "\\" not in mangled
+        words = _shell_words_at(f"git -C {raw} checkout main", 0)
+        assert words[2] == r"D:\work\hermes-agent"
+        assert not _is_mangled_windows_drive(words[2])
+        assert _path_aware_shell_word(raw) == r"D:\work\hermes-agent"
+
+    def test_configured_alias_still_blocks_in_source_repo(self, repo):
+        """Regression: operand-only path-aware words must not break aliases."""
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "alias.co", "checkout"],
+            check=True,
+        )
+        hit, _ = _detect("git co main", repo, repo)
+        assert hit is True
+
+    def test_non_path_words_use_normal_deobfuscation(self):
+        """Path-aware preserve must not blanket every shell token."""
+        raw_path = r'"D:\work\hermes-agent"'
+        # Outside a Git path-operand position, the quoted Windows path is
+        # normal-deobfuscated (backslashes stripped as shell escapes).
+        words = _shell_words_at(f"echo {raw_path}", 0)
+        assert words[0] == "echo"
+        assert words[1] == _deobfuscate_shell_word_for_detection(raw_path)
+        assert "\\" not in words[1]
+        # Contrast: the same token after bare -C keeps separators.
+        git_words = _shell_words_at(f"git -C {raw_path} status", 0)
+        assert git_words[2] == r"D:\work\hermes-agent"
+        assert "\\" in git_words[2]
+
+
+class TestClassBoundaryClosure:
+    """Regression coverage for every explicit-target boundary in the class."""
+
+    def test_balanced_dotdot_into_source_blocks_all_selectors(self, repo, tmp_path):
+        parent = repo.parent
+        balanced = parent.parent / parent.name / ".." / parent.name / repo.name
+        commands = [
+            f"git -C {balanced} checkout main",
+            f"git --git-dir {balanced / '.git'} checkout main",
+            f"git --git-dir={balanced / '.git'} --work-tree={balanced} checkout main",
+            f"GIT_DIR={balanced / '.git'} GIT_WORK_TREE={balanced} git checkout main",
+            f"git worktree remove {balanced}",
+            f"git worktree move {balanced} {tmp_path / 'moved'}",
+        ]
+        for command in commands:
+            hit, _ = _detect(command, tmp_path, repo)
+            assert hit is True, command
+
+    def test_dotdot_escape_outside_source_remains_allowed(self, repo, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        spelling = repo.parent / ".." / "outside"
+        hit, _ = _detect(f"git -C {spelling} checkout main", tmp_path, repo)
+        assert hit is False
+
+    def test_drive_and_git_bash_spellings_are_equivalent_without_host_paths(self):
+        root = Path("c:/tmp/hermes-drive-fixture")
+        native = _explicit_git_path("C:/tmp/hermes-drive-fixture", Path("/"))
+        git_bash = _explicit_git_path("/c/tmp/hermes-drive-fixture", Path("/"))
+        expected = _resolve_for_test(root)
+        assert native == git_bash == expected
+        for spelling in ("C:/tmp/hermes-drive-fixture", "/c/tmp/hermes-drive-fixture"):
+            hit, _ = _detect(
+                f"git -C {spelling} checkout main", Path("/"), root
+            )
+            assert hit is True
+
+    def test_unc_path_is_preserved_in_git_and_environment_positions(self):
+        raw = r'"\\server\share\hermes-agent"'
+        words = _shell_words_at(f"git -C {raw} checkout main", 0)
+        assert words[2] == r"\\server\share\hermes-agent"
+        env_words = _shell_words_at(f"GIT_WORK_TREE={raw} git checkout main", 0)
+        assert env_words[0] == r"GIT_WORK_TREE=\\server\share\hermes-agent"
+
+    def test_native_environment_path_preserves_separators_at_tokenization(self):
+        raw = r'"D:\work\hermes-agent"'
+        words = _shell_words_at(f"GIT_WORK_TREE={raw} git checkout main", 0)
+        assert words[0] == r"GIT_WORK_TREE=D:\work\hermes-agent"
+        assert "\\" in words[0]
+
+    def test_mangled_windows_and_unc_forms_fail_closed(self, repo, tmp_path):
+        assert _is_mangled_windows_drive("D:workhermes")
+        hit, _ = _detect("git -C D:workhermes checkout main", tmp_path, repo)
+        assert hit is True
+        # A raw UNC operand must remain identifiable rather than becoming a
+        # generic shell word whose separators can be lost.
+        raw = r'"\\server\share\hermes-agent"'
+        words = _shell_words_at(f"git -C {raw} checkout main", 0)
+        assert words[2].startswith("\\\\server\\")
+
+    def test_env_chdir_changes_effective_git_cwd(self, repo, tmp_path):
+        for option in ("-C", "--chdir"):
+            hit, _ = _detect(f"env {option} {repo} git checkout main", tmp_path, repo)
+            assert hit is True
+        hit, _ = _detect(f"env --chdir={repo} git checkout main", tmp_path, repo)
+        assert hit is True
+
+    def test_inline_alias_explicit_target_from_outside_blocks(self, repo, tmp_path):
+        command = f'git -c "alias.co=-C {repo} checkout" co main'
+        hit, _ = _detect(command, tmp_path, repo)
+        assert hit is True
+
+    def test_configured_alias_explicit_target_from_outside_blocks(
+        self, repo, tmp_path, monkeypatch
+    ):
+        import tools.self_repo_guard as mod
+
+        monkeypatch.setattr(
+            mod, "_read_git_alias", lambda *args: f"-C {repo} checkout"
+        )
+        hit, _ = _detect("git co main", tmp_path, repo)
+        assert hit is True
+
+
+def _resolve_for_test(path: Path) -> Path:
+    """Match the guard's host-normalized logical path in a test-only helper."""
+    import tools.self_repo_guard as mod
+
+    return mod._resolve(str(path), Path("/"))

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -54,8 +54,24 @@ class TestBlocksMutationsInSourceRepo:
         hit, _ = _detect("git checkout main", repo / "agent", repo)
         assert hit is True
 
-    def test_dash_c_targeting_repo_from_outside(self, repo, tmp_path):
-        hit, _ = _detect(f"git -C {repo} checkout pr-51020", tmp_path, repo)
+    @pytest.mark.parametrize("path_style", ["native", "git_bash"])
+    def test_dash_c_quoted_windows_targeting_repo_from_outside(
+        self, repo, tmp_path, path_style
+    ):
+        native = str(repo)
+        if path_style == "native":
+            target = native
+        else:
+            drive, tail = native.split(":", 1)
+            target = f"/{drive.lower()}{tail.replace(chr(92), '/') }"
+        hit, _ = _detect(f'git -C "{target}" checkout pr-51020', tmp_path, repo)
+        assert hit is True
+
+    def test_rejects_chained_explicit_targets(self, repo, tmp_path):
+        other = tmp_path / "other-project"
+        other.mkdir()
+        command = f'git -C "{repo}" -C "{other}" checkout pr-51020'
+        hit, _ = _detect(command, tmp_path, repo)
         assert hit is True
 
     def test_cd_into_repo_then_checkout(self, repo, tmp_path):

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -59,12 +59,24 @@ class TestBlocksMutationsInSourceRepo:
         self, repo, tmp_path, path_style
     ):
         native = str(repo)
+        cwd = tmp_path
+        source_root = repo
         if path_style == "native":
             target = native
         else:
-            drive, tail = native.split(":", 1)
-            target = f"/{drive.lower()}{tail.replace(chr(92), '/') }"
-        hit, _ = _detect(f'git -C "{target}" checkout pr-51020', tmp_path, repo)
+            if ":" in native:
+                drive, tail = native.split(":", 1)
+                target = f"/{drive.lower()}{tail.replace(chr(92), '/') }"
+            else:
+                # POSIX has no drive to translate. Pair the distinct /c/ form
+                # with the equivalent logical native path for this resolver.
+                drive = "c"
+                target = f"/{drive}{native}"
+                source_root = Path(f"{drive}:{native}")
+                cwd = Path("/")
+            assert target.startswith(f"/{drive.lower()}/")
+            assert target != native
+        hit, _ = _detect(f'git -C "{target}" checkout pr-51020', cwd, source_root)
         assert hit is True
 
     def test_rejects_chained_explicit_targets(self, repo, tmp_path):

--- a/tests/tools/test_self_repo_guard.py
+++ b/tests/tools/test_self_repo_guard.py
@@ -24,6 +24,39 @@ def _detect(command, cwd, root):
     return detect_self_repo_git_mutation(command, str(cwd), source_root=root)
 
 
+def _explicit_target_operands(
+    path: Path, path_style: str, cwd: Path
+) -> tuple[str, Path, Path]:
+    """Return distinct target spellings that share one guard-visible root."""
+    native_path = path
+    source_root = native_path
+    target_cwd = cwd
+    if native_path.drive:
+        drive = native_path.drive.removesuffix(":")
+        native_target = str(native_path)
+    else:
+        # On a host without drive semantics, the production resolver maps
+        # /c/... to the logical c:/... path relative to /. Use that same
+        # controlled logical root for both spellings instead of mixing the
+        # real fixture with an unrelated synthetic root.
+        drive = "c"
+        source_root = Path(f"{drive}:{native_path.as_posix()}")
+        target_cwd = Path("/")
+        native_target = str(source_root)
+
+    if path_style == "native":
+        target = native_target
+    else:
+        if native_path.drive:
+            tail = native_path.as_posix()[len(native_path.drive) :]
+        else:
+            tail = native_path.as_posix()
+        target = f"/{drive.lower()}{tail}"
+        assert target.startswith(f"/{drive.lower()}/")
+        assert target != native_target
+    return target, target_cwd, source_root
+
+
 class TestBlocksMutationsInSourceRepo:
     @pytest.mark.parametrize(
         "sub",
@@ -58,26 +91,22 @@ class TestBlocksMutationsInSourceRepo:
     def test_dash_c_quoted_windows_targeting_repo_from_outside(
         self, repo, tmp_path, path_style
     ):
-        native = str(repo)
-        cwd = tmp_path
-        source_root = repo
-        if path_style == "native":
-            target = native
-        else:
-            if ":" in native:
-                drive, tail = native.split(":", 1)
-                target = f"/{drive.lower()}{tail.replace(chr(92), '/') }"
-            else:
-                # POSIX has no drive to translate. Pair the distinct /c/ form
-                # with the equivalent logical native path for this resolver.
-                drive = "c"
-                target = f"/{drive}{native}"
-                source_root = Path(f"{drive}:{native}")
-                cwd = Path("/")
-            assert target.startswith(f"/{drive.lower()}/")
-            assert target != native
+        target, cwd, source_root = _explicit_target_operands(repo, path_style, tmp_path)
         hit, _ = _detect(f'git -C "{target}" checkout pr-51020', cwd, source_root)
         assert hit is True
+
+    def test_colon_bearing_posix_target_reaches_explicit_target_path(self):
+        colon_path = Path("/tmp/worker:123/hermes-agent")
+        target, cwd, source_root = _explicit_target_operands(
+            colon_path, "git_bash", Path("/")
+        )
+        assert colon_path.drive == ""
+        assert ":" in colon_path.as_posix()
+        hit, message = _detect(
+            f'git -C "{target}" checkout pr-51020', cwd, source_root
+        )
+        assert hit is True
+        assert message is not None
 
     def test_rejects_chained_explicit_targets(self, repo, tmp_path):
         other = tmp_path / "other-project"

--- a/tests/tools/test_terminal_self_repo_guard.py
+++ b/tests/tools/test_terminal_self_repo_guard.py
@@ -116,3 +116,10 @@ class TestSelfRepoGuardWiring:
         result, env = _run("git checkout main", config, monkeypatch, None)
         assert result.get("status") != "blocked"
         env.execute.assert_called_once()
+
+    def test_explicit_dash_c_targeting_repo_is_blocked(self, repo, monkeypatch, tmp_path):
+        config = _make_env_config(cwd=str(tmp_path))
+        result, env = _run(f"git -C {repo} checkout main", config, monkeypatch, repo)
+        assert result["status"] == "blocked"
+        assert str(repo) in result["error"]
+        env.execute.assert_not_called()

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -123,6 +123,27 @@ _WRAPPER_OPTIONS_WITH_ARG = {
 }
 _SIMPLE_WRAPPERS = frozenset({"builtin", "exec", "nohup", "setsid", "time"})
 _MAX_RECURSION = 4
+# Native Windows path: drive letter + separator. Used to avoid treating `\` as a
+# shell escape when the operand is clearly a filesystem path for Git.
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+# After approval.py's escape stripping, `D:\work\repo` becomes `D:workrepo` —
+# drive letter, colon, then a non-separator. Treat as untrusted (fail closed).
+_MANGLED_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[^\\/]")
+# Git-Bash / MSYS drive form: `/d/work/...` → `D:/work/...` (explicit Git
+# path operands only; always recognized so tests can pin behavior on POSIX).
+# Require a slash (or EOS) immediately after the single drive letter so
+# ordinary Unix paths like `/tmp/foo` and `/dev/null` never match.
+_GIT_BASH_DRIVE_RE = re.compile(r"^/([A-Za-z])(?:/(.*))?\Z")
+_GIT_PATH_OPTIONS_WITH_ARG = frozenset({
+    "-C",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+})
+_GIT_PATH_ENV_VARS = frozenset({"GIT_DIR", "GIT_WORK_TREE"})
+_CD_EXECUTABLES = frozenset({"cd", "pushd"})
+_ENV_CHDIR_KEY = "__hermes_env_chdir__"
 
 
 @dataclass
@@ -154,7 +175,19 @@ def _resolve(path_str: str, base: Path) -> Path:
     git_bash_drive = re.fullmatch(r"/([A-Za-z])/(.*)", expanded)
     if git_bash_drive:
         expanded = f"{git_bash_drive.group(1)}:/{git_bash_drive.group(2)}"
-    path = Path(expanded)
+    drive_path = re.match(r"^([A-Za-z]):([\\/].*)\Z", expanded)
+    if drive_path:
+        drive = drive_path.group(1)
+        rest = drive_path.group(2).replace("\\", "/")
+        if os.name != "nt":
+            # POSIX CI has no drive-letter paths.  Use a stable logical root
+            # (/c:/...) and lowercase the drive so native/Git-Bash spellings
+            # compare identically without depending on host mount points.
+            path = Path("/") / f"{drive.lower()}:{rest}"
+        else:
+            path = Path(f"{drive}:{rest}")
+    else:
+        path = Path(expanded)
     if not path.is_absolute():
         path = base / path
     try:
@@ -174,36 +207,210 @@ def _executable_name(value: str) -> str:
     return Path(value.replace("\\", "/")).name.removesuffix(".exe").lower()
 
 
-def _git_path_word(raw_word: str) -> str:
-    """Keep native Windows separators in explicit Git path operands.
+def _unquote_raw_preserve(raw: str) -> str:
+    """Strip a single layer of matching quotes without interpreting escapes."""
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
+        return raw[1:-1]
+    return raw
 
-    The shared shell deobfuscator treats every backslash as a shell escape.
-    That is correct for generic command words but corrupts a native Windows
-    path such as ``D:\\Temp\\hermes`` before Git target resolution sees it.
+
+def _raw_looks_like_windows_path(raw: str) -> bool:
+    """True when *raw* (possibly quoted) is a native Windows drive path."""
+    inner = _unquote_raw_preserve(raw)
+    if inner.startswith("\\\\"):
+        return True
+    if _WINDOWS_DRIVE_PATH_RE.match(inner):
+        return True
+    return bool(re.match(r"^[A-Za-z]:", inner) and "\\" in inner)
+
+
+def _strip_quotes_preserve_windows_path(raw_word: str) -> str:
+    """Strip shell quotes but keep ``\\`` as path separators in Windows paths."""
+    return _unquote_raw_preserve(raw_word)
+
+
+def _path_aware_shell_word(raw_word: str) -> str:
+    """Deobfuscate a shell word, preserving native Windows path separators.
+
+    approval.py's escape strip treats ``\\`` as a shell escape, which mangles
+    quoted paths like ``"D:\\work\\hermes-agent"`` into ``D:workhermes-agent``.
+    For explicit filesystem operands we keep those separators instead.
+
+    Callers must only invoke this for Git path-operand positions (see
+    ``_shell_words_at``); it is not safe to apply to every shell token.
     """
-    if len(raw_word) >= 2 and raw_word[0] == raw_word[-1] == '"':
-        return raw_word[1:-1]
-    return raw_word
+    assign = _ASSIGNMENT_RE.fullmatch(raw_word)
+    if assign:
+        name, _, value_raw = raw_word.partition("=")
+        if name in _GIT_PATH_ENV_VARS and _raw_looks_like_windows_path(value_raw):
+            return f"{name}={_strip_quotes_preserve_windows_path(value_raw)}"
+        return _deobfuscate_shell_word_for_detection(raw_word)
+
+    for prefix in ("--work-tree=", "--git-dir=", "--chdir="):
+        if raw_word.startswith(prefix):
+            value = raw_word[len(prefix) :]
+            if _raw_looks_like_windows_path(value):
+                return prefix + _strip_quotes_preserve_windows_path(value)
+            return _deobfuscate_shell_word_for_detection(raw_word)
+
+    if (
+        raw_word.startswith("-C")
+        and len(raw_word) > 2
+        and not raw_word.startswith("--")
+    ):
+        value = raw_word[2:]
+        if _raw_looks_like_windows_path(value):
+            return "-C" + _strip_quotes_preserve_windows_path(value)
+        return _deobfuscate_shell_word_for_detection(raw_word)
+
+    if _raw_looks_like_windows_path(raw_word):
+        return _strip_quotes_preserve_windows_path(raw_word)
+    return _deobfuscate_shell_word_for_detection(raw_word)
+
+
+def _is_glued_git_path_option(raw_word: str) -> bool:
+    """True for ``-Cpath`` / ``--git-dir=`` / ``--work-tree=`` glued forms."""
+    if raw_word.startswith("--work-tree=") or raw_word.startswith("--git-dir="):
+        return True
+    return (
+        raw_word.startswith("-C")
+        and len(raw_word) > 2
+        and not raw_word.startswith("--")
+    )
+
+
+def _is_git_path_env_assignment(raw_word: str) -> bool:
+    """True for ``GIT_DIR=...`` / ``GIT_WORK_TREE=...`` assignment words."""
+    if not _ASSIGNMENT_RE.fullmatch(raw_word):
+        return False
+    name, _, _ = raw_word.partition("=")
+    return name in _GIT_PATH_ENV_VARS
+
+
+def _windows_git_bash_to_drive(path: str) -> str | None:
+    """Translate Git-Bash ``/d/work/...`` to ``D:/work/...``, else None."""
+    match = _GIT_BASH_DRIVE_RE.fullmatch(path)
+    if not match:
+        return None
+    drive = match.group(1).upper()
+    rest = match.group(2)
+    if rest is None:
+        return f"{drive}:/"
+    return f"{drive}:/{rest}"
+
+
+def _is_mangled_windows_drive(path: str) -> bool:
+    """True when a drive path lost its separators (escape-strip artifact)."""
+    return bool(_MANGLED_WINDOWS_DRIVE_RE.match(path))
+
+
+def _normalize_git_path_operand(path: str) -> str:
+    """Normalize an explicit Git path operand for resolve/compare.
+
+    Preserves native Windows separators; maps Git-Bash drive form to
+    ``D:/...``. Does not require running on Windows.
+    """
+    git_bash = _windows_git_bash_to_drive(path)
+    if git_bash is not None:
+        return git_bash
+    return path
+
+
+def _explicit_git_path(path: str, base: Path) -> Path:
+    """Resolve an explicit Git ``-C`` / work-tree path operand."""
+    return _resolve_git_target(_normalize_git_path_operand(path), base)
+
+
+def _resolve_git_target(path_str: str, base: Path) -> Path:
+    """Resolve a Git path operand with Windows-aware absolute detection.
+
+    Drive-letter paths (``D:/...``, ``D:\\...``) are absolute for comparison
+    even when pathlib on POSIX would treat them as relative.
+    """
+    normalized = _normalize_git_path_operand(path_str)
+    expanded = os.path.expanduser(normalized)
+    if _WINDOWS_DRIVE_PATH_RE.match(expanded):
+        # Resolve rather than returning a lexical Path: Windows Git resolves
+        # balanced ``..`` components before selecting its worktree.  On POSIX,
+        # _resolve supplies the stable logical /d:/... representation used by
+        # the cross-platform tests and by synthetic drive-form roots.
+        return _resolve(expanded, base)
+    return _resolve(expanded, base)
 
 
 def _shell_words_at(command: str, start: int) -> list[str]:
+    """Tokenize a shell command start, path-preserving explicit operands.
+
+    Windows backslash preservation applies solely to:
+    - the next word after bare ``-C`` / ``--git-dir`` / ``--work-tree`` /
+      ``--namespace`` / ``--exec-path``
+    - glued ``--work-tree=VALUE`` / ``--git-dir=VALUE`` / ``-CVALUE``
+    - ``GIT_DIR=`` / ``GIT_WORK_TREE=`` assignment values (when Windows-looking)
+    - ``cd`` / ``pushd`` operands and ``git worktree remove|move`` targets,
+      whose backslash-mangled forms otherwise fail open (same defect class)
+
+    Every other token uses ``_deobfuscate_shell_word_for_detection`` unchanged
+    so non-path words (aliases, subcommands, ordinary args) are not rewritten.
+    """
     words: list[str] = []
     cursor = start
-    preserve_next_git_path = False
+    expect_path_operand = False
+    expect_env_path_operand = False
+    worktree_target_pending = False
+    saw_git = False
+    saw_worktree = False
+    saw_env = False
     for _ in range(64):
         word_start, word_end, raw_word = _read_shell_word(command, cursor)
         if word_start == word_end:
             break
         if words and "\n" in command[cursor:word_start]:
             break
-        if preserve_next_git_path:
-            word = _git_path_word(raw_word)
-            preserve_next_git_path = False
+
+        if _is_git_path_env_assignment(raw_word):
+            # Assignment values are explicit Git selectors too; preserve the
+            # raw path before approval's generic escape deobfuscation.
+            word = _path_aware_shell_word(raw_word)
+        elif worktree_target_pending:
+            if raw_word.startswith("-") and raw_word != "-":
+                word = _deobfuscate_shell_word_for_detection(raw_word)
+            else:
+                word = _path_aware_shell_word(raw_word)
+                worktree_target_pending = False
+        elif expect_env_path_operand:
+            word = _path_aware_shell_word(raw_word)
+            expect_env_path_operand = False
+        elif expect_path_operand:
+            word = _path_aware_shell_word(raw_word)
+            expect_path_operand = False
+        elif _is_glued_git_path_option(raw_word) or (
+            saw_env and raw_word.startswith("--chdir=")
+        ):
+            word = _path_aware_shell_word(raw_word)
         else:
             word = _deobfuscate_shell_word_for_detection(raw_word)
         words.append(word)
-        if word in {"-C", "--git-dir", "--work-tree"}:
-            preserve_next_git_path = True
+
+        if worktree_target_pending:
+            pass
+        elif expect_path_operand:
+            pass
+        elif word in _GIT_PATH_OPTIONS_WITH_ARG:
+            expect_path_operand = True
+        elif saw_env and word in {"-C", "--chdir"}:
+            expect_env_path_operand = True
+        elif not saw_git and _executable_name(word) == "git":
+            saw_git = True
+        elif not saw_git and _executable_name(word) == "env":
+            saw_env = True
+        elif saw_git and not saw_worktree and word == "worktree":
+            saw_worktree = True
+        elif saw_git and saw_worktree and word in _WORKTREE_TARGET_ACTIONS:
+            worktree_target_pending = True
+            saw_worktree = False
+        elif len(words) == 1 and _executable_name(word) in _CD_EXECUTABLES:
+            expect_path_operand = True
+
         cursor = word_end
     return words
 
@@ -244,7 +451,28 @@ def _command_parts(words: list[str]) -> tuple[dict[str, str], str | None, list[s
             index = _consume_options(words, index + 1, _SUDO_OPTIONS_WITH_ARG)
             continue
         if executable == "env":
-            index = _consume_options(words, index + 1, _ENV_OPTIONS_WITH_ARG)
+            option_index = index + 1
+            while option_index < len(words):
+                option = words[option_index]
+                option_name = option.split("=", 1)[0]
+                if option_name in {"-C", "--chdir"}:
+                    if "=" in option:
+                        env[_ENV_CHDIR_KEY] = option.split("=", 1)[1]
+                        option_index += 1
+                    elif option_index + 1 < len(words):
+                        env[_ENV_CHDIR_KEY] = words[option_index + 1]
+                        option_index += 2
+                    else:
+                        option_index += 1
+                    continue
+                if option == "--":
+                    option_index += 1
+                    break
+                if option.startswith("-"):
+                    option_index += 2 if option_name in _ENV_OPTIONS_WITH_ARG and "=" not in option else 1
+                    continue
+                break
+            index = option_index
             continue
         if executable == "command":
             if index + 1 < len(words) and words[index + 1] in {"-v", "-V"}:
@@ -481,13 +709,32 @@ def _git_target_and_subcommand(
     args: list[str],
     current_dir: Path,
     env: dict[str, str],
-) -> tuple[Path, str | None, list[str], dict[str, str], bool]:
+    root: Path | None = None,
+) -> tuple[Path, str | None, list[str], dict[str, str]]:
     target = current_dir
     work_tree: str | None = None
+    git_dir: str | None = None
     aliases: dict[str, str] = {}
-    ambiguous_target = False
-    target_option_seen = False
     index = 0
+    dash_c_count = 0
+    # Conservative multi -C rule: if any intermediate -C lands inside the
+    # source root, treat the effective target as the source root so mutating
+    # subcommands block — even when a later -C leaves the tree. Safe reads and
+    # all-outside chained targets stay allowed. Ambiguous / mangled Windows
+    # operands also fail closed (target := root) rather than falling back to
+    # ambient cwd.
+    any_dash_c_within_root = False
+    untrusted_path_operand = False
+
+    def _apply_explicit_path(path_str: str, base: Path) -> Path:
+        nonlocal any_dash_c_within_root, untrusted_path_operand
+        if _is_mangled_windows_drive(path_str):
+            untrusted_path_operand = True
+            return root if root is not None else base
+        resolved = _explicit_git_path(path_str, base)
+        if root is not None and _is_within(resolved, root):
+            any_dash_c_within_root = True
+        return resolved
 
     while index < len(args):
         arg = args[index]
@@ -495,24 +742,28 @@ def _git_target_and_subcommand(
             index += 1
             break
         if arg == "-C" and index + 1 < len(args):
-            ambiguous_target = ambiguous_target or target_option_seen
-            target_option_seen = True
-            target = _resolve(args[index + 1], target)
+            dash_c_count += 1
+            target = _apply_explicit_path(args[index + 1], target)
             index += 2
             continue
         if arg.startswith("-C") and len(arg) > 2:
-            ambiguous_target = ambiguous_target or target_option_seen
-            target_option_seen = True
-            target = _resolve(arg[2:], target)
+            dash_c_count += 1
+            target = _apply_explicit_path(arg[2:], target)
             index += 1
             continue
         if arg in {"--work-tree", "--git-dir", "--namespace", "--exec-path"}:
             if arg == "--work-tree" and index + 1 < len(args):
                 work_tree = args[index + 1]
+            elif arg == "--git-dir" and index + 1 < len(args):
+                git_dir = args[index + 1]
             index += 2
             continue
         if arg.startswith("--work-tree="):
             work_tree = arg.split("=", 1)[1]
+            index += 1
+            continue
+        if arg.startswith("--git-dir="):
+            git_dir = arg.split("=", 1)[1]
             index += 1
             continue
         if arg == "-c" and index + 1 < len(args):
@@ -532,11 +783,44 @@ def _git_target_and_subcommand(
             continue
         break
 
+    # GIT_DIR / GIT_WORK_TREE assignment values are consumed like their
+    # command-line counterparts (the residual `--git-dir`/`GIT_DIR` fail-open).
+    git_dir = git_dir or env.get("GIT_DIR")
     explicit_work_tree = work_tree or env.get("GIT_WORK_TREE")
+
+    # Map an explicit git-dir operand to the worktree root it governs: a
+    # `.git` directory (or gitdir-file, for linked worktrees) governs its
+    # parent checkout; bare/custom git dirs have no worktree.
+    git_dir_worktree: Path | None = None
+    if git_dir is not None:
+        if _is_mangled_windows_drive(git_dir):
+            untrusted_path_operand = True
+        else:
+            git_dir_path = _explicit_git_path(git_dir, target)
+            if git_dir_path.name.lower() == ".git":
+                git_dir_worktree = git_dir_path.parent
+                if root is not None and _is_within(git_dir_worktree, root):
+                    any_dash_c_within_root = True
+
+    if root is not None and (
+        untrusted_path_operand or (dash_c_count > 1 and any_dash_c_within_root)
+    ):
+        target = root
+    elif git_dir is not None:
+        if git_dir_worktree is None:
+            # Explicit git-dir with no resolvable worktree (bare repo, custom
+            # git dir, submodule git dir): fail closed for mutating
+            # subcommands rather than assuming the ambient cwd is safe.
+            target = root if root is not None else target
+        else:
+            target = git_dir_worktree
     if explicit_work_tree:
-        target = _resolve(explicit_work_tree, target)
+        # The work tree governs which files a checkout rewrites — apply it
+        # last so GIT_DIR=<other> + GIT_WORK_TREE=<source> still blocks.
+        target = _apply_explicit_path(explicit_work_tree, target)
+
     subcommand = args[index].lower() if index < len(args) else None
-    return target, subcommand, args[index + 1 :], aliases, ambiguous_target
+    return target, subcommand, args[index + 1 :], aliases
 
 
 def _mutates_worktree(subcommand: str, args: list[str]) -> bool:
@@ -589,7 +873,12 @@ def _inspect_git_worktree(args: list[str], cwd: Path, root: Path) -> str | None:
     target_index = _next_positional(args, action_index + 1)
     if target_index >= len(args):
         return None
-    if _resolve(args[target_index], cwd) == root:
+    target_word = args[target_index]
+    # Escape-stripped drive operands are untrustworthy in this position too —
+    # fail closed rather than letting a mangled path miss the root comparison.
+    if _is_mangled_windows_drive(target_word):
+        return f"git worktree {action}"
+    if _explicit_git_path(target_word, cwd) == root:
         return f"git worktree {action}"
     return None
 
@@ -617,20 +906,16 @@ def _inspect_git(
     root: Path,
     depth: int,
 ) -> str | None:
-    target, subcommand, sub_args, inline_aliases, ambiguous_target = _git_target_and_subcommand(
-        args, current_dir, env
+    target, subcommand, sub_args, inline_aliases = _git_target_and_subcommand(
+        args, current_dir, env, root=root
     )
     if subcommand is None:
         return None
     # `worktree` names its victim as an argument, so the cwd check does not apply.
     if subcommand == "worktree":
         return _inspect_git_worktree(sub_args, target, root)
-    if ambiguous_target:
-        return f"git {subcommand}"
-    if not _is_within(target, root):
-        return None
     if _mutates_worktree(subcommand, sub_args):
-        return f"git {subcommand}"
+        return f"git {subcommand}" if _is_within(target, root) else None
     if subcommand in _KNOWN_GIT_BUILTINS:
         return None
     if depth >= _MAX_RECURSION:
@@ -703,24 +988,28 @@ def _find_mutation(command: str, cwd: Path, root: Path, depth: int = 0) -> str |
             continue
 
         current_dir = cwd_by_scope[scope]
-        cd_target = _cd_target(executable, args, current_dir)
+        env_chdir = env.pop(_ENV_CHDIR_KEY, None)
+        effective_dir = (
+            _resolve(env_chdir, current_dir) if env_chdir else current_dir
+        )
+        cd_target = _cd_target(executable, args, effective_dir)
         if cd_target is not None:
             pending_cd[scope] = cd_target
             continue
 
         executable_name = _executable_name(executable)
         if executable_name == "git":
-            operation = _inspect_git(executable, args, current_dir, env, root, depth)
+            operation = _inspect_git(executable, args, effective_dir, env, root, depth)
             if operation:
                 return operation
         elif executable_name in {"gh", "hub"}:
-            operation = _inspect_github_cli(executable, args, current_dir, root)
+            operation = _inspect_github_cli(executable, args, effective_dir, root)
             if operation:
                 return operation
         elif executable_name in _SHELL_EXECUTABLES:
             script = _shell_script_arg(args)
             if script:
-                operation = _find_mutation(script, current_dir, root, depth + 1)
+                operation = _find_mutation(script, effective_dir, root, depth + 1)
                 if operation:
                     return operation
 

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -150,7 +150,11 @@ def get_running_source_root() -> Path | None:
 
 
 def _resolve(path_str: str, base: Path) -> Path:
-    path = Path(os.path.expanduser(path_str))
+    expanded = os.path.expanduser(path_str)
+    git_bash_drive = re.fullmatch(r"/([A-Za-z])/(.*)", expanded)
+    if git_bash_drive:
+        expanded = f"{git_bash_drive.group(1)}:/{git_bash_drive.group(2)}"
+    path = Path(expanded)
     if not path.is_absolute():
         path = base / path
     try:
@@ -170,16 +174,36 @@ def _executable_name(value: str) -> str:
     return Path(value.replace("\\", "/")).name.removesuffix(".exe").lower()
 
 
+def _git_path_word(raw_word: str) -> str:
+    """Keep native Windows separators in explicit Git path operands.
+
+    The shared shell deobfuscator treats every backslash as a shell escape.
+    That is correct for generic command words but corrupts a native Windows
+    path such as ``D:\\Temp\\hermes`` before Git target resolution sees it.
+    """
+    if len(raw_word) >= 2 and raw_word[0] == raw_word[-1] == '"':
+        return raw_word[1:-1]
+    return raw_word
+
+
 def _shell_words_at(command: str, start: int) -> list[str]:
     words: list[str] = []
     cursor = start
+    preserve_next_git_path = False
     for _ in range(64):
         word_start, word_end, raw_word = _read_shell_word(command, cursor)
         if word_start == word_end:
             break
         if words and "\n" in command[cursor:word_start]:
             break
-        words.append(_deobfuscate_shell_word_for_detection(raw_word))
+        if preserve_next_git_path:
+            word = _git_path_word(raw_word)
+            preserve_next_git_path = False
+        else:
+            word = _deobfuscate_shell_word_for_detection(raw_word)
+        words.append(word)
+        if word in {"-C", "--git-dir", "--work-tree"}:
+            preserve_next_git_path = True
         cursor = word_end
     return words
 
@@ -457,10 +481,12 @@ def _git_target_and_subcommand(
     args: list[str],
     current_dir: Path,
     env: dict[str, str],
-) -> tuple[Path, str | None, list[str], dict[str, str]]:
+) -> tuple[Path, str | None, list[str], dict[str, str], bool]:
     target = current_dir
     work_tree: str | None = None
     aliases: dict[str, str] = {}
+    ambiguous_target = False
+    target_option_seen = False
     index = 0
 
     while index < len(args):
@@ -469,10 +495,14 @@ def _git_target_and_subcommand(
             index += 1
             break
         if arg == "-C" and index + 1 < len(args):
+            ambiguous_target = ambiguous_target or target_option_seen
+            target_option_seen = True
             target = _resolve(args[index + 1], target)
             index += 2
             continue
         if arg.startswith("-C") and len(arg) > 2:
+            ambiguous_target = ambiguous_target or target_option_seen
+            target_option_seen = True
             target = _resolve(arg[2:], target)
             index += 1
             continue
@@ -506,7 +536,7 @@ def _git_target_and_subcommand(
     if explicit_work_tree:
         target = _resolve(explicit_work_tree, target)
     subcommand = args[index].lower() if index < len(args) else None
-    return target, subcommand, args[index + 1 :], aliases
+    return target, subcommand, args[index + 1 :], aliases, ambiguous_target
 
 
 def _mutates_worktree(subcommand: str, args: list[str]) -> bool:
@@ -587,7 +617,7 @@ def _inspect_git(
     root: Path,
     depth: int,
 ) -> str | None:
-    target, subcommand, sub_args, inline_aliases = _git_target_and_subcommand(
+    target, subcommand, sub_args, inline_aliases, ambiguous_target = _git_target_and_subcommand(
         args, current_dir, env
     )
     if subcommand is None:
@@ -595,6 +625,8 @@ def _inspect_git(
     # `worktree` names its victim as an argument, so the cwd check does not apply.
     if subcommand == "worktree":
         return _inspect_git_worktree(sub_args, target, root)
+    if ambiguous_target:
+        return f"git {subcommand}"
     if not _is_within(target, root):
         return None
     if _mutates_worktree(subcommand, sub_args):


### PR DESCRIPTION
## Summary

Fixes #82569 by closing the full explicit Git-target fail-open and over-block class in the live-source mutation guard:

- resolves `-C`, `--git-dir`, `--work-tree`, `GIT_DIR`, and `GIT_WORK_TREE` through one effective-target model;
- preserves native Windows, Git-Bash, UNC, quoted, glued, environment, colon-bearing POSIX, and balanced-`..` path semantics;
- honors `env -C` / `env --chdir`, worktree remove/move targets, configured and inline aliases, and chained targets;
- blocks mutations resolving into the running source checkout while preserving safe reads and targets proven outside it.

## Collision, dedup, and credit

#82586 is the competing implementation for the same issue. It supplied useful Windows/path coverage, but its pinned head introduced an alias regression and did not close every selector family. This PR is the canonical non-regressing union.

The final class-close commit preserves that contribution explicitly:

`Co-authored-by: Olympusbuildz <Olympus.roots@outlook.com>`

Origin credit is also preserved through #65791 → merged salvage #81627. Shared-file PRs #81664, #81702, #82002, and #82560 close distinct sibling defects; they are coordinated in the #79564 merge order rather than silently reimplemented.

## Verification

Exact head: `3b5e06be8e86b5b69875d62d8007787dd69ab90b`  
Tree: `705b31c376e81455cff234f56f1bb45ca8851fb0`  
Parent: `167127b49aa5ab3f111081d9b2d52cb6c8bfda6e`

- `scripts/run_tests.sh tests/tools/test_self_repo_guard.py -q ...`: **148 passed / 1 failed** — only the pre-existing Windows `HOME`/`USERPROFILE` tilde baseline.
- `scripts/run_tests.sh tests/tools/test_terminal_self_repo_guard.py -q ...`: **8 passed / 0 failed**.
- Independent real-mutation batteries: balanced-dotdot `-C`, `--git-dir`, `--work-tree`, environment, and `env --chdir` forms were blocked; the same unguarded commands returned `0` and switched fixture branches.
- Two independent final reviewers: **APPROVED** (`7e286d45daa0a3636fab2260708ae4d08cfb5d1715e937ae47b8b56b79b5f3f0`, `7160022cf9de8f54b139100f47626f94455b1cf54edff9830644d5be61c31c46`).
- Windows-footgun scan: **0 matches / 939 files**; `git diff --check`: clean; all changed files compile.
- 2k Law: `1043`, `760`, and `125` lines — every changed file below 2,000.
- Single DCO-signed class-close commit by Axl Ibiza, MBA with contributor co-authorship preserved.

## Scope

Only:

- `tools/self_repo_guard.py`
- `tests/tools/test_self_repo_guard.py`
- `tests/tools/test_terminal_self_repo_guard.py`

## Interlock

Part of #79564 — canonical Wave C class-close for the self-repo Git mutation guard.  
Discovery context: #82496.  
Fixes #82569.  
Supersedes with credit: #82586.
