### PR TITLE
fix(cron): resolve executions ledger path at runtime

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -12,21 +12,54 @@ import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+_IMPORT_EXECUTIONS_FILE = EXECUTIONS_FILE
 MAX_TERMINAL_EXECUTIONS = 1000
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
 
+def _current_executions_file() -> Path:
+    """Resolve the ledger path at call time from the ACTIVE cron store.
+
+    The jobs store already resolves its paths dynamically
+    (``cron.jobs._current_cron_store``): an explicit ``use_cron_store()``
+    override wins, then deliberately re-pointed module constants, then the
+    ACTIVE profile home resolved fresh. The ledger must follow the same
+    store or it silently writes to the import-time home after a
+    profile/store context switch (#82651).
+
+    Precedence, most explicit first:
+
+    1. an active ``use_cron_store()`` override (ContextVar) — its cron dir
+       owns the ledger;
+    2. a deliberately re-pointed ``EXECUTIONS_FILE`` module constant — the
+       documented compatibility surface tests/embedders use to redirect the
+       ledger without touching the jobs store;
+    3. the ACTIVE profile home, resolved fresh via ``get_hermes_home()``, so
+       a HERMES_HOME switch after import reads/writes the new home's ledger;
+    4. the import-time constant (home unchanged since import).
+    """
+    from cron.jobs import _cron_store_override, _current_cron_store
+
+    if _cron_store_override.get() is not None:
+        return _current_cron_store().cron_dir / "executions.db"
+    if EXECUTIONS_FILE != _IMPORT_EXECUTIONS_FILE:
+        return EXECUTIONS_FILE
+    return _current_cron_store().cron_dir / "executions.db"
+
+
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    path = _current_executions_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(path, timeout=5)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -397,3 +397,69 @@ def test_job_listing_exposes_latest_execution(monkeypatch, tmp_path):
     listed = jobs.list_jobs(include_disabled=True)
     assert listed[0]["latest_execution"]["id"] == record["id"]
     assert listed[0]["latest_execution"]["status"] == "running"
+
+
+def test_use_cron_store_routes_ledger_to_active_profile(monkeypatch, tmp_path):
+    """#82651: ledger reads/writes must follow use_cron_store(), not the
+    import-time home — an explicit store override wins even over a
+    re-pointed EXECUTIONS_FILE module constant."""
+    import cron.executions as executions
+    from cron.jobs import use_cron_store
+
+    # Simulate a ledger already frozen at an "import-time" home.
+    import_home = tmp_path / "import-home"
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", import_home / "cron" / "executions.db"
+    )
+    profile_home = tmp_path / "profile-under-test"
+
+    with use_cron_store(profile_home):
+        record = executions.create_execution("ledger-profile-repro", source="direct")
+        listed = executions.list_executions(job_id="ledger-profile-repro")
+        assert [row["id"] for row in listed] == [record["id"]]
+
+    profile_db = profile_home / "cron" / "executions.db"
+    assert profile_db.exists()
+    assert not (import_home / "cron" / "executions.db").exists()
+
+
+def test_ledger_follows_store_switch_in_fresh_home_subprocess(tmp_path):
+    """#82651 E2E: with a fresh HERMES_HOME, a late use_cron_store() switch
+    must route the ledger to the profile home, not the import-time home."""
+    home = tmp_path / "home"
+    repo = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(repo)
+
+    script = """
+import json
+import os
+from pathlib import Path
+
+from cron.executions import create_execution, list_executions
+from cron.jobs import use_cron_store
+
+base_home = Path(os.environ["HERMES_HOME"]).resolve()
+profile_home = base_home / "profile-under-test"
+
+with use_cron_store(profile_home):
+    create_execution("ledger-profile-repro", source="direct")
+    rows = list_executions(job_id="ledger-profile-repro")
+
+print(json.dumps({
+    "base_db_exists": (base_home / "cron" / "executions.db").exists(),
+    "profile_db_exists": (profile_home / "cron" / "executions.db").exists(),
+    "count": len(rows),
+}))
+"""
+    run = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    result = json.loads(run.stdout.strip())
+    assert result == {"base_db_exists": False, "profile_db_exists": True, "count": 1}


### PR DESCRIPTION
## Summary
The cron execution ledger froze `EXECUTIONS_FILE` at module import time, while job storage follows `use_cron_store(profile_home)` at runtime. After a profile/store context switch, `create_execution()` wrote to the original/default Hermes home's `cron/executions.db` instead of the active profile's ledger.

## Root Cause
`cron/executions.py` resolved the ledger path once at import. The job store resolves its path per-call via `use_cron_store()`, so a late context switch left the ledger pointing at the wrong home.

## Change
- `cron/executions.py`: new `_current_executions_file()` resolves the path at runtime with the same precedence as `cron.jobs._current_cron_store()`:
  1. active `use_cron_store()` override (ContextVar) → `store.cron_dir / "executions.db"`;
  2. re-pointed `EXECUTIONS_FILE` (compat surface tests use);
  3. fresh `get_hermes_home()` for post-import switches;
  4. import-time constant as fallback.
  `_connect()` uses it; `EXECUTIONS_FILE` stays exported for compat.
- `tests/cron/test_execution_ledger.py`: 2 new tests — in-process override wins over monkeypatch (reads + writes), and an E2E fresh-`HERMES_HOME` subprocess proving the ledger follows the store switch (exact issue repro).

## Verification
- Repro before fix: `{'base_db_exists': True, 'profile_db_exists': False}`; after: `{'base_db_exists': False, 'profile_db_exists': True}`. Mutation check: reverting the fix flips it back.
- `tests/cron/test_execution_ledger.py` + `tests/test_journal_mode_config.py`: **20 passed**.

Closes #82651