### PR TITLE
feat(web): add Codex web search + extract backend plugin

### DIFF
--- a/plugins/web/codex/__init__.py
+++ b/plugins/web/codex/__init__.py
@@ -1,0 +1,16 @@
+"""Codex web search + extract plugin — bundled, auto-loaded.
+
+Backed by OpenAI Codex's standalone web-retrieval endpoint. Auth comes from
+``~/.codex/auth.json`` (created by ``codex login``) or the
+``CODEX_ACCESS_TOKEN`` env var. Retrieval only — zero GPT inference tokens;
+the active Hermes model does all the reasoning on the raw results.
+"""
+
+from __future__ import annotations
+
+from plugins.web.codex.provider import CodexWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Codex provider with the plugin context."""
+    ctx.register_web_search_provider(CodexWebSearchProvider())

--- a/plugins/web/codex/plugin.yaml
+++ b/plugins/web/codex/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-codex
+version: 1.0.0
+description: "Codex web search + content extraction via OpenAI's standalone Codex retrieval endpoint. Reuses an existing `codex login` session (~/.codex/auth.json) or CODEX_ACCESS_TOKEN — zero GPT inference tokens."
+author: lgwacker
+kind: backend
+provides_web_providers:
+  - codex

--- a/plugins/web/codex/provider.py
+++ b/plugins/web/codex/provider.py
@@ -1,0 +1,290 @@
+"""Codex standalone web search + content extraction — Hermes web backend.
+
+Reuses OpenAI Codex's standalone web-retrieval backend
+(``https://chatgpt.com/backend-api/codex/alpha/search``) with the OAuth
+credentials from ``~/.codex/auth.json`` (created by ``codex login``) or the
+``CODEX_ACCESS_TOKEN`` env var. **Zero GPT model inference**: the search
+operation is a pure retrieval call; the active Hermes model receives the
+raw results and does all the reasoning.
+
+Config keys this provider responds to::
+
+    web:
+      backend: "codex"          # shared fallback for both capabilities
+      search_backend: "codex"   # per-capability override (optional)
+      extract_backend: "codex"  # per-capability override (optional)
+
+Env vars::
+
+    CODEX_ACCESS_TOKEN=...      # optional; overrides ~/.codex/auth.json
+    CODEX_ACCOUNT_ID=...        # optional; multi-account setups
+
+Auth resolution order (mirrors the codex-search-opencode plugin):
+1. ``CODEX_ACCESS_TOKEN`` (+ optional ``CODEX_ACCOUNT_ID``)
+2. ``~/.codex/auth.json`` → ``tokens.access_token`` / ``tokens.account_id``
+
+Privacy: only the search query / opened URL is sent to the retrieval
+service — never conversation history, code, or system prompt.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from typing import Any, Dict, List
+from uuid import uuid4
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_ENDPOINT = "https://chatgpt.com/backend-api/codex/alpha/search"
+_MODEL = "gpt-4o"  # selects the search backend contract; NOT an inference call
+_USER_AGENT = "codex-cli/0.147.0-alpha.6.5"
+_TIMEOUT_S = 25
+_MAX_RETRIES = 2
+_AUTH_PATH = os.path.expanduser("~/.codex/auth.json")
+
+# Output cleanup. The retrieval backend wraps page text in private-use
+# citation markers (\ue200cite\ue202<ref>\ue201) and numbers each line
+# ("L0: ..."). Patterns use \uXXXX escapes in NON-raw strings so Python
+# decodes them to the real codepoints at import time.
+_CITE_REF_RE = re.compile("\ue200cite\ue202[^\ue201†]*\ue201")
+_CITE_NUM_RE = re.compile("\ue200cite\ue202\\d+†")
+_CITE_END_RE = re.compile("\ue201")
+_INLINE_LINE_MARKER_RE = re.compile(" (?=L\\d+:)")
+_LINE_PREFIX_RE = re.compile(r"^\s*L\d+:\s?", re.MULTILINE)
+_LINE_MARKER_RE = re.compile(r"(^|\s)L\d+:")
+
+
+def _clean_output(output: str) -> str:
+    """Strip citation markers, the retrieval header, and line numbers."""
+    text = _CITE_REF_RE.sub("", output)
+    text = _CITE_NUM_RE.sub("", text)
+    text = _CITE_END_RE.sub("", text)
+
+    # Break inline "L<N>:" markers onto their own lines so the prefix strip
+    # below catches every marker (the backend occasionally packs several
+    # numbered lines onto one physical line after cite removal).
+    text = _INLINE_LINE_MARKER_RE.sub("\n", text)
+
+    # Cut everything before the first "L<N>:" page-line marker.
+    m = _LINE_MARKER_RE.search(text)
+    if m:
+        text = text[m.start() :]
+    text = _LINE_PREFIX_RE.sub("", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+class CodexError(Exception):
+    """Base error for Codex search backend failures."""
+
+
+class CodexAuthExpiredError(CodexError):
+    """Token rejected by the backend (401/403) — needs a fresh `codex login`."""
+
+
+def _load_codex_auth() -> tuple[str, str | None]:
+    """Resolve (access_token, account_id) from env, then ~/.codex/auth.json."""
+    from agent.web_search_provider import get_provider_env
+
+    token = get_provider_env("CODEX_ACCESS_TOKEN")
+    account_id = get_provider_env("CODEX_ACCOUNT_ID") or None
+    if token:
+        return token, account_id
+
+    try:
+        with open(_AUTH_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        tokens = data.get("tokens") or {}
+        access = tokens.get("access_token")
+        if isinstance(access, str) and access:
+            acct = tokens.get("account_id")
+            return access, acct if isinstance(acct, str) and acct else None
+    except Exception:  # noqa: BLE001 — missing/invalid auth file => no auth
+        pass
+    return "", None
+
+
+def _post(payload: Dict[str, Any], token: str, account_id: str | None) -> Dict[str, Any]:
+    """POST to the Codex search endpoint with retries on transient failures."""
+    import httpx
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "User-Agent": _USER_AGENT,
+    }
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+
+    last_err: Exception | None = None
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            resp = httpx.post(_ENDPOINT, json=payload, headers=headers, timeout=_TIMEOUT_S)
+        except httpx.RequestError as exc:
+            last_err = exc
+            if attempt < _MAX_RETRIES:
+                time.sleep(0.5 * (attempt + 1))
+                continue
+            break
+
+        if resp.status_code in (502, 503, 504):
+            last_err = CodexError(f"Codex search backend unavailable (HTTP {resp.status_code})")
+            if attempt < _MAX_RETRIES:
+                time.sleep(0.5 * (attempt + 1))
+                continue
+            break
+        if resp.status_code in (401, 403):
+            raise CodexAuthExpiredError(
+                "Codex auth rejected (HTTP %d). Refresh with `codex login` "
+                "or update CODEX_ACCESS_TOKEN." % resp.status_code
+            )
+        if resp.status_code == 429:
+            raise CodexError("Codex search rate limited (HTTP 429) — try again later.")
+        if resp.status_code >= 400:
+            raise CodexError(
+                f"Codex search returned HTTP {resp.status_code}: {resp.text[:200]}"
+            )
+        return resp.json()
+
+    raise CodexError(f"Codex search request failed: {last_err}")
+
+
+class CodexWebSearchProvider(WebSearchProvider):
+    """Search + extract backend backed by OpenAI Codex's standalone retrieval."""
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    @property
+    def display_name(self) -> str:
+        return "Codex Search (OpenAI standalone)"
+
+    def is_available(self) -> bool:
+        """True when a Codex credential is present (cheap check, no network)."""
+        from agent.web_search_provider import get_provider_env
+
+        if get_provider_env("CODEX_ACCESS_TOKEN"):
+            return True
+        try:
+            with open(_AUTH_PATH, encoding="utf-8") as f:
+                data = json.load(f)
+            return bool((data.get("tokens") or {}).get("access_token"))
+        except Exception:  # noqa: BLE001 — any failure means "not available"
+            return False
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Single-query lookup against the Codex retrieval backend.
+
+        Returns ``{"success": True, "data": {"web": [{"title", "url",
+        "description", "position"}]}}`` or ``{"success": False, "error"}``.
+        """
+        token, account_id = _load_codex_auth()
+        if not token:
+            return {
+                "success": False,
+                "error": "Codex auth not found. Run `codex login` or set CODEX_ACCESS_TOKEN.",
+            }
+
+        payload = {
+            "id": f"hermes_{uuid4().hex[:12]}",
+            "model": _MODEL,
+            "commands": {"search_query": [{"q": query}]},
+        }
+        try:
+            body = _post(payload, token, account_id)
+        except CodexError as exc:
+            logger.warning("Codex search failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+        count = max(1, min(int(limit), 20))
+        web: List[Dict[str, Any]] = []
+        for i, r in enumerate((body.get("results") or [])[:count]):
+            title = (r.get("title") or "").strip()
+            url = (r.get("url") or "").strip()
+            if not title and not url:
+                continue
+            web.append(
+                {
+                    "title": title,
+                    "url": url,
+                    "description": (r.get("snippet") or "").strip(),
+                    "position": i + 1,
+                }
+            )
+
+        logger.info("Codex search '%s': %d results (limit %d)", query, len(web), limit)
+        return {"success": True, "data": {"web": web}}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Open each URL through the Codex retrieval backend and return page text.
+
+        Each URL is fetched with the ``open`` command using the URL itself as
+        the reference id (validated live against the endpoint). Returns the
+        list shape the ``web_extract`` wrapper expects.
+        """
+        token, account_id = _load_codex_auth()
+        if not token:
+            msg = "Codex auth not found. Run `codex login` or set CODEX_ACCESS_TOKEN."
+            return [{"url": u, "error": msg} for u in urls]
+
+        out: List[Dict[str, Any]] = []
+        for url in urls:
+            payload = {
+                "id": f"hermes_{uuid4().hex[:12]}",
+                "model": _MODEL,
+                "commands": {"open": [{"ref_id": url}], "response_length": "long"},
+            }
+            try:
+                body = _post(payload, token, account_id)
+            except CodexError as exc:
+                logger.warning("Codex extract %s failed: %s", url, exc)
+                out.append({"url": url, "error": str(exc)})
+                continue
+
+            raw = body.get("output") or ""
+            results = body.get("results") or []
+            title = (results[0].get("title") or "").strip() if results else ""
+            ref_id = results[0].get("ref_id") if results else None
+            # The web_extract wrapper consumes ``raw_content`` (falling back
+            # to ``content``) as the page text, so both carry the cleaned
+            # text — the cite markers / line numbers are protocol artifacts,
+            # not page content.
+            cleaned = _clean_output(raw)
+            out.append(
+                {
+                    "url": url,
+                    "title": title,
+                    "content": cleaned,
+                    "raw_content": cleaned,
+                    "metadata": {"ref_id": ref_id} if ref_id else {},
+                }
+            )
+            logger.info("Codex extract %s: %d chars (cleaned %d)", url, len(raw), len(cleaned))
+        return out
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Codex Search (OpenAI standalone)",
+            "badge": "free",
+            "tag": "Reuses your `codex login` session — zero GPT tokens, search + extract.",
+            "env_vars": [
+                {
+                    "key": "CODEX_ACCESS_TOKEN",
+                    "prompt": "Codex access token (optional — defaults to ~/.codex/auth.json)",
+                    "url": "https://github.com/openai/codex",
+                },
+            ],
+        }

--- a/tests/plugins/web/test_codex_provider.py
+++ b/tests/plugins/web/test_codex_provider.py
@@ -1,0 +1,478 @@
+"""Tests for the bundled Codex web search + extract plugin.
+
+Covers:
+
+- Registration: the plugin registers a ``codex`` provider with search +
+  extract capabilities through the plugin registry.
+- ``is_available()``: reflects ``CODEX_ACCESS_TOKEN`` or a valid
+  ``~/.codex/auth.json`` — cheap file/env checks, no network.
+- Auth resolution order: env var wins over the auth file; a missing or
+  malformed auth file degrades to no auth.
+- Output cleanup: citation markers (private-use codepoints), numbered
+  ``L<N>:`` line markers, and the retrieval header are stripped.
+- ``search()`` / ``extract()`` envelopes: response shapes match the
+  documented ``WebSearchProvider`` contract; failures map to
+  ``{"success": False, "error": ...}`` / per-URL errors.
+- Transport: transient HTTP failures are retried; 401/403 and 429 map
+  to actionable errors.
+
+Per the dev skill, these tests use *real* imports from the plugin module —
+only the network hop (``httpx.post``) is faked.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from plugins.web.codex import provider as codex_provider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clear_codex_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every Codex credential env var."""
+    monkeypatch.delenv("CODEX_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("CODEX_ACCOUNT_ID", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clean_codex_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts with no Codex credentials — env or auth file."""
+    _clear_codex_env(monkeypatch)
+    # Neutralize the real ~/.codex/auth.json on developer machines.
+    monkeypatch.setattr(
+        codex_provider, "_AUTH_PATH", "/nonexistent/.codex/auth.json"
+    )
+
+
+def _ensure_plugins_loaded() -> None:
+    """Idempotently load plugins so the registry is populated."""
+    from hermes_cli.plugins import _ensure_plugins_discovered
+
+    _ensure_plugins_discovered()
+
+
+def _write_auth_file(
+    tmp_path: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    token: str = "tok-file",
+    account_id: str | None = "acct-file",
+    malformed: bool = False,
+) -> str:
+    """Write a ~/.codex/auth.json under tmp_path and point the module at it."""
+    auth_dir = tmp_path / ".codex"
+    auth_dir.mkdir()
+    auth_path = auth_dir / "auth.json"
+    if malformed:
+        auth_path.write_text("{not json", encoding="utf-8")
+    else:
+        tokens: dict[str, str] = {"access_token": token}
+        if account_id is not None:
+            tokens["account_id"] = account_id
+        auth_path.write_text(
+            json.dumps({"tokens": tokens}), encoding="utf-8"
+        )
+    monkeypatch.setattr(codex_provider, "_AUTH_PATH", str(auth_path))
+    return str(auth_path)
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``httpx.Response``."""
+
+    def __init__(self, status_code: int, payload: dict | str) -> None:
+        self.status_code = status_code
+        self.text = payload if isinstance(payload, str) else json.dumps(payload)
+        self._payload = payload
+
+    def json(self) -> dict:
+        if isinstance(self._payload, dict):
+            return self._payload
+        raise ValueError(f"not JSON: {self.text!r}")
+
+
+class _FakePost:
+    """Queued ``httpx.post`` stand-in: each call pops the next response."""
+
+    def __init__(self, responses: list[tuple[int, dict | str]]) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+
+    def __call__(self, url: str, json: dict | None = None, **kwargs) -> _FakeResponse:
+        self.calls.append((url, json or {}))
+        status, payload = self._responses.pop(0)
+        return _FakeResponse(status, payload)
+
+
+# ---------------------------------------------------------------------------
+# Registration + capability flags
+# ---------------------------------------------------------------------------
+
+
+class TestPluginRegistration:
+    def test_codex_provider_registered(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        provider = get_provider("codex")
+        assert provider is not None, "codex plugin not registered"
+        assert provider.name == "codex"
+        assert provider.display_name
+
+    def test_codex_supports_search_and_extract(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        provider = get_provider("codex")
+        assert provider is not None
+        assert provider.supports_search() is True
+        assert provider.supports_extract() is True
+
+
+# ---------------------------------------------------------------------------
+# is_available() — cheap checks only, no network
+# ---------------------------------------------------------------------------
+
+
+class TestIsAvailable:
+    def test_not_available_without_credentials(self) -> None:
+        provider = codex_provider.CodexWebSearchProvider()
+        assert provider.is_available() is False
+
+    def test_available_with_env_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok-env")
+        provider = codex_provider.CodexWebSearchProvider()
+        assert provider.is_available() is True
+
+    def test_available_with_auth_file(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_auth_file(tmp_path, monkeypatch)
+        provider = codex_provider.CodexWebSearchProvider()
+        assert provider.is_available() is True
+
+    def test_auth_file_without_tokens_is_not_available(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_auth_file(tmp_path, monkeypatch, token="", account_id=None)
+        provider = codex_provider.CodexWebSearchProvider()
+        assert provider.is_available() is False
+
+    def test_malformed_auth_file_is_not_available(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_auth_file(tmp_path, monkeypatch, malformed=True)
+        provider = codex_provider.CodexWebSearchProvider()
+        assert provider.is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Auth resolution order
+# ---------------------------------------------------------------------------
+
+
+class TestAuthResolution:
+    def test_env_token_wins_over_auth_file(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_auth_file(tmp_path, monkeypatch, token="tok-file")
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok-env")
+        monkeypatch.setenv("CODEX_ACCOUNT_ID", "acct-env")
+
+        token, account_id = codex_provider._load_codex_auth()
+        assert token == "tok-env"
+        assert account_id == "acct-env"
+
+    def test_auth_file_fallback(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_auth_file(tmp_path, monkeypatch, token="tok-file", account_id="acct-file")
+
+        token, account_id = codex_provider._load_codex_auth()
+        assert token == "tok-file"
+        assert account_id == "acct-file"
+
+    def test_no_credentials_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            codex_provider, "_AUTH_PATH", "/nonexistent/.codex/auth.json"
+        )
+        assert codex_provider._load_codex_auth() == ("", None)
+
+
+# ---------------------------------------------------------------------------
+# Output cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCleanOutput:
+    def test_strips_citation_ref_markers(self) -> None:
+        raw = "\ue200cite\ue202https://example.com\ue201L0: Body"
+        assert codex_provider._clean_output(raw) == "Body"
+
+    def test_strips_numbered_citation_markers(self) -> None:
+        raw = "text \ue200cite\ue2025†more"
+        assert codex_provider._clean_output(raw) == "text more"
+
+    def test_strips_dangling_end_marker(self) -> None:
+        assert codex_provider._clean_output("\ue201L0: Body") == "Body"
+
+    def test_cuts_header_before_first_line_marker(self) -> None:
+        raw = "Retrieval summary prose that is not page content.\nL0: Real page"
+        assert codex_provider._clean_output(raw) == "Real page"
+
+    def test_strips_line_number_prefixes(self) -> None:
+        raw = "L0: Alpha\nL1: Beta\nL2: Gamma"
+        assert codex_provider._clean_output(raw) == "Alpha\nBeta\nGamma"
+
+    def test_splits_inline_line_markers(self) -> None:
+        raw = "L0: Alpha L1: Beta"
+        assert codex_provider._clean_output(raw) == "Alpha\nBeta"
+
+    def test_collapses_excess_blank_lines(self) -> None:
+        # Blank lines in the MIDDLE of content collapse to at most one blank.
+        raw = "L0: Alpha\n\n\n\nBody text"
+        assert codex_provider._clean_output(raw) == "Alpha\n\nBody text"
+        # Blank lines immediately before a line marker are eaten by the
+        # prefix strip — no leading noise after the marker.
+        raw = "L0: Alpha\n\n\n\nL1: Beta"
+        assert codex_provider._clean_output(raw) == "Alpha\nBeta"
+
+    def test_combined_realistic_sample(self) -> None:
+        raw = (
+            "Here is what I found about the topic.\n"
+            "\ue200cite\ue2021\ue201L0: Hermes Agent is an open-source agent "
+            "\ue200cite\ue2022†framework L1: by Nous Research"
+        )
+        assert codex_provider._clean_output(raw) == (
+            "Hermes Agent is an open-source agent framework\nby Nous Research"
+        )
+
+
+# ---------------------------------------------------------------------------
+# search() envelope
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    def test_success_envelope(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            codex_provider,
+            "_post",
+            lambda *a, **kw: {
+                "results": [
+                    {"title": "One", "url": "https://one.example", "snippet": "s1"},
+                    {"title": "Two", "url": "https://two.example", "snippet": "s2"},
+                ]
+            },
+        )
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        result = codex_provider.CodexWebSearchProvider().search("query")
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert web == [
+            {
+                "title": "One",
+                "url": "https://one.example",
+                "description": "s1",
+                "position": 1,
+            },
+            {
+                "title": "Two",
+                "url": "https://two.example",
+                "description": "s2",
+                "position": 2,
+            },
+        ]
+
+    def test_limit_clamps_result_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        results = [
+            {"title": f"R{i}", "url": f"https://r{i}.example", "snippet": ""}
+            for i in range(4)
+        ]
+        monkeypatch.setattr(
+            codex_provider, "_post", lambda *a, **kw: {"results": results}
+        )
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        provider = codex_provider.CodexWebSearchProvider()
+        assert len(provider.search("q", limit=2)["data"]["web"]) == 2
+        # limit=0 clamps up to 1 (the backend rejects 0)
+        assert len(provider.search("q", limit=0)["data"]["web"]) == 1
+
+    def test_skips_entries_without_title_and_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            codex_provider,
+            "_post",
+            lambda *a, **kw: {
+                "results": [
+                    {"title": "", "url": "", "snippet": "empty"},
+                    {"title": "Real", "url": "https://real.example", "snippet": "s"},
+                ]
+            },
+        )
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        web = codex_provider.CodexWebSearchProvider().search("q")["data"]["web"]
+        assert len(web) == 1
+        assert web[0]["title"] == "Real"
+
+    def test_missing_auth_returns_actionable_error(self) -> None:
+        result = codex_provider.CodexWebSearchProvider().search("q")
+        assert result["success"] is False
+        assert "codex login" in result["error"]
+
+    def test_expired_auth_returns_actionable_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*a, **kw):
+            raise codex_provider.CodexAuthExpiredError(
+                "Codex auth rejected (HTTP 401). Refresh with `codex login`."
+            )
+
+        monkeypatch.setattr(codex_provider, "_post", _boom)
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "stale")
+
+        result = codex_provider.CodexWebSearchProvider().search("q")
+        assert result["success"] is False
+        assert "codex login" in result["error"]
+
+    def test_backend_error_maps_to_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _rate_limited(*a, **kw):
+            raise codex_provider.CodexError("Codex search rate limited (HTTP 429)")
+
+        monkeypatch.setattr(codex_provider, "_post", _rate_limited)
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        result = codex_provider.CodexWebSearchProvider().search("q")
+        assert result["success"] is False
+        assert "429" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# extract() envelope
+# ---------------------------------------------------------------------------
+
+
+class TestExtract:
+    def test_success_cleans_output_into_both_content_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            codex_provider,
+            "_post",
+            lambda *a, **kw: {
+                "output": "\ue200cite\ue2021\ue201L0: Page body text",
+                "results": [{"title": "Page Title", "ref_id": "ref-1"}],
+            },
+        )
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        out = codex_provider.CodexWebSearchProvider().extract(["https://a.example"])
+        assert out[0]["url"] == "https://a.example"
+        assert out[0]["title"] == "Page Title"
+        # The web_extract wrapper consumes raw_content first — both must be clean.
+        assert out[0]["content"] == "Page body text"
+        assert out[0]["raw_content"] == "Page body text"
+        assert out[0]["metadata"] == {"ref_id": "ref-1"}
+        assert "error" not in out[0]
+
+    def test_per_url_error_keeps_other_urls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _flaky(*a, **kw):
+            raise codex_provider.CodexError("Codex search backend unavailable (HTTP 503)")
+
+        monkeypatch.setattr(codex_provider, "_post", _flaky)
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        out = codex_provider.CodexWebSearchProvider().extract(
+            ["https://a.example", "https://b.example"]
+        )
+        assert len(out) == 2
+        assert all("error" in item and "503" in item["error"] for item in out)
+
+    def test_missing_auth_returns_per_url_error(self) -> None:
+        out = codex_provider.CodexWebSearchProvider().extract(["https://a.example"])
+        assert out[0]["url"] == "https://a.example"
+        assert "codex login" in out[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Transport: retries + error mapping (httpx.post faked)
+# ---------------------------------------------------------------------------
+
+
+class TestTransport:
+    def test_retries_transient_failures_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakePost([(503, "unavailable"), (503, "unavailable"), (200, {"results": []})])
+        monkeypatch.setattr(httpx, "post", fake)
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        body = codex_provider._post({"id": "x"}, "tok", None)
+        assert body == {"results": []}
+        assert len(fake.calls) == 3
+
+    def test_gives_up_after_max_retries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakePost([(503, "unavailable")] * 3)
+        monkeypatch.setattr(httpx, "post", fake)
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        with pytest.raises(codex_provider.CodexError, match="unavailable"):
+            codex_provider._post({"id": "x"}, "tok", None)
+        assert len(fake.calls) == 3
+
+    def test_401_raises_auth_expired(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakePost([(401, "unauthorized")])
+        monkeypatch.setattr(httpx, "post", fake)
+
+        with pytest.raises(codex_provider.CodexAuthExpiredError, match="codex login"):
+            codex_provider._post({"id": "x"}, "tok", None)
+
+    def test_429_raises_rate_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakePost([(429, "slow down")])
+        monkeypatch.setattr(httpx, "post", fake)
+
+        with pytest.raises(codex_provider.CodexError, match="rate limited"):
+            codex_provider._post({"id": "x"}, "tok", None)
+
+    def test_request_error_retried_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = {"n": 0}
+
+        def _flaky_post(*a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ConnectError("boom", request=None)
+            return _FakeResponse(200, {"results": []})
+
+        monkeypatch.setattr(httpx, "post", _flaky_post)
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "tok")
+
+        body = codex_provider._post({"id": "x"}, "tok", None)
+        assert body == {"results": []}
+        assert calls["n"] == 2

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+- All nine bundled plugins (brave-free, codex, ddgs, searxng, exa, parallel,
   tavily, firecrawl, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
@@ -45,6 +45,8 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "CODEX_ACCESS_TOKEN",
+        "CODEX_ACCOUNT_ID",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -70,13 +72,14 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestBundledPluginsRegister:
     """All eight bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
         names = sorted(p.name for p in list_providers())
         assert names == [
             "brave-free",
+            "codex",
             "ddgs",
             "exa",
             "firecrawl",
@@ -90,6 +93,7 @@ class TestBundledPluginsRegister:
         "plugin_name,expected_search,expected_extract",
         [
             ("brave-free", True, False),
+            ("codex", True, True),
             ("ddgs", True, False),
             ("searxng", True, False),
             ("exa", True, True),
@@ -116,7 +120,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "codex", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -187,8 +187,18 @@ class TestUnconfiguredErrorEnvelopeParity:
             "FIRECRAWL_API_URL",
             "FIRECRAWL_GATEWAY_URL",
             "TOOL_GATEWAY_DOMAIN",
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_ACCOUNT_ID",
         ):
             monkeypatch.delenv(k, raising=False)
+        # The Codex backend also authenticates via ~/.codex/auth.json — point
+        # it at a nonexistent path so the "unconfigured" state is
+        # deterministic regardless of the developer machine.
+        from plugins.web.codex import provider as codex_provider
+
+        monkeypatch.setattr(
+            codex_provider, "_AUTH_PATH", "/nonexistent/.codex/auth.json"
+        )
 
     def test_unconfigured_search_emits_top_level_error(self, monkeypatch):
         """``web_search_tool`` with no creds returns ``{"error": "Error searching web: ..."}``

--- a/website/docs/developer-guide/web-search-provider-plugin.md
+++ b/website/docs/developer-guide/web-search-provider-plugin.md
@@ -6,7 +6,7 @@ description: "How to build a web-search/extract/crawl backend plugin for Hermes 
 
 # Building a Web Search Provider Plugin
 
-Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, and DDGS — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
+Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, DDGS, and Codex — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
 
 :::tip
 Web search is one of several **backend plugins** Hermes supports. The others (with their own ABCs) are [Image Generation Provider Plugins](/developer-guide/image-gen-provider-plugin), [Video Generation Provider Plugins](/developer-guide/video-gen-provider-plugin), [Memory Provider Plugins](/developer-guide/memory-provider-plugin), [Context Engine Plugins](/developer-guide/context-engine-plugin), and [Model Provider Plugins](/developer-guide/model-provider-plugin). General tool/hook/CLI plugins live in [Build a Hermes Plugin](/developer-guide/plugins).
@@ -241,6 +241,7 @@ If your provider wraps a third-party SDK (like DDGS does with the `ddgs` package
 - **`plugins/web/ddgs/`** — no-key provider that lazy-installs its SDK. Useful pattern for backends that wrap a Python package.
 - **`plugins/web/firecrawl/`** — full multi-capability provider (search + extract + crawl) with multiple format modes.
 - **`plugins/web/searxng/`** — self-hosted, URL-configured backend with no auth.
+- **`plugins/web/codex/`** — search + extract with no API key, reusing an existing CLI login (`~/.codex/auth.json`). Shows file-based credential resolution, retry/error mapping, and protocol-text cleanup (citation markers / line numbers).
 - **`plugins/web/xai/`** — LLM-backed search via Grok's server-side `web_search` tool. Shows how to reuse an existing OAuth/env-var credential surface (`tools/xai_http.py`) without adding new env vars, and how to write a cheap `is_available()` that honors the no-network contract.
 
 ## Distribute via pip

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -145,6 +145,8 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `TAVILY_BASE_URL` | Override the Tavily API endpoint. Useful for corporate proxies and self-hosted Tavily-compatible search backends. Same pattern as `GROQ_BASE_URL`. |
 | `EXA_API_KEY` | Exa API key for AI-native web search and contents ([exa.ai](https://exa.ai/)) |
 | `BRAVE_SEARCH_API_KEY` | Brave Search API subscription token for web search (free tier available) ([brave.com/search/api](https://brave.com/search/api/)) |
+| `CODEX_ACCESS_TOKEN` | Optional bearer token for the Codex web search/extract backend. Falls back to `~/.codex/auth.json` (created by `codex login`) when unset. |
+| `CODEX_ACCOUNT_ID` | Optional account id for multi-account Codex setups. Read from `~/.codex/auth.json` when unset. |
 | `BROWSERBASE_API_KEY` | Browser automation ([browserbase.com](https://browserbase.com/)) |
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser API key ([browser-use.com](https://browser-use.com/)) |

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -19,6 +19,7 @@ Both are configured through a single backend selection. Providers are chosen via
 | Provider | Env Var | Search | Extract | Free tier |
 |----------|---------|--------|---------|-----------|
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | 500 credits/mo |
+| **Codex (OpenAI)** | `CODEX_ACCESS_TOKEN` (optional — reuses `~/.codex/auth.json`) | ✔ | ✔ | ✔ Free (reuses `codex login`) |
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | ✔ Free (self-hosted) |
 | **Brave Search (free tier)** | `BRAVE_SEARCH_API_KEY` | ✔ | — | 2 000 queries/mo |
 | **DDGS (DuckDuckGo)** | — (no key) | ✔ | — | ✔ Free |
@@ -86,6 +87,30 @@ FIRECRAWL_API_URL=http://localhost:3002
 ```
 
 When `FIRECRAWL_API_URL` is set, the API key is optional (disable server auth with `USE_DB_AUTHENTICATION=false`).
+
+---
+
+### Codex (OpenAI standalone)
+
+Search and extract through OpenAI Codex's standalone web-retrieval endpoint — the same backend the Codex CLI uses. **Zero GPT inference tokens**: the operation is pure retrieval; the active Hermes model receives the raw results and does all the reasoning.
+
+**No API key required** — Hermes reuses your existing Codex CLI login:
+
+```bash
+codex login   # creates ~/.codex/auth.json
+```
+
+Alternatively, set `CODEX_ACCESS_TOKEN` (and optionally `CODEX_ACCOUNT_ID` for multi-account setups) in `~/.hermes/.env`. When both are present, the env var wins.
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  backend: "codex"   # search + extract
+```
+
+:::note
+The endpoint is an internal Codex CLI contract and may change without notice. If search returns `{"success": false}` with a 401/403 error, re-run `codex login` to refresh the token. Rate limits (HTTP 429) surface as tool errors the agent can report.
+:::
 
 ---
 
@@ -326,7 +351,7 @@ Set one provider for all web capabilities:
 ```yaml
 # ~/.hermes/config.yaml
 web:
-  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
+  backend: "searxng"   # firecrawl | codex | searxng | brave-free | ddgs | tavily | exa | parallel | xai
 ```
 
 ### Per-capability configuration
@@ -360,6 +385,7 @@ If no backend is explicitly configured, Hermes picks the first available one bas
 | `SEARXNG_URL` | searxng |
 | `BRAVE_SEARCH_API_KEY` | brave-free |
 | `ddgs` package importable | ddgs |
+| `CODEX_ACCESS_TOKEN` or `~/.codex/auth.json` present | codex |
 
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
 


### PR DESCRIPTION
## What does this PR do?

Adds a bundled **Codex web search + extract backend** (`plugins/web/codex/`), servicing `web_search` and `web_extract` through OpenAI Codex's standalone web-retrieval endpoint — the same backend the Codex CLI uses. No API key required: auth reuses an existing `codex login` session (`~/.codex/auth.json`) or `CODEX_ACCESS_TOKEN`. **Zero GPT inference tokens** — the operation is pure retrieval; the active Hermes model does all the reasoning on the raw results.

This complements (does not overlap with) the existing codex PRs (#69752, #79103, #73553): those add *provider-level* native Responses `web_search` for specific providers, while this is a *web backend plugin* selectable via `web.backend` / `web.search_backend` / `web.extract_backend` for **any** model — including the zero-token standalone retrieval path.

## Related Issue

Closes #82716

## Distribution

Until this merges (or if it doesn't), the backend is also distributed as a **user plugin** from [github.com/lgwacker/codex-search-hermes](https://github.com/lgwacker/codex-search-hermes) — installable via Hermes' native plugin mechanism:

```bash
hermes plugins install lgwacker/codex-search-hermes/plugins/web/codex --enable
```

The standalone repo carries the same test suite plus a CI workflow that runs it against a Hermes checkout (currently green: 32 passed).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/web/codex/plugin.yaml`, `__init__.py`, `provider.py` — new bundled backend per the `plugins/web/<name>/` layout (mirrors exa/firecrawl conventions: `kind: backend`, `provides_web_providers: [codex]`, `WebSearchProvider` subclass)
  - `search()` / `extract()` with the documented response envelopes; `extract()` uses the URL itself as `ref_id` (validated live), one call per URL
  - Transport: retries 502/503/504 (2×, backoff); 401/403 → actionable "run `codex login`" error; 429 → rate-limit error
  - Protocol-text cleanup: strips private-use citation markers (U+E200/U+E201/U+E202) and numbered `L<N>:` line markers from extracted page text (cleaned text goes in both `content` and `raw_content` since the wrapper consumes `raw_content` first)
  - `get_setup_schema()` for the `hermes tools` picker (all bundled providers implement it)
- `tests/plugins/web/test_codex_provider.py` — 30 tests: registration, capability flags, `is_available()` (env + auth-file, incl. malformed file), auth resolution order, output cleanup, envelope shapes (limit clamp, empty-entry skip, per-URL errors), transport retries/error mapping. Only the network hop (`httpx.post`) is faked — real imports throughout.
- `tests/plugins/web/test_web_search_provider_plugins.py` — registry exact-list test + capability/name parametrizations extended to the 9th plugin; env strip list includes codex vars
- `tests/tools/test_web_providers.py` — "unconfigured" regression test now also neutralizes the codex auth file so it's deterministic on machines with `~/.codex/auth.json`
- Docs: `website/docs/user-guide/features/web-search.md` (backends table, new Codex section, config comment, auto-detection table), `website/docs/reference/environment-variables.md` (`CODEX_ACCESS_TOKEN` / `CODEX_ACCOUNT_ID`), `website/docs/developer-guide/web-search-provider-plugin.md` (built-in list + reference-implementation bullet)

## How to Test

1. `codex login` (or `export CODEX_ACCESS_TOKEN=...`)
2. `hermes config set web.backend codex`
3. `hermes chat -q "Use web_search then web_extract and summarize"` — or run the unit suite:

```bash
uv run pytest tests/plugins/web/ tests/tools/test_web_providers.py -q   # 153 tests
```

Verified locally: `62 passed` (plugins/web), `91 passed` (tools web surface), `ruff check` clean, zero DeprecationWarnings. Sabotage run: registry test fails without the plugin, passes with it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(web): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted pytest suites locally (full suite runs in CI)
- [x] I've added tests for my changes
- [x] I've tested on my platform: WSL2 / Ubuntu 24.04, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] `cli-config.yaml.example` — **N/A** (no new config keys; reuses existing `web.backend`/`web.search_backend`/`web.extract_backend`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — **N/A** (no architecture changes)
- [x] Cross-platform: auth-file path uses `os.path.expanduser("~/.codex/auth.json")`, no platform-specific code
- [x] Tool descriptions/schemas — **N/A** (no tool behavior change)

## Notes for maintainers

- The endpoint (`chatgpt.com/backend-api/codex/alpha/search`) is an internal Codex CLI contract and may change without notice; documented in the feature page. Failure modes surface as actionable tool errors (`codex login` hint on 401/403).
- Original reverse-engineering credit: [mateusdcc/codex-search-opencode](https://github.com/mateusdcc/codex-search-opencode) (MIT), adapted and hardened for Hermes (retries, cleanup, envelopes, tests).
- This backend is in daily use on my install (`web.backend: codex`).

