### PR TITLE
fix(simplex): deliver DMs addressed by display name

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -101,6 +101,19 @@ def _redact_id(contact_id: str) -> str:
     return s[:2] + "**" + s[-2:]
 
 
+def _text_send_command(chat_id: str, text: str) -> str:
+    """Compose a text send for a numeric ID, group ID, or display name."""
+    if chat_id.startswith("group:"):
+        chat_ref = f"#{chat_id[6:]}"
+    elif chat_id.isdigit():
+        chat_ref = f"@{chat_id}"
+    else:
+        return f"@{chat_id} {text}"
+
+    composed = json.dumps([{"msgContent": {"type": "text", "text": text}}])
+    return f"/_send {chat_ref} json {composed}"
+
+
 def _guess_extension(data: bytes) -> str:
     """Guess file extension from magic bytes."""
     if data[:4] == b"\x89PNG":
@@ -814,9 +827,10 @@ class SimplexAdapter(BasePlatformAdapter):
         Groups use the structured ``/_send #<id> json [...]`` form
         because the bracket chat-command syntax (``#[<id>] text``) is
         parsed by the daemon as a display-name lookup, which silently
-        drops when the group's display name isn't the literal ID. DMs
-        use the simple ``@<id> text`` form which has always worked in
-        production.
+        drops when the group's display name isn't the literal ID. Numeric
+        DM contact IDs use the same structured form; display-name DMs use
+        the bare ``@<name> text`` form because the daemon rejects names in
+        structured chat references.
 
         The call is fire-and-forget at the WebSocket level: the daemon
         doesn't always return a corrId reply for chat commands, and
@@ -830,18 +844,7 @@ class SimplexAdapter(BasePlatformAdapter):
 
         if content:
             corr_id = self._make_corr_id()
-            # Structured form: addresses by ID, and json.dumps escapes
-            # newlines + special chars correctly.  The bare @id text
-            # syntax is unreliable for DMs — the daemon silently drops
-            # messages when it cannot resolve the display name.
-            composed = json.dumps(
-                [{"msgContent": {"type": "text", "text": content}}]
-            )
-            if chat_id.startswith("group:"):
-                cmd_str = f"/_send #{chat_id[6:]} json {composed}"
-            else:
-                cmd_str = f"/_send @{chat_id} json {composed}"
-
+            cmd_str = _text_send_command(chat_id, content)
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 
         for path in media_paths:
@@ -1262,15 +1265,7 @@ async def _standalone_send(
         return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
 
     try:
-        composed = json.dumps(
-            [{"msgContent": {"type": "text", "text": message}}]
-        )
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            cmd_str = f"/_send #{group_id} json {composed}"
-        else:
-            cmd_str = f"/_send @{chat_id} json {composed}"
-
+        cmd_str = _text_send_command(chat_id, message)
         payload = {
             "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",
             "cmd": cmd_str,

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -105,7 +105,7 @@ def _text_send_command(chat_id: str, text: str) -> str:
     """Compose a text send for a numeric ID, group ID, or display name."""
     if chat_id.startswith("group:"):
         chat_ref = f"#{chat_id[6:]}"
-    elif chat_id.isdigit():
+    elif chat_id.isascii() and chat_id.isdigit():
         chat_ref = f"@{chat_id}"
     else:
         return f"@{chat_id} {text}"

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -134,8 +134,8 @@ def test_corr_id_pending_set_self_trims():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_send_dm():
-    """DMs use the structured ``/_send @<id> json [...]`` form.
+async def test_send_numeric_dm():
+    """Numeric DMs use the structured ``/_send @<id> json [...]`` form.
 
     The bare ``@<id> text`` chat-command form is unreliable — the
     daemon silently drops messages when it cannot resolve the display
@@ -150,15 +150,30 @@ async def test_send_dm():
     mock_ws = AsyncMock()
     adapter._ws = mock_ws
 
-    result = await adapter.send("contact-42", "Hello, SimpleX!")
+    result = await adapter.send("42", "Hello, SimpleX!")
     mock_ws.send.assert_called_once()
     payload = json.loads(mock_ws.send.call_args[0][0])
-    assert payload["cmd"].startswith("/_send @contact-42 json ")
+    assert payload["cmd"].startswith("/_send @42 json ")
     msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
         "msgContent"
     ]
     assert msg_content == {"type": "text", "text": "Hello, SimpleX!"}
     assert payload["corrId"].startswith(_CORR_PREFIX)
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_send_display_name_dm():
+    """Display-name DMs use the bare command accepted by the daemon."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    adapter._ws = AsyncMock()
+
+    result = await adapter.send("alice", "Hello, SimpleX!")
+
+    payload = json.loads(adapter._ws.send.call_args[0][0])
+    assert payload["cmd"] == "@alice Hello, SimpleX!"
     assert result.success is True
 
 
@@ -325,13 +340,38 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
     import websockets
     monkeypatch.setattr(websockets, "connect", fake_connect)
 
-    result = await _standalone_send(pconfig, "contact-42", "hi")
-    assert result == {"success": True, "platform": "simplex", "chat_id": "contact-42"}
-    assert sent_payloads[0]["cmd"].startswith("/_send @contact-42 json ")
+    result = await _standalone_send(pconfig, "42", "hi")
+    assert result == {"success": True, "platform": "simplex", "chat_id": "42"}
+    assert sent_payloads[0]["cmd"].startswith("/_send @42 json ")
     msg_content = json.loads(
         sent_payloads[0]["cmd"].split(" json ", 1)[1]
     )[0]["msgContent"]
     assert msg_content == {"type": "text", "text": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_display_name_dm(monkeypatch):
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+    sent_payloads = []
+
+    class DummyWs:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def send(self, payload):
+            sent_payloads.append(json.loads(payload))
+
+    import websockets
+    monkeypatch.setattr(websockets, "connect", lambda *args, **kwargs: DummyWs())
+
+    result = await _standalone_send(pconfig, "alice", "hi")
+
+    assert sent_payloads[0]["cmd"] == "@alice hi"
+    assert result == {"success": True, "platform": "simplex", "chat_id": "alice"}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -163,17 +163,18 @@ async def test_send_numeric_dm():
 
 
 @pytest.mark.asyncio
-async def test_send_display_name_dm():
+@pytest.mark.parametrize("chat_id", ["alice", "１２"])
+async def test_send_display_name_dm(chat_id):
     """Display-name DMs use the bare command accepted by the daemon."""
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
     adapter = SimplexAdapter(cfg)
     adapter._ws = AsyncMock()
 
-    result = await adapter.send("alice", "Hello, SimpleX!")
+    result = await adapter.send(chat_id, "Hello, SimpleX!")
 
     payload = json.loads(adapter._ws.send.call_args[0][0])
-    assert payload["cmd"] == "@alice Hello, SimpleX!"
+    assert payload["cmd"] == f"@{chat_id} Hello, SimpleX!"
     assert result.success is True
 
 
@@ -350,7 +351,8 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_standalone_send_display_name_dm(monkeypatch):
+@pytest.mark.parametrize("chat_id", ["alice", "１２"])
+async def test_standalone_send_display_name_dm(monkeypatch, chat_id):
     pconfig = MagicMock()
     pconfig.extra = {"ws_url": "ws://localhost:5225"}
     sent_payloads = []
@@ -368,10 +370,10 @@ async def test_standalone_send_display_name_dm(monkeypatch):
     import websockets
     monkeypatch.setattr(websockets, "connect", lambda *args, **kwargs: DummyWs())
 
-    result = await _standalone_send(pconfig, "alice", "hi")
+    result = await _standalone_send(pconfig, chat_id, "hi")
 
-    assert sent_payloads[0]["cmd"] == "@alice hi"
-    assert result == {"success": True, "platform": "simplex", "chat_id": "alice"}
+    assert sent_payloads[0]["cmd"] == f"@{chat_id} hi"
+    assert result == {"success": True, "platform": "simplex", "chat_id": chat_id}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

SimpleX users can again send ordinary DMs to contacts selected by display name. The adapter previously sent every DM through structured `/_send`, which simplex-chat v7.0.0.11 rejects for display-name references with `commandError: Failed reading: empty`, so those messages were not delivered. This change keeps structured sending for numeric contact IDs and group IDs while using the daemon-compatible bare command for display-name DMs in both live and standalone text paths.

### Symptom

Sending an ordinary DM to a channel-directory contact identified by display name returns `commandError: Failed reading: empty` from the daemon and delivers no message.

### Impact

Display-name-addressed SimpleX DMs fail consistently. Numeric contact-ID and group delivery continue to work and must retain their structured addressing behavior.

### Bug Cause

**Trigger:** `plugins/platforms/simplex/adapter.py:814` in `SimplexAdapter.send()` and `plugins/platforms/simplex/adapter.py:1233` in `_standalone_send()` when `chat_id` is a display name.

**Causal chain:**
1. The channel directory exposes a contact display name as the DM target.
2. Both text-send paths unconditionally build `/_send @<target> json [...]`.
3. simplex-chat parses structured direct-chat references as numeric contact IDs, rejects the display name, and does not deliver the message.

**Why it is wrong:** A display name and a numeric contact ID require different daemon command forms, but the send paths applied the numeric-ID form to both.

**Working sibling / contrast:** Structured `/_send` succeeds for numeric contact IDs and group IDs. Bare `@<display-name> <text>` succeeds for display-name DMs.

**Ruled out:** This is not a general WebSocket or message-content encoding failure: the same daemon connection delivered bare display-name messages and structured numeric-ID messages with the exact test markers.

### Fix

A shared command builder now selects structured JSON sends for ASCII numeric contact IDs and group IDs, and bare sends for display-name targets. The live adapter and standalone cron delivery path use the same rule. ASCII-only numeric detection prevents Unicode digit-only display names from being misclassified as contact IDs.

## Related Issue

Closes #82648

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py` - select the text-send command from the target type and share it across live and standalone delivery.
- `tests/gateway/test_simplex_plugin.py` - cover numeric IDs, ordinary display names, Unicode digit-only display names, groups, and standalone delivery.

## How to Test

1. With simplex-chat v7.0.0.11, send a DM through the adapter to a display-name target and confirm the receiver gets the exact message.
2. Repeat with a numeric contact ID, the standalone sender, and a Unicode digit-only display name; confirm all markers are delivered through their expected command forms.
3. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/gateway/test_simplex_plugin.py -v
uvx ruff check plugins/platforms/simplex/adapter.py tests/gateway/test_simplex_plugin.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for the changed behavior
- [x] I've tested on Windows 10 with simplex-chat v7.0.0.11

### Documentation & Housekeeping

- [x] Documentation and docstrings are updated where relevant
- [x] Configuration examples are not affected
- [x] Contributor and architecture documentation are not affected
- [x] Cross-platform impact has been considered
- [x] Tool descriptions and schemas are not affected

## Screenshots / Logs

- Before: structured display-name send returned `commandError: Failed reading: empty` and delivered nothing.
- After: display-name, numeric-ID, standalone, and Unicode digit-only display-name markers were delivered in the real daemon environment.
- Automated: 20 focused tests passed; ruff reported no issues.
