### PR TITLE
fix(config): preserve flat MoA settings during merge

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -29,7 +29,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, cast
 
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -2460,6 +2460,38 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
+_LEGACY_FLAT_MOA_SLOT_KEYS = frozenset({"reference_models", "aggregator"})
+
+
+def _merge_config_layer(base: dict, override: dict) -> dict:
+    """Merge one config layer without shadowing an explicit flat MoA preset.
+
+    ``DEFAULT_CONFIG`` contains ``moa.presets.default``.  A legacy flat MoA
+    layer deliberately has no ``presets`` key, so an ordinary deep merge would
+    retain that inherited preset and make ``normalize_moa_config`` ignore the
+    layer's explicit slot settings.  Remove only the inherited preset selectors
+    before merging such a layer; named-preset layers keep normal deep-merge
+    behavior.
+    """
+    moa_override = override.get("moa")
+    if (
+        isinstance(moa_override, dict)
+        and "presets" not in moa_override
+        and not {"default_preset", "active_preset"}.intersection(moa_override)
+        and _LEGACY_FLAT_MOA_SLOT_KEYS.intersection(moa_override)
+    ):
+        base = base.copy()
+        inherited_moa = base.get("moa")
+        base_moa = (
+            dict(inherited_moa) if isinstance(inherited_moa, dict) else {}
+        )
+        base_moa.pop("presets", None)
+        base_moa.pop("default_preset", None)
+        base_moa.pop("active_preset", None)
+        base["moa"] = base_moa
+    return _deep_merge(base, override)
+
+
 def _strip_dotted_keys(cfg: dict, dotted_keys: set) -> Tuple[dict, set]:
     """Remove the given dotted leaf keys from a nested config dict.
 
@@ -3403,7 +3435,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     user_config["agent"] = agent_user_config
                     user_config.pop("max_turns", None)
 
-                config = _deep_merge(config, user_config)
+                config = _merge_config_layer(config, user_config)
             except Exception as e:
                 # Last-known-good fallback (port of openai/codex#31188's
                 # invariant: a parse failure in a policy/config file must not
@@ -3455,7 +3487,10 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         managed_config = managed_scope.load_managed_config()
         if managed_config:
             managed_expanded = _expand_env_vars(managed_config)
-            expanded = _deep_merge(expanded, managed_expanded)
+            expanded = _merge_config_layer(
+                cast(Dict[str, Any], expanded),
+                cast(Dict[str, Any], managed_expanded),
+            )
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_sig is not None:
             # Cache stores a separate deepcopy so subsequent ``load_config()``

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -19,7 +19,7 @@ import unicodedata
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, cast
 
 import yaml
 
@@ -1499,6 +1499,38 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
+_LEGACY_FLAT_MOA_SLOT_KEYS = frozenset({"reference_models", "aggregator"})
+
+
+def _merge_config_layer(base: dict, override: dict) -> dict:
+    """Merge one config layer without shadowing an explicit flat MoA preset.
+
+    ``DEFAULT_CONFIG`` contains ``moa.presets.default``.  A legacy flat MoA
+    layer deliberately has no ``presets`` key, so an ordinary deep merge would
+    retain that inherited preset and make ``normalize_moa_config`` ignore the
+    layer's explicit slot settings.  Remove only the inherited preset selectors
+    before merging such a layer; named-preset layers keep normal deep-merge
+    behavior.
+    """
+    moa_override = override.get("moa")
+    if (
+        isinstance(moa_override, dict)
+        and "presets" not in moa_override
+        and not {"default_preset", "active_preset"}.intersection(moa_override)
+        and _LEGACY_FLAT_MOA_SLOT_KEYS.intersection(moa_override)
+    ):
+        base = base.copy()
+        inherited_moa = base.get("moa")
+        base_moa = (
+            dict(inherited_moa) if isinstance(inherited_moa, dict) else {}
+        )
+        base_moa.pop("presets", None)
+        base_moa.pop("default_preset", None)
+        base_moa.pop("active_preset", None)
+        base["moa"] = base_moa
+    return _deep_merge(base, override)
+
+
 def _strip_dotted_keys(cfg: dict, dotted_keys: set) -> Tuple[dict, set]:
     """Remove dotted leaf keys from *cfg* in place -> ``(cfg, keys_actually_present)``.
     ``save_config`` drops managed-scope leaves this way so a bulk write never persists a user
@@ -2146,7 +2178,7 @@ def _merge_managed_overlay(expanded: Dict[str, Any]) -> Tuple[Dict[str, Any], An
     if isinstance(managed_normalized.get("model"), str):
         managed_normalized = dict(managed_normalized)
         managed_normalized["model"] = {"default": managed_normalized["model"]}
-    return _deep_merge(expanded, _expand_env_vars(managed_normalized)), managed_config
+    return _merge_config_layer(expanded, cast(Dict[str, Any], _expand_env_vars(managed_normalized))), managed_config
 
 
 def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
@@ -2182,7 +2214,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     user_config["agent"] = agent_user_config
                     user_config.pop("max_turns", None)
 
-                config = _deep_merge(config, user_config)
+                config = _merge_config_layer(config, user_config)
             except Exception as e:
                 lkg_copy = _last_known_good_fallback(config_path, path_key, cache_sig, e)
                 if lkg_copy is not None:

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -159,7 +159,11 @@ def apply_managed_overlay(config: dict) -> dict:
         if not managed:
             return config
         # Imported lazily to avoid an import cycle (config imports managed_scope).
-        from hermes_cli.config import _deep_merge, _expand_env_vars, _normalize_root_model_keys
+        from hermes_cli.config import (
+            _expand_env_vars,
+            _merge_config_layer,
+            _normalize_root_model_keys,
+        )
 
         managed_expanded = _normalize_root_model_keys(_expand_env_vars(managed))
         # A bare ``model: x/y`` string in the managed file must merge as
@@ -171,7 +175,7 @@ def apply_managed_overlay(config: dict) -> dict:
         if isinstance(managed_expanded.get("model"), str):
             managed_expanded = dict(managed_expanded)
             managed_expanded["model"] = {"default": managed_expanded["model"]}
-        return _deep_merge(config, managed_expanded)
+        return _merge_config_layer(config, managed_expanded)
     except Exception:  # noqa: BLE001 — overlay must never break a caller
         logger.warning("managed scope: failed to apply config overlay", exc_info=True)
         return config

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -121,7 +121,11 @@ def apply_managed_overlay(config: dict) -> dict:
         if not managed:
             return config
         # Imported lazily to avoid an import cycle (config imports managed_scope).
-        from hermes_cli.config import _deep_merge, _expand_env_vars, _normalize_root_model_keys
+        from hermes_cli.config import (
+            _expand_env_vars,
+            _merge_config_layer,
+            _normalize_root_model_keys,
+        )
         managed_expanded = _normalize_root_model_keys(_expand_env_vars(managed))
         # _normalize_root_model_keys only promotes the string when root provider/base_url
         # keys exist to migrate; handle the bare case here (matches cli.py) so _deep_merge
@@ -129,7 +133,7 @@ def apply_managed_overlay(config: dict) -> dict:
         if isinstance(managed_expanded.get("model"), str):
             managed_expanded = dict(managed_expanded)
             managed_expanded["model"] = {"default": managed_expanded["model"]}
-        return _deep_merge(config, managed_expanded)
+        return _merge_config_layer(config, managed_expanded)
     except Exception:  # noqa: BLE001 — overlay must never break a caller
         logger.warning("managed scope: failed to apply config overlay", exc_info=True)
         return config

--- a/tests/hermes_cli/test_managed_scope_overlay.py
+++ b/tests/hermes_cli/test_managed_scope_overlay.py
@@ -42,3 +42,64 @@ def test_overlay_preserves_user_siblings(managed):
     assert out["display"]["show_reasoning"] is True
 
 
+def _write_flat_moa(md):
+    _write(
+        md,
+        """
+        moa:
+          reference_models:
+            - provider: anthropic
+              model: claude-fable-5
+          aggregator:
+            provider: openai-codex
+            model: gpt-5.6-sol
+        """,
+    )
+
+
+def _assert_flat_moa_resolves(out):
+    from hermes_cli.moa_config import resolve_moa_preset
+
+    resolved = resolve_moa_preset(out["moa"])
+    assert resolved["reference_models"] == [
+        {"provider": "anthropic", "model": "claude-fable-5", "enabled": True}
+    ]
+    assert resolved["aggregator"]["provider"] == "openai-codex"
+    assert resolved["aggregator"]["model"] == "gpt-5.6-sol"
+
+
+def test_flat_managed_moa_replaces_inherited_named_presets(managed):
+    from hermes_cli import managed_scope
+
+    _write_flat_moa(managed)
+    out = managed_scope.apply_managed_overlay(
+        {
+            "moa": {
+                "default_preset": "custom",
+                "presets": {
+                    "custom": {
+                        "reference_models": [
+                            {"provider": "openrouter", "model": "old/reference"}
+                        ],
+                        "aggregator": {
+                            "provider": "openrouter",
+                            "model": "old/aggregator",
+                        },
+                    }
+                },
+            }
+        }
+    )
+
+    _assert_flat_moa_resolves(out)
+
+
+def test_flat_managed_moa_replaces_malformed_user_value(managed):
+    from hermes_cli import managed_scope
+
+    _write_flat_moa(managed)
+    out = managed_scope.apply_managed_overlay({"moa": "invalid"})
+
+    _assert_flat_moa_resolves(out)
+
+

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -1,6 +1,7 @@
 import pytest
 
 from agent.errors import MoAPresetNotFoundError
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli.moa_config import (
     DEFAULT_MOA_AGGREGATOR,
     DEFAULT_MOA_PRESET_NAME,
@@ -46,6 +47,58 @@ def test_normalize_moa_config_uses_default_named_preset():
     assert list(cfg["presets"]) == [DEFAULT_MOA_PRESET_NAME]
     assert cfg["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
     assert cfg["aggregator"] == DEFAULT_MOA_AGGREGATOR
+
+
+def test_load_config_preserves_explicit_flat_moa_slots(tmp_path):
+    """Flat user slots must not be shadowed by the merged default preset."""
+    from hermes_cli import config as config_module
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "moa:\n"
+        "  reference_models:\n"
+        "    - provider: anthropic\n"
+        "      model: claude-fable-5\n"
+        "  aggregator:\n"
+        "    provider: openai-codex\n"
+        "    model: gpt-5.6-sol\n",
+        encoding="utf-8",
+    )
+
+    token = set_hermes_home_override(home)
+    config_module._LOAD_CONFIG_CACHE.clear()
+    config_module._RAW_CONFIG_CACHE.clear()
+    try:
+        loaded = config_module.load_config()
+        resolved = resolve_moa_preset(loaded["moa"])
+    finally:
+        config_module._LOAD_CONFIG_CACHE.clear()
+        config_module._RAW_CONFIG_CACHE.clear()
+        reset_hermes_home_override(token)
+
+    assert resolved["reference_models"] == [
+        {"provider": "anthropic", "model": "claude-fable-5", "enabled": True}
+    ]
+    assert resolved["aggregator"]["provider"] == "openai-codex"
+    assert resolved["aggregator"]["model"] == "gpt-5.6-sol"
+
+
+def test_partial_flat_moa_layer_does_not_discard_named_presets():
+    """A later scalar override is not enough evidence to replace named presets."""
+    from hermes_cli.config import _merge_config_layer
+
+    preset = {
+        "reference_models": [{"provider": "anthropic", "model": "claude-fable-5"}],
+        "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-sol"},
+    }
+    merged = _merge_config_layer(
+        {"moa": {"default_preset": "custom", "presets": {"custom": preset}}},
+        {"moa": {"max_tokens": 512}},
+    )
+
+    assert merged["moa"]["default_preset"] == "custom"
+    assert merged["moa"]["presets"] == {"custom": preset}
 
 
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -1,6 +1,7 @@
 import pytest
 
 from agent.errors import MoAPresetNotFoundError
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli.moa_config import (
     DEFAULT_MOA_AGGREGATOR,
     DEFAULT_MOA_PRESET_NAME,
@@ -44,6 +45,58 @@ def test_normalize_moa_config_uses_default_named_preset():
     assert list(cfg["presets"]) == [DEFAULT_MOA_PRESET_NAME]
     assert cfg["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
     assert cfg["aggregator"] == DEFAULT_MOA_AGGREGATOR
+
+
+def test_load_config_preserves_explicit_flat_moa_slots(tmp_path):
+    """Flat user slots must not be shadowed by the merged default preset."""
+    from hermes_cli import config as config_module
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "moa:\n"
+        "  reference_models:\n"
+        "    - provider: anthropic\n"
+        "      model: claude-fable-5\n"
+        "  aggregator:\n"
+        "    provider: openai-codex\n"
+        "    model: gpt-5.6-sol\n",
+        encoding="utf-8",
+    )
+
+    token = set_hermes_home_override(home)
+    config_module._LOAD_CONFIG_CACHE.clear()
+    config_module._RAW_CONFIG_CACHE.clear()
+    try:
+        loaded = config_module.load_config()
+        resolved = resolve_moa_preset(loaded["moa"])
+    finally:
+        config_module._LOAD_CONFIG_CACHE.clear()
+        config_module._RAW_CONFIG_CACHE.clear()
+        reset_hermes_home_override(token)
+
+    assert resolved["reference_models"] == [
+        {"provider": "anthropic", "model": "claude-fable-5", "enabled": True}
+    ]
+    assert resolved["aggregator"]["provider"] == "openai-codex"
+    assert resolved["aggregator"]["model"] == "gpt-5.6-sol"
+
+
+def test_partial_flat_moa_layer_does_not_discard_named_presets():
+    """A later scalar override is not enough evidence to replace named presets."""
+    from hermes_cli.config import _merge_config_layer
+
+    preset = {
+        "reference_models": [{"provider": "anthropic", "model": "claude-fable-5"}],
+        "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-sol"},
+    }
+    merged = _merge_config_layer(
+        {"moa": {"default_preset": "custom", "presets": {"custom": preset}}},
+        {"moa": {"max_tokens": 512}},
+    )
+
+    assert merged["moa"]["default_preset"] == "custom"
+    assert merged["moa"]["presets"] == {"custom": preset}
 
 
 


### PR DESCRIPTION
## Summary

- preserve explicit legacy flat MoA slot configuration across both canonical and shared managed-overlay config merges
- tolerate malformed lower-priority `moa` values when a valid managed flat override replaces them
- keep named-preset and scalar-only override behavior unchanged
- add end-to-end regressions through `load_config()` and `apply_managed_overlay()`

## Root cause

`load_config()` starts from `DEFAULT_CONFIG`, which contains `moa.presets.default`, and deep-merges the user's config. A flat MoA block therefore inherits that preset. `normalize_moa_config()` sees `presets` and skips its documented flat compatibility path, silently resolving the built-in models instead of the configured references and aggregator.

This change removes only inherited preset selectors before merging a layer that unambiguously supplies flat slots (`reference_models` or `aggregator`) and supplies no named preset or selector. Named-preset layers continue through the ordinary deep merge. The same merge helper is used by the shared managed-overlay path, and malformed lower-priority `moa` values are safely replaced by valid managed flat configuration.

Fixes #82726.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_managed_scope_overlay.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_loader_e2e.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_read_guard.py -q`
  - 98 passed
- `ruff check hermes_cli/config.py hermes_cli/managed_scope.py tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_managed_scope_overlay.py`
- `git diff --check upstream/main...HEAD`
- isolated post-push fork probe resolved exactly:
  - references: `anthropic/claude-fable-5`, `openrouter/moonshotai/kimi-k3`
  - aggregator: `openai-codex/gpt-5.6-sol`
- broad canonical suite comparison: candidate and unmodified upstream baseline produced the same 22 failing files / 78 failing tests on this macOS environment; none touched the changed config/MoA surfaces
