### PR TITLE
fix(agent): treat provider overload envelope text as invalid response

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -58,6 +58,70 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 # narrower non-rate-limit case.  See issue #24996.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
 
+# ── Provider error envelope detection (issue #82662) ──────────────────────
+# Some providers report failures as ordinary assistant text instead of a
+# structured error / SSE frame — e.g. "[Error] Our servers are currently
+# overloaded. Please try again later." arrives as the message content of a
+# chat completion with finish_reason="stop".  Detection is deliberately
+# CONSERVATIVE: the text must be SHORT, must OPEN with an "[Error]" tag
+# (optionally behind a symbol prefix), and must contain a clear
+# service-failure marker.  Assistant prose that merely mentions an error word
+# ("[Error] The file does not exist. Please try again.") or a long answer
+# that happens to include "overloaded" must NOT match.
+
+# Matches the "[Error]" opening tag (with an optional leading symbol prefix
+# like "*", ">" or "—") at the start of the text.
+_PROVIDER_ERROR_ENVELOPE_OPEN_RE = re.compile(
+    r"^\s*(?:[*>#\-–—~•·]+\s*)?\[error\]",
+    re.IGNORECASE,
+)
+
+# Service-failure markers that distinguish a provider overload / outage
+# envelope from ordinary assistant content.  Deliberately excludes generic
+# "please try again" / "could not find" phrasing so content-style errors
+# like "[Error] The file does not exist. Please try again." stay False.
+_PROVIDER_ERROR_ENVELOPE_MARKERS = (
+    "overload",
+    "try again later",
+    "currently unavailable",
+    "temporarily unavailable",
+    "at capacity",
+    "too many requests",
+    "server error",
+    "service unavailable",
+)
+
+
+def looks_like_provider_error_envelope(text) -> bool:
+    """True when ``text`` is a short provider error envelope, not real content.
+
+    Conservative detector for the bug class where a provider returns its
+    failure as inline assistant text ("[Error] Our servers are currently
+    overloaded. Please try again later.") instead of a structured error —
+    see issue #82662.  Requires ALL of:
+
+    1. Short text (<= 400 chars, <= 4 lines) — real envelopes are 1-3 lines;
+       assistant answers are longer.
+    2. An "[Error]" opening tag at the start (optional symbol prefix).
+    3. A clear service-failure marker inside (overload / unavailable /
+       at capacity / too many requests / server error / ...).
+
+    Anything failing any condition returns False: "[Error] The file does not
+    exist. Please try again." (no marker), "[Error] I could not find the
+    file...", or a long answer that merely mentions "overloaded".
+    """
+    if not text:
+        return False
+    body = str(text).strip()
+    # Provider failure envelopes are short. Assistant answers that happen
+    # to mention "overloaded" tend to be much longer.
+    if len(body) > 400 or body.count("\n") > 4:
+        return False
+    if not _PROVIDER_ERROR_ENVELOPE_OPEN_RE.match(body):
+        return False
+    lowered = body.lower()
+    return any(marker in lowered for marker in _PROVIDER_ERROR_ENVELOPE_MARKERS)
+
 
 def _context_thread_target(callback):
     """Bind a no-argument thread target to the caller's ContextVars."""

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -26,6 +26,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.chat_completion_helpers import looks_like_provider_error_envelope
 from agent.conversation_compression import (
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
     COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE,
@@ -2864,6 +2865,29 @@ def run_conversation(
                             error_details.append("response.choices is None")
                         else:
                             error_details.append("response.choices is empty")
+
+                    # Provider error envelope returned as content (issue
+                    # #82662): some providers return "[Error] Our servers are
+                    # currently overloaded. Please try again later." as
+                    # ordinary completion text (finish_reason="stop") instead
+                    # of a structured error.  Detect by TEXT here, BEFORE the
+                    # finish-reason normalization below, so the invalid-
+                    # response path (retry/fallback) is taken and the envelope
+                    # is never persisted as a successful answer.
+                    if not response_invalid:
+                        try:
+                            _first_choice_content = response.choices[0].message.content
+                        except (AttributeError, IndexError, TypeError):
+                            _first_choice_content = None
+                        if (
+                            isinstance(_first_choice_content, str)
+                            and looks_like_provider_error_envelope(_first_choice_content)
+                        ):
+                            response_invalid = True
+                            error_details.append(
+                                "response content is a provider error envelope: "
+                                + repr(_first_choice_content[:80])
+                            )
 
                 if response_invalid:
                     agent._invoke_api_request_error_hook(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -58,6 +58,7 @@ from agent.conversation_compression import (
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
 )
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+from agent.chat_completion_helpers import looks_like_provider_error_envelope
 from agent.i18n import t
 from agent.interrupt_compat import request_hard_interrupt
 from agent.turn_context import (
@@ -691,6 +692,11 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     2. AND the error marker appears at the start of the message (optionally
        behind a punctuation/symbol prefix), not buried mid-paragraph in an
        explanation like "HTTP 404 means 'not found' — ...".
+
+    Defense in depth (issue #82662): providers that report their failure as
+    ordinary content ("[Error] Our servers are currently overloaded. Please
+    try again later.") never match the shape regex, so the shared envelope
+    detector used by the conversation loop is also consulted.
     """
     if not text:
         return False
@@ -699,6 +705,8 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     # to mention HTTP status codes ("HTTP 404 means...") tend to be longer.
     if len(body) > 400 or body.count("\n") > 4:
         return False
+    if looks_like_provider_error_envelope(body):
+        return True
     return bool(_GATEWAY_PROVIDER_ERROR_SHAPE_RE.search(body))
 
 

--- a/tests/run_agent/test_82662_provider_overload_envelope.py
+++ b/tests/run_agent/test_82662_provider_overload_envelope.py
@@ -1,0 +1,347 @@
+"""Regression tests for issue #82662 — provider error envelope in final response.
+
+Some providers report failures as ordinary assistant text instead of a
+structured error / SSE frame: "[Error] Our servers are currently overloaded.
+Please try again later." arrives as the message content of a chat completion
+with finish_reason="stop". Before this fix Hermes treated it as a successful
+final answer (delivered verbatim on Telegram), the turn ended, and NO
+retry/fallback/recovery ever ran.  Distinct from #58017 (structured SSE
+frames) which does not cover inline text.
+
+Pins the contract:
+
+- ``looks_like_provider_error_envelope`` is CONSERVATIVE: short text + a
+  leading "[Error]" tag + a clear service-failure marker are all required;
+  "[Error] The file does not exist. Please try again." stays False.
+- The conversation loop marks such responses invalid BEFORE finish-reason
+  normalization, so the existing retry/fallback path runs and the envelope
+  is never persisted as a successful answer (finish_reason="stop" does NOT
+  override text detection).
+- The gateway rewrites the envelope to a safe provider-failure reply instead
+  of delivering it raw to chat surfaces (defense in depth).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+from agent.chat_completion_helpers import looks_like_provider_error_envelope
+from gateway.config import Platform
+from gateway.run import (
+    _looks_like_gateway_provider_error,
+    _sanitize_gateway_final_response,
+)
+
+OVERLOAD_ENVELOPE = (
+    "[Error] Our servers are currently overloaded. Please try again later."
+)
+
+
+def _mock_response(content="Hello", finish_reason="stop"):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_tool_defs(*names: str) -> list:
+    """Build minimal tool definition list accepted by AIAgent.__init__."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    """Minimal AIAgent with mocked OpenAI client and tool loading."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+def _setup_agent(agent):
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+
+
+def _make_fast_time_mock():
+    """Return a mock time module where sleep loops exit instantly."""
+    mock_time = MagicMock()
+    _t = [1000.0]
+
+    def _advancing_time():
+        _t[0] += 500.0  # jump 500s per call so sleep_end is always in the past
+        return _t[0]
+
+    mock_time.time.side_effect = _advancing_time
+    mock_time.sleep = MagicMock()  # no-op
+    mock_time.monotonic.return_value = 12345.0
+    return mock_time
+
+
+# ---------------------------------------------------------------------------
+# Unit — conservative envelope detector
+# ---------------------------------------------------------------------------
+
+
+class TestProviderErrorEnvelopeDetector:
+    def test_exact_envelope_detected(self):
+        assert looks_like_provider_error_envelope(OVERLOAD_ENVELOPE) is True
+
+    def test_uppercase_envelope_detected(self):
+        assert (
+            looks_like_provider_error_envelope(
+                "[ERROR] OUR SERVERS ARE CURRENTLY OVERLOADED. "
+                "PLEASE TRY AGAIN LATER."
+            )
+            is True
+        )
+
+    def test_symbol_prefix_envelope_detected(self):
+        assert looks_like_provider_error_envelope(f"* {OVERLOAD_ENVELOPE}") is True
+        assert looks_like_provider_error_envelope(f"> {OVERLOAD_ENVELOPE}") is True
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "[Error] The service is at capacity right now. Please retry shortly.",
+            "[Error] Too many requests. Slow down and try again.",
+            "[Error] Our service is temporarily unavailable. Try again later.",
+            "[Error] Internal server error. Please try again later.",
+            "[Error] Service unavailable. Try again in a few minutes.",
+        ],
+    )
+    def test_service_marker_variants_detected(self, variant):
+        assert looks_like_provider_error_envelope(variant) is True
+
+    def test_normal_content_not_detected(self):
+        assert (
+            looks_like_provider_error_envelope("Here is the answer to your question.")
+            is False
+        )
+
+    def test_error_tag_without_marker_not_detected(self):
+        assert (
+            looks_like_provider_error_envelope(
+                "[Error] The file does not exist. Please try again."
+            )
+            is False
+        )
+
+    def test_error_tag_file_not_found_not_detected(self):
+        assert (
+            looks_like_provider_error_envelope(
+                "[Error] I could not find the file you asked about."
+            )
+            is False
+        )
+
+    def test_long_text_mentioning_overloaded_not_detected(self):
+        long_text = (
+            "The provider reported that its servers were overloaded for a "
+            "moment, but here is the full explanation of what happened and "
+            "what it means for your request. "
+            * 5
+        )
+        assert len(long_text) > 400
+        assert looks_like_provider_error_envelope(long_text) is False
+
+    @pytest.mark.parametrize("empty", ["", "   ", None])
+    def test_empty_and_none_not_detected(self, empty):
+        assert looks_like_provider_error_envelope(empty) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration — conversation loop routes the envelope through retry/fallback
+# ---------------------------------------------------------------------------
+
+
+class TestProviderOverloadEnvelopeConversationLoop:
+    def test_overload_envelope_retries_and_recovers(self, agent):
+        """First attempt returns the overload envelope → retried → recovered."""
+        _setup_agent(agent)
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=OVERLOAD_ENVELOPE),
+            _mock_response(content="recovered"),
+        ]
+        relay_attempts = []
+        logical_completions = []
+
+        def execute(request, callback, **kwargs):
+            relay_attempts.append(kwargs)
+            return callback(request)
+
+        from agent import conversation_loop as _conv_loop
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.time", _make_fast_time_mock()),
+            patch.object(_conv_loop, "time", _make_fast_time_mock()),
+            patch("agent.relay_llm.execute", side_effect=execute),
+            patch(
+                "agent.relay_llm.complete_logical_call",
+                side_effect=lambda request_id, *, outcome: logical_completions.append(
+                    (request_id, outcome)
+                ),
+            ),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert len(relay_attempts) == 2
+        assert "recovered" in result["final_response"]
+        request_ids = {
+            attempt["metadata"]["api_request_id"] for attempt in relay_attempts
+        }
+        assert len(request_ids) == 1
+        assert logical_completions == [(request_ids.pop(), "success")]
+
+    def test_overload_envelope_every_attempt_fails_turn(self, agent):
+        """Envelope on every attempt → retries exhaust → turn fails, never a success."""
+        _setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content=OVERLOAD_ENVELOPE
+        )
+        relay_attempts = []
+        hook_messages = []
+
+        def execute(request, callback, **kwargs):
+            relay_attempts.append(kwargs)
+            return callback(request)
+
+        def record_hook(**kwargs):
+            hook_messages.append(kwargs.get("error_message", ""))
+
+        from agent import conversation_loop as _conv_loop
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_invoke_api_request_error_hook", side_effect=record_hook),
+            patch("run_agent.time", _make_fast_time_mock()),
+            patch.object(_conv_loop, "time", _make_fast_time_mock()),
+            patch("agent.relay_llm.execute", side_effect=execute),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+        assert "error" in result
+        assert "Invalid API response" in result["error"]
+        # The envelope was never accepted: every attempt went through the
+        # invalid-response path (proved by the error hook receiving the
+        # envelope detail + multiple relay attempts).
+        assert len(relay_attempts) >= 2
+        assert any("provider error envelope" in m for m in hook_messages)
+
+    def test_normal_stop_response_unchanged_single_attempt(self, agent):
+        """Ordinary finish_reason=stop content is untouched: 1 attempt, success."""
+        _setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="A perfectly normal answer."
+        )
+        relay_attempts = []
+
+        def execute(request, callback, **kwargs):
+            relay_attempts.append(kwargs)
+            return callback(request)
+
+        from agent import conversation_loop as _conv_loop
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.time", _make_fast_time_mock()),
+            patch.object(_conv_loop, "time", _make_fast_time_mock()),
+            patch("agent.relay_llm.execute", side_effect=execute),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert len(relay_attempts) == 1
+        assert "A perfectly normal answer." in result["final_response"]
+
+    def test_error_tag_without_marker_is_success(self, agent):
+        """'[Error]' WITHOUT a service marker is legitimate content — no retry."""
+        _setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="[Error] The file does not exist. Please try again."
+        )
+        relay_attempts = []
+
+        def execute(request, callback, **kwargs):
+            relay_attempts.append(kwargs)
+            return callback(request)
+
+        from agent import conversation_loop as _conv_loop
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.time", _make_fast_time_mock()),
+            patch.object(_conv_loop, "time", _make_fast_time_mock()),
+            patch("agent.relay_llm.execute", side_effect=execute),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert len(relay_attempts) == 1
+        assert "[Error] The file does not exist." in result["final_response"]
+
+
+# ---------------------------------------------------------------------------
+# Gateway — defense in depth: never deliver the envelope raw to chat surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestProviderErrorEnvelopeGatewayDefense:
+    def test_gateway_detector_true_for_envelope(self):
+        assert _looks_like_gateway_provider_error(OVERLOAD_ENVELOPE) is True
+
+    def test_gateway_detector_false_for_normal(self):
+        assert _looks_like_gateway_provider_error("A perfectly normal answer.") is False
+        assert (
+            _looks_like_gateway_provider_error(
+                "[Error] The file does not exist. Please try again."
+            )
+            is False
+        )
+
+    def test_gateway_sanitize_rewrites_envelope_to_safe_reply(self):
+        sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, OVERLOAD_ENVELOPE)
+        # The raw envelope must never reach a chat surface...
+        assert "overloaded" not in sanitized
+        assert "try again later" not in sanitized
+        # ...and the rewrite must be the safe provider-failure reply.
+        assert "model provider" in sanitized


### PR DESCRIPTION
## Summary
Hermes treated a provider overload failure returned as ordinary assistant text as a successful final answer. Observed exact text: `[Error] Our servers are currently overloaded. Please try again later.` — delivered as a normal final response on Telegram, turn ended, and no safe provider-failure/recovery path ran. Distinct from #58017/#56522 (structured SSE error frames — not inline text).

## Change
- `agent/chat_completion_helpers.py`: new `looks_like_provider_error_envelope()` + `_PROVIDER_ERROR_ENVELOPE_OPEN_RE` (`[Error]` with optional symbol prefix, IGNORECASE) + `_PROVIDER_ERROR_ENVELOPE_MARKERS` (8 service markers: overload, try again later, currently/temporarily unavailable, at capacity, too many requests, server error, service unavailable). Conservative detection: text ≤400 chars and ≤4 lines, opens with `[Error]`, contains a marker. Anti-false-positive: `[Error] The file does not exist. Please try again.` → False (generic "please try again" excluded from markers on purpose); long text mentioning "overloaded" → False.
- `agent/conversation_loop.py`: in the chat_completions validation block, checks `response.choices[0].message.content` **before** finish_reason normalization → `response_invalid=True` with `error_details` → routes through the existing retry/fallback (invalid-response path); never persists as success; `finish_reason=stop` does not override.
- `gateway/run.py`: `_looks_like_gateway_provider_error` also uses `looks_like_provider_error_envelope` — defense in depth: if an envelope reaches delivery, it's rewritten as a safe provider-failure response, never delivered raw to Telegram.
- `tests/run_agent/test_82662_provider_overload_envelope.py` (new): unit detector cases (exact/upper-case/variants → True; normal text, `[Error]` without marker, long text, empty → False) + integration (overload → retry with 2 relay_attempts and recovered content; overload on all attempts → `completed=False, failed=True`; normal `finish_reason=stop` → unchanged success; `[Error]` without service marker → success) + gateway sanitize.

## Verification
- `tests/run_agent/test_82662_provider_overload_envelope.py`: **22 passed**.
- Full affected set (run_agent hot path, partial-stream, chat_completions, gateway provider_error/sanitize, telegram_noise_filter): **472 passed, 1 skipped, 0 failures**.

Closes #82662