### PR TITLE
fix(approval): default dangerous command prompts to deny (#82647)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13507,7 +13507,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     allow_permanent=allow_permanent,
                     smart_denied=smart_denied,
                 ),
-                "selected": 0,
+                # Start on the fail-closed choice. Enter must never approve
+                # a dangerous command before the user explicitly navigates to
+                # an affirmative option. The deny index depends on which
+                # optional approval choices are available.
+                "selected": self._approval_choices(
+                    command,
+                    allow_permanent=allow_permanent,
+                    smart_denied=smart_denied,
+                ).index("deny"),
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -67,6 +67,52 @@ def _make_background_cli_stub():
 
 
 class TestCliApprovalUi:
+    def test_approval_callback_starts_on_deny(self):
+        cli = _make_cli_stub()
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback(
+                "git reset --hard HEAD~1",
+                "destructive git reset",
+            )
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+
+        deadline = time.time() + 2
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._approval_state is not None
+        assert cli._approval_state["choices"][cli._approval_state["selected"]] == "deny"
+
+        cli._approval_state["response_queue"].put("deny")
+        thread.join(timeout=2)
+        assert result["value"] == "deny"
+
+    def test_approval_callback_starts_on_deny_without_permanent_allow(self):
+        cli = _make_cli_stub()
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback(
+                "git clean -fd", "destructive cleanup", allow_permanent=False,
+            )
+
+        thread = threading.Thread(target=_run_callback, daemon=True)
+        thread.start()
+        deadline = time.time() + 2
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._approval_state is not None
+        assert cli._approval_state["choices"][cli._approval_state["selected"]] == "deny"
+        cli._approval_state["response_queue"].put("deny")
+        thread.join(timeout=2)
+        assert result["value"] == "deny"
+
+
     def test_smart_denied_callback_offers_only_once_and_deny(self):
         cli = _make_cli_stub()
         result = {}


### PR DESCRIPTION
## Summary
- default interactive dangerous-command approval prompts to the fail-closed `deny` choice
- prevent a bare Enter on the initial prompt from authorizing destructive commands
- add regression coverage for full and restricted approval choice sets

## Tests
- `python3 -m pytest -q tests/cli/test_cli_approval_ui.py` (17 passed)
- `python3 -m py_compile cli.py`

Closes #82647
