### PR TITLE
fix(desktop): stop adopting session providers without credentials into the composer

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -14,7 +14,7 @@ import { coerceGatewayText, coerceThinkingText, normalizePersonalityValue } from
 import { playCompletionSound } from '@/lib/completion-sound'
 import { resolveGatewayEventSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
-import { modelOptionsQueryKey } from '@/lib/model-options'
+import { modelOptionsQueryKey, sessionProviderAdoptableFromCache } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
 import { type AgentNoticePayload, clearAgentNotice, nativeNoticeInput, showAgentNotice } from '@/store/agent-notices'
@@ -45,6 +45,7 @@ import { followActiveSessionCwd } from '@/store/projects'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import { recordAgentReaction } from '@/store/reactions-local'
 import {
+  $activeSessionId,
   $currentCwd,
   $currentModel,
   $currentProvider,
@@ -54,7 +55,10 @@ import {
   setCurrentBranch,
   setCurrentCwdTransient,
   setCurrentFastMode,
+  setCurrentModel,
+  setCurrentModelSource,
   setCurrentPersonality,
+  setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
@@ -1316,6 +1320,21 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         if (looksLikeProviderSetup) {
           requestDesktopOnboarding(errorMessage)
+
+          // The composer may be holding a provider whose credentials are gone
+          // (adopted from a legacy session before the catalog proved it dead —
+          // e.g. "No xAI OAuth credentials stored"). Reset to the profile
+          // default so the next send stops failing with the same auth error
+          // instead of leaving the user stuck in a retry loop.
+          if (
+            isActiveEvent &&
+            sessionId === $activeSessionId.get() &&
+            !sessionProviderAdoptableFromCache($currentProvider.get())
+          ) {
+            setCurrentModel('')
+            setCurrentProvider('')
+            setCurrentModelSource('default')
+          }
         } else if (isDiskFullErrorMessage(errorMessage)) {
           notifyError(new Error(errorMessage), translateNow('notifications.errors.diskFull'))
         } else {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -3,6 +3,7 @@ import { getSession } from '@/hermes'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
+import { sessionProviderAdoptableFromCache } from '@/lib/model-options'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
@@ -953,11 +954,17 @@ interface ApplyRuntimeInfoOptions {
 /** Mirror a session's runtime state into the composer atoms the MAIN pane
  *  renders from. Foreground sessions only — see ApplyRuntimeInfoOptions. */
 function publishRuntimeToComposer(state: SessionRuntimeStatePatch): void {
-  if (state.model !== undefined) {
+  // Same dead-provider guard as syncRuntimeMetadataToView: a session's runtime
+  // may still report a provider whose credentials were removed — never drag it
+  // into the sticky composer selection, or every send fails with a cryptic
+  // auth error ("No xAI OAuth credentials stored...").
+  const adopt = sessionProviderAdoptableFromCache(state.provider ?? '')
+
+  if (adopt && state.model !== undefined) {
     setCurrentModel(state.model)
   }
 
-  if (state.provider !== undefined) {
+  if (adopt && state.provider !== undefined) {
     setCurrentProvider(state.provider)
   }
 

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -5,6 +5,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
+import { sessionProviderAdoptableFromCache } from '@/lib/model-options'
 import { setMutableRef } from '@/lib/mutable-ref'
 import {
   $activeSessionId,
@@ -36,8 +37,17 @@ interface SessionStateCacheOptions {
 }
 
 function syncRuntimeMetadataToView(state: ClientSessionState) {
-  setCurrentModel(state.model ?? '')
-  setCurrentProvider(state.provider ?? '')
+  // A resumed session may still report a provider whose credentials were
+  // removed (OAuth revoked, API key deleted). Adopting it into the sticky
+  // composer state would make the next send fail with a cryptic auth error
+  // ("No xAI OAuth credentials stored..."); keep the user's pick / profile
+  // default instead. The catalog read is the module-level mirror of the last
+  // model-options response — conservative (adopt) when nothing has loaded yet.
+  if (sessionProviderAdoptableFromCache(state.provider ?? '')) {
+    setCurrentModel(state.model ?? '')
+    setCurrentProvider(state.provider ?? '')
+  }
+
   setCurrentReasoningEffort(state.reasoningEffort ?? '')
   setCurrentServiceTier(state.serviceTier ?? '')
   setCurrentFastMode(state.fast ?? false)

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelOptions } from '@/hermes'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import {
   _resetLastLoadedProvidersForTests,
@@ -14,7 +15,8 @@ import {
 const globalOptions = { model: 'hermes-4', provider: 'nous', providers: [] }
 
 vi.mock('@/hermes', () => ({
-  getGlobalModelOptions: vi.fn(() => Promise.resolve(globalOptions))
+  getGlobalModelOptions: vi.fn(() => Promise.resolve(globalOptions)),
+  setApiRequestProfile: vi.fn()
 }))
 
 describe('requestModelOptions', () => {
@@ -153,6 +155,11 @@ describe('sessionProviderAdoptableFromCache', () => {
 
   beforeEach(() => {
     _resetLastLoadedProvidersForTests()
+    $activeGatewayProfile.set('default')
+  })
+
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
   })
 
   it('adopts when no catalog has loaded yet', () => {
@@ -172,5 +179,47 @@ describe('sessionProviderAdoptableFromCache', () => {
     expect(sessionProviderAdoptableFromCache('deepseek')).toBe(true)
     expect(sessionProviderAdoptableFromCache('xai-oauth')).toBe(false)
     expect(sessionProviderAdoptableFromCache('anthropic')).toBe(false)
+  })
+
+  it('keys the mirror by profile: another profile catalog never leaks in', async () => {
+    await requestModelOptions({
+      gateway: {
+        request: vi.fn(() =>
+          Promise.resolve({ model: 'deepseek-v4-flash', provider: 'deepseek', providers: cachedCatalog })
+        )
+      } as never,
+      sessionId: null
+    })
+    // Profile 'default' now has a loaded catalog that would block xai-oauth.
+
+    $activeGatewayProfile.set('compass')
+
+    // The active profile has no entry yet — conservative, nothing to prove.
+    expect(sessionProviderAdoptableFromCache('xai-oauth')).toBe(true)
+    expect(sessionProviderAdoptableFromCache('deepseek')).toBe(true)
+
+    // A catalog fetched for 'compass' lands in its own slot and drives its own
+    // decisions while active...
+    await requestModelOptions({
+      gateway: {
+        request: vi.fn(() =>
+          Promise.resolve({
+            model: 'claude-sonnet-4.6',
+            provider: 'anthropic',
+            providers: [{ name: 'Anthropic', slug: 'anthropic', models: ['claude-sonnet-4.6'] }]
+          })
+        )
+      } as never,
+      sessionId: null
+    })
+    expect(sessionProviderAdoptableFromCache('anthropic')).toBe(true)
+    expect(sessionProviderAdoptableFromCache('xai-oauth')).toBe(false)
+
+    // ...while 'default' keeps its own view when re-activated (anthropic is
+    // absent from its catalog, so it must NOT inherit compass's verdict).
+    $activeGatewayProfile.set('default')
+    expect(sessionProviderAdoptableFromCache('anthropic')).toBe(false)
+    expect(sessionProviderAdoptableFromCache('xai-oauth')).toBe(false)
+    expect(sessionProviderAdoptableFromCache('deepseek')).toBe(true)
   })
 })

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -1,8 +1,15 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelOptions } from '@/hermes'
 
-import { manualPickRemoved, modelOptionsQueryKey, requestModelOptions } from './model-options'
+import {
+  _resetLastLoadedProvidersForTests,
+  manualPickRemoved,
+  modelOptionsQueryKey,
+  requestModelOptions,
+  sessionProviderAdoptable,
+  sessionProviderAdoptableFromCache
+} from './model-options'
 
 const globalOptions = { model: 'hermes-4', provider: 'nous', providers: [] }
 
@@ -95,5 +102,75 @@ describe('manualPickRemoved', () => {
 
   it('never clobbers when there is no pick', () => {
     expect(manualPickRemoved(providers, '', '')).toBe(false)
+  })
+})
+
+describe('sessionProviderAdoptable', () => {
+  const providers = [
+    { name: 'DeepSeek', slug: 'deepseek', models: ['deepseek-v4-flash'], authenticated: true },
+    // Current-provider skeleton row: present but credentials are gone.
+    { name: 'xAI', slug: 'xai-oauth', models: ['grok-4.20-0309-reasoning'], authenticated: false },
+    // Legacy row without an explicit flag — treat as usable.
+    { name: 'OpenRouter', slug: 'openrouter', models: ['gpt-5.5'] }
+  ]
+
+  it('adopts a provider that is in the loaded catalog with credentials', () => {
+    expect(sessionProviderAdoptable(providers, 'deepseek')).toBe(true)
+  })
+
+  it('adopts a provider whose row carries no explicit authenticated flag', () => {
+    expect(sessionProviderAdoptable(providers, 'openrouter')).toBe(true)
+  })
+
+  it('matches the provider by name as well as slug', () => {
+    expect(sessionProviderAdoptable(providers, 'DeepSeek')).toBe(true)
+  })
+
+  it('blocks a provider explicitly marked unauthenticated (re-auth skeleton)', () => {
+    expect(sessionProviderAdoptable(providers, 'xai-oauth')).toBe(false)
+    expect(sessionProviderAdoptable(providers, 'xAI')).toBe(false)
+  })
+
+  it('blocks a provider absent from a loaded catalog (unconfigured)', () => {
+    expect(sessionProviderAdoptable(providers, 'anthropic')).toBe(false)
+  })
+
+  it('conservatively adopts on a not-yet-loaded catalog or empty provider', () => {
+    expect(sessionProviderAdoptable(undefined, 'xai-oauth')).toBe(true)
+    expect(sessionProviderAdoptable(providers, '')).toBe(true)
+  })
+
+  it('treats an empty loaded catalog as nothing configured (no adoption)', () => {
+    expect(sessionProviderAdoptable([], 'xai-oauth')).toBe(false)
+  })
+})
+
+describe('sessionProviderAdoptableFromCache', () => {
+  const cachedCatalog = [
+    { name: 'DeepSeek', slug: 'deepseek', models: ['deepseek-v4-flash'], authenticated: true },
+    { name: 'xAI', slug: 'xai-oauth', models: ['grok-4.20-0309-reasoning'], authenticated: false }
+  ]
+
+  beforeEach(() => {
+    _resetLastLoadedProvidersForTests()
+  })
+
+  it('adopts when no catalog has loaded yet', () => {
+    expect(sessionProviderAdoptableFromCache('xai-oauth')).toBe(true)
+  })
+
+  it('blocks a provider the last loaded catalog proves unauthenticated', async () => {
+    await requestModelOptions({
+      gateway: {
+        request: vi.fn(() =>
+          Promise.resolve({ model: 'deepseek-v4-flash', provider: 'deepseek', providers: cachedCatalog })
+        )
+      } as never,
+      sessionId: null
+    })
+
+    expect(sessionProviderAdoptableFromCache('deepseek')).toBe(true)
+    expect(sessionProviderAdoptableFromCache('xai-oauth')).toBe(false)
+    expect(sessionProviderAdoptableFromCache('anthropic')).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -1,4 +1,5 @@
 import { getGlobalModelOptions, type HermesGateway, type ModelOptionsResponse } from '@/hermes'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import type { ModelOptionProvider } from '@/types/hermes'
 
 /**
@@ -56,6 +57,11 @@ export function requestModelOptions({
   refresh = false,
   sessionId
 }: ModelOptionsRequest): Promise<ModelOptionsResponse> {
+  // The catalog is scoped to the active gateway's profile; capture the identity
+  // at REQUEST time so a late response resolving after a profile swap is still
+  // keyed to the profile it was fetched for (see rememberProviders).
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+
   if (gateway) {
     const params: Record<string, unknown> = {}
 
@@ -71,10 +77,10 @@ export function requestModelOptions({
       params.explicit_only = true
     }
 
-    return rememberProviders(gateway.request<ModelOptionsResponse>('model.options', params))
+    return rememberProviders(gateway.request<ModelOptionsResponse>('model.options', params), profile)
   }
 
-  return rememberProviders(getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) }))
+  return rememberProviders(getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) }), profile)
 }
 
 // The composer-sync paths (session runtime state → sticky composer atoms) run
@@ -84,19 +90,27 @@ export function requestModelOptions({
 // synchronous reads. The mirror is read-only: the query cache stays
 // authoritative for writes/refetches, and a stale mirror can at worst delay
 // adopting a provider the user just re-enabled until the next catalog fetch.
-let lastLoadedProviders: ModelOptionProvider[] | undefined
+//
+// The mirror is keyed by the gateway profile the catalog belongs to (the query
+// cache uses the same identity), so a response fetched for one profile can
+// never drive adoptability decisions for another:
+// `sessionProviderAdoptableFromCache` only consults the entry of the CURRENTLY
+// active profile, and a late response from a previously active profile lands in
+// that profile's own slot, inert.
+let lastLoadedByProfile: Record<string, ModelOptionProvider[] | undefined> = {}
 
 /** @internal Reset the mirror for tests. */
 export function _resetLastLoadedProvidersForTests(): void {
-  lastLoadedProviders = undefined
+  lastLoadedByProfile = {}
 }
 
 async function rememberProviders(
-  response: ModelOptionsResponse | Promise<ModelOptionsResponse>
+  response: ModelOptionsResponse | Promise<ModelOptionsResponse>,
+  profile: string
 ): Promise<ModelOptionsResponse> {
   const resolved = await response
 
-  lastLoadedProviders = resolved?.providers
+  lastLoadedByProfile[profile] = resolved?.providers
 
   return resolved
 }
@@ -131,7 +145,7 @@ export function sessionProviderAdoptable(providers: ModelOptionProvider[] | unde
   return !row ? false : row.authenticated !== false
 }
 
-/** `sessionProviderAdoptable` against the most recently loaded catalog. */
+/** `sessionProviderAdoptable` against the current profile's last loaded catalog. */
 export function sessionProviderAdoptableFromCache(provider: string): boolean {
-  return sessionProviderAdoptable(lastLoadedProviders, provider)
+  return sessionProviderAdoptable(lastLoadedByProfile[normalizeProfileKey($activeGatewayProfile.get())], provider)
 }

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -71,8 +71,67 @@ export function requestModelOptions({
       params.explicit_only = true
     }
 
-    return gateway.request<ModelOptionsResponse>('model.options', params)
+    return rememberProviders(gateway.request<ModelOptionsResponse>('model.options', params))
   }
 
-  return getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })
+  return rememberProviders(getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) }))
+}
+
+// The composer-sync paths (session runtime state → sticky composer atoms) run
+// outside React, where the queryClient cache is not reachable. Every catalog
+// fetch (chat view, model picker, model menu) funnels through
+// requestModelOptions, so mirror the last loaded provider list here for those
+// synchronous reads. The mirror is read-only: the query cache stays
+// authoritative for writes/refetches, and a stale mirror can at worst delay
+// adopting a provider the user just re-enabled until the next catalog fetch.
+let lastLoadedProviders: ModelOptionProvider[] | undefined
+
+/** @internal Reset the mirror for tests. */
+export function _resetLastLoadedProvidersForTests(): void {
+  lastLoadedProviders = undefined
+}
+
+async function rememberProviders(
+  response: ModelOptionsResponse | Promise<ModelOptionsResponse>
+): Promise<ModelOptionsResponse> {
+  const resolved = await response
+
+  lastLoadedProviders = resolved?.providers
+
+  return resolved
+}
+
+/**
+ * Whether the composer may adopt `provider` from a resumed session's runtime
+ * state.
+ *
+ * A session created under a provider whose credentials were later removed
+ * (OAuth revoked, API key deleted) keeps stamping the dead provider on every
+ * session.info heartbeat. Syncing it into the sticky composer state makes the
+ * next send fail with a cryptic auth error ("No xAI OAuth credentials
+ * stored...", "No Codex credentials stored..."). This guard blocks adoption
+ * only when a LOADED catalog proves the provider has no usable credentials; an
+ * unknown/not-yet-loaded catalog conservatively allows the sync — the same
+ * philosophy as `manualPickRemoved`, so a still-valid pick is never clobbered
+ * by a stale catalog.
+ *
+ * The chat catalog is fetched `explicitOnly`, so a loaded list contains only
+ * configured providers plus the current provider's skeleton row (which carries
+ * `authenticated: false` when it lost its credential). A present row with an
+ * explicit `authenticated: false` or a provider absent from the loaded list is
+ * therefore not usable right now.
+ */
+export function sessionProviderAdoptable(providers: ModelOptionProvider[] | undefined, provider: string): boolean {
+  if (!provider || !Array.isArray(providers)) {
+    return true
+  }
+
+  const row = providers.find(p => p.slug === provider || p.name === provider)
+
+  return !row ? false : row.authenticated !== false
+}
+
+/** `sessionProviderAdoptable` against the most recently loaded catalog. */
+export function sessionProviderAdoptableFromCache(provider: string): boolean {
+  return sessionProviderAdoptable(lastLoadedProviders, provider)
 }

--- a/apps/desktop/src/lib/provider-setup-errors.test.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.test.ts
@@ -18,6 +18,15 @@ describe('isProviderSetupErrorMessage', () => {
     ).toBe(true)
   })
 
+  it('matches OAuth providers whose stored credentials are gone', () => {
+    expect(
+      isProviderSetupErrorMessage(
+        'No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.'
+      )
+    ).toBe(true)
+    expect(isProviderSetupErrorMessage('No Codex credentials stored. Run `hermes auth` to authenticate.')).toBe(true)
+  })
+
   it('does not match bare env var mentions from auxiliary warnings', () => {
     expect(isProviderSetupErrorMessage('OPENROUTER_API_KEY not set')).toBe(false)
     expect(isProviderSetupErrorMessage('Run `hermes setup` or set OPENROUTER_API_KEY.')).toBe(false)
@@ -34,6 +43,9 @@ describe('isProviderSetupErrorMessage', () => {
     expect(
       isProviderSetupErrorMessage('Selected runtime is not available. setup.status reports configured credentials.')
     ).toBe(false)
+    expect(isProviderSetupErrorMessage('Upstream connect error or disconnect/reset before headers.')).toBe(false)
+    expect(isProviderSetupErrorMessage('HTTP 503: the upstream service is unavailable')).toBe(false)
+    expect(isProviderSetupErrorMessage('Session not found')).toBe(false)
   })
 
   it('returns false for empty input', () => {

--- a/apps/desktop/src/lib/provider-setup-errors.ts
+++ b/apps/desktop/src/lib/provider-setup-errors.ts
@@ -1,5 +1,5 @@
 const PROVIDER_SETUP_ERROR_RE =
-  /No (?:inference|Hermes) provider(?: is)? configured|no_provider_configured|set an API key/i
+  /No (?:inference|Hermes) provider(?: is)? configured|no_provider_configured|set an API key|No [A-Za-z][A-Za-z ]* credentials stored/i
 
 const SESSION_INFO_CREDENTIAL_WARNING_RE = /^No API key configured for provider '[^']*'\. First message will fail\.$/
 


### PR DESCRIPTION
## Problem

A session created under a provider whose credentials were later removed (OAuth revoked, API key deleted — e.g. switching away from xAI Grok OAuth) keeps stamping the dead provider on every `session.info` heartbeat. When the desktop app resumes such a session — including the **first-launch auto-restore of the most recent session** — `syncRuntimeMetadataToView` / `publishRuntimeToComposer` copy that provider into the **sticky composer state** (which is deliberately meant to be user UI state, not session-derivable). Every subsequent send then fails with a cryptic auth error:

> No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.

The desktop does not even classify this as a provider-setup error, so the user gets a raw error toast, the composer keeps the dead provider, and every retry fails the same way — with no recovery affordance.

### Repro

1. Use xAI Grok OAuth (or any provider), create a session.
2. Remove that provider's credentials (switch providers, revoke OAuth, delete the key).
3. Open the desktop app fresh — it auto-restores the most recent session.
4. Type a message → `No xAI OAuth credentials stored...`; every retry fails identically.

## Fix

Three small desktop-side changes:

1. **Guard adoption of dead providers** — new `sessionProviderAdoptable()` in `lib/model-options.ts`, applied at the two composer-sync sites (`use-session-state-cache.ts`, `use-session-actions/utils.ts`). A session's provider is only mirrored into the sticky composer state when a **loaded** model-options catalog proves it still has credentials. The chat catalog is fetched `explicitOnly`, so an absent provider, or a row carrying `authenticated: false` (the re-auth skeleton the backend emits for the current provider), is not adopted. An unknown/not-yet-loaded catalog conservatively allows the sync — same philosophy as `manualPickRemoved` — so a still-valid pick is never clobbered by a stale catalog. `requestModelOptions` mirrors the last loaded provider list module-level so the sync paths (which run outside React) can read it synchronously.

2. **Recognize the error family** — `lib/provider-setup-errors.ts` now classifies `No ... credentials stored` (xAI OAuth, Codex, and future OAuth providers) as a provider-setup error, so the desktop routes it to the onboarding/setup affordance instead of a raw toast.

3. **Self-heal on failure** — in the gateway error handler (`use-message-stream/gateway-event.ts`), when a provider-setup error hits the active session while the composer holds an unauthenticated provider, reset the composer to the profile default so the next send succeeds instead of retry-looping.

## Tests

- `sessionProviderAdoptable`: present/absent/`authenticated: false`/name-match/not-yet-loaded/empty-catalog cases, plus the cache-mirror variant.
- `isProviderSetupErrorMessage`: new OAuth "credentials stored" cases, with the existing negative cases (env-var mentions, auxiliary warnings, runtime failures) preserved.
- Existing suites for the touched modules pass (`utils.test.ts`, `use-session-state-cache.test.tsx`, `delta-flush.test.tsx`).

## Notes / possible follow-up

The backend's `_probe_credentials` (`tui_gateway/server.py`) only checks `agent.api_key`, so OAuth providers never get a `credential_warning` on `session.info` — extending it would surface the problem even before the first send. Left out of this PR to keep it desktop-scoped.
