### PR TITLE
fix(desktop): prevent searchable select option clipping

### DIFF
--- a/apps/desktop/src/app/settings/searchable-select.test.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.test.tsx
@@ -95,6 +95,17 @@ describe('SearchableSelect', () => {
 
     expect(screen.getByRole('combobox').textContent).toContain('Search…')
   })
+
+  it('lets the option list grow wider than the trigger for long values', () => {
+    render(<SearchableSelect onChange={vi.fn()} options={['America/Argentina/Buenos_Aires']} value="" />)
+
+    fireEvent.click(screen.getByRole('combobox'))
+
+    const popover = screen.getByText('America/Argentina/Buenos_Aires').closest('[data-slot="popover-content"]')
+    expect(popover?.classList.contains('w-max')).toBe(true)
+    expect(popover?.classList.contains('min-w-[var(--radix-popover-trigger-width)]')).toBe(true)
+    expect(popover?.classList.contains('w-[var(--radix-popover-trigger-width)]')).toBe(false)
+  })
 })
 
 describe('ConfigField searchable routing', () => {

--- a/apps/desktop/src/app/settings/searchable-select.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.tsx
@@ -88,7 +88,10 @@ export function SearchableSelect({
           <Codicon className="shrink-0 opacity-60" name={open ? 'chevron-up' : 'chevron-down'} size="1rem" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent
+        align="start"
+        className="w-max min-w-[var(--radix-popover-trigger-width)] max-w-[calc(100vw-2rem)] p-0"
+      >
         <Command filter={rankSearchOption}>
           <CommandInput autoFocus placeholder={placeholder} />
           <CommandList>


### PR DESCRIPTION
## Summary
- let searchable-select popovers grow to their content width instead of pinning them to the trigger
- preserve the trigger width as a minimum and cap the popover to the viewport
- add a focused regression test using a long IANA timezone identifier

## Tests
- `npm run test:ui --workspace apps/desktop -- src/app/settings/searchable-select.test.tsx` (13 passed)
- `npx eslint apps/desktop/src/app/settings/searchable-select.tsx apps/desktop/src/app/settings/searchable-select.test.tsx`
- `npm run typecheck --workspace apps/desktop`

Fixes #82635
