### PR TITLE
fix(skills): stop tap installs from dropping files and executable modes

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -122,6 +122,14 @@ def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
     return lines
 
 
+def _bundle_warning_messages(bundle) -> list[str]:
+    """Return source limitations that must remain visible on forced installs."""
+    warnings = (getattr(bundle, "metadata", {}) or {}).get("bundle_warnings", [])
+    if not isinstance(warnings, list):
+        return []
+    return [warning for warning in warnings if isinstance(warning, str) and warning]
+
+
 def _resolve_source_meta_and_bundle(identifier: str, sources):
     """Resolve metadata and bundle for a specific identifier."""
     meta = None
@@ -609,6 +617,12 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         if meta is not None:
             meta.name = bundle.name
             meta.path = bundle.name
+
+    bundle_warnings = _bundle_warning_messages(bundle)
+    for warning in bundle_warnings:
+        c.print(f"[bold yellow]Warning:[/] {warning}")
+    if bundle_warnings:
+        c.print()
 
     # URL-sourced skills: offer to pick a category interactively when the
     # caller didn't specify one (TTY only — non-interactive installs fall

--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -162,7 +162,9 @@ def test_real_temp_repo_and_home_install_e2e(served_repo, monkeypatch, tmp_path)
     entry = json.loads((home / "skills" / ".hub" / "lock.json").read_text())["installed"]["demo-bundle"]
     assert entry["scan_provenance"]["source_url"] == url
     assert entry["scan_provenance"]["fresh"] is True
-    assert "Scan provenance: fresh" in sink.getvalue()
+    output = sink.getvalue()
+    assert "Scan provenance: fresh" in output
+    assert "Raw SKILL.md URLs cannot enumerate sibling files" in output
 
 
 def test_bundled_optional_source_still_includes_support_files(tmp_path, monkeypatch):

--- a/tests/tools/test_skill_bundle_provenance.py
+++ b/tests/tools/test_skill_bundle_provenance.py
@@ -106,7 +106,11 @@ def test_url_source_rejects_traversal_reference(monkeypatch):
 
 def test_github_source_rejects_symlink_in_referenced_directory(monkeypatch):
     source = GitHubSource(GitHubAuth())
-    monkeypatch.setattr(source, "_fetch_file_content", lambda _repo, path: SKILL_MD if path.endswith("SKILL.md") else "x")
+    monkeypatch.setattr(
+        source,
+        "_fetch_file_content",
+        lambda _repo, path, **_kwargs: SKILL_MD if path.endswith("SKILL.md") else "x",
+    )
     source._tree_cache["owner/repo"] = (
         "main",
         [

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -30,6 +30,7 @@ from tools.skills_guard import (
     _determine_verdict,
     _resolve_trust_level,
     _check_structure,
+    _is_recognized_script,
     _unicode_char_name,
     _load_skill_ignore,
     MAX_FILE_COUNT,
@@ -243,6 +244,18 @@ class TestScanSkill:
 
 
 class TestCheckStructure:
+    def test_recognizes_extensionless_shebang_script(self, tmp_path):
+        script = tmp_path / "selftest"
+        script.write_bytes(b"#!/usr/bin/env bash\nset -eu\n")
+
+        assert _is_recognized_script(script) is True
+
+    def test_extensionless_non_script_is_not_recognized(self, tmp_path):
+        data = tmp_path / "payload"
+        data.write_bytes(b"not a script\n")
+
+        assert _is_recognized_script(data) is False
+
     def test_structural_limits(self, tmp_path):
         for i in range(MAX_FILE_COUNT + 5):
             (tmp_path / f"file_{i}.txt").write_text("x")

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -307,7 +307,11 @@ class TestGitHubBundleFetch:
                  {"path": "skills/demo/assets/logo.png", "type": "blob", "mode": "100644"},
                  {"path": "skills/other/SKILL.md", "type": "blob", "mode": "100644"},
              ])), \
-             patch.object(source, "_fetch_file_bytes", side_effect=lambda _repo, path: path.encode()):
+             patch.object(
+                 source,
+                 "_fetch_file_bytes",
+                 side_effect=lambda _repo, path, **_kwargs: path.encode(),
+             ):
             bundle = source.fetch("owner/repo/skills/demo")
 
         assert bundle is not None
@@ -320,6 +324,33 @@ class TestGitHubBundleFetch:
         }
         assert bundle.metadata["source_revision"] == "abc123"
         assert bundle.metadata["bundle_warnings"] == []
+
+    def test_fetch_pins_every_tree_backed_file_to_one_revision(self):
+        source = self._source()
+        source._tree_revisions["owner/repo"] = "abc123"
+        skill_md = "---\nname: demo\n---\n"
+
+        with patch.object(
+            source, "_fetch_file_content", return_value=skill_md
+        ) as fetch_text, patch.object(
+            source,
+            "_get_repo_tree",
+            return_value=("main", [
+                {"path": "demo/SKILL.md", "type": "blob", "mode": "100644"},
+                {"path": "demo/scripts/run", "type": "blob", "mode": "100755"},
+            ]),
+        ), patch.object(
+            source, "_fetch_file_bytes", return_value=b"#!/bin/sh\n"
+        ) as fetch_bytes:
+            bundle = source.fetch("owner/repo/demo")
+
+        assert bundle is not None
+        fetch_text.assert_called_once_with(
+            "owner/repo", "demo/SKILL.md", ref="abc123"
+        )
+        fetch_bytes.assert_called_once_with(
+            "owner/repo", "demo/scripts/run", ref="abc123"
+        )
 
     def test_fetch_fails_instead_of_returning_partial_tree_bundle(self):
         source = self._source()
@@ -380,7 +411,7 @@ class TestGitHubBundleFetch:
              patch.object(
                  source,
                  "_fetch_file_bytes",
-                 side_effect=lambda _repo, path: path.encode(),
+                 side_effect=lambda _repo, path, **_kwargs: path.encode(),
              ):
             files = source._download_bundle_via_contents("owner/repo", "demo")
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -289,6 +289,107 @@ class TestFindSkillInRepoTree:
         assert result is None
 
 
+class TestGitHubBundleFetch:
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    def test_fetch_includes_unreferenced_files_and_git_modes(self):
+        source = self._source()
+        skill_md = "---\nname: demo\n---\n\n# Demo\n"
+        source._tree_revisions["owner/repo"] = "abc123"
+
+        with patch.object(source, "_fetch_file_content", return_value=skill_md), \
+             patch.object(source, "_get_repo_tree", return_value=("main", [
+                 {"path": "skills/demo/SKILL.md", "type": "blob", "mode": "100644"},
+                 {"path": "skills/demo/scripts/selftest", "type": "blob", "mode": "100755"},
+                 {"path": "skills/demo/assets/logo.png", "type": "blob", "mode": "100644"},
+                 {"path": "skills/other/SKILL.md", "type": "blob", "mode": "100644"},
+             ])), \
+             patch.object(source, "_fetch_file_bytes", side_effect=lambda _repo, path: path.encode()):
+            bundle = source.fetch("owner/repo/skills/demo")
+
+        assert bundle is not None
+        assert set(bundle.files) == {"SKILL.md", "scripts/selftest", "assets/logo.png"}
+        assert bundle.files["scripts/selftest"] == b"skills/demo/scripts/selftest"
+        assert bundle.file_modes == {
+            "SKILL.md": 0o644,
+            "assets/logo.png": 0o644,
+            "scripts/selftest": 0o755,
+        }
+        assert bundle.metadata["source_revision"] == "abc123"
+        assert bundle.metadata["bundle_warnings"] == []
+
+    def test_fetch_fails_instead_of_returning_partial_tree_bundle(self):
+        source = self._source()
+        with patch.object(source, "_fetch_file_content", return_value="# Demo\n"), \
+             patch.object(source, "_get_repo_tree", return_value=("main", [
+                 {"path": "demo/SKILL.md", "type": "blob", "mode": "100644"},
+                 {"path": "demo/scripts/selftest", "type": "blob", "mode": "100755"},
+             ])), \
+             patch.object(source, "_fetch_file_bytes", return_value=None):
+            assert source.fetch("owner/repo/demo") is None
+
+    def test_fetch_rejects_complete_bundle_with_missing_referenced_file(self):
+        source = self._source()
+        skill_md = "Run `scripts/missing` when needed.\n"
+        with patch.object(source, "_fetch_file_content", return_value=skill_md), \
+             patch.object(source, "_get_repo_tree", return_value=("main", [
+                 {"path": "demo/SKILL.md", "type": "blob", "mode": "100644"},
+             ])):
+            assert source.fetch("owner/repo/demo") is None
+
+    def test_fetch_rejects_unreferenced_symlink(self):
+        source = self._source()
+        with patch.object(source, "_fetch_file_content", return_value="# Demo\n"), \
+             patch.object(source, "_get_repo_tree", return_value=("main", [
+                 {"path": "demo/SKILL.md", "type": "blob", "mode": "100644"},
+                 {"path": "demo/scripts/link", "type": "blob", "mode": "120000"},
+             ])):
+            assert source.fetch("owner/repo/demo") is None
+
+    def test_contents_fallback_is_complete_and_warns_when_modes_are_unavailable(self):
+        source = self._source()
+        downloaded = {
+            "SKILL.md": b"# Demo\n",
+            "scripts/unreferenced": b"#!/bin/sh\n",
+        }
+        with patch.object(source, "_fetch_file_content", return_value="# Demo\n"), \
+             patch.object(source, "_get_repo_tree", return_value=None), \
+             patch.object(source, "_download_bundle_via_contents", return_value=downloaded):
+            bundle = source.fetch("owner/repo/demo")
+
+        assert bundle is not None
+        assert set(bundle.files) == {"SKILL.md", "scripts/unreferenced"}
+        assert bundle.file_modes == {}
+        assert "executable bits could not be preserved" in bundle.metadata["bundle_warnings"][0]
+
+    def test_contents_fallback_recursively_downloads_every_regular_file(self):
+        source = self._source()
+        root = MagicMock(status_code=200)
+        root.json.return_value = [
+            {"name": "SKILL.md", "path": "demo/SKILL.md", "type": "file"},
+            {"name": "scripts", "path": "demo/scripts", "type": "dir"},
+        ]
+        scripts = MagicMock(status_code=200)
+        scripts.json.return_value = [
+            {"name": "selftest", "path": "demo/scripts/selftest", "type": "file"},
+        ]
+        with patch.object(source, "_github_get", side_effect=[root, scripts]), \
+             patch.object(
+                 source,
+                 "_fetch_file_bytes",
+                 side_effect=lambda _repo, path: path.encode(),
+             ):
+            files = source._download_bundle_via_contents("owner/repo", "demo")
+
+        assert files == {
+            "SKILL.md": b"demo/SKILL.md",
+            "scripts/selftest": b"demo/scripts/selftest",
+        }
+
+
 class TestWellKnownSkillSource:
     @pytest.fixture(autouse=True)
     def _allow_public_skill_fetches(self, monkeypatch):
@@ -397,6 +498,22 @@ class TestUrlSource:
         assert self._source().fetch("http://127.0.0.1/SKILL.md") is None
         mock_get.assert_not_called()
 
+    def test_fetch_warns_that_raw_bundle_completeness_and_modes_are_unknown(self):
+        source = self._source()
+        skill_md = (
+            "---\nname: demo\ndescription: test\n---\n\n"
+            "Run `scripts/known` when needed.\n"
+        )
+        with patch.object(source, "_fetch_text", return_value=skill_md), \
+             patch.object(source, "_fetch_bytes", return_value=b"#!/bin/sh\n"):
+            bundle = source.fetch("https://example.com/demo/SKILL.md")
+
+        assert bundle is not None
+        assert set(bundle.files) == {"SKILL.md", "scripts/known"}
+        warning = bundle.metadata["bundle_warnings"][0]
+        assert "cannot enumerate sibling files" in warning
+        assert "cannot" in warning and "executable modes" in warning
+
 
     def test_is_valid_skill_name_rejects_sentinel_and_garbage(self):
         invalid = [
@@ -427,9 +544,9 @@ class TestCheckForSkillUpdates:
         )
         skill_dir = tmp_path / "demo-skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "SKILL.md").write_bytes(b"same content")
         (skill_dir / "references").mkdir()
-        (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+        (skill_dir / "references" / "checklist.md").write_bytes(b"- [ ] security\n")
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
@@ -458,6 +575,32 @@ class TestCheckForSkillUpdates:
 
         assert len(results) == 1
         assert results[0]["name"] == "demo-skill"
+        assert results[0]["status"] == "update_available"
+
+    def test_reports_update_when_only_remote_file_modes_differ(self):
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "same", "scripts/run": "#!/bin/sh\n"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+            file_modes={"SKILL.md": 0o644, "scripts/run": 0o755},
+        )
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": bundle_content_hash(bundle),
+            "file_modes": {},
+            "install_path": "demo-skill",
+        }]
+        source = MagicMock()
+        source.source_id.return_value = "github"
+        source.fetch.return_value = bundle
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
         assert results[0]["status"] == "update_available"
 
 class TestCreateSourceRouter:
@@ -491,6 +634,7 @@ class TestHubLockFile:
             name="s1", source="github", identifier="x",
             trust_level="trusted", scan_verdict="pass",
             skill_hash="h1", install_path="s1", files=["SKILL.md"],
+            file_modes={"SKILL.md": 0o644},
         )
         lock.record_install(
             name="s2", source="clawhub", identifier="y",
@@ -501,6 +645,7 @@ class TestHubLockFile:
         assert len(installed) == 2
         names = {e["name"] for e in installed}
         assert names == {"s1", "s2"}
+        assert lock.get_installed("s1")["file_modes"] == {"SKILL.md": 0o644}
 
 
 # ---------------------------------------------------------------------------
@@ -762,8 +907,8 @@ class TestOptionalSkillSourceBinaryAssets:
         (skill_dir / "assets" / "neutts-cli" / "samples" / "jo.wav").write_bytes(
             wav_bytes
         )
-        (skill_dir / "assets" / "neutts-cli" / "samples" / "jo.txt").write_text(
-            "hello\n", encoding="utf-8"
+        (skill_dir / "assets" / "neutts-cli" / "samples" / "jo.txt").write_bytes(
+            b"hello\n"
         )
         pycache_dir = skill_dir / "assets" / "neutts-cli" / "src" / "neutts_cli" / "__pycache__"
         pycache_dir.mkdir(parents=True)
@@ -824,6 +969,52 @@ class TestQuarantineBundleBinaryAssets:
 
         assert (q_path / "SKILL.md").read_text(encoding="utf-8").startswith("---")
         assert (q_path / "assets" / "neutts-cli" / "samples" / "jo.wav").read_bytes() == b"RIFF\x00\x01fakewav"
+
+    def test_quarantine_bundle_applies_validated_file_modes(self, tmp_path):
+        import tools.skills_hub as hub
+
+        hub_dir = tmp_path / "skills" / ".hub"
+        bundle = SkillBundle(
+            name="demo",
+            files={"SKILL.md": "# Demo\n", "scripts/run": b"#!/bin/sh\n"},
+            source="github",
+            identifier="owner/repo/demo",
+            trust_level="community",
+            file_modes={"SKILL.md": 0o644, "scripts/run": 0o755},
+        )
+        with patch.object(hub, "SKILLS_DIR", tmp_path / "skills"), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"), \
+             patch("pathlib.Path.chmod") as chmod:
+            quarantine_bundle(bundle)
+
+        assert [call.args[0] for call in chmod.call_args_list] == [0o644, 0o755]
+
+    def test_quarantine_bundle_rejects_mode_for_missing_file(self, tmp_path):
+        import tools.skills_hub as hub
+
+        hub_dir = tmp_path / "skills" / ".hub"
+        bundle = SkillBundle(
+            name="demo",
+            files={"SKILL.md": "# Demo\n"},
+            source="github",
+            identifier="owner/repo/demo",
+            trust_level="community",
+            file_modes={"scripts/missing": 0o755},
+        )
+        with patch.object(hub, "SKILLS_DIR", tmp_path / "skills"), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            with pytest.raises(ValueError, match="missing bundle file"):
+                quarantine_bundle(bundle)
 
     def test_quarantine_bundle_rejects_traversal_file_paths(self, tmp_path):
         import tools.skills_hub as hub

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -700,11 +700,14 @@ def _content_digest(skill_path: Path) -> str:
     """Canonical SHA-256 over relative paths and exact file bytes."""
     h = hashlib.sha256()
     if skill_path.is_dir():
-        for file_path in sorted(skill_path.rglob("*")):
-            if file_path.is_file():
-                rel = file_path.relative_to(skill_path).as_posix()
-                h.update(rel.encode("utf-8") + b"\x00")
-                h.update(file_path.read_bytes())
+        files = (path for path in skill_path.rglob("*") if path.is_file())
+        for file_path in sorted(
+            files,
+            key=lambda path: path.relative_to(skill_path).as_posix(),
+        ):
+            rel = file_path.relative_to(skill_path).as_posix()
+            h.update(rel.encode("utf-8") + b"\x00")
+            h.update(file_path.read_bytes())
     else:
         h.update(skill_path.read_bytes())
     return h.hexdigest()
@@ -869,6 +872,20 @@ def content_hash(skill_path: Path) -> str:
 # Structural checks
 # ---------------------------------------------------------------------------
 
+_SCRIPT_EXTENSIONS = frozenset({'.sh', '.bash', '.py', '.rb', '.pl'})
+
+
+def _is_recognized_script(path: Path) -> bool:
+    """Recognize extensionless executable scripts by their shebang."""
+    if path.suffix.lower() in _SCRIPT_EXTENSIONS:
+        return True
+    try:
+        with path.open("rb") as handle:
+            return handle.read(2) == b"#!"
+    except OSError:
+        return False
+
+
 def _check_structure(skill_dir: Path, ignore=None) -> List[Finding]:
     """
     Check the skill directory for structural anomalies:
@@ -959,8 +976,9 @@ def _check_structure(skill_dir: Path, ignore=None) -> List[Finding]:
                 description=f"binary/executable file ({ext}) should not be in a skill",
             ))
 
-        # Executable permission on non-script files
-        if ext not in {'.sh', '.bash', '.py', '.rb', '.pl'} and f.stat().st_mode & 0o111:
+        # Executable permission on non-script files. Extensionless command-line
+        # scripts are common in skill bundles, so recognize a real shebang.
+        if not _is_recognized_script(f) and f.stat().st_mode & 0o111:
             findings.append(Finding(
                 pattern_id="unexpected_executable",
                 severity="medium",

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -150,6 +150,14 @@ class SkillBundle:
     identifier: str
     trust_level: str
     metadata: Dict[str, Any] = field(default_factory=dict)
+    file_modes: Dict[str, int] = field(default_factory=dict)
+
+
+_GIT_BLOB_MODES = {
+    "100644": 0o644,
+    "100755": 0o755,
+}
+_ALLOWED_BUNDLE_FILE_MODES = frozenset(_GIT_BLOB_MODES.values())
 
 
 _ALLOWED_SUPPORT_DIRS = frozenset({"references", "templates", "scripts", "assets", "examples"})
@@ -657,37 +665,76 @@ class GitHubSource(SkillSource):
         skill_md = self._fetch_file_content(repo, f"{skill_path.rstrip('/')}/SKILL.md")
         if skill_md is None:
             return None
+        # Keep link validation even though GitHub bundles are now enumerated
+        # from the repository tree. Traversal remains unsafe, and a referenced
+        # file that is absent from the complete bundle must still fail closed.
         referenced = _referenced_support_paths(skill_md)
         if referenced is None:
             return None
 
         files: Dict[str, Union[str, bytes]] = {"SKILL.md": skill_md}
+        file_modes: Dict[str, int] = {}
+        warnings: List[str] = []
         tree = self._get_repo_tree(repo)
         if tree is not None:
             branch, entries = tree
             prefix = f"{skill_path.rstrip('/')}/"
-            entries_by_path = {item.get("path", ""): item for item in entries}
-            for rel_path in sorted(referenced):
-                item_path = f"{prefix}{rel_path}"
-                item = entries_by_path.get(item_path)
-                if item is None:
-                    logger.warning("Referenced skill support file is missing: %s", item_path)
-                    return None
-                if item.get("type") != "blob" or item.get("mode") == "120000":
+            saw_skill_md = False
+            for item in sorted(entries, key=lambda entry: entry.get("path", "")):
+                item_path = item.get("path", "")
+                if not item_path.startswith(prefix):
+                    continue
+                if item.get("type") == "tree":
+                    continue
+                if item.get("type") != "blob":
                     logger.warning("Rejected non-regular file in skill bundle: %s", item_path)
                     return None
+                git_mode = item.get("mode")
+                file_mode = _GIT_BLOB_MODES.get(git_mode)
+                if file_mode is None:
+                    logger.warning(
+                        "Rejected unsupported Git mode %r in skill bundle: %s",
+                        git_mode,
+                        item_path,
+                    )
+                    return None
+                try:
+                    rel_path = _validate_bundle_rel_path(item_path[len(prefix):])
+                except ValueError:
+                    logger.warning("Rejected unsafe file in skill bundle: %s", item_path)
+                    return None
+                file_modes[rel_path] = file_mode
+                if rel_path == "SKILL.md":
+                    saw_skill_md = True
+                    continue
                 content = self._fetch_file_bytes(repo, item_path)
                 if content is None:
+                    logger.warning("Failed to fetch skill bundle file: %s", item_path)
                     return None
                 files[rel_path] = content
+            if not saw_skill_md:
+                logger.warning("Git tree did not contain the resolved skill file: %sSKILL.md", prefix)
+                return None
             revision = self._tree_revisions.get(repo) or branch
         else:
-            for rel_path in referenced:
-                content = self._fetch_file_bytes(repo, f"{skill_path.rstrip('/')}/{rel_path}")
-                if content is None:
-                    return None
-                files[rel_path] = content
+            downloaded = self._download_bundle_via_contents(repo, skill_path)
+            if downloaded is None or "SKILL.md" not in downloaded:
+                return None
+            files.update(downloaded)
+            files["SKILL.md"] = skill_md
+            warnings.append(
+                "GitHub file modes were unavailable. The complete skill directory was "
+                "downloaded, but executable bits could not be preserved."
+            )
             revision = ""
+
+        missing_references = referenced.difference(files)
+        if missing_references:
+            logger.warning(
+                "Referenced skill support files are missing: %s",
+                ", ".join(sorted(missing_references)),
+            )
+            return None
 
         skill_name = skill_path.rstrip("/").split("/")[-1]
         trust = self.trust_level_for(identifier)
@@ -704,8 +751,53 @@ class GitHubSource(SkillSource):
                     if revision else f"https://github.com/{repo}/{skill_path}"
                 ),
                 "source_revision": revision,
+                "bundle_warnings": warnings,
             },
+            file_modes=file_modes,
         )
+
+    def _download_bundle_via_contents(
+        self, repo: str, path: str
+    ) -> Optional[Dict[str, bytes]]:
+        """Strictly download a complete directory when the Trees API is unavailable."""
+        url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
+        resp = self._github_get(url)
+        if resp is None or resp.status_code != 200:
+            return None
+        try:
+            entries = resp.json()
+        except ValueError:
+            return None
+        if not isinstance(entries, list):
+            return None
+
+        files: Dict[str, bytes] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                return None
+            name = entry.get("name", "")
+            entry_path = entry.get("path", "")
+            entry_type = entry.get("type", "")
+            try:
+                safe_name = _validate_bundle_rel_path(name)
+            except ValueError:
+                return None
+            if entry_type == "file":
+                content = self._fetch_file_bytes(repo, entry_path)
+                if content is None:
+                    logger.warning("Failed to fetch skill bundle file: %s", entry_path)
+                    return None
+                files[safe_name] = content
+            elif entry_type == "dir":
+                nested = self._download_bundle_via_contents(repo, entry_path)
+                if nested is None:
+                    return None
+                for nested_path, content in nested.items():
+                    files[f"{safe_name}/{nested_path}"] = content
+            else:
+                logger.warning("Rejected non-regular file in skill bundle: %s", entry_path)
+                return None
+        return files
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Fetch just the SKILL.md metadata for preview."""
@@ -1540,7 +1632,17 @@ class UrlSource(SkillSource):
             source="url",
             identifier=url,
             trust_level="community",
-            metadata={"url": url, "source_url": url, "awaiting_name": not skill_name},
+            metadata={
+                "url": url,
+                "source_url": url,
+                "awaiting_name": not skill_name,
+                "bundle_warnings": [
+                    "Raw SKILL.md URLs cannot enumerate sibling files or preserve "
+                    "executable modes. Only files explicitly referenced by SKILL.md can "
+                    "be installed; use a GitHub tap or manifest-based source for a "
+                    "complete bundle."
+                ],
+            },
         )
 
     @staticmethod
@@ -3336,7 +3438,7 @@ class OptionalSkillSource(SkillSource):
                 and "__pycache__" not in f.parts
                 and f.suffix != ".pyc"
             ):
-                rel_path = str(f.relative_to(skill_dir))
+                rel_path = f.relative_to(skill_dir).as_posix()
                 try:
                     files[rel_path] = f.read_bytes()
                 except OSError:
@@ -3530,6 +3632,7 @@ class HubLockFile:
         files: List[str],
         metadata: Optional[Dict[str, Any]] = None,
         scan_provenance: Optional[Dict[str, Any]] = None,
+        file_modes: Optional[Dict[str, int]] = None,
     ) -> None:
         # Validate both the skill name and the install path SHAPE before
         # writing into lock.json. A poisoned lock entry is the precondition
@@ -3546,6 +3649,7 @@ class HubLockFile:
             "content_hash": skill_hash,
             "install_path": safe_install_path,
             "files": files,
+            "file_modes": file_modes or {},
             "metadata": metadata or {},
             "scan_provenance": scan_provenance or {},
             "installed_at": datetime.now(timezone.utc).isoformat(),
@@ -3665,6 +3769,18 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
     for rel_path, file_content in bundle.files.items():
         safe_rel_path = _validate_bundle_rel_path(rel_path)
         validated_files.append((safe_rel_path, file_content))
+    validated_modes: Dict[str, int] = {}
+    for rel_path, file_mode in bundle.file_modes.items():
+        safe_rel_path = _validate_bundle_rel_path(rel_path)
+        if safe_rel_path not in bundle.files:
+            raise ValueError(f"File mode references missing bundle file: {safe_rel_path}")
+        if (
+            isinstance(file_mode, bool)
+            or not isinstance(file_mode, int)
+            or file_mode not in _ALLOWED_BUNDLE_FILE_MODES
+        ):
+            raise ValueError(f"Unsupported bundle file mode for {safe_rel_path}: {file_mode!r}")
+        validated_modes[safe_rel_path] = file_mode
 
     dest = _quarantine_dir() / skill_name
     if dest.exists():
@@ -3678,6 +3794,9 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
             file_dest.write_bytes(file_content)
         else:
             file_dest.write_text(file_content, encoding="utf-8")
+        file_mode = validated_modes.get(rel_path)
+        if file_mode is not None:
+            file_dest.chmod(file_mode)
 
     return dest
 
@@ -3825,6 +3944,7 @@ def install_from_quarantine(
         skill_hash=content_hash(install_dir),
         install_path=str(install_dir.relative_to(_skills_dir())),
         files=list(bundle.files.keys()),
+        file_modes=bundle.file_modes,
         metadata=bundle.metadata,
         scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),
     )
@@ -3960,7 +4080,13 @@ def check_for_skill_updates(
 
         current_hash = entry.get("content_hash", "")
         latest_hash = bundle_content_hash(bundle)
-        status = "up_to_date" if current_hash == latest_hash else "update_available"
+        current_modes = entry.get("file_modes", {})
+        latest_modes = bundle.file_modes
+        status = (
+            "up_to_date"
+            if current_hash == latest_hash and current_modes == latest_modes
+            else "update_available"
+        )
         results.append({
             "name": entry.get("name", ""),
             "identifier": identifier,

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -662,7 +662,21 @@ class GitHubSource(SkillSource):
         repo = f"{parts[0]}/{parts[1]}"
         skill_path = parts[2]
 
-        skill_md = self._fetch_file_content(repo, f"{skill_path.rstrip('/')}/SKILL.md")
+        # Resolve the tree first so every byte in the tree-backed bundle can
+        # be fetched from the same immutable snapshot as its path and mode.
+        # Contents API requests without ``ref`` follow the moving default
+        # branch and can otherwise mix revisions during a concurrent push.
+        tree = self._get_repo_tree(repo)
+        revision = ""
+        if tree is not None:
+            branch, _entries = tree
+            revision = self._tree_revisions.get(repo) or branch
+
+        skill_md = self._fetch_file_content(
+            repo,
+            f"{skill_path.rstrip('/')}/SKILL.md",
+            ref=revision or None,
+        )
         if skill_md is None:
             return None
         # Keep link validation even though GitHub bundles are now enumerated
@@ -675,7 +689,6 @@ class GitHubSource(SkillSource):
         files: Dict[str, Union[str, bytes]] = {"SKILL.md": skill_md}
         file_modes: Dict[str, int] = {}
         warnings: List[str] = []
-        tree = self._get_repo_tree(repo)
         if tree is not None:
             branch, entries = tree
             prefix = f"{skill_path.rstrip('/')}/"
@@ -707,7 +720,7 @@ class GitHubSource(SkillSource):
                 if rel_path == "SKILL.md":
                     saw_skill_md = True
                     continue
-                content = self._fetch_file_bytes(repo, item_path)
+                content = self._fetch_file_bytes(repo, item_path, ref=revision)
                 if content is None:
                     logger.warning("Failed to fetch skill bundle file: %s", item_path)
                     return None
@@ -715,7 +728,6 @@ class GitHubSource(SkillSource):
             if not saw_skill_md:
                 logger.warning("Git tree did not contain the resolved skill file: %sSKILL.md", prefix)
                 return None
-            revision = self._tree_revisions.get(repo) or branch
         else:
             downloaded = self._download_bundle_via_contents(repo, skill_path)
             if downloaded is None or "SKILL.md" not in downloaded:
@@ -1153,9 +1165,11 @@ class GitHubSource(SkillSource):
 
         return None
 
-    def _fetch_file_content(self, repo: str, path: str) -> Optional[str]:
+    def _fetch_file_content(
+        self, repo: str, path: str, *, ref: Optional[str] = None
+    ) -> Optional[str]:
         """Fetch a single text file from GitHub."""
-        content = self._fetch_file_bytes(repo, path)
+        content = self._fetch_file_bytes(repo, path, ref=ref)
         if content is None:
             return None
         try:
@@ -1163,11 +1177,14 @@ class GitHubSource(SkillSource):
         except UnicodeDecodeError:
             return None
 
-    def _fetch_file_bytes(self, repo: str, path: str) -> Optional[bytes]:
+    def _fetch_file_bytes(
+        self, repo: str, path: str, *, ref: Optional[str] = None
+    ) -> Optional[bytes]:
         """Fetch exact file bytes from GitHub without text decoding."""
         url = f"https://api.github.com/repos/{repo}/contents/{path}"
         resp = self._github_get(
             url,
+            params={"ref": ref} if ref else None,
             headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"},
         )
         if resp is not None and resp.status_code == 200:


### PR DESCRIPTION
## What does this PR do?

GitHub tap installs no longer silently drop unreferenced skill support files or discard executable modes. The installer now builds a complete, revision-consistent bundle from the GitHub tree, preserves supported regular-file modes through quarantine and lock metadata, fails closed on incomplete or unsafe bundles, and warns when a raw SKILL.md URL cannot provide sibling enumeration or mode data.

### Symptom

A GitHub or raw URL install could report success while installing only SKILL.md and explicitly linked files. GitHub scripts stored as mode 100755 also lost that mode during installation.

### Impact

Affected skills could be installed as incomplete bundles, leaving required assets, templates, references, examples, or scripts unavailable at runtime. On POSIX systems, discarded executable metadata can also leave command scripts non-executable even though the repository marks them executable.

### Bug Cause

**Trigger:** `tools/skills_hub.py:661` in `GitHubSource.fetch`, `tools/skills_hub.py:1648` in `UrlSource.fetch`, and `tools/skills_hub.py:3785` in `quarantine_bundle`.

**Causal chain:**
1. A user installs a repository skill that contains support files not linked from SKILL.md or a regular file with Git mode 100755.
2. The GitHub and raw source adapters construct `SkillBundle.files` from SKILL.md references only, while `SkillBundle` and the quarantine path carry no file-mode channel.
3. Installation succeeds with a partial tree and mode-less files, so support files are missing and executable scripts can no longer be launched directly on POSIX.

**Why it is wrong:** The GitHub Trees API already exposes the complete skill subtree and each blob mode, but the fetch path discarded both kinds of information. The raw HTTP path has no equivalent sibling-enumeration or Git-mode channel and previously hid that limitation.

**Working sibling / contrast:** Local, ZIP, optional, and manifest-backed sources already enumerate their declared or complete file sets. GitHub can provide the same completeness from its repository APIs; standalone raw SKILL.md URLs cannot do so without a manifest.

**Ruled out:** This is not a scanner-only omission. Reproduction on current main showed that the bundle itself contained only the referenced paths and the lock entry had no mode metadata before scanning or final installation could preserve them.

### Fix

- Enumerate every regular blob under the resolved GitHub skill directory, reject unsupported modes and non-regular entries, and fail if any file cannot be fetched.
- Pin tree paths, modes, SKILL.md, and support-file contents to one immutable revision so concurrent branch updates cannot produce mixed bundles.
- Carry validated 0644 and 0755 modes through `SkillBundle`, quarantine writes, lock metadata, and update comparisons.
- Recognize shebang-based extensionless scripts when validating executable files.
- Show an explicit raw URL warning that only SKILL.md references can be installed and executable modes cannot be preserved.

## Related Issue

Closes #82657

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py` - builds complete revision-pinned GitHub bundles, validates and preserves file modes, records mode metadata, and reports raw source limitations.
- `tools/skills_guard.py` - handles deterministic path hashing and recognizes extensionless shebang scripts as valid executable scripts.
- `hermes_cli/skills_hub.py` - displays source limitation warnings before installation, including forced installs.
- `tests/tools/test_skills_hub.py` - covers complete tree downloads, partial-fetch failure, unsafe entries, immutable revisions, mode preservation, lock/update behavior, and raw warnings.
- `tests/tools/test_skills_guard.py` and `tests/tools/test_skill_bundle_provenance.py` - cover executable shebang handling and the new bundle metadata behavior.

## How to Test

1. Install a GitHub skill whose repository directory includes unreferenced support files and a 100755 script; verify that every regular file is installed and the lock records mode 493 for the executable script.
2. Install a raw SKILL.md URL; verify that the CLI warns that sibling files and executable modes cannot be discovered from the raw source.
3. Run the focused regression suite:

```bash
scripts/run_tests.sh tests/tools/test_skills_hub.py tests/tools/test_skills_guard.py tests/tools/test_skill_bundle_provenance.py tests/hermes_cli/test_skills_hub.py
```

Result: 113 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added regression tests for this bug fix
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant user-facing limitations are reported directly by the CLI; no standalone documentation update is required
- [x] N/A - no configuration keys changed
- [x] N/A - no contributor workflow or architecture documentation changed
- [x] Cross-platform impact was considered: POSIX mode application is preserved, while Windows retains portable mode metadata even when its filesystem does not expose POSIX execute bits
- [x] N/A - no model tool descriptions or schemas changed

## Screenshots / Logs

N/A - automated and manual verification results are summarized above.
