### PR TITLE
fix(anthropic): fact-check billing-shaped 400s against the OAuth usage endpoint (#82154)

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
@@ -748,6 +749,33 @@ def redeem_codex_reset_credit(
     )
 
 
+_ANTHROPIC_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+
+# The utilization windows Anthropic reports on the OAuth usage endpoint, each
+# paired with the label it renders under.
+_ANTHROPIC_USAGE_WINDOWS = (
+    ("five_hour", "Current session"),
+    ("seven_day", "Current week"),
+    ("seven_day_opus", "Opus week"),
+    ("seven_day_sonnet", "Sonnet week"),
+)
+
+
+def _fetch_anthropic_usage_payload(token: str, *, timeout: float = 15.0) -> dict:
+    """GET the raw OAuth usage payload for *token* (raises on transport/HTTP error)."""
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "anthropic-beta": "oauth-2025-04-20",
+        "User-Agent": "claude-code/2.1.0",
+    }
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(_ANTHROPIC_USAGE_URL, headers=headers)
+        response.raise_for_status()
+    return response.json() or {}
+
+
 def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
     token = (resolve_anthropic_token() or "").strip()
     if not token:
@@ -759,25 +787,9 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
             fetched_at=_utc_now(),
             unavailable_reason="Anthropic account limits are only available for OAuth-backed Claude accounts.",
         )
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "anthropic-beta": "oauth-2025-04-20",
-        "User-Agent": "claude-code/2.1.0",
-    }
-    with httpx.Client(timeout=15.0) as client:
-        response = client.get("https://api.anthropic.com/api/oauth/usage", headers=headers)
-        response.raise_for_status()
-    payload = response.json() or {}
+    payload = _fetch_anthropic_usage_payload(token)
     windows: list[AccountUsageWindow] = []
-    mapping = (
-        ("five_hour", "Current session"),
-        ("seven_day", "Current week"),
-        ("seven_day_opus", "Opus week"),
-        ("seven_day_sonnet", "Sonnet week"),
-    )
-    for key, label in mapping:
+    for key, label in _ANTHROPIC_USAGE_WINDOWS:
         window = payload.get(key) or {}
         util = window.get("utilization")
         if util is None:
@@ -807,6 +819,101 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         windows=tuple(windows),
         details=tuple(details),
     )
+
+
+# ── Subscription capacity fact-check ────────────────────────────────────
+#
+# Anthropic's OAuth billing classifier rejects some *prompt content* with an
+# HTTP 400 whose body is the billing sentence "You're out of extra usage. Add
+# more at claude.ai/settings/usage and keep going." — byte-for-byte what a
+# genuinely depleted account gets.  The message therefore cannot discriminate
+# between "the account is out of paid capacity" and "the classifier disliked
+# this request's content" (#82154: removing one sentence of a built-in system
+# prompt flipped the same credential from 400 to 200).
+#
+# The usage endpoint can discriminate: it reports the very quota the message
+# claims is gone.  One authenticated GET settles it — no model tokens, no
+# guessing at which prose upset the classifier.
+_CAPACITY_CACHE_TTL_SECONDS = 60.0
+
+# token-fingerprint → (monotonic timestamp, verdict). Bounded by the number of
+# distinct Anthropic OAuth credentials a process uses, i.e. a handful.
+_capacity_cache: dict[str, tuple[float, Optional[bool]]] = {}
+
+# Anthropic reports utilization as a 0..1 fraction (or an already-scaled
+# percentage). A window this close to its cap is spent for our purposes.
+_WINDOW_SATURATED_PERCENT = 99.5
+
+
+def _capacity_exhausted_from_usage(payload: dict) -> Optional[bool]:
+    """Decide whether an OAuth usage payload shows exhausted paid capacity.
+
+    Returns True (exhausted), False (capacity remains), or None (the payload
+    carries no usable signal). Pure — no I/O, so the decision table is
+    directly testable.
+
+    Ordering is deliberate:
+      1. Extra-usage credits still available outranks a saturated plan window,
+         because overage would be billed rather than refused — "out of extra
+         usage" cannot be literally true while credits remain.
+      2. Extra-usage credits spent is exactly what the error message claims.
+      3. Only then do plan windows decide.
+    """
+    extra = payload.get("extra_usage") or {}
+    if extra.get("is_enabled"):
+        used = extra.get("used_credits")
+        limit = extra.get("monthly_limit")
+        if _is_finite_num(used) and _is_finite_num(limit):
+            return float(used) >= float(limit)
+
+    utilizations: list[float] = []
+    for key, _label in _ANTHROPIC_USAGE_WINDOWS:
+        window = payload.get(key) or {}
+        util = window.get("utilization")
+        if not _is_finite_num(util):
+            continue
+        utilizations.append(float(util) * 100 if float(util) <= 1 else float(util))
+
+    if not utilizations:
+        return None
+    return any(u >= _WINDOW_SATURATED_PERCENT for u in utilizations)
+
+
+def anthropic_subscription_capacity_exhausted() -> Optional[bool]:
+    """Is the active Anthropic subscription actually out of paid capacity?
+
+    Returns True when the account genuinely has nothing left to spend, False
+    when capacity remains (so a billing-shaped rejection is about the request,
+    not the account), and None when the question cannot be answered — no OAuth
+    credential, endpoint unreachable, or a payload without usage fields.
+
+    Callers MUST treat None as "keep the existing billing behaviour": this is a
+    fact-check that can only *downgrade* a false billing verdict, never invent
+    one.
+    """
+    token = (resolve_anthropic_token() or "").strip()
+    # API keys never see the subscription classifier's billing-shaped 400, so
+    # there is nothing to disambiguate for them.
+    if not token or not _is_oauth_token(token):
+        return None
+
+    fingerprint = token[-12:]
+    now = time.monotonic()
+    cached = _capacity_cache.get(fingerprint)
+    if cached is not None and (now - cached[0]) < _CAPACITY_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    try:
+        payload = _fetch_anthropic_usage_payload(token, timeout=8.0)
+    except Exception:
+        # Transient failures are NOT cached — a fix must be able to prove
+        # itself on the next attempt rather than wait out a stale verdict.
+        logger.debug("Anthropic OAuth usage probe failed", exc_info=True)
+        return None
+
+    verdict = _capacity_exhausted_from_usage(payload)
+    _capacity_cache[fingerprint] = (now, verdict)
+    return verdict
 
 
 def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -23,6 +23,7 @@ import random
 import re
 import ssl
 import time
+from dataclasses import replace as dataclass_replace
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
@@ -535,6 +536,86 @@ def _print_billing_or_entitlement_guidance(
     for line in message.splitlines():
         agent._vprint(f"{agent.log_prefix}   💡 {line}", force=True)
     return True
+
+
+# Shown instead of the generic content-policy trailer when the account itself
+# has contradicted the "out of extra usage" claim. The point of the wording is
+# to stop the user from buying quota they already have (#82154: the billing
+# link in Anthropic's message cost the reporter three debugging sessions).
+_ANTHROPIC_OAUTH_CONTENT_FILTER_HINT = (
+    "Your subscription is NOT exhausted — Hermes checked the Anthropic OAuth usage "
+    "endpoint and it still reports available capacity. Anthropic's subscription "
+    "classifier rejects certain request *content* using its billing message, so this "
+    "is a content rejection wearing a billing error. Do not buy extra usage for it.\n"
+    "The classifier keys off system-prompt text, so the trigger is usually injected "
+    "guidance rather than your own message. Bisect the system blocks in the request "
+    "dump written above, or retry on an `sk-ant-api…` API key — API keys do not go "
+    "through this classifier."
+)
+
+
+def _reclassify_verified_anthropic_content_filter(agent, classified):
+    """Re-label an Anthropic billing 400 that the account itself contradicts.
+
+    Anthropic's subscription (OAuth) endpoint answers a content rejection with
+    the *billing* sentence "You're out of extra usage. Add more at
+    claude.ai/settings/usage and keep going." — the identical body a genuinely
+    depleted account gets, on the identical HTTP 400. Message matching alone
+    therefore cannot tell the two apart, and the classifier commits to
+    ``billing``: the user is told to buy quota, and — worse for diagnosis — the
+    credential is marked exhausted for the pool's cooldown, so every later
+    attempt replays the stored error without issuing a request and a real fix
+    looks like it did nothing (#82154).
+
+    The account settles it. One authenticated GET against the OAuth usage
+    endpoint reports the very quota the message claims is gone, so when it
+    shows remaining capacity the 400 provably was not about billing. Only then
+    is the verdict rewritten to ``content_policy_blocked`` — which already has
+    end-to-end handling (fallback attempt, dedicated abort message) and, being
+    request-scoped, does NOT rotate or quarantine the credential.
+
+    Deliberately one-directional: an unknown or exhausted answer leaves the
+    billing classification exactly as it was. This can only clear a false
+    billing verdict, never manufacture one — so a real spend wall keeps every
+    bit of today's behaviour.
+
+    Rewording whichever prompt string currently upsets the classifier is a
+    separate, per-occurrence fix (see #65365, #25255, #20865). This is the
+    layer that keeps the *next* trigger from being misdiagnosed at all.
+    """
+    if (
+        classified.reason != FailoverReason.billing
+        or classified.status_code != 400
+        or (getattr(agent, "provider", "") or "").strip().lower() != "anthropic"
+    ):
+        return classified
+
+    try:
+        from agent.account_usage import anthropic_subscription_capacity_exhausted
+
+        exhausted = anthropic_subscription_capacity_exhausted()
+    except Exception:
+        logger.debug("Anthropic capacity fact-check unavailable", exc_info=True)
+        return classified
+
+    # None (unknown) and True (really exhausted) both keep the billing verdict.
+    if exhausted is not False:
+        return classified
+
+    logger.warning(
+        "Anthropic HTTP 400 carried a billing message but the OAuth usage endpoint "
+        "reports remaining capacity — reclassifying as content_policy_blocked and "
+        "leaving the credential healthy (#82154)."
+    )
+    return dataclass_replace(
+        classified,
+        reason=FailoverReason.content_policy_blocked,
+        should_rotate_credential=False,
+        error_context={
+            **(classified.error_context or {}),
+            "anthropic_oauth_content_filter": True,
+        },
+    )
 
 
 def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:
@@ -4154,6 +4235,11 @@ def run_conversation(
                     context_length=_ctx_len,
                     num_messages=len(api_messages) if api_messages else 0,
                 )
+                # classify_api_error() is pure by contract; the Anthropic
+                # billing-400 verdict is the one case that needs an external
+                # fact to be trustworthy, so the check lives here — before the
+                # credential pool acts on the reason below.
+                classified = _reclassify_verified_anthropic_content_filter(agent, classified)
                 logger.debug(
                     "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s",
                     classified.reason.value, classified.status_code,
@@ -5645,11 +5731,20 @@ def run_conversation(
                     else:
                         agent._persist_session(messages, conversation_history)
                     if classified.reason == FailoverReason.content_policy_blocked:
+                        # A verified Anthropic billing-shaped rejection needs the
+                        # opposite of the generic trailer: the provider message
+                        # says "buy quota", and the whole point is that the user
+                        # must not act on it.
+                        _policy_hint = (
+                            _ANTHROPIC_OAUTH_CONTENT_FILTER_HINT
+                            if (classified.error_context or {}).get("anthropic_oauth_content_filter")
+                            else _CONTENT_POLICY_RECOVERY_HINT
+                        )
                         _policy_response = (
                             "⚠️  The model provider's safety filter blocked this request "
                             "(not a Hermes/gateway failure).\n\n"
                             f"Provider message: {_nonretryable_summary}\n\n"
-                            f"{_CONTENT_POLICY_RECOVERY_HINT}"
+                            f"{_policy_hint}"
                         )
                         return _content_policy_blocked_result(
                             messages,

--- a/tests/agent/test_anthropic_billing_400_capacity_check.py
+++ b/tests/agent/test_anthropic_billing_400_capacity_check.py
@@ -1,0 +1,231 @@
+"""Anthropic OAuth billing-shaped 400 vs. real subscription exhaustion (#82154).
+
+Anthropic's subscription endpoint answers a *content* rejection with its
+billing sentence ("You're out of extra usage. Add more at
+claude.ai/settings/usage and keep going.") on an HTTP 400 — byte-for-byte what
+a genuinely depleted account gets. Message matching cannot separate the two,
+so Hermes asks the account: the OAuth usage endpoint reports the very quota the
+message claims is gone.
+
+These tests pin both halves: the pure decision table over a usage payload, and
+the one-directional reclassification that only ever *clears* a false billing
+verdict.
+"""
+
+import pytest
+
+from agent import account_usage
+from agent.conversation_loop import _reclassify_verified_anthropic_content_filter
+from agent.error_classifier import ClassifiedError, FailoverReason
+
+
+@pytest.fixture(autouse=True)
+def _clear_capacity_cache():
+    account_usage._capacity_cache.clear()
+    yield
+    account_usage._capacity_cache.clear()
+
+
+def _window(utilization):
+    return {"utilization": utilization, "resets_at": "2026-08-09T12:00:00Z"}
+
+
+def _billing_400(**overrides):
+    kwargs = {
+        "reason": FailoverReason.billing,
+        "status_code": 400,
+        "provider": "anthropic",
+        "model": "claude-opus-5",
+        "message": "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+        "retryable": False,
+        "should_rotate_credential": True,
+        "should_fallback": True,
+    }
+    kwargs.update(overrides)
+    return ClassifiedError(**kwargs)
+
+
+class _Agent:
+    def __init__(self, provider="anthropic"):
+        self.provider = provider
+
+
+# ── Decision table over a usage payload ─────────────────────────────────
+
+def test_extra_usage_credits_remaining_means_capacity_available():
+    """Money left in the overage bucket — "out of extra usage" cannot be literal."""
+    payload = {
+        "five_hour": _window(1.0),  # plan window fully spent
+        "extra_usage": {"is_enabled": True, "used_credits": 3.5, "monthly_limit": 25.0},
+    }
+    assert account_usage._capacity_exhausted_from_usage(payload) is False
+
+
+def test_extra_usage_credits_spent_means_exhausted():
+    payload = {
+        "five_hour": _window(0.2),
+        "extra_usage": {"is_enabled": True, "used_credits": 25.0, "monthly_limit": 25.0},
+    }
+    assert account_usage._capacity_exhausted_from_usage(payload) is True
+
+
+def test_plan_windows_below_cap_mean_capacity_available():
+    payload = {"five_hour": _window(0.42), "seven_day": _window(0.10)}
+    assert account_usage._capacity_exhausted_from_usage(payload) is False
+
+
+def test_any_saturated_plan_window_means_exhausted():
+    payload = {"five_hour": _window(0.42), "seven_day_opus": _window(1.0)}
+    assert account_usage._capacity_exhausted_from_usage(payload) is True
+
+
+def test_percentage_encoded_utilization_is_not_rescaled():
+    """Values above 1 are already percentages — 45 is 45%, not 4500%."""
+    payload = {"five_hour": _window(45)}
+    assert account_usage._capacity_exhausted_from_usage(payload) is False
+
+
+def test_payload_without_usage_fields_is_unknown():
+    assert account_usage._capacity_exhausted_from_usage({}) is None
+    assert account_usage._capacity_exhausted_from_usage({"five_hour": {}}) is None
+
+
+def test_extra_usage_without_numbers_falls_through_to_windows():
+    payload = {
+        "extra_usage": {"is_enabled": True},
+        "seven_day": _window(1.0),
+    }
+    assert account_usage._capacity_exhausted_from_usage(payload) is True
+
+
+# ── Probe gating, caching, and failure handling ─────────────────────────
+
+def test_api_key_credentials_are_never_probed(monkeypatch):
+    """An sk-ant-api… key never meets the subscription classifier."""
+    calls = []
+    monkeypatch.setattr(account_usage, "resolve_anthropic_token", lambda: "sk-ant-api03-xxx")
+    monkeypatch.setattr(account_usage, "_is_oauth_token", lambda _t: False)
+    monkeypatch.setattr(
+        account_usage, "_fetch_anthropic_usage_payload",
+        lambda *a, **k: calls.append(1) or {},
+    )
+
+    assert account_usage.anthropic_subscription_capacity_exhausted() is None
+    assert calls == []
+
+
+def test_probe_failure_is_unknown_and_not_cached(monkeypatch):
+    """A transient failure must not lock in a verdict — the next attempt retries."""
+    attempts = []
+
+    def _boom(*_a, **_k):
+        attempts.append(1)
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(account_usage, "resolve_anthropic_token", lambda: "sk-ant-oat01-xxx")
+    monkeypatch.setattr(account_usage, "_is_oauth_token", lambda _t: True)
+    monkeypatch.setattr(account_usage, "_fetch_anthropic_usage_payload", _boom)
+
+    assert account_usage.anthropic_subscription_capacity_exhausted() is None
+    assert account_usage.anthropic_subscription_capacity_exhausted() is None
+    assert len(attempts) == 2
+    assert account_usage._capacity_cache == {}
+
+
+def test_verdict_is_cached_within_the_ttl(monkeypatch):
+    payload = {"five_hour": _window(0.1)}
+    fetches = []
+
+    monkeypatch.setattr(account_usage, "resolve_anthropic_token", lambda: "sk-ant-oat01-xxx")
+    monkeypatch.setattr(account_usage, "_is_oauth_token", lambda _t: True)
+    monkeypatch.setattr(
+        account_usage, "_fetch_anthropic_usage_payload",
+        lambda *a, **k: fetches.append(1) or payload,
+    )
+
+    assert account_usage.anthropic_subscription_capacity_exhausted() is False
+    assert account_usage.anthropic_subscription_capacity_exhausted() is False
+    assert len(fetches) == 1
+
+
+# ── Reclassification is one-directional ─────────────────────────────────
+
+def _force_capacity(monkeypatch, verdict):
+    monkeypatch.setattr(
+        account_usage, "anthropic_subscription_capacity_exhausted", lambda: verdict
+    )
+
+
+def test_available_capacity_reclassifies_and_spares_the_credential(monkeypatch):
+    _force_capacity(monkeypatch, False)
+    original = _billing_400()
+
+    refined = _reclassify_verified_anthropic_content_filter(_Agent(), original)
+
+    assert refined.reason is FailoverReason.content_policy_blocked
+    assert refined.should_rotate_credential is False
+    assert refined.error_context["anthropic_oauth_content_filter"] is True
+    # Non-retryable + fallback-eligible semantics are preserved.
+    assert refined.retryable is False
+    assert refined.should_fallback is True
+    # The input verdict is left untouched for any other reader.
+    assert original.reason is FailoverReason.billing
+    assert original.should_rotate_credential is True
+
+
+@pytest.mark.parametrize("verdict", [True, None])
+def test_exhausted_or_unknown_capacity_keeps_the_billing_verdict(monkeypatch, verdict):
+    _force_capacity(monkeypatch, verdict)
+
+    refined = _reclassify_verified_anthropic_content_filter(_Agent(), _billing_400())
+
+    assert refined.reason is FailoverReason.billing
+    assert refined.should_rotate_credential is True
+
+
+def test_probe_errors_keep_the_billing_verdict(monkeypatch):
+    def _boom():
+        raise RuntimeError("usage endpoint down")
+
+    monkeypatch.setattr(account_usage, "anthropic_subscription_capacity_exhausted", _boom)
+
+    refined = _reclassify_verified_anthropic_content_filter(_Agent(), _billing_400())
+
+    assert refined.reason is FailoverReason.billing
+
+
+def test_other_providers_are_never_probed(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        account_usage, "anthropic_subscription_capacity_exhausted",
+        lambda: calls.append(1) or False,
+    )
+
+    refined = _reclassify_verified_anthropic_content_filter(
+        _Agent(provider="openrouter"), _billing_400(provider="openrouter")
+    )
+
+    assert refined.reason is FailoverReason.billing
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"status_code": 402},  # a real payment-required wall, not the 400 shape
+        {"reason": FailoverReason.rate_limit},
+        {"reason": FailoverReason.auth},
+    ],
+)
+def test_only_the_billing_400_shape_is_fact_checked(monkeypatch, overrides):
+    calls = []
+    monkeypatch.setattr(
+        account_usage, "anthropic_subscription_capacity_exhausted",
+        lambda: calls.append(1) or False,
+    )
+
+    original = _billing_400(**overrides)
+    refined = _reclassify_verified_anthropic_content_filter(_Agent(), original)
+
+    assert refined is original
+    assert calls == []


### PR DESCRIPTION
## What does this PR do?

On an Anthropic **subscription OAuth** credential, a content rejection and a genuinely depleted account produce the **same HTTP 400 with the same body**:

```
You're out of extra usage. Add more at claude.ai/settings/usage and keep going.
```

Message matching cannot separate them, so `_classify_400` commits to `FailoverReason.billing`. Two things follow, and both are wrong when the account is healthy:

1. The user is pointed at a billing page to buy quota they already have — the reporter lost three debugging sessions to exactly this.
2. `recover_with_credential_pool` rotates and **quarantines the credential** for the pool cooldown. Every later attempt then replays the stored error *without issuing a request*, so a real fix looks like it changed nothing. That is the reporter's observation 1, and it is what made this bug expensive rather than merely annoying.

**This PR asks the account instead of guessing at the prose.** Anthropic's OAuth usage endpoint (`GET /api/oauth/usage`, already used by `hermes usage`) reports the very quota the error message claims is gone. When an Anthropic 400 is classified as billing, one authenticated GET settles which condition actually holds:

- **capacity remains** → the rejection provably was not about billing → reclassify as `content_policy_blocked` and leave the credential healthy;
- **exhausted, or unanswerable** → keep today's billing verdict, byte for byte.

`content_policy_blocked` is not a new taxonomy — it already exists with full end-to-end handling (fallback activation, dedicated abort result via `_content_policy_blocked_result`) and, being request-scoped, it does **not** set `should_rotate_credential`. Reclassifying is enough to stop the credential poisoning; no pool machinery is touched.

### Why this is the root-cause layer, not another reword

The same class of bug has now landed repeatedly — the `mcp_` tool-name fingerprint (#25255), the `Hermes Agent` / `Nous Research` brand strings (already sanitized in `build_anthropic_kwargs`), `SKILLS_GUIDANCE` + `MEMORY_GUIDANCE` (#20865), `session_search` / `memory` (#65365), and now `SKILLS_GUIDANCE` sentence 1 (this issue). Each was fixed by finding the offending string and rewording it. That is whack-a-mole against a server-side classifier nobody outside Anthropic can enumerate.

Rewording the current trigger is still worth doing per occurrence — **and it is not what this PR does.** This PR makes the *next* trigger diagnosable in minutes instead of sessions, regardless of which prose it turns out to be.

### One-directional by construction

The fact-check can only **clear** a false billing verdict, never manufacture one:

| usage endpoint says | verdict |
|---|---|
| extra-usage credits remaining | capacity available → reclassify |
| extra-usage credits spent | exhausted → **unchanged** |
| a plan window at or above its cap, no extra usage | exhausted → **unchanged** |
| every plan window below cap | capacity available → reclassify |
| no usage fields / endpoint unreachable / non-OAuth token | unknown → **unchanged** |

Credit headroom deliberately outranks a saturated plan window: while credits remain, overage is *billed* rather than refused, so "out of extra usage" cannot be literally true.

### Cost and blast radius

- Fires only on `provider == "anthropic"` **and** `status_code == 400` **and** `reason == billing` — i.e. on a request that has already failed non-retryably. Never on the success path.
- A plain GET. No model tokens.
- Skipped entirely for `sk-ant-api…` keys, which never meet the subscription classifier.
- 60 s TTL cache keyed by token fingerprint, so a retry storm cannot fan out into a probe storm. **Failures are not cached** — a fix must be able to prove itself on the next attempt rather than wait out a stale verdict, which is the same trap this PR is trying to close.
- `classify_api_error` stays pure. The fact-check runs at its single call site in `run_conversation`, before the credential pool reads the reason. `agent/context_compressor.py` and `agent/chat_completion_helpers.py` classify independently and are unchanged.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Anthropic HTTP 400] -->|Billing-shaped body| B[⚡ classify_api_error]
    B -->|FailoverReason.billing| C{🚀 OAuth Usage Fact-Check}
    C -->|Not anthropic / not 400 / API key| D[💳 Verdict Unchanged]
    C -->|Endpoint unreachable or no usage fields| D
    C -->|Capacity exhausted| D
    C -->|Capacity remains| E[⚡ content_policy_blocked]
    D --> F[💳 Billing Guidance + Credential Quarantined]
    E --> G[🔒 Credential Left Healthy]
    E --> H[🚀 Accurate Abort — Do Not Buy Quota]
```

## Related Issue

Fixes #82154

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`agent/account_usage.py`** — extracted `_fetch_anthropic_usage_payload()` out of `_fetch_anthropic_account_usage()` (same request, same headers, no behaviour change) so the raw payload is reachable; added the pure decision table `_capacity_exhausted_from_usage()` and the cached, tri-state `anthropic_subscription_capacity_exhausted()`.
- **`agent/conversation_loop.py`** — added `_reclassify_verified_anthropic_content_filter()` and wired it immediately after the single `classify_api_error()` call, ahead of `_recover_with_credential_pool`. The content-policy abort now renders an Anthropic-specific trailer that explicitly tells the user **not** to buy extra usage and points at the request dump this path already writes.
- **`tests/agent/test_anthropic_billing_400_capacity_check.py`** — new, 18 tests.

## Test plan

- [x] `pytest tests/agent/test_anthropic_billing_400_capacity_check.py -q` → **18 passed**. Covers the full decision table (credit headroom, credits spent, saturated window, sub-cap windows, percentage-encoded utilization, empty payload, extra-usage-without-numbers), probe gating (API keys never probed), failure handling (transient errors are unknown **and** uncached), TTL caching, and every branch of the one-directional reclassification including object non-mutation.
- [x] Regression sweep downstream of the billing verdict — `tests/agent/test_error_classifier.py`, `test_anthropic_billing_guidance.py`, `test_account_usage.py` (both copies), `test_credits_view.py`, `test_nous_credits_snapshot.py`, `test_nous_credits_gauge.py`, `test_credits_fixture_snapshot.py` → **94 passed**.
- [x] Credential-pool and failover paths — `tests/run_agent/test_credential_pool_interrupt.py`, `test_codex_xai_oauth_recovery.py`, `test_fallback_credential_isolation.py`, `tests/gateway/test_usage_command.py` → **34 passed**; `tests/agent/test_context_compressor.py`, `tests/run_agent/test_long_context_tier_429.py`, `test_auth_provider_failover.py`, `test_nous_429_fallback_reentry.py` → **149 passed**.
- [x] Anthropic adapter surface — `tests/agent/test_anthropic_adapter.py`, `test_anthropic_mcp_prefix_strip.py`, `tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py`, `tests/agent/test_failover_identity.py` → **113 passed, 1 skipped**.
- [x] `ruff check` clean on all three files.
- [ ] ⚠️ `tests/agent/test_credential_pool_routing.py::TestFailureAttribution::test_unmatched_key_does_not_retry_only_pool_entry` fails — **pre-existing**, reproduced identically on a clean tree with these changes stashed. Unrelated to this PR (`credential_pool.py` is untouched here).
- [ ] Not verified against a live subscription-OAuth credential — I don't hold one. The probe path is fully mocked in tests; a maintainer with an OAuth token can confirm end-to-end by reproducing the issue's bisect and checking that the abort no longer names billing and `hermes auth status` no longer shows the credential exhausted.

## Relationship to the other open PRs on this issue — please read before merging

This is deliberately **not** another copy of the reword. It is the layer none of them touch.

- **#82177** applies the issue's suggested reword and *hedges the wording* of `_billing_or_entitlement_message` ("is exhausted" → "may be exhausted", plus a manual discriminator for the operator). Its author explicitly left the credential-quarantine mechanism alone as out of blast radius. This PR replaces the guesswork that hedge asks the human to do with an authoritative answer from the account, and fixes the quarantine as a consequence. The two do not conflict — merged together, the hedged wording simply stops being reachable in the case it was written for.
- **#78025** (mine, targets #65365) rewords the whole `SKILLS_GUIDANCE` block plus the `session_search` / `memory` wire aliases. That is the per-occurrence trigger fix for this same classifier. **No file overlap with this PR.**
- **#82181** (mine) covers the issue's secondary observations — the `[cached]` label on replayed exhausted-credential errors and the `CLAUDE_CODE_OAUTH_TOKEN` registry note. Complementary: that one labels the stale replay, this one stops the healthy credential from being quarantined in the first place. **No file overlap.**

If maintainers prefer the reword to land from #82177 or #78025, this PR is unaffected — it deliberately changes no prompt text.

## Known limitations

- Anthropic-specific. Other providers' billing-shaped rejections stay on the message-matching path, because no equivalent authoritative usage endpoint is wired up for them.
- The verdict is only as good as the usage endpoint. If Anthropic ever reported capacity the inference endpoint won't honour, the fact-check would clear a billing verdict it should have kept — the failure mode is then a `content_policy_blocked` abort with a fallback attempt instead of a billing message, which is recoverable and visible, not silent.
- Covers the main conversation loop. Compression and auxiliary calls classify through their own paths and still see the raw billing verdict; folding them in would mean touching shared helpers used by every provider and is better as a follow-up.
