### PR TITLE
fix(desktop): keep react-router in one runtime chunk

### DIFF
--- a/apps/desktop/scripts/assert-dist-built.mjs
+++ b/apps/desktop/scripts/assert-dist-built.mjs
@@ -11,9 +11,11 @@
 // inherits it. It fails loud and early instead of shipping a broken bundle.
 // See issues #39484 (renderer blank page) and #41327 / #39472 (dashboard 404).
 
-import { existsSync, statSync, readdirSync } from "fs"
+import { existsSync, readFileSync, statSync, readdirSync } from "fs"
 import { join, resolve } from "path"
 import { isMain } from "./utils.mjs"
+
+const ROUTER_CONTEXT_ERROR = "may be used only in the context of a"
 
 // Pure check — returns { ok: true } or { ok: false, error: "..." }.
 // Kept side-effect-free so it can be unit tested without spawning a process.
@@ -39,6 +41,17 @@ export function checkDistBuilt(distDir) {
     readdirSync(assetsDir).some(name => name.endsWith(".js"))
   if (!hasAssets) {
     return { ok: false, error: `dist/assets has no built JS bundle (expected vite output under ${assetsDir})` }
+  }
+
+  const routerContextAssets = readdirSync(assetsDir)
+    .filter(name => name.endsWith(".js"))
+    .filter(name => readFileSync(join(assetsDir, name), "utf8").includes(ROUTER_CONTEXT_ERROR))
+
+  if (routerContextAssets.length > 1) {
+    return {
+      ok: false,
+      error: `react-router context invariant found in multiple JS assets: ${routerContextAssets.join(", ")}`
+    }
   }
 
   return { ok: true }

--- a/apps/desktop/scripts/assert-dist-built.test.mjs
+++ b/apps/desktop/scripts/assert-dist-built.test.mjs
@@ -14,6 +14,14 @@ function makeDist(extra) {
   return { tempRoot, distDir }
 }
 
+function writeRouterAsset(distDir, name) {
+  fs.writeFileSync(
+    path.join(distDir, 'assets', name),
+    `throw new Error('may be used only in the context of a <Router>')`,
+    'utf8',
+  )
+}
+
 test('checkDistBuilt passes when index.html + an assets JS bundle exist', () => {
   const { tempRoot, distDir } = makeDist(d => {
     fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html><div id=root></div>', 'utf8')
@@ -78,6 +86,38 @@ test('checkDistBuilt fails when assets/ has no JS bundle', () => {
     const result = checkDistBuilt(distDir)
     assert.equal(result.ok, false)
     assert.match(result.error, /no built JS bundle/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt passes when the Router context invariant is in one JS asset', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    writeRouterAsset(d, 'vendor-react-abc123.js')
+    fs.writeFileSync(path.join(d, 'assets', 'command-def456.js'), 'console.log(1)', 'utf8')
+  })
+  try {
+    assert.deepEqual(checkDistBuilt(distDir), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt fails when the Router context invariant is in multiple JS assets', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    writeRouterAsset(d, 'vendor-react-abc123.js')
+    writeRouterAsset(d, 'command-def456.js')
+  })
+  try {
+    const result = checkDistBuilt(distDir)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /react-router context invariant found in multiple JS assets/)
+    assert.match(result.error, /vendor-react-abc123\.js/)
+    assert.match(result.error, /command-def456\.js/)
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -112,7 +112,7 @@ export default defineConfig(({ command }) => ({
             // the heavy chunk, and the entry then statically imports 19 MB of
             // shiki just to reach react/hast utils — putting the heavy chunk
             // right back on the boot path.
-            { name: 'vendor-react', test: /node_modules[\\/](react|react-dom|scheduler)[\\/]/ },
+            { name: 'vendor-react', test: /node_modules[\\/](react|react-dom|scheduler|react-router)[\\/]/ },
             {
               name: 'vendor-md',
               test: /node_modules[\\/](property-information|hast-util-[^\\/]+|mdast-util-[^\\/]+|micromark[^\\/]*|unist-util-[^\\/]+|vfile[^\\/]*|unified|stringify-entities|space-separated-tokens|comma-separated-tokens|zwitch|html-void-elements|devlop|style-to-js|style-to-object|clsx)[\\/]/
@@ -152,7 +152,7 @@ export default defineConfig(({ command }) => ({
       'react/jsx-dev-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-dev-runtime.js'),
       'react/jsx-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-runtime.js')
     },
-    dedupe: ['react', 'react-dom']
+    dedupe: ['react', 'react-dom', 'react-router']
   },
   server: {
     host: '127.0.0.1',


### PR DESCRIPTION
## What does this PR do?

  Fixes a clean-install crash in Hermes Desktop where duplicated `react-router` modules caused the renderer to throw:

  `useLocation() may be used only in the context of a component.`

  `react-router` is now bundled into the shared React vendor chunk and deduplicated by Vite, ensuring Router context is shared across lazy-loaded chunks.

  ## Related Issue

  Fixes #82696

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - Updated `apps/desktop/vite.config.ts`:
    - Added `react-router` to the `vendor-react` advanced chunk group.
    - Added `react-router` to `resolve.dedupe`.
  - Updated `apps/desktop/scripts/assert-dist-built.mjs` with a packaging guard that fails when the Router-context invariant appears in multiple JavaScript assets.
  - Added regression tests in `apps/desktop/scripts/assert-dist-built.test.mjs` covering:
    - A single Router-context asset.
    - Duplicate Router-context assets and offending filenames.

  ## How to Test

  1. From `apps/desktop`, run:
     ```bash
     npm test -- scripts/assert-dist-built.test.mjs

  Expected: 7 tests pass.

  2. Run:

     npm run typecheck

  3. Build the renderer:

     npm run build

  4. Verify the Router invariant appears in only one asset:

     node scripts/assert-dist-built.mjs
     rg -l --glob '*.js' 'may be used only in the context of a' dist/assets

     Expected: only the vendor-react-*.js asset is reported.

  The renderer and Electron main/preload bundles built successfully. Native dependency staging and packaging require platform-specific Electron native binaries and were
  blocked in the Linux environment used for validation.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass — not applicable to this desktop renderer change
  - [x] I've added tests for my changes
  - [x] I've tested on Linux; Windows/macOS packaging was not available in this environment

  ### Documentation & Housekeeping

  - [ ] Documentation update not required
  - [ ] Config keys were not changed
  - [x] Cross-platform impact considered; the Vite bundling fix applies to all desktop platforms
  - [x] Tool descriptions and schemas were not changed

  ## Screenshots / Logs

  Not applicable. The failure occurs during renderer startup; validation is covered by the build output scan and regression tests.