### PR TITLE
fix(deps): hold the [tool.uv] overrides on the lazy-install path

### DIFF
--- a/tests/tools/test_lazy_deps_durable_target.py
+++ b/tests/tools/test_lazy_deps_durable_target.py
@@ -180,7 +180,8 @@ class TestInstallArgConstruction:
         assert cmd[-1] == "somepkg==1.2.3"
 
     def test_no_target_args_in_venv_scoped_mode(self, monkeypatch):
-        # Env unset → plain venv-scoped install, no --target / --constraint.
+        # Env unset → plain venv-scoped install, no --target and no
+        # core-constraints file.
         monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
         monkeypatch.setattr(ld.shutil, "which", lambda _: None)
         captured = {}
@@ -194,8 +195,20 @@ class TestInstallArgConstruction:
         monkeypatch.setattr(ld.subprocess, "run", fake_run)
         result = ld._venv_pip_install(("somepkg==1.2.3",))
         assert result.success
-        assert "--target" not in captured["cmd"]
-        assert "--constraint" not in captured["cmd"]
+        cmd = captured["cmd"]
+        assert "--target" not in cmd
+        # The durable-target mode's core-constraints file must be absent. The
+        # pip tier does still carry a --constraint holding the security floor
+        # (see tools/lazy_deps._security_overrides), so assert on the file's
+        # role rather than on the flag's mere presence.
+        constraint_paths = [
+            Path(cmd[i + 1])
+            for i, tok in enumerate(cmd)
+            if tok == "--constraint"
+        ]
+        assert not any(
+            p.name.startswith("hermes-core-constraints-") for p in constraint_paths
+        ), f"venv-scoped install must not pin against a core-constraints file: {cmd}"
 
     def test_uv_resolution_failure_does_not_fall_through_to_pip(self, monkeypatch):
         monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)

--- a/tests/tools/test_lazy_deps_security_overrides.py
+++ b/tests/tools/test_lazy_deps_security_overrides.py
@@ -1,0 +1,225 @@
+"""Lazy installs must not downgrade security-pinned core packages.
+
+``uv pip install`` / ``pip install`` do not read ``[tool.uv]
+override-dependencies`` from pyproject.toml. A backend whose transitive deps
+cap a security-pinned package below its patched floor therefore *downgrades*
+the core venv the first time that backend is enabled.
+
+The measured case: the core venv ships ``cryptography==50.0.0``; enabling
+DingTalk pulls ``alibabacloud-dingtalk`` -> ``alibabacloud-tea-openapi==0.4.5``,
+which caps ``cryptography<49``, and the install resolves ``cryptography`` back
+to 48.0.1 — re-introducing GHSA-m2h6-j472-rp4c, GHSA-jwv3-5hgf-82ww and
+CVE-2026-69247.
+
+``tools/lazy_deps.py`` guards this by reading ``override-dependencies``
+straight from pyproject.toml and passing it as an overrides file to every
+lazy install. These tests assert the *contract* — the reader returns exactly
+the pyproject list, the list is usable as requirement specs, and both
+installer tiers receive it — rather than snapshotting the current overrides.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import managed_uv
+from tools import lazy_deps as ld
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _canonical(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def _requirement_name(spec: str) -> str:
+    head = spec.split(";", 1)[0].split("@", 1)[0].split("[", 1)[0]
+    return _canonical(re.split(r"[=<>!~]", head, maxsplit=1)[0])
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+class TestOverridesComeFromPyproject:
+    """The lazy path forces exactly what ``[tool.uv]`` forces — no drift."""
+
+    def test_reader_returns_the_uv_override_list(self):
+        """``_security_overrides()`` must return ``override-dependencies``
+        verbatim. The single source of truth is pyproject.toml; a transform
+        or filter here would reopen the gap this module closes.
+        """
+        expected = tuple(
+            _pyproject().get("tool", {}).get("uv", {}).get("override-dependencies", [])
+        )
+        assert ld._security_overrides() == expected
+
+    def test_reader_swallows_a_missing_pyproject(self, monkeypatch):
+        """Outside a checkout the reader degrades to no overrides, not a crash."""
+        real = Path.read_text
+
+        def boom(self, *a, **kw):
+            if self.name == "pyproject.toml":
+                raise FileNotFoundError(self)
+            return real(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", boom)
+        assert ld._security_overrides() == ()
+
+    def test_overrides_are_valid_requirement_specs(self):
+        for spec in ld._security_overrides():
+            assert _requirement_name(spec), f"unparseable override spec: {spec!r}"
+            assert any(op in spec for op in ("==", ">=", "<", ">", "~=")), (
+                f"override {spec!r} has no version constraint — it would not "
+                "force anything"
+            )
+
+    def test_override_floor_is_not_below_the_core_pin(self):
+        """An override must never permit a version older than the core pin.
+
+        If pyproject pins ``cryptography==50.0.0`` but the override says
+        ``>=48``, the lazy path can still install 48 and undo the pin.
+        """
+        core = {}
+        for dep in _pyproject()["project"]["dependencies"]:
+            m = re.match(r"^\s*([A-Za-z0-9._-]+)\s*==\s*([0-9][^\s,;]*)", dep)
+            if m:
+                core[_canonical(m.group(1))] = m.group(2)
+
+        for spec in ld._security_overrides():
+            name = _requirement_name(spec)
+            pinned = core.get(name)
+            if not pinned:
+                continue
+            lower = re.search(r">=\s*([0-9][^\s,]*)", spec)
+            assert lower, (
+                f"{name} is exact-pinned to {pinned} in pyproject but its "
+                f"override {spec!r} has no lower bound"
+            )
+            got = tuple(int(x) for x in re.findall(r"\d+", lower.group(1)))
+            want = tuple(int(x) for x in re.findall(r"\d+", pinned))
+            assert got >= want[: len(got)], (
+                f"override for {name} allows {lower.group(1)}, which is "
+                f"below the core pin {pinned}"
+            )
+
+
+class TestOverridesReachBothInstallerTiers:
+    """Both tiers of the install ladder must receive the floor.
+
+    The two tiers are reached by uv being present or absent, never by uv
+    running and failing: that outcome is authoritative and ends the ladder.
+    The last test holds that boundary, because a fallthrough there would
+    discard uv policy such as exclude-newer.
+    """
+
+    BACKEND = "alibabacloud-dingtalk==2.2.42"
+
+    @pytest.fixture
+    def install(self, monkeypatch):
+        """Run ``_venv_pip_install`` with the ladder stubbed, capturing argv.
+
+        The returned callable takes ``uv``, whether the ladder finds a uv
+        binary, and ``uv_ok``, whether that uv succeeds. Temp files are read
+        *during* the stubbed call, because ``_venv_pip_install`` unlinks them
+        in its ``finally`` block.
+        """
+
+        def run(*, uv: bool, uv_ok: bool = True):
+            calls: list[list[str]] = []
+            contents: dict[str, str] = {}
+
+            def fake_run(cmd, *a, **kw):
+                cmd = list(cmd)
+                calls.append(cmd)
+                for flag in ("--overrides", "--constraint"):
+                    if flag in cmd:
+                        p = Path(cmd[cmd.index(flag) + 1])
+                        if p.exists():
+                            contents[flag] = p.read_text(encoding="utf-8")
+
+                class R:
+                    returncode = 0 if (uv_ok or "uv" not in cmd[0]) else 1
+                    stdout = "pip 24.0"
+                    stderr = "stubbed"
+
+                return R()
+
+            uv_bin = "/usr/bin/uv" if uv else None
+            monkeypatch.setattr(ld.subprocess, "run", fake_run)
+            monkeypatch.setattr(ld.shutil, "which", lambda _n: uv_bin)
+            monkeypatch.setattr(managed_uv, "resolve_uv", lambda: uv_bin)
+            monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+            ld._venv_pip_install((self.BACKEND,))
+            return calls, contents
+
+        return run
+
+    def test_uv_tier_receives_overrides_flag(self, install):
+        calls, contents = install(uv=True)
+        uv_calls = [c for c in calls if "uv" in c[0] and "pip" in c]
+        assert uv_calls, f"no uv tier invocation captured: {calls}"
+        cmd = uv_calls[0]
+        assert "--overrides" in cmd, (
+            f"uv tier must pass --overrides so [tool.uv] semantics apply: {cmd}"
+        )
+        body = contents.get("--overrides", "")
+        for spec in ld._security_overrides():
+            assert spec in body, (
+                f"override {spec!r} missing from the file handed to uv: {body!r}"
+            )
+
+    def test_pip_tier_receives_the_floor_as_a_constraint(self, install):
+        """pip has no --overrides; it must still get the floor via --constraint."""
+        calls, contents = install(uv=False)
+        pip_installs = [
+            c for c in calls if "-m" in c and "pip" in c and "install" in c
+        ]
+        assert pip_installs, f"no pip tier install captured: {calls}"
+        cmd = pip_installs[0]
+        assert "--constraint" in cmd, (
+            f"pip tier must receive the security floor as a constraint: {cmd}"
+        )
+        body = contents.get("--constraint", "")
+        for spec in ld._security_overrides():
+            assert spec in body
+
+    @pytest.mark.parametrize("uv", [True, False])
+    def test_temp_files_are_cleaned_up(self, install, uv):
+        calls, _ = install(uv=uv)
+        for cmd in calls:
+            for flag in ("--overrides", "--constraint"):
+                if flag in cmd:
+                    leaked = Path(cmd[cmd.index(flag) + 1])
+                    assert not leaked.exists(), (
+                        f"{flag} temp file leaked after install: {leaked}"
+                    )
+
+    @pytest.mark.parametrize("uv", [True, False])
+    def test_specs_still_reach_the_installer(self, install, uv):
+        """The override plumbing must not displace the actual packages."""
+        calls, _ = install(uv=uv)
+        installs = [c for c in calls if "install" in c]
+        assert installs, f"no install invocation captured: {calls}"
+        for cmd in installs:
+            assert self.BACKEND in cmd, (
+                f"requested spec missing from install command: {cmd}"
+            )
+
+    def test_failed_uv_does_not_fall_through_to_pip(self, install):
+        """A uv resolver failure ends the ladder.
+
+        pip reads neither exclude-newer nor override-dependencies, so a
+        fallthrough here could install a release the project quarantined.
+        The pip tier stays reachable through uv being absent, which the
+        tests above use.
+        """
+        calls, _ = install(uv=True, uv_ok=False)
+        assert all("uv" in c[0] for c in calls), (
+            f"a failed uv run must not reach the pip tier: {calls}"
+        )

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -698,6 +698,65 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
+# Overrides forced onto every lazy install: the ``[tool.uv]
+# override-dependencies`` list, read from pyproject.toml.
+#
+# ``uv pip install`` / ``pip install`` do NOT read ``[tool.uv]``, so a
+# transitive dep that caps a security-pinned package below its patched floor
+# silently DOWNGRADES the core venv on first use of the backend that pulls it.
+# Measured with cryptography: the core venv ships 50.0.0, then enabling
+# DingTalk (``alibabacloud-dingtalk`` -> ``alibabacloud-tea-openapi==0.4.5``,
+# which caps ``cryptography<49``) resolved to::
+#
+#     + cryptography==48.0.1     # three open advisories, re-introduced
+#
+# Pinning the floor alongside the specs is NOT a fix: the resolver satisfies
+# it by walking ``alibabacloud-tea-openapi`` back to 0.3.16 (a two-year-old
+# sdist build) instead, and pinning both is simply unsatisfiable. An overrides
+# file is the only mechanism that forces the patched version while keeping the
+# backend at its intended version, so it is passed to the uv tier below.
+#
+# Lazy installs only ever run from a source checkout (the one wheel-shaped
+# install, Nix, seals its venv and cannot lazy-install), so pyproject.toml is
+# always on disk next to this package and there is no second copy of the list
+# to keep in sync.
+
+
+def _security_overrides() -> tuple[str, ...]:
+    """Read ``[tool.uv] override-dependencies`` from pyproject.toml."""
+    try:
+        import tomllib
+
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        return tuple(data.get("tool", {}).get("uv", {}).get("override-dependencies", []))
+    except Exception as e:
+        logger.debug("Could not read override-dependencies from pyproject.toml: %s", e)
+        return ()
+
+
+def _security_overrides_file() -> Optional[Path]:
+    """Write the overrides to a temp requirements file for ``--overrides``.
+
+    Returns the path, or None if there are no overrides or the file can't be
+    written (in which case the caller installs without overrides — same
+    behaviour as before, just with the downgrade risk this guards against).
+    """
+    overrides = _security_overrides()
+    if not overrides:
+        return None
+    try:
+        import tempfile
+
+        fd, path = tempfile.mkstemp(prefix="hermes-lazy-overrides-", suffix=".txt")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("\n".join(overrides) + "\n")
+        return Path(path)
+    except Exception as e:
+        logger.debug("Could not build security overrides file: %s", e)
+        return None
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
@@ -726,6 +785,8 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             return _InstallResult(False, "", err)
         constraints = _core_constraints_file()
 
+    overrides = _security_overrides_file()
+
     target_args: list[str] = []
     if target is not None:
         # --target tells both uv and pip to install into an arbitrary dir.
@@ -733,6 +794,23 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
     constraint_args: list[str] = []
     if constraints is not None:
         constraint_args = ["--constraint", str(constraints)]
+    # uv-only: pip has no --overrides. See _security_overrides().
+    override_args: list[str] = []
+    # pip tier: --overrides doesn't exist, but --constraint enforces the same
+    # floor. Measured difference on the DingTalk case: with the constraint pip
+    # holds cryptography at 50.0.0 and resolves alibabacloud-tea-openapi back
+    # to 0.3.16; without it, cryptography is downgraded to 48.0.1 instead. An
+    # older backend is a functional regression, a downgraded cryptography is a
+    # security one — so the fallback tier takes the constraint. (uv's
+    # --overrides avoids the tradeoff entirely and is tried first.) When the
+    # backend spec is exact-pinned AND caps the floored package (discord.py
+    # 2.7.1 caps pynacl<1.6), pip has no version to walk back to and the
+    # install fails closed. That is the intended order: a failed optional
+    # install over a silent downgrade of the core venv.
+    pip_override_args: list[str] = []
+    if overrides is not None:
+        override_args = ["--overrides", str(overrides)]
+        pip_override_args = ["--constraint", str(overrides)]
 
     try:
         venv_root = Path(sys.executable).parent.parent
@@ -756,7 +834,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         if uv_bin:
             try:
                 r = subprocess.run(
-                    [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
+                    [uv_bin, "pip", "install", *target_args, *constraint_args, *override_args, *specs],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                     creationflags=windows_hide_flags(),
@@ -804,7 +882,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
 
         try:
             r = subprocess.run(
-                pip_cmd + ["install", *target_args, *constraint_args, *specs],
+                pip_cmd + ["install", *target_args, *constraint_args, *pip_override_args, *specs],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
                 stdin=subprocess.DEVNULL,
                 creationflags=windows_hide_flags(),
@@ -817,11 +895,12 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         except Exception as e:
             return _InstallResult(False, "", f"pip install failed: {e}")
     finally:
-        if constraints is not None:
-            try:
-                constraints.unlink()
-            except OSError:
-                pass
+        for tmp in (constraints, overrides):
+            if tmp is not None:
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
 
 
 # =============================================================================


### PR DESCRIPTION
## What does this PR do?

Part 2/5 of the security + sidecar stack (base: #82134).

`uv pip install` and `pip install` do not read `[tool.uv] override-dependencies` from pyproject.toml. A backend whose transitive deps cap a security-pinned package below its patched floor therefore downgrades the core venv the first time that backend is enabled.

The measured case: the core venv ships cryptography 50.0.0 (#82134). The first DingTalk install pulls alibabacloud-tea-openapi 0.4.5, which caps cryptography<49, and the resolver moves cryptography back to 48.0.1 — with its three advisories. Pinning the floor next to the specs is not a fix: the resolver satisfies it by walking tea-openapi back to 0.3.16, a two-year-old sdist build, and pinning both is unsatisfiable.

`tools/lazy_deps.py` now reads `override-dependencies` from pyproject.toml and hands the list to both installer tiers: uv gets it as `--overrides`, pip gets it as `--constraint`. pyproject.toml is the one source of truth, so there is no second list to keep in sync. Lazy installs only run from a source checkout — the one wheel-shaped install, Nix, seals its venv and cannot lazy-install — so the file is always on disk.

This also covers the pynacl override: a lazy discord.py install caps pynacl below the patched 1.6 floor, and would move the core venv back to 1.5.0.

## Related Issue

None. Found while validating the cryptography bump in #82134.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/lazy_deps.py` — read the overrides from pyproject.toml, pass them to both installer tiers
- `tests/tools/test_lazy_deps_security_overrides.py` — new contract tests: the reader returns the pyproject list verbatim, and both tiers receive it
- `tests/tools/test_lazy_deps_durable_target.py` — comment update

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_lazy_deps_security_overrides.py tests/tools/test_lazy_deps_durable_target.py tests/tools/test_lazy_deps.py`.
2. In a clean venv, run `uv pip install alibabacloud-dingtalk` with the overrides file. cryptography stays at 50.0.0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
