### PR TITLE
fix(tui): paste local clipboard images through remote gateways

### DIFF
--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -2,29 +2,75 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { isUsableClipboardText, readClipboardImage, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 
+/** Minimal 1x1 PNG — signature must match what readClipboardImage accepts. */
+const MINIMAL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+const MINIMAL_PNG_BASE64 = MINIMAL_PNG.toString('base64')
+
 describe('readClipboardImage', () => {
   it('extracts a PNG from the native Windows clipboard via PowerShell', async () => {
-    const contentBase64 = Buffer.from('png bytes').toString('base64')
-    const run = vi.fn().mockResolvedValue({ stdout: `${contentBase64}\r\n` })
+    const run = vi.fn().mockResolvedValue({ stdout: `${MINIMAL_PNG_BASE64}\r\n` })
 
-    await expect(readClipboardImage('win32', run)).resolves.toEqual({ contentBase64, filename: 'clipboard.png' })
+    await expect(readClipboardImage('win32', run)).resolves.toEqual({
+      contentBase64: MINIMAL_PNG_BASE64,
+      filename: 'clipboard.png'
+    })
     expect(run).toHaveBeenCalledWith(
       'powershell',
       expect.arrayContaining(['-NoProfile', '-NonInteractive', '-Command']),
-      expect.objectContaining({ encoding: 'utf8', windowsHide: true })
+      expect.objectContaining({ encoding: 'utf8', timeout: 3_000, windowsHide: true })
     )
     expect(run.mock.calls[0]![1].at(-1)).toContain('[System.Windows.Forms.Clipboard]::GetImage()')
   })
 
   it('uses the Windows clipboard first from WSL', async () => {
-    const contentBase64 = Buffer.from('png bytes').toString('base64')
-    const run = vi.fn().mockResolvedValue({ stdout: contentBase64 })
+    const run = vi.fn().mockResolvedValue({ stdout: MINIMAL_PNG_BASE64 })
 
     await expect(readClipboardImage('linux', run, { WSL_INTEROP: '/tmp/socket' })).resolves.toEqual({
-      contentBase64,
+      contentBase64: MINIMAL_PNG_BASE64,
       filename: 'clipboard.png'
     })
-    expect(run).toHaveBeenCalledWith('powershell.exe', expect.any(Array), expect.objectContaining({ encoding: 'utf8' }))
+    expect(run).toHaveBeenCalledWith(
+      'powershell.exe',
+      expect.any(Array),
+      expect.objectContaining({ encoding: 'utf8', timeout: 3_000 })
+    )
+  })
+
+  it('skips non-PNG stdout and tries the next clipboard backend', async () => {
+    const junkBase64 = Buffer.from('png bytes').toString('base64')
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: junkBase64 })
+      .mockResolvedValueOnce({ stdout: MINIMAL_PNG_BASE64 })
+
+    await expect(
+      readClipboardImage('linux', run, { WSL_INTEROP: '/tmp/socket', WAYLAND_DISPLAY: 'wayland-1' })
+    ).resolves.toEqual({
+      contentBase64: MINIMAL_PNG_BASE64,
+      filename: 'clipboard.png'
+    })
+    expect(run).toHaveBeenNthCalledWith(1, 'powershell.exe', expect.any(Array), expect.anything())
+    expect(run).toHaveBeenNthCalledWith(
+      2,
+      'wl-paste',
+      ['--type', 'image/png'],
+      expect.objectContaining({ encoding: 'base64', timeout: 3_000 })
+    )
+  })
+
+  it('returns null when a backend times out and no later backend yields a PNG', async () => {
+    const timedOut = Object.assign(new Error('timed out'), { killed: true, code: 'ETIMEDOUT' })
+    const run = vi.fn().mockRejectedValue(timedOut)
+
+    await expect(readClipboardImage('win32', run)).resolves.toBeNull()
+    expect(run).toHaveBeenCalledWith(
+      'powershell',
+      expect.any(Array),
+      expect.objectContaining({ timeout: 3_000 })
+    )
   })
 
   it('returns null when no local clipboard backend yields image bytes', async () => {

--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -1,6 +1,38 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { isUsableClipboardText, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import { isUsableClipboardText, readClipboardImage, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+
+describe('readClipboardImage', () => {
+  it('extracts a PNG from the native Windows clipboard via PowerShell', async () => {
+    const contentBase64 = Buffer.from('png bytes').toString('base64')
+    const run = vi.fn().mockResolvedValue({ stdout: `${contentBase64}\r\n` })
+
+    await expect(readClipboardImage('win32', run)).resolves.toEqual({ contentBase64, filename: 'clipboard.png' })
+    expect(run).toHaveBeenCalledWith(
+      'powershell',
+      expect.arrayContaining(['-NoProfile', '-NonInteractive', '-Command']),
+      expect.objectContaining({ encoding: 'utf8', windowsHide: true })
+    )
+    expect(run.mock.calls[0]![1].at(-1)).toContain('[System.Windows.Forms.Clipboard]::GetImage()')
+  })
+
+  it('uses the Windows clipboard first from WSL', async () => {
+    const contentBase64 = Buffer.from('png bytes').toString('base64')
+    const run = vi.fn().mockResolvedValue({ stdout: contentBase64 })
+
+    await expect(readClipboardImage('linux', run, { WSL_INTEROP: '/tmp/socket' })).resolves.toEqual({
+      contentBase64,
+      filename: 'clipboard.png'
+    })
+    expect(run).toHaveBeenCalledWith('powershell.exe', expect.any(Array), expect.objectContaining({ encoding: 'utf8' }))
+  })
+
+  it('returns null when no local clipboard backend yields image bytes', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('no image'))
+
+    await expect(readClipboardImage('win32', run)).resolves.toBeNull()
+  })
+})
 
 describe('readClipboardText', () => {
   it('reads text from pbpaste on macOS', async () => {

--- a/ui-tui/src/__tests__/useComposerState.test.ts
+++ b/ui-tui/src/__tests__/useComposerState.test.ts
@@ -1,6 +1,43 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { looksLikeDroppedPath } from '../app/useComposerState.js'
+import { looksLikeDroppedPath, requestClipboardImage } from '../app/useComposerState.js'
+
+describe('requestClipboardImage', () => {
+  it('uploads local image bytes when the TUI is attached to a remote gateway', async () => {
+    const response = { attached: true, name: 'upload.png', path: '/gateway/upload.png' }
+    const gw = { request: vi.fn().mockResolvedValue(response) }
+    const readImage = vi.fn().mockResolvedValue({ contentBase64: 'cG5n', filename: 'clipboard.png' })
+
+    await expect(
+      requestClipboardImage(gw, 'session-1', readImage, { HERMES_TUI_GATEWAY_URL: 'ws://gateway.test/api/ws' })
+    ).resolves.toEqual(response)
+    expect(gw.request).toHaveBeenCalledWith('image.attach_bytes', {
+      content_base64: 'cG5n',
+      filename: 'clipboard.png',
+      session_id: 'session-1'
+    })
+  })
+
+  it('keeps gateway-side clipboard extraction for a spawned local gateway', async () => {
+    const response = { attached: true, path: '/local/clip.png' }
+    const gw = { request: vi.fn().mockResolvedValue(response) }
+    const readImage = vi.fn()
+
+    await expect(requestClipboardImage(gw, 'session-1', readImage, {})).resolves.toEqual(response)
+    expect(readImage).not.toHaveBeenCalled()
+    expect(gw.request).toHaveBeenCalledWith('clipboard.paste', { session_id: 'session-1' })
+  })
+
+  it('does not inspect the remote gateway clipboard when the client has no image', async () => {
+    const gw = { request: vi.fn() }
+    const readImage = vi.fn().mockResolvedValue(null)
+
+    await expect(
+      requestClipboardImage(gw, 'session-1', readImage, { HERMES_TUI_GATEWAY_URL: 'ws://gateway.test/api/ws' })
+    ).resolves.toBeNull()
+    expect(gw.request).not.toHaveBeenCalled()
+  })
+})
 
 describe('looksLikeDroppedPath', () => {
   it('recognizes macOS screenshot temp paths and file URIs', () => {

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -13,7 +13,7 @@ import type { ClipboardPasteResponse, ImageAttachResponse, InputDetectDropRespon
 import { useCompletion } from '../hooks/useCompletion.js'
 import { useInputHistory } from '../hooks/useInputHistory.js'
 import { useQueue } from '../hooks/useQueue.js'
-import { isUsableClipboardText, readClipboardText } from '../lib/clipboard.js'
+import { isUsableClipboardText, readClipboardImage, readClipboardText } from '../lib/clipboard.js'
 import { resolveEditor } from '../lib/editor.js'
 import { readOsc52Clipboard } from '../lib/osc52.js'
 import { isRemoteShellSession } from '../lib/terminalSetup.js'
@@ -103,6 +103,35 @@ export function looksLikeDroppedPath(text: string): boolean {
   }
 
   return false
+}
+
+interface ClipboardGateway {
+  request<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T>
+}
+
+type ClipboardImageResponse = ClipboardPasteResponse & ImageAttachResponse & { path?: string }
+
+export async function requestClipboardImage(
+  gw: ClipboardGateway,
+  sessionId: string,
+  readImage: typeof readClipboardImage = readClipboardImage,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<ClipboardImageResponse | null> {
+  if (env.HERMES_TUI_GATEWAY_URL?.trim()) {
+    const image = await readImage()
+
+    if (!image) {
+      return null
+    }
+
+    return gw.request<ClipboardImageResponse>('image.attach_bytes', {
+      content_base64: image.contentBase64,
+      filename: image.filename,
+      session_id: sessionId
+    })
+  }
+
+  return gw.request<ClipboardImageResponse>('clipboard.paste', { session_id: sessionId })
 }
 
 export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions): UseComposerStateResult {
@@ -213,9 +242,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
         return null
       }
 
-      const r = await gw
-        .request<ClipboardPasteResponse & { path?: string }>('clipboard.paste', { session_id: sid })
-        .catch(() => null)
+      const r = await requestClipboardImage(gw, sid).catch(() => null)
 
       if (r?.attached) {
         return attachImageToken(r, value, cursor)

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -3,6 +3,7 @@ import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 const CLIPBOARD_MAX_BUFFER = 4 * 1024 * 1024
+const CLIPBOARD_IMAGE_MAX_BUFFER = 36 * 1024 * 1024
 
 // PowerShell read: base64-encode the clipboard content to avoid ANSI codepage
 // corruption (same problem as the write path — see comment at line 94).
@@ -14,6 +15,80 @@ const POWERSHELL_READ_ARGS = [
 ] as const
 
 type ClipboardRun = typeof execFileAsync
+
+export interface ClipboardImagePayload {
+  contentBase64: string
+  filename: string
+}
+
+interface ClipboardImageCommand {
+  args: readonly string[]
+  cmd: string
+  output: 'base64' | 'binary'
+}
+
+const POWERSHELL_READ_IMAGE_ARGS = [
+  '-NoProfile',
+  '-NonInteractive',
+  '-Command',
+  'Add-Type -AssemblyName System.Windows.Forms;' +
+    'Add-Type -AssemblyName System.Drawing;' +
+    '$img = [System.Windows.Forms.Clipboard]::GetImage();' +
+    'if ($null -eq $img) { exit 1 };' +
+    '$ms = New-Object System.IO.MemoryStream;' +
+    '$img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png);' +
+    '[System.Convert]::ToBase64String($ms.ToArray())'
+] as const
+
+function readClipboardImageCommands(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): ClipboardImageCommand[] {
+  if (platform === 'darwin') {
+    return [{ cmd: 'pngpaste', args: ['-'], output: 'binary' }]
+  }
+
+  if (platform === 'win32') {
+    return [{ cmd: 'powershell', args: POWERSHELL_READ_IMAGE_ARGS, output: 'base64' }]
+  }
+
+  const attempts: ClipboardImageCommand[] = []
+
+  if (env.WSL_INTEROP || env.WSL_DISTRO_NAME) {
+    attempts.push({ cmd: 'powershell.exe', args: POWERSHELL_READ_IMAGE_ARGS, output: 'base64' })
+  }
+
+  if (env.WAYLAND_DISPLAY) {
+    attempts.push({ cmd: 'wl-paste', args: ['--type', 'image/png'], output: 'binary' })
+  }
+
+  attempts.push({ cmd: 'xclip', args: ['-selection', 'clipboard', '-out', '-target', 'image/png'], output: 'binary' })
+
+  return attempts
+}
+
+/** Read a clipboard image on the TUI host and normalize it to base64 PNG. */
+export async function readClipboardImage(
+  platform: NodeJS.Platform = process.platform,
+  run: ClipboardRun = execFileAsync,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<ClipboardImagePayload | null> {
+  for (const attempt of readClipboardImageCommands(platform, env)) {
+    try {
+      const result = await run(attempt.cmd, [...attempt.args], {
+        encoding: attempt.output === 'base64' ? 'utf8' : 'base64',
+        maxBuffer: CLIPBOARD_IMAGE_MAX_BUFFER,
+        windowsHide: true
+      })
+      const contentBase64 = typeof result.stdout === 'string' ? result.stdout.replace(/\s/g, '') : ''
+
+      if (contentBase64 && /^[A-Za-z0-9+/]+={0,2}$/.test(contentBase64)) {
+        return { contentBase64, filename: 'clipboard.png' }
+      }
+    } catch {
+      // Fall through to the next clipboard backend.
+    }
+  }
+
+  return null
+}
 
 export function isUsableClipboardText(text: null | string): text is string {
   if (!text || !/[^\s]/.test(text)) {

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -4,6 +4,9 @@ import { promisify } from 'node:util'
 const execFileAsync = promisify(execFile)
 const CLIPBOARD_MAX_BUFFER = 4 * 1024 * 1024
 const CLIPBOARD_IMAGE_MAX_BUFFER = 36 * 1024 * 1024
+/** Bound stalled clipboard owners (xclip/wl-paste) so paste cannot hang the composer. */
+const CLIPBOARD_IMAGE_TIMEOUT_MS = 3_000
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
 
 // PowerShell read: base64-encode the clipboard content to avoid ANSI codepage
 // corruption (same problem as the write path — see comment at line 94).
@@ -64,6 +67,15 @@ function readClipboardImageCommands(platform: NodeJS.Platform, env: NodeJS.Proce
   return attempts
 }
 
+function isPngBase64(contentBase64: string): boolean {
+  if (!contentBase64 || !/^[A-Za-z0-9+/]+={0,2}$/.test(contentBase64)) {
+    return false
+  }
+
+  const bytes = Buffer.from(contentBase64, 'base64')
+  return bytes.length >= PNG_SIGNATURE.length && bytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)
+}
+
 /** Read a clipboard image on the TUI host and normalize it to base64 PNG. */
 export async function readClipboardImage(
   platform: NodeJS.Platform = process.platform,
@@ -75,11 +87,12 @@ export async function readClipboardImage(
       const result = await run(attempt.cmd, [...attempt.args], {
         encoding: attempt.output === 'base64' ? 'utf8' : 'base64',
         maxBuffer: CLIPBOARD_IMAGE_MAX_BUFFER,
+        timeout: CLIPBOARD_IMAGE_TIMEOUT_MS,
         windowsHide: true
       })
       const contentBase64 = typeof result.stdout === 'string' ? result.stdout.replace(/\s/g, '') : ''
 
-      if (contentBase64 && /^[A-Za-z0-9+/]+={0,2}$/.test(contentBase64)) {
+      if (isPngBase64(contentBase64)) {
         return { contentBase64, filename: 'clipboard.png' }
       }
     } catch {


### PR DESCRIPTION
## What does this PR do?

Native Windows TUI sessions attached to a remote Linux gateway currently send Ctrl+V and `/paste` to the gateway host clipboard, so users get `No image found in clipboard` even while a valid image remains on the client clipboard. This change reads PNG bytes on the TUI host and uploads them through the existing attachment RPC, while preserving gateway-side clipboard extraction for spawned local sessions.

### Symptom

With `HERMES_TUI_GATEWAY_URL` pointing a native Windows TUI at a remote Linux gateway, both Ctrl+V and `/paste` report `No image found in clipboard` for a valid Windows clipboard image.

### Impact

Native Windows TUI users cannot paste clipboard images when the gateway runs on another host. The same attachment flow works when the client uploads the clipboard bytes instead of asking the remote host to read a clipboard it cannot access.

### Bug Cause

**Trigger:** `ui-tui/src/app/useComposerState.ts` / `pasteClipboardImage()` while `HERMES_TUI_GATEWAY_URL` selects an attached gateway.

**Causal chain:**
1. Ctrl+V or `/paste` invokes the TUI clipboard image path.
2. The composer sends `clipboard.paste`, which reads the gateway host clipboard rather than the TUI client's clipboard.
3. A remote Linux gateway cannot access the native Windows clipboard, so the TUI reports that no image was found.

**Why it is wrong:** Clipboard ownership changes across the remote client/gateway boundary, but the previous route always performed extraction on the gateway side.

**Working sibling / contrast:** The Desktop client already uploads local attachment bytes, and the existing `image.attach_bytes` RPC accepted the same PNG bytes in the reproduced topology.

**Ruled out:** The failure is not caused by a missing or invalid client image. The Windows clipboard retained a valid bitmap after both failed paste attempts, and uploading its extracted bytes to the same gateway succeeded.

### Fix

Add cross-platform client clipboard image extraction for Windows, WSL, macOS, Wayland, and X11. Attached TUI sessions now send normalized base64 PNG bytes through `image.attach_bytes`; spawned local sessions continue using `clipboard.paste`. Both explicit and bracketed paste entry points share this routing.

## Related Issue

Closes #82624

## Type of Change

- [x] Bug fix

## Changes Made

- `ui-tui/src/lib/clipboard.ts` - extract local clipboard images as base64 PNG payloads.
- `ui-tui/src/app/useComposerState.ts` - route attached gateways through `image.attach_bytes` and retain the local spawned-gateway path.
- `ui-tui/src/__tests__/clipboard.test.ts` - cover Windows and WSL image extraction plus unavailable clipboard backends.
- `ui-tui/src/__tests__/useComposerState.test.ts` - cover remote upload, local fallback, and remote no-image behavior.

## How to Test

1. Set `HERMES_TUI_GATEWAY_URL` so a native Windows TUI connects to a remote Linux gateway, copy an image, and verify both Ctrl+V and `/paste` create image tokens without a remote `clipboard.paste` call.
2. Unset `HERMES_TUI_GATEWAY_URL`, launch the TUI with its spawned local gateway, and verify Ctrl+V still creates an image token through `clipboard.paste`.
3. Run the focused automated checks from `ui-tui`:

```bash
npm test -- src/__tests__/clipboard.test.ts src/__tests__/useComposerState.test.ts
npm run typecheck
```

The focused Vitest run passed 35 tests, and TypeScript typecheck passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant TUI Vitest and TypeScript checks and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 client with an isolated Ubuntu/WSL2 Linux gateway

### Documentation & Housekeeping

- [x] Relevant documentation is N/A because this restores the documented paste behavior
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact for Windows, WSL, macOS, Wayland, and X11 clipboard backends
- [x] Tool descriptions and schemas are N/A because no model tool changed

## Screenshots / Logs

Real environment verification confirmed that Ctrl+V and `/paste` each uploaded the same local PNG bytes to the remote gateway, created image tokens, and made zero remote `clipboard.paste` calls. A spawned local gateway control still attached the clipboard image through `clipboard.paste`.
