### PR TITLE
fix(updates): report backend update failures truthfully

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -161,10 +161,54 @@ def _is_official_ssh_remote(url: str | None) -> bool:
     return _is_ssh_remote(url) and _canonical_github_remote(url) == _OFFICIAL_REPO_CANONICAL
 
 
-def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
+def _classify_git_stderr(stderr: str | None) -> Optional[str]:
+    """Map git stderr to a stable machine-readable error code."""
+    text = (stderr or "").lower()
+    if not text:
+        return None
+    if "dubious ownership" in text or "safe.directory" in text:
+        return "git-ownership"
+    if (
+        "permission denied" in text
+        or "read-only file system" in text
+        or "operation not permitted" in text
+    ):
+        return "git-permission"
+    if (
+        "could not resolve host" in text
+        or "unable to access" in text
+        or "network is unreachable" in text
+        or "connection refused" in text
+        or "timed out" in text
+        or "temporary failure in name resolution" in text
+    ):
+        return "offline"
+    return None
+
+
+def _git_cmd_prefix(cwd: Path, *, relax_ownership: bool) -> list[str]:
+    """Build a ``git`` argv prefix.
+
+    When ``relax_ownership`` is True, add a *process-local*
+    ``-c safe.directory=<abs>`` so read-only probes work on root-owned
+    checkouts (e.g. ``/opt/hermes-agent``). Never writes global git config.
+    """
+    cmd = ["git"]
+    if relax_ownership:
+        cmd.extend(["-c", f"safe.directory={cwd.resolve()}"])
+    return cmd
+
+
+def _git_run(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int = 5,
+    relax_ownership: bool = False,
+) -> Optional[subprocess.CompletedProcess]:
     try:
-        result = subprocess.run(
-            ["git", *args],
+        return subprocess.run(
+            [*_git_cmd_prefix(cwd, relax_ownership=relax_ownership), *args],
             capture_output=True,
             text=True,
             # git output is UTF-8; on Windows text=True defaults to the ANSI
@@ -177,7 +221,19 @@ def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str
         )
     except Exception:
         return None
-    if result.returncode != 0:
+
+
+def _git_stdout(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int = 5,
+    relax_ownership: bool = False,
+) -> Optional[str]:
+    result = _git_run(
+        args, cwd=cwd, timeout=timeout, relax_ownership=relax_ownership
+    )
+    if result is None or result.returncode != 0:
         return None
     return (result.stdout or "").strip()
 
@@ -204,15 +260,59 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
-def _check_via_local_git(repo_dir: Path) -> Optional[int]:
-    """Count commits behind origin/main in a local checkout."""
-    origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
+def repo_install_writable(repo_dir: Path) -> bool:
+    """True when this process can write the install root and its ``.git``."""
+    try:
+        if not os.access(repo_dir, os.W_OK):
+            return False
+        git_dir = repo_dir / ".git"
+        if git_dir.exists() and not os.access(git_dir, os.W_OK):
+            return False
+        return True
+    except OSError:
+        return False
+
+
+def _check_via_local_git(repo_dir: Path) -> tuple[Optional[int], Optional[str], Optional[str]]:
+    """Count commits behind origin/main in a local checkout.
+
+    Returns ``(behind, error_code, current_revision)``.
+
+    Uses process-local ``safe.directory`` for **read-only** git ops so
+    root-owned installs still report availability. Fetch (which writes
+    ``.git``) is attempted normally; if it cannot write, falls back to
+    ``HEAD`` + ``ls-remote`` (``UPDATE_AVAILABLE_NO_COUNT`` when SHAs differ).
+    Never sets global ``safe.directory``.
+    """
+    # Ownership-safe read of HEAD — needed both for the compare and for
+    # surfacing current_revision when the check otherwise fails.
+    head = _git_run(
+        ["rev-parse", "HEAD"], cwd=repo_dir, relax_ownership=True
+    )
+    head_rev = (head.stdout or "").strip() if head and head.returncode == 0 else None
+    head_err = _classify_git_stderr(head.stderr if head else None)
+
+    if not head_rev:
+        # Retry without relax in case the first failure was unrelated; still
+        # classify ownership from whichever attempt produced stderr.
+        return None, head_err or "check-failed", None
+
+    origin = _git_run(
+        ["remote", "get-url", "origin"], cwd=repo_dir, relax_ownership=True
+    )
+    origin_url = (
+        (origin.stdout or "").strip()
+        if origin and origin.returncode == 0
+        else None
+    )
+
     if _is_official_ssh_remote(origin_url):
-        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        checked = _check_via_rev(head_rev) if head_rev else None
+        checked = _check_via_rev(head_rev)
+        if checked is None:
+            return None, "offline", head_rev
         if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1
-        return checked
+            return 1, None, head_rev
+        return checked, None, head_rev
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would
@@ -222,9 +322,15 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     # --depth 1 to preserve the boundary and compare tip SHAs instead of
     # counting. Full clones (developers, Docker dev images) keep the exact
     # count path unchanged. Mirrors the desktop fix in apps/desktop/electron/main.cjs.
-    shallow = _git_stdout(["rev-parse", "--is-shallow-repository"], cwd=repo_dir)
+    shallow = _git_stdout(
+        ["rev-parse", "--is-shallow-repository"],
+        cwd=repo_dir,
+        relax_ownership=True,
+    )
     is_shallow = shallow == "true"
 
+    fetch_ok = False
+    fetch_error: Optional[str] = None
     try:
         # Scope the fetch to the one branch the behind-count compares against.
         # An unscoped ``git fetch origin`` transfers every remote head (~1,400
@@ -234,43 +340,186 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         # ref on a scoped fetch, so the ``HEAD..origin/main`` count below is
         # unaffected; the shallow path compares against FETCH_HEAD, which a
         # scoped fetch also updates.
-        fetch_args = ["git", "fetch", "origin", "main"]
+        #
+        # Fetch writes into ``.git`` — do NOT pass safe.directory here as a
+        # way to paper over root-owned installs; if the tree isn't writable
+        # the fetch fails and we fall back to ls-remote below.
+        fetch_args = ["fetch", "origin", "main"]
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")
-        subprocess.run(
-            fetch_args,
-            capture_output=True, timeout=10,
-            cwd=str(repo_dir),
+        # Fetch writes into ``.git`` — never pass process-local safe.directory
+        # here. Ownership / permission failures fall through to the read-only
+        # ls-remote compare below.
+        fetch_result = _git_run(
+            fetch_args, cwd=repo_dir, timeout=10, relax_ownership=False
         )
+        if fetch_result is not None and fetch_result.returncode == 0:
+            fetch_ok = True
+        elif fetch_result is not None:
+            fetch_error = _classify_git_stderr(fetch_result.stderr) or "check-failed"
     except Exception:
-        pass  # Offline or timeout — use stale refs, that's fine
+        fetch_error = "check-failed"
+
+    if not fetch_ok:
+        # Read-only / non-writable .git / offline fetch — compare tip SHAs
+        # via ls-remote against the official HTTPS remote. No local writes.
+        checked = _check_via_rev(head_rev)
+        if checked is not None:
+            return checked, None, head_rev
+        return None, fetch_error or "offline", head_rev
 
     if is_shallow:
         # No history to count across the shallow boundary. `origin/main` may not
         # be a tracking ref in a `clone --depth 1`, so prefer FETCH_HEAD (just
         # updated by the fetch above) and fall back to origin/main.
-        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         target_rev = (
-            _git_stdout(["rev-parse", "FETCH_HEAD"], cwd=repo_dir)
-            or _git_stdout(["rev-parse", "origin/main"], cwd=repo_dir)
+            _git_stdout(
+                ["rev-parse", "FETCH_HEAD"], cwd=repo_dir, relax_ownership=True
+            )
+            or _git_stdout(
+                ["rev-parse", "origin/main"], cwd=repo_dir, relax_ownership=True
+            )
         )
-        if not head_rev or not target_rev:
-            return None
-        return 0 if head_rev == target_rev else UPDATE_AVAILABLE_NO_COUNT
+        if not target_rev:
+            checked = _check_via_rev(head_rev)
+            if checked is not None:
+                return checked, None, head_rev
+            return None, "check-failed", head_rev
+        behind = 0 if head_rev == target_rev else UPDATE_AVAILABLE_NO_COUNT
+        return behind, None, head_rev
+
+    count = _git_run(
+        ["rev-list", "--count", "HEAD..origin/main"],
+        cwd=repo_dir,
+        relax_ownership=True,
+    )
+    if count is not None and count.returncode == 0:
+        try:
+            return int((count.stdout or "").strip()), None, head_rev
+        except ValueError:
+            pass
+
+    # Count failed (missing origin/main ref, etc.) — last-resort SHA compare.
+    checked = _check_via_rev(head_rev)
+    if checked is not None:
+        return checked, None, head_rev
+    return None, _classify_git_stderr(count.stderr if count else None) or "check-failed", head_rev
+
+
+def check_for_updates_details() -> Dict[str, Optional[object]]:
+    """Rich update check for API consumers.
+
+    Returns a dict with:
+      - behind: int | None (null only on true failure / N/A)
+      - error_code: str | None (set when behind is null due to a failed check)
+      - current_revision: str | None
+      - message: str | None
+      - repo_writable: bool | None (git installs only)
+    """
+    hermes_home = get_hermes_home()
+    cache_file = hermes_home / ".update_check"
+    embedded_rev = os.environ.get("HERMES_REVISION") or None
 
     try:
-        result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=5,
-            cwd=str(repo_dir),
-        )
-        if result.returncode == 0:
-            return int(result.stdout.strip())
+        from hermes_cli.config import detect_install_method, get_project_root
+        if detect_install_method(get_project_root()) == "docker":
+            return {
+                "behind": None,
+                "error_code": None,
+                "current_revision": None,
+                "message": None,
+                "repo_writable": None,
+            }
     except Exception:
         pass
-    return None
+
+    now = time.time()
+    try:
+        if cache_file.exists():
+            cached = json.loads(cache_file.read_text(encoding="utf-8"))
+            if (
+                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+                and cached.get("rev") == embedded_rev
+                and cached.get("ver") == VERSION
+            ):
+                return {
+                    "behind": cached.get("behind"),
+                    "error_code": cached.get("error_code"),
+                    "current_revision": cached.get("current_revision"),
+                    "message": cached.get("message"),
+                    "repo_writable": cached.get("repo_writable"),
+                }
+    except Exception:
+        pass
+
+    behind: Optional[int] = None
+    error_code: Optional[str] = None
+    current_revision: Optional[str] = embedded_rev
+    message: Optional[str] = None
+    repo_writable: Optional[bool] = None
+
+    if embedded_rev:
+        behind = _check_via_rev(embedded_rev)
+        if behind is None:
+            error_code = "offline"
+            message = "Couldn't reach the update source — try again later."
+    else:
+        repo_dir = Path(__file__).parent.parent.resolve()
+        if not (repo_dir / ".git").exists():
+            repo_dir = hermes_home / "hermes-agent"
+        if not (repo_dir / ".git").exists():
+            behind = None
+            # No checkout — not a failed check; caller (docker/unknown) decides.
+            error_code = None
+        else:
+            repo_writable = repo_install_writable(repo_dir)
+            behind, error_code, current_revision = _check_via_local_git(repo_dir)
+            if behind is None and error_code:
+                if error_code == "git-ownership":
+                    message = (
+                        "Git refused this checkout due to ownership mismatch. "
+                        "Updates can't be applied from this process; reinstall "
+                        "or fix directory ownership, then retry."
+                    )
+                elif error_code == "git-permission":
+                    message = (
+                        "The Hermes install directory isn't writable by this "
+                        "process, so the update check couldn't refresh refs. "
+                        "Update from an account that owns the install, or "
+                        "reinstall into a user-writable location."
+                    )
+                elif error_code == "offline":
+                    message = "Couldn't reach the update source — try again later."
+                else:
+                    message = "Couldn't check for updates — try again later."
+
+    try:
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "ts": now,
+                    "behind": behind,
+                    "rev": embedded_rev,
+                    "ver": VERSION,
+                    "error_code": error_code,
+                    "current_revision": current_revision,
+                    "message": message,
+                    "repo_writable": repo_writable,
+                }
+            ),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
+    return {
+        "behind": behind,
+        "error_code": error_code,
+        "current_revision": current_revision,
+        "message": message,
+        "repo_writable": repo_writable,
+    }
 
 
 def check_for_updates() -> Optional[int]:
@@ -284,65 +533,7 @@ def check_for_updates() -> Optional[int]:
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if
     the check failed or doesn't apply. Cached for 6 hours.
     """
-    hermes_home = get_hermes_home()
-    cache_file = hermes_home / ".update_check"
-    embedded_rev = os.environ.get("HERMES_REVISION") or None
-
-    # Docker images have no working tree to count commits against — the
-    # published image excludes `.git` (see .dockerignore) and sets no
-    # HERMES_REVISION (that's nix-only). Returning None makes both the Rich
-    # banner (build_welcome_banner) and the Ink badge (branding.tsx, guarded
-    # on `typeof === 'number' && > 0`) show nothing. The dashboard's REST
-    # `/api/hermes/update/check` endpoint short-circuits docker the same way
-    # (web_server.py); mirror that here so the banner/TUI surfaces agree.
-    try:
-        from hermes_cli.config import detect_install_method, get_project_root
-        if detect_install_method(get_project_root()) == "docker":
-            return None
-    except Exception:
-        pass
-
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check.
-    now = time.time()
-    try:
-        if cache_file.exists():
-            cached = json.loads(cache_file.read_text(encoding="utf-8"))
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-                and cached.get("ver") == VERSION
-            ):
-                return cached.get("behind")
-    except Exception:
-        pass
-
-    if embedded_rev:
-        behind = _check_via_rev(embedded_rev)
-    else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
-            # No git checkout and no embedded revision — can't determine
-            # update status. This is the Docker path (already short-circuited
-            # above) or an unsupported install without a source tree.
-            behind = None
-        else:
-            behind = _check_via_local_git(repo_dir)
-
-    try:
-        cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
-            encoding="utf-8",
-        )
-    except Exception:
-        pass
-
-    return behind
+    return check_for_updates_details().get("behind")  # type: ignore[return-value]
 
 
 def _resolve_repo_dir() -> Optional[Path]:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4270,10 +4270,16 @@ async def check_hermes_update(force: bool = False):
                 check could not run (offline, no remote, etc.)
         update_available: convenience bool (behind is non-zero and not null)
         can_apply: True when the dashboard's update button can apply it
-                   in place (git); False for other install methods where the
-                   user must update out-of-band
+                   in place (writable git install); False when the user
+                   must update out-of-band
         update_command: the recommended command for this install method
-        message: human-readable guidance for non-applyable methods
+        message: human-readable guidance
+        error_code: stable machine-readable failure reason when the check
+                    failed (e.g. git-ownership, git-permission, offline,
+                    check-failed). Absent/null for unsupported install
+                    methods (docker/managed) where behind is null without
+                    an error.
+        current_revision: git HEAD (or HERMES_REVISION) when known
         commits: for git installs that are behind, a list of the commits
                  the local checkout is behind upstream by — each
                  {sha, summary, author, at}. Absent/empty otherwise. The
@@ -4292,30 +4298,43 @@ async def check_hermes_update(force: bool = False):
                 "Hermes updates are managed outside this dashboard in "
                 "containerized environments."
             ),
+            "error_code": None,
+            "current_revision": None,
         }
 
     install_method = detect_install_method(PROJECT_ROOT)
     update_command = recommended_update_command_for_method(install_method)
+
+    repo_writable = True
+    if install_method == "git":
+        try:
+            from hermes_cli.banner import repo_install_writable
+
+            repo_writable = repo_install_writable(PROJECT_ROOT)
+        except Exception:
+            repo_writable = os.access(PROJECT_ROOT, os.W_OK)
 
     payload: Dict[str, Any] = {
         "install_method": install_method,
         "current_version": __version__,
         "behind": None,
         "update_available": False,
-        "can_apply": install_method == "git",
+        "can_apply": install_method == "git" and repo_writable,
         "update_command": update_command,
         "message": None,
+        "error_code": None,
+        "current_revision": None,
     }
 
     if install_method == "docker":
         payload["message"] = format_docker_update_message()
         return payload
 
-    # banner.check_for_updates() handles git / nix-revision paths and
+    # banner.check_for_updates_details() handles git / nix-revision paths and
     # caches the result for 6h. ``force`` busts the cache so the "Check now"
     # button reflects reality immediately.
     try:
-        from hermes_cli.banner import check_for_updates
+        from hermes_cli.banner import check_for_updates_details
 
         if force:
             try:
@@ -4323,18 +4342,55 @@ async def check_hermes_update(force: bool = False):
             except OSError:
                 pass
 
-        behind = await asyncio.to_thread(check_for_updates)
+        details = await asyncio.to_thread(check_for_updates_details)
     except Exception:
         _log.exception("Update check failed")
-        behind = None
+        details = {
+            "behind": None,
+            "error_code": "check-failed",
+            "current_revision": None,
+            "message": "Couldn't check for updates — try again later.",
+            "repo_writable": repo_writable if install_method == "git" else None,
+        }
+
+    behind = details.get("behind")
+    error_code = details.get("error_code")
+    current_revision = details.get("current_revision")
+    detail_message = details.get("message")
+    detail_writable = details.get("repo_writable")
+
+    if install_method == "git":
+        if detail_writable is False:
+            repo_writable = False
+        payload["can_apply"] = bool(repo_writable)
 
     payload["behind"] = behind
+    payload["error_code"] = error_code
+    payload["current_revision"] = current_revision
+
     if behind is None:
-        payload["message"] = "Couldn't reach the update source — try again later."
+        if error_code:
+            payload["message"] = (
+                detail_message
+                or "Couldn't check for updates — try again later."
+            )
+        else:
+            # Unsupported / N/A (no error_code) — keep prior guidance when set.
+            payload["message"] = (
+                detail_message
+                or "Couldn't reach the update source — try again later."
+            )
     elif behind == 0:
         payload["message"] = "You're on the latest version."
     else:
         payload["update_available"] = True
+        if install_method == "git" and not repo_writable:
+            payload["message"] = detail_message or (
+                "An update is available, but this install directory isn't "
+                "writable by the backend process. Update from an account that "
+                "owns the install (or reinstall into a user-writable location), "
+                f"then run: {update_command}"
+            )
         # Enrich with the actual commits we're behind by, so the desktop's
         # remote update overlay can show "what's changed". git only;
         # best-effort (empty list on any failure).

--- a/tests/hermes_cli/test_banner_update_git_ownership.py
+++ b/tests/hermes_cli/test_banner_update_git_ownership.py
@@ -1,0 +1,136 @@
+"""Tests for ownership-safe local git update checks in hermes_cli.banner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli.banner import (
+    UPDATE_AVAILABLE_NO_COUNT,
+    _check_via_local_git,
+    _classify_git_stderr,
+    repo_install_writable,
+)
+
+
+def test_classify_git_stderr_ownership_and_permission():
+    assert (
+        _classify_git_stderr(
+            "fatal: detected dubious ownership in repository at '/opt/hermes-agent'"
+        )
+        == "git-ownership"
+    )
+    assert _classify_git_stderr("error: cannot open '.git/FETCH_HEAD': Permission denied") == (
+        "git-permission"
+    )
+    assert _classify_git_stderr("fatal: unable to access 'https://...': Could not resolve host") == (
+        "offline"
+    )
+
+
+def test_repo_install_writable_false_when_root_not_writable(tmp_path, monkeypatch):
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    monkeypatch.setattr("hermes_cli.banner.os.access", lambda path, mode: False)
+    assert repo_install_writable(repo) is False
+
+
+def test_check_via_local_git_falls_back_to_ls_remote_when_fetch_blocked(tmp_path, monkeypatch):
+    """Root-owned / non-writable .git: read HEAD with process-local safe.directory,
+    skip fetch writes, compare via ls-remote. Never touch global safe.directory.
+    """
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    head_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    upstream_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stdout = ""
+        completed.stderr = ""
+
+        # Process-local ownership relax for read-only ops only.
+        if cmd[:1] == ["git"] and "-c" in cmd:
+            cfg = cmd[cmd.index("-c") + 1]
+            assert cfg.startswith("safe.directory=")
+            assert "safe.directory" not in "".join(
+                c for c in cmd if c.startswith("--global")
+            )
+
+        if "rev-parse" in cmd and "HEAD" in cmd and "FETCH_HEAD" not in cmd:
+            completed.stdout = head_sha + "\n"
+            return completed
+        if "remote" in cmd and "get-url" in cmd:
+            completed.stdout = "https://github.com/NousResearch/hermes-agent.git\n"
+            return completed
+        if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+            completed.stdout = "false\n"
+            return completed
+        if "fetch" in cmd:
+            completed.returncode = 128
+            completed.stderr = (
+                "error: cannot open '.git/FETCH_HEAD': Permission denied\n"
+            )
+            return completed
+        if "ls-remote" in cmd:
+            completed.stdout = f"{upstream_sha}\trefs/heads/main\n"
+            return completed
+
+        completed.returncode = 1
+        completed.stderr = "unexpected"
+        return completed
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+
+    behind, error_code, current_revision = _check_via_local_git(repo)
+
+    assert behind == UPDATE_AVAILABLE_NO_COUNT
+    assert error_code is None
+    assert current_revision == head_sha
+
+    fetch_cmds = [c for c in calls if "fetch" in c]
+    assert fetch_cmds, "expected a fetch attempt"
+    for cmd in fetch_cmds:
+        # Fetch must not paper over ownership with -c safe.directory.
+        assert "-c" not in cmd
+
+    read_cmds = [c for c in calls if "rev-parse" in c and "HEAD" in c]
+    assert any("-c" in c for c in read_cmds)
+
+    # Never mutate global git config in this path.
+    assert not any("config" in c and "--global" in c for c in calls)
+
+
+def test_check_via_local_git_reports_ownership_when_head_unreadable(tmp_path, monkeypatch):
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        completed = MagicMock()
+        completed.returncode = 128
+        completed.stdout = ""
+        completed.stderr = (
+            "fatal: detected dubious ownership in repository at "
+            f"'{repo}'\n"
+        )
+        return completed
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+
+    behind, error_code, current_revision = _check_via_local_git(repo)
+    assert behind is None
+    assert error_code == "git-ownership"
+    assert current_revision is None

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -783,7 +783,19 @@ class TestUpdateCheckEndpoint:
         # Stub the shared checker so the contract is deterministic (no network).
         import hermes_cli.banner as banner
 
-        monkeypatch.setattr(banner, "check_for_updates", lambda: 5)
+        monkeypatch.setattr(
+            banner,
+            "check_for_updates_details",
+            lambda: {
+                "behind": 5,
+                "error_code": None,
+                "current_revision": "deadbeef",
+                "message": None,
+                "repo_writable": True,
+            },
+        )
+        monkeypatch.setattr(banner, "repo_install_writable", lambda *_a, **_k: True)
+        monkeypatch.setattr(ws, "_recent_upstream_commits", lambda n=20: [])
 
         r = self.client.get("/api/hermes/update/check")
         assert r.status_code == 200
@@ -802,6 +814,8 @@ class TestUpdateCheckEndpoint:
         assert body["update_available"] is True
         # git/pip installs can apply the update in place from the dashboard.
         assert body["can_apply"] is True
+        assert body.get("error_code") in (None, "")
+        assert body.get("current_revision") == "deadbeef"
 
 
 
@@ -822,7 +836,77 @@ class TestUpdateCheckEndpoint:
         assert body["can_apply"] is False
         assert body["update_available"] is False
         assert body["behind"] is None
+        assert body.get("error_code") in (None, "")
         assert "managed outside this dashboard" in body["message"]
+
+    def test_docker_behind_null_is_unsupported_not_error(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "docker")
+        monkeypatch.setattr(
+            ws, "format_docker_update_message", lambda: "Docker images are immutable."
+        )
+
+        body = self.client.get("/api/hermes/update/check").json()
+        assert body["behind"] is None
+        assert body["update_available"] is False
+        assert body["can_apply"] is False
+        assert body.get("error_code") in (None, "")
+        assert "immutable" in body["message"].lower() or "Docker" in body["message"]
+
+    def test_git_check_failure_exposes_error_code_not_latest(self, monkeypatch):
+        import hermes_cli.web_server as ws
+        import hermes_cli.banner as banner
+
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "git")
+        monkeypatch.setattr(banner, "repo_install_writable", lambda *_a, **_k: False)
+        monkeypatch.setattr(
+            banner,
+            "check_for_updates_details",
+            lambda: {
+                "behind": None,
+                "error_code": "git-ownership",
+                "current_revision": "1c9433897c",
+                "message": "Git refused this checkout due to ownership mismatch.",
+                "repo_writable": False,
+            },
+        )
+
+        body = self.client.get("/api/hermes/update/check").json()
+        assert body["behind"] is None
+        assert body["update_available"] is False
+        assert body["can_apply"] is False
+        assert body["error_code"] == "git-ownership"
+        assert body["current_revision"] == "1c9433897c"
+        assert "ownership" in body["message"].lower()
+        assert body["message"] != "You're on the latest version."
+
+    def test_git_update_available_but_not_writable_disables_apply(self, monkeypatch):
+        import hermes_cli.web_server as ws
+        import hermes_cli.banner as banner
+
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "git")
+        monkeypatch.setattr(banner, "repo_install_writable", lambda *_a, **_k: False)
+        monkeypatch.setattr(
+            banner,
+            "check_for_updates_details",
+            lambda: {
+                "behind": 12,
+                "error_code": None,
+                "current_revision": "abc1234",
+                "message": None,
+                "repo_writable": False,
+            },
+        )
+        monkeypatch.setattr(ws, "_recent_upstream_commits", lambda n=20: [])
+
+        body = self.client.get("/api/hermes/update/check").json()
+        assert body["behind"] == 12
+        assert body["update_available"] is True
+        assert body["can_apply"] is False
+        assert body.get("error_code") in (None, "")
+        assert body["current_revision"] == "abc1234"
+        assert "writable" in body["message"].lower()
 
 
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -58,5 +58,95 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def test_check_via_local_git_ownership_falls_back_to_ls_remote(tmp_path, monkeypatch):
+    """Root-owned / non-fetchable checkouts must still report availability.
 
+    Process-local safe.directory is used for read-only HEAD; fetch write
+    failures fall back to ls-remote. Never treat this as up-to-date/null.
+    """
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "install"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    upstream = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+    def fake_run(args, **kwargs):
+        # args is full argv including optional -c safe.directory=
+        argv = list(args)
+        # strip leading git [-c safe.directory=...]
+        while argv and argv[0] == "git":
+            argv = argv[1:]
+        while len(argv) >= 2 and argv[0] == "-c":
+            argv = argv[2:]
+
+        class R:
+            def __init__(self, rc=0, out="", err=""):
+                self.returncode = rc
+                self.stdout = out
+                self.stderr = err
+
+        if argv[:2] == ["rev-parse", "HEAD"]:
+            return R(0, head + "\n")
+        if argv[:3] == ["remote", "get-url", "origin"]:
+            return R(0, "https://github.com/NousResearch/hermes-agent.git\n")
+        if argv[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return R(0, "false\n")
+        if argv[:3] == ["fetch", "origin", "main"]:
+            return R(1, "", "fatal: Unable to create temporary file: Permission denied\n")
+        if argv[:2] == ["ls-remote", banner._UPSTREAM_REPO_URL]:
+            return R(0, f"{upstream}\trefs/heads/main\n")
+        if argv[:3] == ["rev-list", "--count", "HEAD..origin/main"]:
+            return R(128, "", "fatal: bad revision\n")
+        return R(128, "", "unexpected: " + " ".join(argv))
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    behind, err, rev = banner._check_via_local_git(repo)
+    assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert err is None
+    assert rev == head
+
+
+def test_check_via_local_git_head_failure_is_error_not_zero(tmp_path, monkeypatch):
+    """If even ownership-relaxed HEAD fails, return null + error_code."""
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "install"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    def fake_run(args, **kwargs):
+        class R:
+            returncode = 128
+            stdout = ""
+            stderr = (
+                "fatal: detected dubious ownership in repository at "
+                f"'{repo}'\n"
+            )
+
+        return R()
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    behind, err, rev = banner._check_via_local_git(repo)
+    assert behind is None
+    assert err == "git-ownership"
+    assert rev is None
+
+
+def test_repo_install_writable_false_when_git_not_writable(tmp_path):
+    from hermes_cli.banner import repo_install_writable
+
+    repo = tmp_path / "install"
+    git = repo / ".git"
+    repo.mkdir()
+    git.mkdir()
+    git.chmod(0o555)
+    repo.chmod(0o555)
+    try:
+        assert repo_install_writable(repo) is False
+    finally:
+        repo.chmod(0o755)
+        git.chmod(0o755)
 


### PR DESCRIPTION
Summary

Backend update checks now distinguish “already current” from “could not determine update state.” This preserves the independent Backend status needed by Desktop PR #82608.

What changed

- return structured backend update facts instead of collapsing Git failures into zero-behind
- classify repository ownership and writable-install failures without exposing raw command output
- surface truthful update capability and error codes through the Dashboard API
- retain remote-target-aware update facts

Scope

Backend only: hermes_cli/banner.py, hermes_cli/web_server.py, and three focused Python test files. Desktop UI changes remain isolated in PR #82608.

Verification at exact head 9d0e565085218ee7ee8982c91e2aaae3a6c586f3

- 256 related banner, updater, and Dashboard admin endpoint tests passed
- the ownership regression fails against untouched base `244d296646909aca1dd16c9759491da0ef4cd163` (missing structured checker), proving it detects the old behavior
- Ruff passed on all five touched files
- `git diff --check` passed
- Real classifier probe: clean candidate returned `behind=0`, `repo_writable=true`; root-owned `/opt/hermes-agent` returned the intentional update-available-without-count sentinel with `repo_writable=false`, which the API maps to `update_available=true`, `can_apply=false`
