### PR TITLE
feat(tui,desktop): per-turn tool summary after each turn (refs #1433)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -69,6 +69,7 @@ import { pruneDelegateFallbackSubagents, pruneFinishedSessionSubagents, upsertSu
 import { clearActiveSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
+import { beginTurnSummary, recordTurnTool } from '@/store/turn-summaries'
 import { reportInstallMethodWarning } from '@/store/updates'
 import { notifyWorkspaceChanged, toolChangedPath, toolMayMutateFiles } from '@/store/workspace-events'
 // Leaf import (not the `@/themes` barrel) to avoid pulling the ThemeProvider
@@ -596,6 +597,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         setSessionCompacting(sessionId, false)
         compactedTurnRef.current.delete(sessionId)
         nativeSubagentSessionsRef.current.delete(sessionId)
+        // A fresh turn starts a fresh tool tally (display.turn_summary parity).
+        beginTurnSummary(sessionId)
         // A fresh turn on this session optimistically clears its billing wall;
         // if credits are still exhausted the next failure re-raises it.
         clearBillingBlock(sessionId)
@@ -864,6 +867,19 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         if (sessionId) {
           flushQueuedDeltas(sessionId)
           upsertToolCall(sessionId, toTodoPayload(payload) ?? payload, 'complete', event.type)
+
+          // Per-turn tool tally (display.turn_summary parity), fed per event
+          // so multi-segment turns (interim-sealed tool bubble + distinct
+          // text-only final) still count every tool. inline_diff feeds the
+          // +A -B delta counter; the plain result only when no diff exists.
+          recordTurnTool(
+            sessionId,
+            payload?.name,
+            Boolean(payload?.error),
+            typeof payload?.inline_diff === 'string' && payload.inline_diff
+              ? { diff: payload.inline_diff }
+              : payload?.result
+          )
 
           if (isActiveEvent) {
             setPetActivity({ toolRunning: false })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -26,6 +26,7 @@ import { isDiskFullErrorMessage, notifyError } from '@/store/notifications'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { upsertSubagent } from '@/store/subagents'
 import { setSessionTodos } from '@/store/todos'
+import { recordTurnSummary, renderTurnSummary } from '@/store/turn-summaries'
 
 import type { ClientSessionState } from '../../../types'
 
@@ -650,6 +651,28 @@ export function useMessageStream({
             }
           } else if (finalText) {
             nextMessages = [...prev, newAssistantFromCompletion()]
+          }
+        }
+
+        // Per-turn tool summary (CLI display.turn_summary parity): rendered
+        // once from the per-session collector, which is fed by tool.complete
+        // events across ALL segments of the turn — an interim-sealed tool
+        // bubble followed by a distinct text-only final would otherwise lose
+        // the tally. Wall-clock from turnStartedAt, not tool durations.
+        // Hard error turns (no kept partial text) skip the summary — same as
+        // the pre-rework behavior where the error branch returned early.
+        const isHardErrorTurn = Boolean(completionError && !keepFailedPartialText)
+
+        if (!isHardErrorTurn) {
+          const summaryElapsed = state.turnStartedAt ? Math.max(0, (Date.now() - state.turnStartedAt) / 1000) : 0
+          const turnSummary = renderTurnSummary(sessionId, summaryElapsed)
+
+          if (turnSummary) {
+            const finalBubble = [...nextMessages].reverse().find(m => m.role === 'assistant' && !m.hidden)
+
+            if (finalBubble) {
+              recordTurnSummary(finalBubble.id, turnSummary)
+            }
           }
         }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/turn-summary-wiring.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/turn-summary-wiring.test.tsx
@@ -1,0 +1,135 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $turnSummaries } from '@/store/turn-summaries'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'summary-session'
+
+// Module-scoped so a test can seed session state before the handler reads it.
+const sessionStates = new Map<string, ClientSessionState>()
+let handleEvent: ((event: RpcEvent) => void) | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(sessionStates)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const next = updater(sessionStates.get(sessionId) ?? createClientSessionState())
+      sessionStates.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}, sessionId = SID) {
+  act(() => handleEvent!({ payload, session_id: sessionId, type }))
+}
+
+describe('per-turn tool summary wiring', () => {
+  beforeEach(() => {
+    handleEvent = null
+    sessionStates.clear()
+    $turnSummaries.set({})
+  })
+
+  afterEach(() => {
+    cleanup()
+    sessionStates.clear()
+    $turnSummaries.set({})
+    vi.restoreAllMocks()
+  })
+
+  it('publishes a summary line for a tool-call turn when it settles', async () => {
+    await mountStream()
+
+    emit('message.start')
+    emit('message.delta', { text: 'working…' })
+    emit('tool.start', { name: 'terminal', tool_id: 'tool-1' })
+    emit('tool.complete', { name: 'terminal', tool_id: 'tool-1', error: null })
+    emit('tool.start', { name: 'read_file', tool_id: 'tool-2' })
+    emit('tool.complete', { name: 'read_file', tool_id: 'tool-2', error: null })
+    emit('message.complete', { text: 'done' })
+
+    const entries = Object.entries($turnSummaries.get())
+    expect(entries.length).toBe(1)
+    const [messageId, summary] = entries[0]
+    expect(messageId).toMatch(/^assistant-/)
+    expect(summary).toMatch(/^⋯ \d+(\.\d+)?s · read 1 file · ran 1 command$/)
+  })
+
+  it('publishes nothing for a fast plain-chat reply', async () => {
+    await mountStream()
+
+    emit('message.start')
+    emit('message.delta', { text: 'hi' })
+    emit('message.complete', { text: 'hello!' })
+
+    // No tool calls → empty tally; the turn settles well under the 2s
+    // toolless threshold, so the formatter returns '' and nothing is stored.
+    expect($turnSummaries.get()).toEqual({})
+  })
+
+  it('excludes failed tool calls from the tally', async () => {
+    await mountStream()
+
+    emit('message.start')
+    emit('message.delta', { text: 'working…' })
+    emit('tool.start', { name: 'write_file', tool_id: 'tool-1' })
+    emit('tool.complete', { name: 'write_file', tool_id: 'tool-1', error: 'denied by approval' })
+    emit('message.complete', { text: 'done' })
+
+    const summary = Object.values($turnSummaries.get())[0] ?? ''
+    // Never over-claim an edit: the denied write must not count.
+    expect(summary).not.toContain('edited')
+  })
+
+  it('tallies tools across an interim-sealed multi-segment turn', async () => {
+    await mountStream()
+
+    // The normal Desktop tool-call turn: message.interim seals the tool
+    // bubble (streamId → null) and the final answer lands as a DISTINCT
+    // text-only bubble. The tally must come from the per-session collector
+    // fed by tool.complete, not from the final bubble's parts (which carry
+    // no tool-call entries).
+    emit('message.start')
+    emit('message.delta', { text: 'running…' })
+    emit('tool.start', { name: 'terminal', tool_id: 'tool-1' })
+    emit('tool.complete', { name: 'terminal', tool_id: 'tool-1', error: null })
+    emit('message.interim', { text: 'command ran…' })
+    emit('message.delta', { text: 'final answer' })
+    emit('message.complete', { text: 'final answer' })
+
+    const entries = Object.entries($turnSummaries.get())
+    expect(entries.length).toBe(1)
+    const [messageId, summary] = entries[0]
+    expect(messageId).toMatch(/^assistant-/)
+    expect(summary).toMatch(/^⋯ \d+(\.\d+)?s · ran 1 command$/)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -33,6 +33,7 @@ import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notifyError } from '@/store/notifications'
+import { $turnSummaries } from '@/store/turn-summaries'
 import { $voicePlayback } from '@/store/voice-playback'
 
 // Stable empty identity for the settled-parts selector — a fresh [] per render
@@ -56,6 +57,9 @@ export const AssistantMessage: FC<{
   const messageId = useAuiState(s => s.message.id)
   const messageRuntime = useMessageRuntime()
   const { t } = useI18n()
+  // Per-turn tool summary (CLI display.turn_summary parity), computed when
+  // the turn settles in use-message-stream and published per message id.
+  const turnSummary = useStore($turnSummaries)[messageId] || ''
 
   // PERF: this component must NOT subscribe to the streaming text. Every
   // selector here returns a value that stays referentially stable across
@@ -164,6 +168,14 @@ export const AssistantMessage: FC<{
       {/* Last thing in the turn — under the action bar, the way Cursor ends a
           turn on its summary rather than burying it above the controls. */}
       <ChangedFilesCard parts={settledParts} />
+      {!isRunning && turnSummary && (
+        <div
+          className="mt-1 text-[length:var(--conversation-tool-font-size)] leading-5 text-(--ui-text-tertiary)"
+          data-slot="aui_turn-summary"
+        >
+          {turnSummary}
+        </div>
+      )}
     </MessagePrimitive.Root>
   )
 }

--- a/apps/desktop/src/lib/turn-summary.test.ts
+++ b/apps/desktop/src/lib/turn-summary.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatElapsed,
+  formatTokenFlow,
+  formatTurnSummary,
+  TurnSummaryCollector,
+} from './turn-summary'
+
+describe('formatElapsed', () => {
+  it('formats sub-minute seconds with one decimal', () => {
+    expect(formatElapsed(-5)).toBe('0.0s')
+    expect(formatElapsed(0)).toBe('0.0s')
+    expect(formatElapsed(1.0)).toBe('1.0s')
+    expect(formatElapsed(12.4)).toBe('12.4s')
+    expect(formatElapsed(59.9)).toBe('59.9s')
+  })
+
+  it('formats minutes with zero-padded seconds', () => {
+    expect(formatElapsed(60)).toBe('1m00s')
+    expect(formatElapsed(125)).toBe('2m05s')
+    expect(formatElapsed(3605)).toBe('60m05s')
+  })
+})
+
+describe('TurnSummaryCollector / formatTurnSummary', () => {
+  it('renders single and multiple nouns with correct pluralization', () => {
+    const collector = new TurnSummaryCollector()
+    collector.recordTool('read_file')
+    expect(collector.render(1.0)).toBe('⋯ 1.0s · read 1 file')
+
+    collector.begin()
+    collector.recordTool('read_file')
+    collector.recordTool('read_file')
+    collector.recordTool('read_file')
+    expect(collector.render(1.0)).toBe('⋯ 1.0s · read 3 files')
+  })
+
+  it('handles irregular pluralization (ies/ses and compound nouns)', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('memory')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · updated 1 memory')
+
+    c.begin()
+    c.recordTool('memory')
+    c.recordTool('memory')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · updated 2 memories')
+
+    c.begin()
+    c.recordTool('todo')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · updated 1 task list')
+
+    c.begin()
+    c.recordTool('todo')
+    c.recordTool('todo')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · updated 2 task lists')
+
+    c.begin()
+    c.recordTool('web_search')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · searched the web 1 time')
+  })
+
+  it('renders edit tools with line deltas from object and JSON patch results', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('patch', { result: { diff: '--- a/f\n+++ b/f\n+line 1\n+line 2\n-line 3' } })
+    c.recordTool('write_file')
+    expect(c.render(12.4)).toBe('⋯ 12.4s · edited 2 files +2 -1')
+
+    c.begin()
+    c.recordTool('patch', { result: JSON.stringify({ diff: '--- a\n+++ b\n+added' }) })
+    expect(c.render(2.0)).toBe('⋯ 2.0s · edited 1 file +1 -0')
+  })
+
+  it('ignores +0 -0 diffs and does not set hasLineDeltas', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('patch', { result: { diff: '--- a/f\n+++ b/f\n' } })
+    expect(c.tally.hasLineDeltas).toBe(false)
+    expect(c.render(1.0)).toBe('⋯ 1.0s · edited 1 file')
+  })
+
+  it('buckets unknown tools into a called-N-tools segment', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('unknown_tool_a')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · called 1 tool')
+
+    c.recordTool('unknown_tool_b')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · called 2 tools')
+  })
+
+  it('ignores errors and underscore-prefixed internal tools', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('read_file', { isError: true })
+    c.recordTool('_thinking')
+    c.recordTool(null)
+    c.recordTool(undefined)
+    c.recordTool('')
+    expect(c.tally.totalTools).toBe(0)
+    expect(c.render(1.0)).toBe('')
+  })
+
+  it('returns empty string for toolless turns under the 2s threshold', () => {
+    expect(formatTurnSummary(1.0, null)).toBe('')
+    const c = new TurnSummaryCollector()
+    expect(c.render(1.5)).toBe('')
+  })
+
+  it('renders elapsed-only line for toolless turns at/over the 2s threshold (Python parity)', () => {
+    const c = new TurnSummaryCollector()
+    expect(c.render(2.0)).toBe('⋯ 2.0s')
+    expect(c.render(5.0)).toBe('⋯ 5.0s')
+  })
+
+  it('collapses excess verb segments at maxSegments, keeping elapsed prepended', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('patch') // edited
+    c.recordTool('read_file') // read
+    c.recordTool('terminal') // ran
+    c.recordTool('web_search') // searched the web
+    c.recordTool('unknown_tool') // called 1 tool
+    // 5 verb segments; maxSegments=4 keeps 4 and appends +1 more
+    expect(formatTurnSummary(10.0, c.tally, { maxSegments: 4 })).toBe(
+      '⋯ 10.0s · edited 1 file · read 1 file · ran 1 command · searched the web 1 time · +1 more',
+    )
+  })
+
+  it('orders edited, read, ran before other verbs in first-seen order', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('memory') // updated
+    c.recordTool('write_file') // edited
+    c.recordTool('terminal') // ran
+    c.recordTool('read_file') // read
+    expect(c.render(3.0)).toBe('⋯ 3.0s · edited 1 file · read 1 file · ran 1 command · updated 1 memory')
+  })
+})
+
+describe('formatTokenFlow', () => {
+  it('returns empty for non-positive or unparseable input', () => {
+    expect(formatTokenFlow(null)).toBe('')
+    expect(formatTokenFlow(undefined)).toBe('')
+    expect(formatTokenFlow(0)).toBe('')
+    expect(formatTokenFlow(-100)).toBe('')
+    expect(formatTokenFlow('invalid')).toBe('')
+  })
+
+  it('formats positive counts with k/M suffixes', () => {
+    expect(formatTokenFlow(123)).toBe('↓ 123 tok')
+    expect(formatTokenFlow('123')).toBe('↓ 123 tok')
+    expect(formatTokenFlow(1000)).toBe('↓ 1k tok')
+    expect(formatTokenFlow(1200)).toBe('↓ 1.2k tok')
+    expect(formatTokenFlow(1_000_000)).toBe('↓ 1M tok')
+    expect(formatTokenFlow(1_200_000)).toBe('↓ 1.2M tok')
+  })
+
+  it('honors a custom arrow', () => {
+    expect(formatTokenFlow(500, { arrow: '→' })).toBe('→ 500 tok')
+  })
+})

--- a/apps/desktop/src/lib/turn-summary.ts
+++ b/apps/desktop/src/lib/turn-summary.ts
@@ -1,0 +1,349 @@
+/**
+ * Per-turn tool summary — TS port of `agent/turn_summary.py` (CLI parity).
+ *
+ * A tiny pure module that tallies what a turn actually did and renders one
+ * dim line, e.g.:
+ *
+ *     ⋯ 12.4s · edited 2 files +18 -3 · read 4 files · ran 3 commands
+ *
+ * Ported from the Python CLI module so every surface renders byte-identical
+ * output. Holds no agent state: the caller feeds completed tool events via
+ * `recordTool` and renders when the turn ends.
+ */
+
+export interface TurnTally {
+  /** verb -> plural-noun -> count; insertion order preserved for stable rendering. */
+  verbs: Record<string, Record<string, number>>
+  /** Tools with no curated verb, counted together. */
+  otherTools: number
+  /** Aggregated unified-diff line deltas across edit tools, when reported. */
+  linesAdded: number
+  linesRemoved: number
+  /** True once at least one edit tool reported a countable diff. */
+  hasLineDeltas: boolean
+  /** Sum of all verb counts + otherTools. */
+  totalTools: number
+}
+
+const VERB_TABLE: Record<string, [string, string, string]> = {
+  write_file: ['edited', 'file', 'files'],
+  patch: ['edited', 'file', 'files'],
+  read_file: ['read', 'file', 'files'],
+  web_extract: ['read', 'page', 'pages'],
+  terminal: ['ran', 'command', 'commands'],
+  execute_code: ['ran', 'script', 'scripts'],
+  search_files: ['searched', 'path', 'paths'],
+  web_search: ['searched the web', 'time', 'times'],
+  session_search: ['searched sessions', 'time', 'times'],
+  browser_navigate: ['browsed', 'page', 'pages'],
+  skill_view: ['read', 'skill', 'skills'],
+  skill_manage: ['updated', 'skill', 'skills'],
+  skills_list: ['listed skills', 'time', 'times'],
+  todo: ['updated', 'task list', 'task lists'],
+  delegate_task: ['delegated', 'task', 'tasks'],
+  memory: ['updated', 'memory', 'memories'],
+}
+
+const EDIT_VERB = 'edited'
+
+// Render order: edits first (the thing users most want confirmed), then reads,
+// then commands. Anything else follows in first-seen order.
+const VERB_PRIORITY: readonly string[] = ['edited', 'read', 'ran']
+
+// Tools whose results may report a unified diff we can count lines from.
+const DIFF_RESULT_TOOLS = new Set(['patch'])
+
+// Leading glyph for the summary line. Deliberately not an emoji — the line is
+// meant to read as terminal chrome, not as agent speech.
+const SUMMARY_PREFIX = '⋯ '
+
+// A turn that called no tools and finished this fast has nothing worth
+// reporting (plain chat reply). Below the threshold the formatter returns ''.
+const MIN_TOOLLESS_SECONDS = 2.0
+
+// Max number of "verb + count" segments rendered before collapsing the rest
+// into a "+N more" tail, so a 12-tool turn cannot blow past one line.
+const MAX_SEGMENTS = 4
+
+function singularize(pluralNoun: string): string {
+  if (pluralNoun.endsWith('ies')) {
+    return pluralNoun.slice(0, -3) + 'y'
+  }
+
+  if (pluralNoun.endsWith('ses')) {
+    return pluralNoun.slice(0, -2)
+  }
+
+  if (pluralNoun.endsWith('s')) {
+    return pluralNoun.slice(0, -1)
+  }
+
+  return pluralNoun
+}
+
+function countDiffLines(diff: string): [number, number] {
+  let added = 0
+  let removed = 0
+
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith('+++') || line.startsWith('---')) {
+      continue
+    }
+
+    if (line.startsWith('+')) {
+      added += 1
+    } else if (line.startsWith('-')) {
+      removed += 1
+    }
+  }
+
+  return [added, removed]
+}
+
+function extractLineDeltas(toolName: string, result: unknown): [number, number] | null {
+  if (!DIFF_RESULT_TOOLS.has(toolName)) {
+    return null
+  }
+
+  let diffStr: string | undefined
+
+  if (typeof result === 'string') {
+    try {
+      const parsed = JSON.parse(result) as unknown
+
+      if (parsed && typeof parsed === 'object' && typeof (parsed as { diff?: unknown }).diff === 'string') {
+        diffStr = (parsed as { diff: string }).diff
+      }
+    } catch {
+      // strict=False tolerance: retry with control characters escaped so raw
+      // newlines inside an embedded diff string don't fail parsing.
+      try {
+        // eslint-disable-next-line no-control-regex -- intentionally matching control chars to strip from tool results
+        const controlChars = new RegExp('[\\x00-\\x1f\\x7f]', 'g')
+
+        const sanitized = result.replace(controlChars, c => {
+          if (c === '\n') {return '\\n'}
+
+          if (c === '\r') {return '\\r'}
+
+          if (c === '\t') {return '\\t'}
+
+          return ''
+        })
+
+        const parsed = JSON.parse(sanitized) as unknown
+
+        if (parsed && typeof parsed === 'object' && typeof (parsed as { diff?: unknown }).diff === 'string') {
+          diffStr = (parsed as { diff: string }).diff
+        }
+      } catch {
+        // ignore invalid JSON
+      }
+    }
+  } else if (result && typeof result === 'object') {
+    const obj = result as Record<string, unknown>
+
+    if (typeof obj.diff === 'string') {
+      diffStr = obj.diff
+    }
+  }
+
+  if (!diffStr) {
+    return null
+  }
+
+  const [added, removed] = countDiffLines(diffStr)
+
+  // A diff that carries no +/- content lines (e.g. a bare hunk header) tells
+  // us nothing — report it as unknown rather than rendering a misleading
+  // "+0 -0" next to a real edit.
+  if (added === 0 && removed === 0) {
+    return null
+  }
+
+  return [added, removed]
+}
+
+function emptyTally(): TurnTally {
+  return {
+    verbs: {},
+    otherTools: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    hasLineDeltas: false,
+    totalTools: 0,
+  }
+}
+
+export class TurnSummaryCollector {
+  private _tally: TurnTally = emptyTally()
+
+  begin(): void {
+    this._tally = emptyTally()
+  }
+
+  recordTool(toolName: string | null | undefined, opts?: { result?: unknown; isError?: boolean }): void {
+    if (!toolName || opts?.isError === true || toolName.startsWith('_')) {
+      return
+    }
+
+    const mapping = VERB_TABLE[toolName]
+
+    if (!mapping) {
+      this._tally.otherTools += 1
+
+      return
+    }
+
+    const [verb, , pluralNoun] = mapping
+    const nouns = (this._tally.verbs[verb] ??= {})
+    nouns[pluralNoun] = (nouns[pluralNoun] ?? 0) + 1
+
+    if (verb === EDIT_VERB) {
+      const deltas = extractLineDeltas(toolName, opts?.result)
+
+      if (deltas) {
+        this._tally.linesAdded += deltas[0]
+        this._tally.linesRemoved += deltas[1]
+        this._tally.hasLineDeltas = true
+      }
+    }
+  }
+
+  get tally(): TurnTally {
+    let counted = 0
+    const verbsCopy: Record<string, Record<string, number>> = {}
+
+    for (const [verb, nounMap] of Object.entries(this._tally.verbs)) {
+      verbsCopy[verb] = { ...nounMap }
+
+      for (const count of Object.values(nounMap)) {
+        counted += count
+      }
+    }
+
+    return {
+      verbs: verbsCopy,
+      otherTools: this._tally.otherTools,
+      linesAdded: this._tally.linesAdded,
+      linesRemoved: this._tally.linesRemoved,
+      hasLineDeltas: this._tally.hasLineDeltas,
+      totalTools: counted + this._tally.otherTools,
+    }
+  }
+
+  render(elapsedSeconds: number): string {
+    return formatTurnSummary(elapsedSeconds, this.tally)
+  }
+}
+
+export function formatElapsed(seconds: number): string {
+  const secs = Math.max(0, seconds)
+
+  if (secs < 60) {
+    return `${secs.toFixed(1)}s`
+  }
+
+  const mins = Math.floor(secs / 60)
+  const remSecs = Math.floor(secs % 60)
+
+  return `${mins}m${String(remSecs).padStart(2, '0')}s`
+}
+
+function pluralize(count: number, pluralNoun: string): string {
+  if (count === 1) {
+    return `1 ${singularize(pluralNoun)}`
+  }
+
+  return `${count} ${pluralNoun}`
+}
+
+export function formatTurnSummary(
+  elapsedSeconds: number,
+  tally: TurnTally | null,
+  opts?: { maxSegments?: number },
+): string {
+  const totalTools = tally ? tally.totalTools : 0
+
+  if (totalTools === 0 && elapsedSeconds < MIN_TOOLLESS_SECONDS) {
+    return ''
+  }
+
+  const maxSegments = opts?.maxSegments ?? MAX_SEGMENTS
+
+  // Verb segments only — the elapsed piece is always prepended and never
+  // counts against the cap (Python parity: max_segments trims the verb list).
+  const verbSegments: string[] = []
+
+  if (tally) {
+    const presentVerbs = Object.keys(tally.verbs)
+
+    const orderedVerbs = [
+      ...VERB_PRIORITY.filter(v => presentVerbs.includes(v)),
+      ...presentVerbs.filter(v => !VERB_PRIORITY.includes(v)),
+    ]
+
+    for (const verb of orderedVerbs) {
+      const nounCounts = tally.verbs[verb]
+
+      if (!nounCounts) {
+        continue
+      }
+
+      const parts = Object.entries(nounCounts)
+        .filter(([, count]) => count > 0)
+        .map(([pluralNoun, count]) => pluralize(count, pluralNoun))
+
+      if (!parts.length) {
+        continue
+      }
+
+      let segment = `${verb} ${parts.join(', ')}`
+
+      if (verb === EDIT_VERB && tally.hasLineDeltas) {
+        segment += ` +${tally.linesAdded} -${tally.linesRemoved}`
+      }
+
+      verbSegments.push(segment)
+    }
+
+    if (tally.otherTools > 0) {
+      verbSegments.push(
+        tally.otherTools === 1 ? 'called 1 tool' : `called ${tally.otherTools} tools`,
+      )
+    }
+  }
+
+  if (maxSegments > 0 && verbSegments.length > maxSegments) {
+    const hidden = verbSegments.length - maxSegments
+    verbSegments.splice(maxSegments, verbSegments.length - maxSegments, `+${hidden} more`)
+  }
+
+  return `${SUMMARY_PREFIX}${[formatElapsed(elapsedSeconds), ...verbSegments].join(' · ')}`
+}
+
+export function formatTokenFlow(outputTokens: unknown, opts?: { arrow?: string }): string {
+  const arrow = opts?.arrow ?? '↓'
+
+  if (outputTokens === null || outputTokens === undefined) {
+    return ''
+  }
+
+  const num = typeof outputTokens === 'number' ? outputTokens : Number(outputTokens)
+
+  if (!Number.isFinite(num) || num <= 0) {
+    return ''
+  }
+
+  let formatted: string
+
+  if (num < 1000) {
+    formatted = `${num} tok`
+  } else if (num < 1_000_000) {
+    formatted = `${(num / 1000).toFixed(1).replace(/\.0$/, '')}k tok`
+  } else {
+    formatted = `${(num / 1_000_000).toFixed(1).replace(/\.0$/, '')}M tok`
+  }
+
+  return `${arrow} ${formatted}`
+}

--- a/apps/desktop/src/store/turn-summaries.ts
+++ b/apps/desktop/src/store/turn-summaries.ts
@@ -1,0 +1,64 @@
+import { atom } from 'nanostores'
+
+import { TurnSummaryCollector } from '@/lib/turn-summary'
+
+// Per-turn tool summary lines keyed by assistant message id (CLI
+// display.turn_summary parity). Computed once when the turn settles in
+// use-message-stream; read by the assistant message row to render the dim
+// summary under the bubble. Keyed by message id like $toolDiffs — a stale
+// entry is inert because it only renders when its message id is live.
+const $turnSummaries = atom<Record<string, string>>({})
+
+export { $turnSummaries }
+
+// Per-session collectors for the ACTIVE turn. Fed from `tool.complete` events
+// as they arrive — NOT derived from the settled message's parts — so
+// multi-segment turns (an interim-sealed tool bubble followed by a distinct
+// text-only final bubble) still tally every tool. Reset at `message.start`.
+const collectors = new Map<string, TurnSummaryCollector>()
+
+export function beginTurnSummary(sessionId: string) {
+  collectors.set(sessionId, new TurnSummaryCollector())
+}
+
+export function recordTurnTool(
+  sessionId: string,
+  toolName: string | null | undefined,
+  isError: boolean,
+  result?: unknown,
+) {
+  collectors.get(sessionId)?.recordTool(toolName, { isError, result })
+}
+
+export function renderTurnSummary(sessionId: string, elapsedSeconds: number): string {
+  const collector = collectors.get(sessionId)
+
+  if (!collector) {
+    return ''
+  }
+
+  // One render per turn: drop the collector so a closed session can't leak a
+  // tally and a second completion for the same turn renders nothing new
+  // (recordTurnSummary dedupes identical values anyway).
+  collectors.delete(sessionId)
+
+  return collector.render(elapsedSeconds)
+}
+
+export function recordTurnSummary(messageId: string, summary: string) {
+  if (!messageId) {
+    return
+  }
+
+  const current = $turnSummaries.get()
+
+  if (current[messageId] === summary) {
+    return
+  }
+
+  $turnSummaries.set({ ...current, [messageId]: summary })
+}
+
+export function getTurnSummary(messageId: string): string {
+  return messageId ? $turnSummaries.get()[messageId] || '' : ''
+}

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -748,6 +748,25 @@ describe('createGatewayEventHandler', () => {
     expect(appended[1]?.tools ?? []).toEqual([])
   })
 
+  it('appends a per-turn tool summary event line after a completed tool turn', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+    const diff = '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { context: 'foo.ts', name: 'patch', tool_id: 'tool-1' }, type: 'tool.start' } as any)
+    onEvent({ payload: { inline_diff: diff, summary: 'patched', tool_id: 'tool-1' }, type: 'tool.complete' } as any)
+    onEvent({ payload: { text: 'done' }, type: 'message.complete' } as any)
+
+    // The turn summary (CLI display.turn_summary parity) lands as the last
+    // transcript line: a dim ◈ event whose text tallies the turn's tools.
+    const summary = appended.find(msg => msg.kind === 'event')
+    expect(summary).toBeDefined()
+    expect(summary?.role).toBe('system')
+    expect(summary?.text).toMatch(/^⋯ \d+(\.\d+)?s · edited 1 file \+1 -1$/)
+    expect(appended[appended.length - 1]).toBe(summary)
+  })
+
   it('shows setup panel for missing provider startup error', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/__tests__/turn-summary.test.ts
+++ b/ui-tui/src/__tests__/turn-summary.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatElapsed,
+  formatTokenFlow,
+  formatTurnSummary,
+  TurnSummaryCollector,
+} from '../lib/turn-summary.js'
+
+describe('formatElapsed', () => {
+  it('formats sub-minute seconds with one decimal', () => {
+    expect(formatElapsed(-5)).toBe('0.0s')
+    expect(formatElapsed(0)).toBe('0.0s')
+    expect(formatElapsed(1.0)).toBe('1.0s')
+    expect(formatElapsed(12.4)).toBe('12.4s')
+    expect(formatElapsed(59.9)).toBe('59.9s')
+  })
+
+  it('formats minutes with zero-padded seconds', () => {
+    expect(formatElapsed(60)).toBe('1m00s')
+    expect(formatElapsed(125)).toBe('2m05s')
+    expect(formatElapsed(3605)).toBe('60m05s')
+  })
+})
+
+describe('TurnSummaryCollector / formatTurnSummary', () => {
+  it('renders single and multiple nouns with correct pluralization', () => {
+    const collector = new TurnSummaryCollector()
+    collector.recordTool('read_file')
+    expect(collector.render(1.0)).toBe('⋯ 1.0s · read 1 file')
+
+    collector.begin()
+    collector.recordTool('read_file')
+    collector.recordTool('read_file')
+    collector.recordTool('read_file')
+    expect(collector.render(1.0)).toBe('⋯ 1.0s · read 3 files')
+  })
+
+  it('handles irregular pluralization (ies/ses and compound nouns)', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('memory')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · updated 1 memory')
+
+    c.begin()
+    c.recordTool('memory')
+    c.recordTool('memory')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · updated 2 memories')
+
+    c.begin()
+    c.recordTool('todo')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · updated 1 task list')
+
+    c.begin()
+    c.recordTool('todo')
+    c.recordTool('todo')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · updated 2 task lists')
+
+    c.begin()
+    c.recordTool('web_search')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · searched the web 1 time')
+  })
+
+  it('renders edit tools with line deltas from object and JSON patch results', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('patch', { result: { diff: '--- a/f\n+++ b/f\n+line 1\n+line 2\n-line 3' } })
+    c.recordTool('write_file')
+    expect(c.render(12.4)).toBe('⋯ 12.4s · edited 2 files +2 -1')
+
+    c.begin()
+    c.recordTool('patch', { result: JSON.stringify({ diff: '--- a\n+++ b\n+added' }) })
+    expect(c.render(2.0)).toBe('⋯ 2.0s · edited 1 file +1 -0')
+  })
+
+  it('ignores +0 -0 diffs and does not set hasLineDeltas', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('patch', { result: { diff: '--- a/f\n+++ b/f\n' } })
+    expect(c.tally.hasLineDeltas).toBe(false)
+    expect(c.render(1.0)).toBe('⋯ 1.0s · edited 1 file')
+  })
+
+  it('buckets unknown tools into a called-N-tools segment', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('unknown_tool_a')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · called 1 tool')
+
+    c.recordTool('unknown_tool_b')
+    expect(c.render(1.0)).toBe('⋯ 1.0s · called 2 tools')
+  })
+
+  it('ignores errors and underscore-prefixed internal tools', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('read_file', { isError: true })
+    c.recordTool('_thinking')
+    c.recordTool(null)
+    c.recordTool(undefined)
+    c.recordTool('')
+    expect(c.tally.totalTools).toBe(0)
+    expect(c.render(1.0)).toBe('')
+  })
+
+  it('returns empty string for toolless turns under the 2s threshold', () => {
+    expect(formatTurnSummary(1.0, null)).toBe('')
+    const c = new TurnSummaryCollector()
+    expect(c.render(1.5)).toBe('')
+  })
+
+  it('renders elapsed-only line for toolless turns at/over the 2s threshold (Python parity)', () => {
+    const c = new TurnSummaryCollector()
+    expect(c.render(2.0)).toBe('⋯ 2.0s')
+    expect(c.render(5.0)).toBe('⋯ 5.0s')
+  })
+
+  it('collapses excess verb segments at maxSegments, keeping elapsed prepended', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('patch') // edited
+    c.recordTool('read_file') // read
+    c.recordTool('terminal') // ran
+    c.recordTool('web_search') // searched the web
+    c.recordTool('unknown_tool') // called 1 tool
+    // 5 verb segments; maxSegments=4 keeps 4 and appends +1 more
+    expect(formatTurnSummary(10.0, c.tally, { maxSegments: 4 })).toBe(
+      '⋯ 10.0s · edited 1 file · read 1 file · ran 1 command · searched the web 1 time · +1 more',
+    )
+  })
+
+  it('orders edited, read, ran before other verbs in first-seen order', () => {
+    const c = new TurnSummaryCollector()
+    c.recordTool('memory') // updated
+    c.recordTool('write_file') // edited
+    c.recordTool('terminal') // ran
+    c.recordTool('read_file') // read
+    expect(c.render(3.0)).toBe('⋯ 3.0s · edited 1 file · read 1 file · ran 1 command · updated 1 memory')
+  })
+})
+
+describe('formatTokenFlow', () => {
+  it('returns empty for non-positive or unparseable input', () => {
+    expect(formatTokenFlow(null)).toBe('')
+    expect(formatTokenFlow(undefined)).toBe('')
+    expect(formatTokenFlow(0)).toBe('')
+    expect(formatTokenFlow(-100)).toBe('')
+    expect(formatTokenFlow('invalid')).toBe('')
+  })
+
+  it('formats positive counts with k/M suffixes', () => {
+    expect(formatTokenFlow(123)).toBe('↓ 123 tok')
+    expect(formatTokenFlow('123')).toBe('↓ 123 tok')
+    expect(formatTokenFlow(1000)).toBe('↓ 1k tok')
+    expect(formatTokenFlow(1200)).toBe('↓ 1.2k tok')
+    expect(formatTokenFlow(1_000_000)).toBe('↓ 1M tok')
+    expect(formatTokenFlow(1_200_000)).toBe('↓ 1.2M tok')
+  })
+
+  it('honors a custom arrow', () => {
+    expect(formatTokenFlow(500, { arrow: '→' })).toBe('→ 500 tok')
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1349,6 +1349,14 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           const msgs: Msg[] = finalMessages.length ? finalMessages : [{ role: 'assistant', text: finalText }]
           msgs.forEach(appendMessage)
 
+          // Per-turn tool summary (CLI display.turn_summary parity): the
+          // summary text (⋯ prefix) renders as a dim ◈ timeline event line.
+          const turnSummary = turnController.renderTurnSummary()
+
+          if (turnSummary) {
+            appendMessage({ kind: 'event', role: 'system', text: turnSummary })
+          }
+
           // Pet beat: celebrate a finished plan, otherwise a clean-finish wave.
           flashPet(isTodoDone(getTurnState().todos) ? 'jump' : 'wave')
 

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -17,6 +17,7 @@ import {
   sameToolTrailGroup,
   toolTrailLabel
 } from '../lib/text.js'
+import { TurnSummaryCollector } from '../lib/turn-summary.js'
 import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '../types.js'
 
 import type { Notice } from './interfaces.js'
@@ -133,6 +134,11 @@ class TurnController {
   private streamTimer: Timer = null
   private streamDelay = STREAM_IDLE_BATCH_MS
   private toolProgressTimer: Timer = null
+  // Per-turn tool tally (display.turn_summary parity with the CLI). Fed from
+  // the same tool-complete feed that builds trail lines; rendered at
+  // message.complete as a dim ◈ event line.
+  private turnSummary: TurnSummaryCollector | null = null
+  private turnStartMs = 0
 
   // ── Credits notice machinery (Strategy B) ───────────────────────────
   //
@@ -555,6 +561,21 @@ class TurnController {
     this.flushPendingNotice()
   }
 
+  /**
+   * Render the completed turn's tool summary line, or '' when there is
+   * nothing to report. Wall-clock from message.start to message.complete —
+   * not the sum of tool durations, which would miss LLM reasoning time.
+   */
+  renderTurnSummary(): string {
+    if (!this.turnSummary) {
+      return ''
+    }
+
+    const elapsed = this.turnStartMs ? (Date.now() - this.turnStartMs) / 1000 : 0
+
+    return this.turnSummary.render(elapsed)
+  }
+
   recordMessageComplete(payload: {
     rendered?: string
     reasoning?: string
@@ -797,6 +818,10 @@ class TurnController {
       return
     }
 
+    const done = this.activeTools.find(tool => tool.id === toolId)
+    const name = done?.name ?? fallbackName ?? 'tool'
+    this.turnSummary?.recordTool(name, { isError: Boolean(error), result: resultText })
+
     this.recordTodos(todos)
     const line = this.completeTool(toolId, fallbackName, error, summary, duration, resultText)
 
@@ -816,6 +841,10 @@ class TurnController {
     if (this.interrupted) {
       return
     }
+
+    const done = this.activeTools.find(tool => tool.id === toolId)
+    const name = done?.name ?? fallbackName ?? 'tool'
+    this.turnSummary?.recordTool(name, { isError: Boolean(error), result: { diff: diffText } })
 
     this.flushStreamingSegment()
     this.pushInlineDiffSegment(diffText, [this.completeTool(toolId, fallbackName, error, '', duration, resultText)])
@@ -931,6 +960,10 @@ class TurnController {
     this.turnTools = []
     this.toolTokenAcc = 0
     this.persistedToolLabels.clear()
+    // Session boundary: drop per-turn summary state too so a session A tally
+    // can't bleed into session B (same rule as the notice state below).
+    this.turnSummary = null
+    this.turnStartMs = 0
     // Session boundary: drop notice state so session A's sticky can't bleed
     // into session B (R3-H5). reset()/fullReset() CLEAR — they never flush.
     this.clearNoticeState()
@@ -988,6 +1021,8 @@ class TurnController {
     this.toolTokenAcc = 0
     this.interrupted = false
     this.persistedToolLabels.clear()
+    this.turnSummary = new TurnSummaryCollector()
+    this.turnStartMs = Date.now()
     // "Flash and yield" notices clear when a new turn starts: a usage-band heads-up
     // (credits.usage, 50/75/90%) and the one-time "grant spent" transition
     // (credits.grant_spent) should show once, then get out of the way — not camp the

--- a/ui-tui/src/lib/turn-summary.ts
+++ b/ui-tui/src/lib/turn-summary.ts
@@ -1,0 +1,349 @@
+/**
+ * Per-turn tool summary — TS port of `agent/turn_summary.py` (CLI parity).
+ *
+ * A tiny pure module that tallies what a turn actually did and renders one
+ * dim line, e.g.:
+ *
+ *     ⋯ 12.4s · edited 2 files +18 -3 · read 4 files · ran 3 commands
+ *
+ * Ported from the Python CLI module so every surface renders byte-identical
+ * output. Holds no agent state: the caller feeds completed tool events via
+ * `recordTool` and renders when the turn ends.
+ */
+
+export interface TurnTally {
+  /** verb -> plural-noun -> count; insertion order preserved for stable rendering. */
+  verbs: Record<string, Record<string, number>>
+  /** Tools with no curated verb, counted together. */
+  otherTools: number
+  /** Aggregated unified-diff line deltas across edit tools, when reported. */
+  linesAdded: number
+  linesRemoved: number
+  /** True once at least one edit tool reported a countable diff. */
+  hasLineDeltas: boolean
+  /** Sum of all verb counts + otherTools. */
+  totalTools: number
+}
+
+const VERB_TABLE: Record<string, [string, string, string]> = {
+  write_file: ['edited', 'file', 'files'],
+  patch: ['edited', 'file', 'files'],
+  read_file: ['read', 'file', 'files'],
+  web_extract: ['read', 'page', 'pages'],
+  terminal: ['ran', 'command', 'commands'],
+  execute_code: ['ran', 'script', 'scripts'],
+  search_files: ['searched', 'path', 'paths'],
+  web_search: ['searched the web', 'time', 'times'],
+  session_search: ['searched sessions', 'time', 'times'],
+  browser_navigate: ['browsed', 'page', 'pages'],
+  skill_view: ['read', 'skill', 'skills'],
+  skill_manage: ['updated', 'skill', 'skills'],
+  skills_list: ['listed skills', 'time', 'times'],
+  todo: ['updated', 'task list', 'task lists'],
+  delegate_task: ['delegated', 'task', 'tasks'],
+  memory: ['updated', 'memory', 'memories'],
+}
+
+const EDIT_VERB = 'edited'
+
+// Render order: edits first (the thing users most want confirmed), then reads,
+// then commands. Anything else follows in first-seen order.
+const VERB_PRIORITY: readonly string[] = ['edited', 'read', 'ran']
+
+// Tools whose results may report a unified diff we can count lines from.
+const DIFF_RESULT_TOOLS = new Set(['patch'])
+
+// Leading glyph for the summary line. Deliberately not an emoji — the line is
+// meant to read as terminal chrome, not as agent speech.
+const SUMMARY_PREFIX = '⋯ '
+
+// A turn that called no tools and finished this fast has nothing worth
+// reporting (plain chat reply). Below the threshold the formatter returns ''.
+const MIN_TOOLLESS_SECONDS = 2.0
+
+// Max number of "verb + count" segments rendered before collapsing the rest
+// into a "+N more" tail, so a 12-tool turn cannot blow past one line.
+const MAX_SEGMENTS = 4
+
+function singularize(pluralNoun: string): string {
+  if (pluralNoun.endsWith('ies')) {
+    return pluralNoun.slice(0, -3) + 'y'
+  }
+
+  if (pluralNoun.endsWith('ses')) {
+    return pluralNoun.slice(0, -2)
+  }
+
+  if (pluralNoun.endsWith('s')) {
+    return pluralNoun.slice(0, -1)
+  }
+
+  return pluralNoun
+}
+
+function countDiffLines(diff: string): [number, number] {
+  let added = 0
+  let removed = 0
+
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith('+++') || line.startsWith('---')) {
+      continue
+    }
+
+    if (line.startsWith('+')) {
+      added += 1
+    } else if (line.startsWith('-')) {
+      removed += 1
+    }
+  }
+
+  return [added, removed]
+}
+
+function extractLineDeltas(toolName: string, result: unknown): [number, number] | null {
+  if (!DIFF_RESULT_TOOLS.has(toolName)) {
+    return null
+  }
+
+  let diffStr: string | undefined
+
+  if (typeof result === 'string') {
+    try {
+      const parsed = JSON.parse(result) as unknown
+
+      if (parsed && typeof parsed === 'object' && typeof (parsed as { diff?: unknown }).diff === 'string') {
+        diffStr = (parsed as { diff: string }).diff
+      }
+    } catch {
+      // strict=False tolerance: retry with control characters escaped so raw
+      // newlines inside an embedded diff string don't fail parsing.
+      try {
+        // eslint-disable-next-line no-control-regex -- intentionally matching control chars to strip from tool results
+        const controlChars = new RegExp('[\\x00-\\x1f\\x7f]', 'g')
+
+        const sanitized = result.replace(controlChars, c => {
+          if (c === '\n') {return '\\n'}
+
+          if (c === '\r') {return '\\r'}
+
+          if (c === '\t') {return '\\t'}
+
+          return ''
+        })
+
+        const parsed = JSON.parse(sanitized) as unknown
+
+        if (parsed && typeof parsed === 'object' && typeof (parsed as { diff?: unknown }).diff === 'string') {
+          diffStr = (parsed as { diff: string }).diff
+        }
+      } catch {
+        // ignore invalid JSON
+      }
+    }
+  } else if (result && typeof result === 'object') {
+    const obj = result as Record<string, unknown>
+
+    if (typeof obj.diff === 'string') {
+      diffStr = obj.diff
+    }
+  }
+
+  if (!diffStr) {
+    return null
+  }
+
+  const [added, removed] = countDiffLines(diffStr)
+
+  // A diff that carries no +/- content lines (e.g. a bare hunk header) tells
+  // us nothing — report it as unknown rather than rendering a misleading
+  // "+0 -0" next to a real edit.
+  if (added === 0 && removed === 0) {
+    return null
+  }
+
+  return [added, removed]
+}
+
+function emptyTally(): TurnTally {
+  return {
+    verbs: {},
+    otherTools: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    hasLineDeltas: false,
+    totalTools: 0,
+  }
+}
+
+export class TurnSummaryCollector {
+  private _tally: TurnTally = emptyTally()
+
+  begin(): void {
+    this._tally = emptyTally()
+  }
+
+  recordTool(toolName: string | null | undefined, opts?: { result?: unknown; isError?: boolean }): void {
+    if (!toolName || opts?.isError === true || toolName.startsWith('_')) {
+      return
+    }
+
+    const mapping = VERB_TABLE[toolName]
+
+    if (!mapping) {
+      this._tally.otherTools += 1
+
+      return
+    }
+
+    const [verb, , pluralNoun] = mapping
+    const nouns = (this._tally.verbs[verb] ??= {})
+    nouns[pluralNoun] = (nouns[pluralNoun] ?? 0) + 1
+
+    if (verb === EDIT_VERB) {
+      const deltas = extractLineDeltas(toolName, opts?.result)
+
+      if (deltas) {
+        this._tally.linesAdded += deltas[0]
+        this._tally.linesRemoved += deltas[1]
+        this._tally.hasLineDeltas = true
+      }
+    }
+  }
+
+  get tally(): TurnTally {
+    let counted = 0
+    const verbsCopy: Record<string, Record<string, number>> = {}
+
+    for (const [verb, nounMap] of Object.entries(this._tally.verbs)) {
+      verbsCopy[verb] = { ...nounMap }
+
+      for (const count of Object.values(nounMap)) {
+        counted += count
+      }
+    }
+
+    return {
+      verbs: verbsCopy,
+      otherTools: this._tally.otherTools,
+      linesAdded: this._tally.linesAdded,
+      linesRemoved: this._tally.linesRemoved,
+      hasLineDeltas: this._tally.hasLineDeltas,
+      totalTools: counted + this._tally.otherTools,
+    }
+  }
+
+  render(elapsedSeconds: number): string {
+    return formatTurnSummary(elapsedSeconds, this.tally)
+  }
+}
+
+export function formatElapsed(seconds: number): string {
+  const secs = Math.max(0, seconds)
+
+  if (secs < 60) {
+    return `${secs.toFixed(1)}s`
+  }
+
+  const mins = Math.floor(secs / 60)
+  const remSecs = Math.floor(secs % 60)
+
+  return `${mins}m${String(remSecs).padStart(2, '0')}s`
+}
+
+function pluralize(count: number, pluralNoun: string): string {
+  if (count === 1) {
+    return `1 ${singularize(pluralNoun)}`
+  }
+
+  return `${count} ${pluralNoun}`
+}
+
+export function formatTurnSummary(
+  elapsedSeconds: number,
+  tally: TurnTally | null,
+  opts?: { maxSegments?: number },
+): string {
+  const totalTools = tally ? tally.totalTools : 0
+
+  if (totalTools === 0 && elapsedSeconds < MIN_TOOLLESS_SECONDS) {
+    return ''
+  }
+
+  const maxSegments = opts?.maxSegments ?? MAX_SEGMENTS
+
+  // Verb segments only — the elapsed piece is always prepended and never
+  // counts against the cap (Python parity: max_segments trims the verb list).
+  const verbSegments: string[] = []
+
+  if (tally) {
+    const presentVerbs = Object.keys(tally.verbs)
+
+    const orderedVerbs = [
+      ...VERB_PRIORITY.filter(v => presentVerbs.includes(v)),
+      ...presentVerbs.filter(v => !VERB_PRIORITY.includes(v)),
+    ]
+
+    for (const verb of orderedVerbs) {
+      const nounCounts = tally.verbs[verb]
+
+      if (!nounCounts) {
+        continue
+      }
+
+      const parts = Object.entries(nounCounts)
+        .filter(([, count]) => count > 0)
+        .map(([pluralNoun, count]) => pluralize(count, pluralNoun))
+
+      if (!parts.length) {
+        continue
+      }
+
+      let segment = `${verb} ${parts.join(', ')}`
+
+      if (verb === EDIT_VERB && tally.hasLineDeltas) {
+        segment += ` +${tally.linesAdded} -${tally.linesRemoved}`
+      }
+
+      verbSegments.push(segment)
+    }
+
+    if (tally.otherTools > 0) {
+      verbSegments.push(
+        tally.otherTools === 1 ? 'called 1 tool' : `called ${tally.otherTools} tools`,
+      )
+    }
+  }
+
+  if (maxSegments > 0 && verbSegments.length > maxSegments) {
+    const hidden = verbSegments.length - maxSegments
+    verbSegments.splice(maxSegments, verbSegments.length - maxSegments, `+${hidden} more`)
+  }
+
+  return `${SUMMARY_PREFIX}${[formatElapsed(elapsedSeconds), ...verbSegments].join(' · ')}`
+}
+
+export function formatTokenFlow(outputTokens: unknown, opts?: { arrow?: string }): string {
+  const arrow = opts?.arrow ?? '↓'
+
+  if (outputTokens === null || outputTokens === undefined) {
+    return ''
+  }
+
+  const num = typeof outputTokens === 'number' ? outputTokens : Number(outputTokens)
+
+  if (!Number.isFinite(num) || num <= 0) {
+    return ''
+  }
+
+  let formatted: string
+
+  if (num < 1000) {
+    formatted = `${num} tok`
+  } else if (num < 1_000_000) {
+    formatted = `${(num / 1000).toFixed(1).replace(/\.0$/, '')}k tok`
+  } else {
+    formatted = `${(num / 1_000_000).toFixed(1).replace(/\.0$/, '')}M tok`
+  }
+
+  return `${arrow} ${formatted}`
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #1433 (agent transparency): a per-turn tool summary for the **TUI** and **Desktop** apps, matching the CLI's existing `display.turn_summary` line (`agent/turn_summary.py`).

After each completed turn, both clients now show a dim tally of what the turn did, byte-identical to the CLI:

```
⋯ 12.4s · edited 2 files +18 -3 · read 4 files · ran 3 commands
```

- **TUI** (`ui-tui`): the turn controller records completed tool calls from the existing `tool.complete` feed and renders the summary as a dim `◈` event line at `message.complete`.
- **Desktop** (`apps/desktop`): the message-stream hook tallies the settled turn's tool-call parts (wall-clock from `turnStartedAt`) and publishes the line per message id; the assistant bubble renders it under the changed-files card when settled.

Both apps get a pure port of `agent/turn_summary.py` (`lib/turn-summary.ts`) with the same verb table, pluralization, elapsed formatting, `+A -B` diff counting, and error/`_`-internal-tool exclusion — so all three surfaces report identically. No prompt changes, no new persisted data, no prompt-caching impact.

## Design notes

- Duplicated the pure module per app rather than introducing a shared TS package (none exists today; the module is ~300 lines).
- Failed/denied tool calls are excluded from the tally — a summary never over-claims "edited 2 files" when a write was denied.
- Wall-clock elapsed is measured turn start → turn end (not the sum of tool durations), matching the CLI.
- No config gate in the clients (always on), matching the CLI default (`display.turn_summary: true`).
- Subagent tool calls are intentionally not rolled up into the parent turn's summary.
- The summary lines are display-only — computed from the live turn and not persisted to the session store.

## Tests

- `ui-tui`: `turn-summary.test.ts` (15 cases — pluralization, deltas, error/underscore exclusion, segment caps, elapsed formats); full suite shows no regressions vs main.
- `apps/desktop`: `turn-summary.test.ts` (15 cases) + `turn-summary-wiring.test.tsx` (3 cases — publish on settle, empty for fast plain reply, denied tool excluded); full `vitest run --project ui` suite passes (407 files / 3638 tests).
- `tsc` clean in both apps; eslint clean on all changed files.

Refs #1433 — Phase 1 of a multi-phase plan (phases 2-4 are tracked on the issue; related work: #1092, #16636, #53007).
