### PR TITLE
fix(web_server): recheck WEB_DIST existence dynamically in mount_spa

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4418,3 +4418,28 @@ class TestDashboardComponentHealth:
         assert self.ws.DASHBOARD_HEALTH.selftest_status == "failing"
         assert self.ws.DASHBOARD_HEALTH.selftest_http_status == 500
         assert self.ws.DASHBOARD_HEALTH.snapshot()["status"] == "degraded"
+
+
+def test_mount_spa_dynamic_web_dist_recheck(tmp_path, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from hermes_cli import web_server
+
+    app = FastAPI()
+    dist = tmp_path / "web_dist"
+    monkeypatch.setattr(web_server, "WEB_DIST", dist)
+
+    web_server.mount_spa(app)
+    client = TestClient(app)
+
+    # 1. missing build -> 404
+    res1 = client.get("/")
+    assert res1.status_code == 404
+    assert res1.json()["error"] == "Frontend not built. Run: cd web && npm run build"
+
+    # 2. build created dynamically -> 200
+    dist.mkdir(parents=True, exist_ok=True)
+    (dist / "index.html").write_text("<html><body>Test</body></html>")
+    res2 = client.get("/")
+    assert res2.status_code == 200
+    assert "Test" in res2.text


### PR DESCRIPTION
### Summary

When `hermes dashboard --skip-build` runs across agent updates, `mount_spa()` checked `WEB_DIST.exists()` once at server startup and mounted an immutable 404 handler if the build was missing. As a result, subsequent builds while the server process was running continued to serve 404 "Frontend not built" until manually restarted.

### Changes Made
- Removed early static return in `mount_spa()`.
- Moved `WEB_DIST.exists()` check to execute dynamically inside `_serve_index()` and `serve_spa()` on every request.
- Mounted `/assets` StaticFiles with `check_dir=False` so startup does not crash when `web_dist/assets` is missing.
- Added unit test `test_mount_spa_dynamic_web_dist_recheck` in `tests/hermes_cli/test_web_server.py`.

Closes #82614