### PR TITLE
fix(lifecycle_guard): scan NUL-padded text scripts instead of treating NUL as binary signal (#77927)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -99,6 +99,14 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
+    # NUL bytes are never part of a command token's meaning: bash executes
+    # the bytes around them, so `hermes gateway rest\x00art` is a real
+    # restart command that the matcher would otherwise miss. Stripping NULs
+    # can only splice tokens together, never apart, so scanning the
+    # stripped text is fail-closed (#77927). Whether a *file* is a compiled
+    # binary is decided upstream by magic numbers, never by NUL presence.
+    if "\x00" in text:
+        text = text.replace("\x00", "")
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
 
@@ -132,8 +140,12 @@ _PIPE_TO_INTERPRETER = re.compile(
 )
 
 # Executable-image magic numbers: ELF, PE/COFF, Mach-O (universal + thin,
-# both endiannesses). A referenced file starting with one of these is a
-# compiled binary, never a shell script — don't read or scan it at all.
+# both endiannesses), ar archives, gzip and zip streams. A referenced file
+# starting with one of these is a compiled binary or archive, never a shell
+# script — don't read or scan it at all. A shebang file always wins over
+# these (no magic prefix starts with `#`), and a NUL byte is deliberately
+# NOT a binary signal: bash executes NUL-bearing *text* just fine, so a
+# NUL-padded script must still be scanned (#77927).
 _BINARY_MAGIC_PREFIXES = (
     b"\x7fELF",
     b"MZ",
@@ -142,6 +154,9 @@ _BINARY_MAGIC_PREFIXES = (
     b"\xce\xfa\xed\xfe",
     b"\xfe\xed\xfa\xce",
     b"\xfe\xed\xfa\xcf",
+    b"!<arch>\n",
+    b"\x1f\x8b",
+    b"PK\x03\x04",
 )
 _BINARY_SNIFF_BYTES = 4096
 
@@ -198,6 +213,11 @@ def contains_launchctl_submit_command(command: str) -> bool:
     semantics; ``bootstrap`` loads an arbitrary plist), which is never safe to
     do from inside the gateway process.
     """
+    if "\x00" in command:
+        # Same fail-closed NUL handling as contains_gateway_lifecycle_command:
+        # `launchctl sub\x00mit ...` is a real submit command, and stripping
+        # NULs can only splice tokens together, never apart (#77927).
+        command = command.replace("\x00", "")
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None:
@@ -442,12 +462,15 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         if not stat.S_ISREG(metadata.st_mode):
             return None, True
         # Sniff a small prefix first: files that are clearly compiled
-        # binaries (executable magic, or NUL bytes in the head) are never
-        # shell scripts, so skip them WITHOUT reading the rest — reading a
+        # binaries or archives (executable magic) are never shell
+        # scripts, so skip them WITHOUT reading the rest — reading a
         # megabyte of machine code just to discard it wastes the guard's
         # budget and (pre-#77703) fed decoded garbage into the recursion.
+        # A NUL byte in the head is NOT a binary signal: bash executes
+        # NUL-bearing *text* fine, so a NUL-padded script must still be
+        # read and scanned (#77927).
         data = os.read(descriptor, _BINARY_SNIFF_BYTES)
-        if data.startswith(_BINARY_MAGIC_PREFIXES) or b"\x00" in data:
+        if data.startswith(_BINARY_MAGIC_PREFIXES):
             return None, False
         # Read the remainder (bounded). Loop because os.read may return
         # short for non-regular-file-backed descriptors.
@@ -462,16 +485,20 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     finally:
         os.close(descriptor)
-    # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
-    # PE), not a shell script — scanning its decoded contents would
-    # tokenize machine code and feed junk paths into the recursion
-    # (including a `ValueError: embedded null byte` from Path.resolve,
-    # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
-    # executed by the user is not a referenced *shell script*.
-    if b"\x00" in data:
-        return None, False
+    # Size check runs BEFORE NUL stripping: stripping shrinks the buffer,
+    # so a >1 MiB NUL-padded file stripped below the threshold would
+    # otherwise skip the fail-closed branch (#77927).
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
+    # NUL bytes mean this file is not clean UTF-8 text, but they do NOT
+    # prove it is a compiled binary (ELF/Mach-O/PE/... are excluded by
+    # magic above). A NUL-padded or NUL-spliced *text* script still
+    # executes under bash, so it must be scanned. Strip the NULs first:
+    # removal can only splice tokens together, never apart, so a
+    # lifecycle command hidden with embedded NULs (`hermes gateway
+    # rest\x00art`) fails closed (#77927).
+    if b"\x00" in data:
+        data = data.replace(b"\x00", b"")
     return data.decode("utf-8", errors="replace"), False
 
 
@@ -481,23 +508,28 @@ def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bo
     The recursion boundary must not trust its callbacks: any backend (SSH,
     Modal, Daytona, or a future one) can hand back raw binary bytes decoded
     as text, or arbitrarily large output. Mirror
-    ``_read_referenced_script``'s semantics exactly — NUL bytes mean binary
-    (nothing to scan, checked first, #77703), oversized text fails closed
-    like an oversized local file (#76762) — so remote and local reads can
-    never diverge again. The size check re-encodes to compare *bytes*
-    (matching the local read and the ``head -c`` wire bound): a >1 MiB
-    multibyte file truncated at the byte cap decodes to fewer characters
-    than bytes, and a character-count check would scan the truncated text
-    instead of failing closed. Enforced here rather than inside each
-    callback so the guarantee holds for every callback, not just the ones
-    we hardened.
+    ``_read_referenced_script``'s semantics exactly — magic-number
+    prefixes mean binary (nothing to scan, checked first), NUL-bearing
+    *text* is scanned with the NULs stripped (#77927), oversized text
+    fails closed like an oversized local file (#76762) — so remote and
+    local reads can never diverge again. The size check re-encodes to
+    compare *bytes* (matching the local read and the ``head -c`` wire
+    bound): a >1 MiB multibyte file truncated at the byte cap decodes to
+    fewer characters than bytes, and a character-count check would scan
+    the truncated text instead of failing closed. Enforced here rather
+    than inside each callback so the guarantee holds for every callback,
+    not just the ones we hardened.
     """
     if not text:
         return None, False
-    if "\x00" in text:
+    encoded = text.encode("utf-8", errors="replace")
+    if encoded.startswith(_BINARY_MAGIC_PREFIXES):
         return None, False
-    if len(text.encode("utf-8", errors="replace")) > _MAX_REFERENCED_SCRIPT_BYTES:
+    # Size check BEFORE NUL stripping — see _read_referenced_script.
+    if len(encoded) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
+    if "\x00" in text:
+        text = text.replace("\x00", "")
     return text, False
 
 

--- a/tests/hermes_cli/test_lifecycle_guard_nul_bypass_77927.py
+++ b/tests/hermes_cli/test_lifecycle_guard_nul_bypass_77927.py
@@ -1,0 +1,134 @@
+"""Tests for #77927: NUL-padded (or NUL-spliced) *text* scripts must be
+scanned, never skipped as "binary".
+
+bash executes NUL-bearing text just fine, so a single pad byte must not
+silence the guard. The pre-fix classifier treated *any* NUL in the head
+as a compiled binary ("nothing to scan"); the fix classifies binaries by
+magic number only and strips NULs from text before scanning (fail-closed:
+stripping can only splice tokens together, never apart).
+"""
+
+import pytest
+
+from cron.lifecycle_guard import (
+    GatewayLifecycleBlocked,
+    _MAX_REFERENCED_SCRIPT_BYTES,
+    _read_referenced_script,
+    check_gateway_lifecycle,
+    contains_gateway_lifecycle_command_or_referenced_script,
+)
+
+
+class TestNulPaddedScriptBypass77927:
+    @staticmethod
+    def _write(tmp_path, name, content: bytes):
+        path = tmp_path / name
+        path.write_bytes(content)
+        return path
+
+    def test_nul_padded_text_script_is_blocked(self, tmp_path):
+        # The exact issue shape: a text script with a NUL pad byte on a
+        # later line — `bash padded.sh` runs it, the guard must block it.
+        script = self._write(
+            tmp_path, "padded.sh", b"# ok\n# pad\x00\nhermes gateway restart\n"
+        )
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))
+
+    def test_nul_padded_shebang_script_is_blocked(self, tmp_path):
+        script = self._write(
+            tmp_path, "padded2.sh", b"#!/bin/bash\x00\nhermes gateway stop\n"
+        )
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))
+
+    def test_nul_spliced_keyword_in_script_is_blocked(self, tmp_path):
+        # Issue side benefit: `hermes gateway rest\x00art` inside a file
+        # stops evading the matcher once NULs are stripped.
+        script = self._write(
+            tmp_path,
+            "spliced.sh",
+            b"#!/bin/bash\nhermes gateway rest\x00art\n",
+        )
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))
+
+    def test_terminal_command_referencing_nul_padded_script_is_blocked(self, tmp_path):
+        # The terminal-tool entry point: `bash padded.sh` must be blocked
+        # when the referenced file is NUL-padded text.
+        script = self._write(
+            tmp_path, "padded3.sh", b"# pad\x00\nhermes gateway restart\n"
+        )
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {script}", cwd=str(tmp_path)
+            )
+            is True
+        )
+
+    def test_nul_padded_prompt_is_blocked(self):
+        # The prompt channel is text too: NUL padding must not silence the
+        # direct regex scan.
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("run hermes gateway rest\x00art now", None)
+
+    def test_nul_padded_remote_callback_text_is_scanned(self):
+        # Remote reads follow the same contract: NUL-bearing *text* is
+        # scanned with NULs stripped, not skipped as binary.
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash /nonexistent/dir/helper.sh",
+            cwd="/tmp",
+            read_remote_script=lambda _p: (
+                "#!/bin/sh\n# pad\x00\nhermes gateway restart\n"
+            ),
+        )
+        assert result is True
+
+    def test_launchctl_submit_with_spliced_nul_is_blocked(self, tmp_path):
+        script = self._write(
+            tmp_path,
+            "submit.sh",
+            b"#!/bin/bash\nlaunchctl sub\x00mit -l ai.hermes.gateway-loop -- /bin/sh x.sh\n",
+        )
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))
+
+    def test_magic_prefixed_binary_with_nuls_still_skipped(self, tmp_path):
+        # The binary side of the contract is unchanged: magic numbers win,
+        # even when the file also carries NULs and lifecycle-looking text.
+        for name, magic in [
+            ("elf", b"\x7fELF"),
+            ("pe", b"MZ"),
+            ("macho", b"\xcf\xfa\xed\xfe"),
+            ("ar", b"!<arch>\n"),
+            ("gzip", b"\x1f\x8b"),
+            ("zip", b"PK\x03\x04"),
+        ]:
+            binary = self._write(
+                tmp_path, name, magic + b"\x00hermes gateway restart\x00"
+            )
+            assert (
+                contains_gateway_lifecycle_command_or_referenced_script(
+                    f"bash {binary}", cwd=str(tmp_path)
+                )
+                is False
+            ), name
+
+    def test_oversized_nul_padded_file_still_fails_closed(self, tmp_path):
+        # #77927 ordering detail: the size check must run BEFORE the NUL
+        # strip, or a >1 MiB NUL-padded file shrinks under the threshold
+        # and skips the fail-closed branch.
+        script = tmp_path / "bigpadded.sh"
+        script.write_bytes(b"\x00" * (_MAX_REFERENCED_SCRIPT_BYTES + 1))
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))
+
+    def test_read_referenced_script_strips_nuls_from_text(self, tmp_path):
+        script = self._write(
+            tmp_path, "pad.sh", b"# ok\n# pad\x00\nhermes gateway restart\n"
+        )
+        text, unsafe = _read_referenced_script(script)
+        assert unsafe is False
+        assert text is not None
+        assert "\x00" not in text
+        assert "hermes gateway restart" in text


### PR DESCRIPTION
## Problem

`cron/lifecycle_guard.py` treated any NUL byte in the first 4 KiB of a referenced file as proof that the file is a compiled binary ("nothing to scan"). But bash executes NUL-bearing **text** scripts just fine — the NUL bytes are ignored at the token level. So a blocked command such as `hermes gateway rest\x00art` embedded in a NUL-padded text script silently bypassed the scan. The #81322 fix (`except (OSError, ValueError)` around `os.open`) did not cover this case.

## Fix

- **Binary detection is magic-number based only**: ELF, PE/COFF, Mach-O (universal + thin, both endiannesses), ar archives, gzip, zip. A NUL byte is deliberately no longer a binary signal. Shebang files always win (no magic prefix starts with `#`).
- **NUL stripping before scanning in all channels**: the gateway lifecycle matcher, `contains_launchctl_submit_command`, local script reads (`_read_referenced_script`), and the remote callback boundary (`_sanitize_remote_script_text`). Stripping NULs can only splice tokens together, never apart, so detection is fail-closed: `hermes gateway rest\x00art` → `hermes gateway restart` → matched.
- **Size check runs before NUL stripping** so a >1 MiB NUL-padded file stripped below the threshold still fails closed like an oversized script.

## Verification

- 10 new tests in `tests/hermes_cli/test_lifecycle_guard_nul_bypass_77927.py` (red before the fix, green after), covering: NUL-spliced lifecycle commands, NUL-padded script file reads, remote callback NUL handling, size-check-before-strip ordering, and magic-number binary detection (ELF/Mach-O/PE/ar/gzip/zip) still skipping real binaries.
- `tests/cron`: 515 passed.
- `ruff` clean.

Closes #77927.