### PR TITLE
fix(desktop): follow default microphone changes during wake capture

### DIFF
--- a/apps/desktop/src/lib/wake-client-capture.test.ts
+++ b/apps/desktop/src/lib/wake-client-capture.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { startClientWakeCapture } from './wake-client-capture'
+
+function fakeNode() {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn()
+  }
+}
+
+function fakeStream(label: string) {
+  const track = new EventTarget() as EventTarget & {
+    label: string
+    stop: ReturnType<typeof vi.fn>
+  }
+
+  track.label = label
+  track.stop = vi.fn()
+
+  return {
+    getTracks: vi.fn(() => [track]),
+    track
+  }
+}
+
+function installAudioContext(options: { failReplacementConnect?: Error } = {}) {
+  const sources: Array<ReturnType<typeof fakeNode> & { stream: unknown }> = []
+
+  const processor = {
+    ...fakeNode(),
+    onaudioprocess: null as ((event: AudioProcessingEvent) => void) | null
+  }
+
+  const mute = {
+    ...fakeNode(),
+    gain: { value: 1 }
+  }
+
+  const context = {
+    close: vi.fn().mockResolvedValue(undefined),
+    createGain: vi.fn(() => mute),
+    createMediaStreamSource: vi.fn((stream: unknown) => {
+      const source = { ...fakeNode(), stream }
+
+      if (sources.length > 0 && options.failReplacementConnect) {
+        source.connect.mockImplementation(() => {
+          throw options.failReplacementConnect
+        })
+      }
+
+      sources.push(source)
+
+      return source
+    }),
+    createScriptProcessor: vi.fn(() => processor),
+    destination: {},
+    resume: vi.fn().mockResolvedValue(undefined),
+    sampleRate: 48_000,
+    state: 'running'
+  }
+
+  function FakeAudioContext() {
+    return context
+  }
+
+  vi.stubGlobal('AudioContext', FakeAudioContext)
+
+  return { context, mute, processor, sources }
+}
+
+async function flushAsyncWork() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined
+  let reject: (reason?: unknown) => void = () => undefined
+
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+
+  return { promise, reject, resolve }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('startClientWakeCapture microphone handoff', () => {
+  it('swaps to the new default input when media devices change', async () => {
+    const first = fakeStream('Built-in Microphone')
+    const second = fakeStream('AirPods Max')
+
+    const mediaDevices = new EventTarget() as EventTarget & {
+      getUserMedia: ReturnType<typeof vi.fn>
+    }
+
+    mediaDevices.getUserMedia = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+    vi.stubGlobal('navigator', { mediaDevices })
+    const { context, processor, sources } = installAudioContext()
+
+    const capture = await startClientWakeCapture({ request: vi.fn().mockResolvedValue({}) })
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    await flushAsyncWork()
+
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(2)
+    expect(context.createMediaStreamSource).toHaveBeenNthCalledWith(2, second)
+    expect(sources[1]?.connect).toHaveBeenCalledWith(processor)
+    expect(sources[0]?.disconnect).toHaveBeenCalledOnce()
+    expect(first.track.stop).toHaveBeenCalledOnce()
+    expect(second.track.stop).not.toHaveBeenCalled()
+
+    capture.stop()
+  })
+
+  it('serializes rapid device changes so an older stream cannot win the race', async () => {
+    const first = fakeStream('Built-in Microphone')
+    const second = fakeStream('AirPods Max — connecting')
+    const third = fakeStream('AirPods Max')
+    const firstHandoff = deferred<typeof second>()
+    const queuedHandoff = deferred<typeof third>()
+
+    const mediaDevices = new EventTarget() as EventTarget & {
+      getUserMedia: ReturnType<typeof vi.fn>
+    }
+
+    mediaDevices.getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockImplementationOnce(() => firstHandoff.promise)
+      .mockImplementationOnce(() => queuedHandoff.promise)
+    vi.stubGlobal('navigator', { mediaDevices })
+    installAudioContext()
+
+    const capture = await startClientWakeCapture({ request: vi.fn().mockResolvedValue({}) })
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    await flushAsyncWork()
+
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(2)
+
+    firstHandoff.resolve(second)
+    await flushAsyncWork()
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(3)
+
+    queuedHandoff.resolve(third)
+    await flushAsyncWork()
+
+    expect(first.track.stop).toHaveBeenCalledOnce()
+    expect(second.track.stop).toHaveBeenCalledOnce()
+    expect(third.track.stop).not.toHaveBeenCalled()
+
+    capture.stop()
+  })
+
+  it('reacquires the default input when the active track ends', async () => {
+    const first = fakeStream('AirPods Max')
+    const second = fakeStream('Built-in Microphone')
+
+    const mediaDevices = new EventTarget() as EventTarget & {
+      getUserMedia: ReturnType<typeof vi.fn>
+    }
+
+    mediaDevices.getUserMedia = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+    vi.stubGlobal('navigator', { mediaDevices })
+    const { context } = installAudioContext()
+
+    const capture = await startClientWakeCapture({ request: vi.fn().mockResolvedValue({}) })
+
+    first.track.dispatchEvent(new Event('ended'))
+    await flushAsyncWork()
+
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(2)
+    expect(context.createMediaStreamSource).toHaveBeenNthCalledWith(2, second)
+    expect(first.track.stop).toHaveBeenCalledOnce()
+
+    capture.stop()
+  })
+
+  it('ignores a failed handoff after wake capture has stopped', async () => {
+    const first = fakeStream('AirPods Max')
+    const handoff = deferred<ReturnType<typeof fakeStream>>()
+
+    const mediaDevices = new EventTarget() as EventTarget & {
+      getUserMedia: ReturnType<typeof vi.fn>
+    }
+
+    mediaDevices.getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockImplementationOnce(() => handoff.promise)
+    vi.stubGlobal('navigator', { mediaDevices })
+    installAudioContext()
+    const onError = vi.fn()
+
+    const capture = await startClientWakeCapture({ onError, request: vi.fn().mockResolvedValue({}) })
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    capture.stop()
+    handoff.reject(new Error('device vanished'))
+    await flushAsyncWork()
+
+    expect(onError).not.toHaveBeenCalled()
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    await flushAsyncWork()
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(2)
+  })
+
+  it('releases a replacement stream that resolves after capture has stopped', async () => {
+    const first = fakeStream('AirPods Max')
+    const replacement = fakeStream('Built-in Microphone')
+    const handoff = deferred<typeof replacement>()
+
+    const mediaDevices = new EventTarget() as EventTarget & {
+      getUserMedia: ReturnType<typeof vi.fn>
+    }
+
+    mediaDevices.getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockImplementationOnce(() => handoff.promise)
+    vi.stubGlobal('navigator', { mediaDevices })
+    const { context } = installAudioContext()
+    const onError = vi.fn()
+
+    const capture = await startClientWakeCapture({ onError, request: vi.fn().mockResolvedValue({}) })
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    capture.stop()
+    handoff.resolve(replacement)
+    await flushAsyncWork()
+
+    expect(replacement.track.stop).toHaveBeenCalledOnce()
+    expect(context.createMediaStreamSource).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('moves track-ended recovery to each replacement and removes all listeners on stop', async () => {
+    const first = fakeStream('Built-in Microphone')
+    const second = fakeStream('AirPods Max')
+    const third = fakeStream('Studio Display Microphone')
+
+    const mediaDevices = new EventTarget() as EventTarget & {
+      getUserMedia: ReturnType<typeof vi.fn>
+    }
+
+    mediaDevices.getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+      .mockResolvedValueOnce(third)
+    vi.stubGlobal('navigator', { mediaDevices })
+    installAudioContext()
+
+    const capture = await startClientWakeCapture({ request: vi.fn().mockResolvedValue({}) })
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    await flushAsyncWork()
+
+    first.track.dispatchEvent(new Event('ended'))
+    await flushAsyncWork()
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(2)
+
+    second.track.dispatchEvent(new Event('ended'))
+    await flushAsyncWork()
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(3)
+
+    capture.stop()
+    second.track.dispatchEvent(new Event('ended'))
+    third.track.dispatchEvent(new Event('ended'))
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    await flushAsyncWork()
+
+    expect(mediaDevices.getUserMedia).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps the current stream after a transient acquisition failure and recovers later', async () => {
+    const first = fakeStream('Built-in Microphone')
+    const second = fakeStream('AirPods Max')
+    const failure = new Error('default input is changing')
+
+    const mediaDevices = new EventTarget() as EventTarget & {
+      getUserMedia: ReturnType<typeof vi.fn>
+    }
+
+    mediaDevices.getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(second)
+    vi.stubGlobal('navigator', { mediaDevices })
+    const { processor, sources } = installAudioContext()
+    const onError = vi.fn()
+
+    const capture = await startClientWakeCapture({ onError, request: vi.fn().mockResolvedValue({}) })
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    await flushAsyncWork()
+
+    expect(onError).toHaveBeenCalledOnce()
+    expect(onError).toHaveBeenCalledWith(failure)
+    expect(sources[0]?.disconnect).not.toHaveBeenCalled()
+    expect(first.track.stop).not.toHaveBeenCalled()
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    await flushAsyncWork()
+
+    expect(sources[1]?.connect).toHaveBeenCalledWith(processor)
+    expect(sources[0]?.disconnect).toHaveBeenCalledOnce()
+    expect(first.track.stop).toHaveBeenCalledOnce()
+    expect(second.track.stop).not.toHaveBeenCalled()
+
+    capture.stop()
+  })
+
+  it('releases a replacement stream when its audio source cannot connect', async () => {
+    const first = fakeStream('Built-in Microphone')
+    const replacement = fakeStream('AirPods Max')
+
+    const mediaDevices = new EventTarget() as EventTarget & {
+      getUserMedia: ReturnType<typeof vi.fn>
+    }
+
+    mediaDevices.getUserMedia = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(replacement)
+    vi.stubGlobal('navigator', { mediaDevices })
+    const failure = new Error('audio graph rejected replacement')
+    installAudioContext({ failReplacementConnect: failure })
+    const onError = vi.fn()
+
+    const capture = await startClientWakeCapture({ onError, request: vi.fn().mockResolvedValue({}) })
+
+    mediaDevices.dispatchEvent(new Event('devicechange'))
+    await flushAsyncWork()
+
+    expect(onError).toHaveBeenCalledWith(failure)
+    expect(replacement.track.stop).toHaveBeenCalledOnce()
+    expect(first.track.stop).not.toHaveBeenCalled()
+
+    capture.stop()
+  })
+})

--- a/apps/desktop/src/lib/wake-client-capture.ts
+++ b/apps/desktop/src/lib/wake-client-capture.ts
@@ -10,6 +10,16 @@
 const TARGET_RATE = 16_000
 const DEFAULT_FRAME = 1280 // 80 ms @ 16 kHz — matches tools/wake_word.py
 
+const DEFAULT_MICROPHONE_CONSTRAINTS = {
+  audio: {
+    channelCount: 1,
+    echoCancellation: true,
+    noiseSuppression: true,
+    autoGainControl: true
+  },
+  video: false
+} satisfies MediaStreamConstraints
+
 export type WakeFeedRequester = (method: string, params?: Record<string, unknown>) => Promise<unknown>
 
 export interface ClientWakeCaptureOptions {
@@ -95,18 +105,10 @@ export async function startClientWakeCapture(options: ClientWakeCaptureOptions):
     throw new Error('getUserMedia unavailable for client wake capture')
   }
 
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      channelCount: 1,
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: true
-    },
-    video: false
-  })
+  let stream = await navigator.mediaDevices.getUserMedia(DEFAULT_MICROPHONE_CONSTRAINTS)
 
   const context = new AudioContextCtor()
-  const source = context.createMediaStreamSource(stream)
+  let source = context.createMediaStreamSource(stream)
   // ScriptProcessor is deprecated but widely available and simple for PCM export.
   // Buffer size 4096 keeps callback rate reasonable on desktop.
   const processor = context.createScriptProcessor(4096, 1, 1)
@@ -203,6 +205,74 @@ export async function startClientWakeCapture(options: ClientWakeCaptureOptions):
   processor.connect(mute)
   mute.connect(context.destination)
 
+  let handoffRunning = false
+  let handoffQueued = false
+
+  function handleInputChange() {
+    void replaceDefaultInput()
+  }
+
+  function attachTrackEndListeners(target: MediaStream) {
+    target.getTracks().forEach(track => track.addEventListener('ended', handleInputChange))
+  }
+
+  function detachTrackEndListeners(target: MediaStream) {
+    target.getTracks().forEach(track => track.removeEventListener('ended', handleInputChange))
+  }
+
+  async function replaceDefaultInput() {
+    if (handoffRunning) {
+      handoffQueued = true
+
+      return
+    }
+
+    handoffRunning = true
+
+    try {
+      do {
+        handoffQueued = false
+        let replacementStream: MediaStream | null = null
+        let replacementSource: MediaStreamAudioSourceNode | null = null
+
+        try {
+          replacementStream = await navigator.mediaDevices.getUserMedia(DEFAULT_MICROPHONE_CONSTRAINTS)
+
+          if (stopped) {
+            replacementStream.getTracks().forEach(track => track.stop())
+
+            return
+          }
+
+          replacementSource = context.createMediaStreamSource(replacementStream)
+          replacementSource.connect(processor)
+          detachTrackEndListeners(stream)
+          source.disconnect()
+          stream.getTracks().forEach(track => track.stop())
+          source = replacementSource
+          stream = replacementStream
+          attachTrackEndListeners(stream)
+          replacementSource = null
+          replacementStream = null
+        } catch (error) {
+          replacementSource?.disconnect()
+          replacementStream?.getTracks().forEach(track => track.stop())
+
+          if (!stopped) {
+            options.onError?.(error instanceof Error ? error : new Error(String(error)))
+          }
+        }
+      } while (handoffQueued && !stopped)
+    } finally {
+      handoffRunning = false
+    }
+  }
+
+  const handleDeviceChange = handleInputChange
+
+  navigator.mediaDevices.addEventListener('devicechange', handleDeviceChange)
+  attachTrackEndListeners(stream)
+
   if (context.state === 'suspended') {
     await context.resume().catch(() => undefined)
   }
@@ -218,6 +288,8 @@ export async function startClientWakeCapture(options: ClientWakeCaptureOptions):
 
       stopped = true
       queue.length = 0
+      navigator.mediaDevices.removeEventListener('devicechange', handleDeviceChange)
+      detachTrackEndListeners(stream)
 
       try {
         processor.disconnect()


### PR DESCRIPTION
# fix(desktop): follow default microphone changes during wake capture

## Summary

Remote Desktop wake capture opens the system-default microphone once and keeps that `MediaStream` for the lifetime of the listener. If the user changes the macOS default input—such as moving between AirPods and the MacBook microphone—wake listening can remain attached to the old or disconnected device until it is toggled off and on.

This change:

- reacquires the current default microphone after `MediaDevices.devicechange`;
- also recovers when the active `MediaStreamTrack` ends;
- connects a replacement source before releasing the current stream, so a failed replacement leaves the existing capture intact;
- serializes rapid input changes so stale asynchronous acquisitions cannot win;
- removes device/track listeners and releases pending replacement streams when capture stops.

This is intentionally limited to the existing Remote Desktop client-capture path. It does not add a microphone picker or change voice/STT device selection. Related: #76866.

## Reproduction

1. Run packaged Hermes Desktop in Remote mode with wake capture using the client microphone.
2. Set AirPods as the macOS default input and enable wake listening.
3. Change the macOS default input to the MacBook microphone without toggling wake listening.
4. Speak the wake phrase into the MacBook microphone.

Before this change, the original stream remains attached to the previous device or becomes silent. Toggling wake listening off and on reacquires the new default input.

After this change, the active client capture hands off to the current default microphone while wake listening remains armed.

## Tests

Automated verification on Linux x64:

- `npm --workspace apps/desktop exec -- vitest run src/lib/wake-client-capture.test.ts --project ui` — 8 passed
- `npm --workspace apps/desktop run typecheck` — passed
- targeted ESLint and Prettier checks for the changed source and test — passed
- `npm --workspace apps/desktop run test:ui` — 3,637 passed
- `npm --workspace apps/desktop run test:desktop:platforms` — 1,000 passed, 2 skipped
- `npm --workspace apps/desktop run build` — passed
- `git diff --check` — passed

Manual verification on packaged macOS arm64:

- initial AirPods capture;
- AirPods → MacBook microphone;
- MacBook microphone → AirPods;
- wake-listener ownership remained active through both handoffs.

## Test coverage added

The focused regression suite covers:

- switching to the new default input;
- serializing rapid consecutive device changes;
- reacquiring after the active track ends;
- suppressing errors and releasing streams when capture stops during a pending handoff;
- migrating track-ended listeners to each replacement and removing all input-change listeners on stop;
- preserving the current stream through a transient acquisition failure and recovering on the next device change;
- cleaning up a replacement whose audio source cannot connect.

## Disclosure

Implementation and regression-test development were assisted by Hermes Agent. The failure was reproduced and the packaged macOS arm64 microphone-handoff matrix was manually validated.
