### PR TITLE
fix(cron): revalidate persisted job before executing stale scheduler snapshot

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2598,6 +2598,14 @@ def _sweep_completed_oneshots(
     return removed
 
 
+#: Transient provenance marker stamped on scheduler snapshots returned by
+#: ``get_due_jobs()``. ``run_one_job`` uses it to tell store-originated
+#: snapshots apart from direct/manual handed-in job dictionaries: only the
+#: former fail closed when the authoritative row was deleted or paused after
+#: enumeration (#82650). Never persisted — the snapshots are deep copies.
+SNAPSHOT_ORIGIN_MARKER = "_cron_scheduler_snapshot"
+
+
 def get_due_jobs() -> List[Dict[str, Any]]:
     """Get all jobs that are due to run now.
 
@@ -2613,7 +2621,14 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     a ``repeat.times`` limit consumes one of its runs on that catch-up fire.
     """
     with _jobs_lock():
-        return _get_due_jobs_locked()
+        due = _get_due_jobs_locked()
+    # Stamp provenance on each returned snapshot. The dicts are deep copies, so
+    # this marker never round-trips back into jobs.json; it exists solely so
+    # ``run_one_job`` can fail closed at dispatch admission when the persisted
+    # row was deleted/paused after this snapshot was taken (#82650).
+    for job in due:
+        job[SNAPSHOT_ORIGIN_MARKER] = True
+    return due
 
 
 def _get_due_jobs_locked() -> List[Dict[str, Any]]:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -290,7 +290,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim
+from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim, get_job, SNAPSHOT_ORIGIN_MARKER
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -4534,6 +4534,31 @@ def run_one_job(
     Returns True if the job was processed (even if the job itself failed —
     failure is recorded via ``mark_job_run``), False only if processing raised.
     """
+    # Dispatch-admission revalidation (#82650): ``job`` may be a stale
+    # scheduler snapshot taken before the persisted row was deleted or paused.
+    # Re-read the authoritative row and fail closed — a job that no longer
+    # exists or is no longer runnable must never reach the executor, the
+    # execution-running transition, completion accounting, or delivery.
+    # Handed-in job dictionaries (no snapshot marker) keep their historical
+    # missing-row compatibility: a missing row is only fatal when the dict
+    # provably came from the store (``get_due_jobs`` / provider ``fire_due``).
+    persisted = get_job(job["id"])
+    if persisted is not None:
+        if not persisted.get("enabled", True) or persisted.get("state") == "paused":
+            logger.info(
+                "Job '%s': skipping at dispatch admission — no longer runnable "
+                "(paused/disabled) since the snapshot was taken",
+                job.get("name", job["id"]),
+            )
+            return True
+    elif job.get(SNAPSHOT_ORIGIN_MARKER):
+        logger.info(
+            "Job '%s': skipping at dispatch admission — persisted record no "
+            "longer exists",
+            job.get("name", job["id"]),
+        )
+        return True
+
     execution_id = job.get("execution_id")
     if not execution_id:
         execution_id = create_execution(job["id"], source="direct")["id"]

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -110,7 +110,7 @@ class CronScheduler(ABC):
         Returns True if THIS caller claimed and ran the job, False if the claim
         was lost (another machine/retry won it) or the job no longer exists.
         """
-        from cron.jobs import claim_job_for_fire, get_job
+        from cron.jobs import claim_job_for_fire, get_job, SNAPSHOT_ORIGIN_MARKER
         from cron.executions import create_execution
         from cron.scheduler import run_one_job
 
@@ -120,6 +120,10 @@ class CronScheduler(ABC):
         if job is None:
             return False  # job removed (e.g. repeat-N exhausted) between arm and fire
         job["execution_id"] = create_execution(job_id, source=self.name)["id"]
+        # Mark the dict as store-originated so run_one_job's dispatch-admission
+        # revalidation (#82650) fails closed if the row is deleted/paused
+        # between this load and the run.
+        job[SNAPSHOT_ORIGIN_MARKER] = True
         return run_one_job(job, adapters=adapters, loop=loop)
 
     def reconcile(self) -> None:

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -109,3 +109,85 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert ss.current_secret_scope() is None
 
 
+class TestRunOneJobRevalidatesPersistedJob:
+    """Regression for #82650: a scheduler snapshot must fail closed at
+    dispatch admission if the persisted job was deleted or paused after the
+    snapshot was taken. The stale dict must NOT reach the executor, the
+    execution-running transition, completion accounting, or delivery.
+
+    These exercise the real store (temp HERMES_HOME via the session conftest)
+    against real create/trigger/due/pause/remove operations, then drive the
+    shared ``run_one_job`` body with the pipeline primitives patched so the
+    test can observe whether the agent path was reached.
+    """
+
+    def _due_snapshot(self, job_id):
+        return next(j for j in s.get_due_jobs() if j["id"] == job_id)
+
+    def test_deleted_job_snapshot_is_skipped(self, monkeypatch):
+        """Snapshot enumerated, then the row removed → job must not execute."""
+        from cron.jobs import create_job, trigger_job, remove_job
+
+        job = create_job(
+            name="stale delete repro",
+            schedule="every 60m",
+            prompt="must not execute after authoritative state changes",
+        )
+        assert trigger_job(job["id"]) is not None
+        snapshot = self._due_snapshot(job["id"])
+        assert remove_job(job["id"]) is True
+
+        calls = _patch_pipeline(monkeypatch)
+        result = s.run_one_job(snapshot)
+
+        assert result is True
+        assert calls == [], "deleted job reached the executor/delivery path"
+
+    def test_paused_job_snapshot_is_skipped(self, monkeypatch):
+        """Snapshot enumerated, then the row paused → job must not execute."""
+        from cron.jobs import create_job, trigger_job, pause_job
+
+        job = create_job(
+            name="stale pause repro",
+            schedule="every 60m",
+            prompt="must not execute after authoritative state changes",
+        )
+        assert trigger_job(job["id"]) is not None
+        snapshot = self._due_snapshot(job["id"])
+        assert pause_job(job["id"]) is not None
+
+        calls = _patch_pipeline(monkeypatch)
+        result = s.run_one_job(snapshot)
+
+        assert result is True
+        assert calls == [], "paused job reached the executor/delivery path"
+
+    def test_valid_job_snapshot_still_executes(self, monkeypatch):
+        """A still-valid snapshot keeps the full execute→save→deliver→mark run."""
+        from cron.jobs import create_job, trigger_job
+
+        job = create_job(
+            name="valid repro",
+            schedule="every 60m",
+            prompt="must execute normally",
+        )
+        assert trigger_job(job["id"]) is not None
+        snapshot = self._due_snapshot(job["id"])
+
+        calls = _patch_pipeline(monkeypatch)
+        result = s.run_one_job(snapshot)
+
+        assert result is True
+        assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
+
+    def test_handed_in_dict_missing_row_keeps_compat(self, monkeypatch):
+        """Direct/manual handed-in dicts (no store row, no snapshot marker)
+        retain the historical missing-row compatibility: they still execute."""
+        calls = _patch_pipeline(monkeypatch)
+
+        ok = s.run_one_job({"id": "handed-in-no-row", "name": "t"})
+
+        assert ok is True
+        assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
+
+


### PR DESCRIPTION
## Summary
A persisted recurring cron job could still enter the executor after being deleted or paused. The built-in scheduler enumerated a due-job dictionary, then `run_one_job()` used that stale dictionary without authoritatively reloading and revalidating that the persisted row still existed and was runnable.

## Root Cause
`tick()` called `get_due_jobs()` (a snapshot), then `run_one_job()` executed the dict without re-reading the persisted row — a job deleted/paused between enumeration and execution still ran.

## Change
- `cron/jobs.py`: `get_due_jobs()` now stamps each snapshot with a transitive `SNAPSHOT_ORIGIN_MARKER` (dicts are deep copies, so it never persists to jobs.json).
- `cron/scheduler.py`: `run_one_job()` revalidates at dispatch admission, before `create_execution`/`claim_dispatch` — row exists but `enabled=False`/`state=="paused"` → skip; row gone AND dict is a store snapshot → skip (fail-closed). Manual dicts without a row keep historical compat.
- `cron/scheduler_provider.py`: `fire_due` stamps the dict as store-originated — closes the delete/pause race post-claim on the external provider (Chronos) path.
- `tests/cron/test_run_one_job.py`: new `TestRunOneJobRevalidatesPersistedJob` — deleted→skip, paused→skip, valid→runs, manual dict without row→runs (compat).

## Verification
- `tests/cron/test_run_one_job.py`: **7 passed**.

Closes #82650