### PR TITLE
fix(desktop): harden untrusted preview and embed boundaries (#82344)

### DIFF
--- a/apps/desktop/electron/link-title-window.test.ts
+++ b/apps/desktop/electron/link-title-window.test.ts
@@ -10,13 +10,16 @@ import {
 } from './link-title-window'
 
 function makeFakeBrowserWindow() {
-  const calls = { audioMuted: [] }
+  const calls = { audioMuted: [], windowOpenHandlers: [] }
 
   const FakeBrowserWindow = function (options) {
     this.options = options
     this.webContents = {
       setAudioMuted(value) {
         calls.audioMuted.push(value)
+      },
+      setWindowOpenHandler(handler) {
+        calls.windowOpenHandlers.push(handler)
       }
     }
   }
@@ -47,10 +50,20 @@ test('createLinkTitleWindow mutes audio so historical links never autoplay sound
   assert.deepEqual(calls.audioMuted, [true])
 })
 
+test('createLinkTitleWindow denies popup creation from fetched pages', () => {
+  const { FakeBrowserWindow, calls } = makeFakeBrowserWindow()
+
+  createLinkTitleWindow(FakeBrowserWindow, { id: 'link-titles' })
+
+  assert.equal(calls.windowOpenHandlers.length, 1)
+  assert.deepEqual(calls.windowOpenHandlers[0]({ url: 'https://attacker.example/popup' }), { action: 'deny' })
+})
+
 test('createLinkTitleWindow still returns the window if muting throws', () => {
   const ThrowingBrowserWindow = function (options) {
     this.options = options
     this.webContents = {
+      setWindowOpenHandler() {},
       setAudioMuted() {
         throw new Error('webContents unavailable')
       }

--- a/apps/desktop/electron/link-title-window.ts
+++ b/apps/desktop/electron/link-title-window.ts
@@ -3,6 +3,8 @@
 // in an offscreen window and read its title. That window loads arbitrary
 // user-linked pages, so it must never emit sound or trigger real downloads.
 
+import { installWindowOpenDenyGuard } from './window-open-guard'
+
 export function linkTitleWindowOptions(partitionSession) {
   return {
     show: false,
@@ -31,6 +33,12 @@ export function linkTitleWindowOptions(partitionSession) {
 // audio every time a session containing such links is re-rendered. See #49505.
 export function createLinkTitleWindow(BrowserWindow, partitionSession) {
   const window = new BrowserWindow(linkTitleWindowOptions(partitionSession))
+
+  // The title fetcher loads arbitrary remote pages in a hidden, sandboxed
+  // window. Keep their renderer-level `window.open()` requests from creating a
+  // native BrowserWindow; the visible app's explicit external-link bridge is
+  // the only supported path for opening a URL.
+  installWindowOpenDenyGuard(window.webContents)
 
   try {
     window.webContents.setAudioMuted(true)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -218,7 +218,13 @@ import {
 import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
+import {
+  enforcePreviewWebviewPolicy,
+  installPreviewWebviewNavigationGuard,
+  isAllowedPreviewWebviewUrl
+} from './webview-guard'
 import { readWindowBelow } from './window-below'
+import { installWindowOpenDenyGuard } from './window-open-guard'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -5010,6 +5016,39 @@ async function previewFileTarget(rawTarget, baseDir) {
   }
 }
 
+/**
+ * The normal preview policy accepts local files with an empty URL host. On
+ * Windows, pathToFileURL intentionally emits `file://server/share/...` for a
+ * validated UNC file. Keep that compatibility path narrow: the URL must be
+ * a Windows UNC shape, resolve through the existing IPC path normalizer, name
+ * an existing regular file, and round-trip byte-for-byte through Node's
+ * canonical pathToFileURL helper. This prevents arbitrary file authorities
+ * from becoming an attachment policy just because they have a hostname.
+ */
+function isValidatedPreviewWebviewUrl(rawUrl) {
+  const exactRawUrl = String(rawUrl || '')
+
+  if (isAllowedPreviewWebviewUrl(exactRawUrl)) {
+    return true
+  }
+
+  if (!IS_WINDOWS || !isAllowedPreviewWebviewUrl(exactRawUrl, { allowWindowsUnc: true })) {
+    return false
+  }
+
+  try {
+    new URL(exactRawUrl)
+    const resolved = resolveRequestedPathForIpc(exactRawUrl, { purpose: 'Preview webview' })
+
+    // Compare with the exact source URL Electron will load. URL's
+    // serializer can normalize spelling (for example, escaping or casing),
+    // which must not turn a non-canonical UNC request into an allowed one.
+    return fileExists(resolved) && pathToFileURL(resolved).toString() === exactRawUrl
+  } catch {
+    return false
+  }
+}
+
 function previewUrlTarget(rawTarget) {
   const raw = String(rawTarget || '').trim()
   const url = new URL(raw)
@@ -8829,10 +8868,21 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
   }
 
   installContextMenu(win)
-  win.webContents.setWindowOpenHandler(details => {
-    openExternalUrl(details.url)
-
-    return { action: 'deny' }
+  // Popup requests are untrusted renderer content. Denying them must not also
+  // dispatch the requested URL to the OS; explicit app links use the validated
+  // Desktop bridge and the preview header uses openPreviewInBrowser instead.
+  installWindowOpenDenyGuard(win.webContents)
+  win.webContents.on('will-attach-webview', (event, webPreferences, params) => {
+    enforcePreviewWebviewPolicy(event, webPreferences, params, isValidatedPreviewWebviewUrl)
+  })
+  // `<webview>` guests have their own WebContents and do not inherit the
+  // BrowserWindow's handler. Preview pages are arbitrary remote content, so
+  // deny their popup requests at the guest boundary as well. Users can use the
+  // preview header's explicit "open in browser" action when they want the
+  // current page outside Hermes.
+  win.webContents.on('did-attach-webview', (_event, guestContents) => {
+    installWindowOpenDenyGuard(guestContents)
+    installPreviewWebviewNavigationGuard(guestContents, isValidatedPreviewWebviewUrl)
   })
   win.webContents.on('will-navigate', (event, url) => {
     if ((DEV_SERVER && url.startsWith(DEV_SERVER)) || (!DEV_SERVER && url.startsWith('file:'))) {

--- a/apps/desktop/electron/webview-guard.test.ts
+++ b/apps/desktop/electron/webview-guard.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict'
+
+import type { WebContents } from 'electron'
+import { test } from 'vitest'
+
+import {
+  enforcePreviewWebviewPolicy,
+  installPreviewWebviewNavigationGuard,
+  isAllowedPreviewWebviewUrl,
+  PREVIEW_WEBVIEW_PARTITION
+} from './webview-guard'
+
+function fixture({
+  isAllowedUrl = isAllowedPreviewWebviewUrl,
+  partition = PREVIEW_WEBVIEW_PARTITION,
+  src = 'http://127.0.0.1:5173/'
+} = {}) {
+  let prevented = false
+
+  const webPreferences = {
+    allowRunningInsecureContent: true,
+    contextIsolation: false,
+    disableBlinkFeatures: 'DisableAttackerFeature',
+    enableBlinkFeatures: 'EnableAttackerFeature',
+    experimentalFeatures: true,
+    nodeIntegration: true,
+    nodeIntegrationInSubFrames: true,
+    nodeIntegrationInWorker: true,
+    partition: 'persist:attacker',
+    plugins: true,
+    preload: '/tmp/attacker-preload.js',
+    sandbox: false,
+    webSecurity: false,
+    webviewTag: true
+  }
+
+  const params: Record<string, string> = {
+    allowpopups: 'true',
+    blinkfeatures: 'EnableAttackerFeature',
+    disableblinkfeatures: 'DisableAttackerFeature',
+    nodeintegration: 'true',
+    nodeintegrationinsubframes: 'true',
+    partition,
+    preload: '/tmp/attacker-preload.js',
+    src,
+    webpreferences: 'nodeIntegration=yes,preload=/tmp/attacker-preload.js'
+  }
+
+  enforcePreviewWebviewPolicy({ preventDefault: () => (prevented = true) }, webPreferences, params, isAllowedUrl)
+
+  return { params, prevented, webPreferences }
+}
+
+test('pre-attach policy strips renderer preload and unsafe preferences', () => {
+  const { params, prevented, webPreferences } = fixture()
+
+  assert.equal(prevented, false)
+  assert.equal(webPreferences.preload, undefined)
+  assert.equal(webPreferences.enableBlinkFeatures, undefined)
+  assert.equal(webPreferences.disableBlinkFeatures, undefined)
+  assert.equal(webPreferences.nodeIntegration, false)
+  assert.equal(webPreferences.nodeIntegrationInSubFrames, false)
+  assert.equal(webPreferences.nodeIntegrationInWorker, false)
+  assert.equal(webPreferences.contextIsolation, true)
+  assert.equal(webPreferences.sandbox, true)
+  assert.equal(webPreferences.webSecurity, true)
+  assert.equal(webPreferences.webviewTag, false)
+  assert.equal(webPreferences.partition, PREVIEW_WEBVIEW_PARTITION)
+  assert.equal(params.preload, undefined)
+  assert.equal(params.blinkfeatures, undefined)
+  assert.equal(params.disableblinkfeatures, undefined)
+  assert.equal(params.webpreferences, undefined)
+  assert.equal(params.allowpopups, undefined)
+  assert.equal(params.partition, PREVIEW_WEBVIEW_PARTITION)
+})
+
+test('pre-attach policy rejects remote and non-preview guest sources', () => {
+  for (const source of ['https://attacker.example/', 'data:text/html,owned', 'about:blank']) {
+    const { prevented } = fixture({ src: source })
+
+    assert.equal(prevented, true, source)
+  }
+
+  assert.equal(fixture({ partition: 'persist:attacker' }).prevented, true)
+  assert.equal(isAllowedPreviewWebviewUrl('file:///tmp/preview.html'), true)
+  assert.equal(isAllowedPreviewWebviewUrl('file://server/share/report.html'), false)
+  assert.equal(isAllowedPreviewWebviewUrl('file://server/share/report.html', { allowWindowsUnc: true }), true)
+  assert.equal(isAllowedPreviewWebviewUrl('file://server'), false)
+  assert.equal(
+    fixture({
+      isAllowedUrl: url => isAllowedPreviewWebviewUrl(url, { allowWindowsUnc: true }),
+      src: 'file://server/share/report.html'
+    }).prevented,
+    false
+  )
+  assert.equal(isAllowedPreviewWebviewUrl('https://localhost:3000/'), true)
+  assert.equal(isAllowedPreviewWebviewUrl('https://[::1]:3000/'), true)
+  assert.equal(isAllowedPreviewWebviewUrl('https://[::2]:3000/'), false)
+  assert.equal(isAllowedPreviewWebviewUrl('https://attacker.example/'), false)
+})
+
+test('guest navigation guard blocks main-frame escapes but leaves safe subframes alone', () => {
+  const listeners = new Map<
+    string,
+    (event: { isMainFrame?: boolean; preventDefault: () => void; url: string }) => void
+  >()
+
+  installPreviewWebviewNavigationGuard({
+    on(event, listener) {
+      listeners.set(
+        event,
+        listener as (event: { isMainFrame?: boolean; preventDefault: () => void; url: string }) => void
+      )
+
+      return this
+    }
+  } as Pick<WebContents, 'on'>)
+
+  for (const event of ['will-navigate', 'will-frame-navigate', 'will-redirect']) {
+    const listener = listeners.get(event)
+
+    assert.ok(listener, `${event} listener was not installed`)
+
+    let prevented = false
+    listener({
+      isMainFrame: true,
+      preventDefault: () => (prevented = true),
+      url: 'https://attacker.example/redirect'
+    })
+    assert.equal(prevented, true, `${event} must block remote navigation`)
+
+    prevented = false
+    listener({
+      isMainFrame: true,
+      preventDefault: () => (prevented = true),
+      url: event === 'will-frame-navigate' ? 'file:///tmp/preview.html' : 'http://localhost:5173/preview'
+    })
+    assert.equal(prevented, false, `${event} must preserve allowed preview navigation`)
+
+    prevented = false
+    listener({
+      isMainFrame: false,
+      preventDefault: () => (prevented = true),
+      url: 'https://attacker.example/embedded'
+    })
+    assert.equal(prevented, false, `${event} must preserve non-main-frame embeds`)
+
+    prevented = false
+    listener({
+      isMainFrame: false,
+      preventDefault: () => (prevented = true),
+      url: event === 'will-redirect' ? 'about:srcdoc' : 'about:blank'
+    })
+    assert.equal(prevented, false, `${event} must preserve safe about subframes`)
+  }
+})

--- a/apps/desktop/electron/webview-guard.ts
+++ b/apps/desktop/electron/webview-guard.ts
@@ -1,0 +1,128 @@
+import type { Event, WebContents, WebPreferences } from 'electron'
+
+/** The one partition used by the user-facing local preview webview. */
+export const PREVIEW_WEBVIEW_PARTITION = 'persist:hermes-preview'
+
+const LOCAL_PREVIEW_HOSTS = new Set(['127.0.0.1', '0.0.0.0', '::1', '[::1]', 'localhost'])
+
+const WINDOWS_UNC_HOST_RE =
+  /^(?=.{1,255}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\.(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$/i
+
+export interface PreviewWebviewUrlOptions {
+  /**
+   * Shape-check a Windows UNC URL. Callers must still validate the canonical
+   * path against the normalized preview target before enabling this option.
+   */
+  allowWindowsUnc?: boolean
+}
+
+function isWindowsUncFileUrl(url: URL): boolean {
+  return (
+    Boolean(url.hostname) &&
+    WINDOWS_UNC_HOST_RE.test(url.hostname) &&
+    !url.username &&
+    !url.password &&
+    !url.port &&
+    url.pathname.length > 1
+  )
+}
+
+/**
+ * Preview webviews intentionally render local files and local development
+ * servers. No other scheme or remote host is an intended guest source.
+ */
+export function isAllowedPreviewWebviewUrl(rawUrl: string, options: PreviewWebviewUrlOptions = {}): boolean {
+  let url: URL
+
+  try {
+    url = new URL(String(rawUrl || '').trim())
+  } catch {
+    return false
+  }
+
+  if (url.protocol === 'file:') {
+    return !url.hostname || Boolean(options.allowWindowsUnc && isWindowsUncFileUrl(url))
+  }
+
+  return (url.protocol === 'http:' || url.protocol === 'https:') && LOCAL_PREVIEW_HOSTS.has(url.hostname.toLowerCase())
+}
+
+/**
+ * Keep an attached preview guest on the same local/file allowlist as its
+ * initial source. The event payloads for these Electron navigation events all
+ * expose the destination as `event.url`, including subframe navigations.
+ */
+export function installPreviewWebviewNavigationGuard(
+  webContents: Pick<WebContents, 'on'>,
+  isAllowedUrl: (rawUrl: string) => boolean = isAllowedPreviewWebviewUrl
+): void {
+  // `will-frame-navigate` and `will-redirect` also describe child frames. The
+  // preview boundary applies to the top-level document; sandboxing and the
+  // browser's normal frame policy continue to govern about:blank/srcdoc and
+  // provider/app subframes without breaking legitimate preview content.
+  const denyOffAllowlist = (event: Pick<Event, 'preventDefault'> & { isMainFrame?: boolean }, url: string) => {
+    if (event.isMainFrame === false) {
+      return
+    }
+
+    if (!isAllowedUrl(url)) {
+      event.preventDefault()
+    }
+  }
+
+  webContents.on('will-navigate', event => denyOffAllowlist(event, event.url))
+  webContents.on('will-frame-navigate', event => denyOffAllowlist(event, event.url))
+  webContents.on('will-redirect', event => denyOffAllowlist(event, event.url))
+}
+
+/**
+ * Enforce the preview guest policy before Electron attaches a webview.
+ * Renderer attributes are attacker-controlled at this boundary, so the
+ * intended source and partition are checked and all preload/Node-capable
+ * preferences are replaced with the safe preview values.
+ */
+export function enforcePreviewWebviewPolicy(
+  event: Pick<Event, 'preventDefault'>,
+  webPreferences: WebPreferences,
+  params: Record<string, string>,
+  isAllowedUrl: (rawUrl: string) => boolean = isAllowedPreviewWebviewUrl
+): void {
+  const requestedPartition = params.partition?.trim()
+
+  const allowed = isAllowedUrl(params.src) && (!requestedPartition || requestedPartition === PREVIEW_WEBVIEW_PARTITION)
+
+  if (!allowed) {
+    event.preventDefault()
+
+    return
+  }
+
+  // Electron accepts these renderer-supplied attributes before this event;
+  // remove them from both representations so they cannot be re-applied by
+  // the attachment machinery after this callback returns.
+  delete params.preload
+  delete params.webpreferences
+  delete params.allowpopups
+  delete params.nodeintegration
+  delete params.nodeintegrationinsubframes
+  delete params.plugins
+  delete params.blinkfeatures
+  delete params.disableblinkfeatures
+  params.partition = PREVIEW_WEBVIEW_PARTITION
+
+  delete webPreferences.preload
+  delete webPreferences.enableBlinkFeatures
+  delete webPreferences.disableBlinkFeatures
+  webPreferences.allowRunningInsecureContent = false
+  webPreferences.contextIsolation = true
+  webPreferences.experimentalFeatures = false
+  webPreferences.javascript = true
+  webPreferences.nodeIntegration = false
+  webPreferences.nodeIntegrationInSubFrames = false
+  webPreferences.nodeIntegrationInWorker = false
+  webPreferences.partition = PREVIEW_WEBVIEW_PARTITION
+  webPreferences.plugins = false
+  webPreferences.sandbox = true
+  webPreferences.webSecurity = true
+  webPreferences.webviewTag = false
+}

--- a/apps/desktop/electron/window-open-guard.test.ts
+++ b/apps/desktop/electron/window-open-guard.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { installWindowOpenDenyGuard } from './window-open-guard'
+
+test('window-open guard denies every guest popup request', () => {
+  let handler: ((details: unknown) => { action: 'deny' }) | undefined
+
+  installWindowOpenDenyGuard({
+    setWindowOpenHandler(next) {
+      handler = next as (details: unknown) => { action: 'deny' }
+    }
+  })
+
+  assert.ok(handler)
+  assert.deepEqual(handler({ disposition: 'foreground-tab', url: 'https://attacker.example/popup' }), {
+    action: 'deny'
+  })
+  assert.deepEqual(handler({ disposition: 'new-window', url: 'file:///sensitive' }), { action: 'deny' })
+})
+
+test('a denied popup request does not reach an external opener', () => {
+  let handler: ((details: unknown) => { action: 'deny' }) | undefined
+  const openExternal = vi.fn()
+
+  installWindowOpenDenyGuard({
+    setWindowOpenHandler(next) {
+      handler = details => {
+        const response = (next as unknown as (details: unknown) => { action: 'deny' | 'allow' })(details)
+
+        if (response.action !== 'deny') {
+          openExternal((details as { url: string }).url)
+        }
+
+        return response as { action: 'deny' }
+      }
+    }
+  })
+
+  const response = handler?.({ disposition: 'new-window', url: 'https://attacker.example/' })
+
+  assert.deepEqual(response, { action: 'deny' })
+  assert.equal(openExternal.mock.calls.length, 0)
+})

--- a/apps/desktop/electron/window-open-guard.ts
+++ b/apps/desktop/electron/window-open-guard.ts
@@ -1,0 +1,12 @@
+import type { WebContents } from 'electron'
+
+/**
+ * Install the fail-closed popup policy used for untrusted guest content.
+ *
+ * Legitimate Desktop links use the explicit `hermes:openExternal` bridge. A
+ * guest page must not turn a renderer-level `window.open()` into a native
+ * BrowserWindow, regardless of the requested URL or disposition.
+ */
+export function installWindowOpenDenyGuard(webContents: Pick<WebContents, 'setWindowOpenHandler'>): void {
+  webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+}

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -144,11 +144,98 @@ describe('PreviewPane console state', () => {
     })
 
     expect(rendered.container.querySelector('iframe')).toBeNull()
-    const sourceLink = rendered.container.querySelector('a')
+    const sourceButton = rendered.container.querySelector('button')
 
-    expect(sourceLink?.getAttribute('href')).toBeNull()
-    expect(sourceLink?.getAttribute('target')).toBeNull()
-    expect(fireEvent.click(sourceLink!)).toBe(false)
+    expect(sourceButton?.getAttribute('type')).toBe('button')
+    sourceButton?.focus()
+    expect(document.activeElement).toBe(sourceButton)
+    expect(fireEvent.click(sourceButton!)).toBe(false)
+  })
+
+  it('opens the current localhost preview through the desktop bridge', async () => {
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    window.hermesDesktop = { openPreviewInBrowser } as never
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const button = rendered.container.querySelector('button')
+
+    expect(button?.getAttribute('type')).toBe('button')
+    button?.focus()
+    expect(document.activeElement).toBe(button)
+    expect(fireEvent.click(button!)).toBe(false)
+    await waitFor(() => expect(openPreviewInBrowser).toHaveBeenCalledWith('http://localhost:5174'))
+  })
+
+  it('opens a local file through the desktop bridge and handles middle-click', async () => {
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    const readFileText = vi.fn(async () => ({ path: '/tmp/report.txt', text: 'report' }))
+    window.hermesDesktop = { openPreviewInBrowser, readFileText } as never
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          target={{
+            kind: 'file',
+            label: 'report.txt',
+            path: '/tmp/report.txt',
+            previewKind: 'text',
+            source: '/tmp/report.txt',
+            url: 'file:///tmp/report.txt'
+          }}
+        />
+      )
+    })
+
+    const button = rendered.container.querySelector('button')
+
+    expect(button?.getAttribute('type')).toBe('button')
+    expect(fireEvent(button!, new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 }))).toBe(false)
+    await waitFor(() => expect(openPreviewInBrowser).toHaveBeenCalledWith('file:///tmp/report.txt'))
+  })
+
+  it('opens the navigated preview URL rather than the original target', async () => {
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    window.hermesDesktop = { openPreviewInBrowser } as never
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          target={{
+            kind: 'url',
+            label: 'Preview',
+            source: 'http://localhost:5174',
+            url: 'http://localhost:5174'
+          }}
+        />
+      )
+    })
+
+    const webview = rendered.container.querySelector('webview')
+    const button = rendered.container.querySelector('button')
+
+    expect(webview).not.toBeNull()
+    act(() => {
+      webview?.dispatchEvent(Object.assign(new Event('did-navigate'), { url: 'http://localhost:5174/dashboard' }))
+    })
+
+    expect(button?.getAttribute('type')).toBe('button')
+    expect(fireEvent.click(button!)).toBe(false)
+    await waitFor(() => expect(openPreviewInBrowser).toHaveBeenCalledWith('http://localhost:5174/dashboard'))
   })
 
   it('renders PDF targets in an embedded viewer', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -168,6 +168,16 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const previewLabel =
     target.label && target.label.replace(/\/$/, '') !== currentLabel.replace(/\/$/, '') ? target.label : currentLabel
 
+  const openHeaderTarget = useCallback(() => {
+    // Remote HTML must keep the original target so openPreviewTargetInBrowser
+    // can stage its validated data URL. Ordinary previews, however, may have
+    // navigated within the local webview; open exactly the URL currently shown
+    // instead of falling back to the stale tab target.
+    const browserTarget = isRemoteHtmlTarget ? target : { ...target, url: currentUrl }
+
+    void openPreviewTargetInBrowser(browserTarget).catch(error => notifyError(error, t.preview.unavailable))
+  }, [currentUrl, isRemoteHtmlTarget, t.preview.unavailable, target])
+
   const restartingServer =
     previewServerRestart?.status === 'running' &&
     (previewServerRestart.url === target.url || previewServerRestart.url === currentUrl)
@@ -659,20 +669,24 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
           <div className="pointer-events-none flex min-h-(--titlebar-height) items-center gap-1.5 border-b border-border/60 bg-background px-2 py-1">
             <div className="min-w-0 flex-1">
               <Tip label={copy.openTarget(currentUrl)}>
-                <a
-                  className="pointer-events-auto inline max-w-full truncate text-left text-xs font-medium text-foreground underline-offset-4 decoration-current/20 transition-colors hover:text-primary hover:underline"
-                  href={isRemoteHtmlTarget ? undefined : currentUrl}
-                  onClick={event => {
-                    if (isRemoteHtmlTarget) {
-                      event.preventDefault()
-                      void openPreviewTargetInBrowser(target).catch(error => notifyError(error, t.preview.unavailable))
+                <button
+                  className="pointer-events-auto inline max-w-full truncate border-0 bg-transparent p-0 text-left text-xs font-medium text-foreground underline-offset-4 decoration-current/20 transition-colors hover:text-primary hover:underline"
+                  onAuxClick={event => {
+                    if (event.button !== 1) {
+                      return
                     }
+
+                    event.preventDefault()
+                    openHeaderTarget()
                   }}
-                  rel="noreferrer"
-                  target={isRemoteHtmlTarget ? undefined : '_blank'}
+                  onClick={event => {
+                    event.preventDefault()
+                    openHeaderTarget()
+                  }}
+                  type="button"
                 >
                   {previewLabel || copy.fallbackTitle}
-                </a>
+                </button>
               </Tip>
             </div>
           </div>

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -650,6 +650,14 @@ function PlatformDetail({
             <Button asChild size="sm" variant="textStrong">
               <a
                 href={platform.docs_url}
+                onAuxClick={event => {
+                  if (event.button !== 1) {
+                    return
+                  }
+
+                  event.preventDefault()
+                  openExternalLink(platform.docs_url!)
+                }}
                 onClick={event => {
                   // Route through the validated external opener instead of
                   // letting Electron resolve the anchor. A packaged build's
@@ -853,7 +861,23 @@ function MessagingField({
           {field.url && (
             <Tip label={m.openDocs}>
               <Button asChild className="size-8 shrink-0" variant="ghost">
-                <a href={field.url} rel="noreferrer" target="_blank">
+                <a
+                  href={field.url}
+                  onAuxClick={event => {
+                    if (event.button !== 1) {
+                      return
+                    }
+
+                    event.preventDefault()
+                    openExternalLink(field.url!)
+                  }}
+                  onClick={event => {
+                    event.preventDefault()
+                    openExternalLink(field.url!)
+                  }}
+                  rel="noreferrer"
+                  target="_blank"
+                >
                   <ExternalLink className="size-3.5" />
                 </a>
               </Button>

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -5,6 +5,7 @@ import { BrandMark } from '@/components/brand-mark'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { type Translations, useI18n } from '@/i18n'
+import { openExternalLink } from '@/lib/external-link'
 import { CheckCircle2, ExternalLink, Loader2, RefreshCw } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import {
@@ -156,9 +157,17 @@ export function AboutSettings() {
             <Button asChild className="ml-auto" size="sm" variant="text">
               <a
                 href={RELEASE_NOTES_URL}
+                onAuxClick={event => {
+                  if (event.button !== 1) {
+                    return
+                  }
+
+                  event.preventDefault()
+                  openExternalLink(RELEASE_NOTES_URL)
+                }}
                 onClick={event => {
                   event.preventDefault()
-                  void window.hermesDesktop?.openExternal?.(RELEASE_NOTES_URL)
+                  openExternalLink(RELEASE_NOTES_URL)
                 }}
                 rel="noreferrer"
                 target="_blank"

--- a/apps/desktop/src/app/settings/credential-key-ui.tsx
+++ b/apps/desktop/src/app/settings/credential-key-ui.tsx
@@ -3,6 +3,7 @@ import { type ChangeEvent, type KeyboardEvent } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { translateNow, useI18n } from '@/i18n'
+import { openExternalLink } from '@/lib/external-link'
 import { ChevronDown, ExternalLink, Loader2, Save, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import type { EnvVarInfo } from '@/types/hermes'
@@ -147,7 +148,20 @@ function CredentialDocsLink({ href }: { href: string }) {
     <a
       className="inline-flex w-fit items-center gap-1 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary) underline-offset-4 transition-colors hover:text-foreground hover:underline"
       href={href}
-      onClick={e => e.stopPropagation()}
+      onAuxClick={e => {
+        if (e.button !== 1) {
+          return
+        }
+
+        e.preventDefault()
+        e.stopPropagation()
+        openExternalLink(href)
+      }}
+      onClick={e => {
+        e.preventDefault()
+        e.stopPropagation()
+        openExternalLink(href)
+      }}
       rel="noreferrer"
       target="_blank"
     >

--- a/apps/desktop/src/app/settings/env-var-actions-menu.tsx
+++ b/apps/desktop/src/app/settings/env-var-actions-menu.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { useI18n } from '@/i18n'
+import { openExternalLink } from '@/lib/external-link'
 import { triggerHaptic } from '@/lib/haptics'
 import { ExternalLink, Eye, EyeOff, KeyRound, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
@@ -61,7 +62,7 @@ function useEnvVarItems({
         onSelect: event => {
           event.preventDefault()
           triggerHaptic('selection')
-          window.open(docsUrl!, '_blank', 'noopener,noreferrer')
+          openExternalLink(docsUrl!)
         }
       })
     }

--- a/apps/desktop/src/app/settings/memory/provider-config-modal.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-modal.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { saveMemoryProviderConfig } from '@/hermes'
+import { openExternalLink } from '@/lib/external-link'
 import { ExternalLink, Loader2, Save, SlidersHorizontal } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
@@ -102,9 +103,17 @@ export function ProviderConfigModal({
             <a
               className="inline-flex w-fit items-center gap-1 text-[length:var(--conversation-caption-font-size)] text-(--ui-accent-secondary) underline-offset-4 transition-colors hover:underline"
               href={config.docs_url}
+              onAuxClick={event => {
+                if (event.button !== 1) {
+                  return
+                }
+
+                event.preventDefault()
+                openExternalLink(config.docs_url!)
+              }}
               onClick={event => {
                 event.preventDefault()
-                void window.hermesDesktop?.openExternal?.(config.docs_url)
+                openExternalLink(config.docs_url!)
               }}
               rel="noreferrer"
               target="_blank"

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -18,6 +18,7 @@ import {
   startOAuthLogin
 } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { openExternalLinkWithFallback } from '@/lib/external-link'
 import { Check, Loader2, Save, Terminal } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
@@ -625,16 +626,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
       }
 
       const url = start.verification_url
-
-      if (window.hermesDesktop?.openExternal) {
-        try {
-          await window.hermesDesktop.openExternal(url)
-        } catch {
-          window.open(url, '_blank', 'noopener,noreferrer')
-        }
-      } else {
-        window.open(url, '_blank', 'noopener,noreferrer')
-      }
+      await openExternalLinkWithFallback(url)
 
       // Poll until the device-code session resolves (~5s cadence, bounded).
       for (let attempt = 0; attempt < 120 && mountedRef.current; attempt += 1) {

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -15,6 +15,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Tip, TipKeybindLabel, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { ContribRender } from '@/contrib/react/boundary'
 import { useI18n } from '@/i18n'
+import { openExternalLink } from '@/lib/external-link'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
 import { $statusbarHiddenIds, setStatusbarItemVisible, toggleStatusbarVisible } from '@/store/statusbar-prefs'
@@ -278,6 +279,18 @@ const StatusbarItemView = memo(function StatusbarItemView({
                       <a
                         className="inline-flex w-full items-center gap-2"
                         href={menuItem.href}
+                        onAuxClick={event => {
+                          if (event.button !== 1) {
+                            return
+                          }
+
+                          event.preventDefault()
+                          openExternalLink(menuItem.href!)
+                        }}
+                        onClick={event => {
+                          event.preventDefault()
+                          openExternalLink(menuItem.href!)
+                        }}
                         rel="noreferrer"
                         target="_blank"
                       >
@@ -312,10 +325,39 @@ const StatusbarItemView = memo(function StatusbarItemView({
     )
   }
 
-  if (item.href || item.variant === 'link') {
+  if (item.href) {
     return (
       <Tip label={tooltipLabel}>
-        <a className={cn(STATUSBAR_ACTION_CLASS, item.className)} href={item.href} rel="noreferrer" target="_blank">
+        <a
+          aria-disabled={item.disabled || undefined}
+          className={cn(STATUSBAR_ACTION_CLASS, item.className)}
+          href={item.href}
+          onAuxClick={event => {
+            if (event.button !== 1) {
+              return
+            }
+
+            event.preventDefault()
+
+            if (item.disabled) {
+              return
+            }
+
+            openExternalLink(item.href!)
+          }}
+          onClick={event => {
+            event.preventDefault()
+
+            if (item.disabled) {
+              return
+            }
+
+            openExternalLink(item.href!)
+          }}
+          rel="noreferrer"
+          tabIndex={item.disabled ? -1 : undefined}
+          target="_blank"
+        >
           {content}
         </a>
       </Tip>

--- a/apps/desktop/src/app/shell/statusbar-visibility.test.tsx
+++ b/apps/desktop/src/app/shell/statusbar-visibility.test.tsx
@@ -24,10 +24,19 @@ beforeAll(() => {
   HTMLElement.prototype.scrollIntoView ??= () => undefined
 })
 
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
 afterEach(() => {
   cleanup()
   $statusbarHiddenIds.set([...STATUSBAR_HIDDEN_BY_DEFAULT])
   $statusbarVisible.set(true)
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
 })
 
 const item = (id: string, label: string, extra: Partial<StatusbarItem> = {}): StatusbarItem => ({
@@ -55,6 +64,31 @@ function openContextMenu(target: HTMLElement) {
 }
 
 describe('statusbar item visibility', () => {
+  it('keeps disabled direct links inert and out of the tab order', () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    desktopWindow.hermesDesktop = { openExternal } as unknown as Window['hermesDesktop']
+
+    const statusbar = bar([
+      item('docs', 'Docs', {
+        disabled: true,
+        href: 'https://example.com/docs'
+      })
+    ])
+    const link = within(statusbar).getByRole('link', { name: 'Docs' })
+
+    expect(link.getAttribute('aria-disabled')).toBe('true')
+    expect(link.getAttribute('tabindex')).toBe('-1')
+
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+    const middleClick = new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 })
+    const rightClick = new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 2 })
+
+    expect(link.dispatchEvent(click)).toBe(false)
+    expect(link.dispatchEvent(middleClick)).toBe(false)
+    expect(link.dispatchEvent(rightClick)).toBe(true)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
   it('hides the route/toggle items out of the box and keeps status items', () => {
     bar([
       item('cron', 'Cron'),

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -8,6 +8,7 @@ import { resetLayoutTree } from '@/components/pane-shell/tree/store'
 import { Button } from '@/components/ui/button'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
+import { openExternalLink } from '@/lib/external-link'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
 import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
@@ -301,6 +302,18 @@ function TitlebarToolButton({ navigate, tool }: { navigate: ReturnType<typeof us
           <a
             aria-label={tool.label}
             href={tool.href}
+            onAuxClick={event => {
+              if (event.button !== 1) {
+                return
+              }
+
+              event.preventDefault()
+              openExternalLink(tool.href!)
+            }}
+            onClick={event => {
+              event.preventDefault()
+              openExternalLink(tool.href!)
+            }}
             onPointerDown={event => event.stopPropagation()}
             rel="noreferrer"
             target="_blank"

--- a/apps/desktop/src/components/assistant-ui/embeds/embed-security.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/embed-security.ts
@@ -1,0 +1,5 @@
+// Provider pages are untrusted remote content. Scripts and same-origin keep
+// the provider runtimes functional, while deliberately omitting allow-popups
+// and allow-top-navigation prevents an embedded page from creating a native
+// window or escaping the embed. Explicit app links use the Desktop bridge.
+export const EXTERNAL_FRAME_SANDBOX = 'allow-same-origin allow-scripts allow-presentation'

--- a/apps/desktop/src/components/assistant-ui/embeds/frame-embed.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/frame-embed.test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { FrameEmbed } from './providers/types'
+
+vi.mock('./use-is-dark', () => ({ useIsDark: () => false }))
+
+import { EXTERNAL_FRAME_SANDBOX } from './embed-security'
+import FrameEmbedRenderer from './frame-embed'
+import YouTubeEmbedRenderer from './youtube-embed'
+
+const frame: FrameEmbed = {
+  aspectRatio: 16 / 9,
+  embedUrl: 'https://player.vimeo.com/video/123',
+  id: 'vimeo:123',
+  label: 'Vimeo',
+  maxWidth: 640,
+  provider: 'vimeo',
+  renderer: 'frame',
+  sourceUrl: 'https://vimeo.com/123'
+}
+
+describe('external provider frames', () => {
+  it('sandboxes generic provider frames without popup or top-navigation escapes', () => {
+    const { container } = render(<FrameEmbedRenderer descriptor={frame} />)
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe?.getAttribute('sandbox')).toBe(EXTERNAL_FRAME_SANDBOX)
+    expect(EXTERNAL_FRAME_SANDBOX).not.toContain('allow-popups')
+    expect(EXTERNAL_FRAME_SANDBOX).not.toContain('allow-top-navigation')
+  })
+
+  it('applies the same popup boundary to the dedicated YouTube renderer', () => {
+    const { container } = render(<YouTubeEmbedRenderer descriptor={{ ...frame, provider: 'youtube' }} />)
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe?.getAttribute('sandbox')).toBe(EXTERNAL_FRAME_SANDBOX)
+  })
+
+  it.each([
+    ['Google Maps', 'googlemaps'],
+    ['OpenStreetMap', 'openstreetmap'],
+    ['Instagram', 'instagram'],
+    ['Pinterest', 'pinterest'],
+    ['TikTok', 'tiktok'],
+    ['Vimeo', 'vimeo']
+  ] as const)('keeps the %s frame on the shared sandbox policy', (_label, provider) => {
+    const { container } = render(<FrameEmbedRenderer descriptor={{ ...frame, provider }} />)
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe?.getAttribute('sandbox')).toBe(EXTERNAL_FRAME_SANDBOX)
+  })
+
+  it('keeps long Instagram posts accessible in an internal scrolling frame', () => {
+    const { container } = render(
+      <FrameEmbedRenderer
+        descriptor={{
+          ...frame,
+          aspectRatio: undefined,
+          embedUrl: 'https://www.instagram.com/p/CabcDEF123/embed',
+          height: 450,
+          provider: 'instagram'
+        }}
+      />
+    )
+
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe?.getAttribute('scrolling')).toBe('yes')
+    expect(iframe?.style.height).toBe('450px')
+    expect(iframe?.getAttribute('sandbox')).toBe(EXTERNAL_FRAME_SANDBOX)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/frame-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/frame-embed.tsx
@@ -2,6 +2,7 @@
 
 import { type CSSProperties } from 'react'
 
+import { EXTERNAL_FRAME_SANDBOX } from './embed-security'
 import type { FrameEmbed } from './providers/types'
 import { ScrollGate } from './scroll-gate'
 import { useIsDark } from './use-is-dark'
@@ -14,6 +15,11 @@ const ALLOW = 'autoplay; encrypted-media; picture-in-picture; clipboard-write; f
 export default function FrameEmbedRenderer({ descriptor }: { descriptor: FrameEmbed }) {
   const isDark = useIsDark()
   const isMap = descriptor.provider === 'googlemaps' || descriptor.provider === 'openstreetmap'
+  // Instagram's official post/reel document grows with the caption and
+  // media. Keep the fixed outer bound, but let the provider document scroll
+  // internally so long content remains reachable without a privileged
+  // renderer resize script.
+  const isInternallyScrollable = descriptor.provider === 'instagram'
   // color-scheme makes the iframe's default (unpainted) backdrop follow the
   // theme instead of flashing white at the corners / during load.
   const colorScheme = isDark ? 'dark' : 'light'
@@ -30,6 +36,7 @@ export default function FrameEmbedRenderer({ descriptor }: { descriptor: FrameEm
           className="absolute inset-0 size-full border-0 bg-transparent"
           loading="lazy"
           referrerPolicy="strict-origin-when-cross-origin"
+          sandbox={EXTERNAL_FRAME_SANDBOX}
           src={descriptor.embedUrl}
           style={{ colorScheme }}
           title={`${descriptor.label} embed`}
@@ -46,7 +53,8 @@ export default function FrameEmbedRenderer({ descriptor }: { descriptor: FrameEm
       className="block w-full border-0 bg-transparent"
       loading="lazy"
       referrerPolicy="strict-origin-when-cross-origin"
-      scrolling="no"
+      sandbox={EXTERNAL_FRAME_SANDBOX}
+      scrolling={isInternallyScrollable ? 'yes' : 'no'}
       src={descriptor.embedUrl}
       style={style}
       title={`${descriptor.label} embed`}

--- a/apps/desktop/src/components/assistant-ui/embeds/providers/instagram.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/providers/instagram.ts
@@ -14,7 +14,9 @@ export const instagram: EmbedMatcher = url => {
 
   return {
     embedUrl: `https://www.instagram.com/${type}/${code}/embed`,
-    // Placeholder height for content-visibility; embed.js self-sizes in-document.
+    // Fixed outer height for the official Instagram iframe; the frame renderer
+    // keeps longer posts reachable with internal scrolling. No in-document
+    // widget script is loaded into the privileged Desktop renderer.
     height: 450,
     id: `instagram:${code}`,
     label: 'Instagram',

--- a/apps/desktop/src/components/assistant-ui/embeds/providers/types.ts
+++ b/apps/desktop/src/components/assistant-ui/embeds/providers/types.ts
@@ -11,7 +11,7 @@ export type EmbedRenderer = 'frame' | 'tweet'
 interface EmbedLayout {
   /** Frame aspect ratio (width / height). For video/maps. */
   aspectRatio?: number
-  /** Fixed pixel height for non-ratio embeds (Instagram, Pinterest, Spotify). */
+  /** Fixed outer pixel height for non-ratio embeds (Instagram, Pinterest, Spotify). */
   height?: number
   /** Max rendered width in px; falls back to the conversation column. */
   maxWidth?: number
@@ -35,7 +35,7 @@ export interface FrameEmbed extends BaseEmbed {
   renderer: 'frame'
 }
 
-/** Twitter/X ships no iframe URL — only a widget script (see social-embed.tsx). */
+/** Twitter/X has no fixed iframe URL, so it renders as a safe explicit link card. */
 export interface TweetEmbed extends BaseEmbed {
   renderer: 'tweet'
   tweetId: string

--- a/apps/desktop/src/components/assistant-ui/embeds/social-embed.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/social-embed.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { TweetEmbed } from './providers/types'
+import SocialEmbedRenderer from './social-embed'
+
+const tweet: TweetEmbed = {
+  id: 'twitter:20',
+  label: 'X',
+  maxWidth: 480,
+  provider: 'twitter',
+  renderer: 'tweet',
+  sourceUrl: 'https://x.com/jack/status/20',
+  tweetId: '20'
+}
+
+describe('social provider renderer', () => {
+  it('uses an explicit link card without injecting provider scripts', () => {
+    const { container } = render(<SocialEmbedRenderer descriptor={tweet} />)
+
+    expect(container.querySelectorAll('script')).toHaveLength(0)
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(container.querySelector('a')?.getAttribute('href')).toBe(tweet.sourceUrl)
+    expect(container.textContent).toContain('Open X post')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/social-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/social-embed.tsx
@@ -1,131 +1,27 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useI18n } from '@/i18n'
+import { PrettyLink } from '@/lib/external-link'
 
-import { escapeHtml } from './escape-html'
-import type { EmbedDescriptor } from './providers/types'
-import { useIsDark } from './use-is-dark'
+import type { TweetEmbed } from './providers/types'
 
-// The provider embed scripts need a REAL origin to run (they touch
-// cookies/storage/postMessage), so — exactly like react-social-media-embed — we
-// render the official blockquote in this document and let the script swap it for
-// a correctly-sized iframe. A sandboxed srcDoc iframe gives a null origin and
-// the scripts silently bail (white / 2px). The container is height:auto, so it
-// grows to whatever the provider renders. No measuring, no forced height.
-type EmbedWindow = Window &
-  typeof globalThis & {
-    instgrm?: { Embeds?: { process?: () => void } }
-    twttr?: { widgets?: { load?: (el?: HTMLElement) => void } }
-  }
+/**
+ * X/Twitter does not expose a provider iframe URL that we can safely derive
+ * from the post descriptor. Keep the rich card as an explicit link instead of
+ * loading the provider widget script into the privileged Desktop renderer.
+ * Instagram uses its fixed iframe URL through FrameEmbedRenderer.
+ */
+export default function SocialEmbedRenderer({ descriptor }: { descriptor: TweetEmbed }) {
+  const { t } = useI18n()
+  const copy = t.assistant.embeds
 
-const SCRIPT: Record<string, { id: string; src: string }> = {
-  instagram: { id: 'hermes-ig-embed', src: 'https://www.instagram.com/embed.js' },
-  tiktok: { id: 'hermes-tt-embed', src: 'https://www.tiktok.com/embed.js' },
-  twitter: { id: 'hermes-tw-embed', src: 'https://platform.twitter.com/widgets.js' }
-}
-
-const PROCESS_DELAYS_MS = [0, 300, 800, 1600, 3000]
-
-function markup(descriptor: EmbedDescriptor, theme: 'dark' | 'light'): string {
-  const url = escapeHtml(descriptor.sourceUrl)
-
-  switch (descriptor.provider) {
-    case 'instagram':
-      return `<blockquote class="instagram-media" data-instgrm-permalink="${url}" data-instgrm-version="14" style="margin:0;width:100%;min-width:0;max-width:100%"></blockquote>`
-    case 'tiktok': {
-      const id = escapeHtml(descriptor.id.replace(/^tiktok:/, ''))
-
-      return `<blockquote class="tiktok-embed" cite="${url}" data-video-id="${id}" style="margin:0;max-width:100%"><section></section></blockquote>`
-    }
-
-    case 'twitter':
-      // data-chrome="transparent" drops the card background so the themed page
-      // shows through instead of a white box.
-      return `<blockquote class="twitter-tweet" data-dnt="true" data-theme="${theme}" data-chrome="transparent"><a href="${url}"></a></blockquote>`
-
-    default:
-      return ''
-  }
-}
-
-function loadScript(provider: string): Promise<void> {
-  const { id, src } = SCRIPT[provider]
-
-  // TikTok exposes no re-process API; its script rescans the document each time
-  // it runs, so we re-inject it. The others are loaded once and reused.
-  if (provider === 'tiktok') {
-    document.getElementById(id)?.remove()
-  } else if (document.getElementById(id)) {
-    return Promise.resolve()
-  }
-
-  return new Promise(resolve => {
-    const script = document.createElement('script')
-
-    script.async = true
-    script.id = id
-    script.onload = () => resolve()
-    script.onerror = () => resolve()
-    script.src = src
-    document.body.appendChild(script)
-  })
-}
-
-function processEmbed(provider: string, container: HTMLElement): void {
-  const win = window as EmbedWindow
-
-  if (provider === 'instagram') {
-    win.instgrm?.Embeds?.process?.()
-  } else if (provider === 'twitter') {
-    win.twttr?.widgets?.load?.(container)
-  }
-  // TikTok auto-scans on (re)injection — no manual process call.
-}
-
-export default function SocialEmbedRenderer({ descriptor }: { descriptor: EmbedDescriptor }) {
-  const isDark = useIsDark()
-  const ref = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    const container = ref.current
-
-    if (!container) {
-      return
-    }
-
-    let cancelled = false
-    const timers: number[] = []
-
-    container.innerHTML = markup(descriptor, isDark ? 'dark' : 'light')
-
-    void loadScript(descriptor.provider).then(() => {
-      // The script renders asynchronously; nudge a few times so the embed
-      // settles whether the script was cached or freshly fetched.
-      for (const delay of PROCESS_DELAYS_MS) {
-        timers.push(window.setTimeout(() => !cancelled && processEmbed(descriptor.provider, container), delay))
-      }
-    })
-
-    return () => {
-      cancelled = true
-
-      for (const timer of timers) {
-        clearTimeout(timer)
-      }
-
-      container.innerHTML = ''
-    }
-  }, [descriptor, isDark])
-
-  // The white corner/box on tweets is a color-scheme MISMATCH: when the iframe's
-  // resolved scheme differs from ours, the browser paints an opaque (white)
-  // Canvas behind it. Twitter's embed resolves to `light`, so we force the iframe
-  // to `light` to match — no mismatch, no Canvas — and data-chrome=transparent
-  // then lets the dark page show through. (Confirmed: mkdocs-material #6889.)
   return (
     <div
-      className="w-full [&_.instagram-media]:!min-w-0 [&_iframe]:!m-0 [&_iframe]:!max-w-full [&_iframe]:[color-scheme:light]"
-      ref={ref}
-    />
+      className="flex min-h-32 w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary)/30 p-4"
+      data-provider={descriptor.provider}
+    >
+      <span className="text-xs text-(--ui-text-tertiary)">{copy.openPostOn(descriptor.label)}</span>
+      <PrettyLink fallbackLabel={copy.openPost(descriptor.label)} href={descriptor.sourceUrl} />
+    </div>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/embeds/spotify-embed.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/spotify-embed.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { FrameEmbed } from './providers/types'
+
+vi.mock('./use-is-dark', () => ({ useIsDark: () => false }))
+
+import { EXTERNAL_FRAME_SANDBOX } from './embed-security'
+import SpotifyEmbedRenderer from './spotify-embed'
+
+const spotify: FrameEmbed = {
+  embedUrl: 'https://open.spotify.com/embed/track/4cOdK2wGLETKBW3PvgPWqT',
+  height: 152,
+  id: 'spotify:track:4cOdK2wGLETKBW3PvgPWqT',
+  label: 'Spotify',
+  maxWidth: 480,
+  provider: 'spotify',
+  renderer: 'frame',
+  sourceUrl: 'https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT'
+}
+
+describe('Spotify provider renderer', () => {
+  it('uses the shared sandbox policy', () => {
+    const { container } = render(<SpotifyEmbedRenderer descriptor={spotify} />)
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe?.getAttribute('sandbox')).toBe(EXTERNAL_FRAME_SANDBOX)
+    expect(EXTERNAL_FRAME_SANDBOX).not.toContain('allow-popups')
+    expect(EXTERNAL_FRAME_SANDBOX).not.toContain('allow-top-navigation')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/spotify-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/spotify-embed.tsx
@@ -2,6 +2,7 @@
 
 import { type CSSProperties, useMemo } from 'react'
 
+import { EXTERNAL_FRAME_SANDBOX } from './embed-security'
 import type { FrameEmbed } from './providers/types'
 import { useIsDark } from './use-is-dark'
 
@@ -37,6 +38,8 @@ export default function SpotifyEmbedRenderer({ descriptor }: { descriptor: Frame
       allow={ALLOW}
       className="block w-full border-0 bg-transparent"
       loading="lazy"
+      referrerPolicy="strict-origin-when-cross-origin"
+      sandbox={EXTERNAL_FRAME_SANDBOX}
       src={src}
       style={style}
       title="Spotify embed"

--- a/apps/desktop/src/components/assistant-ui/embeds/url-embed.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/url-embed.test.tsx
@@ -1,0 +1,30 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setEmbedMode } from '@/store/embed-consent'
+
+import { EXTERNAL_FRAME_SANDBOX } from './embed-security'
+import { detectEmbed } from './providers'
+import { UrlEmbed } from './url-embed'
+
+vi.mock('./use-is-dark', () => ({ useIsDark: () => false }))
+
+describe('UrlEmbed provider routing', () => {
+  beforeEach(() => act(() => setEmbedMode('always')))
+  afterEach(() => act(() => setEmbedMode('ask')))
+
+  it('routes Instagram through the sandboxed frame renderer without scripts', async () => {
+    const descriptor = detectEmbed('https://www.instagram.com/p/CabcDEF123/')
+
+    if (!descriptor || descriptor.renderer !== 'frame') {
+      throw new Error('expected an Instagram frame descriptor')
+    }
+
+    const { container } = render(<UrlEmbed descriptor={descriptor} />)
+
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+
+    expect(container.querySelector('iframe')?.getAttribute('sandbox')).toBe(EXTERNAL_FRAME_SANDBOX)
+    expect(container.querySelectorAll('script')).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/embeds/url-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/url-embed.tsx
@@ -26,9 +26,10 @@ function intrinsicHeight(descriptor: EmbedDescriptor): number {
 }
 
 function LazyRenderer({ descriptor }: { descriptor: EmbedDescriptor }) {
-  // X and Instagram load their official blockquote script in-document. The tweet
-  // check also narrows the union to FrameEmbed for the iframe renderers below.
-  if (descriptor.renderer === 'tweet' || descriptor.provider === 'instagram') {
+  // X/Twitter has no fixed iframe URL, so it uses the safe explicit-link card.
+  // Instagram is a fixed FrameEmbed and must stay on the sandboxed iframe path;
+  // no third-party provider script is ever loaded into this renderer.
+  if (descriptor.renderer === 'tweet') {
     return <SocialEmbedRenderer descriptor={descriptor} />
   }
 

--- a/apps/desktop/src/components/assistant-ui/embeds/youtube-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/youtube-embed.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react'
 
+import { EXTERNAL_FRAME_SANDBOX } from './embed-security'
 import type { FrameEmbed } from './providers/types'
 import { useIsDark } from './use-is-dark'
 
@@ -38,6 +39,7 @@ export default function YouTubeEmbedRenderer({ descriptor }: { descriptor: Frame
       className="block aspect-video w-full border-0 bg-transparent"
       loading="lazy"
       referrerPolicy="strict-origin-when-cross-origin"
+      sandbox={EXTERNAL_FRAME_SANDBOX}
       scrolling="no"
       src={src}
       style={{ colorScheme: isDark ? 'dark' : 'light' }}

--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $connection } from '@/store/session'
@@ -77,5 +77,37 @@ describe('MarkdownImage media routing', () => {
 
     expect(container.querySelector('video')).toBeNull()
     expect(container.querySelector('audio')).toBeNull()
+  })
+
+  it('opens local media through the validated preview bridge', async () => {
+    const openPreviewInBrowser = vi.fn(async () => undefined)
+    const originalDesktop = window.hermesDesktop
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { openPreviewInBrowser }
+    })
+
+    try {
+      const { container } = render(<MarkdownImage alt="note" src="file:///tmp/note.mp3" />)
+
+      const audio = await waitFor(() => {
+        const element = container.querySelector('audio')
+
+        expect(element).not.toBeNull()
+
+        return element as HTMLAudioElement
+      })
+
+      fireEvent.error(audio)
+      fireEvent.click(await screen.findByRole('button', { name: 'Open audio file' }))
+
+      expect(openPreviewInBrowser).toHaveBeenCalledWith('file:///tmp/note.mp3')
+    } finally {
+      Object.defineProperty(window, 'hermesDesktop', {
+        configurable: true,
+        value: originalDesktop
+      })
+    }
   })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -15,7 +15,7 @@ import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { detectArtifact } from '@/lib/artifact-detect'
-import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
+import { ExternalLink, normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
@@ -105,9 +105,33 @@ function useOpenMediaFile(path: string) {
     if (window.hermesDesktop && isRemoteGateway()) {
       setOpenFailed(false)
       void downloadGatewayMediaFile(path).catch(() => setOpenFailed(true))
-    } else {
-      openExternalLink(mediaExternalUrl(path))
+
+      return
     }
+
+    const href = mediaExternalUrl(path)
+
+    // Local media is an explicit file-preview action, not a general external
+    // link. Keep it on the main-process file opener, which validates the
+    // requested file path; the shared external-link helper intentionally
+    // rejects file: URLs before either a bridge or browser navigation.
+    if (/^file:/i.test(href)) {
+      const openFile = window.hermesDesktop?.openPreviewInBrowser ?? window.hermesDesktop?.openExternal
+
+      if (!openFile) {
+        setOpenFailed(true)
+
+        return
+      }
+
+      setOpenFailed(false)
+      void openFile(href).catch(() => setOpenFailed(true))
+
+      return
+    }
+
+    setOpenFailed(false)
+    openExternalLink(href)
   }
 
   return { open, openFailed }
@@ -272,15 +296,9 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
 
   if (!target || !/^https?:\/\//i.test(target)) {
     return (
-      <a
-        className={cn('ref wrap-anywhere', className)}
-        href={href}
-        rel="noopener noreferrer"
-        target="_blank"
-        {...props}
-      >
+      <ExternalLink className={cn('wrap-anywhere', className)} href={target || ''} {...props}>
         {children}
-      </a>
+      </ExternalLink>
     )
   }
 

--- a/apps/desktop/src/components/onboarding/flow.tsx
+++ b/apps/desktop/src/components/onboarding/flow.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Loader } from '@/components/ui/loader'
 import { getGlobalModelOptions } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { openExternalLink } from '@/lib/external-link'
 import { ExternalLink, Loader2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import {
@@ -333,7 +334,23 @@ function ConfirmingModelPanel({
 export function DocsLink({ children, href }: { children: React.ReactNode; href: string }) {
   return (
     <Button asChild size="xs" variant="text">
-      <a href={href} rel="noreferrer" target="_blank">
+      <a
+        href={href}
+        onAuxClick={event => {
+          if (event.button !== 1) {
+            return
+          }
+
+          event.preventDefault()
+          openExternalLink(href)
+        }}
+        onClick={event => {
+          event.preventDefault()
+          openExternalLink(href)
+        }}
+        rel="noreferrer"
+        target="_blank"
+      >
         <ExternalLink className="size-3" />
         {children}
       </a>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2777,6 +2777,10 @@ export const en: Translations = {
       sendEdited: 'Send edited message',
       attachingFile: 'Attaching…'
     },
+    embeds: {
+      openPostOn: label => `Open this post on ${label}`,
+      openPost: label => `Open ${label} post`
+    },
     approval: {
       gatewayDisconnected: 'Hermes gateway is not connected',
       sendFailed: 'Could not send approval response',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2365,6 +2365,10 @@ export interface Translations {
       sendEdited: string
       attachingFile: string
     }
+    embeds: {
+      openPostOn: (label: string) => string
+      openPost: (label: string) => string
+    }
     approval: {
       gatewayDisconnected: string
       sendFailed: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2950,6 +2950,10 @@ export const zh: Translations = {
       sendEdited: '发送编辑后的消息',
       attachingFile: '正在附加…'
     },
+    embeds: {
+      openPostOn: label => `在 ${label} 上打开此帖子`,
+      openPost: label => `打开 ${label} 帖子`
+    },
     approval: {
       gatewayDisconnected: 'Hermes 网关未连接',
       sendFailed: '无法发送审批响应',

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -8,6 +8,8 @@ import {
   hostPathLabel,
   isTitleFetchable,
   LinkifiedText,
+  openExternalLink,
+  openExternalLinkWithFallback,
   PrettyLink,
   urlSlugTitleLabel
 } from './external-link'
@@ -110,6 +112,119 @@ describe('external link helpers', () => {
 
     fireEvent.click(screen.getByRole('link', { name: 'Example link' }))
     expect(openExternal).toHaveBeenCalledWith('https://example.com/path/to/resource')
+  })
+
+  it('opens intercepted links in a browser preview without the desktop bridge', () => {
+    const popup = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+    delete desktopWindow.hermesDesktop
+
+    render(<ExternalLink href="mailto:hello@example.com">Email link</ExternalLink>)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Email link' }))
+
+    expect(popup).toHaveBeenCalledWith('mailto:hello@example.com', '_blank', 'noopener,noreferrer')
+  })
+
+  it('does not bypass a present but incomplete desktop bridge', () => {
+    const popup = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+    desktopWindow.hermesDesktop = {} as Window['hermesDesktop']
+
+    render(<ExternalLink href="https://example.com/path/to/resource">Example link</ExternalLink>)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Example link' }))
+
+    expect(popup).not.toHaveBeenCalled()
+  })
+
+  it('routes middle-clicks through the bridge while preserving right-click menus', () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    installDesktopBridge({ openExternal: openExternal as unknown as Window['hermesDesktop']['openExternal'] })
+
+    render(<ExternalLink href="https://example.com/path/to/resource">Example link</ExternalLink>)
+
+    const link = screen.getByRole('link', { name: 'Example link' })
+    const middleClick = new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 })
+    expect(link.dispatchEvent(middleClick)).toBe(false)
+    expect(openExternal).toHaveBeenCalledWith('https://example.com/path/to/resource')
+
+    openExternal.mockClear()
+    const rightClick = new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 2 })
+    expect(link.dispatchEvent(rightClick)).toBe(true)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('uses a browser popup only without the desktop bridge and surfaces bridge failures', async () => {
+    const popup = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+    delete desktopWindow.hermesDesktop
+
+    await openExternalLinkWithFallback('https://example.com/sign-in')
+    expect(popup).toHaveBeenCalledWith('https://example.com/sign-in', '_blank', 'noopener,noreferrer')
+
+    const bridgeError = new Error('OS opener unavailable')
+    installDesktopBridge({ openExternal: vi.fn().mockRejectedValue(bridgeError) })
+
+    await expect(openExternalLinkWithFallback('https://example.com/sign-in')).rejects.toBe(bridgeError)
+    expect(popup).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not treat a null browser popup result as a navigation failure', async () => {
+    const popup = vi.spyOn(window, 'open').mockReturnValue(null)
+    delete desktopWindow.hermesDesktop
+
+    await expect(openExternalLinkWithFallback('https://example.com/sign-in')).resolves.toBeUndefined()
+    expect(popup).toHaveBeenCalledWith('https://example.com/sign-in', '_blank', 'noopener,noreferrer')
+  })
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'file:///tmp/demo.html',
+    'spotify:track:123',
+    '/relative/path',
+    'not a URL',
+    'https:///missing-host'
+  ])('rejects unsafe external schemes before bridge or browser navigation: %s', async href => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    const popup = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+    installDesktopBridge({ openExternal: openExternal as unknown as Window['hermesDesktop']['openExternal'] })
+
+    openExternalLink(href)
+    await expect(openExternalLinkWithFallback(href)).rejects.toThrow('Unsupported external URL')
+
+    expect(openExternal).not.toHaveBeenCalled()
+    expect(popup).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsafe external schemes in browser fallback mode', async () => {
+    const popup = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+    delete desktopWindow.hermesDesktop
+
+    openExternalLink('javascript:alert(1)')
+    await expect(openExternalLinkWithFallback('file:///tmp/demo.html')).rejects.toThrow('Unsupported external URL')
+
+    expect(popup).not.toHaveBeenCalled()
+  })
+
+  it('preserves supported external schemes after normalization', async () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+    installDesktopBridge({ openExternal: openExternal as unknown as Window['hermesDesktop']['openExternal'] })
+
+    openExternalLink('example.com/docs')
+    await openExternalLinkWithFallback('mailto:hello@example.com')
+
+    expect(openExternal).toHaveBeenNthCalledWith(1, 'https://example.com/docs')
+    expect(openExternal).toHaveBeenNthCalledWith(2, 'mailto:hello@example.com')
+  })
+
+  it('returns without a browser fallback when window is unavailable', async () => {
+    delete desktopWindow.hermesDesktop
+    vi.stubGlobal('window', undefined)
+
+    try {
+      await expect(openExternalLinkWithFallback('https://example.com/sign-in')).resolves.toBeUndefined()
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 
   it('hides the trailing external-link icon by default', () => {

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -22,6 +22,7 @@ const EXPLICIT_URL_RE = /(?:https?:\/\/|www\.)[^\s<>"'`]+[^\s<>"'`.,;:!?)]/gi
 const DOMAIN_RE = /^(?:www\.)?[a-z0-9](?:[a-z0-9-]*\.)+[a-z]{2,}(?::\d+)?(?:[/?#][^\s]*)?$/i
 const SKIP_PROTO_RE = /^(?:file|data|mailto|javascript|blob|chrome|about|hermes):/i
 const LOCAL_HOST_RE = /^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?$/i
+const EXTERNAL_NAVIGATION_PROTOCOLS = new Set(['http:', 'https:', 'mailto:'])
 
 const ERROR_TITLE_RE =
   /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|not found|request blocked|too many requests)\b/i
@@ -195,10 +196,107 @@ export function useLinkTitle(url?: null | string): string {
   return title
 }
 
-export function openExternalLink(href: string): void {
-  if (href) {
-    void window.hermesDesktop?.openExternal?.(href)
+function normalizeAllowedExternalUrl(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
   }
+
+  const normalized = normalizeExternalUrl(value)
+
+  if (!normalized) {
+    return null
+  }
+
+  let parsed: URL
+
+  try {
+    parsed = new URL(normalized)
+  } catch {
+    return null
+  }
+
+  if (!EXTERNAL_NAVIGATION_PROTOCOLS.has(parsed.protocol)) {
+    return null
+  }
+
+  // URL accepts some malformed authority forms by treating the first path
+  // segment as a host. Require an explicit authority and a real host for
+  // network URLs before handing them to either the Desktop bridge or the
+  // browser fallback.
+  if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+    if (!/^https?:\/\/(?=[^/?#\s])/i.test(normalized) || !parsed.hostname) {
+      return null
+    }
+  }
+
+  // A bare `mailto:` has no destination and is not a useful external action.
+  if (parsed.protocol === 'mailto:' && !parsed.pathname) {
+    return null
+  }
+
+  return normalized
+}
+
+export function openExternalLink(href: string): void {
+  const normalizedHref = normalizeAllowedExternalUrl(href)
+
+  if (!normalizedHref || typeof window === 'undefined') {
+    return
+  }
+
+  // In Electron the Desktop bridge owns external navigation. Browser/dev
+  // previews have no bridge, so callers that already cancelled an anchor
+  // event must still get the normal popup behavior instead of silently doing
+  // nothing. Keep a present-but-incomplete bridge fail-closed; it is an
+  // application integration failure, not permission to bypass the bridge.
+  if (window.hermesDesktop) {
+    if (window.hermesDesktop.openExternal) {
+      void window.hermesDesktop.openExternal(normalizedHref)
+    }
+
+    return
+  }
+
+  window.open(normalizedHref, '_blank', 'noopener,noreferrer')
+}
+
+/**
+ * Open an OAuth or other user-requested URL in the current runtime.
+ *
+ * Electron's common window-open policy is deny-only, so a failed Desktop
+ * bridge must not fall through to window.open() inside the app. A missing
+ * bridge is the explicit browser/dev-preview contract where window.open is
+ * still the appropriate fallback; a present bridge that rejects is surfaced
+ * to the caller so it can show recovery UI instead of silently stalling.
+ */
+export async function openExternalLinkWithFallback(href: string): Promise<void> {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const normalizedHref = normalizeAllowedExternalUrl(href)
+
+  if (!normalizedHref) {
+    throw new Error('Unsupported external URL')
+  }
+
+  const bridge = window.hermesDesktop
+
+  if (bridge) {
+    if (!bridge.openExternal) {
+      throw new Error('Desktop external-link bridge is unavailable')
+    }
+
+    await bridge.openExternal(normalizedHref)
+
+    return
+  }
+
+  // Browsers may return null even after starting a successful navigation
+  // (notably with `noopener`), so the return value is not a reliable failure
+  // signal. Keep this operation best-effort and let the browser own popup
+  // policy and user-activation behavior.
+  window.open(normalizedHref, '_blank', 'noopener,noreferrer')
 }
 
 interface ExternalLinkProps extends Omit<ComponentProps<'a'>, 'href' | 'target'> {
@@ -232,6 +330,7 @@ export function ExternalLink({
   className,
   href,
   onClick,
+  onAuxClick,
   showExternalIcon = false,
   ...rest
 }: ExternalLinkProps) {
@@ -241,6 +340,17 @@ export function ExternalLink({
     <a
       className={cn('ref', className)}
       href={target}
+      onAuxClick={event => {
+        onAuxClick?.(event)
+
+        if (event.button !== 1 || event.defaultPrevented) {
+          return
+        }
+
+        event.stopPropagation()
+        event.preventDefault()
+        openExternalLink(target)
+      }}
       onClick={event => {
         event.stopPropagation()
         onClick?.(event)

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -133,6 +133,17 @@ describe('remote HTML previews', () => {
     expect(localPreviewTarget('//srv/share/report #1?.html')?.url).toBe('file:////srv/share/report%20%231%3F.html')
   })
 
+  it('round-trips Windows UNC file URLs without dropping the server authority', () => {
+    const target = localPreviewTarget('file://server/share/report.html')
+
+    expect(target?.path).toBe('\\\\server\\share\\report.html')
+    expect(target?.url).toBe('file://server/share/report.html')
+  })
+
+  it('keeps the localhost file URL alias on the local path contract', () => {
+    expect(localPreviewTarget('file://localhost/tmp/report.html')?.path).toBe('/tmp/report.html')
+  })
+
   it('opens ordinary targets without staging them', async () => {
     const openPreviewInBrowser = vi.fn(async () => undefined)
     const saveImageBuffer = vi.fn()

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -193,7 +193,14 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
 
   if (/^file:\/\//i.test(raw)) {
     try {
-      path = decodeURIComponent(new URL(raw).pathname)
+      const parsed = new URL(raw)
+      const decodedPath = decodeURIComponent(parsed.pathname)
+
+      // URL.pathname drops the authority from Windows UNC file URLs. Keep it
+      // as a Windows path so the canonical pathToFileUrl helper round-trips
+      // `\\server\share\file` back to `file://server/share/file`.
+      const uncHost = parsed.hostname && parsed.hostname.toLowerCase() !== 'localhost' ? parsed.hostname : ''
+      path = uncHost ? `\\\\${uncHost}${decodedPath.replace(/\//g, '\\')}` : decodedPath
     } catch {
       path = raw.replace(/^file:\/\//i, '')
     }

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -12,6 +12,7 @@ import {
   submitOAuthCode,
   validateProviderCredential
 } from '@/hermes'
+import { openExternalLinkWithFallback } from '@/lib/external-link'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { notify, notifyError } from '@/store/notifications'
@@ -557,24 +558,11 @@ export async function refreshOnboarding(ctx: OnboardingContext) {
   return false
 }
 
-// Open a sign-in URL via the desktop bridge, falling back to window.open
-// when the bridge isn't present (e.g. the web dashboard / dev preview) so
-// the flow never silently stalls in a waiting state. Mirrors the pattern in
-// apps/desktop/src/app/artifacts/index.tsx.
+// Open a sign-in URL through the explicit Desktop bridge/browser contract. A
+// bridge rejection is allowed to reach startProviderOAuth's error state;
+// window.open is reserved for the non-Electron browser/dev-preview case.
 async function openSignInUrl(url: string) {
-  if (window.hermesDesktop?.openExternal) {
-    try {
-      await window.hermesDesktop.openExternal(url)
-
-      return
-    } catch {
-      // Bridge present but failed (no OS handler, user denied, etc.). Fall
-      // through to window.open so the sign-in URL still opens and the flow
-      // doesn't strand a pending OAuth session in a waiting state.
-    }
-  }
-
-  window.open(url, '_blank', 'noopener,noreferrer')
+  await openExternalLinkWithFallback(url)
 }
 
 export async function startProviderOAuth(provider: OAuthProvider, ctx: OnboardingContext) {


### PR DESCRIPTION
## Summary
- Harden external-link handling and preview/browser boundaries with validated HTTP(S)/mailto navigation while preserving local-file preview behavior.
- Constrain Electron webviews, popups, navigation, preload, Node/Blink capabilities, and provider iframe embeds.
- Preserve supported preview and browser fallback paths with regression coverage.

## Validation
- Full UI suite: 3663 passed.
- Full Electron suite: 962 passed, 2 skipped.
- Full Electron/platform suite: 1006 passed, 2 skipped.
- Typecheck, lint, and diff checks passed.
- Independent security and compatibility reviews were clean.

Closes #82344