### PR TITLE
fix(desktop): send full tool args to desktop so expanded rows show the whole command

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -17,6 +17,30 @@ import {
 } from './chat-messages'
 
 describe('toChatMessages', () => {
+  it('rebuilds the full command from a gateway tool row carrying args', () => {
+    // Gateway watch-window hydration projects tool rows as
+    // {role:'tool', name, context, args?}. `context` is an 80-char preview;
+    // the backend also ships the full args, and the part must carry them so
+    // the expanded `$` transcript shows the whole command.
+    const longCommand = `echo ${'x'.repeat(200)}`
+    const messages = toChatMessages([
+      { role: 'user', content: 'run it', timestamp: 1 },
+      {
+        role: 'tool',
+        name: 'terminal',
+        content: '',
+        context: `${longCommand.slice(0, 79)}…`,
+        args: { command: longCommand },
+        timestamp: 2
+      }
+    ])
+
+    const toolPart = messages.flatMap(m => m.parts).find(part => part.type === 'tool-call')
+
+    expect(toolPart).toBeDefined()
+    expect((toolPart as { args: { command?: string } }).args.command).toBe(longCommand)
+  })
+
   it('keeps a turn with interleaved tool-only rows in a single bubble', () => {
     const messages = toChatMessages([
       { role: 'assistant', content: 'Planning.', timestamp: 1 },

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -861,7 +861,12 @@ function applyStoredToolResultToParts(parts: ChatMessagePart[], toolMessage: Ses
 function storedToolMessagePart(toolMessage: SessionMessage, fallbackIndex: number): ChatMessagePart {
   const name = toolMessage.tool_name || toolMessage.name || 'tool'
   const context = textFromUnknown(toolMessage.context || toolMessage.text || toolMessage.content || '')
-  const args = context ? { context } : {}
+  // Prefer the full arguments when the gateway projection carries them:
+  // `context` is an 80-char display preview, and the expanded tool row
+  // rebuilds the real command from args. Keep `context` alongside as the
+  // title-side placeholder.
+  const storedArgs = parseMaybeJsonObject(toolMessage.args)
+  const args = { ...storedArgs, ...(context ? { context } : {}) }
 
   return {
     type: 'tool-call',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -542,6 +542,12 @@ export interface MessageReaction {
 }
 
 export interface SessionMessage {
+  /**
+   * Full tool arguments for a gateway-projected tool row (`role: 'tool'`).
+   * `context` is an 80-char display preview. The expanded tool row rebuilds
+   * the full call from this field. Absent on a backend older than this app.
+   */
+  args?: unknown
   codex_reasoning_items?: unknown
   content: unknown
   context?: unknown

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2190,10 +2190,75 @@ def test_history_to_messages_preserves_tool_calls_for_resume_display():
 
     assert server._history_to_messages(history) == [
         {"role": "user", "text": "first prompt"},
-        {"context": "resume", "name": "search_files", "role": "tool"},
+        {
+            "args": {"pattern": "resume"},
+            "context": "resume",
+            "name": "search_files",
+            "role": "tool",
+        },
         {"role": "assistant", "text": "first answer"},
         {"role": "user", "text": "second prompt"},
     ]
+
+
+def test_history_to_messages_ships_full_tool_args():
+    # This is the display projection. `context` is an 80-char preview for
+    # collapsed row titles. A renderer that shows the full call (the expanded
+    # `$` transcript in the desktop) rebuilds it from `args`. When the
+    # projection dropped the args, the preview truncation was permanent.
+    long_command = "echo " + "x" * 200
+    history = [
+        {"role": "user", "content": "run it"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": long_command}),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "content": "{}", "tool_call_id": "call_1"},
+    ]
+
+    rows = server._history_to_messages(history)
+    assert rows[1]["args"] == {"command": long_command}
+    # The preview stays alongside for the collapsed title.
+    assert rows[1]["context"]
+
+    # A tool row with no recorded args keeps the old small shape.
+    argless = server._history_to_messages(
+        [{"role": "tool", "content": "{}", "tool_call_id": "missing"}]
+    )
+    assert "args" not in argless[0]
+
+
+def test_tool_start_ships_full_args(monkeypatch):
+    # The desktop rebuilds the expanded row's `$` transcript from args. When
+    # only the 80-char `context` preview shipped, the expanded command was
+    # truncated until tool.complete. tool.complete already ships full args to
+    # every client, so tool.start does too. There is no per-client gate.
+    events: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+    )
+    long_command = "echo " + "y" * 200
+    monkeypatch.setitem(
+        server._sessions,
+        "args-test",
+        {"source": "desktop", "tool_progress_mode": "all", "tool_started_at": {}},
+    )
+
+    server._on_tool_start("args-test", "tool-1", "terminal", {"command": long_command})
+    server._on_tool_start("args-test", "tool-2", "terminal", {})
+
+    assert events[0][2]["args"] == {"command": long_command}
+    # Empty args stay omitted. Argless tools get no noise key.
+    assert "args" not in events[1][2]
 
 
 def test_tool_ctx_sends_an_arg_preview_not_a_phrased_label():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5439,11 +5439,18 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
     if _tool_progress_enabled(sid) or _tool_lifecycle_required_for_ui(name):
-        payload = {
+        payload: dict[str, object] = {
             "tool_id": tool_call_id,
             "name": name,
             "context": _tool_ctx(name, args),
         }
+        # The desktop renders the expanded tool row (the `$` transcript) from
+        # the args of the part, and `context` is an 80-char display preview.
+        # tool.complete already ships full args to every client. When
+        # tool.start ships them too, the expanded row is complete while the
+        # tool runs, at the cost of one duplicate transient payload per call.
+        if args:
+            payload["args"] = args
         if _session_verbose(sid):
             args_text = _tool_args_text(args)
             if args_text:
@@ -7112,9 +7119,15 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             tc_info = tool_call_args.get(tc_id) if tc_id else None
             name = (tc_info[0] if tc_info else None) or m.get("tool_name") or "tool"
             args = (tc_info[1] if tc_info else None) or {}
-            messages.append(
-                {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
-            )
+            tool_msg = {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
+            # This is the display projection, so keep it faithful. `context`
+            # is an 80-char preview for collapsed row titles. A renderer that
+            # shows the full call (the expanded `$` transcript in the desktop)
+            # rebuilds it from args. When only the preview shipped, that
+            # truncation was permanent.
+            if args:
+                tool_msg["args"] = args
+            messages.append(tool_msg)
             continue
         # An assistant turn may carry only reasoning/thinking content with no
         # visible text (extended-thinking turns, thinking-only recovery


### PR DESCRIPTION
## What does this PR do?

In the desktop app, a long terminal command shows `...` in the tool-row title. This truncation is correct for the title. But the command stays truncated after the user expands the row.

The desktop rebuilds the expanded row (the `$` transcript) from the args of the tool part. The gateway sent only `context`, an 80-char preview from `build_tool_preview(max_len=80)`. When the args were absent, `shellCommand()` fell back to the preview. Two paths had this fault:

- **`tool.start`** (`_on_tool_start`): the payload had no args. Full args arrived only on `tool.complete`. The expanded row was truncated for the full run time of the tool.
- **`_history_to_messages`**: the projection read the full arguments from `tool_calls`, then discarded them after it built the preview. Watch-window (subagent) hydration kept only the preview, so the truncation was permanent there.

The fix sends the full `args` in both paths. `tool.start` ships the args, the same as `tool.complete` already does. `_history_to_messages` is the display view of the transcript, so its tool rows now carry the args. Each renderer decides what to paint: the preview stays for collapsed titles, and the expanded row rebuilds the full call from the args. The DB schema and rows do not change: the args already persist in `tool_calls` on the assistant row.

### Before

Toolcall running:
<img width="1062" height="216" alt="image" src="https://github.com/user-attachments/assets/28dc1ac2-0eff-428a-b00e-07299e91d4c0" />

Toolcall done:
<img width="1008" height="307" alt="image" src="https://github.com/user-attachments/assets/747bde5b-8fbe-4da8-96aa-97d843e166b4" />

### After:
Toolcall running:
<img width="958" height="196" alt="image" src="https://github.com/user-attachments/assets/1f9dcc2c-b875-4e01-9971-6c0731a935eb" />

Toolcall done:
<img width="972" height="310" alt="image" src="https://github.com/user-attachments/assets/d13edcbf-96bf-4e19-a24d-20650937eabb" />

## Related Issue

Fixes # (no issue — found during desktop use)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: `_on_tool_start` adds `args` to the `tool.start` payload. `_history_to_messages` adds `args` to each tool row that has recorded arguments.
- `apps/desktop/src/types/hermes.ts`: `SessionMessage` gets an optional `args` field.
- `apps/desktop/src/lib/chat-messages.ts`: `storedToolMessagePart` merges the full args into the tool part. `context` stays as the title-side preview.
- `tests/test_tui_gateway_server.py`, `apps/desktop/src/lib/chat-messages.test.ts`: tests for both sides.

## How to Test

1. In the desktop app, run a terminal command that is longer than 80 characters.
2. Expand the tool row while the command runs. Before this fix, the `$` line ended in `...`. Now it shows the full command.
3. Open a subagent watch window with a long command in its history. The expanded row shows the full command.
4. Run `scripts/run_tests.sh tests/tui_gateway tests/test_tui_gateway_server.py tests/test_tui_gateway_server_crash_history.py tests/test_tui_gateway_ws.py` — 942 tests pass.
5. From `apps/desktop`, run `npx vitest run src/lib/` — 649 tests pass — and `npx tsc --noEmit` — clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


