### PR TITLE
fix(feishu): keep quoted DMs out of topic routing

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3346,7 +3346,13 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # In a Feishu DM, root_id identifies the root of a quote/reply chain;
+        # promoting it to thread metadata hides the response from the main
+        # conversation. Group topics may use root_id as their routing context,
+        # so preserve the existing fallback outside p2p chats.
+        thread_id = getattr(message, "thread_id", None) or None
+        if not thread_id and chat_type != "p2p":
+            thread_id = getattr(message, "root_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -950,6 +950,83 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.source.user_id_alt, "on_union")
         self.assertEqual(event.source.chat_name, "Feishu DM")
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_quoted_reply_root_id_is_not_treated_as_thread_id(self):
+        """A Feishu quote chain root is a reply anchor, not a topic thread."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import _reply_anchor_for_event
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter._resolve_sender_name_from_api = AsyncMock(return_value="张三")
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id=None,
+            root_id="om_quoted_root",
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"follow up"}',
+            message_id="om_trigger",
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=sender_id,
+                chat_type="p2p",
+                message_id="om_trigger",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertIsNone(event.source.thread_id)
+        self.assertEqual(event.reply_to_message_id, "om_quoted_root")
+        self.assertEqual(_reply_anchor_for_event(event), "om_trigger")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_group_topic_root_id_remains_routing_context(self):
+        """The DM fix must not remove root-based Feishu group topic routing."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter._resolve_sender_name_from_api = AsyncMock(return_value="张三")
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_group", "name": "Feishu Group", "type": "group"}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_group",
+            thread_id=None,
+            root_id="om_topic_root",
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"topic follow up"}',
+            message_id="om_topic_message",
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=sender_id,
+                chat_type="group",
+                message_id="om_topic_message",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.thread_id, "om_topic_root")
+
 
     @patch.dict(
         os.environ,


### PR DESCRIPTION
## Summary

Fix Feishu quoted replies in direct messages being routed as topic/thread messages and disappearing from the main conversation.

Feishu sets `root_id` on a quoted/replied DM to identify the root of the reply chain. The adapter previously promoted that value to `source.thread_id` whenever a real `message.thread_id` was absent. Downstream reply routing then treated an ordinary DM quote chain as a topic/thread and anchored the bot response to the quoted message instead of the new triggering message.

## Root cause

```python
thread_id = message.thread_id or message.root_id
```

In a `p2p` chat, `root_id` is reply-chain context, not topic routing metadata. It already remains available through `reply_to_message_id`; it should not also become `source.thread_id`.

## Fix

- In Feishu `p2p` chats, populate normalized `source.thread_id` only from an actual `message.thread_id`.
- Preserve the existing `root_id` fallback for non-`p2p` chats, because Feishu group topics may use it as routing context.
- Preserve `root_id` as the `reply_to_message_id` fallback in all chats.
- Add regression coverage that verifies:
  - a quoted DM has no normalized thread when `message.thread_id` is absent;
  - the quote root remains available as reply context;
  - the outbound reply anchor resolves to the current triggering message;
  - group-topic `root_id` routing remains unchanged.

## Reproduction

On current `main`, the DM regression test fails with:

```text
AssertionError: 'om_quoted_root' is not None
```

The normalized DM event incorrectly receives `source.thread_id = root_id`.

## Test plan

- [x] Verified the new DM regression test fails against the old adapter behavior.
- [x] `scripts/run_tests.sh tests/gateway/test_feishu.py -q`
  - `78 passed, 0 failed`
- [x] `ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py`
- [x] Python bytecode compilation for both changed files
- [x] `git diff --check`
- [x] Live Feishu validation: quoting another message now produces a visible bot reply in the main DM conversation.
