### PR TITLE
fix(agent): exclude write-format aliases from verification

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -146,7 +146,10 @@ _JS_LOCKFILES = (
 )
 
 # package.json scripts / Makefile targets worth surfacing as verify commands.
-_VERIFY_TARGETS = ("test", "tests", "lint", "typecheck", "check", "build", "fmt", "format")
+# Formatting aliases are intentionally excluded: their names alone cannot prove
+# they are non-writing checks, and these commands feed prompt, stop-nudge, and
+# detected-recipe consumers.
+_VERIFY_TARGETS = ("test", "tests", "lint", "typecheck", "check", "build")
 _MAX_VERIFY_COMMANDS = 8
 _MAX_FACT_FILE_BYTES = 256 * 1024
 

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -156,6 +156,37 @@ class TestProjectFacts:
         assert facts.verify_commands == ["pnpm run test"]  # dev excluded
         assert facts.context_files == []
 
+    def test_write_format_script_is_not_a_verification_command(self, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"format": "prettier --write ."}})
+        )
+        (tmp_path / "pnpm-lock.yaml").write_text("")
+
+        facts = cc.detect_project_facts(tmp_path)
+
+        assert facts.verify_commands == []
+
+    def test_format_aliases_are_excluded_while_test_commands_remain(self, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps(
+                {
+                    "scripts": {
+                        "test": "vitest",
+                        "fmt": "prettier --write .",
+                        "format": "prettier --write .",
+                    }
+                }
+            )
+        )
+        (tmp_path / "pnpm-lock.yaml").write_text("")
+        (tmp_path / "Makefile").write_text(
+            "test:\n\t@true\nfmt:\n\t@true\nformat:\n\t@true\n"
+        )
+
+        facts = cc.detect_project_facts(tmp_path)
+
+        assert facts.verify_commands == ["pnpm run test", "make test"]
+
     def test_project_facts_for_matches_prompt_block(self, tmp_path):
         # Invariant: the structured facts the UI consumes must not drift from the
         # commands the prompt snapshot renders — one detector feeds both.

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -165,6 +165,22 @@ def test_no_suite_nudge_uses_canonical_temp_dir(tmp_path, monkeypatch):
     assert str(linked_temp) not in nudge
 
 
+def test_nudge_never_requests_write_format_command(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / "package.json").write_text(
+        json.dumps({"scripts": {"format": "prettier --write ."}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "pnpm-lock.yaml").write_text("", encoding="utf-8")
+
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[str(tmp_path / "src" / "app.ts")],
+    )
+
+    assert nudge is not None
+    assert "pnpm run format" not in nudge
+    assert "No canonical test/lint/build command was detected" in nudge
 
 
 def test_ad_hoc_pass_satisfies_no_suite_stop_loop(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- stop auto-detecting package scripts and Make targets named `fmt` or `format` as verification commands
- prevent write-mode formatter commands such as `pnpm run format` from being injected into the workspace `Verify:` context and verification-on-stop nudge solely because of their name
- preserve existing automatic detection for `test`, `tests`, `lint`, `typecheck`, `check`, and `build`

## Why

`fmt` and `format` conventionally invoke write mode. Hermes currently treats those names as canonical verification commands without inspecting their behavior, so a repository with `"format": "prettier --write ."` can receive a higher-priority completion nudge instructing the agent to run a repository-wide writer.

The detector is centralized in `agent/coding_context.py`; removing these ambiguous aliases there protects workspace facts, prompt rendering, verification-on-stop, evidence matching, and detected verification recipes without disabling verification or adding repository-specific exceptions.

## Reproduction

Before this change, a pnpm project containing only:

```json
{"scripts":{"format":"prettier --write ."}}
```

produces `pnpm run format` as a detected verification command, and the stop nudge names that command. After this change, no canonical test/lint/build command is detected for that project and the stop nudge uses the existing fail-closed ad hoc-verification path instead.

## Test plan

- [x] `scripts/run_tests.sh tests/agent/test_coding_context.py tests/agent/test_verification_stop.py -q`
  - 2 files, 43 passed, 0 failed
- [x] scoped Ruff check on the production file and both test files
- [x] `git diff --check`
- [x] direct runtime probe for project facts, workspace context, and verification-on-stop nudge
- [x] mutation check: reintroducing `fmt` and `format` causes exactly the three new regressions to fail
- [x] current `main` integration check: reviewed paths did not overlap upstream movement; current-base-relative diff remains exactly the three intended paths

## Platform tested

- macOS 27.0
- Python 3.11.15

## Scope

This fixes automatic selection of the demonstrated ambiguous `fmt`/`format` aliases. It does not claim that every arbitrary user-authored `test`, `lint`, `check`, or `build` script is side-effect-free.

> **Merge hold:** This PR is intentionally opened as a draft. No auto-merge is requested. Installation, gateway restart, and runtime activation are separate from this source change.
