### PR TITLE
fix: expose remaining async delegation work

### DIFF
--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -530,6 +530,15 @@ export type TimelineDisplayMetadata =
       completed_count?: number
       failed_count?: number
       duration_seconds?: number
+      remaining_active_delegations?: number
+      remaining_active_subagents?: number
+      pending_completion_delegations?: number
+      pending_completion_subagents?: number
+      unavailable_completion_delegations?: number
+      unavailable_completion_subagents?: number
+      owned_work_state_known?: boolean
+      all_owned_subagents_terminal?: boolean
+      all_owned_results_available?: boolean
     }
   | { reactions: MessageReaction[] }
 

--- a/cli.py
+++ b/cli.py
@@ -10836,10 +10836,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         session identity when draining so another window cannot claim and mark
         delivered a completion that belongs to this one.
         """
-        from tools.process_registry import process_registry
+        from tools.process_registry import (
+            format_process_notification,
+            process_registry,
+        )
         from tools.async_delegation import (
             claim_event_delivery,
             complete_event_delivery,
+            release_event_delivery,
         )
 
         session_key = getattr(self, "session_id", "") or ""
@@ -10847,11 +10851,50 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             session_key=session_key,
             owns_event=self._owns_process_notification,
         ):
-            claim = claim_event_delivery(event, consumer)
+            try:
+                claim = claim_event_delivery(event, consumer)
+            except Exception:
+                process_registry.completion_queue.put(event)
+                continue
             if claim is None:
                 continue
-            self._pending_input.put(synthetic_message)
-            complete_event_delivery(event, claim)
+            accepted = False
+            try:
+                if event.get("type") == "async_delegation":
+                    owner_keys = {
+                        str(event.get("session_key") or ""),
+                        str(session_key),
+                    }
+                    lineage_known = False
+                    try:
+                        session_db = getattr(self, "_session_db", None)
+                        if session_db is not None:
+                            lineage = session_db.get_compression_lineage(session_key)
+                            if lineage:
+                                owner_keys.update(
+                                    str(key) for key in lineage if str(key)
+                                )
+                                lineage_known = True
+                    except Exception:
+                        lineage_known = False
+                    event["_owner_session_lineage_known"] = lineage_known
+                    event["_owner_session_keys"] = sorted(owner_keys - {""})
+                    refreshed = format_process_notification(event)
+                    if refreshed:
+                        synthetic_message = refreshed
+                self._pending_input.put(synthetic_message)
+                accepted = True
+                complete_event_delivery(event, claim)
+            except Exception:
+                # Before Queue.put(), release and requeue for retry. After the
+                # turn has been accepted, doing either would inject a duplicate;
+                # keep the durable claim until expiry for restart-time recovery.
+                if not accepted:
+                    try:
+                        release_event_delivery(event, claim)
+                    except Exception:
+                        pass
+                    process_registry.completion_queue.put(event)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22676,6 +22676,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _deliver_completion_notification(
         self, synth_text: str, evt: dict,
+        preclaimed_durable_id: Optional[str] = None,
     ) -> Optional[bool]:
         """Deliver once per live gateway, or return False for a retry.
 
@@ -22686,11 +22687,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         guarantee is claimed.
         """
         identity = self._completion_delivery_identity(evt)
-        durable_claim_id = ""
+        durable_claim_id = preclaimed_durable_id or ""
         durable_delegation_id = ""
         if evt.get("type") == "async_delegation":
             durable_delegation_id = str(evt.get("delegation_id") or "")
-            if durable_delegation_id:
+            if durable_delegation_id and preclaimed_durable_id is None:
                 try:
                     from tools.async_delegation import claim_completion_delivery
 
@@ -22721,19 +22722,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "delegation records).",
                         durable_delegation_id or "<legacy>", parent_session_id,
                     )
+                    drop_confirmed = not durable_claim_id
                     if durable_claim_id:
                         try:
                             from tools.async_delegation import drop_completion_delivery
 
-                            drop_completion_delivery(
+                            drop_confirmed = drop_completion_delivery(
                                 durable_delegation_id, durable_claim_id,
                             )
+                            if not drop_confirmed:
+                                from tools.async_delegation import get_durable_delegation
+
+                                # Legacy events predate the ledger. A false drop
+                                # for an absent row is already terminal; a row
+                                # that still exists must remain retryable.
+                                drop_confirmed = (
+                                    get_durable_delegation(durable_delegation_id)
+                                    is None
+                                )
                         except Exception:
                             logger.debug(
                                 "Could not drop durable completion claim",
                                 exc_info=True,
                             )
-                    return None
+                    if drop_confirmed:
+                        return None
+                    if durable_claim_id:
+                        try:
+                            from tools.async_delegation import release_completion_delivery
+
+                            release_completion_delivery(
+                                durable_delegation_id, durable_claim_id,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Could not release failed terminal-drop claim",
+                                exc_info=True,
+                            )
+                    return False
                 if verdict == "retry":
                     if durable_claim_id:
                         try:
@@ -22761,6 +22787,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             injection_result = await self._inject_watch_notification(synth_text, evt)
             if injection_result is not True:
+                if injection_result is None and durable_claim_id:
+                    try:
+                        from tools.async_delegation import drop_completion_delivery
+
+                        drop_confirmed = drop_completion_delivery(
+                            durable_delegation_id, durable_claim_id,
+                        )
+                        if not drop_confirmed:
+                            from tools.async_delegation import get_durable_delegation
+
+                            drop_confirmed = (
+                                get_durable_delegation(durable_delegation_id)
+                                is None
+                            )
+                        if drop_confirmed:
+                            # The claim is terminally disposed; do not release it
+                            # in finally and imply a transient retry.
+                            durable_claim_id = ""
+                        else:
+                            injection_result = False
+                    except Exception:
+                        logger.debug(
+                            "Could not terminally drop unroutable async completion",
+                            exc_info=True,
+                        )
+                        injection_result = False
                 return injection_result
             accepted = True
 
@@ -22814,8 +22866,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         expects. Best-effort: a CLI-origin event (empty session_key) is left
         as-is and simply won't route on the gateway.
         """
+        owner_keys = {str(evt.get("session_key") or "")}
+        owner_keys.discard("")
+        parent_ids = {str(evt.get("parent_session_id") or "")}
+        parent_ids.discard("")
+        lineage_known = True
+        try:
+            session_db = getattr(self, "_session_db", None)
+            sync_db = getattr(session_db, "_db", session_db)
+            if parent_ids and sync_db is not None:
+                for session_id in tuple(parent_ids):
+                    lineage = sync_db.get_compression_lineage(session_id)
+                    if not lineage:
+                        lineage_known = False
+                        continue
+                    parent_ids.update(str(item) for item in lineage if str(item))
+            elif parent_ids:
+                lineage_known = False
+        except Exception:
+            lineage_known = False
+        evt["_owner_session_lineage_known"] = lineage_known
+        evt["_owner_session_keys"] = sorted(owner_keys)
+        evt["_owner_parent_session_ids"] = sorted(parent_ids)
+
         if evt.get("platform"):
-            return  # already enriched
+            return  # routing already enriched
         parsed = _parse_session_key(evt.get("session_key", "") or "")
         if not parsed:
             return
@@ -22860,15 +22935,79 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 for evt in requeue:
                     _pr.completion_queue.put(evt)
                 for evt in async_events:
-                    self._enrich_async_delegation_routing(evt)
-                    synth_text = _format_gateway_process_notification(evt)
-                    if not synth_text:
+                    from tools.async_delegation import (
+                        claim_event_delivery,
+                        release_event_delivery,
+                    )
+                    try:
+                        self._enrich_async_delegation_routing(evt)
+                    except Exception as exc:
+                        _pr.completion_queue.put(evt)
+                        logger.error("Async delegation routing error: %s", exc)
+                        continue
+                    # Gateway delivery must be positively routable before it
+                    # competes for the durable claim. TUI/CLI identities share
+                    # this process-wide queue but are owned by their respective
+                    # consumers and must remain pending for them.
+                    try:
+                        route_platform = Platform(str(evt.get("platform") or ""))
+                    except Exception:
+                        route_platform = None
+                    raw_session_id = str(evt.get("origin_session_id") or "").strip()
+                    if not raw_session_id:
+                        raw_session_key = str(evt.get("session_key") or "").strip()
+                        if raw_session_key and _parse_session_key(raw_session_key) is None:
+                            raw_session_id = raw_session_key
+                    raw_api_adapter = self.adapters.get(Platform.API_SERVER)
+                    if raw_api_adapter is not None:
+                        from gateway.wake import adapter_supports_push
+                        raw_api_route = bool(
+                            raw_session_id and not adapter_supports_push(raw_api_adapter)
+                        )
+                    else:
+                        raw_api_route = False
+                    if (
+                        evt.get("origin_ui_session_id")
+                        or (
+                            not raw_api_route
+                            and (
+                                not evt.get("platform")
+                                or not evt.get("chat_id")
+                                or evt.get("chat_type") not in {"dm", "group", "channel", "thread"}
+                                or route_platform not in self.adapters
+                            )
+                        )
+                    ):
+                        _pr.completion_queue.put(evt)
                         continue
                     try:
-                        delivered = await self._deliver_completion_notification(synth_text, evt)
+                        durable_claim = claim_event_delivery(evt, "gateway-watcher")
+                    except Exception as exc:
+                        _pr.completion_queue.put(evt)
+                        logger.error("Async delegation claim error: %s", exc)
+                        continue
+                    if durable_claim is None:
+                        continue
+                    try:
+                        synth_text = _format_gateway_process_notification(evt)
+                        if not synth_text:
+                            release_event_delivery(evt, durable_claim)
+                            _pr.completion_queue.put(evt)
+                            continue
+                        delivered = await self._deliver_completion_notification(
+                            synth_text, evt,
+                            preclaimed_durable_id=durable_claim,
+                        )
                         if delivered is False:
                             _pr.completion_queue.put(evt)
                     except Exception as e:
+                        try:
+                            release_event_delivery(evt, durable_claim)
+                        except Exception:
+                            logger.debug(
+                                "Could not release async delegation formatter claim",
+                                exc_info=True,
+                            )
                         _pr.completion_queue.put(evt)
                         logger.error("Async delegation injection error: %s", e)
             except Exception as e:
@@ -22917,6 +23056,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return
 
         last_output_len = 0
+        formatter_failures = 0
         while True:
             await asyncio.sleep(interval)
 
@@ -22971,7 +23111,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "termination_source": getattr(session, "termination_source", ""),
                         "output": _out,
                     }
-                    synth_text = format_process_notification(completion_evt)
+                    try:
+                        synth_text = format_process_notification(completion_evt)
+                    except Exception as exc:
+                        formatter_failures += 1
+                        logger.error(
+                            "Process completion formatting failed for %s "
+                            "(attempt %d/3): %s",
+                            session_id,
+                            formatter_failures,
+                            exc,
+                        )
+                        if formatter_failures >= 3:
+                            logger.error(
+                                "Giving up process completion formatting for %s",
+                                session_id,
+                            )
+                            break
+                        continue
                     if not synth_text:
                         break
                     delivered = await self._deliver_completion_notification(

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -2,6 +2,8 @@
 
 import queue
 
+import pytest
+
 from cli import HermesCLI
 
 
@@ -38,13 +40,198 @@ def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
         "tools.async_delegation.complete_event_delivery",
         lambda evt, token: completed.append((evt, token)),
     )
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification",
+        lambda evt: "refreshed completion payload",
+    )
 
     cli._drain_process_notifications("cli-idle")
 
     assert calls == [("visible-session", True)]
-    assert cli._pending_input.get_nowait() == "completion payload"
+    assert cli._pending_input.get_nowait() == "refreshed completion payload"
     assert claimed == [(event, "cli-idle")]
     assert completed == [(event, "claim-token")]
+
+
+def test_cli_reformats_each_claimed_completion_after_prior_ack(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    events = [
+        {
+            "type": "async_delegation",
+            "delegation_id": delegation_id,
+            "session_key": "visible-session",
+        }
+        for delegation_id in ("first", "second")
+    ]
+
+    class FakeRegistry:
+        def drain_notifications(self, *, session_key="", owns_event=None):
+            return [(event, "stale") for event in events]
+
+    acknowledged = []
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification",
+        lambda evt: f"{evt['delegation_id']}: prior={len(acknowledged)}",
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery",
+        lambda evt, consumer: f"claim-{evt['delegation_id']}",
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda evt, token: acknowledged.append(evt["delegation_id"]),
+    )
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert cli._pending_input.get_nowait() == "first: prior=0"
+    assert cli._pending_input.get_nowait() == "second: prior=1"
+
+
+def test_cli_passes_compression_lineage_to_completion_formatter(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "session-new"
+    cli._pending_input = queue.Queue()
+    cli._session_db = type(
+        "FakeSessionDB",
+        (),
+        {"get_compression_lineage": lambda self, _key: ["session-old", "session-new"]},
+    )()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-lineage",
+        "session_key": "session-old",
+    }
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, "stale")]
+
+    seen = []
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery", lambda *_args: "claim"
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery", lambda *_args: None
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification",
+        lambda evt: seen.append(set(evt["_owner_session_keys"])) or "formatted",
+    )
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert seen == [{"session-old", "session-new"}]
+
+
+def test_cli_marks_owner_lineage_unknown_when_resolution_fails(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "session-new"
+    cli._pending_input = queue.Queue()
+    cli._session_db = type(
+        "BrokenSessionDB",
+        (),
+        {
+            "get_compression_lineage": lambda self, _key: (_ for _ in ()).throw(
+                RuntimeError("db unavailable")
+            )
+        },
+    )()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-lineage-error",
+        "session_key": "session-old",
+    }
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, "stale")]
+
+    seen = []
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery", lambda *_args: "claim"
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery", lambda *_args: None
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification",
+        lambda evt: seen.append(evt["_owner_session_lineage_known"]) or "formatted",
+    )
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert seen == [False]
+
+
+@pytest.mark.parametrize("failure_stage", ["claim", "format", "ack"])
+def test_cli_drain_requeues_event_when_delivery_step_fails(monkeypatch, failure_stage):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-retry",
+        "session_key": "visible-session",
+    }
+    queued = queue.Queue()
+    released = []
+
+    class FakeRegistry:
+        completion_queue = queued
+
+        def drain_notifications(self, **_kwargs):
+            return [(event, "stale")]
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+
+    def claim(_event, _consumer):
+        if failure_stage == "claim":
+            raise RuntimeError("claim failed")
+        return "claim-token"
+
+    def format_notification(_event):
+        if failure_stage == "format":
+            raise RuntimeError("format failed")
+        return "formatted"
+
+    def acknowledge(_event, _claim):
+        if failure_stage == "ack":
+            raise RuntimeError("ack failed")
+
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", claim)
+    monkeypatch.setattr(
+        "tools.async_delegation.release_event_delivery",
+        lambda evt, token: released.append((evt, token)),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery", acknowledge
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification", format_notification
+    )
+
+    cli._drain_process_notifications("cli-idle")
+
+    if failure_stage == "ack":
+        assert queued.empty(), "accepted input must not be immediately duplicated"
+    else:
+        assert queued.get_nowait() is event
+    expected_release = (
+        []
+        if failure_stage in {"claim", "ack"}
+        else [(event, "claim-token")]
+    )
+    assert released == expected_release
+    if failure_stage == "ack":
+        assert cli._pending_input.get_nowait() == "formatted"
+    else:
+        assert cli._pending_input.empty()
 
 
 def test_cli_completion_ownership_rejects_foreign_session():

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -158,6 +158,499 @@ async def test_consumed_completion_skips_raw_notification_without_agent_notify(
 
 
 @pytest.mark.asyncio
+async def test_process_watcher_retries_after_formatter_error(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    terminal = SimpleNamespace(
+        output_buffer="done\n",
+        exited=True,
+        exit_code=0,
+        command="echo done",
+    )
+    monkeypatch.setattr(
+        pr_module,
+        "process_registry",
+        _FakeRegistry([terminal, terminal], consumed=False),
+    )
+    calls = {"count": 0}
+
+    def flaky_formatter(_event):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("format failed")
+        return "formatted completion"
+
+    monkeypatch.setattr(pr_module, "format_process_notification", flaky_formatter)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._deliver_completion_notification = AsyncMock(return_value=True)
+    watcher = _watcher_dict()
+    watcher["notify_on_complete"] = True
+
+    await runner._run_process_watcher(watcher)
+
+    assert calls["count"] == 2
+    runner._deliver_completion_notification.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_watcher_gives_up_after_persistent_formatter_errors(
+    monkeypatch, tmp_path
+):
+    import tools.process_registry as pr_module
+
+    terminal = SimpleNamespace(
+        output_buffer="done\n",
+        exited=True,
+        exit_code=0,
+        command="echo done",
+    )
+    monkeypatch.setattr(
+        pr_module,
+        "process_registry",
+        _FakeRegistry([terminal, terminal, terminal], consumed=False),
+    )
+    calls = {"count": 0}
+
+    def broken_formatter(_event):
+        calls["count"] += 1
+        raise RuntimeError("persistent format failure")
+
+    monkeypatch.setattr(pr_module, "format_process_notification", broken_formatter)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._deliver_completion_notification = AsyncMock(return_value=True)
+    watcher = _watcher_dict()
+    watcher["notify_on_complete"] = True
+
+    await runner._run_process_watcher(watcher)
+
+    assert calls["count"] == 3
+    runner._deliver_completion_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_watcher_requeues_formatter_error(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+    from tools.process_registry import process_registry
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._running = True
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-format-error",
+        "session_key": "session-a",
+    }
+    process_registry.completion_queue.put(event)
+    monkeypatch.setattr(
+        gateway_run,
+        "_format_gateway_process_notification",
+        lambda _event: (_ for _ in ()).throw(RuntimeError("format failed")),
+    )
+    sleep_calls = {"count": 0}
+
+    async def _stop_after_iteration(*_a, **_kw):
+        sleep_calls["count"] += 1
+        if sleep_calls["count"] >= 2:
+            runner._running = False
+
+    monkeypatch.setattr(asyncio, "sleep", _stop_after_iteration)
+    try:
+        await runner._async_delegation_watcher(interval=0)
+
+        assert process_registry.completion_queue.get_nowait() is event
+    finally:
+        runner._running = False
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_watcher_terminally_drops_no_route(monkeypatch, tmp_path):
+    import time
+
+    import gateway.run as gateway_run
+    import tools.async_delegation as ad
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._running = True
+    delegation_id = "deleg-no-route"
+    event = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "session_key": "agent:main:telegram:dm:123",
+        "status": "completed",
+    }
+    ad._persist_dispatch(
+        {
+            "delegation_id": delegation_id,
+            "session_key": "agent:main:telegram:dm:123",
+            "dispatched_at": time.time(),
+            "goal": "unroutable",
+        }
+    )
+    ad._persist_completion(event, {"status": "completed", "summary": "done"})
+    process_registry.completion_queue.put(event)
+    monkeypatch.setattr(
+        gateway_run, "_format_gateway_process_notification", lambda _event: "formatted"
+    )
+    runner._inject_watch_notification = AsyncMock(return_value=None)
+    sleep_calls = {"count": 0}
+
+    async def _stop_after_iteration(*_a, **_kw):
+        sleep_calls["count"] += 1
+        if sleep_calls["count"] >= 2:
+            runner._running = False
+
+    monkeypatch.setattr(asyncio, "sleep", _stop_after_iteration)
+    try:
+        await runner._async_delegation_watcher(interval=0)
+
+        durable = ad.get_durable_delegation(delegation_id)
+        assert durable is not None
+        assert durable["delivery_state"] == "dropped"
+        assert process_registry.completion_queue.empty()
+    finally:
+        runner._running = False
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_persistent_formatter_failure_converges_to_dropped(
+    monkeypatch, tmp_path
+):
+    import time
+
+    import gateway.run as gateway_run
+    import tools.async_delegation as ad
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    delegation_id = "deleg-persistent-format-error"
+    event = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "session_key": "agent:main:telegram:dm:123",
+        "status": "completed",
+    }
+    ad._persist_dispatch(
+        {
+            "delegation_id": delegation_id,
+            "session_key": "agent:main:telegram:dm:123",
+            "dispatched_at": time.time(),
+            "goal": "formatter convergence",
+        }
+    )
+    ad._persist_completion(event, {"status": "completed", "summary": "done"})
+    process_registry.completion_queue.put(event)
+    monkeypatch.setattr(
+        gateway_run,
+        "_format_gateway_process_notification",
+        lambda _event: (_ for _ in ()).throw(RuntimeError("persistent format failure")),
+    )
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._running = True
+    sleep_calls = {"count": 0}
+
+    async def _stop_after_attempt_budget(*_a, **_kw):
+        sleep_calls["count"] += 1
+        if sleep_calls["count"] >= ad._MAX_DELIVERY_ATTEMPTS + 3:
+            runner._running = False
+
+    monkeypatch.setattr(asyncio, "sleep", _stop_after_attempt_budget)
+    try:
+        await runner._async_delegation_watcher(interval=0)
+
+        durable = ad.get_durable_delegation(delegation_id)
+        assert durable is not None
+        assert durable["delivery_state"] == "dropped"
+        assert durable["delivery_attempts"] == ad._MAX_DELIVERY_ATTEMPTS
+        assert process_registry.completion_queue.empty()
+    finally:
+        runner._running = False
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_watcher_leaves_tui_owned_event_unclaimed(
+    monkeypatch, tmp_path
+):
+    import time
+
+    import tools.async_delegation as ad
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._running = True
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-tui-owner",
+        "session_key": "20260101_120000_abc123",
+        "origin_ui_session_id": "tui-window-1",
+        "status": "completed",
+    }
+    ad._persist_dispatch(
+        {
+            "delegation_id": event["delegation_id"],
+            "session_key": event["session_key"],
+            "origin_ui_session_id": event["origin_ui_session_id"],
+            "dispatched_at": time.time(),
+            "goal": "tui-owned",
+        }
+    )
+    ad._persist_completion(event, {"status": "completed", "summary": "done"})
+    process_registry.completion_queue.put(event)
+    runner._inject_watch_notification = AsyncMock(return_value=None)
+    sleeps = {"count": 0}
+
+    async def _stop(*_args, **_kwargs):
+        sleeps["count"] += 1
+        if sleeps["count"] >= 2:
+            runner._running = False
+
+    monkeypatch.setattr(asyncio, "sleep", _stop)
+    try:
+        await runner._async_delegation_watcher(interval=0)
+        durable = ad.get_durable_delegation(event["delegation_id"])
+        assert durable is not None
+        assert durable["delivery_state"] == "pending"
+        runner._inject_watch_notification.assert_not_awaited()
+        assert process_registry.completion_queue.get_nowait() is event
+    finally:
+        runner._running = False
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_watcher_leaves_unknown_platform_unclaimed(
+    monkeypatch, tmp_path
+):
+    import time
+
+    import tools.async_delegation as ad
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._running = True
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-bad-platform",
+        "session_key": "agent:main:not-a-real-platform:dm:123",
+        "status": "completed",
+    }
+    ad._persist_dispatch({
+        "delegation_id": event["delegation_id"],
+        "session_key": event["session_key"],
+        "dispatched_at": time.time(),
+        "goal": "bad route",
+    })
+    ad._persist_completion(event, {"status": "completed", "summary": "done"})
+    process_registry.completion_queue.put(event)
+    runner._inject_watch_notification = AsyncMock(return_value=None)
+    sleeps = {"count": 0}
+
+    async def _stop(*_args, **_kwargs):
+        sleeps["count"] += 1
+        if sleeps["count"] >= 2:
+            runner._running = False
+
+    monkeypatch.setattr(asyncio, "sleep", _stop)
+    try:
+        await runner._async_delegation_watcher(interval=0)
+        durable = ad.get_durable_delegation(event["delegation_id"])
+        assert durable is not None
+        assert durable["delivery_state"] == "pending"
+        runner._inject_watch_notification.assert_not_awaited()
+        assert process_registry.completion_queue.get_nowait() is event
+    finally:
+        runner._running = False
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+@pytest.mark.asyncio
+async def test_async_delegation_watcher_delivers_raw_api_server_session(
+    monkeypatch, tmp_path
+):
+    import time
+
+    import tools.async_delegation as ad
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner.adapters[Platform.API_SERVER] = SimpleNamespace(
+        supports_async_delivery=False
+    )
+    runner._running = True
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-raw-api",
+        "session_key": "raw-sid-7",
+        "origin_session_id": "raw-sid-7",
+        "status": "completed",
+    }
+    ad._persist_dispatch({
+        "delegation_id": event["delegation_id"],
+        "session_key": event["session_key"],
+        "origin_session_id": event["origin_session_id"],
+        "dispatched_at": time.time(),
+        "goal": "raw api route",
+    })
+    ad._persist_completion(event, {"status": "completed", "summary": "done"})
+    process_registry.completion_queue.put(event)
+    runner._deliver_completion_notification = AsyncMock(return_value=True)
+    sleeps = {"count": 0}
+
+    async def _stop(*_args, **_kwargs):
+        sleeps["count"] += 1
+        if sleeps["count"] >= 2:
+            runner._running = False
+
+    monkeypatch.setattr(asyncio, "sleep", _stop)
+    try:
+        await runner._async_delegation_watcher(interval=0)
+        runner._deliver_completion_notification.assert_awaited_once()
+    finally:
+        runner._running = False
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_gateway_enrichment_counts_active_compression_lineage_sibling(
+    monkeypatch, tmp_path
+):
+    import gateway.run as gateway_run
+    import tools.async_delegation as ad
+
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+
+    class _DB:
+        def get_compression_lineage(self, session_id):
+            assert session_id == "parent-old"
+            return ["parent-old", "parent-new"]
+
+    runner._session_db = SimpleNamespace(_db=_DB())
+    with ad._records_lock:
+        ad._records["active-sibling"] = {
+            "delegation_id": "active-sibling",
+            "status": "running",
+            "session_key": "agent:main:telegram:dm:123",
+            "parent_session_id": "parent-new",
+        }
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "current",
+        "session_key": "agent:main:telegram:dm:123",
+        "parent_session_id": "parent-old",
+        "status": "completed",
+    }
+
+    runner._enrich_async_delegation_routing(event)
+    text = gateway_run._format_gateway_process_notification(event)
+
+    assert event["_owner_parent_session_ids"] == ["parent-new", "parent-old"]
+    assert event["_owner_session_lineage_known"] is True
+    assert event["remaining_active_delegations"] == 1
+    assert event["remaining_active_subagents"] == 1
+    assert event["all_owned_results_available"] is False
+    assert "Do not present a final synthesis yet" in text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("drop_mode", ["false", "raise"])
+async def test_terminal_preflight_drop_failure_is_retryable(
+    monkeypatch, tmp_path, drop_mode
+):
+    import tools.async_delegation as ad
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._classify_completion_target = AsyncMock(return_value="terminal")
+    runner._inject_watch_notification = AsyncMock(return_value=True)
+    released = []
+    monkeypatch.setattr(ad, "claim_completion_delivery", lambda *_args: True)
+
+    def fail_drop(*_args):
+        if drop_mode == "raise":
+            raise RuntimeError("drop failed")
+        return False
+
+    monkeypatch.setattr(ad, "drop_completion_delivery", fail_drop)
+    monkeypatch.setattr(
+        ad, "get_durable_delegation", lambda _delegation_id: {"state": "completed"}
+    )
+    monkeypatch.setattr(
+        ad,
+        "release_completion_delivery",
+        lambda delegation_id, claim_id: released.append((delegation_id, claim_id)) or True,
+    )
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-preflight-drop-failure",
+        "parent_session_id": "gone-parent",
+    }
+
+    result = await runner._deliver_completion_notification("formatted", event)
+
+    assert result is False
+    runner._inject_watch_notification.assert_not_awaited()
+    assert len(released) == 1
+    assert released[0][0] == event["delegation_id"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("drop_mode", ["false", "raise"])
+async def test_no_route_drop_failure_is_retryable(monkeypatch, tmp_path, drop_mode):
+    import tools.async_delegation as ad
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._inject_watch_notification = AsyncMock(return_value=None)
+    released = []
+
+    def fail_drop(*_args):
+        if drop_mode == "raise":
+            raise RuntimeError("drop failed")
+        return False
+
+    monkeypatch.setattr(ad, "drop_completion_delivery", fail_drop)
+    monkeypatch.setattr(
+        ad, "get_durable_delegation", lambda _delegation_id: {"state": "completed"}
+    )
+    monkeypatch.setattr(
+        ad,
+        "release_completion_delivery",
+        lambda delegation_id, claim_id: released.append((delegation_id, claim_id)) or True,
+    )
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-no-route-drop-failure",
+    }
+
+    result = await runner._deliver_completion_notification(
+        "formatted", event, preclaimed_durable_id="claim-token"
+    )
+
+    assert result is False
+    assert released == [(event["delegation_id"], "claim-token")]
+
+
+@pytest.mark.asyncio
 async def test_inject_watch_notification_routes_from_session_store_origin(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -112,7 +112,7 @@ def test_duplicate_async_queue_replay_injects_once(monkeypatch, isolated_registr
     adapter.handle_message.assert_awaited_once()
 
 
-def test_unroutable_async_event_is_not_requeued_forever(
+def test_unroutable_async_event_is_preserved_for_its_non_gateway_owner(
     monkeypatch, isolated_registry,
 ):
     isolated = queue.Queue()
@@ -128,6 +128,7 @@ def test_unroutable_async_event_is_not_requeued_forever(
     asyncio.run(runner._async_delegation_watcher(interval=0))
 
     adapter.handle_message.assert_not_awaited()
+    assert isolated.get_nowait() is event
     assert isolated.empty()
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4565,7 +4565,7 @@ def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
         "exit_code": 0,
         "output": "owner",
     }
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     isolated_queue.put(event)
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     monkeypatch.setattr(server, "_get_db", lambda: None)
@@ -4629,7 +4629,7 @@ def test_completion_ownership_lineage_lookup_failure_fails_closed(monkeypatch):
         "exit_code": 0,
         "output": "unknown",
     }
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     isolated_queue.put(event)
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())
@@ -4672,7 +4672,7 @@ def test_notification_poller_live_loop_drops_addressed_orphan(
         "output": "orphan",
         **routing,
     }
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     isolated_queue.put(event)
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     monkeypatch.setattr(server, "_get_db", lambda: None)
@@ -4725,7 +4725,7 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
     )
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_ghost")
     isolated_queue.put(
@@ -4791,7 +4791,7 @@ def test_notification_poller_delivers_owned_events(
     )
     monkeypatch.setattr(server, "_get_db", lambda: _CompressionDB())
 
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_mine")
     isolated_queue.put(
@@ -4924,6 +4924,126 @@ class _RecordingAgent:
         return {"final_response": "", "messages": []}
 
 
+def test_run_prompt_submit_post_turn_claim_failure_requeues_all_remaining(
+    monkeypatch, tmp_path
+):
+    """A post-turn claim failure preserves the failed and later events."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    turns = []
+    session = _session(
+        session_key="session-a",
+        agent=_RecordingAgent(turns),
+        running=True,
+    )
+    events = [
+        {
+            "type": "async_delegation",
+            "delegation_id": f"deleg-post-{index}",
+            "session_key": "session-a",
+            "status": "completed",
+            "summary": f"result-{index}",
+        }
+        for index in range(2)
+    ]
+    isolated_queue = type(process_registry.completion_queue)()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        process_registry,
+        "drain_notifications",
+        lambda **_kwargs: [(event, "stale") for event in events],
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("claim failed")),
+    )
+    server._sessions["sid_post_claim"] = session
+    try:
+        server._run_prompt_submit("rid-post", "sid_post_claim", session, "primary")
+
+        assert session["running"] is False
+        assert [isolated_queue.get_nowait(), isolated_queue.get_nowait()] == events
+        assert turns == ["primary"]
+    finally:
+        server._sessions.pop("sid_post_claim", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_run_prompt_submit_post_turn_dispatch_failure_requeues_current_and_rest(
+    monkeypatch, tmp_path
+):
+    """A post-turn dispatch failure releases and requeues the whole suffix."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    turns = []
+    session = _session(
+        session_key="session-a",
+        agent=_RecordingAgent(turns),
+        running=True,
+    )
+    events = [
+        {
+            "type": "async_delegation",
+            "delegation_id": f"deleg-post-dispatch-{index}",
+            "session_key": "session-a",
+            "status": "completed",
+            "summary": f"result-{index}",
+        }
+        for index in range(2)
+    ]
+    isolated_queue = type(process_registry.completion_queue)()
+    released = []
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        process_registry,
+        "drain_notifications",
+        lambda **_kwargs: [(event, "stale") for event in events],
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery",
+        lambda *_args: "claim-token",
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.release_event_delivery",
+        lambda event, claim: released.append((event, claim)),
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification",
+        lambda _event: "formatted",
+    )
+    original_run_prompt_submit = server._run_prompt_submit
+    calls = {"count": 0}
+
+    def fail_nested_dispatch(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return original_run_prompt_submit(*args, **kwargs)
+        raise RuntimeError("dispatch failed")
+
+    monkeypatch.setattr(server, "_run_prompt_submit", fail_nested_dispatch)
+    server._sessions["sid_post_dispatch"] = session
+    try:
+        server._run_prompt_submit(
+            "rid-post-dispatch", "sid_post_dispatch", session, "primary"
+        )
+
+        assert session["running"] is False
+        assert [isolated_queue.get_nowait(), isolated_queue.get_nowait()] == events
+        assert released == [(events[0], "claim-token")]
+        assert turns == ["primary"]
+    finally:
+        server._sessions.pop("sid_post_dispatch", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 @pytest.mark.parametrize("exit_code", [0, 7])
 def test_run_prompt_submit_requeues_foreign_completion(
     monkeypatch, tmp_path, exit_code
@@ -4948,7 +5068,7 @@ def test_run_prompt_submit_requeues_foreign_completion(
         "exit_code": exit_code,
         "output": "foreign",
     }
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     isolated_queue.put(event)
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     server._sessions["sid_a"] = session_a
@@ -4986,7 +5106,7 @@ def test_run_prompt_submit_delivers_completion_observed_by_poll(monkeypatch, tmp
         "exit_code": 0,
         "output": "observed but not consumed",
     }
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     isolated_queue.put(event)
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard(event["session_id"])
@@ -5053,7 +5173,7 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
         }
         for index in range(1, 4)
     ]
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     for event in events:
         isolated_queue.put(event)
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
@@ -5134,7 +5254,7 @@ def test_run_prompt_submit_delivers_completion_owned_through_compression_lineage
         "exit_code": 0,
         "output": "owned",
     }
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     isolated_queue.put(event)
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     server._sessions["sid_b"] = session
@@ -5183,7 +5303,7 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
         "exit_code": 0,
         "output": "owned",
     }
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     isolated_queue.put(event)
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     server._sessions["sid_b"] = session
@@ -13857,7 +13977,7 @@ def test_notification_poller_delivers_completion(monkeypatch):
     # agent may be a fixture double without run_conversation. A fresh Queue
     # here fully isolates this test; monkeypatch restores the original on
     # teardown. (Same pattern as test_notification_poller_requeues_when_busy.)
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_poller_test")
 
@@ -13921,7 +14041,7 @@ def test_notification_poller_skips_consumed(monkeypatch):
     # xdist worker can't dequeue this session_key-less event before our poller
     # does. monkeypatch restores the shared singleton on teardown. (Same
     # pattern as test_notification_poller_requeues_when_busy.)
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
 
     process_registry._completion_consumed.add("proc_already_done")
@@ -13963,7 +14083,7 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
     # fresh Queue here means no concurrently-running test in the same xdist
     # worker can put/get on the shared singleton mid-run and drain the event
     # we expect to be requeued. monkeypatch restores the original on teardown.
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_busy_test")
 
@@ -13992,6 +14112,84 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
         assert requeued["session_id"] == "proc_busy_test"
     finally:
         server._sessions.pop("sid_busy", None)
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_notification_poller_claims_before_status_and_requeues_claim_errors(
+    monkeypatch,
+):
+    """A failed durable claim is retryable and never emits losing status."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    emitted = []
+    sess = _session(session_key="session-a")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-claim-error",
+        "session_key": "session-a",
+        "status": "completed",
+        "summary": "result",
+    }
+    isolated_queue = type(process_registry.completion_queue)()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("sqlite unavailable")),
+    )
+
+    server._sessions["sid_claim_error"] = sess
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "sid_claim_error", sess
+        )
+
+        assert sess["running"] is False
+        assert [call for call in emitted if call[0] == "status.update"] == []
+        assert isolated_queue.get_nowait() is event
+    finally:
+        server._sessions.pop("sid_claim_error", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_notification_poller_claim_none_does_not_leave_session_busy(monkeypatch):
+    """Another consumer's claim must not strand this session as busy."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    emitted = []
+    sess = _session(session_key="session-a")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-lost-claim",
+        "session_key": "session-a",
+        "status": "completed",
+        "summary": "result",
+    }
+    isolated_queue = type(process_registry.completion_queue)()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery", lambda *_args: None
+    )
+
+    server._sessions["sid_lost_claim"] = sess
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "sid_lost_claim", sess
+        )
+
+        assert sess["running"] is False
+        assert [call for call in emitted if call[0] == "status.update"] == []
+    finally:
+        server._sessions.pop("sid_lost_claim", None)
         while not process_registry.completion_queue.empty():
             process_registry.completion_queue.get_nowait()
 
@@ -14116,7 +14314,7 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
     monkeypatch.setattr(server, "_run_prompt_submit", _fake_run_prompt_submit)
 
-    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue = type(process_registry.completion_queue)()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
 
     base = {
@@ -16544,3 +16742,329 @@ def test_session_branch_keeps_reasoning_fields(monkeypatch, tmp_path):
     finally:
         server._sessions.pop("sid", None)
         db.close()
+
+
+def test_async_delegation_display_metadata_includes_remaining_work_state():
+    evt = {
+        "delegation_id": "deleg-1",
+        "results": [{"status": "completed"}],
+        "remaining_active_delegations": 2,
+        "remaining_active_subagents": 4,
+        "pending_completion_delegations": 1,
+        "pending_completion_subagents": 3,
+        "unavailable_completion_delegations": 1,
+        "unavailable_completion_subagents": 2,
+        "owned_work_state_known": True,
+        "all_owned_subagents_terminal": False,
+        "all_owned_results_available": False,
+    }
+
+    metadata = server._async_delegation_display_metadata(evt)
+
+    assert metadata["remaining_active_delegations"] == 2
+    assert metadata["remaining_active_subagents"] == 4
+    assert metadata["pending_completion_delegations"] == 1
+    assert metadata["pending_completion_subagents"] == 3
+    assert metadata["unavailable_completion_delegations"] == 1
+    assert metadata["unavailable_completion_subagents"] == 2
+    assert metadata["owned_work_state_known"] is True
+    assert metadata["all_owned_subagents_terminal"] is False
+    assert metadata["all_owned_results_available"] is False
+
+
+def test_async_delegation_display_metadata_empty_failed_batch_is_truthful():
+    metadata = server._async_delegation_display_metadata(
+        {
+            "delegation_id": "deleg-empty-batch",
+            "is_batch": True,
+            "goals": ["one", "two", "three"],
+            "results": [],
+            "status": "failed",
+            "error": "batch failed",
+        }
+    )
+
+    assert metadata["task_count"] == 3
+    assert metadata["completed_count"] == 0
+    assert metadata["failed_count"] == 3
+
+
+def test_notification_owner_session_keys_include_compression_lineage(monkeypatch):
+    class FakeDB:
+        def get_compression_lineage(self, key):
+            return ["session-old", "session-new"] if key else []
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    session = _session(session_key="session-new")
+    event = {"session_key": "session-old"}
+
+    assert set(
+        server._notification_owner_session_keys("ui-session", session, event)
+    ) >= {"session-old", "session-new"}
+    assert event["_owner_session_lineage_known"] is True
+
+
+def test_notification_owner_session_keys_fail_closed_on_lineage_error(monkeypatch):
+    class BrokenDB:
+        def get_compression_lineage(self, _key):
+            raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(server, "_get_db", lambda: BrokenDB())
+    session = _session(session_key="session-new")
+    event = {"session_key": "session-old"}
+
+    server._notification_owner_session_keys("ui-session", session, event)
+
+    assert event["_owner_session_lineage_known"] is False
+
+
+def test_run_prompt_submit_post_turn_ack_failure_requeues_only_remaining(
+    monkeypatch, tmp_path
+):
+    """An accepted completion is not replayed when only durable ack fails."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    _configure_immediate_prompt_run(monkeypatch, tmp_path)
+    turns = []
+    session = _session(
+        session_key="session-a",
+        agent=_RecordingAgent(turns),
+        running=True,
+    )
+    events = [
+        {
+            "type": "async_delegation",
+            "delegation_id": f"deleg-post-ack-{index}",
+            "session_key": "session-a",
+            "status": "completed",
+            "summary": f"result-{index}",
+        }
+        for index in range(2)
+    ]
+    isolated_queue = type(process_registry.completion_queue)()
+    released = []
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        process_registry,
+        "drain_notifications",
+        lambda **_kwargs: [(event, "formatted") for event in events],
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery", lambda *_args: "claim-token"
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("ack failed")),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.release_event_delivery",
+        lambda event, claim: released.append((event, claim)),
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification", lambda _event: "formatted"
+    )
+    original_run_prompt_submit = server._run_prompt_submit
+    calls = {"count": 0}
+
+    def accept_nested_dispatch(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return original_run_prompt_submit(*args, **kwargs)
+        turns.append(args[3])
+        return None
+
+    monkeypatch.setattr(server, "_run_prompt_submit", accept_nested_dispatch)
+    server._sessions["sid_post_ack"] = session
+    try:
+        server._run_prompt_submit("rid-post-ack", "sid_post_ack", session, "primary")
+
+        assert session["running"] is True
+        assert isolated_queue.get_nowait() is events[1]
+        assert isolated_queue.empty()
+        assert released == []
+        assert turns == ["primary", "formatted"]
+    finally:
+        server._sessions.pop("sid_post_ack", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_notification_poller_ack_failure_keeps_async_turn_running(monkeypatch):
+    """Ack failure must not clear running while the accepted turn still executes."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    sess = _session(session_key="session-a")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-ack-error",
+        "session_key": "session-a",
+        "status": "completed",
+        "summary": "result",
+    }
+    isolated_queue = type(process_registry.completion_queue)()
+    isolated_queue.put(event)
+    released = []
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery", lambda *_args: "claim-token"
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("ack failed")),
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.release_event_delivery",
+        lambda evt, claim: released.append((evt, claim)),
+    )
+    server._sessions["sid_ack_error"] = sess
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "sid_ack_error", sess
+        )
+
+        assert sess["running"] is True
+        assert isolated_queue.empty()
+        assert released == []
+    finally:
+        server._sessions.pop("sid_ack_error", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_notification_poller_leaves_unowned_async_in_shared_queue(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    sess = _session(session_key="session-a")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-owner-unknown",
+        "session_key": "compressed-parent",
+        "status": "completed",
+    }
+    isolated_queue = type(process_registry.completion_queue)()
+    isolated_queue.put(event)
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        server, "_notification_event_belongs_elsewhere", lambda *_args: False
+    )
+    monkeypatch.setattr(
+        server, "_session_owns_notification_event", lambda *_args: False
+    )
+    monkeypatch.setattr(server.time, "sleep", lambda *_args: None)
+    server._sessions["sid_owner_unknown"] = sess
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "sid_owner_unknown", sess
+        )
+
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+        assert sess["running"] is False
+    finally:
+        server._sessions.pop("sid_owner_unknown", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_notification_poller_requeues_async_on_between_check_ownership_race(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    sess = _session(session_key="session-a")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-owner-race",
+        "session_key": "session-a",
+        "status": "completed",
+    }
+    isolated_queue = type(process_registry.completion_queue)()
+    isolated_queue.put(event)
+    ownership_checks = {"count": 0}
+    sleeps = []
+
+    def ownership_changes_between_checks(*_args):
+        ownership_checks["count"] += 1
+        return ownership_checks["count"] == 1
+
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        server, "_notification_event_belongs_elsewhere", lambda *_args: False
+    )
+    monkeypatch.setattr(
+        server, "_session_owns_notification_event", ownership_changes_between_checks
+    )
+    monkeypatch.setattr(server.time, "sleep", lambda seconds: sleeps.append(seconds))
+    server._sessions["sid_owner_race"] = sess
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "sid_owner_race", sess
+        )
+
+        assert ownership_checks["count"] >= 2
+        assert sleeps and sleeps[0] == 1.0
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("sid_owner_race", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
+def test_notification_poller_backs_off_when_formatter_returns_empty(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    sess = _session(session_key="session-a")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-empty-format",
+        "session_key": "session-a",
+        "status": "completed",
+    }
+    isolated_queue = type(process_registry.completion_queue)()
+    isolated_queue.put(event)
+    sleeps = []
+    released = []
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        server, "_notification_event_belongs_elsewhere", lambda *_args: False
+    )
+    monkeypatch.setattr(
+        server, "_session_owns_notification_event", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.claim_event_delivery", lambda *_args: "claim-token"
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.release_event_delivery",
+        lambda evt, claim: released.append((evt, claim)),
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification", lambda _evt: ""
+    )
+    monkeypatch.setattr(server.time, "sleep", lambda seconds: sleeps.append(seconds))
+    server._sessions["sid_empty_format"] = sess
+    try:
+        server._notification_poller_loop(
+            _StopAfterOneNotificationPoll(), "sid_empty_format", sess
+        )
+
+        assert len(released) >= 1
+        assert all(item == (event, "claim-token") for item in released)
+        assert sleeps and sleeps[0] == 1.0
+        assert isolated_queue.get_nowait() is event
+        assert isolated_queue.empty()
+    finally:
+        server._sessions.pop("sid_empty_format", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -65,6 +65,28 @@ def _drain_for(delegation_id, timeout=5.0):
     return None
 
 
+def _persist_pending_completion(delegation_id, session_key="session-a"):
+    record = {
+        "delegation_id": delegation_id,
+        "session_key": session_key,
+        "origin_ui_session_id": "",
+        "parent_session_id": None,
+        "status": "running",
+        "dispatched_at": time.time(),
+    }
+    event = {
+        "type": "async_delegation",
+        "delegation_id": delegation_id,
+        "session_key": session_key,
+        "status": "completed",
+        "summary": f"{delegation_id} result",
+        "completed_at": time.time(),
+    }
+    ad._persist_dispatch(record)
+    ad._persist_completion(event, {"summary": event["summary"]})
+    return event
+
+
 def test_active_for_session_counts_every_live_delegation_state():
     with ad._records_lock:
         ad._records.update(
@@ -95,6 +117,340 @@ def test_active_for_session_counts_every_live_delegation_state():
     assert ad.active_for_session("desktop-sid") == 3
     assert ad.active_for_session("other-sid") == 1
     assert ad.active_for_session("") == 0
+
+
+def test_owner_work_counts_excludes_current_and_expands_batches(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    with ad._records_lock:
+        ad._records.update(
+            {
+                "current": {
+                    "delegation_id": "current",
+                    "status": "finalizing",
+                    "session_key": "session-a",
+                },
+                "batch": {
+                    "delegation_id": "batch",
+                    "status": "running",
+                    "session_key": "session-a",
+                    "is_batch": True,
+                    "goals": ["one", "two", "three"],
+                },
+                "stalling": {
+                    "delegation_id": "stalling",
+                    "status": "stalling",
+                    "parent_session_id": "parent-a",
+                },
+                "completed": {
+                    "delegation_id": "completed",
+                    "status": "completed",
+                    "session_key": "session-a",
+                },
+                "other": {
+                    "delegation_id": "other",
+                    "status": "running",
+                    "session_key": "session-b",
+                },
+            }
+        )
+
+    _persist_pending_completion("pending")
+
+    assert ad.owner_work_counts(
+        session_key="session-a",
+        parent_session_id="parent-a",
+        exclude_delegation_id="current",
+    ) == (2, 4, 1, 1, 0, 0, True)
+    assert ad.owner_work_counts() == (0, 0, 0, 0, 0, 0, True)
+
+
+def test_owner_work_counts_matches_all_compression_lineage_keys(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    with ad._records_lock:
+        ad._records["before-compression"] = {
+            "delegation_id": "before-compression",
+            "status": "running",
+            "session_key": "session-old",
+        }
+        ad._records["after-compression"] = {
+            "delegation_id": "after-compression",
+            "status": "running",
+            "session_key": "session-new",
+        }
+
+    assert ad.owner_work_counts(
+        session_keys={"session-old", "session-new"},
+    ) == (2, 2, 0, 0, 0, 0, True)
+
+
+def test_owner_work_counts_terminal_durable_row_supersedes_in_memory_finalizing(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    delegation_id = "same-finalizing"
+    with ad._records_lock:
+        ad._records[delegation_id] = {
+            "delegation_id": delegation_id,
+            "status": "finalizing",
+            "session_key": "session-a",
+        }
+    _persist_pending_completion(delegation_id, session_key="session-a")
+
+    assert ad.owner_work_counts(session_key="session-a") == (
+        0, 0, 1, 1, 0, 0, True
+    )
+
+
+def test_dropped_owned_result_blocks_complete_synthesis(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    dropped = _persist_pending_completion("dropped", session_key="session-a")
+    claim = ad.claim_event_delivery(dropped, "test")
+    assert claim
+    assert ad.drop_completion_delivery("dropped", claim)
+    current = {
+        "type": "async_delegation",
+        "delegation_id": "current",
+        "session_key": "session-a",
+        "status": "completed",
+        "summary": "current result",
+    }
+
+    text = format_process_notification(current)
+
+    assert text is not None
+    assert current["unavailable_completion_delegations"] == 1
+    assert current["unavailable_completion_subagents"] == 1
+    assert current["all_owned_subagents_terminal"] is True
+    assert current["all_owned_results_available"] is False
+    assert "1 result(s) are unavailable" in text
+    assert "Do not claim a complete final synthesis" in text
+
+
+def test_legacy_ack_cannot_convert_dropped_result_to_delivered(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    event = _persist_pending_completion("legacy-ack-dropped", session_key="session-a")
+    claim = ad.claim_event_delivery(event, "test")
+    assert claim
+    assert ad.drop_completion_delivery("legacy-ack-dropped", claim)
+
+    assert ad.mark_completion_delivered("legacy-ack-dropped") is False
+    durable = ad.get_durable_delegation("legacy-ack-dropped")
+    assert durable is not None
+    assert durable["delivery_state"] == "dropped"
+
+
+def test_legacy_ack_cannot_deliver_unknown_result(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    event = _persist_pending_completion("legacy-ack-unknown", session_key="session-a")
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='unknown' WHERE delegation_id=?",
+            (event["delegation_id"],),
+        )
+
+    assert ad.mark_completion_delivered(event["delegation_id"]) is False
+    durable = ad.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["state"] == "unknown"
+    assert durable["delivery_state"] == "pending"
+
+
+def test_legacy_ack_cannot_overwrite_active_modern_claim(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    event = _persist_pending_completion("legacy-vs-modern", session_key="session-a")
+    claim = ad.claim_event_delivery(event, "modern-consumer")
+    assert claim
+
+    assert ad.mark_completion_delivered(event["delegation_id"]) is False
+    durable = ad.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "pending"
+    with ad._DB_LOCK, ad._transaction() as conn:
+        row = conn.execute(
+            "SELECT delivery_claim FROM async_delegations WHERE delegation_id=?",
+            (event["delegation_id"],),
+        ).fetchone()
+    assert row == (claim,)
+
+
+def test_legacy_ack_delivers_success_terminal_result(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    event = _persist_pending_completion("legacy-ack-success", session_key="session-a")
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='success' WHERE delegation_id=?",
+            (event["delegation_id"],),
+        )
+
+    assert ad.mark_completion_delivered(event["delegation_id"]) is True
+    durable = ad.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "delivered"
+
+
+@pytest.mark.parametrize("task_json", ["{", "[]", "null"])
+def test_recover_abandoned_delegation_tolerates_malformed_task_json(
+    monkeypatch, tmp_path, task_json
+):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    ad._persist_dispatch(
+        {
+            "delegation_id": "abandoned",
+            "session_key": "session-a",
+            "status": "running",
+            "dispatched_at": time.time(),
+        }
+    )
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET task_json=? WHERE delegation_id=?",
+            (task_json, "abandoned"),
+        )
+    monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: False)
+
+    assert ad.recover_abandoned_delegations() == 1
+    restored = queue.Queue()
+    assert ad.restore_undelivered_completions(restored) == 1
+    event = restored.get_nowait()
+    assert event["status"] == "unknown"
+    assert event["goal"] == ""
+
+
+def test_unknown_completion_never_authorizes_complete_synthesis(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "unknown",
+        "session_key": "session-a",
+        "status": "unknown",
+        "error": "owner exited",
+    }
+
+    text = format_process_notification(event)
+
+    assert event["all_owned_subagents_terminal"] is True
+    assert event["all_owned_results_available"] is False
+    assert "outcome is unknown" in text
+    assert "Do not claim a complete final synthesis" in text
+
+
+def test_unknown_sibling_rejects_legacy_ack_and_blocks_complete_synthesis(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    _persist_pending_completion("unknown-sibling", session_key="session-a")
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='unknown' WHERE delegation_id=?",
+            ("unknown-sibling",),
+        )
+    assert ad.mark_completion_delivered("unknown-sibling") is False
+    current = {
+        "type": "async_delegation",
+        "delegation_id": "current",
+        "session_key": "session-a",
+        "status": "completed",
+        "summary": "current result",
+    }
+
+    text = format_process_notification(current)
+
+    assert current["unavailable_completion_delegations"] == 1
+    assert current["all_owned_results_available"] is False
+    assert "1 result(s) are unavailable" in text
+    assert "Do not claim a complete final synthesis" in text
+
+
+@pytest.mark.parametrize("bad_event_json", ["{", "[]", "null"])
+def test_restore_skips_malformed_event_and_restores_later_valid_row(
+    monkeypatch, tmp_path, bad_event_json
+):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    _persist_pending_completion("bad", session_key="session-a")
+    valid = _persist_pending_completion("valid", session_key="session-a")
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET event_json=? WHERE delegation_id=?",
+            (bad_event_json, "bad"),
+        )
+    restored = queue.Queue()
+
+    assert ad.restore_undelivered_completions(restored) == 1
+    assert restored.get_nowait()["delegation_id"] == valid["delegation_id"]
+    assert restored.empty()
+    durable_bad = ad.get_durable_delegation("bad")
+    assert durable_bad is not None
+    assert durable_bad["delivery_state"] == "dropped"
+
+
+def test_get_durable_delegation_tolerates_malformed_result_json(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    _persist_pending_completion("malformed-result", session_key="session-a")
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET result_json=? WHERE delegation_id=?",
+            ("{", "malformed-result"),
+        )
+
+    durable = ad.get_durable_delegation("malformed-result")
+
+    assert durable is not None
+    assert durable["result"] is None
+    assert durable["result_parse_error"] is True
+
+
+def test_pending_unknown_counts_as_unavailable_not_pending(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    _persist_pending_completion("unknown-pending", session_key="session-a")
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            "UPDATE async_delegations SET state='unknown' WHERE delegation_id=?",
+            ("unknown-pending",),
+        )
+
+    assert ad.owner_work_counts(session_key="session-a") == (
+        0, 0, 0, 0, 1, 1, True
+    )
+
+
+def test_lineage_resolution_failure_forces_unknown_work_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "current",
+        "session_key": "session-new",
+        "status": "completed",
+        "summary": "result",
+        "_owner_session_lineage_known": False,
+    }
+
+    text = format_process_notification(event)
+
+    assert event["owned_work_state_known"] is False
+    assert event["all_owned_results_available"] is False
+    assert "Could not verify" in text
+
+
+def test_reinjection_fails_closed_when_delivery_ledger_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        ad,
+        "_transaction",
+        lambda: (_ for _ in ()).throw(RuntimeError("ledger unavailable")),
+    )
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "current",
+        "session_key": "session-a",
+        "status": "completed",
+        "summary": "result",
+    }
+
+    text = format_process_notification(evt)
+
+    assert text is not None
+    assert evt["owned_work_state_known"] is False
+    assert evt["all_owned_subagents_terminal"] is False
+    assert evt["all_owned_results_available"] is False
+    assert "Could not verify whether other completion results await delivery" in text
+    assert "Do not present a final synthesis yet" in text
 
 
 def test_dispatch_returns_immediately_without_blocking():
@@ -200,6 +556,182 @@ def test_rich_reinjection_block_is_self_contained():
         "API calls: 7",
     ]:
         assert needle in text, f"missing {needle!r}"
+
+
+def test_reinjection_reports_other_owned_background_work(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    with ad._records_lock:
+        ad._records.update(
+            {
+                "current": {
+                    "delegation_id": "current",
+                    "status": "finalizing",
+                    "session_key": "session-a",
+                },
+                "remaining": {
+                    "delegation_id": "remaining",
+                    "status": "running",
+                    "session_key": "session-a",
+                    "is_batch": True,
+                    "goals": ["one", "two"],
+                },
+            }
+        )
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "current",
+        "session_key": "session-a",
+        "status": "completed",
+        "summary": "first result",
+    }
+
+    text = format_process_notification(evt)
+
+    assert text is not None
+    assert evt["remaining_active_delegations"] == 1
+    assert evt["remaining_active_subagents"] == 2
+    assert evt["pending_completion_delegations"] == 0
+    assert evt["pending_completion_subagents"] == 0
+    assert evt["all_owned_subagents_terminal"] is False
+    assert evt["all_owned_results_available"] is False
+    assert "2 subagent task(s) across 1 delegation(s) are still running" in text
+    assert "Do not present a final synthesis yet" in text
+
+
+def test_reinjection_reports_last_owned_background_completion(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    with ad._records_lock:
+        ad._records["current"] = {
+            "delegation_id": "current",
+            "status": "finalizing",
+            "session_key": "session-a",
+        }
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "current",
+        "session_key": "session-a",
+        "status": "completed",
+        "summary": "last result",
+    }
+
+    text = format_process_notification(evt)
+
+    assert text is not None
+    assert evt["remaining_active_delegations"] == 0
+    assert evt["remaining_active_subagents"] == 0
+    assert evt["pending_completion_delegations"] == 0
+    assert evt["pending_completion_subagents"] == 0
+    assert evt["all_owned_subagents_terminal"] is True
+    assert evt["all_owned_results_available"] is True
+    assert "running or awaiting result delivery" in text
+    assert "after any required parent-side verification" in text
+
+
+def test_two_terminal_results_do_not_allow_synthesis_before_second_delivery(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+
+    events = [
+        _persist_pending_completion(delegation_id)
+        for delegation_id in ("first", "second")
+    ]
+
+    first_text = format_process_notification(events[0])
+    assert first_text is not None
+    assert events[0]["remaining_active_subagents"] == 0
+    assert events[0]["pending_completion_subagents"] == 1
+    assert events[0]["all_owned_subagents_terminal"] is True
+    assert events[0]["all_owned_results_available"] is False
+    assert "1 completed result(s) still await delivery" in first_text
+    assert "Do not present a final synthesis yet" in first_text
+
+    assert ad.mark_completion_delivered("first")
+    second_text = format_process_notification(events[1])
+    assert second_text is not None
+    assert events[1]["pending_completion_subagents"] == 0
+    assert events[1]["all_owned_results_available"] is True
+    assert "running or awaiting result delivery" in second_text
+
+
+def test_pruning_preserves_pending_rows_and_tombstones_overflow(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    _persist_pending_completion("old-pending", session_key="session-a")
+    _persist_pending_completion("new-pending", session_key="session-a")
+    monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 0)
+    monkeypatch.setattr(ad, "_MAX_DURABLE_PENDING", 1)
+
+    ad._prune_durable_records()
+
+    old = ad.get_durable_delegation("old-pending")
+    new = ad.get_durable_delegation("new-pending")
+    assert old is not None
+    assert new is not None
+    assert {old["delivery_state"], new["delivery_state"]} == {
+        "dropped", "pending"
+    }
+    assert ad.owner_work_counts(session_key="session-a") == (
+        0, 0, 1, 1, 1, 1, True
+    )
+
+
+def test_drain_persistent_async_formatter_failure_converges_to_dropped(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    event = _persist_pending_completion(
+        "persistent-drain-format-error", session_key="session-a"
+    )
+    process_registry.completion_queue.put(event)
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification",
+        lambda _event: (_ for _ in ()).throw(RuntimeError("persistent failure")),
+    )
+
+    for _ in range(ad._MAX_DELIVERY_ATTEMPTS + 1):
+        assert process_registry.drain_notifications(session_key="session-a") == []
+
+    durable = ad.get_durable_delegation("persistent-drain-format-error")
+    assert durable is not None
+    assert durable["delivery_state"] == "dropped"
+    assert durable["delivery_attempts"] == ad._MAX_DELIVERY_ATTEMPTS
+    assert process_registry.completion_queue.empty()
+
+
+def test_drain_empty_async_formatter_converges_to_dropped(monkeypatch, tmp_path):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    event = _persist_pending_completion(
+        "persistent-drain-empty-format", session_key="session-a"
+    )
+    process_registry.completion_queue.put(event)
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification", lambda _event: ""
+    )
+
+    for _ in range(ad._MAX_DELIVERY_ATTEMPTS + 1):
+        assert process_registry.drain_notifications(session_key="session-a") == []
+
+    durable = ad.get_durable_delegation("persistent-drain-empty-format")
+    assert durable is not None
+    assert durable["delivery_state"] == "dropped"
+    assert durable["delivery_attempts"] == ad._MAX_DELIVERY_ATTEMPTS
+    assert process_registry.completion_queue.empty()
+
+
+def test_cli_style_drain_marks_only_last_completion_ready_for_synthesis(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    for delegation_id in ("first", "second"):
+        process_registry.completion_queue.put(
+            _persist_pending_completion(delegation_id)
+        )
+
+    drained = process_registry.drain_notifications(session_key="session-a")
+
+    assert len(drained) == 2
+    assert "Do not present a final synthesis yet" in drained[0][1]
+    assert "Do not present a final synthesis yet" in drained[1][1]
 
 
 def test_dispatch_rejected_at_capacity():

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1054,6 +1054,125 @@ class TestProcessToolHandler:
 from tools.process_registry import format_process_notification
 
 
+def test_get_matching_notification_preserves_unmatched_order(registry):
+    first = {"type": "async_delegation", "session_key": "other"}
+    second = {"type": "async_delegation", "session_key": "mine"}
+    third = {"type": "completion", "session_key": "other"}
+    for event in (first, second, third):
+        registry.completion_queue.put(event)
+
+    snapshot = registry.snapshot_notifications(timeout=0)
+    assert registry.get_matching_notification(snapshot, (second,)) is second
+    assert registry.completion_queue.get_nowait() is first
+    assert registry.completion_queue.get_nowait() is third
+    assert registry.completion_queue.empty()
+
+
+def test_snapshot_allows_ownership_evaluation_outside_queue_lock(registry):
+    event = {"type": "async_delegation", "session_key": "mine"}
+    registry.completion_queue.put(event)
+    snapshot = registry.snapshot_notifications(timeout=0)
+    lock_states = []
+
+    accepted = []
+    for candidate in snapshot[0]:
+        lock_states.append(registry.completion_queue.mutex.locked())
+        if candidate is event:
+            accepted.append(candidate)
+
+    assert registry.get_matching_notification(snapshot, accepted) is event
+    assert lock_states == [False]
+
+
+def test_get_matching_notification_completes_removed_queue_task(registry):
+    import threading
+
+    first = {"type": "async_delegation", "session_key": "other"}
+    second = {"type": "async_delegation", "session_key": "mine"}
+    registry.completion_queue.put(first)
+    registry.completion_queue.put(second)
+
+    snapshot = registry.snapshot_notifications(timeout=0)
+    assert registry.get_matching_notification(snapshot, (second,)) is second
+    assert registry.completion_queue.unfinished_tasks == 1
+
+    assert registry.completion_queue.get_nowait() is first
+    joined = threading.Event()
+    waiter = threading.Thread(
+        target=lambda: (registry.completion_queue.join(), joined.set()), daemon=True
+    )
+    waiter.start()
+    waiter.join(timeout=0.5)
+    assert joined.is_set()
+
+
+def test_notification_queue_raw_requeue_balances_tasks_and_advances_generation(registry):
+    event = {"type": "async_delegation", "session_key": "mine"}
+    queue = registry.completion_queue
+    start_generation = queue.mutation_generation
+    queue.put(event)
+    after_put = queue.mutation_generation
+    assert queue.unfinished_tasks == 1
+
+    assert queue.get_nowait() is event
+    after_get = queue.mutation_generation
+    assert queue.unfinished_tasks == 0
+    queue.put(event)
+
+    assert start_generation < after_put < after_get < queue.mutation_generation
+    assert queue.unfinished_tasks == 1
+    assert queue.qsize() == 1
+
+
+def test_snapshot_notifications_honors_empty_queue_deadline(registry):
+    import queue
+    import time
+
+    started = time.monotonic()
+    with pytest.raises(queue.Empty):
+        registry.snapshot_notifications(timeout=0.005)
+    assert time.monotonic() - started < 0.03
+
+
+def test_get_matching_notification_rejects_same_object_requeue_aba(registry):
+    import queue
+
+    event = {"type": "async_delegation", "session_key": "mine"}
+    registry.completion_queue.put(event)
+    snapshot = registry.snapshot_notifications(timeout=0)
+    assert registry.completion_queue.get_nowait() is event
+    registry.completion_queue.put(event)
+
+    with pytest.raises(queue.Empty):
+        registry.get_matching_notification(snapshot, (event,))
+    assert registry.completion_queue.get_nowait() is event
+
+
+def test_get_matching_notification_timeout_leaves_queue_untouched(registry):
+    import queue
+
+    event = {"type": "async_delegation", "session_key": "other"}
+    registry.completion_queue.put(event)
+    snapshot = registry.snapshot_notifications(timeout=0)
+
+    with pytest.raises(queue.Empty):
+        registry.get_matching_notification(snapshot, ())
+    assert registry.completion_queue.get_nowait() is event
+
+
+def test_drain_notifications_requeues_when_formatter_raises(monkeypatch, registry):
+    event = {"type": "completion", "session_id": "proc-format-error"}
+    registry.completion_queue.put(event)
+    monkeypatch.setattr(
+        "tools.process_registry.format_process_notification",
+        lambda _event: (_ for _ in ()).throw(RuntimeError("format failed")),
+    )
+
+    assert registry.drain_notifications() == []
+    assert registry.completion_queue.get_nowait() is event
+    assert registry.completion_queue.empty()
+
+
 def test_drain_notifications_completion_callback_exception_fails_closed(registry):
     event = {
         "type": "completion",

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -240,17 +240,19 @@ def _prune_durable_records() -> None:
             "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
             (cutoff,),
         )
-        terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
+        delivered_count = conn.execute(
+            """SELECT COUNT(*) FROM async_delegations
+               WHERE state NOT IN ('running','finalizing')
+                 AND delivery_state='delivered'"""
         ).fetchone()[0]
-        excess = max(0, terminal_count - _MAX_RETAINED_COMPLETED)
+        excess = max(0, delivered_count - _MAX_RETAINED_COMPLETED)
         if excess:
             conn.execute(
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
                      WHERE state NOT IN ('running','finalizing')
-                     ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
-                              updated_at ASC LIMIT ?
+                       AND delivery_state='delivered'
+                     ORDER BY updated_at ASC LIMIT ?
                    )""",
                 (excess,),
             )
@@ -261,12 +263,15 @@ def _prune_durable_records() -> None:
         overflow = max(0, pending_count - _MAX_DURABLE_PENDING)
         if overflow:
             conn.execute(
-                """DELETE FROM async_delegations WHERE delegation_id IN (
+                """UPDATE async_delegations SET delivery_state='dropped',
+                          delivery_claim=NULL, delivery_claimed_at=NULL,
+                          event_json=NULL, result_json=NULL, updated_at=?
+                   WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
                      WHERE state NOT IN ('running','finalizing') AND delivery_state='pending'
                      ORDER BY updated_at ASC LIMIT ?
                    )""",
-                (overflow,),
+                (now, overflow),
             )
 
 
@@ -315,7 +320,12 @@ def recover_abandoned_delegations() -> int:
                     live = get_process_start_time(int(pid)) == int(started)
             if live:
                 continue
-            task = json.loads(task_json or "{}")
+            try:
+                task = json.loads(task_json or "{}")
+            except (TypeError, json.JSONDecodeError):
+                task = {}
+            if not isinstance(task, dict):
+                task = {}
             event = {
                 "type": "async_delegation", "delegation_id": delegation_id,
                 "session_key": session_key, "origin_ui_session_id": origin_ui,
@@ -360,12 +370,40 @@ def restore_undelivered_completions(target_queue) -> int:
                WHERE state != 'running' AND delivery_state='pending' AND event_json IS NOT NULL
                ORDER BY completed_at, delegation_id"""
         ).fetchall()
-        for _delegation_id, payload in rows:
-            evt = json.loads(payload)
-            if isinstance(evt, dict):
-                evt["restored"] = True
+        restored = 0
+        for delegation_id, payload in rows:
+            try:
+                evt = json.loads(payload)
+            except (TypeError, json.JSONDecodeError):
+                logger.error(
+                    "Skipping malformed durable completion event for %s",
+                    delegation_id,
+                )
+                conn.execute(
+                    """UPDATE async_delegations SET delivery_state='dropped',
+                              delivery_claim=NULL, delivery_claimed_at=NULL,
+                              updated_at=? WHERE delegation_id=?
+                         AND delivery_state='pending'""",
+                    (time.time(), delegation_id),
+                )
+                continue
+            if not isinstance(evt, dict):
+                logger.error(
+                    "Skipping non-object durable completion event for %s",
+                    delegation_id,
+                )
+                conn.execute(
+                    """UPDATE async_delegations SET delivery_state='dropped',
+                              delivery_claim=NULL, delivery_claimed_at=NULL,
+                              updated_at=? WHERE delegation_id=?
+                         AND delivery_state='pending'""",
+                    (time.time(), delegation_id),
+                )
+                continue
+            evt["restored"] = True
             target_queue.put(evt)
-    return len(rows)
+            restored += 1
+    return restored
 
 
 def mark_completion_delivered(delegation_id: str) -> bool:
@@ -374,7 +412,9 @@ def mark_completion_delivered(delegation_id: str) -> bool:
     with _DB_LOCK, _transaction() as conn:
         cur = conn.execute(
             """UPDATE async_delegations SET delivery_state='delivered', delivered_at=?, updated_at=?
-               WHERE delegation_id=? AND delivery_state!='delivered'""",
+               WHERE delegation_id=? AND delivery_state='pending'
+                 AND delivery_claim IS NULL
+                 AND state IN ('completed','success','error','failed','timeout','cancelled','interrupted','stalled')""",
             (now, now, delegation_id),
         )
         return cur.rowcount == 1
@@ -504,10 +544,21 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
         ).fetchone()
     if row is None:
         return None
+    result = None
+    result_parse_error = False
+    if row[4]:
+        try:
+            parsed = json.loads(row[4])
+            if isinstance(parsed, dict):
+                result = parsed
+            else:
+                result_parse_error = True
+        except (TypeError, json.JSONDecodeError):
+            result_parse_error = True
     return {
         "delegation_id": delegation_id, "origin_session": row[0], "state": row[1],
         "dispatched_at": row[2], "completed_at": row[3],
-        "result": json.loads(row[4]) if row[4] else None,
+        "result": result, "result_parse_error": result_parse_error,
         "delivery_state": row[5], "delivery_attempts": row[6],
         "origin_session_id": row[7] or "",
     }
@@ -586,16 +637,143 @@ def active_task_count() -> int:
 
 
 def _matches_session_selectors(
-    record: Dict[str, Any],
+    record: dict,
     *,
     session_key: str = "",
+    session_keys: Optional[set[str]] = None,
     origin_ui_session_id: str = "",
     parent_session_id: str = "",
+    parent_session_ids: Optional[set[str]] = None,
 ) -> bool:
+    lineage_keys = set(session_keys or ())
+    if session_key:
+        lineage_keys.add(session_key)
+    parent_ids = set(parent_session_ids or ())
+    if parent_session_id:
+        parent_ids.add(parent_session_id)
     return (
         (origin_ui_session_id and str(record.get("origin_ui_session_id") or "") == origin_ui_session_id)
-        or (session_key and str(record.get("session_key") or "") == session_key)
-        or (parent_session_id and str(record.get("parent_session_id") or "") == parent_session_id)
+        or (lineage_keys and str(record.get("session_key") or "") in lineage_keys)
+        or (parent_ids and str(record.get("parent_session_id") or "") in parent_ids)
+    )
+
+
+def owner_work_counts(
+    *,
+    session_key: str = "",
+    session_keys: Optional[set[str]] = None,
+    origin_ui_session_id: str = "",
+    parent_session_id: str = "",
+    parent_session_ids: Optional[set[str]] = None,
+    exclude_delegation_id: str = "",
+) -> tuple[int, int, int, int, int, int, bool]:
+    """Return live and pending-delivery work owned by one session.
+
+    ``exclude_delegation_id`` lets a completion formatter ignore the record
+    currently being delivered.
+
+    The tuple is ``(active units, active tasks, pending units, pending tasks,
+    unavailable units, unavailable tasks, delivery state known)``.
+    """
+    lineage_keys = {str(key) for key in (session_keys or set()) if str(key)}
+    if session_key:
+        lineage_keys.add(session_key)
+    parent_lineage_ids = {
+        str(value) for value in (parent_session_ids or set()) if str(value)
+    }
+    if parent_session_id:
+        parent_lineage_ids.add(parent_session_id)
+    if not lineage_keys and not origin_ui_session_id and not parent_lineage_ids:
+        return 0, 0, 0, 0, 0, 0, True
+    excluded = {exclude_delegation_id} if exclude_delegation_id else set()
+    active_units = 0
+    active_tasks = 0
+    active_ids: set[str] = set()
+    active_task_counts: dict[str, int] = {}
+    with _records_lock:
+        for delegation_id, record in _records.items():
+            if delegation_id in excluded:
+                continue
+            if record.get("status") not in {"running", "stalling", "finalizing"}:
+                continue
+            if not _matches_session_selectors(
+                record,
+                session_key=session_key,
+                session_keys=lineage_keys,
+                origin_ui_session_id=origin_ui_session_id,
+                parent_session_id=parent_session_id,
+                parent_session_ids=parent_lineage_ids,
+            ):
+                continue
+            active_ids.add(delegation_id)
+            active_units += 1
+            goals = record.get("goals") if record.get("is_batch") else None
+            record_task_count = (
+                len(goals) if isinstance(goals, (list, tuple)) and goals else 1
+            )
+            active_task_counts[delegation_id] = record_task_count
+            active_tasks += record_task_count
+
+    pending_units = 0
+    pending_tasks = 0
+    unavailable_units = 0
+    unavailable_tasks = 0
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            rows = conn.execute(
+                """SELECT delegation_id, origin_session, origin_ui_session_id,
+                          parent_session_id, state, delivery_state, task_json
+                   FROM async_delegations"""
+            ).fetchall()
+    except Exception:
+        logger.debug("Could not count durable delegation delivery state", exc_info=True)
+        return active_units, active_tasks, 0, 0, 0, 0, False
+
+    for row in rows:
+        (delegation_id, row_session_key, row_origin_ui, row_parent_id,
+         state, delivery_state, task_json) = row
+        if delegation_id in excluded:
+            continue
+        if not (
+            (lineage_keys and str(row_session_key or "") in lineage_keys)
+            or (origin_ui_session_id and str(row_origin_ui or "") == origin_ui_session_id)
+            or (parent_lineage_ids and str(row_parent_id or "") in parent_lineage_ids)
+        ):
+            continue
+        try:
+            task = json.loads(task_json or "{}")
+        except (TypeError, json.JSONDecodeError):
+            task = {}
+        if not isinstance(task, dict):
+            task = {}
+        goals = task.get("goals") if task.get("is_batch") else None
+        task_count = len(goals) if isinstance(goals, list) and goals else 1
+        if state in {"running", "finalizing"}:
+            if delegation_id not in active_ids:
+                active_units += 1
+                active_tasks += task_count
+            continue
+        if delegation_id in active_ids:
+            active_ids.remove(delegation_id)
+            active_units -= 1
+            active_tasks -= active_task_counts.pop(delegation_id, 0)
+        if state == "unknown":
+            unavailable_units += 1
+            unavailable_tasks += task_count
+        elif delivery_state == "pending":
+            pending_units += 1
+            pending_tasks += task_count
+        elif delivery_state == "dropped":
+            unavailable_units += 1
+            unavailable_tasks += task_count
+    return (
+        active_units,
+        active_tasks,
+        pending_units,
+        pending_tasks,
+        unavailable_units,
+        unavailable_tasks,
+        True,
     )
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -34,6 +34,7 @@ import json
 import logging
 import os
 import platform
+import queue
 import shlex
 import signal
 import subprocess
@@ -46,13 +47,38 @@ _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
 
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
+
+
+class _NotificationQueue(queue.Queue):
+    """Queue whose tasks complete when notifications are removed.
+
+    Notification consumers either consume immediately or requeue explicitly;
+    none has a post-processing ``task_done`` phase. Track every structural
+    mutation with a monotonic generation for fail-closed snapshot validation.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.mutation_generation = 0
+
+    def _put(self, item):
+        super()._put(item)
+        self.mutation_generation += 1
+
+    def _get(self):
+        item = super()._get()
+        self.mutation_generation += 1
+        self.unfinished_tasks -= 1
+        if self.unfinished_tasks == 0:
+            self.all_tasks_done.notify_all()
+        return item
 
 
 # Checkpoint file for crash recovery (gateway only)
@@ -446,8 +472,7 @@ class ProcessRegistry:
         # Completion notifications (notify_on_complete) and watch pattern matches
         # both land here, distinguished by "type" field.  CLI process_loop and
         # gateway drain this after each agent turn to auto-trigger new turns.
-        import queue as _queue_mod
-        self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
+        self.completion_queue: _NotificationQueue = _NotificationQueue()
         # Rehydrate durable delegation completions only at registry startup.
         # Consumers still inject them as fresh turns through this existing rail.
         try:
@@ -489,6 +514,66 @@ class ProcessRegistry:
         # terminal tab. Distinct from kill — the process keeps running; only the
         # UI view is dropped (the user can reopen it from the status stack).
         self.on_close = None
+
+    def snapshot_notifications(self, timeout: float = 0.5) -> tuple[tuple[dict, ...], int]:
+        """Return an immutable snapshot token after waiting for queue availability.
+
+        The token includes Queue task generation state. Callers may perform
+        arbitrary ownership/lineage checks outside the Queue mutex, then pass
+        the snapshot to ``get_matching_notification`` for atomic validation.
+        """
+        import queue as _queue_mod
+
+        q = self.completion_queue
+        with q.not_empty:
+            if not q.queue:
+                if timeout <= 0 or not q.not_empty.wait_for(
+                    lambda: bool(q.queue), timeout=max(0.0, timeout)
+                ):
+                    raise _queue_mod.Empty
+            return tuple(q.queue), q.mutation_generation
+
+    def get_matching_notification(
+        self,
+        snapshot: tuple[tuple[dict, ...], int],
+        accepted_events,
+    ) -> dict:
+        """Atomically dequeue the first accepted event from a valid snapshot.
+
+        Ownership is evaluated by the caller outside the Queue lock. The
+        queue identity sequence and task-generation count must still match the
+        snapshot; any get/put/requeue race fails closed and the caller retries.
+        The removed queue task is completed here because callers consume or
+        explicitly requeue the returned event and never call ``task_done()``.
+        """
+        import queue as _queue_mod
+
+        snapshot_events, snapshot_generation = snapshot
+        accepted_ids = {id(event) for event in accepted_events}
+        if not accepted_ids:
+            raise _queue_mod.Empty
+
+        q = self.completion_queue
+        with q.not_empty:
+            if (
+                q.mutation_generation != snapshot_generation
+                or len(q.queue) != len(snapshot_events)
+                or any(
+                    current is not previous
+                    for current, previous in zip(q.queue, snapshot_events)
+                )
+            ):
+                raise _queue_mod.Empty
+            for index, event in enumerate(q.queue):
+                if id(event) in accepted_ids:
+                    del q.queue[index]
+                    q.mutation_generation += 1
+                    q.unfinished_tasks -= 1
+                    if q.unfinished_tasks == 0:
+                        q.all_tasks_done.notify_all()
+                    q.not_full.notify()
+                    return event
+        raise _queue_mod.Empty
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
@@ -1717,9 +1802,53 @@ class ProcessRegistry:
             ):
                 continue
 
-            text = format_process_notification(evt)
+            try:
+                text = format_process_notification(evt)
+            except Exception:
+                logger.exception("Could not format process notification; requeueing")
+                if is_async_delegation:
+                    try:
+                        from tools.async_delegation import (
+                            claim_event_delivery,
+                            release_event_delivery,
+                        )
+                        format_claim = claim_event_delivery(
+                            evt, "process-registry-formatter"
+                        )
+                    except Exception:
+                        format_claim = ""
+                    if format_claim is None:
+                        continue
+                    if format_claim:
+                        try:
+                            release_event_delivery(evt, format_claim)
+                        except Exception:
+                            pass
+                requeue.append(evt)
+                continue
             if text:
                 results.append((evt, text))
+            elif is_async_delegation:
+                # Empty output is also an unformattable durable payload. Count
+                # it against the same bounded attempt budget as exceptions.
+                try:
+                    from tools.async_delegation import (
+                        claim_event_delivery,
+                        release_event_delivery,
+                    )
+                    format_claim = claim_event_delivery(
+                        evt, "process-registry-empty-formatter"
+                    )
+                except Exception:
+                    format_claim = ""
+                if format_claim is None:
+                    continue
+                if format_claim:
+                    try:
+                        release_event_delivery(evt, format_claim)
+                    except Exception:
+                        pass
+                requeue.append(evt)
         for evt in requeue:
             self.completion_queue.put(evt)
         return results
@@ -2626,6 +2755,106 @@ def _format_age(seconds: float) -> str:
     return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
+def _async_delegation_runtime_state_lines(evt: dict) -> list[str]:
+    """Annotate a completion with live and not-yet-delivered sibling work."""
+    session_key = str(evt.get("session_key") or "")
+    owner_session_keys = {
+        str(key) for key in (evt.get("_owner_session_keys") or []) if str(key)
+    }
+    origin_ui_session_id = str(evt.get("origin_ui_session_id") or "")
+    parent_session_id = str(evt.get("parent_session_id") or "")
+    owner_parent_session_ids = {
+        str(value)
+        for value in (evt.get("_owner_parent_session_ids") or [])
+        if str(value)
+    }
+    if not session_key and not owner_session_keys and not origin_ui_session_id and not parent_session_id:
+        return []
+
+    from tools.async_delegation import owner_work_counts
+
+    (
+        active_units,
+        active_tasks,
+        pending_units,
+        pending_tasks,
+        unavailable_units,
+        unavailable_tasks,
+        state_known,
+    ) = owner_work_counts(
+        session_key=session_key,
+        session_keys=owner_session_keys,
+        origin_ui_session_id=origin_ui_session_id,
+        parent_session_id=parent_session_id,
+        parent_session_ids=owner_parent_session_ids,
+        exclude_delegation_id=str(evt.get("delegation_id") or ""),
+    )
+    lineage_known = evt.get("_owner_session_lineage_known", True) is not False
+    outcome_known = str(evt.get("status") or "completed") != "unknown"
+    state_known = state_known and lineage_known
+    evt["remaining_active_delegations"] = active_units
+    evt["remaining_active_subagents"] = active_tasks
+    evt["pending_completion_delegations"] = pending_units
+    evt["pending_completion_subagents"] = pending_tasks
+    evt["unavailable_completion_delegations"] = unavailable_units
+    evt["unavailable_completion_subagents"] = unavailable_tasks
+    evt["owned_work_state_known"] = state_known
+    evt["all_owned_subagents_terminal"] = state_known and active_units == 0
+    evt["all_owned_results_available"] = (
+        state_known
+        and outcome_known
+        and active_units == 0
+        and pending_units == 0
+        and unavailable_units == 0
+    )
+
+    if not state_known:
+        return [
+            "",
+            "--- BACKGROUND WORK STATE ---",
+            "Could not verify whether other completion results await delivery. "
+            "Do not present a final synthesis yet unless the user explicitly "
+            "asks for a partial result.",
+        ]
+    if active_units or pending_units:
+        return [
+            "",
+            "--- BACKGROUND WORK STATE ---",
+            f"{active_tasks} subagent task(s) across {active_units} delegation(s) "
+            f"are still running; {pending_tasks} completed result(s) still await "
+            f"delivery across {pending_units} delegation(s). Do not present a "
+            "final synthesis yet; "
+            "wait for the remaining completion event(s), unless the user "
+            "explicitly asks for a partial result.",
+        ]
+    if unavailable_units:
+        return [
+            "",
+            "--- BACKGROUND WORK STATE ---",
+            f"{unavailable_tasks} result(s) are unavailable across "
+            f"{unavailable_units} delegation(s) because they were dropped or "
+            "their outcome is unknown. Do not claim a complete final "
+            "synthesis from the delivered results; inspect the delegation "
+            "records or rerun the missing work.",
+        ]
+    if not outcome_known:
+        return [
+            "",
+            "--- BACKGROUND WORK STATE ---",
+            "This delegation's outcome is unknown because its owner exited "
+            "before recording a terminal result. Do not claim a complete final "
+            "synthesis from the delivered results; inspect the delegation "
+            "records or rerun the missing work.",
+        ]
+    return [
+        "",
+        "--- BACKGROUND WORK STATE ---",
+        "No other background delegations owned by this session are still "
+        "running or awaiting result delivery. This result may now be included "
+        "in a final synthesis after any required parent-side verification.",
+    ]
+
+
 def _format_async_delegation(evt: dict) -> str:
     """Format an async-delegation completion into a self-contained re-injection.
 
@@ -2682,6 +2911,7 @@ def _format_async_delegation(evt: dict) -> str:
         if error and not results:
             lines.append("--- ERROR ---")
             lines.append(f"The batch did not complete successfully: {error}")
+            lines.extend(_async_delegation_runtime_state_lines(evt))
             return "\n".join(lines)
         for r in sorted(results, key=lambda x: x.get("task_index", 0)):
             idx = r.get("task_index", 0)
@@ -2719,6 +2949,7 @@ def _format_async_delegation(evt: dict) -> str:
                 lines.append(
                     f"Full live transcript (complete tool/assistant trace): {r_live}"
                 )
+        lines.extend(_async_delegation_runtime_state_lines(evt))
         return "\n".join(lines)
 
     age = ""
@@ -2762,6 +2993,7 @@ def _format_async_delegation(evt: dict) -> str:
         if summary:
             lines.append("Partial output:")
             lines.append(summary)
+    lines.extend(_async_delegation_runtime_state_lines(evt))
     return "\n".join(lines)
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8949,6 +8949,33 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
     return resolved_key in current_keys
 
 
+def _notification_owner_session_keys(sid: str, session: dict, evt: dict) -> list[str]:
+    """Return compression-lineage session keys for owner-scoped work counts."""
+    keys = {
+        str(evt.get("session_key") or ""),
+        str(session.get("session_key") or ""),
+        str(_session_lookup_key(session, fallback=sid) or ""),
+    }
+    lineage_keys = {key for key in keys if key}
+    lineage_known = not lineage_keys
+    try:
+        db = _get_db()
+        if lineage_keys and db is not None:
+            lineage_known = True
+            for key in tuple(lineage_keys):
+                lineage = db.get_compression_lineage(key)
+                if not lineage:
+                    lineage_known = False
+                    continue
+                keys.update(str(item) for item in lineage if str(item))
+        elif lineage_keys:
+            lineage_known = False
+    except Exception:
+        lineage_known = False
+    evt["_owner_session_lineage_known"] = lineage_known
+    return sorted(keys - {""})
+
+
 def _notification_event_requires_owner(evt: dict) -> bool:
     """Whether ``evt`` must be positively claimed before TUI delivery."""
     return evt.get("type") == "async_delegation" or bool(
@@ -9222,8 +9249,33 @@ def _notification_poller_loop(
                         )
                         with session["history_lock"]:
                             session["running"] = False
+        def _poller_accepts_event(candidate: dict) -> bool:
+            if _notification_event_belongs_elsewhere(sid, session, candidate):
+                return False
+            if not _notification_event_requires_owner(candidate):
+                return True
+            if _session_owns_notification_event(sid, session, candidate):
+                return True
+            # Preserve unresolved async events in the shared queue. Ordinary
+            # addressed notifications retain the legacy dequeue-and-drop path.
+            return candidate.get("type") != "async_delegation"
+
         try:
-            evt = process_registry.completion_queue.get(timeout=0.5)
+            notification_snapshot = process_registry.snapshot_notifications(timeout=0.5)
+        except Exception:
+            continue
+        accepted_events = tuple(
+            candidate
+            for candidate in notification_snapshot[0]
+            if _poller_accepts_event(candidate)
+        )
+        if not accepted_events:
+            time.sleep(0.1)
+            continue
+        try:
+            evt = process_registry.get_matching_notification(
+                notification_snapshot, accepted_events
+            )
         except Exception:
             continue
 
@@ -9250,54 +9302,92 @@ def _notification_poller_loop(
                 else logger.debug
             )
             log(
-                "Dropping unowned %s notification (origin=%r key=%r) instead "
+                "%s unowned %s notification (origin=%r key=%r) instead "
                 "of delivering to session %s",
+                "Deferring durably" if evt.get("type") == "async_delegation" else "Dropping",
                 evt.get("type", "completion"),
                 str(evt.get("origin_ui_session_id") or ""),
                 str(evt.get("session_key") or ""),
                 sid,
             )
+            # The selective dequeue predicate proved ownership once, but a
+            # session finalization/lineage race or transient DB failure can make
+            # this second check fail. Put async events back: selective dequeue
+            # prevents unrelated pollers from stealing them, so this no longer
+            # creates the old cross-session get/put ping-pong.
+            if evt.get("type") == "async_delegation":
+                process_registry.completion_queue.put(evt)
+                time.sleep(1.0)
             continue
 
         _evt_sid = evt.get("session_id", "")
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
             continue
 
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        # Only emit the same notification identity to TUI once — re-queued
-        # completions get re-emitted every 0.5s otherwise when session is busy,
-        # while distinct watch_match events from the same process must remain
-        # visible independently.
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        _requeued = False
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                _requeued = True
-            else:
-                session["running"] = True
-        if _requeued:
-            # Back off before re-polling: the re-queued event keeps the queue
-            # non-empty, so without a sleep this loop spins at full speed
-            # (100% CPU, GIL churn) for as long as the session stays busy.
-            time.sleep(0.25)
-            continue
-
-        rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
             claim_event_delivery, complete_event_delivery, release_event_delivery,
         )
-        _claim = claim_event_delivery(evt, "tui-poller")
+        try:
+            _claim = claim_event_delivery(evt, "tui-poller")
+        except Exception as exc:
+            process_registry.completion_queue.put(evt)
+            print(
+                f"[tui_gateway] notification claim failed: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            continue
         if _claim is None:
             continue
+        _turn_started = False
+        _accepted = False
         try:
+            if evt.get("type") == "async_delegation":
+                evt["_owner_session_keys"] = _notification_owner_session_keys(
+                    sid, session, evt
+                )
+            text = format_process_notification(evt)
+            if not text:
+                try:
+                    release_event_delivery(evt, _claim)
+                except Exception:
+                    pass
+                process_registry.completion_queue.put(evt)
+                # Empty formatter output is retryable, but an immediately
+                # requeued event keeps the shared queue hot. Back off so a
+                # persistent invalid payload cannot spin at 100% CPU or burn
+                # the durable attempt budget in a tight loop.
+                time.sleep(1.0)
+                continue
+
+            # Claim before emitting status so a losing consumer never shows a
+            # duplicate visible completion.
+            _dedup_key = _notification_event_dedup_key(evt)
+            if _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                _emitted.add(_dedup_key)
+
+            with session["history_lock"]:
+                if session.get("running"):
+                    process_registry.completion_queue.put(evt)
+                    _requeued = True
+                else:
+                    session["running"] = True
+                    _turn_started = True
+                    _requeued = False
+            if _requeued:
+                try:
+                    release_event_delivery(evt, _claim)
+                except Exception:
+                    pass
+                # Back off before re-polling: the re-queued event keeps the
+                # queue non-empty, so without a sleep this loop spins at full
+                # speed (100% CPU, GIL churn) for as long as the session stays
+                # busy.
+                time.sleep(0.25)
+                continue
+
+            rid = f"__notif__{int(time.time() * 1000)}"
             _emit("message.start", sid)
             if evt.get("type") == "async_delegation":
                 _run_prompt_submit(
@@ -9310,16 +9400,23 @@ def _notification_poller_loop(
                 )
             else:
                 _run_prompt_submit(rid, sid, session, text)
+            _accepted = True
             complete_event_delivery(evt, _claim)
         except Exception as exc:
-            release_event_delivery(evt, _claim)
+            if not _accepted:
+                try:
+                    release_event_delivery(evt, _claim)
+                except Exception:
+                    pass
+                process_registry.completion_queue.put(evt)
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
             with session["history_lock"]:
-                session["running"] = False
+                if _turn_started and not _accepted:
+                    session["running"] = False
 
     # Drain any remaining events after stop signal (process all pending
     # before exiting so nothing is lost on shutdown). Events owned by other
@@ -9353,29 +9450,46 @@ def _notification_poller_loop(
         _evt_sid = evt.get("session_id", "")
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
             continue
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                break
-            session["running"] = True
-
-        rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
             claim_event_delivery, complete_event_delivery, release_event_delivery,
         )
-        _claim = claim_event_delivery(evt, "tui-poller")
+        try:
+            _claim = claim_event_delivery(evt, "tui-poller")
+        except Exception as exc:
+            deferred.append(evt)
+            print(
+                f"[tui_gateway] notification claim failed during shutdown drain: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            continue
         if _claim is None:
             continue
+        _accepted = False
         try:
+            if evt.get("type") == "async_delegation":
+                evt["_owner_session_keys"] = _notification_owner_session_keys(
+                    sid, session, evt
+                )
+            text = format_process_notification(evt)
+            if not text:
+                release_event_delivery(evt, _claim)
+                deferred.append(evt)
+                continue
+
+            _dedup_key = _notification_event_dedup_key(evt)
+            if _dedup_key not in _emitted:
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                _emitted.add(_dedup_key)
+
+            with session["history_lock"]:
+                if session.get("running"):
+                    process_registry.completion_queue.put(evt)
+                    release_event_delivery(evt, _claim)
+                    break
+                session["running"] = True
+
+            rid = f"__notif__{int(time.time() * 1000)}"
             _emit("message.start", sid)
             if evt.get("type") == "async_delegation":
                 _run_prompt_submit(
@@ -9388,16 +9502,23 @@ def _notification_poller_loop(
                 )
             else:
                 _run_prompt_submit(rid, sid, session, text)
+            _accepted = True
             complete_event_delivery(evt, _claim)
         except Exception as exc:
-            release_event_delivery(evt, _claim)
+            if not _accepted:
+                try:
+                    release_event_delivery(evt, _claim)
+                except Exception:
+                    pass
+                process_registry.completion_queue.put(evt)
             print(
                 f"[tui_gateway] notification poller dispatch failed: "
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
             with session["history_lock"]:
-                session["running"] = False
+                if not _accepted:
+                    session["running"] = False
 
     # Hand any other sessions' events back to the shared queue.
     for evt in deferred:
@@ -9410,7 +9531,10 @@ def _async_delegation_display_metadata(evt: dict) -> dict:
     results: list[dict] = [
         result for result in raw_results if isinstance(result, dict)
     ] if isinstance(raw_results, list) else []
-    task_count = len(results) or 1
+    raw_goals = evt.get("goals")
+    goals = raw_goals if isinstance(raw_goals, list) else []
+    is_batch = bool(evt.get("is_batch")) or isinstance(raw_results, list)
+    task_count = len(goals) if is_batch and goals else (len(results) or 1)
     completed_count = sum(
         1 for result in results
         if result.get("status") in {"completed", "success"}
@@ -9419,15 +9543,41 @@ def _async_delegation_display_metadata(evt: dict) -> dict:
         1 for result in results
         if result.get("status") in {"failed", "error"}
     )
+    if not results and is_batch and evt.get("error"):
+        failed_count = task_count
+    elif not results and not is_batch:
+        status = str(evt.get("status") or "completed")
+        completed_count = 1 if status in {"completed", "success"} else 0
+        failed_count = 1 if status in {"failed", "error"} else 0
     metadata = {
         "delegation_id": str(evt.get("delegation_id") or ""),
         "task_count": task_count,
-        "completed_count": completed_count or task_count - failed_count,
+        "completed_count": completed_count,
         "failed_count": failed_count,
     }
     duration = evt.get("total_duration_seconds") or evt.get("duration_seconds")
     if isinstance(duration, (int, float)):
         metadata["duration_seconds"] = duration
+    for key in (
+        "remaining_active_delegations",
+        "remaining_active_subagents",
+        "pending_completion_delegations",
+        "pending_completion_subagents",
+        "unavailable_completion_delegations",
+        "unavailable_completion_subagents",
+    ):
+        value = evt.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            metadata[key] = value
+    terminal = evt.get("all_owned_subagents_terminal")
+    if isinstance(terminal, bool):
+        metadata["all_owned_subagents_terminal"] = terminal
+    available = evt.get("all_owned_results_available")
+    if isinstance(available, bool):
+        metadata["all_owned_results_available"] = available
+    state_known = evt.get("owned_work_state_known")
+    if isinstance(state_known, bool):
+        metadata["owned_work_state_known"] = state_known
     return metadata
 
 
@@ -10311,8 +10461,10 @@ def _run_prompt_submit(
         # requeues every addressed event this session cannot positively claim;
         # the poller then delivers it to a live owner or drops an orphan.
         try:
-            from tools.process_registry import process_registry
-
+            from tools.process_registry import (
+                format_process_notification,
+                process_registry,
+            )
             # Positive-proof ownership (compression-chain aware) — the same
             # fail-closed gate the poller uses, so the post-turn drain can't
             # adopt another session's addressed notification while a
@@ -10323,32 +10475,70 @@ def _run_prompt_submit(
                 owns_event=lambda e: _session_owns_notification_event(sid, session, e),
                 skip_poll_observed=False,
             )
+            def _requeue_notifications(start_index: int) -> None:
+                for pending_evt, _pending_synth in drained[start_index:]:
+                    process_registry.completion_queue.put(pending_evt)
+
             for index, (_evt, synth) in enumerate(drained):
                 with session["history_lock"]:
                     if session.get("running"):
-                        for pending_evt, _pending_synth in drained[index:]:
-                            process_registry.completion_queue.put(pending_evt)
+                        _requeue_notifications(index)
                         break
-                    session["running"] = True
+
                 from tools.async_delegation import (
                     claim_event_delivery, complete_event_delivery, release_event_delivery,
                 )
-                _claim = claim_event_delivery(_evt, "tui-post-turn")
+                try:
+                    _claim = claim_event_delivery(_evt, "tui-post-turn")
+                except Exception as _claim_exc:
+                    _requeue_notifications(index)
+                    print(
+                        f"[tui_gateway] completion notification claim failed: "
+                        f"{type(_claim_exc).__name__}: {_claim_exc}",
+                        file=sys.stderr,
+                    )
+                    break
                 if _claim is None:
                     continue
+                _accepted = False
                 try:
+                    if _evt.get("type") == "async_delegation":
+                        _evt["_owner_session_keys"] = _notification_owner_session_keys(
+                            sid, session, _evt
+                        )
+                        refreshed = format_process_notification(_evt)
+                        if refreshed:
+                            synth = refreshed
+                    with session["history_lock"]:
+                        if session.get("running"):
+                            release_event_delivery(_evt, _claim)
+                            _requeue_notifications(index)
+                            break
+                        session["running"] = True
                     _emit("message.start", sid)
                     _run_prompt_submit(rid, sid, session, synth)
+                    _accepted = True
                     complete_event_delivery(_evt, _claim)
                 except Exception as _n_exc:
-                    release_event_delivery(_evt, _claim)
+                    if not _accepted:
+                        try:
+                            release_event_delivery(_evt, _claim)
+                        except Exception:
+                            pass
+                        _requeue_notifications(index)
+                    else:
+                        # Current turn was accepted. Requeue only the untouched
+                        # suffix; replaying this event would duplicate the turn.
+                        _requeue_notifications(index + 1)
                     print(
                         f"[tui_gateway] completion notification dispatch failed: "
                         f"{type(_n_exc).__name__}: {_n_exc}",
                         file=sys.stderr,
                     )
                     with session["history_lock"]:
-                        session["running"] = False
+                        if not _accepted:
+                            session["running"] = False
+                    break
         except Exception as _drain_exc:
             print(
                 f"[tui_gateway] completion queue drain failed: "


### PR DESCRIPTION
## What does this PR do?

Async delegation completion turns currently describe only the child that just finished. When a parent owns multiple background delegations, it can mistake an intermediate completion for the last result and publish a final synthesis before the remaining results arrive.

This change annotates each completion at delivery time with owner-scoped background-work state. It distinguishes live child work, terminal results still pending delivery, and results dropped before delivery. It tells the parent not to claim a complete synthesis unless the state is known and every result is available. The count combines the in-memory live registry with the existing durable delivery ledger, follows compression lineage, fails closed if the ledger cannot be read, and does not block the agent loop or mutate prior conversation history.

## Related Issue

No existing issue or PR found after searching open and closed issues/PRs for active subagents, async delegation completion, premature final responses, and background delegation metadata.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/async_delegation.py`: count owner-scoped live units/tasks plus pending and dropped terminal results, using both the live registry and durable SQLite ledger; corrupted persisted events are terminally marked dropped instead of remaining pending forever.
- `tools/process_registry.py`: append a fail-closed background-work-state block, expose additive fields for active/pending/unavailable/terminal/synthesis-ready state, selectively dequeue owner-matching events, and route persistent formatter failures through the bounded durable attempt ledger.
- `cli.py`: resolve compression lineage and reformat each async completion only after its durable delivery claim succeeds; claim/format failures remain retryable without immediately duplicating an already accepted turn after ack failure.
- `gateway/run.py`: claim async completions before enrichment/formatting so persistent failures consume the bounded durable retry budget; requeue transient failures, and cap ordinary terminal formatter retries at three attempts.
- `tui_gateway/server.py`: claim before visible emission, preserve retryability across claim/format/dispatch failures with bounded backoff, selectively dequeue only owner-proven async events, avoid wedging `session.running`, avoid replaying accepted turns on ack failure, and pass additive state into timeline metadata.
- `apps/desktop/src/types/hermes.ts`: type the optional delegation metadata fields for Desktop consumers.
- Tests cover session isolation and compression lineage, batch task expansion, multiple terminal results waiting before delivery, dropped/unknown results, malformed durable JSON, competing claims, real-drain formatter failures, claim/format/dispatch/ack failures, multi-event drains, last-result signaling, fail-closed ledger/lineage errors, async busy-state ownership, and metadata propagation.

## How to Test

1. Run targeted backend coverage:
   ```bash
   python -m pytest -q \
     tests/tools/test_async_delegation.py \
     tests/tools/test_process_registry.py \
     tests/cli/test_cli_async_delegation_delivery.py
   ```
   Result after rebasing on current `main`: targeted module and mixed-order coverage reports `703 passed`, with the same two unrelated toolset failures explicitly deselected after reproduction on clean `main`.
2. Run Desktop checks:
   ```bash
   npm run typecheck --workspace apps/desktop
   eslint apps/desktop/src/types/hermes.ts
   ```
   Result: both pass.
3. An earlier full repository-wrapper comparison was also run on the branch and a detached clean-main worktree:
   ```bash
   scripts/run_tests.sh
   ```
   Before the final rebase, the branch had 38 failures in 13 files plus one collection failure; clean `main` had 40 failures in 15 files plus the same collection failure. Branch failures were a strict subset of the baseline and were caused by unavailable optional integrations/lazy installs in this local profile. The post-rebase changed scope was then rerun with the results above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full-suite failures are baseline-only and documented above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux, Python 3.11, Node 22

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented in code and completion text
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — stdlib Python/SQLite and additive JSON metadata only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

Targeted tests:

```text
703 passed, 2 known baseline toolset tests deselected (mixed CLI/gateway/TUI/async/registry order)
```

The regression coverage includes the critical ordering case where two delegations are already terminal before either completion is integrated: the first turn reports another pending result and forbids final synthesis; only the last delivered turn reports all results available.

Selective TUI dequeue coverage also verifies that ownership callbacks run outside the shared Queue mutex, unmatched event order is preserved, and Queue task accounting reaches `join()` after the remaining task is completed.
