### PR TITLE
fix(desktop): reject SSH backends with replaced runtimes

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7365,9 +7365,7 @@ async function sshProbeReuseProof(baseUrl, token, spawnNonce) {
   try {
     const proof: any = await fetchJson(`${baseUrl}/api/ssh/ownership`, token)
 
-    return proof?.ok === true && proof.sshOwnerNonce === spawnNonce && proof.protocolVersion === 1
-      ? 'authenticated-ok'
-      : 'authenticated-stale'
+    return remoteLifecycle.classifySshReuseProof(proof, spawnNonce)
   } catch (error: any) {
     if (/^(401|403|404):/.test(String(error?.message || ''))) {
       return 'authenticated-stale'

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { test } from 'vitest'
 import { profileSshOverride } from './connection-config'
 import {
   buildSpawnCommand,
+  classifySshReuseProof,
   cleanupStale,
   connect,
   expandRemotePath,
@@ -31,6 +32,23 @@ import {
 
 const OWNERSHIP_ID = '0123456789abcdef0123456789abcdef'
 const SPAWN_NONCE = '0123456789abcdef'
+
+test('SSH reuse proof rejects a backend whose runtime was replaced', () => {
+  assert.equal(
+    classifySshReuseProof(
+      { ok: true, sshOwnerNonce: SPAWN_NONCE, protocolVersion: 1, runtimeIntact: false },
+      SPAWN_NONCE
+    ),
+    'authenticated-stale'
+  )
+})
+
+test('SSH reuse proof remains compatible when runtime state is absent', () => {
+  assert.equal(
+    classifySshReuseProof({ ok: true, sshOwnerNonce: SPAWN_NONCE, protocolVersion: 1 }, SPAWN_NONCE),
+    'authenticated-ok'
+  )
+})
 
 function ownedLock(over: any = {}) {
   return {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -38,6 +38,15 @@ const SUPPORTED_REMOTE_OS = new Set(['Linux', 'Darwin'])
 const DEFAULT_READY_TIMEOUT_MS = 45_000
 const READY_POLL_INTERVAL_MS = 750
 
+function classifySshReuseProof(proof, spawnNonce) {
+  return proof?.ok === true &&
+    proof.sshOwnerNonce === spawnNonce &&
+    proof.protocolVersion === PROTOCOL_VERSION &&
+    proof.runtimeIntact !== false
+    ? 'authenticated-ok'
+    : 'authenticated-stale'
+}
+
 function mintToken() {
   return crypto.randomBytes(32).toString('hex')
 }
@@ -874,6 +883,7 @@ async function connect(deps) {
 export {
   adoptOwnedServedToken,
   buildSpawnCommand,
+  classifySshReuseProof,
   cleanupStale,
   connect,
   DEFAULT_READY_TIMEOUT_MS,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -38,6 +38,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import threading
 import time
@@ -334,6 +335,7 @@ def _resolve_session_token() -> str:
 _SESSION_TOKEN = _resolve_session_token()
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 _SSH_OWNER_NONCE: Optional[str] = None
+_SSH_RUNTIME_PURELIB: Optional[Tuple[str, int, int]] = None
 
 
 def _apply_ssh_session_token(token: str) -> None:
@@ -343,8 +345,27 @@ def _apply_ssh_session_token(token: str) -> None:
 
 
 def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
-    global _SSH_OWNER_NONCE
+    global _SSH_OWNER_NONCE, _SSH_RUNTIME_PURELIB
     _SSH_OWNER_NONCE = nonce
+    _SSH_RUNTIME_PURELIB = None
+    if nonce:
+        try:
+            purelib = sysconfig.get_paths()["purelib"]
+            stat = os.stat(purelib)
+            _SSH_RUNTIME_PURELIB = (purelib, stat.st_dev, stat.st_ino)
+        except (KeyError, OSError):
+            pass
+
+
+def _ssh_runtime_intact() -> bool:
+    if _SSH_RUNTIME_PURELIB is None:
+        return True
+    purelib, device, inode = _SSH_RUNTIME_PURELIB
+    try:
+        stat = os.stat(purelib)
+    except OSError:
+        return False
+    return (stat.st_dev, stat.st_ino) == (device, inode)
 
 # In-browser Chat tab (/chat, /api/pty, /api/ws, …).  Always enabled: the
 # desktop app and the dashboard's own Chat tab both drive the agent over the
@@ -3022,7 +3043,12 @@ async def get_ssh_ownership(request: Request):
     _require_token(request)
     if not _SSH_OWNER_NONCE:
         raise HTTPException(status_code=404, detail="SSH ownership is not active")
-    return {"ok": True, "sshOwnerNonce": _SSH_OWNER_NONCE, "protocolVersion": 1}
+    return {
+        "ok": True,
+        "sshOwnerNonce": _SSH_OWNER_NONCE,
+        "protocolVersion": 1,
+        "runtimeIntact": _ssh_runtime_intact(),
+    }
 
 
 @app.get("/api/health")

--- a/tests/hermes_cli/test_ssh_ownership_endpoint.py
+++ b/tests/hermes_cli/test_ssh_ownership_endpoint.py
@@ -21,7 +21,22 @@ def test_ssh_ownership_endpoint_requires_token_and_returns_exact_nonce(monkeypat
         "ok": True,
         "sshOwnerNonce": nonce,
         "protocolVersion": 1,
+        "runtimeIntact": True,
     }
+
+
+def test_ssh_ownership_reports_replaced_runtime(monkeypatch):
+    token = "t" * 64
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
+    monkeypatch.setattr(web_server, "_SSH_OWNER_NONCE", "0123456789abcdef")
+    monkeypatch.setattr(web_server, "_SSH_RUNTIME_PURELIB", ("/venv/site-packages", 10, 20))
+    monkeypatch.setattr(web_server.os, "stat", lambda _path: type("Stat", (), {"st_dev": 10, "st_ino": 21})())
+    client = TestClient(web_server.app)
+
+    response = client.get("/api/ssh/ownership", headers={"X-Hermes-Session-Token": token})
+
+    assert response.status_code == 200
+    assert response.json()["runtimeIntact"] is False
 
 
 def test_ssh_ownership_endpoint_is_absent_without_owner_nonce(monkeypatch):


### PR DESCRIPTION
## Summary

- snapshot the SSH backend's `purelib` device/inode when SSH ownership starts
- report whether that runtime still exists through the authenticated ownership proof
- reject reuse only when a new backend explicitly reports `runtimeIntact: false`
- preserve compatibility with older remotes that omit the field

When a remote venv is replaced underneath a long-lived SSH backend, the process and ownership proof remain live even though its imported packages point into a deleted runtime. The next Desktop connection therefore reused a backend that could no longer initialize agents. The runtime inode gives the running process a stable signal for both a removed interpreter-version directory and same-path venv recreation without reacting to ordinary package updates.

## Validation

- Regression tests added for changed-runtime detection and backward-compatible proof classification.
- `python3 -m py_compile hermes_cli/web_server.py`
- `git diff --check`

Targeted pytest/vitest execution was not available in this isolated checkout: the host Python lacks pytest and the sparse clone has no Desktop node_modules. I did not claim platform-specific SSH validation.

Fixes #82429
