### PR TITLE
fix(image-gen): keep upscale policy docs and Krea tests cross-platform

### DIFF
--- a/tests/plugins/image_gen/test_krea_provider.py
+++ b/tests/plugins/image_gen/test_krea_provider.py
@@ -166,7 +166,7 @@ class TestGenerate:
             result = KreaImageGenProvider().generate(prompt="A cinematic lamp", upscale=False)
 
         assert result["success"] is True
-        assert result["image"] == "/tmp/krea_krea-2-medium_test.png"
+        assert Path(result["image"]) == Path("/tmp/krea_krea-2-medium_test.png")
         assert result["provider"] == "krea"
         assert result["model"] == "krea-2-medium"
         assert result["aspect_ratio"] == "landscape"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -13,8 +13,8 @@ Architecture:
   aspect_ratio) into the model-specific payload and filters to the
   ``supports`` whitelist so models never receive rejected keys.
 - Upscaling via FAL's Clarity Upscaler is gated per-model via the ``upscale``
-  flag — on for FLUX 2 Pro (backward-compat), off for all faster/newer models
-  where upscaling would either hurt latency or add marginal quality.
+  flag — on by default for sub-2MP models, off for models that already emit
+  high-resolution images, and explicitly overridable by the caller.
 
 Pricing shown in UI strings is as-of the initial commit; we accept drift and
 update when it's noticed.


### PR DESCRIPTION
## What does this PR do?

Krea's successful-generation test now compares output paths semantically, so the targeted provider suite does not fail only because Windows uses native backslash separators. The image generation architecture note also reflects the current default-on upscale policy for sub-2MP models instead of the obsolete catalog behavior. Runtime image generation behavior is unchanged.

## Related Issue

Fixes #82683

## Type of Change

- [x] Bug fix

## Changes Made

- `tests/plugins/image_gen/test_krea_provider.py` - compare the generated output as a `Path` on every platform.
- `tools/image_generation_tool.py` - describe the current sub-2MP upscale default and explicit caller override.

## How to Test

1. On Windows, run the Krea provider suite and confirm `TestGenerate.test_successful_generation` accepts the native path representation.
2. Run the focused image and video generation regression suite:

```bash
scripts/run_tests.sh tests/tools/test_image_generation.py tests/tools/test_image_generation_image_to_image.py tests/tools/test_video_generation_dispatch.py tests/plugins/image_gen/test_krea_provider.py tests/plugins/video_gen/test_fal_plugin.py -q
```

Result: 142 passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] This PR contains only changes related to this fix.
- [x] I ran the repository test entry on the relevant suites and all 142 tests pass.
- [x] I updated the regression assertion for the affected platform behavior.
- [x] I tested on Windows 10 with Python 3.11.15.

### Documentation & Housekeeping

- [x] I updated the relevant module documentation.
- [x] N/A - no configuration keys changed.
- [x] N/A - no architecture or contributor workflow changed.
- [x] I considered Windows, macOS, and Linux path behavior.
- [x] N/A - runtime tool behavior and schema are unchanged.

## Screenshots / Logs

N/A - test and documentation correction only.
