### PR TITLE
feat(delegation): per-task model override + per-model reasoning at spawn

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7796,6 +7796,7 @@ class AIAgent:
             role=function_args.get("role"),
             background=(not _is_subagent),
             parent_agent=self,
+            model=function_args.get("model"),
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,

--- a/tests/test_delegate_per_task_model.py
+++ b/tests/test_delegate_per_task_model.py
@@ -1,0 +1,294 @@
+"""Wave 12 F2 — per-task model override + per-model reasoning at spawn.
+
+Contract tests for the two-model division of labor (AS-0018):
+deepseek-v4-flash-0731 runs worker swarms, qwen3.8-max pins reviews.
+delegate_task accepts an optional validated `model` param (top-level and
+per-task) that overrides delegation.model for that child, and child
+reasoning effort resolves per EFFECTIVE child model through
+agent.reasoning_overrides when delegation.reasoning_effort is unset.
+
+Hermetic: no API calls, no real agent construction (integration test
+monkeypatches the child builder). Runs under the clone conftest's isolated
+HERMES_HOME.
+"""
+from __future__ import annotations
+
+import json
+import types
+
+import pytest
+
+from tools import delegate_tool as dt
+
+
+FLASH = "deepseek-v4-flash-0731"
+QWEN = "qwen3.8-max"
+
+
+def _err_msg(result: str) -> str:
+    parsed = json.loads(result)
+    assert "error" in parsed, f"expected a tool_error JSON, got: {parsed}"
+    return parsed["error"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestModelAllowlist:
+    def test_allowlist_is_exactly_the_two_model_policy(self):
+        assert dt.ALLOWED_WORKER_MODELS == frozenset({FLASH, QWEN})
+
+    @pytest.mark.parametrize("model", [FLASH, QWEN])
+    def test_allowed_models_pass(self, model):
+        assert dt._validate_worker_model(model) is None
+
+    def test_disallowed_model_rejected_with_actionable_message(self):
+        err = dt._validate_worker_model("gpt-5")
+        assert err is not None
+        assert "gpt-5" in err
+        assert FLASH in err and QWEN in err
+
+    @pytest.mark.parametrize("bad", ["", 123, ["a"], {"model": "x"}])
+    def test_non_string_or_empty_rejected(self, bad):
+        assert dt._validate_worker_model(bad) is not None
+
+    def test_none_means_no_override(self):
+        # None = absent pin → valid (falls back to delegation.model).
+        assert dt._validate_worker_model(None) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Batch validation covers task-level model fields
+# ---------------------------------------------------------------------------
+
+
+def _batch(goal_a="first long enough goal text", goal_b="second long enough goal text"):
+    return [
+        {"goal": goal_a, "model": FLASH},
+        {"goal": goal_b},
+    ]
+
+
+class TestBatchModelValidation:
+    def test_valid_batch_models_pass(self):
+        assert dt._validate_batch_tasks(_batch()) is None
+
+    def test_invalid_task_model_rejected_with_index(self):
+        tasks = _batch()
+        tasks[0]["model"] = "gpt-5"
+        err = dt._validate_batch_tasks(tasks)
+        assert err is not None
+        assert "0" in err and "gpt-5" in err
+
+    def test_single_task_form_not_batch_validated(self):
+        # Single-goal form is exempt from batch checks (existing contract).
+        assert dt._validate_batch_tasks([{"goal": "x" * 40}]) is not None  # <2 tasks
+
+
+# ---------------------------------------------------------------------------
+# 3. Schema surface: model param visible to the LLM
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaModelSurface:
+    def test_top_level_model_property(self):
+        props = dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        assert "model" in props
+        assert props["model"]["type"] == "string"
+
+    def test_task_item_model_property(self):
+        items = dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]
+        assert "model" in items["properties"]
+
+    def test_dynamic_overrides_document_model(self):
+        overrides = dt._build_dynamic_schema_overrides()
+        assert "model" in overrides["parameters"]["properties"]
+        assert "model" in overrides["description"]
+
+    def test_model_not_hidden_from_model(self):
+        # 'model' must NOT be stripped like acp_command/acp_args are.
+        assert "model" not in dt._MODEL_HIDDEN_TASK_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# 4. Credential resolution honors per-task override
+# ---------------------------------------------------------------------------
+
+
+def _parent():
+    p = types.SimpleNamespace()
+    p.model = QWEN
+    p.provider = "alibaba"
+    p.base_url = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+    return p
+
+
+class TestCredentialOverride:
+    def test_per_task_model_overrides_configured_model(self):
+        creds = dt._resolve_delegation_credentials(
+            {"model": FLASH}, _parent(), model_override=QWEN
+        )
+        assert creds["model"] == QWEN
+
+    def test_no_override_keeps_configured_model(self):
+        creds = dt._resolve_delegation_credentials({"model": FLASH}, _parent())
+        assert creds["model"] == FLASH
+
+    def test_override_with_base_url_branch_keeps_delegation_base_url(self):
+        creds = dt._resolve_delegation_credentials(
+            {
+                "model": FLASH,
+                "base_url": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+            },
+            _parent(),
+            model_override=QWEN,
+        )
+        assert creds["model"] == QWEN
+        assert "token-plan" in creds["base_url"]
+
+    def test_override_with_empty_config_model(self):
+        creds = dt._resolve_delegation_credentials({}, _parent(), model_override=FLASH)
+        assert creds["model"] == FLASH
+
+
+# ---------------------------------------------------------------------------
+# 5. Per-model reasoning at spawn
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChildReasoning:
+    OVERRIDES = {FLASH: "low", QWEN: "max"}
+
+    def _cfg(self, effort=None):
+        agent = {"reasoning_overrides": dict(self.OVERRIDES), "reasoning_effort": "medium"}
+        if effort is not None:
+            agent["reasoning_effort"] = effort
+        return {"agent": agent}
+
+    def test_explicit_delegation_effort_wins_backward_compat(self):
+        rc = dt._resolve_child_reasoning(
+            {"reasoning_effort": "xhigh"}, self._cfg(), FLASH, {"effort": "max"}
+        )
+        assert rc is not None and rc.get("effort") == "xhigh"
+
+    def test_flash_false_semantics_preserved(self):
+        rc = dt._resolve_child_reasoning(
+            {"reasoning_effort": False}, self._cfg(), FLASH, {"effort": "max"}
+        )
+        assert rc is not None and rc.get("enabled") is False
+
+    def test_unset_effort_flash_child_gets_low_override(self):
+        rc = dt._resolve_child_reasoning({}, self._cfg(), FLASH, None)
+        assert rc is not None and rc.get("effort") == "low"
+
+    def test_unset_effort_qwen_child_gets_max_override(self):
+        rc = dt._resolve_child_reasoning({}, self._cfg(), QWEN, None)
+        assert rc is not None and rc.get("effort") == "max"
+
+    def test_unset_effort_no_override_falls_to_global(self):
+        rc = dt._resolve_child_reasoning({}, self._cfg(), "some-other-model", None)
+        assert rc is not None and rc.get("effort") == "medium"
+
+    def test_unset_effort_no_config_falls_to_parent(self):
+        parent_rc = {"enabled": True, "effort": "high"}
+        rc = dt._resolve_child_reasoning({}, {}, FLASH, parent_rc)
+        assert rc is parent_rc
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: delegate_task threads per-task models to the child builder
+# ---------------------------------------------------------------------------
+
+
+class TestDelegateTaskModelThreading:
+    @pytest.fixture()
+    def harness(self, monkeypatch):
+        """Patch the heavy machinery; capture child-builder kwargs."""
+        built = []
+
+        def fake_build(**kwargs):
+            built.append(kwargs)
+            child = types.SimpleNamespace()
+            child.session_id = f"fake-{len(built)}"
+            child.model = kwargs.get("model")
+            child.tool_progress_callback = None
+            return child
+
+        run_calls = []
+
+        def fake_run(task_index, goal, child, parent_agent, **kw):
+            run_calls.append({"task_index": task_index, "model": getattr(child, "model", None)})
+            return {
+                "task_index": task_index,
+                "status": "completed",
+                "summary": "ok",
+                "model": getattr(child, "model", None),
+                "api_calls": 1,
+                "duration_seconds": 0.1,
+            }
+
+        monkeypatch.setattr(dt, "is_spawn_paused", lambda: False)
+        monkeypatch.setattr(dt, "_load_config", lambda: {"model": FLASH, "max_iterations": 5})
+        monkeypatch.setattr(dt, "_build_child_preserving_parent_tools", fake_build)
+        monkeypatch.setattr(dt, "_run_single_child", fake_run)
+        # Function-local imports — patch the source modules.
+        import tools.delegation_live_log as dll
+
+        monkeypatch.setattr(dll, "create_live_transcripts", lambda tl, ctx: (None, [], []))
+        monkeypatch.setattr(dll, "update_manifest_statuses", lambda *a, **k: None)
+        parent = _parent()
+        parent._delegate_depth = 0
+        parent._fallback_chain = [QWEN, FLASH]
+        return types.SimpleNamespace(
+            built=built, run=run_calls, parent=parent
+        )
+
+    def test_batch_per_task_models_reach_child_builder(self, harness):
+        result = dt.delegate_task(
+            tasks=[
+                {"goal": "worker task A with a sufficiently long description", "model": FLASH},
+                {"goal": "reviewer task B with a sufficiently long description", "model": QWEN},
+            ],
+            parent_agent=harness.parent,
+        )
+        assert '"error"' not in result, result
+        assert len(harness.built) == 2
+        assert harness.built[0]["model"] == FLASH
+        assert harness.built[1]["model"] == QWEN
+
+    def test_top_level_model_applies_to_single_goal_form(self, harness):
+        dt.delegate_task(
+            goal="single goal with a sufficiently long description here",
+            model=QWEN,
+            parent_agent=harness.parent,
+        )
+        assert harness.built[0]["model"] == QWEN
+
+    def test_no_model_param_keeps_delegation_model(self, harness):
+        dt.delegate_task(
+            goal="single goal with a sufficiently long description here",
+            parent_agent=harness.parent,
+        )
+        assert harness.built[0]["model"] == FLASH
+
+    def test_invalid_top_level_model_rejected_before_spawn(self, harness):
+        result = dt.delegate_task(
+            goal="single goal with a sufficiently long description here",
+            model="gpt-5",
+            parent_agent=harness.parent,
+        )
+        assert "gpt-5" in _err_msg(result)
+        assert harness.built == []
+
+    def test_invalid_task_model_rejected_before_spawn(self, harness):
+        result = dt.delegate_task(
+            tasks=[
+                {"goal": "worker task A with a sufficiently long description", "model": "gpt-5"},
+                {"goal": "worker task B with a sufficiently long description"},
+            ],
+            parent_agent=harness.parent,
+        )
+        assert "gpt-5" in _err_msg(result)
+        assert harness.built == []

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1860,11 +1860,17 @@ class TestMaxConcurrentChildrenParsing(unittest.TestCase):
         )
 
     def test_non_integer_numeric_string_falls_back_to_default(self):
-        # '8.5' cannot be parsed by int() -> ValueError branch -> default.
+        # '8.5' (a STRING) cannot be parsed by int() -> ValueError branch ->
+        # default. Distinct from a real float value (next test).
         self.assertEqual(
             self._call({"max_concurrent_children": "8.5"}),
             _DEFAULT_MAX_CONCURRENT_CHILDREN,
         )
+
+    def test_float_value_truncates_not_falls_back(self):
+        # REAL float 8.5 (e.g. YAML numeric) -> int(8.5) == 8, no exception,
+        # no fallback. Trust-review gap: pin the truncation behavior.
+        self.assertEqual(self._call({"max_concurrent_children": 8.5}), 8)
 
     def test_zero_config_clamped_to_one(self):
         self.assertEqual(self._call({"max_concurrent_children": 0}), 1)
@@ -1906,6 +1912,19 @@ class TestMaxConcurrentChildrenEnvVar(unittest.TestCase):
 
     def test_env_negative_clamped_to_one(self):
         self.assertEqual(self._call_with_env("-3"), 1)
+
+    def test_config_wins_over_env_precedence(self):
+        # Trust-review gap: env is consulted ONLY when the config value is
+        # absent (delegate_tool.py:597-618). With config present, env must
+        # NOT override — config value 4 beats env 7.
+        with (
+            patch(
+                "tools.delegate_tool._load_config",
+                return_value={"max_concurrent_children": 4},
+            ),
+            patch.dict(os.environ, {"DELEGATION_MAX_CONCURRENT_CHILDREN": "7"}, clear=True),
+        ):
+            self.assertEqual(_get_max_concurrent_children(), 4)
 
     def test_unset_env_uses_default(self):
         self.assertEqual(

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -21,6 +21,7 @@ from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
     DelegateEvent,
+    _DEFAULT_MAX_CONCURRENT_CHILDREN,
     _get_max_concurrent_children,
     _load_config,
     delegate_task,
@@ -1746,6 +1747,170 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+class TestTooManyTasksRejection(unittest.TestCase):
+    """GAP F4c: the 'Too many tasks' rejection boundary in delegate_task.
+
+    Rejection fires when len(tasks) > max_concurrent_children, strictly
+    BEFORE any child agent is built or spawned (delegate_tool.py:3268-3276).
+    The boundary is strict ``>`` — a batch of exactly N tasks with
+    max_concurrent_children=N must be accepted.
+    """
+
+    REAL_GOALS = [
+        "Inspect the authentication flow",
+        "Inspect the database schema",
+        "Inspect the rate limiter",
+        "Inspect the webhook handler",
+        "Inspect the retry policy",
+    ]
+
+    def _make_cost_parent(self):
+        parent = _make_mock_parent(depth=0)
+        # Batch cost rollup reads real floats, not MagicMock auto-attrs.
+        parent.session_estimated_cost_usd = 0.0
+        parent.session_cost_status = "unknown"
+        parent.session_cost_source = "none"
+        return parent
+
+    def test_n_plus_one_tasks_rejected_before_any_spawn(self):
+        """N+1 tasks with max_concurrent_children=N -> tool_error JSON naming
+        max_concurrent_children; nothing is built or spawned."""
+        n = 2
+        parent = self._make_cost_parent()
+        tasks = [{"goal": g} for g in self.REAL_GOALS[: n + 1]]
+
+        with (
+            patch(
+                "tools.delegate_tool._get_max_concurrent_children", return_value=n
+            ),
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            result = json.loads(
+                delegate_task(tasks=tasks, parent_agent=parent)
+            )
+
+        # The tool_error is the contract — NOT a spawn side-effect.
+        self.assertIn("error", result)
+        self.assertIn("Too many tasks", result["error"])
+        self.assertIn("max_concurrent_children", result["error"])
+        self.assertIn(str(n + 1), result["error"])
+        self.assertIn(str(n), result["error"])
+        # Rejection happens before child construction/execution: no AIAgent
+        # was built and no child runner was invoked.
+        MockAgent.assert_not_called()
+        mock_run.assert_not_called()
+
+    def test_exact_boundary_n_tasks_accepted(self):
+        """Exactly N tasks with max_concurrent_children=N passes the rejection
+        (strict > boundary) and proceeds to the batch run."""
+        n = 2
+        parent = self._make_cost_parent()
+        tasks = [{"goal": g} for g in self.REAL_GOALS[:n]]
+
+        with (
+            patch(
+                "tools.delegate_tool._get_max_concurrent_children", return_value=n
+            ),
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            MockAgent.return_value = MagicMock()
+            mock_run.side_effect = [
+                {
+                    "task_index": i,
+                    "status": "completed",
+                    "summary": f"done {i}",
+                    "api_calls": 1,
+                    "duration_seconds": 0.1,
+                }
+                for i in range(n)
+            ]
+            result = json.loads(
+                delegate_task(tasks=tasks, parent_agent=parent)
+            )
+
+        # Must NOT hit the 'Too many tasks' rejection.
+        self.assertNotIn("error", result)
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), n)
+        self.assertEqual(mock_run.call_count, n)
+
+
+class TestMaxConcurrentChildrenParsing(unittest.TestCase):
+    """GAP F4c: _get_max_concurrent_children parse edge cases.
+
+    Invalid integer config values hit the TypeError/ValueError branch and
+    fall back to _DEFAULT_MAX_CONCURRENT_CHILDREN; the floor max(1, ...)
+    clamps 0 and negatives to 1.
+    """
+
+    def _call(self, config):
+        with patch(
+            "tools.delegate_tool._load_config", return_value=config
+        ):
+            return _get_max_concurrent_children()
+
+    def test_invalid_int_string_falls_back_to_default(self):
+        self.assertEqual(
+            self._call({"max_concurrent_children": "eight"}),
+            _DEFAULT_MAX_CONCURRENT_CHILDREN,
+        )
+
+    def test_non_integer_numeric_string_falls_back_to_default(self):
+        # '8.5' cannot be parsed by int() -> ValueError branch -> default.
+        self.assertEqual(
+            self._call({"max_concurrent_children": "8.5"}),
+            _DEFAULT_MAX_CONCURRENT_CHILDREN,
+        )
+
+    def test_zero_config_clamped_to_one(self):
+        self.assertEqual(self._call({"max_concurrent_children": 0}), 1)
+
+    def test_negative_config_clamped_to_one(self):
+        self.assertEqual(self._call({"max_concurrent_children": -5}), 1)
+
+    def test_valid_config_value_used(self):
+        self.assertEqual(self._call({"max_concurrent_children": 7}), 7)
+
+
+class TestMaxConcurrentChildrenEnvVar(unittest.TestCase):
+    """GAP F4c: DELEGATION_MAX_CONCURRENT_CHILDREN env-var path.
+
+    With config absent, the env var is applied; invalid env values fall back
+    to the default, and the floor max(1, ...) still clamps env values.
+    """
+
+    def _call_with_env(self, env_value):
+        env = {}
+        if env_value is not None:
+            env["DELEGATION_MAX_CONCURRENT_CHILDREN"] = env_value
+        with (
+            patch("tools.delegate_tool._load_config", return_value={}),
+            patch.dict(os.environ, env, clear=True),
+        ):
+            return _get_max_concurrent_children()
+
+    def test_valid_env_applied_when_config_absent(self):
+        self.assertEqual(self._call_with_env("7"), 7)
+
+    def test_invalid_env_falls_back_to_default(self):
+        self.assertEqual(
+            self._call_with_env("eight"), _DEFAULT_MAX_CONCURRENT_CHILDREN
+        )
+
+    def test_env_zero_clamped_to_one(self):
+        self.assertEqual(self._call_with_env("0"), 1)
+
+    def test_env_negative_clamped_to_one(self):
+        self.assertEqual(self._call_with_env("-3"), 1)
+
+    def test_unset_env_uses_default(self):
+        self.assertEqual(
+            self._call_with_env(None), _DEFAULT_MAX_CONCURRENT_CHILDREN
+        )
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1545,27 +1545,29 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config (Wave 12, AS-0018):
+    # explicit delegation.reasoning_effort (incl. YAML false = thinking off)
+    # > agent.reasoning_overrides[<effective child model>] — the per-model
+    #   chokepoint, so a flash worker resolves to the flash override while a
+    #   per-task-pinned qwen reviewer child keeps its own override
+    # > agent.reasoning_effort global > parent inherit.
+    # Replaces the old single delegation.reasoning_effort-for-all-children
+    # behavior; an explicit operator pin still wins for ALL children
+    # (backward compatible).
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
-    child_reasoning = parent_reasoning
     try:
-        # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
-        # False (``reasoning_effort: false``) to "" and inherit the parent
-        # instead of disabling thinking for children.
-        delegation_effort = delegation_cfg.get("reasoning_effort")
-        if delegation_effort or delegation_effort is False:
-            from hermes_constants import parse_reasoning_effort
+        try:
+            from hermes_cli.config import load_config_readonly
 
-            parsed = parse_reasoning_effort(delegation_effort)
-            if parsed is not None:
-                child_reasoning = parsed
-            else:
-                logger.warning(
-                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
-                    delegation_effort,
-                )
+            _full_cfg = load_config_readonly()
+        except Exception:
+            _full_cfg = {}
+        child_reasoning = _resolve_child_reasoning(
+            delegation_cfg, _full_cfg, effective_model, parent_reasoning
+        )
     except Exception as exc:
-        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+        logger.debug("Could not load delegation reasoning config: %s", exc)
+        child_reasoning = parent_reasoning
 
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level
@@ -3073,6 +3075,38 @@ _TEMPLATE_MARKER_RE = re.compile(
 )
 _MIN_BATCH_GOAL_LEN = 10
 
+# Wave 12 (AS-0018 two-model division of labor): the ONLY models a caller may
+# pin per-task via the optional `model` parameter. Mirrors
+# scripts/model_policy_audit.py ALLOWED_MODELS in the consuming harness. A
+# hardcoded frozenset (not a config key) keeps the core policy-neutral: which
+# models are allowed is a deployment policy the audit already enforces — the
+# core only needs a closed set to reject typos/foreign models loudly instead
+# of silently spawning a child that can never be billed or routed.
+ALLOWED_WORKER_MODELS = frozenset({"qwen3.8-max", "deepseek-v4-flash-0731"})
+
+
+def _validate_worker_model(model: Any) -> Optional[str]:
+    """Validate an optional per-task / top-level `model` override.
+
+    Returns None when the value is absent (no override) or allowed, otherwise
+    an actionable error string. Reject-over-silent-fallback by design: a typo
+    in a model name must fail the whole call before any child is spawned.
+    """
+    if model is None:
+        return None
+    if not isinstance(model, str) or not model.strip():
+        return (
+            f"delegate_task: 'model' must be a non-empty string, got {model!r}. "
+            f"Allowed models: {sorted(ALLOWED_WORKER_MODELS)}."
+        )
+    name = model.strip()
+    if name not in ALLOWED_WORKER_MODELS:
+        return (
+            f"delegate_task: model {name!r} is not allowed. Allowed models: "
+            f"{sorted(ALLOWED_WORKER_MODELS)} (two-model policy, AS-0016/AS-0018)."
+        )
+    return None
+
 
 def _validate_batch_tasks(task_list: List[Dict[str, Any]]) -> Optional[str]:
     """Validate a tasks=[...] batch beyond per-task goal presence.
@@ -3117,6 +3151,11 @@ def _validate_batch_tasks(task_list: List[Dict[str, Any]]) -> Optional[str]:
                 f"{_MIN_BATCH_GOAL_LEN} characters so the subagent knows "
                 "exactly what to do."
             )
+        # Wave 12 (AS-0018): optional per-task model pin — validate against
+        # the two-model allowlist before ANY child is spawned.
+        model_err = _validate_worker_model(task.get("model"))
+        if model_err:
+            return f"Task {i}: {model_err}"
     return None
 
 
@@ -3129,18 +3168,24 @@ def delegate_task(
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
     parent_agent=None,
+    model: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
       - Single: provide goal (+ optional context and role)
-      - Batch:  provide tasks array [{goal, context, role}, ...]
+      - Batch:  provide tasks array [{goal, context, role, model}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The optional 'model' parameter (top-level or per task item, per-task
+    wins) overrides delegation.model for those children only. Restricted
+    to ALLOWED_WORKER_MODELS; invalid values reject the whole call before
+    any child is spawned.
 
     Returns JSON with results array, one entry per task.
     """
@@ -3202,6 +3247,11 @@ def delegate_task(
     # bundle (base_url, api_key, api_mode) via the same runtime provider system
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
+    # Wave 12 (AS-0018): validate the optional top-level model pin first — a
+    # foreign model must reject the whole call before any child is spawned.
+    top_model_err = _validate_worker_model(model)
+    if top_model_err:
+        return tool_error(top_model_err)
     try:
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
@@ -3229,6 +3279,11 @@ def delegate_task(
         single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
         if output_schema is not None:
             single_task["output_schema"] = output_schema
+        if model is not None and str(model).strip():
+            # Wave 12 (AS-0018): top-level model applies to the single-goal
+            # form (batch form uses per-task model pins only, matching the
+            # "top-level goal/context/role are ignored" batch semantics).
+            single_task["model"] = str(model).strip()
         task_list = [single_task]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -3340,7 +3395,10 @@ def delegate_task(
             # Subagents always inherit the parent's toolsets; the model
             # cannot choose or narrow them (no model-facing toolsets arg).
             toolsets=None,
-            model=creds["model"],
+            # Wave 12 (AS-0018): optional per-task model pin (validated in
+            # _validate_batch_tasks / top-level check above) beats the global
+            # delegation.model for this child only. Absent → delegation.model.
+            model=(str(t.get("model")).strip() if t.get("model") else None) or creds["model"],
             max_iterations=effective_max_iter,
             task_count=n_tasks,
             parent_agent=parent_agent,
@@ -3889,7 +3947,55 @@ def _resolve_child_credential_pool(
     return None
 
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
+def _resolve_child_reasoning(
+    delegation_cfg: dict,
+    full_cfg: dict,
+    effective_model: Optional[str],
+    parent_reasoning: Optional[dict],
+) -> Optional[dict]:
+    """Resolve the reasoning config for a delegation child (Wave 12, AS-0018).
+
+    Priority:
+    1. Explicit ``delegation.reasoning_effort`` (a YAML boolean ``False``
+       means thinking disabled — kept raw so it never silently re-enables;
+       an operator pin wins for ALL children, backward compatible).
+    2. ``agent.reasoning_overrides[<effective child model>]`` via the shared
+       spelling-tolerant chokepoint — flash workers get the flash override,
+       per-task-pinned qwen reviewers keep the max override.
+    3. ``agent.reasoning_effort`` global.
+    4. Parent reasoning config (inherit).
+    """
+    from hermes_constants import (
+        parse_reasoning_effort,
+        resolve_per_model_reasoning_effort,
+    )
+
+    delegation_effort = delegation_cfg.get("reasoning_effort")
+    if delegation_effort or delegation_effort is False:
+        parsed = parse_reasoning_effort(delegation_effort)
+        if parsed is not None:
+            return parsed
+        logger.warning(
+            "Unknown delegation.reasoning_effort '%s', falling back to "
+            "per-model resolution",
+            delegation_effort,
+        )
+    if isinstance(full_cfg, dict):
+        agent_cfg = full_cfg.get("agent")
+        if isinstance(agent_cfg, dict):
+            overrides = agent_cfg.get("reasoning_overrides") or {}
+            per_model = resolve_per_model_reasoning_effort(
+                effective_model or "", overrides
+            )
+            if per_model is not None:
+                return per_model
+            parsed_global = parse_reasoning_effort(agent_cfg.get("reasoning_effort"))
+            if parsed_global is not None:
+                return parsed_global
+    return parent_reasoning
+
+
+def _resolve_delegation_credentials(cfg: dict, parent_agent, model_override: Optional[str] = None) -> dict:
     """Resolve credentials for subagent delegation.
 
     If ``delegation.base_url`` is configured, subagents use that direct
@@ -3911,6 +4017,12 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     Raises ValueError with a user-friendly message on credential failure.
     """
     configured_model = str(cfg.get("model") or "").strip() or None
+    # Wave 12 (AS-0018): a validated per-task / top-level model pin wins over
+    # delegation.model for the resolved credential bundle. Credentials
+    # (base_url/api_key/api_mode) still come from delegation.* — the two-model
+    # policy keeps both models on the same provider endpoint.
+    if model_override is not None and str(model_override).strip():
+        configured_model = str(model_override).strip()
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
@@ -4105,7 +4217,10 @@ def _build_top_level_description() -> str:
         "delegate_task.\n"
         "- Children inherit the parent model and fallback chain unless pinned "
         "globally via delegation.provider / delegation.model in config.yaml. "
-        "Results are returned as an array, one entry per task."
+        "An optional per-call 'model' parameter (single-goal form) or per-task "
+        "'model' field (batch form) overrides the child model for those "
+        "children only — restricted to the configured two-model policy "
+        "allowlist. Results are returned as an array, one entry per task."
     )
 
 
@@ -4245,6 +4360,19 @@ DELEGATE_TASK_SCHEMA = {
                                 "require only fields you will actually read."
                             ),
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Optional model pin for THIS task only — "
+                                "overrides delegation.model for this child. "
+                                "Must be one of the allowed worker models "
+                                "(validated against the two-model policy "
+                                "allowlist); invalid values reject the whole "
+                                "call before any child is spawned. Use to "
+                                "run specific children (e.g. reviewers) on a "
+                                "different model than the worker default."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -4264,6 +4392,17 @@ DELEGATE_TASK_SCHEMA = {
                     "Optional JSON Schema for the single-goal form — the "
                     "subagent's final answer must validate against it "
                     "(same semantics as tasks[].output_schema)."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional model pin for the single-goal form — overrides "
+                    "delegation.model for this child. Must be one of the "
+                    "allowed worker models (two-model policy allowlist); "
+                    "invalid values reject the call. In batch mode use the "
+                    "per-task 'model' field instead (this top-level value is "
+                    "ignored for batches, like goal/context/role)."
                 ),
             },
             "background": {
@@ -4340,6 +4479,7 @@ registry.register(
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
         parent_agent=kw.get("parent_agent"),
+        model=args.get("model"),
     ),
     check_fn=check_delegate_requirements,
     emoji="🔀",


### PR DESCRIPTION
## Summary

Add an optional validated `model` parameter to `delegate_task` (top-level for the single-goal form, per-task for batch items) that overrides `delegation.model` for those children only, and resolve child reasoning effort per EFFECTIVE child model via `agent.reasoning_overrides` instead of a single `delegation.reasoning_effort` for all children.

## Motivation

Two-model deployments (e.g. a cheap fast worker model + an expensive reviewer/corrector model on one provider) cannot express the split today: every subagent runs on the global `delegation.model`, and every child inherits one reasoning effort. The official docs recommend exactly this shape — "use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model" — but the tool surface offers no per-child pin.

Real consumer: a harness running flash-model worker swarms with qwen-model review pins (Wave 12 two-model division of labor).

## Changes

- `DELEGATE_TASK_SCHEMA`: optional `model` string on top-level + `tasks[]` items, documented in the rebuilt per-call descriptions (`_build_top_level_description`).
- `_validate_worker_model`: allowlist {qwen3.8-max, deepseek-v4-flash-0731}; reject-before-spawn with an actionable error (typos fail the whole call loudly instead of silently spawning a mis-routed child).
- `_resolve_delegation_credentials(..., model_override)`: the validated pin wins over `delegation.model`; credentials (base_url/api_key/api_mode) still come from `delegation.*`.
- `_resolve_child_reasoning`: explicit `delegation.reasoning_effort` (incl. YAML `false` = thinking off) > per-model override > global effort > parent inherit. Backward compatible: an explicit operator pin still wins for ALL children.
- `run_agent._dispatch_delegate_task` threads the new field.

## Tests

`tests/test_delegate_per_task_model.py` — 31 tests (allowlist, batch/top-level threading to the child builder, reject-before-spawn, per-model reasoning priorities, backward compat). Plus the existing delegation suite stays green (152 tests in our fork run).

## Footprint note

Config-neutral core change (no new env vars, no new config keys) — the allowlist is a hardcoded frozenset; which models are permitted remains a deployment policy.