### PR TITLE
fix(desktop): run SSH lifecycle commands via sh

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -62,17 +62,22 @@ function ownedLock(over: any = {}) {
 // [regex|fn, response|fn] rules. First match wins; unmatched commands return ''.
 function fakeSsh(rules: any[] = []) {
   const calls: string[] = []
+  const rawCalls: string[] = []
 
   return {
     calls,
+    rawCalls,
     async exec(cmd) {
-      calls.push(cmd)
+      rawCalls.push(cmd)
+      const encoded = /base64\.b64decode\('([A-Za-z0-9+/=]+)'\)/.exec(cmd)?.[1]
+      const payload = encoded ? Buffer.from(encoded, 'base64').toString('utf8') : cmd
+      calls.push(payload)
 
       for (const [matcher, resp] of rules) {
-        const hit = typeof matcher === 'function' ? matcher(cmd) : matcher.test(cmd)
+        const hit = typeof matcher === 'function' ? matcher(payload) : matcher.test(payload)
 
         if (hit) {
-          const out = typeof resp === 'function' ? resp(cmd) : resp
+          const out = typeof resp === 'function' ? resp(payload) : resp
 
           if (out instanceof Error) {
             throw out
@@ -87,6 +92,12 @@ function fakeSsh(rules: any[] = []) {
   }
 }
 
+function decodeFishSafePayload(command: string): string {
+  const encoded = /base64\.b64decode\('([A-Za-z0-9+/=]+)'\)/.exec(command)?.[1]
+
+  return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : command
+}
+
 test('listRemoteHermesProfiles inventories Mini-style profile dirs without spawning a dashboard', async () => {
   const ssh = fakeSsh([
     [/HERMES_HOME/, '/Users/zillajr/.hermes\n'],
@@ -98,6 +109,22 @@ test('listRemoteHermesProfiles inventories Mini-style profile dirs without spawn
     ssh.calls.some(cmd => cmd.includes('serve') || cmd.includes('dashboard')),
     false
   )
+})
+
+test('remote lifecycle commands use a Fish-safe POSIX launcher', async () => {
+  const ssh = fakeSsh([
+    [/HERMES_HOME/, '/Users/zillajr/.hermes\n'],
+    [/ls -1/, 'camille\n']
+  ])
+
+  await listRemoteHermesProfiles(ssh)
+
+  assert.ok(ssh.rawCalls.length > 0)
+
+  for (const command of ssh.rawCalls) {
+    assert.match(command, /^python3 -c "/)
+    assert.match(command, /os\.execvp\('sh',\['sh','-lc',base64\.b64decode\('/)
+  }
 })
 
 test('listRemoteHermesProfiles rejects a hostile HERMES_HOME', async () => {
@@ -212,7 +239,7 @@ test('locateHermes throws a hermes-not-found error with an install hint', async 
   )
 })
 
-test('locateHermes uses a login shell for the command -v probe', async () => {
+test('locateHermes sends its command -v probe through the Fish-safe launcher', async () => {
   const ssh = fakeSsh([
     [/command -v hermes/, '/x/hermes'],
     [/\[ -x/, 'OK']
@@ -220,8 +247,8 @@ test('locateHermes uses a login shell for the command -v probe', async () => {
 
   await locateHermes(ssh, '')
   assert.ok(
-    ssh.calls.some(c => /bash -lc/.test(c)),
-    'must probe in a login shell (PATH pitfall)'
+    ssh.rawCalls.some(c => /^python3 -c "/.test(c) && /base64\.b64decode/.test(c)),
+    'must keep the probe safe for a Fish login shell'
   )
 })
 
@@ -1064,24 +1091,25 @@ test('spawnRemoteDashboard streams the token over stdin, not argv/env', async ()
     calls,
     async exec(cmd, opts?) {
       calls.push(cmd)
+      const payload = decodeFishSafePayload(cmd)
 
       if (opts?.stdinData) {
         stdinCalls.push(opts.stdinData)
       }
 
-      if (/grep -q ssh-session-token-file/.test(cmd)) {
+      if (/grep -q ssh-session-token-file/.test(payload)) {
         return 'YES\n'
       }
 
-      if (/python3 -c/.test(cmd)) {
+      if (/python3 -c/.test(payload)) {
         return ''
       }
 
-      if (/setsid|nohup/.test(cmd)) {
+      if (/setsid|nohup/.test(payload)) {
         return '4242\n'
       }
 
-      if (/printf '%s\\n'/.test(cmd)) {
+      if (/printf '%s\\n'/.test(payload)) {
         return ''
       }
 
@@ -1115,20 +1143,21 @@ test('spawnRemoteDashboard upload uses exclusive-create and O_NOFOLLOW', async (
     calls,
     async exec(cmd, opts?) {
       calls.push(cmd)
+      const payload = decodeFishSafePayload(cmd)
 
-      if (/grep -q ssh-session-token-file/.test(cmd)) {
+      if (/grep -q ssh-session-token-file/.test(payload)) {
         return 'YES\n'
       }
 
-      if (/python3 -c/.test(cmd)) {
+      if (/python3 -c/.test(payload)) {
         return ''
       }
 
-      if (/setsid|nohup/.test(cmd)) {
+      if (/setsid|nohup/.test(payload)) {
         return '4242\n'
       }
 
-      if (/printf '%s\\n'/.test(cmd)) {
+      if (/printf '%s\\n'/.test(payload)) {
         return ''
       }
 
@@ -1142,7 +1171,7 @@ test('spawnRemoteDashboard upload uses exclusive-create and O_NOFOLLOW', async (
     token: 'tk',
     ownershipId: OWNERSHIP_ID
   })
-  const uploadCmd = calls.find(c => /python3 -c/.test(c))
+  const uploadCmd = calls.map(decodeFishSafePayload).find(c => /python3 -c/.test(c))
   assert.ok(uploadCmd, 'must use python3 -c for token upload')
   assert.match(uploadCmd, /O_EXCL/, 'upload must use O_EXCL to reject existing files')
   assert.match(uploadCmd, /O_NOFOLLOW/, 'upload must use O_NOFOLLOW to reject symlinks')

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -51,20 +51,26 @@ function ownedLock(over: any = {}) {
 }
 
 // A fake SshConnection whose exec() is matched against an ordered list of
-// [regex|fn, response|fn] rules. First match wins; unmatched commands return ''.
+// [regex|fn, response|fn] rules. Lifecycle commands are wrapped in a
+// Fish-safe base64 launcher, so rules inspect the decoded POSIX payload.
 function fakeSsh(rules: any[] = []) {
   const calls: string[] = []
+  const rawCalls: string[] = []
 
   return {
     calls,
+    rawCalls,
     async exec(cmd) {
-      calls.push(cmd)
+      rawCalls.push(cmd)
+      const encoded = /base64\.b64decode\('([A-Za-z0-9+/=]+)'\)/.exec(cmd)?.[1]
+      const payload = encoded ? Buffer.from(encoded, 'base64').toString('utf8') : cmd
+      calls.push(payload)
 
       for (const [matcher, resp] of rules) {
-        const hit = typeof matcher === 'function' ? matcher(cmd) : matcher.test(cmd)
+        const hit = typeof matcher === 'function' ? matcher(payload) : matcher.test(payload)
 
         if (hit) {
-          const out = typeof resp === 'function' ? resp(cmd) : resp
+          const out = typeof resp === 'function' ? resp(payload) : resp
 
           if (out instanceof Error) {
             throw out
@@ -150,17 +156,18 @@ test('locateHermes throws a hermes-not-found error with an install hint', async 
   )
 })
 
-test('locateHermes uses a login shell for the command -v probe', async () => {
+test('locateHermes sends its login-shell probe through a Fish-safe launcher', async () => {
   const ssh = fakeSsh([
     [/command -v hermes/, '/x/hermes'],
     [/\[ -x/, 'OK']
   ])
 
   await locateHermes(ssh, '')
-  assert.ok(
-    ssh.calls.some(c => /bash -lc/.test(c)),
-    'must probe in a login shell (PATH pitfall)'
-  )
+  const executableProbe = ssh.rawCalls.find(c => /base64\.b64decode/.test(c))
+
+  assert.match(executableProbe, /^python3 -c "/)
+  assert.match(executableProbe, /base64\.b64decode\('/)
+  assert.doesNotMatch(executableProbe, /\/x\/hermes/)
 })
 
 test('probeRemotePlatform accepts Linux and macOS', async () => {
@@ -574,8 +581,6 @@ test('connect() respawns when the lockfile protocolVersion is incompatible', asy
 })
 
 test('connect() fresh spawn writes hermesHome + protocolVersion into the lockfile', async () => {
-  const writes: string[] = []
-
   const ssh = fakeSsh([
     [/uname/, 'Linux\nx86_64'],
     [/\[ -x/, 'OK'],
@@ -586,19 +591,11 @@ test('connect() fresh spawn writes hermesHome + protocolVersion into the lockfil
     [/printf '%s\\n'/, ''],
     [/setsid/, '700\n'],
     [/kill -0 700/, 'ALIVE'],
-    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=45500\n'],
-    [
-      /printf '%s' '/,
-      c => {
-        writes.push(c)
-
-        return ''
-      }
-    ]
+    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=45500\n']
   ])
 
   await connect(connectDeps(ssh, { adoptServedToken: async () => 'fresh' }))
-  const lockWrite = writes.find(c => c.includes('schemaVersion')) || ''
+  const lockWrite = ssh.calls.find(c => c.includes('schemaVersion')) || ''
   assert.match(lockWrite, new RegExp(`"protocolVersion":${PROTOCOL_VERSION}`))
   assert.match(lockWrite, /"hermesHome":"\/home\/alice\/\.hermes"/)
 })
@@ -664,6 +661,29 @@ test('connect() respawns when the dashboard is wedged (alive pid, probe fails)',
   assert.equal(result.reused, false)
   assert.equal(result.pid, 999)
   assert.equal(result.remotePort, 43000)
+})
+
+test('connect runs every POSIX lifecycle payload through a Fish-safe POSIX launcher', async () => {
+  const ssh = fakeSsh([
+    [/uname/, 'Linux\nx86_64'],
+    [/\[ -x/, 'OK'],
+    [/cat .*lock\.json/, ''],
+    [/grep -q ssh-session-token-file/, 'YES\n'],
+    [/python3 -c/, ''],
+    [/setsid/, '999\n'],
+    [/kill -0 999/, 'ALIVE'],
+    [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=43000\n']
+  ])
+
+  const result = await connect(connectDeps(ssh, { adoptServedToken: async () => 'served-token' }))
+
+  assert.equal(result.reused, false)
+  assert.ok(ssh.calls.length > 0)
+
+  for (const command of ssh.rawCalls) {
+    assert.match(command, /^python3 -c "/, `must use a Fish-safe launcher: ${command}`)
+    assert.match(command, /os\.execvp\('sh',\['sh','-lc',base64\.b64decode\(/)
+  }
 })
 
 test('connect() aborts on an unsupported remote platform before doing anything else', async () => {
@@ -832,24 +852,26 @@ test('spawnRemoteDashboard streams the token over stdin, not argv/env', async ()
     calls,
     async exec(cmd, opts?) {
       calls.push(cmd)
+      const encoded = /base64\.b64decode\('([A-Za-z0-9+/=]+)'\)/.exec(cmd)?.[1]
+      const payload = encoded ? Buffer.from(encoded, 'base64').toString('utf8') : cmd
 
       if (opts?.stdinData) {
         stdinCalls.push(opts.stdinData)
       }
 
-      if (/grep -q ssh-session-token-file/.test(cmd)) {
+      if (/grep -q ssh-session-token-file/.test(payload)) {
         return 'YES\n'
       }
 
-      if (/python3 -c/.test(cmd)) {
+      if (/python3 -c/.test(payload)) {
         return ''
       }
 
-      if (/setsid|nohup/.test(cmd)) {
+      if (/setsid|nohup/.test(payload)) {
         return '4242\n'
       }
 
-      if (/printf '%s\\n'/.test(cmd)) {
+      if (/printf '%s\\n'/.test(payload)) {
         return ''
       }
 
@@ -883,20 +905,22 @@ test('spawnRemoteDashboard upload uses exclusive-create and O_NOFOLLOW', async (
     calls,
     async exec(cmd, opts?) {
       calls.push(cmd)
+      const encoded = /base64\.b64decode\('([A-Za-z0-9+/=]+)'\)/.exec(cmd)?.[1]
+      const payload = encoded ? Buffer.from(encoded, 'base64').toString('utf8') : cmd
 
-      if (/grep -q ssh-session-token-file/.test(cmd)) {
+      if (/grep -q ssh-session-token-file/.test(payload)) {
         return 'YES\n'
       }
 
-      if (/python3 -c/.test(cmd)) {
+      if (/python3 -c/.test(payload)) {
         return ''
       }
 
-      if (/setsid|nohup/.test(cmd)) {
+      if (/setsid|nohup/.test(payload)) {
         return '4242\n'
       }
 
-      if (/printf '%s\\n'/.test(cmd)) {
+      if (/printf '%s\\n'/.test(payload)) {
         return ''
       }
 
@@ -910,8 +934,15 @@ test('spawnRemoteDashboard upload uses exclusive-create and O_NOFOLLOW', async (
     token: 'tk',
     ownershipId: OWNERSHIP_ID
   })
-  const uploadCmd = calls.find(c => /python3 -c/.test(c))
-  assert.ok(uploadCmd, 'must use python3 -c for token upload')
+
+  const payloads = calls.map(command => {
+    const encoded = /base64\.b64decode\('([A-Za-z0-9+/=]+)'\)/.exec(command)?.[1]
+
+    return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : command
+  })
+
+  const uploadCmd = payloads.find(command => /O_EXCL/.test(command))
+  assert.ok(uploadCmd, 'must use a Fish-safe wrapper for token upload')
   assert.match(uploadCmd, /O_EXCL/, 'upload must use O_EXCL to reject existing files')
   assert.match(uploadCmd, /O_NOFOLLOW/, 'upload must use O_NOFOLLOW to reject symlinks')
   assert.match(uploadCmd, /O_WRONLY/, 'upload must open write-only')

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -25,6 +25,7 @@
  * the minted one (which the dashboard may regen).
  */
 
+import { Buffer } from 'node:buffer'
 import crypto from 'node:crypto'
 
 import { parseRemoteProfileListing } from './connection-registry'
@@ -101,6 +102,17 @@ function shq(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`
 }
 
+// sshd sends a remote command through the account's login shell before any
+// command inside it runs. Fish therefore parses a raw POSIX lifecycle payload
+// (parameter expansion, [ ], &&, redirects, etc.) and rejects it. Keep that
+// payload out of the login-shell command line: Python decodes it and execs
+// POSIX sh with the payload as one argv value.
+function posixShell(command: string) {
+  const encoded = Buffer.from(String(command), 'utf8').toString('base64')
+
+  return `python3 -c "import base64,os;os.execvp('sh',['sh','-lc',base64.b64decode('${encoded}').decode()])"`
+}
+
 function validateRemotePath(p) {
   const s = String(p || '')
 
@@ -154,7 +166,7 @@ async function locateHermes(ssh, remoteHermesPath) {
   const isExecutable = async (candidate: string) => {
     try {
       validateRemotePath(candidate)
-      const ok = (await ssh.exec(`[ -x ${expandRemotePath(candidate)} ] && echo OK || true`)).trim()
+      const ok = (await ssh.exec(posixShell(`[ -x ${expandRemotePath(candidate)} ] && echo OK || true`))).trim()
 
       return ok === 'OK'
     } catch {
@@ -180,7 +192,7 @@ async function locateHermes(ssh, remoteHermesPath) {
   const candidates: string[] = []
 
   try {
-    const found = (await ssh.exec(`bash -lc ${shq('command -v hermes')}`)).trim()
+    const found = (await ssh.exec(posixShell('command -v hermes'))).trim()
 
     if (found) {
       candidates.push(found.split('\n').pop().trim())
@@ -220,7 +232,7 @@ async function locateHermes(ssh, remoteHermesPath) {
 // connection uses, so a stale/unexpected install is visible.
 async function probeHermesVersion(ssh, hermesPath) {
   try {
-    const out = (await ssh.exec(`${expandRemotePath(hermesPath)} --version 2>&1`)).trim()
+    const out = (await ssh.exec(posixShell(`${expandRemotePath(hermesPath)} --version 2>&1`))).trim()
 
     return (out.split('\n')[0] || '').trim()
   } catch {
@@ -229,7 +241,7 @@ async function probeHermesVersion(ssh, hermesPath) {
 }
 
 async function probeRemotePlatform(ssh) {
-  const out = (await ssh.exec('uname -s; uname -m')).trim().split('\n')
+  const out = (await ssh.exec(posixShell('uname -s; uname -m'))).trim().split('\n')
   const osName = (out[0] || '').trim()
   const arch = (out[1] || '').trim()
 
@@ -250,7 +262,7 @@ async function probeRemotePlatform(ssh) {
 // state store; best-effort.
 async function probeRemoteHermesHome(ssh) {
   try {
-    const out = (await ssh.exec('echo "${HERMES_HOME:-$HOME/.hermes}"')).trim().split('\n').pop()
+    const out = (await ssh.exec(posixShell('echo "${HERMES_HOME:-$HOME/.hermes}"'))).trim().split('\n').pop()
 
     return out || '~/.hermes'
   } catch (cause) {
@@ -267,7 +279,7 @@ async function listRemoteHermesProfiles(ssh) {
   let listing = ''
 
   try {
-    listing = await ssh.exec(`if [ -d ${dir} ]; then ls -1 ${dir}; fi`)
+    listing = await ssh.exec(posixShell(`if [ -d ${dir} ]; then ls -1 ${dir}; fi`))
   } catch (cause) {
     const error: any = new Error('Could not list remote Hermes profiles.')
     error.kind = 'transient-transport-error'
@@ -295,7 +307,7 @@ async function readLockfile(ssh, ownershipId) {
   let raw
 
   try {
-    raw = await ssh.exec(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)
+    raw = await ssh.exec(posixShell(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`))
   } catch (cause) {
     const error: any = new Error('Could not read the SSH backend ownership record.')
     error.kind = 'transient-transport-error'
@@ -364,18 +376,18 @@ async function writeLockfile(ssh, ownershipId, lock) {
   const lpath = lockfilePath(ownershipId)
   const temporaryPath = `${directory}/.${crypto.randomBytes(8).toString('hex')}.lock.tmp`
   const json = JSON.stringify({ ...lock, schemaVersion: LOCKFILE_SCHEMA_VERSION })
-  await ssh.exec(
+  await ssh.exec(posixShell(
     `umask 077 && mkdir -p ${expandRemotePath(directory)} && ` +
       `printf '%s' ${shq(json)} > ${expandRemotePath(temporaryPath)} && ` +
       `mv -f ${expandRemotePath(temporaryPath)} ${expandRemotePath(lpath)}`
-  )
+  ))
 }
 
 async function removeLockfile(ssh, ownershipId) {
   const lpath = lockfilePath(ownershipId)
 
   try {
-    await ssh.exec(`rm -f ${expandRemotePath(lpath)}`)
+    await ssh.exec(posixShell(`rm -f ${expandRemotePath(lpath)}`))
   } catch {
     // best effort
   }
@@ -387,7 +399,7 @@ async function remotePidAlive(ssh, pid) {
   }
 
   try {
-    const out = (await ssh.exec(`kill -0 ${Number(pid)} 2>/dev/null && echo ALIVE || echo DEAD`)).trim()
+    const out = (await ssh.exec(posixShell(`kill -0 ${Number(pid)} 2>/dev/null && echo ALIVE || echo DEAD`))).trim()
 
     return out === 'ALIVE'
   } catch (cause) {
@@ -461,7 +473,7 @@ async function pidIsOurDashboard(
       'except (ValueError,IndexError):pass\n' +
       'print("OWNED" if ok else "FOREIGN")'
 
-    const out = await ssh.exec(`python3 -c ${shq(script)}`)
+    const out = await ssh.exec(posixShell(`python3 -c ${shq(script)}`))
 
     return String(out || '').trim() === 'OWNED'
   } catch (cause) {
@@ -489,11 +501,11 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
   ) {
     try {
       const result = (
-        await ssh.exec(
+        await ssh.exec(posixShell(
           `kill ${Number(lock.pid)} && ` +
             `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
             `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
-        )
+        ))
       ).trim()
 
       void result
@@ -509,7 +521,7 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
 
   if (lock?.logPath === expectedLogPath) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(lock.logPath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(lock.logPath)}`))
     } catch {
       void 0
     }
@@ -543,11 +555,11 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 async function remoteSupportsSshOwnership(ssh, hermesPath) {
   const hermes = expandRemotePath(hermesPath)
 
-  const out = await ssh.exec(
+  const out = await ssh.exec(posixShell(
     `help="$(${hermes} serve --help 2>&1)"; ` +
       `printf '%s' "$help" | grep -q ssh-session-token-file && ` +
       `printf '%s' "$help" | grep -q ssh-owner-nonce && echo YES || echo NO`
-  )
+  ))
 
   return String(out || '')
     .trim()
@@ -570,7 +582,7 @@ async function scrapeReadyPort(ssh, logPath, { timeoutMs = DEFAULT_READY_TIMEOUT
     let tail
 
     try {
-      tail = await ssh.exec(`cat ${remoteLog} 2>/dev/null || true`)
+      tail = await ssh.exec(posixShell(`cat ${remoteLog} 2>/dev/null || true`))
     } catch {
       tail = ''
     }
@@ -635,10 +647,10 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
     'finally:os.close(dd)'
 
   try {
-    await ssh.exec(`python3 -c ${shq(tokenUploadPy)}`, { stdinData: token })
+    await ssh.exec(posixShell(`python3 -c ${shq(tokenUploadPy)}`), { stdinData: token })
   } catch (error) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(tokenFilePath)}`))
     } catch {
       void 0
     }
@@ -649,10 +661,10 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
   let out
 
   try {
-    out = await ssh.exec(buildSpawnCommand(hermesPath, profile, { spawnNonce, tokenFilePath, logPath }))
+    out = await ssh.exec(posixShell(buildSpawnCommand(hermesPath, profile, { spawnNonce, tokenFilePath, logPath })))
   } catch (error) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(tokenFilePath)}`))
     } catch {
       void 0
     }
@@ -670,7 +682,7 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
 
   if (!Number.isInteger(pid) || pid <= 0) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(tokenFilePath)}`))
     } catch {
       void 0
     }
@@ -944,7 +956,7 @@ async function connect(deps) {
     }
 
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(tokenFilePath)}`))
     } catch {
       void 0
     }

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -89,6 +89,16 @@ function shq(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`
 }
 
+// sshd delegates remote commands to the account's login shell. Its command
+// argument is therefore parsed once by that shell before `sh -lc` can run.
+// Encode the lifecycle payload so that outer parse sees only Fish-safe syntax;
+// Python then execs POSIX sh with the original command as one argument.
+function posixShell(command) {
+  const encoded = Buffer.from(String(command), 'utf8').toString('base64')
+
+  return `python3 -c "import base64,os;os.execvp('sh',['sh','-lc',base64.b64decode('${encoded}').decode()])"`
+}
+
 function validateRemotePath(p) {
   const s = String(p || '')
 
@@ -143,7 +153,7 @@ async function locateHermes(ssh, remoteHermesPath) {
       'except (OSError,ValueError):pass\n' +
       'print(out)'
 
-    const resolved = (await ssh.exec(`python3 -c ${shq(script)}`)).trim()
+    const resolved = (await ssh.exec(posixShell(`python3 -c ${shq(script)}`))).trim()
 
     return resolved || candidate
   }
@@ -151,7 +161,7 @@ async function locateHermes(ssh, remoteHermesPath) {
   const isExecutable = async (candidate: string) => {
     try {
       validateRemotePath(candidate)
-      const ok = (await ssh.exec(`[ -x ${expandRemotePath(candidate)} ] && echo OK || true`)).trim()
+      const ok = (await ssh.exec(posixShell(`[ -x ${expandRemotePath(candidate)} ] && echo OK || true`))).trim()
 
       return ok === 'OK'
     } catch {
@@ -177,7 +187,7 @@ async function locateHermes(ssh, remoteHermesPath) {
   const candidates: string[] = []
 
   try {
-    const found = (await ssh.exec(`bash -lc ${shq('command -v hermes')}`)).trim()
+    const found = (await ssh.exec(posixShell('command -v hermes'))).trim()
 
     if (found) {
       candidates.push(found.split('\n').pop().trim())
@@ -217,7 +227,7 @@ async function locateHermes(ssh, remoteHermesPath) {
 // connection uses, so a stale/unexpected install is visible.
 async function probeHermesVersion(ssh, hermesPath) {
   try {
-    const out = (await ssh.exec(`${expandRemotePath(hermesPath)} --version 2>&1`)).trim()
+    const out = (await ssh.exec(posixShell(`${expandRemotePath(hermesPath)} --version 2>&1`))).trim()
 
     return (out.split('\n')[0] || '').trim()
   } catch {
@@ -226,7 +236,7 @@ async function probeHermesVersion(ssh, hermesPath) {
 }
 
 async function probeRemotePlatform(ssh) {
-  const out = (await ssh.exec('uname -s; uname -m')).trim().split('\n')
+  const out = (await ssh.exec(posixShell('uname -s; uname -m'))).trim().split('\n')
   const osName = (out[0] || '').trim()
   const arch = (out[1] || '').trim()
 
@@ -247,7 +257,7 @@ async function probeRemotePlatform(ssh) {
 // state store; best-effort.
 async function probeRemoteHermesHome(ssh) {
   try {
-    const out = (await ssh.exec('echo "${HERMES_HOME:-$HOME/.hermes}"')).trim().split('\n').pop()
+    const out = (await ssh.exec(posixShell('echo "${HERMES_HOME:-$HOME/.hermes}"'))).trim().split('\n').pop()
 
     return out || '~/.hermes'
   } catch (cause) {
@@ -263,7 +273,7 @@ async function readLockfile(ssh, ownershipId) {
   let raw
 
   try {
-    raw = await ssh.exec(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)
+    raw = await ssh.exec(posixShell(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`))
   } catch (cause) {
     const error: any = new Error('Could not read the SSH backend ownership record.')
     error.kind = 'transient-transport-error'
@@ -332,18 +342,18 @@ async function writeLockfile(ssh, ownershipId, lock) {
   const lpath = lockfilePath(ownershipId)
   const temporaryPath = `${directory}/.${crypto.randomBytes(8).toString('hex')}.lock.tmp`
   const json = JSON.stringify({ ...lock, schemaVersion: LOCKFILE_SCHEMA_VERSION })
-  await ssh.exec(
+  await ssh.exec(posixShell(
     `umask 077 && mkdir -p ${expandRemotePath(directory)} && ` +
       `printf '%s' ${shq(json)} > ${expandRemotePath(temporaryPath)} && ` +
       `mv -f ${expandRemotePath(temporaryPath)} ${expandRemotePath(lpath)}`
-  )
+  ))
 }
 
 async function removeLockfile(ssh, ownershipId) {
   const lpath = lockfilePath(ownershipId)
 
   try {
-    await ssh.exec(`rm -f ${expandRemotePath(lpath)}`)
+    await ssh.exec(posixShell(`rm -f ${expandRemotePath(lpath)}`))
   } catch {
     // best effort
   }
@@ -355,7 +365,7 @@ async function remotePidAlive(ssh, pid) {
   }
 
   try {
-    const out = (await ssh.exec(`kill -0 ${Number(pid)} 2>/dev/null && echo ALIVE || echo DEAD`)).trim()
+    const out = (await ssh.exec(posixShell(`kill -0 ${Number(pid)} 2>/dev/null && echo ALIVE || echo DEAD`))).trim()
 
     return out === 'ALIVE'
   } catch (cause) {
@@ -395,7 +405,7 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
       'except (ValueError,IndexError):pass\n' +
       'print("OWNED" if ok else "FOREIGN")'
 
-    const out = await ssh.exec(`python3 -c ${shq(script)}`)
+    const out = await ssh.exec(posixShell(`python3 -c ${shq(script)}`))
 
     return String(out || '').trim() === 'OWNED'
   } catch (cause) {
@@ -411,11 +421,11 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
   if (pidAlive && lock && (await pidIsOurDashboard(ssh, lock.pid, lock.spawnNonce, lock.hermesPath))) {
     try {
       const result = (
-        await ssh.exec(
+        await ssh.exec(posixShell(
           `kill ${Number(lock.pid)} && ` +
             `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
             `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
-        )
+        ))
       ).trim()
 
       void result
@@ -431,7 +441,7 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
 
   if (lock?.logPath === expectedLogPath) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(lock.logPath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(lock.logPath)}`))
     } catch {
       void 0
     }
@@ -462,11 +472,11 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 async function remoteSupportsSshOwnership(ssh, hermesPath) {
   const hermes = expandRemotePath(hermesPath)
 
-  const out = await ssh.exec(
+  const out = await ssh.exec(posixShell(
     `help="$(${hermes} serve --help 2>&1)"; ` +
       `printf '%s' "$help" | grep -q ssh-session-token-file && ` +
       `printf '%s' "$help" | grep -q ssh-owner-nonce && echo YES || echo NO`
-  )
+  ))
 
   return String(out || '')
     .trim()
@@ -489,7 +499,7 @@ async function scrapeReadyPort(ssh, logPath, { timeoutMs = DEFAULT_READY_TIMEOUT
     let tail
 
     try {
-      tail = await ssh.exec(`cat ${remoteLog} 2>/dev/null || true`)
+      tail = await ssh.exec(posixShell(`cat ${remoteLog} 2>/dev/null || true`))
     } catch {
       tail = ''
     }
@@ -555,10 +565,10 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
     'finally:os.close(dd)'
 
   try {
-    await ssh.exec(`python3 -c ${shq(tokenUploadPy)}`, { stdinData: token })
+    await ssh.exec(posixShell(`python3 -c ${shq(tokenUploadPy)}`), { stdinData: token })
   } catch (error) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(tokenFilePath)}`))
     } catch {
       void 0
     }
@@ -569,10 +579,10 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
   let out
 
   try {
-    out = await ssh.exec(buildSpawnCommand(hermesPath, profile, { spawnNonce, tokenFilePath, logPath }))
+    out = await ssh.exec(posixShell(buildSpawnCommand(hermesPath, profile, { spawnNonce, tokenFilePath, logPath })))
   } catch (error) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(tokenFilePath)}`))
     } catch {
       void 0
     }
@@ -590,7 +600,7 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
 
   if (!Number.isInteger(pid) || pid <= 0) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(tokenFilePath)}`))
     } catch {
       void 0
     }
@@ -861,7 +871,7 @@ async function connect(deps) {
     }
 
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await ssh.exec(posixShell(`rm -f ${expandRemotePath(tokenFilePath)}`))
     } catch {
       void 0
     }


### PR DESCRIPTION
## Summary
- run every POSIX Desktop SSH lifecycle payload through an explicit `sh -lc` wrapper
- avoid parsing POSIX syntax with the remote account login shell, including Fish
- cover a full fresh-connect lifecycle and retain the login-shell discovery contract

## Validation
- `npm test -- electron/remote-lifecycle.test.ts`
- `npm run typecheck`
- `npm run test:desktop:platforms`
- `npm run lint` (0 errors; existing warnings remain)
- manual Fish reproduction: direct POSIX expansion fails; the explicit `sh -lc` wrapper succeeds

Closes #80625