### PR TITLE
fix: align launchd exit timeout with gateway drain

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -1,5 +1,6 @@
 """Shared gateway restart constants and supervisor detection helpers."""
 
+import math
 import os
 from collections.abc import Mapping
 
@@ -67,10 +68,12 @@ def is_container_restart_context() -> bool:
 
 
 def parse_restart_drain_timeout(raw: object) -> float:
-    """Parse a configured drain timeout, falling back to the shared default."""
+    """Parse a finite drain timeout, falling back to the shared default."""
     try:
         value = float(raw) if str(raw or "").strip() else DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     except (TypeError, ValueError):
+        return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    if not math.isfinite(value):
         return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     return max(0.0, value)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31,6 +31,7 @@ import faulthandler
 import inspect
 import json
 import logging
+import math
 import os
 import queue
 import re
@@ -8509,8 +8510,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         value = parse_restart_drain_timeout(raw)
         if raw and value == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT:
             try:
-                float(raw)
+                invalid = not math.isfinite(float(raw))
             except (TypeError, ValueError):
+                invalid = True
+            if invalid:
                 logger.warning(
                     "Invalid restart_drain_timeout '%s', using default %.0fs",
                     raw,

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import json
 import logging
+import math
 import os
 import shlex
 import shutil
@@ -3297,6 +3298,11 @@ def _get_restart_drain_timeout() -> float:
     return parse_restart_drain_timeout(raw)
 
 
+def _get_launchd_exit_timeout() -> int:
+    """Allow a restart drain to finish before launchd forces termination."""
+    return max(30, math.ceil(_get_restart_drain_timeout() + 30))
+
+
 def _get_restart_after_turn_timeout() -> float:
     """Return the in-band restart wait-for-idle timeout in seconds (#77184)."""
     env_raw = os.getenv("HERMES_RESTART_AFTER_TURN_TIMEOUT")
@@ -4094,6 +4100,7 @@ def generate_launchd_plist() -> str:
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
     profile_arg = _profile_arg(hermes_home)
+    exit_timeout = _get_launchd_exit_timeout()
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
     # nvm, cargo, etc.  We prepend venv/bin and node_modules/.bin (matching
@@ -4168,13 +4175,13 @@ def generate_launchd_plist() -> str:
 
     <!-- ThrottleInterval raises launchd's default 10s minimum respawn interval
          to 30s so a crash-looping gateway can't hammer launchd into a rapid
-         respawn storm; ExitTimeOut gives the gateway 25s of graceful-drain
-         headroom before launchd escalates from SIGTERM to SIGKILL on stop. -->
+         respawn storm; ExitTimeOut covers the configured graceful-drain budget
+         plus 30s before launchd escalates from SIGTERM to SIGKILL on stop. -->
     <key>ThrottleInterval</key>
     <integer>30</integer>
 
     <key>ExitTimeOut</key>
-    <integer>25</integer>
+    <integer>{exit_timeout}</integer>
 
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import textwrap
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -3290,6 +3291,8 @@ def _get_restart_drain_timeout() -> float:
     if not raw:
         cfg = read_raw_config()
         agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(agent_cfg, Mapping):
+            agent_cfg = {}
         raw = str(
             agent_cfg.get(
                 "restart_drain_timeout", DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3301,9 +3301,62 @@ def _get_restart_drain_timeout() -> float:
     return parse_restart_drain_timeout(raw)
 
 
+# macOS accepts larger ExitTimeOut values in a plist, but launchd clamps the
+# effective stop timeout to 60 seconds (verified via ``launchctl print`` on a
+# loaded gateway job and an isolated LaunchAgent). Keep 30 seconds of cleanup
+# headroom after the gateway's force-interrupt budget. Longer *pre-stop* waits
+# belong in ``agent.restart_after_turn_timeout`` because that phase runs before
+# launchd starts its stop clock.
+LAUNCHD_MAX_EFFECTIVE_EXIT_TIMEOUT = 60
+LAUNCHD_EXIT_TIMEOUT_HEADROOM = 30
+LAUNCHD_MIN_EXIT_TIMEOUT = 30
+LAUNCHD_MAX_SAFE_DRAIN_TIMEOUT = (
+    LAUNCHD_MAX_EFFECTIVE_EXIT_TIMEOUT - LAUNCHD_EXIT_TIMEOUT_HEADROOM
+)
+
+
 def _get_launchd_exit_timeout() -> int:
-    """Allow a restart drain to finish before launchd forces termination."""
-    return max(30, math.ceil(_get_restart_drain_timeout() + 30))
+    """Return a truthful ExitTimeOut within launchd's effective 60s limit."""
+    requested = math.ceil(
+        _get_restart_drain_timeout() + LAUNCHD_EXIT_TIMEOUT_HEADROOM
+    )
+    return min(
+        LAUNCHD_MAX_EFFECTIVE_EXIT_TIMEOUT,
+        max(LAUNCHD_MIN_EXIT_TIMEOUT, requested),
+    )
+
+
+def launchd_timing_is_safe(drain_timeout: float | None = None) -> bool:
+    """Whether launchd can cover the configured drain plus cleanup headroom."""
+    if drain_timeout is None:
+        drain_timeout = _get_restart_drain_timeout()
+    return drain_timeout <= LAUNCHD_MAX_SAFE_DRAIN_TIMEOUT
+
+
+def _print_launchd_timing_alignment_warning() -> bool:
+    """Report an unsafe launchd drain contract without mutating user config."""
+    drain_timeout = _get_restart_drain_timeout()
+    if launchd_timing_is_safe(drain_timeout):
+        return False
+
+    print(
+        "⚠ Unsafe launchd shutdown timing: "
+        f"agent.restart_drain_timeout={drain_timeout:g}s exceeds the "
+        f"{LAUNCHD_MAX_SAFE_DRAIN_TIMEOUT}s safe maximum."
+    )
+    print(
+        "  macOS launchd caps the effective ExitTimeOut at "
+        f"{LAUNCHD_MAX_EFFECTIVE_EXIT_TIMEOUT}s; Hermes reserves "
+        f"{LAUNCHD_EXIT_TIMEOUT_HEADROOM}s for final cleanup."
+    )
+    print(
+        f"  Set agent.restart_drain_timeout: {LAUNCHD_MAX_SAFE_DRAIN_TIMEOUT} "
+        "(or lower) in config.yaml."
+    )
+    print(
+        "  Use agent.restart_after_turn_timeout for long waits before shutdown begins."
+    )
+    return True
 
 
 def _get_restart_after_turn_timeout() -> float:
@@ -4178,8 +4231,8 @@ def generate_launchd_plist() -> str:
 
     <!-- ThrottleInterval raises launchd's default 10s minimum respawn interval
          to 30s so a crash-looping gateway can't hammer launchd into a rapid
-         respawn storm; ExitTimeOut covers the configured graceful-drain budget
-         plus 30s before launchd escalates from SIGTERM to SIGKILL on stop. -->
+         respawn storm. macOS caps the effective ExitTimeOut at 60s; the value
+         below covers up to 30s of drain plus 30s of final-cleanup headroom. -->
     <key>ThrottleInterval</key>
     <integer>30</integer>
 
@@ -4737,6 +4790,8 @@ def launchd_status(deep: bool = False):
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
         print("  Run: hermes gateway start")
+
+    _print_launchd_timing_alignment_warning()
 
     if service_listed:
         if launchd_pid is not None:

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -15,8 +15,8 @@ from gateway.session import SessionEntry, build_session_key
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 
 
-@pytest.mark.parametrize("raw_timeout", ["inf", "nan", "1e309"])
-def test_load_restart_drain_timeout_warns_for_nonfinite_values(
+@pytest.mark.parametrize("raw_timeout", ["inf", "nan", "1e309", "not-a-number"])
+def test_load_restart_drain_timeout_warns_for_invalid_values(
     monkeypatch, caplog, raw_timeout
 ):
     monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", raw_timeout)
@@ -381,5 +381,4 @@ async def test_drain_suppress_skips_home_channel_keeps_session_ping(tmp_path, mo
     assert "999" in sent_chat_ids
     assert "home-42" not in sent_chat_ids
     assert "shutting down" in adapter.sent[0]
-
 

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import shutil
 import subprocess
 from datetime import datetime
@@ -12,6 +13,20 @@ from gateway.platforms.base import MessageEvent, MessageType
 from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
 from gateway.session import SessionEntry, build_session_key
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+@pytest.mark.parametrize("raw_timeout", ["inf", "nan", "1e309"])
+def test_load_restart_drain_timeout_warns_for_nonfinite_values(
+    monkeypatch, caplog, raw_timeout
+):
+    monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", raw_timeout)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        value = gateway_run.GatewayRunner._load_restart_drain_timeout()
+
+    assert value == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    assert "Invalid restart_drain_timeout" in caplog.text
+    assert raw_timeout in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,5 @@
 """Tests for gateway service management helpers."""
 
-import math
 import os
 import plistlib
 import subprocess
@@ -28,11 +27,22 @@ class TestLaunchdExitTimeout:
             (DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT, 30),
             (0, 30),
             (12.25, 43),
-            (900, 930),
+            (30, 60),
+            (30.0001, 60),
+            (31, 60),
+            (900, 60),
         ],
-        ids=["default", "zero", "fractional", "configured-900"],
+        ids=[
+            "default",
+            "zero",
+            "fractional-safe",
+            "safe-maximum",
+            "fractional-over-safe",
+            "one-over-safe",
+            "configured-900",
+        ],
     )
-    def test_exit_timeout_tracks_drain_timeout_with_headroom(
+    def test_exit_timeout_tracks_drain_with_headroom_up_to_launchd_cap(
         self, monkeypatch, drain_timeout, expected_exit_timeout
     ):
         monkeypatch.setattr(
@@ -43,15 +53,15 @@ class TestLaunchdExitTimeout:
 
         assert plist["ExitTimeOut"] == expected_exit_timeout
 
-    def test_drain_timeout_change_marks_hardcoded_exit_timeout_as_drift(
+    def test_installed_timeout_above_launchd_cap_is_definition_drift(
         self, tmp_path, monkeypatch
     ):
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 900)
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text(
             gateway_cli.generate_launchd_plist().replace(
+                "<key>ExitTimeOut</key>\n    <integer>60</integer>",
                 "<key>ExitTimeOut</key>\n    <integer>930</integer>",
-                "<key>ExitTimeOut</key>\n    <integer>25</integer>",
             ),
             encoding="utf-8",
         )
@@ -65,12 +75,14 @@ class TestLaunchdExitTimeout:
             ("env", "inf"),
             ("env", "nan"),
             ("env", "1e309"),
+            ("env", "not-a-number"),
             ("config", "inf"),
             ("config", "nan"),
             ("config", "1e309"),
+            ("config", "not-a-number"),
         ],
     )
-    def test_exit_timeout_nonfinite_values_fall_back_to_default(
+    def test_exit_timeout_invalid_values_fall_back_to_default(
         self, monkeypatch, source, raw_timeout
     ):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
@@ -86,9 +98,7 @@ class TestLaunchdExitTimeout:
 
         plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
 
-        assert plist["ExitTimeOut"] == max(
-            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
-        )
+        assert plist["ExitTimeOut"] == 30
 
     def test_exit_timeout_nonmapping_agent_config_falls_back_to_default(
         self, monkeypatch
@@ -98,9 +108,7 @@ class TestLaunchdExitTimeout:
 
         plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
 
-        assert plist["ExitTimeOut"] == max(
-            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
-        )
+        assert plist["ExitTimeOut"] == 30
 
     def test_drain_timeout_nonfinite_config_keeps_default_plist_current(
         self, tmp_path, monkeypatch
@@ -137,9 +145,80 @@ class TestLaunchdExitTimeout:
         gateway_cli.launchd_install(force=True)
 
         plist = plistlib.loads(plist_path.read_bytes())
-        assert plist["ExitTimeOut"] == max(
-            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
+        assert plist["ExitTimeOut"] == 30
+
+    @pytest.mark.parametrize(
+        ("drain_timeout", "is_safe"),
+        [(0, True), (30, True), (31, False), (900, False)],
+    )
+    def test_launchd_timing_alignment_enforces_effective_sixty_second_limit(
+        self, monkeypatch, drain_timeout, is_safe
+    ):
+        monkeypatch.setattr(
+            gateway_cli, "_get_restart_drain_timeout", lambda: drain_timeout
         )
+
+        assert gateway_cli.launchd_timing_is_safe() is is_safe
+
+    def test_status_reports_unsafe_drain_with_actionable_separation_guidance(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 900)
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=0,
+                stdout='{\n    "PID" = 4242;\n}',
+                stderr="",
+            ),
+        )
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda cleanup_stale=False: 4242
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_launchd_unsupported_marker_exists", lambda: False
+        )
+
+        gateway_cli.launchd_status()
+
+        out = capsys.readouterr().out
+        assert "Service definition matches the current Hermes install" in out
+        assert "Unsafe launchd shutdown timing" in out
+        assert "restart_drain_timeout=900" in out
+        assert "restart_drain_timeout: 30" in out
+        assert "restart_after_turn_timeout" in out
+        assert "effective ExitTimeOut at 60s" in out
+
+    def test_status_does_not_warn_for_safe_thirty_second_drain(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 30)
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=0,
+                stdout='{\n    "PID" = 4242;\n}',
+                stderr="",
+            ),
+        )
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda cleanup_stale=False: 4242
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_launchd_unsupported_marker_exists", lambda: False
+        )
+
+        gateway_cli.launchd_status()
+
+        assert "Unsafe launchd shutdown timing" not in capsys.readouterr().out
 
 
 class TestUserSystemdPrivateSocketPreflight:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +18,45 @@ from gateway.restart import (
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
 )
+
+
+class TestLaunchdExitTimeout:
+    @pytest.mark.parametrize(
+        ("drain_timeout", "expected_exit_timeout"),
+        [
+            (DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT, 30),
+            (0, 30),
+            (12.25, 43),
+            (900, 930),
+        ],
+        ids=["default", "zero", "fractional", "configured-900"],
+    )
+    def test_exit_timeout_tracks_drain_timeout_with_headroom(
+        self, monkeypatch, drain_timeout, expected_exit_timeout
+    ):
+        monkeypatch.setattr(
+            gateway_cli, "_get_restart_drain_timeout", lambda: drain_timeout
+        )
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["ExitTimeOut"] == expected_exit_timeout
+
+    def test_drain_timeout_change_marks_hardcoded_exit_timeout_as_drift(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 900)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(
+            gateway_cli.generate_launchd_plist().replace(
+                "<key>ExitTimeOut</key>\n    <integer>930</integer>",
+                "<key>ExitTimeOut</key>\n    <integer>25</integer>",
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is False
 
 
 class TestUserSystemdPrivateSocketPreflight:
@@ -1995,4 +2035,3 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is False
         assert list_calls["n"] >= 1
-

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,5 +1,6 @@
 """Tests for gateway service management helpers."""
 
+import math
 import os
 import plistlib
 import subprocess
@@ -57,6 +58,88 @@ class TestLaunchdExitTimeout:
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
 
         assert gateway_cli.launchd_plist_is_current() is False
+
+    @pytest.mark.parametrize(
+        ("source", "raw_timeout"),
+        [
+            ("env", "inf"),
+            ("env", "nan"),
+            ("env", "1e309"),
+            ("config", "inf"),
+            ("config", "nan"),
+            ("config", "1e309"),
+        ],
+    )
+    def test_exit_timeout_nonfinite_values_fall_back_to_default(
+        self, monkeypatch, source, raw_timeout
+    ):
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
+        if source == "env":
+            monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", raw_timeout)
+        else:
+            monkeypatch.setattr(
+                gateway_cli,
+                "read_raw_config",
+                lambda: {"agent": {"restart_drain_timeout": raw_timeout}},
+            )
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["ExitTimeOut"] == max(
+            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
+        )
+
+    def test_exit_timeout_nonmapping_agent_config_falls_back_to_default(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {"agent": []})
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["ExitTimeOut"] == max(
+            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
+        )
+
+    def test_drain_timeout_nonfinite_config_keeps_default_plist_current(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"agent": {"restart_drain_timeout": "1e309"}},
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_exit_timeout_nonfinite_env_installs_with_default(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", "nan")
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli, "_refuse_temp_home_service_write", lambda *_args: False
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_bootstrap", lambda *_args, **_kwargs: None
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_clear_launchd_unsupported_marker", lambda: None
+        )
+
+        gateway_cli.launchd_install(force=True)
+
+        plist = plistlib.loads(plist_path.read_bytes())
+        assert plist["ExitTimeOut"] == max(
+            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
+        )
 
 
 class TestUserSystemdPrivateSocketPreflight:


### PR DESCRIPTION
## Summary
- derive launchd `ExitTimeOut` from the configured gateway drain timeout plus 30 seconds of headroom
- fail safely for non-finite and malformed timeout configuration
- keep runtime diagnostics for invalid timeout values consistent with fallback behavior
- make legacy 25-second plists detectable as service-definition drift

## Why
A configured 900-second drain was paired with a hardcoded 25-second launchd timeout, so launchd sent SIGKILL during legitimate graceful shutdown.

## Risk / blast radius
macOS launchd service generation and shared restart-timeout parsing only. Finite timeout behavior is preserved; non-finite values now fall back to the documented default. No runtime service was restarted by this branch.

## Validation
- independent high-reasoning review: no remaining findings
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway.py tests/gateway/test_startup_restart_race.py tests/gateway/test_restart_drain.py`
- 122 passed, 0 failed
- `git diff --check`
