### PR TITLE
fix(verification): language-scope the verify-on-stop nudge to the workspace's verify commands

### DIFF
--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -72,6 +72,29 @@ def _filter_verifiable_paths(paths: Iterable[str]) -> list[str]:
     return [p for p in paths if p and not _is_non_code_path(p)]
 
 
+def _verify_language_suffixes(verify_commands: list[str]) -> set[str] | None:
+    """Map a workspace's verify commands to the file suffixes they can check.
+
+    ``None`` for empty/unknown commands keeps the nudge's current behaviour —
+    language scoping must never disable verification for a stack we cannot map.
+    """
+    suffixes: set[str] = set()
+    for command in verify_commands:
+        tokens = command.split()
+        if not tokens:
+            continue
+        head = tokens[0].lower()
+        if head in ("python", "python3", "pytest") or "pytest" in tokens:
+            suffixes |= {".py"}
+        elif head == "dotnet":
+            suffixes |= {".cs", ".csproj", ".sln", ".props", ".targets", ".fs", ".fsproj"}
+        elif head in ("npm", "bun", "yarn", "pnpm"):
+            suffixes |= {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".vue", ".svelte"}
+        else:
+            return None
+    return suffixes or None
+
+
 def _session_is_messaging_surface() -> bool:
     """Whether this turn is delivered over a human messaging channel.
 
@@ -251,6 +274,17 @@ def build_verify_on_stop_nudge(
         for cmd in (facts.get("verifyCommands") or [])
         if str(cmd).strip()
     ]
+
+    # Language scoping (issue #52612): only edits the workspace's detected
+    # verify commands can actually check should trigger the nudge. A state or
+    # config file (e.g. .ai-badger/state.json) is not verifiable by pytest, so
+    # a turn that touched only those has nothing to verify and must not nudge.
+    suffixes = _verify_language_suffixes(verify_commands)
+    if suffixes is not None:
+        scoped = [p for p in paths if Path(p).suffix.lower() in suffixes]
+        if not scoped:
+            return None
+        paths = scoped
 
     state = str(status.get("status") or "unverified")
     if state == "passed":

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -9,6 +9,7 @@ from agent.verification_evidence import (
     record_terminal_result,
 )
 from agent.verification_stop import (
+    _verify_language_suffixes,
     build_verify_on_stop_nudge,
     verify_on_stop_enabled,
 )
@@ -25,6 +26,14 @@ def _node_project(root: Path) -> None:
 def _make_project(root: Path) -> None:
     root.mkdir()
     _node_project(root)
+
+
+def _py_project(root: Path) -> None:
+    """A pytest workspace — project detection yields verifyCommands=[\"pytest\"]."""
+    (root / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\ntestpaths = [\"tests\"]\n",
+        encoding="utf-8",
+    )
 
 
 @pytest.fixture
@@ -233,3 +242,52 @@ def test_is_non_code_path_classification():
     assert _is_non_code_path("src/app.ts") is False
     assert _is_non_code_path("config.yaml") is False
     assert _is_non_code_path("run_agent.py") is False
+
+
+# ---------------------------------------------------------------------------
+# Language scoping (issue #52612 follow-up): only edits the workspace's
+# detected verify commands can actually check should trip the nudge — a
+# pytest workspace must not nudge for a .json state file, but must for .py.
+# ---------------------------------------------------------------------------
+
+
+def test_verify_language_suffixes_mapping():
+    assert _verify_language_suffixes(["pytest"]) == {".py"}
+    assert _verify_language_suffixes(["python3 -m pytest tests"]) == {".py"}
+    assert _verify_language_suffixes(["dotnet test"]) == {
+        ".cs", ".csproj", ".sln", ".props", ".targets", ".fs", ".fsproj",
+    }
+    assert _verify_language_suffixes(["make test"]) is None  # unknown -> fail open
+    assert _verify_language_suffixes([]) is None
+
+
+def test_no_nudge_for_json_state_edit_in_pytest_workspace(tmp_path, monkeypatch):
+    """A state/config .json edit is not verifiable by pytest — no nudge."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _py_project(tmp_path)
+    state = str(tmp_path / ".ai-badger" / "state.json")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[state])
+
+    assert build_verify_on_stop_nudge(session_id="s1", changed_paths=[state]) is None
+
+
+def test_nudge_fires_for_python_edit_in_pytest_workspace(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _py_project(tmp_path)
+    code = str(tmp_path / "scripts" / "mod.py")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[code])
+
+    nudge = build_verify_on_stop_nudge(session_id="s1", changed_paths=[code])
+    assert nudge is not None
+    assert code in nudge
+
+
+def test_unknown_verify_command_keeps_current_behaviour(tmp_path, monkeypatch):
+    """Unmapped commands must not disable the nudge (fail open)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / "Makefile").write_text("test:\n\t@echo ok\n", encoding="utf-8")
+    changed = str(tmp_path / "src" / "app.ts")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+
+    nudge = build_verify_on_stop_nudge(session_id="s1", changed_paths=[changed])
+    assert nudge is not None


### PR DESCRIPTION
## What does this PR do?

The verify-on-stop nudge still fires for edits pytest cannot verify. A repo whose only verify command is pytest gets nudged for a .json state file edit, because the non-code exclusion list from #52615 has no entry for .json, .yaml, .toml, or anything else not enumerated.

This scopes the nudge positively instead: only edits whose file suffix the workspace's detected verify commands can check trigger it.

- pytest / python -m pytest -> .py
- dotnet test / dotnet build -> .cs, .csproj, .sln, .props, .targets, .fs, .fsproj
- npm / bun / yarn / pnpm -> .ts, .tsx, .js, .jsx, .mjs, .cjs, .vue, .svelte
- unmapped commands -> unchanged behavior (fail open; the gate must never disable itself for a stack we do not recognize)

## Related Issue

Fixes #82723

Refs #52612 (path-agnostic trigger), #52615 (exclusion-list fix; does not cover non-code config/state formats).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- agent/verification_stop.py: _verify_language_suffixes() maps verify commands to the file suffixes they can check; build_verify_on_stop_nudge() returns None when every changed path falls outside that set.
- tests/agent/test_verification_stop.py: 4 new tests (state.json no-nudge in a pytest workspace, .py edit still nudges, suffix mapping, unknown command fails open).

## Verification

scripts/run_tests.sh tests/agent/test_verification_stop.py tests/verify/test_ledger_and_nudge_integration.py tests/run_agent/test_verification_continuation_budget.py -> 3 files, 38 tests passed, 0 failed.