### PR TITLE
fix(buzz): preserve literal mentions and exact UUID targets

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -88,6 +88,40 @@ from gateway.config import Platform
 # returns housekeeping kinds (joins, canvas updates, …) — only kind 9 is
 # dispatched to the agent.
 _CHAT_KIND = 9
+_UNRESOLVED_MENTION_ERROR_RE = re.compile(
+    r"mention '@(?P<name>[^']+)' does not match a current channel member"
+)
+_BUZZ_PRESENTATION_MENTION_SEPARATOR = "\u200b"
+
+
+def _escape_unresolved_presentation_mention(content: str, error: str) -> Optional[str]:
+    """Make one CLI-rejected ``@name`` token presentation-only.
+
+    Buzz resolves whitespace-prefixed ``@name`` tokens into notification
+    p-tags before signing or publishing. Ordinary prose such as a Hermes
+    ``@session:...`` link can therefore fail mention preflight. Insert an
+    invisible separator only after the rejected ``@`` so the rendered text
+    remains readable while valid member mentions remain unchanged.
+
+    Return ``None`` for unrelated errors or absent tokens. Callers retry at
+    most once.
+    """
+    match = _UNRESOLVED_MENTION_ERROR_RE.search(error or "")
+    if match is None:
+        return None
+    name = match.group("name")
+    if not name:
+        return None
+    token = re.compile(
+        rf"(?<!\S)@{re.escape(name)}(?=$|[^A-Za-z0-9._-])",
+        re.IGNORECASE,
+    )
+    escaped, count = token.subn(
+        lambda found: "@" + _BUZZ_PRESENTATION_MENTION_SEPARATOR + found.group(0)[1:],
+        content,
+    )
+    return escaped if count else None
+
 # How many events to request per poll / seed call.
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
@@ -599,6 +633,19 @@ class BuzzAdapter(BasePlatformAdapter):
 
     # ── Sending ───────────────────────────────────────────────────────────
 
+    async def _run_message_send(self, args: List[str], content: str):
+        """Run one send with a single unresolved-mention preflight retry."""
+        code, out, err = await self._run_cli(args, input_text=content)
+        if code == 0:
+            return code, out, err
+        escaped = _escape_unresolved_presentation_mention(content, err)
+        if escaped is None:
+            return code, out, err
+        logger.info(
+            "Buzz: retrying message after unresolved presentation-mention preflight"
+        )
+        return await self._run_cli(args, input_text=escaped)
+
     async def send(
         self,
         chat_id: str,
@@ -612,7 +659,7 @@ class BuzzAdapter(BasePlatformAdapter):
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=content)
+        code, out, err = await self._run_message_send(args, content)
         if code != 0:
             return SendResult(
                 success=False,
@@ -683,7 +730,7 @@ class BuzzAdapter(BasePlatformAdapter):
             ]
             if reply_to:
                 args += ["--reply-to", str(reply_to)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
+            code, out, err = await self._run_message_send(args, caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
             try:
@@ -1394,6 +1441,20 @@ async def _standalone_send(
         code, out, err = await _exec_buzz(
             cli_path, args, relay_url=relay, private_key=private_key, input_text=message
         )
+        if code != 0:
+            escaped = _escape_unresolved_presentation_mention(message, err)
+            if escaped is not None:
+                logger.info(
+                    "Buzz: retrying standalone message after unresolved "
+                    "presentation-mention preflight"
+                )
+                code, out, err = await _exec_buzz(
+                    cli_path,
+                    args,
+                    relay_url=relay,
+                    private_key=private_key,
+                    input_text=escaped,
+                )
     except asyncio.CancelledError:
         raise
     except OSError as e:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -407,6 +407,60 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_send_retries_unresolved_presentation_mention_without_notifying(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=(
+                "mention '@session' does not match a current channel member; "
+                "retry with --mention <pubkey>"
+            ),
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt124", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "Continue in @session:default/20260809_092321_24aa09.",
+        )
+
+        assert result.success is True
+        assert result.message_id == "evt124"
+        assert len(cli.calls) == 2
+        assert cli.calls[0][1] == (
+            "Continue in @session:default/20260809_092321_24aa09."
+        )
+        assert cli.calls[1][1] == (
+            "Continue in @\u200bsession:default/20260809_092321_24aa09."
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_retry_unrelated_cli_failure(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="relay unavailable",
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "hello @session")
+
+        assert result.success is False
+        assert len(cli.calls) == 1
+
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -420,6 +474,40 @@ class TestBuzzAdapterSend:
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    async def test_send_image_retries_unresolved_presentation_mention(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=(
+                "mention '@session' does not match a current channel member; "
+                "retry with --mention <pubkey>"
+            ),
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt127", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(
+            CHANNEL,
+            str(img),
+            caption="See @session:default/example.",
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 2
+        assert cli.calls[0][1] == "See @session:default/example."
+        assert cli.calls[1][1] == "See @\u200bsession:default/example."
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -536,5 +624,57 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_retries_unresolved_presentation_mention(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        sent = []
+
+        async def fake_exec(
+            cli_path,
+            args,
+            *,
+            relay_url,
+            private_key,
+            input_text=None,
+            timeout=30.0,
+        ):
+            sent.append(input_text)
+            if len(sent) == 1:
+                return (
+                    1,
+                    "",
+                    "user_error: mention '@session' does not match a current "
+                    "channel member; retry with --mention <pubkey>",
+                )
+            return (
+                0,
+                json.dumps(
+                    {"accepted": True, "event_id": "evt-standalone", "message": ""}
+                ),
+                "",
+            )
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "See @session:default/example.",
+        )
+
+        assert result == {"success": True, "message_id": "evt-standalone"}
+        assert sent == [
+            "See @session:default/example.",
+            "See @\u200bsession:default/example.",
+        ]
 
 

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -29,6 +29,55 @@ def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
 
 
+def test_buzz_uuid_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "buzz", "e74ae728-e68a-4f8b-b285-3f19ad2df1f8"
+    )
+
+    assert chat_id == "e74ae728-e68a-4f8b-b285-3f19ad2df1f8"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_send_message_routes_buzz_uuid_without_home_fallback() -> None:
+    buzz = Platform("buzz")
+    buzz_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={buzz: buzz_cfg},
+        get_home_channel=lambda _platform: SimpleNamespace(
+            chat_id="93b1a8c9-7093-4117-9db1-7199bacabd48"
+        ),
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("raw Buzz UUID should not resolve via directory")), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "buzz:e74ae728-e68a-4f8b-b285-3f19ad2df1f8",
+                    "message": "exact DM",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert "note" not in result
+    send_mock.assert_awaited_once_with(
+        buzz,
+        buzz_cfg,
+        "e74ae728-e68a-4f8b-b285-3f19ad2df1f8",
+        "exact DM",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+    )
+
+
 def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
     whatsapp_cfg = SimpleNamespace(enabled=True, token=None, extra={"api_url": "http://bridge"})
     config = SimpleNamespace(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -52,6 +52,12 @@ _WHATSAPP_JID_RE = re.compile(
     r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
     re.IGNORECASE,
 )
+# Buzz channels and DMs use native UUID identifiers. They are explicit
+# targets and must never substitute the configured home channel.
+_BUZZ_UUID_RE = re.compile(
+    r"^\s*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\s*$",
+    re.IGNORECASE,
+)
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -591,6 +597,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # through to the _PHONE_PLATFORMS handler below.
         if _WHATSAPP_JID_RE.fullmatch(target_ref):
             return target_ref.strip(), None, True
+    if platform_name == "buzz" and _BUZZ_UUID_RE.fullmatch(target_ref):
+        return target_ref.strip(), None, True
     stripped_target = target_ref.strip()
     if platform_name == "signal" and stripped_target.startswith("group:"):
         group_id = stripped_target[len("group:"):].strip()


### PR DESCRIPTION
## Summary

Fix two Buzz outbound delivery regressions without changing PR #81996:

1. treat RFC-shaped Buzz channel/DM UUIDs as explicit platform-native targets, so `buzz:<UUID>` never falls through name resolution to the configured home channel;
2. retry exactly once when the pinned Buzz CLI rejects a visible, non-member `@name` token during pre-publication mention validation, escaping only that rejected presentation token with U+200B.

The retry contract covers live text sends, image captions, and standalone/cron sends. Valid member mentions are unchanged; unrelated failures do not retry.

Depends only on current Buzz platform/send infrastructure. #81996 remains an independent DM-classification change and is not modified by this PR.

Related active work: #76156 changes inbound shared-channel p-tag/name addressing and dynamic membership. This PR is orthogonal: it fixes outbound target parsing and Buzz CLI presentation-mention failures. #81352 changes live DM discovery and may touch adjacent adapter lines but does not own either outbound bug.

## Why

The pinned Buzz CLI interprets every visible `@name` token as a member mention and fails before publication when no member matches. Hermes session links such as `@session:default/...` are presentation text, not Buzz mentions. Separately, generic target parsing did not recognize Buzz UUIDs as explicit IDs.

Pinned-source inspection confirms unresolved-mention failure occurs before media upload, signing, and event publication, so the bounded retry preserves at-most-once publication.

## Verification

```text
scripts/run_tests.sh -j 2 \
  tests/gateway/test_buzz_adapter.py \
  tests/gateway/test_buzz_websocket.py \
  tests/tools/test_send_message_target_parse.py \
  tests/tools/test_send_message_tool.py

36 passed, 0 failed, 1 skipped
```

Also passed:

- Ruff on all changed Python files;
- `git diff --check`;
- accepted-head combined integration suite with the independently reviewed first-message correction: 49 passed, 0 failed, 1 skipped;
- current-upstream combined preflight: 46 passed, 0 failed, 1 skipped.

Real `hermes send` canary:

- exact target: private Buzz DM UUID;
- content included literal `@session:default/buzz-canary`;
- exactly one event was stored;
- stored event used the requested channel tag;
- visible text remained unchanged, with one U+200B preventing Buzz mention interpretation.

## Scope

Changed files:

- `plugins/platforms/buzz/adapter.py`
- `tools/send_message_tool.py`
- `tests/gateway/test_buzz_adapter.py`
- `tests/tools/test_send_message_target_parse.py`

No migration. Gateway restart is required only when installing the code.

## Review

Final exact-tree independent review: **APPROVED** on `c22d23d5c0df467a6d936de5ef185c599d8ad700`; no blocker, high, medium, or low findings. The optional-dependency `test_send_message_tool.py` module was skipped by the hermetic runner, while the changed UUID parser and end-to-end routing regressions executed in `test_send_message_target_parse.py` and passed.
