### PR TITLE
fix(conversation_loop): honor classified.should_fallback before fallback (#82688)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5482,20 +5482,21 @@ def run_conversation(
                     # exists; otherwise "trying fallback..." is a lie and the
                     # session looks like it's recovering when it's about to
                     # abort silently (#35314, #17446).
-                    if agent._has_pending_fallback():
-                        if classified.reason == FailoverReason.content_policy_blocked:
-                            agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
-                        elif classified.reason == FailoverReason.ssl_cert_verification:
-                            agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
-                        else:
-                            agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
-                        active_system_prompt = _sync_failover_system_message(
-                            agent, api_messages, active_system_prompt)
-                        retry_count = 0
-                        compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
-                        continue
+                    if classified.should_fallback:
+                        if agent._has_pending_fallback():
+                            if classified.reason == FailoverReason.content_policy_blocked:
+                                agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
+                            elif classified.reason == FailoverReason.ssl_cert_verification:
+                                agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
+                            else:
+                                agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                        if agent._try_activate_fallback():
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            continue
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,

--- a/tests/run_agent/test_nonretryable_error_html_summary.py
+++ b/tests/run_agent/test_nonretryable_error_html_summary.py
@@ -127,3 +127,24 @@ def test_non_retryable_failure_error_is_summarized_not_raw_html():
     # The original page was tens of kilobytes; a summary is short.
     assert len(error) < 500
     assert len(error) < len(_CLOUDFLARE_CHALLENGE_HTML)
+
+
+def test_non_retryable_failure_without_fallback_permission_skips_activation():
+    """A terminal classification with ``should_fallback=False`` must abort."""
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = Exception(
+        "SSL: CERTIFICATE_VERIFY_FAILED"
+    )
+
+    with (
+        patch.object(agent, "_has_pending_fallback") as has_pending_fallback,
+        patch.object(agent, "_try_activate_fallback") as try_activate_fallback,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("daily briefing please")
+
+    assert result.get("failed") is True
+    has_pending_fallback.assert_not_called()
+    try_activate_fallback.assert_not_called()


### PR DESCRIPTION
Fixes #82688

## Summary
`classified.should_fallback` was calculated in `agent/error_classifier.py` but ignored in `agent/conversation_loop.py`, causing non-retryable errors with `should_fallback=False` (e.g., TLS verification failures, provider policy blocks) to fall back regardless.

## Changes
- Updated `agent/conversation_loop.py` to consult `classified.should_fallback` before invoking `_has_pending_fallback()` and `_try_activate_fallback()`.
- Added unit tests in `tests/` to verify that fallback activation is skipped when `classified.should_fallback` is `False`.