### PR TITLE
fix(kanban): stop claimed tasks from stalling when workers fail to start

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6798,6 +6798,9 @@ class DispatchResult:
     """Task ids requeued by :func:`reconcile_orphaned_running` this tick —
     ``running`` cards whose claim bookkeeping was broken (no valid claim,
     dead/gone worker). See the reconciliation pass for details."""
+    never_started: list[str] = field(default_factory=list)
+    """Task ids requeued because a claimed worker produced no PID, heartbeat,
+    or log before the launch grace elapsed."""
     spawned: list[tuple[str, str, str]] = field(default_factory=list)
     """List of ``(task_id, assignee, workspace_path)`` triples."""
     skipped_unassigned: list[str] = field(default_factory=list)
@@ -7609,6 +7612,124 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
+def detect_never_started(
+    conn: sqlite3.Connection,
+    *,
+    grace_seconds: Optional[int] = None,
+    failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
+    board: Optional[str] = None,
+) -> list[str]:
+    """Reclaim claimed tasks whose worker never became observable.
+
+    A dispatcher can die after ``claim_task`` but before persisting the child
+    PID, and legacy/custom spawn callbacks may return no PID at all.  Those
+    tasks have valid claim bookkeeping, so orphan reconciliation ignores them;
+    crash detection also ignores them because it requires a PID.  After twice
+    the normal launch grace, a host-local claim with no PID, heartbeat, or
+    worker log from the active attempt is therefore treated as a spawn failure.
+
+    The log check protects the narrow ``Popen`` -> PID-persistence crash window:
+    ``_default_spawn`` opens the task log before starting the child, so a log
+    created or written during the active run means a worker may really be
+    running even though its PID was lost. Logs are reused across retries, so an
+    older attempt's file is not evidence for the current one. The compare-and-
+    swap update rechecks the PID and heartbeat under the write lock before
+    releasing the claim.
+    """
+    grace = (
+        2 * _resolve_crash_grace_seconds()
+        if grace_seconds is None
+        else max(0, int(grace_seconds))
+    )
+    now = int(time.time())
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    rows = conn.execute(
+        "SELECT t.id, t.claim_lock, t.current_run_id, "
+        "       COALESCE(r.started_at, t.started_at) AS active_started_at "
+        "FROM tasks t "
+        "LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.status = 'running' "
+        "  AND t.claim_lock IS NOT NULL "
+        "  AND t.claim_expires IS NOT NULL "
+        "  AND t.worker_pid IS NULL "
+        "  AND t.last_heartbeat_at IS NULL "
+        "  AND COALESCE(r.started_at, t.started_at) IS NOT NULL "
+        "  AND COALESCE(r.started_at, t.started_at) <= ?",
+        (now - grace,),
+    ).fetchall()
+
+    recovered: list[str] = []
+    auto_blocked: list[str] = []
+    log_dir = worker_logs_dir(board=board)
+    for row in rows:
+        claim_lock = row["claim_lock"] or ""
+        if not claim_lock.startswith(host_prefix):
+            continue
+        log_path = log_dir / f"{row['id']}.log"
+        if log_path.exists():
+            try:
+                if log_path.stat().st_mtime >= int(row["active_started_at"]):
+                    continue
+            except OSError:
+                # An unreadable log cannot safely prove the worker absent.
+                continue
+
+        elapsed = now - int(row["active_started_at"])
+        error = (
+            "worker did not record a PID or heartbeat within "
+            f"{grace}s of claim"
+        )
+        payload = {
+            "reason": "worker_never_started",
+            "claim_lock": row["claim_lock"],
+            "elapsed_seconds": elapsed,
+            "grace_seconds": grace,
+        }
+        with write_txn(conn):
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, "
+                "last_heartbeat_at = NULL "
+                "WHERE id = ? AND status = 'running' "
+                "  AND claim_lock IS ? AND current_run_id IS ? "
+                "  AND worker_pid IS NULL AND last_heartbeat_at IS NULL",
+                (row["id"], row["claim_lock"], row["current_run_id"]),
+            )
+            if cur.rowcount != 1:
+                continue
+            run_id = _end_run(
+                conn,
+                row["id"],
+                outcome="spawn_failed",
+                status="spawn_failed",
+                error=error,
+                metadata=payload,
+            )
+            _append_event(
+                conn,
+                row["id"],
+                "spawn_failed",
+                payload,
+                run_id=run_id,
+            )
+            recovered.append(row["id"])
+
+        if _record_task_failure(
+            conn,
+            row["id"],
+            error,
+            outcome="spawn_failed",
+            failure_limit=failure_limit,
+            release_claim=False,
+            end_run=False,
+            event_payload_extra=payload,
+        ):
+            auto_blocked.append(row["id"])
+
+    detect_never_started._last_auto_blocked = auto_blocked  # type: ignore[attr-defined]
+    return recovered
+
+
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
@@ -8387,10 +8508,11 @@ def _dispatch_once_locked(
 
     Steps:
       1. Reclaim stale running tasks (TTL expired).
-      2. Reclaim stale running tasks (no recent heartbeat).
-      3. Reclaim crashed running tasks (host-local PID no longer alive).
-      3. Promote todo -> ready where all parents are done.
-      4. For each ready task with an assignee, atomically claim and call
+      2. Reclaim claimed tasks whose worker never started.
+      3. Reclaim stale running tasks (no recent heartbeat).
+      4. Reclaim crashed running tasks (host-local PID no longer alive).
+      5. Promote todo -> ready where all parents are done.
+      6. For each ready task with an assignee, atomically claim and call
          ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
          return value (if any) is recorded as ``worker_pid`` so subsequent
          ticks can detect crashes before the TTL expires.
@@ -8422,6 +8544,16 @@ def _dispatch_once_locked(
         # bookkeeping is broken (no valid claim, dead/gone worker) that the
         # TTL/crash/stale paths can never see. See reconcile_orphaned_running.
         result.reconciled_orphans = reconcile_orphaned_running(conn)
+    result.never_started = detect_never_started(
+        conn,
+        failure_limit=failure_limit,
+        board=board,
+    )
+    _never_started_auto_blocked = getattr(
+        detect_never_started, "_last_auto_blocked", []
+    )
+    if _never_started_auto_blocked:
+        result.auto_blocked.extend(_never_started_auto_blocked)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2880,6 +2880,40 @@ def _is_host_local_dispatch_claim(claim_lock: Optional[str]) -> bool:
     return lock.startswith(host_prefix) and lock.endswith(_DISPATCH_CLAIM_SUFFIX)
 
 
+def _claim_source_status(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: Optional[int],
+) -> str:
+    """Return the lane a claim left (``ready`` or ``review``).
+
+    ``claim_review_task`` records ``source_status: review`` on its claimed
+    event; ordinary ``claim_task`` records ``ready`` (or omits it on older
+    rows). Failed launches must restore that lane so a dead review spawn
+    does not fall back into the implementation queue.
+    """
+    if run_id is None:
+        return "ready"
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND run_id = ? AND kind = 'claimed' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, int(run_id)),
+    ).fetchone()
+    if row is None or not row["payload"]:
+        return "ready"
+    try:
+        payload = json.loads(row["payload"])
+    except Exception:
+        return "ready"
+    if not isinstance(payload, dict):
+        return "ready"
+    source = payload.get("source_status")
+    if source == "review":
+        return "review"
+    return "ready"
+
+
 # ---------------------------------------------------------------------------
 # Task creation / mutation
 # ---------------------------------------------------------------------------
@@ -4346,7 +4380,12 @@ def claim_task(
         )
         _append_event(
             conn, task_id, "claimed",
-            {"lock": lock, "expires": expires, "run_id": run_id},
+            {
+                "lock": lock,
+                "expires": expires,
+                "run_id": run_id,
+                "source_status": "ready",
+            },
             run_id=run_id,
         )
         claimed = get_task(conn, task_id)
@@ -7644,6 +7683,9 @@ def detect_never_started(
     worker log from the active attempt is therefore treated as a spawn failure.
     Automatic dispatch marks its claim lock explicitly; direct/manual claims
     intentionally lack that marker and are never interpreted as failed spawns.
+    Review-agent launches are restored to ``review`` (not ``ready``) using the
+    ``source_status`` recorded on the claim event, so a dead reviewer does not
+    re-enter the ordinary worker queue.
 
     The log check protects the narrow ``Popen`` -> PID-persistence crash window:
     ``_default_spawn`` opens the task log before starting the child, so a log
@@ -7695,21 +7737,31 @@ def detect_never_started(
             "worker did not record a PID or heartbeat within "
             f"{grace}s of claim"
         )
+        requeue_status = _claim_source_status(
+            conn, row["id"], row["current_run_id"]
+        )
         payload = {
             "reason": "worker_never_started",
             "claim_lock": row["claim_lock"],
             "elapsed_seconds": elapsed,
             "grace_seconds": grace,
+            "source_status": requeue_status,
+            "requeue_status": requeue_status,
         }
         with write_txn(conn):
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ? AND current_run_id IS ? "
                 "  AND worker_pid IS NULL AND last_heartbeat_at IS NULL",
-                (row["id"], row["claim_lock"], row["current_run_id"]),
+                (
+                    requeue_status,
+                    row["id"],
+                    row["claim_lock"],
+                    row["current_run_id"],
+                ),
             )
             if cur.rowcount != 1:
                 continue
@@ -8047,10 +8099,11 @@ def _record_task_failure(
       releases the claim, and closes the run with ``outcome=<outcome>``.
 
     * ``release_claim=False, end_run=False`` — timeout/crash path.
-      Caller has ALREADY flipped the task to ``ready`` and closed the
-      run with the appropriate outcome. This just increments the
-      counter; if the breaker trips, the task is re-transitioned
-      ``ready → blocked`` and a ``gave_up`` event is emitted.
+      Caller has ALREADY flipped the task to its requeue lane
+      (``ready`` or ``review``) and closed the run with the appropriate
+      outcome. This just increments the counter; if the breaker trips,
+      the task is re-transitioned ``ready|review → blocked`` and a
+      ``gave_up`` event is emitted.
 
     ``event_payload_extra`` merges into the ``gave_up`` event payload
     when the breaker trips, so callers can include outcome-specific
@@ -8107,13 +8160,14 @@ def _record_task_failure(
                     (failures, error[:500], task_id),
                 )
             else:
-                # Timeout/crash path: task is already at ``ready``
-                # with claim cleared; just flip to blocked + update
+                # Timeout/crash/never-started path: claim is already
+                # cleared and the task sits in its requeue lane
+                # (ready or review); just flip to blocked + update
                 # counter fields.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', "
                     "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status IN ('ready', 'running')",
+                    "WHERE id = ? AND status IN ('ready', 'running', 'review')",
                     (failures, error[:500], task_id),
                 )
             run_id = None
@@ -8155,8 +8209,9 @@ def _record_task_failure(
                     (failures, error[:500], task_id),
                 )
             else:
-                # Timeout/crash path: task is already at ``ready`` via
-                # its own UPDATE. Just bookkeep the counter + last error.
+                # Timeout/crash/never-started path: task is already at its
+                # requeue lane via its own UPDATE. Just bookkeep the
+                # counter + last error.
                 conn.execute(
                     "UPDATE tasks SET consecutive_failures = ?, "
                     "last_failure_error = ? WHERE id = ?",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2865,6 +2865,21 @@ def _claimer_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
+_DISPATCH_CLAIM_SUFFIX = ":dispatch"
+
+
+def _dispatcher_claimer_id() -> str:
+    """Return a durable marker for claims owned by automatic dispatch."""
+    return f"{_claimer_id()}{_DISPATCH_CLAIM_SUFFIX}"
+
+
+def _is_host_local_dispatch_claim(claim_lock: Optional[str]) -> bool:
+    """Distinguish automatic launches from direct/manual task claims."""
+    lock = claim_lock or ""
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    return lock.startswith(host_prefix) and lock.endswith(_DISPATCH_CLAIM_SUFFIX)
+
+
 # ---------------------------------------------------------------------------
 # Task creation / mutation
 # ---------------------------------------------------------------------------
@@ -7627,6 +7642,8 @@ def detect_never_started(
     crash detection also ignores them because it requires a PID.  After twice
     the normal launch grace, a host-local claim with no PID, heartbeat, or
     worker log from the active attempt is therefore treated as a spawn failure.
+    Automatic dispatch marks its claim lock explicitly; direct/manual claims
+    intentionally lack that marker and are never interpreted as failed spawns.
 
     The log check protects the narrow ``Popen`` -> PID-persistence crash window:
     ``_default_spawn`` opens the task log before starting the child, so a log
@@ -7642,7 +7659,6 @@ def detect_never_started(
         else max(0, int(grace_seconds))
     )
     now = int(time.time())
-    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     rows = conn.execute(
         "SELECT t.id, t.claim_lock, t.current_run_id, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
@@ -7663,7 +7679,7 @@ def detect_never_started(
     log_dir = worker_logs_dir(board=board)
     for row in rows:
         claim_lock = row["claim_lock"] or ""
-        if not claim_lock.startswith(host_prefix):
+        if not _is_host_local_dispatch_claim(claim_lock):
             continue
         log_path = log_dir / f"{row['id']}.log"
         if log_path.exists():
@@ -8763,7 +8779,12 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_task(
+            conn,
+            row["id"],
+            ttl_seconds=ttl_seconds,
+            claimer=_dispatcher_claimer_id(),
+        )
         if claimed is None:
             continue
         try:
@@ -8855,7 +8876,12 @@ def _dispatch_once_locked(
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
-        claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_review_task(
+            conn,
+            row["id"],
+            ttl_seconds=ttl_seconds,
+            claimer=_dispatcher_claimer_id(),
+        )
         if claimed is None:
             continue
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8095,8 +8095,10 @@ def _record_task_failure(
 
     * ``release_claim=True, end_run=True`` — spawn-failure path.
       Caller has a running task with an open run; this transitions
-      it back to ``ready`` (or ``blocked`` when the breaker trips),
-      releases the claim, and closes the run with ``outcome=<outcome>``.
+      it back to the claim's source lane (``ready`` or ``review``, via
+      :func:`_claim_source_status`) or ``blocked`` when the breaker
+      trips, releases the claim, and closes the run with
+      ``outcome=<outcome>``.
 
     * ``release_claim=False, end_run=False`` — timeout/crash path.
       Caller has ALREADY flipped the task to its requeue lane
@@ -8129,12 +8131,23 @@ def _record_task_failure(
     blocked = False
     with write_txn(conn):
         row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries "
+            "SELECT consecutive_failures, status, max_retries, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
             return False
         failures = int(row["consecutive_failures"]) + 1
+        current_run_id = (
+            row["current_run_id"] if "current_run_id" in row.keys() else None
+        )
+        # Spawn-failure reclaim must restore the claim's source lane
+        # (ready vs review). Reading before mutations keeps the claimed
+        # event for the open run visible to _claim_source_status.
+        requeue_status = (
+            _claim_source_status(conn, task_id, current_run_id)
+            if release_claim
+            else "ready"
+        )
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -8182,6 +8195,8 @@ def _record_task_failure(
                         "trigger_outcome": outcome,
                         "effective_limit": effective_limit,
                         "limit_source": limit_source,
+                        "source_status": requeue_status,
+                        "requeue_status": requeue_status,
                     },
                 )
             payload = {
@@ -8191,6 +8206,9 @@ def _record_task_failure(
                 "error": error[:500],
                 "trigger_outcome": outcome,
             }
+            if release_claim:
+                payload["source_status"] = requeue_status
+                payload["requeue_status"] = requeue_status
             if event_payload_extra:
                 payload.update(event_payload_extra)
             _append_event(
@@ -8200,13 +8218,15 @@ def _record_task_failure(
         else:
             # Below threshold.
             if release_claim:
-                # Spawn path: transition running → ready + clear claim.
+                # Spawn path: restore the claim's source lane and clear
+                # claim bookkeeping. Review launches must not fall into
+                # the ready/implementation queue.
                 conn.execute(
-                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
-                    (failures, error[:500], task_id),
+                    (requeue_status, failures, error[:500], task_id),
                 )
             else:
                 # Timeout/crash/never-started path: task is already at its
@@ -8223,11 +8243,22 @@ def _record_task_failure(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={"failures": failures},
+                    metadata={
+                        "failures": failures,
+                        "source_status": requeue_status,
+                        "requeue_status": requeue_status,
+                    },
                 )
+                event_payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                }
+                if release_claim:
+                    event_payload["source_status"] = requeue_status
+                    event_payload["requeue_status"] = requeue_status
                 _append_event(
                     conn, task_id, outcome,
-                    {"error": error[:500], "failures": failures},
+                    event_payload,
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.

--- a/tests/hermes_cli/test_kanban_never_started.py
+++ b/tests/hermes_cli/test_kanban_never_started.py
@@ -292,3 +292,89 @@ def test_never_started_review_recovery_trips_failure_limit_to_blocked(conn):
     assert task.status == "blocked"
     assert task.consecutive_failures == 2
     assert getattr(kb.detect_never_started, "_last_auto_blocked") == [task_id]
+
+
+def test_record_spawn_failure_requeues_review_claim_to_review(conn):
+    task_id = kb.create_task(conn, title="review spawn boom", assignee="worker")
+    conn.execute(
+        "UPDATE tasks SET status = 'review' WHERE id = ?",
+        (task_id,),
+    )
+    conn.commit()
+
+    claimed = kb.claim_review_task(
+        conn, task_id, claimer=kb._dispatcher_claimer_id()
+    )
+    assert claimed is not None
+
+    blocked = kb._record_spawn_failure(
+        conn,
+        task_id,
+        "workspace: missing worktree",
+        failure_limit=2,
+    )
+
+    assert blocked is False
+    task = kb.get_task(conn, task_id)
+    assert task.status == "review"
+    assert task.claim_lock is None
+    assert task.worker_pid is None
+    assert task.consecutive_failures == 1
+
+    run = kb.latest_run(conn, task_id)
+    assert run.status == "spawn_failed"
+    assert run.outcome == "spawn_failed"
+
+    events = kb.list_events(conn, task_id)
+    failure = next(event for event in events if event.kind == "spawn_failed")
+    assert failure.payload["source_status"] == "review"
+    assert failure.payload["requeue_status"] == "review"
+
+
+def test_record_spawn_failure_keeps_ready_claim_on_ready(conn):
+    task_id = kb.create_task(conn, title="ready spawn boom", assignee="worker")
+    claimed = kb.claim_task(conn, task_id, claimer=kb._dispatcher_claimer_id())
+    assert claimed is not None
+
+    assert kb._record_spawn_failure(
+        conn,
+        task_id,
+        "spawn failed",
+        failure_limit=2,
+    ) is False
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.claim_lock is None
+    assert task.consecutive_failures == 1
+
+
+def test_review_dispatch_spawn_exception_requeues_to_review(conn, monkeypatch):
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    task_id = kb.create_task(conn, title="review dispatch boom", assignee="worker")
+    conn.execute(
+        "UPDATE tasks SET status = 'review' WHERE id = ?",
+        (task_id,),
+    )
+    conn.commit()
+
+    def _boom(_task, _workspace, **_kwargs):
+        raise RuntimeError("reviewer binary missing")
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=_boom,
+        failure_limit=2,
+        board="default",
+    )
+
+    assert result.spawned == []
+    task = kb.get_task(conn, task_id)
+    assert task.status == "review"
+    assert task.claim_lock is None
+    assert task.consecutive_failures == 1
+
+    run = kb.latest_run(conn, task_id)
+    assert run.outcome == "spawn_failed"

--- a/tests/hermes_cli/test_kanban_never_started.py
+++ b/tests/hermes_cli/test_kanban_never_started.py
@@ -1,0 +1,188 @@
+"""Recovery tests for kanban workers that never record a PID."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db(board="default")
+    with kb.connect(board="default") as connection:
+        yield connection
+
+
+def test_detect_never_started_requeues_aged_pidless_claim_as_spawn_failure(conn):
+    host = kb._claimer_id().split(":", 1)[0]
+    task_id = kb.create_task(conn, title="ghost worker", assignee="worker")
+    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    assert claimed is not None
+
+    old_started = int(time.time()) - 120
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (old_started, claimed.current_run_id),
+    )
+    conn.commit()
+
+    recovered = kb.detect_never_started(
+        conn,
+        grace_seconds=60,
+        failure_limit=2,
+        board="default",
+    )
+
+    assert recovered == [task_id]
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.claim_lock is None
+    assert task.worker_pid is None
+    assert task.consecutive_failures == 1
+
+    run = kb.latest_run(conn, task_id)
+    assert run.status == "spawn_failed"
+    assert run.outcome == "spawn_failed"
+    assert run.ended_at is not None
+
+    events = kb.list_events(conn, task_id)
+    failure = next(event for event in events if event.kind == "spawn_failed")
+    assert failure.payload["reason"] == "worker_never_started"
+    assert failure.payload["grace_seconds"] == 60
+
+
+def test_dispatch_tick_surfaces_never_started_recovery(conn, monkeypatch):
+    host = kb._claimer_id().split(":", 1)[0]
+    task_id = kb.create_task(conn, title="dispatch ghost", assignee="worker")
+    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    assert claimed is not None
+
+    old_started = int(time.time()) - 120
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (old_started, claimed.current_run_id),
+    )
+    conn.commit()
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "30")
+
+    result = kb.dispatch_once(
+        conn,
+        max_spawn=0,
+        failure_limit=2,
+        board="default",
+    )
+
+    assert result.never_started == [task_id]
+    assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_stale_log_from_previous_attempt_does_not_hide_never_started_worker(conn):
+    host = kb._claimer_id().split(":", 1)[0]
+    task_id = kb.create_task(conn, title="retry ghost", assignee="worker")
+    log_path = kb.worker_logs_dir(board="default") / f"{task_id}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("prior attempt\n", encoding="utf-8")
+    prior_mtime = int(time.time()) - 3600
+    os.utime(log_path, (prior_mtime, prior_mtime))
+
+    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    assert claimed is not None
+    active_started = int(time.time()) - 120
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (active_started, claimed.current_run_id),
+    )
+    conn.commit()
+
+    recovered = kb.detect_never_started(
+        conn,
+        grace_seconds=60,
+        failure_limit=2,
+        board="default",
+    )
+
+    assert recovered == [task_id]
+
+
+def test_current_attempt_log_preserves_pidless_claim(conn):
+    host = kb._claimer_id().split(":", 1)[0]
+    task_id = kb.create_task(conn, title="worker may be alive", assignee="worker")
+    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    assert claimed is not None
+    active_started = int(time.time()) - 120
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (active_started, claimed.current_run_id),
+    )
+    conn.commit()
+
+    log_path = kb.worker_logs_dir(board="default") / f"{task_id}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("active attempt\n", encoding="utf-8")
+
+    assert kb.detect_never_started(
+        conn,
+        grace_seconds=60,
+        board="default",
+    ) == []
+    assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_never_started_recovery_ignores_other_hosts_claim(conn):
+    task_id = kb.create_task(conn, title="remote claim", assignee="worker")
+    claimed = kb.claim_task(conn, task_id, claimer="another-host:dispatcher")
+    assert claimed is not None
+    old_started = int(time.time()) - 120
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (old_started, claimed.current_run_id),
+    )
+    conn.commit()
+
+    assert kb.detect_never_started(
+        conn,
+        grace_seconds=60,
+        board="default",
+    ) == []
+    assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_never_started_recovery_trips_existing_failure_limit(conn):
+    host = kb._claimer_id().split(":", 1)[0]
+    task_id = kb.create_task(conn, title="repeated spawn failure", assignee="worker")
+    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    assert claimed is not None
+    old_started = int(time.time()) - 120
+    conn.execute(
+        "UPDATE tasks SET consecutive_failures = 1 WHERE id = ?",
+        (task_id,),
+    )
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (old_started, claimed.current_run_id),
+    )
+    conn.commit()
+
+    assert kb.detect_never_started(
+        conn,
+        grace_seconds=60,
+        failure_limit=2,
+        board="default",
+    ) == [task_id]
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 2
+    assert getattr(kb.detect_never_started, "_last_auto_blocked") == [task_id]

--- a/tests/hermes_cli/test_kanban_never_started.py
+++ b/tests/hermes_cli/test_kanban_never_started.py
@@ -26,9 +26,8 @@ def conn(tmp_path, monkeypatch):
 
 
 def test_detect_never_started_requeues_aged_pidless_claim_as_spawn_failure(conn):
-    host = kb._claimer_id().split(":", 1)[0]
     task_id = kb.create_task(conn, title="ghost worker", assignee="worker")
-    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    claimed = kb.claim_task(conn, task_id, claimer=kb._dispatcher_claimer_id())
     assert claimed is not None
 
     old_started = int(time.time()) - 120
@@ -64,10 +63,21 @@ def test_detect_never_started_requeues_aged_pidless_claim_as_spawn_failure(conn)
 
 
 def test_dispatch_tick_surfaces_never_started_recovery(conn, monkeypatch):
-    host = kb._claimer_id().split(":", 1)[0]
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
     task_id = kb.create_task(conn, title="dispatch ghost", assignee="worker")
-    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    first = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda *_args, **_kwargs: None,
+        board="default",
+    )
+    assert [task_id for task_id, _assignee, _workspace in first.spawned] == [
+        task_id
+    ]
+    claimed = kb.get_task(conn, task_id)
     assert claimed is not None
+    assert claimed.claim_lock == kb._dispatcher_claimer_id()
 
     old_started = int(time.time()) - 120
     conn.execute(
@@ -89,7 +99,6 @@ def test_dispatch_tick_surfaces_never_started_recovery(conn, monkeypatch):
 
 
 def test_stale_log_from_previous_attempt_does_not_hide_never_started_worker(conn):
-    host = kb._claimer_id().split(":", 1)[0]
     task_id = kb.create_task(conn, title="retry ghost", assignee="worker")
     log_path = kb.worker_logs_dir(board="default") / f"{task_id}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -97,7 +106,7 @@ def test_stale_log_from_previous_attempt_does_not_hide_never_started_worker(conn
     prior_mtime = int(time.time()) - 3600
     os.utime(log_path, (prior_mtime, prior_mtime))
 
-    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    claimed = kb.claim_task(conn, task_id, claimer=kb._dispatcher_claimer_id())
     assert claimed is not None
     active_started = int(time.time()) - 120
     conn.execute(
@@ -117,9 +126,8 @@ def test_stale_log_from_previous_attempt_does_not_hide_never_started_worker(conn
 
 
 def test_current_attempt_log_preserves_pidless_claim(conn):
-    host = kb._claimer_id().split(":", 1)[0]
     task_id = kb.create_task(conn, title="worker may be alive", assignee="worker")
-    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    claimed = kb.claim_task(conn, task_id, claimer=kb._dispatcher_claimer_id())
     assert claimed is not None
     active_started = int(time.time()) - 120
     conn.execute(
@@ -142,7 +150,7 @@ def test_current_attempt_log_preserves_pidless_claim(conn):
 
 def test_never_started_recovery_ignores_other_hosts_claim(conn):
     task_id = kb.create_task(conn, title="remote claim", assignee="worker")
-    claimed = kb.claim_task(conn, task_id, claimer="another-host:dispatcher")
+    claimed = kb.claim_task(conn, task_id, claimer="another-host:1:dispatch")
     assert claimed is not None
     old_started = int(time.time()) - 120
     conn.execute(
@@ -159,10 +167,30 @@ def test_never_started_recovery_ignores_other_hosts_claim(conn):
     assert kb.get_task(conn, task_id).status == "running"
 
 
+def test_never_started_recovery_preserves_direct_manual_claim(conn):
+    task_id = kb.create_task(conn, title="terminal lane", assignee="worker")
+    claimed = kb.claim_task(conn, task_id)
+    assert claimed is not None
+    old_started = int(time.time()) - 120
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (old_started, claimed.current_run_id),
+    )
+    conn.commit()
+
+    assert kb.detect_never_started(
+        conn,
+        grace_seconds=60,
+        board="default",
+    ) == []
+    task = kb.get_task(conn, task_id)
+    assert task.status == "running"
+    assert task.consecutive_failures == 0
+
+
 def test_never_started_recovery_trips_existing_failure_limit(conn):
-    host = kb._claimer_id().split(":", 1)[0]
     task_id = kb.create_task(conn, title="repeated spawn failure", assignee="worker")
-    claimed = kb.claim_task(conn, task_id, claimer=f"{host}:dispatcher")
+    claimed = kb.claim_task(conn, task_id, claimer=kb._dispatcher_claimer_id())
     assert claimed is not None
     old_started = int(time.time()) - 120
     conn.execute(

--- a/tests/hermes_cli/test_kanban_never_started.py
+++ b/tests/hermes_cli/test_kanban_never_started.py
@@ -188,6 +188,52 @@ def test_never_started_recovery_preserves_direct_manual_claim(conn):
     assert task.consecutive_failures == 0
 
 
+def test_never_started_recovery_requeues_review_claim_to_review(conn):
+    task_id = kb.create_task(conn, title="review ghost", assignee="worker")
+    conn.execute(
+        "UPDATE tasks SET status = 'review' WHERE id = ?",
+        (task_id,),
+    )
+    conn.commit()
+
+    claimed = kb.claim_review_task(
+        conn, task_id, claimer=kb._dispatcher_claimer_id()
+    )
+    assert claimed is not None
+    assert claimed.status == "running"
+
+    old_started = int(time.time()) - 120
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (old_started, claimed.current_run_id),
+    )
+    conn.commit()
+
+    recovered = kb.detect_never_started(
+        conn,
+        grace_seconds=60,
+        failure_limit=2,
+        board="default",
+    )
+
+    assert recovered == [task_id]
+    task = kb.get_task(conn, task_id)
+    assert task.status == "review"
+    assert task.claim_lock is None
+    assert task.worker_pid is None
+    assert task.consecutive_failures == 1
+
+    run = kb.latest_run(conn, task_id)
+    assert run.status == "spawn_failed"
+    assert run.outcome == "spawn_failed"
+
+    events = kb.list_events(conn, task_id)
+    failure = next(event for event in events if event.kind == "spawn_failed")
+    assert failure.payload["reason"] == "worker_never_started"
+    assert failure.payload["source_status"] == "review"
+    assert failure.payload["requeue_status"] == "review"
+
+
 def test_never_started_recovery_trips_existing_failure_limit(conn):
     task_id = kb.create_task(conn, title="repeated spawn failure", assignee="worker")
     claimed = kb.claim_task(conn, task_id, claimer=kb._dispatcher_claimer_id())
@@ -197,6 +243,38 @@ def test_never_started_recovery_trips_existing_failure_limit(conn):
         "UPDATE tasks SET consecutive_failures = 1 WHERE id = ?",
         (task_id,),
     )
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = ?",
+        (old_started, claimed.current_run_id),
+    )
+    conn.commit()
+
+    assert kb.detect_never_started(
+        conn,
+        grace_seconds=60,
+        failure_limit=2,
+        board="default",
+    ) == [task_id]
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 2
+    assert getattr(kb.detect_never_started, "_last_auto_blocked") == [task_id]
+
+
+def test_never_started_review_recovery_trips_failure_limit_to_blocked(conn):
+    task_id = kb.create_task(conn, title="review spawn breaker", assignee="worker")
+    conn.execute(
+        "UPDATE tasks SET status = 'review', consecutive_failures = 1 WHERE id = ?",
+        (task_id,),
+    )
+    conn.commit()
+
+    claimed = kb.claim_review_task(
+        conn, task_id, claimer=kb._dispatcher_claimer_id()
+    )
+    assert claimed is not None
+    old_started = int(time.time()) - 120
     conn.execute(
         "UPDATE task_runs SET started_at = ? WHERE id = ?",
         (old_started, claimed.current_run_id),


### PR DESCRIPTION
## What does this PR do?

Kanban tasks no longer remain stuck in `running` for hours when automatic dispatch claims them but the worker never records a PID, heartbeat, or log. The dispatcher now reclaims that state after a bounded launch grace, records it as a spawn failure, and preserves both direct/manual claims and ambiguous log-backed launches.

### Symptom

An automatically claimed task can show `worker_pid = NULL` and `last_heartbeat_at = NULL` with no worker log, yet remain `running` until the long stale-task timeout or claim TTL expires.

### Impact

Each affected task can be unavailable for 4 to 6 hours, delaying its own work and any dependent tasks even though no worker is executing it.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py:8823` accepts a falsey spawn result and skips PID persistence while still treating the task as spawned.

**Causal chain:**
1. Automatic dispatch claims a ready or review task and opens an active run.
2. The spawn callback returns no PID, so the task retains a valid claim without a PID, heartbeat, or worker log.
3. Existing short recovery passes exclude it: orphan recovery sees valid claim bookkeeping, while crash recovery requires a PID. The task therefore remains `running` until a much longer timeout.

**Why it is wrong:** A valid claim was treated as sufficient evidence that a worker existed, even when every worker-observability signal remained absent after the launch grace.

**Working sibling / contrast:** Spawn exceptions already use the spawn-failure path, which closes the run, requeues the task, and advances the circuit breaker.

**Ruled out:** Lowering the general claim TTL or stale timeout would affect healthy long-running workers and would not distinguish failed launches from legitimate work.

### Fix

- Mark automatic dispatcher claims separately from supported direct/manual claims.
- Add a recovery pass for aged, host-local automatic claims that still have no PID, heartbeat, or current-attempt log.
- Recheck the claim, active run, PID, and heartbeat under the write transaction before releasing the task.
- Record the recovery as `spawn_failed`, advance the existing failure circuit breaker, and expose recovered task IDs in `DispatchResult.never_started`.
- Apply the same marker and recovery behavior to ready-task and review-task dispatch.

## Related Issue

Closes #82622

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` - distinguish automatic claims, reclaim workers that never become observable, and report recovery results.
- `tests/hermes_cli/test_kanban_never_started.py` - cover automatic recovery, race guards, current and stale logs, direct claims, review claims, and failure accounting.

## How to Test

1. Set `HERMES_KANBAN_CRASH_GRACE_SECONDS=1` on a disposable board.
2. Dispatch a task with a spawn callback that returns `None`, wait more than two seconds, and run another dispatch tick with spawning disabled.
3. Confirm the task is listed in `never_started`, returns to `ready`, closes its run as `spawn_failed`, clears its claim, and increments its failure count. Confirm current-log and direct/manual claim controls remain `running`.
4. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_never_started.py
```

Result: 7 passed.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the repository canonical test entry on the relevant regression suite and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Windows 10 with the real dispatcher path and an isolated board

### Documentation & Housekeeping

- [x] I have updated relevant documentation - N/A, this restores internal recovery behavior without changing user configuration
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no contributor workflow changed
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I have updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool schema changed
