### PR TITLE
fix(kanban): add profile-scoped default board

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2316,6 +2316,10 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Profile-scoped board used by CLI and model tools when a call does not
+        # pass an explicit board. ``None`` preserves the shared human CLI
+        # current-board pointer for backward compatibility.
+        "default_board": None,
         # Auto-subscribe the originating gateway/TUI session to task
         # completion + block events when ``kanban_create`` is called from
         # inside a session that has a persistent delivery channel. The

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1322,7 +1322,16 @@ def _cmd_boards_switch(args: argparse.Namespace) -> int:
         )
         return 1
     kb.set_current_board(normed)
-    print(f"Active board is now {normed!r}.")
+    effective = kb.get_current_board()
+    if effective != normed:
+        print(
+            f"Shared fallback board is now {normed!r}; this profile remains on "
+            f"{effective!r} because a higher-precedence profile or environment "
+            "default is configured. Use --board for one command, or update "
+            "kanban.default_board / HERMES_KANBAN_BOARD.",
+        )
+    else:
+        print(f"Active board is now {normed!r}.")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -32,9 +32,12 @@ Board resolution order (highest precedence first, all optional):
 * ``HERMES_KANBAN_DB`` env var (pins the DB file path directly — legacy
   override still honoured; highest precedence when the file path itself
   is what the caller wants to force).
-* ``<root>/kanban/current`` — a one-line text file holding the slug of
-  the "currently selected" board. Written by ``hermes kanban boards
-  switch <slug>``. When absent, the active board is ``default``.
+* Profile-scoped ``kanban.default_board`` from ``config.yaml``. Repository
+  profiles use this to avoid inheriting another profile's ambient selection.
+* ``<root>/kanban/current`` — a one-line text file holding the shared fallback
+  board. Written by ``hermes kanban boards switch <slug>`` and used when
+  the active profile has no ``kanban.default_board``. When absent, the active
+  board is ``default``.
 
 In standard installs ``<root>`` is ``~/.hermes``. In Docker / custom
 deployments where ``HERMES_HOME`` points outside ``~/.hermes`` (e.g.
@@ -464,11 +467,18 @@ def get_current_board() -> str:
 
     Order (highest precedence first):
 
-    1. ``HERMES_KANBAN_BOARD`` env var (set by the dispatcher on worker
+    1. A request-scoped override used by in-process callers.
+    2. ``HERMES_KANBAN_BOARD`` env var (set by the dispatcher on worker
        spawn, or manually for ad-hoc overrides).
-    2. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
+    3. Profile-scoped ``kanban.default_board`` from ``config.yaml``.
+    4. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
        switch``), but only when that board still exists.
-    3. ``DEFAULT_BOARD`` (``"default"``).
+    5. ``DEFAULT_BOARD`` (``"default"``).
+
+    The profile default deliberately precedes the shared current-board file:
+    a repository profile must not inherit whichever board a different profile
+    last selected in the human CLI. An explicit configured default may name a
+    board that has not been initialized yet; the first connection bootstraps it.
 
     A malformed or stale slug at any step falls through to the next layer
     with a best-effort warning — the dispatcher must never crash because a
@@ -492,6 +502,34 @@ def get_current_board() -> str:
         except ValueError:
             pass
     try:
+        # Profile-scoped default for ordinary CLI/tool calls. This sits above
+        # the deployment-wide ``kanban/current`` convenience pointer so one
+        # repository profile cannot silently inherit another profile's board.
+        # Import lazily to keep kanban_db importable in lightweight test rigs.
+        try:
+            from hermes_cli.config import load_config_readonly
+            configured = load_config_readonly().get("kanban", {}).get("default_board")
+        except Exception as exc:
+            _log.warning("Unable to load kanban.default_board: %s", exc)
+        else:
+            try:
+                if configured is None or configured == "":
+                    pass
+                elif not isinstance(configured, str):
+                    raise ValueError("must be a board slug string or null")
+                elif configured.strip():
+                    normed = _normalize_board_slug(configured.strip())
+                    if normed:
+                        if not board_exists(normed):
+                            _log.warning(
+                                "kanban.default_board %r does not exist yet; "
+                                "the first connection will initialize it",
+                                normed,
+                            )
+                        return normed
+            except (TypeError, ValueError) as exc:
+                _log.warning("Ignoring invalid kanban.default_board: %s", exc)
+
         f = current_board_path()
         if f.exists():
             val = f.read_text(encoding="utf-8").strip()

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -112,7 +112,106 @@ class TestPathResolution:
 
 class TestCurrentBoard:
 
+    def test_profile_default_board_beats_shared_current_pointer(self, fresh_home):
+        """A repository profile must not inherit another profile's CLI board."""
+        kb.create_board("repo-alpha")
+        kb.create_board("repo-beta")
+        kb.set_current_board("repo-beta")
+        (fresh_home / "config.yaml").write_text(
+            "kanban:\n  default_board: repo-alpha\n",
+            encoding="utf-8",
+        )
 
+        assert kb.get_current_board() == "repo-alpha"
+        assert kb.kanban_db_path() == (
+            fresh_home / "kanban" / "boards" / "repo-alpha" / "kanban.db"
+        )
+
+    def test_env_board_still_overrides_profile_default(self, fresh_home, monkeypatch):
+        kb.create_board("repo-alpha")
+        kb.create_board("explicit")
+        (fresh_home / "config.yaml").write_text(
+            "kanban:\n  default_board: repo-alpha\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "explicit")
+
+        assert kb.get_current_board() == "explicit"
+
+    def test_two_profiles_resolve_different_defaults_on_one_shared_board_root(
+        self, fresh_home, monkeypatch
+    ):
+        profiles = fresh_home / "profiles"
+        alpha = profiles / "alpha"
+        beta = profiles / "beta"
+        alpha.mkdir(parents=True)
+        beta.mkdir(parents=True)
+        (alpha / "config.yaml").write_text(
+            "kanban:\n  default_board: repo-alpha\n", encoding="utf-8"
+        )
+        (beta / "config.yaml").write_text(
+            "kanban:\n  default_board: repo-beta\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(fresh_home))
+        kb.create_board("repo-alpha")
+        kb.create_board("repo-beta")
+        kb.set_current_board("repo-beta")
+
+        monkeypatch.setenv("HERMES_HOME", str(alpha))
+        assert kb.get_current_board() == "repo-alpha"
+        monkeypatch.setenv("HERMES_HOME", str(beta))
+        assert kb.get_current_board() == "repo-beta"
+
+    def test_none_profile_default_preserves_shared_pointer(self, fresh_home):
+        kb.create_board("shared")
+        kb.set_current_board("shared")
+        (fresh_home / "config.yaml").write_text(
+            "kanban:\n  default_board: null\n", encoding="utf-8"
+        )
+
+        assert kb.get_current_board() == "shared"
+
+    def test_invalid_profile_default_warns_and_preserves_shared_pointer(
+        self, fresh_home, caplog
+    ):
+        kb.create_board("shared")
+        kb.set_current_board("shared")
+        (fresh_home / "config.yaml").write_text(
+            "kanban:\n  default_board: ../../wrong\n", encoding="utf-8"
+        )
+
+        assert kb.get_current_board() == "shared"
+        assert "Ignoring invalid kanban.default_board" in caplog.text
+
+    def test_non_string_profile_default_warns_and_preserves_shared_pointer(
+        self, fresh_home, caplog
+    ):
+        kb.create_board("shared")
+        kb.set_current_board("shared")
+        (fresh_home / "config.yaml").write_text(
+            "kanban:\n  default_board: 123\n", encoding="utf-8"
+        )
+
+        assert kb.get_current_board() == "shared"
+        assert "must be a board slug string or null" in caplog.text
+
+    def test_profile_default_bootstraps_board_schema(self, fresh_home, caplog):
+        (fresh_home / "config.yaml").write_text(
+            "kanban:\n  default_board: repo-new\n", encoding="utf-8"
+        )
+        assert not kb.board_exists("repo-new")
+
+        with kb.connect() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+
+        assert kb.board_exists("repo-new")
+        assert "does not exist yet; the first connection will initialize it" in caplog.text
+        assert {"tasks", "task_events"}.issubset(tables)
 
     def test_stale_file_pointer_falls_back_to_default(self, fresh_home):
         current = fresh_home / "kanban" / "current"
@@ -308,6 +407,20 @@ def _cli(args: list[str], env_extra: dict | None = None) -> subprocess.Completed
 
 
 class TestCLI:
+    def test_switch_reports_profile_default_precedence(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        (tmp_path / "config.yaml").write_text(
+            "kanban:\n  default_board: pinned\n", encoding="utf-8"
+        )
+        assert _cli(["boards", "create", "pinned"], env_extra=env).returncode == 0
+        assert _cli(["boards", "create", "other"], env_extra=env).returncode == 0
+
+        res = _cli(["boards", "switch", "other"], env_extra=env)
+
+        assert res.returncode == 0, res.stderr
+        assert "Shared fallback board is now 'other'" in res.stdout
+        assert "this profile remains on 'pinned'" in res.stdout
+
     def test_boards_list_default_only(self, tmp_path):
         env = {"HERMES_HOME": str(tmp_path)}
         res = _cli(["boards", "list", "--json"], env_extra=env)


### PR DESCRIPTION
## Summary
- add `kanban.default_board` as a profile-scoped board selection above the deployment-wide `kanban/current` pointer
- preserve explicit request/environment pinning and legacy behavior when the profile default is unset
- warn on invalid values and first-use board initialization; make `boards switch` report when a higher-precedence profile default remains active
- cover two profiles sharing one Kanban root, malformed/unset/default/bootstrap behavior, schema initialization, CLI truthfulness, and env precedence

## Root-cause chain
1. Multi-profile repository sessions inherited the single shared `kanban/current` pointer. This PR fixes the runtime selection mechanism.
2. Claudius must project the canonical repository board into every resident and builder profile. That landed in nterprise-ai/claudius#962.
3. An explicit unknown `project` also failed open to an unscoped workspace. Existing PR #70534 fixes that separate fail-open path.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_boards.py -q` — 29 passed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban.py tests/test_config.py -q` — 203 passed
- Ruff + py_compile on changed Python files — passed
- independent Claude Opus review of the exact head — APPROVED; provisioning dependency is already merged via Claudius #962

Closes #21877.