### PR TITLE
fix(desktop-ssh): stop resolving exec-wrappers to python in locateHermes

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -112,14 +112,41 @@ test('locateHermes falls back to the login-shell command -v probe', async () => 
   assert.equal(await locateHermes(ssh, ''), '/home/u/.local/bin/hermes')
 })
 
-test('locateHermes canonicalizes an installer wrapper to its executable target', async () => {
+test('locateHermes preserves an installer wrapper instead of resolving its interpreter', async () => {
+  // install.sh venv mode writes: exec "$HERMES_BIN" "$HERMES_ENTRYPOINT" "$@",
+  // where $HERMES_BIN is the venv python. The old canonicalization returned
+  // that interpreter, so `<python> --version` printed "Python x.y.z" and
+  // `<python> serve --help` failed outright (#74411). The wrapper itself is
+  // executable and forwards args correctly — return it untouched.
   const ssh = fakeSsh([
     [/command -v hermes/, '/home/u/.local/bin/hermes\n'],
     [/\[ -x .*\.local\/bin\/hermes/, 'OK'],
-    [/python3 -c/, '/home/u/.hermes/hermes-agent/venv/bin/hermes\n']
+    // If the removed python3 wrapper-parser were ever reintroduced, this rule
+    // would reward it with an interpreter path and the assertions below fail.
+    [/python3 -c/, '/home/u/.hermes/hermes-agent/venv/bin/python\n']
   ])
 
-  assert.equal(await locateHermes(ssh, ''), '/home/u/.hermes/hermes-agent/venv/bin/hermes')
+  assert.equal(await locateHermes(ssh, ''), '/home/u/.local/bin/hermes')
+  assert.ok(
+    !ssh.calls.some(cmd => cmd.includes('python3 -c')),
+    'locateHermes must not shell out to a python3 parser to rewrite the launcher'
+  )
+})
+
+test('locateHermes returns an explicit remoteHermesPath unchanged', async () => {
+  // The override half of #74411: an explicit remoteHermesPath pointing at a
+  // wrapper was also canonicalized to its interpreter, so overriding to
+  // ~/.local/bin/hermes changed nothing for affected users.
+  const ssh = fakeSsh([
+    [/\[ -x .*\.local\/bin\/hermes/, 'OK'],
+    [/python3 -c/, '/home/u/.hermes/hermes-agent/venv/bin/python\n']
+  ])
+
+  assert.equal(await locateHermes(ssh, '~/.local/bin/hermes'), '~/.local/bin/hermes')
+  assert.ok(
+    !ssh.calls.some(cmd => cmd.includes('python3 -c')),
+    'an explicit remoteHermesPath must never be rewritten'
+  )
 })
 
 test('locateHermes falls back to ~/.local/bin/hermes when the login-shell probe misses', async () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -128,25 +128,16 @@ function expandRemotePath(p) {
 // non-login `ssh host cmd` PATH misses user installs), then known install paths.
 async function locateHermes(ssh, remoteHermesPath) {
   const resolveLauncher = async (candidate: string) => {
-    const script =
-      'import os,shlex,sys\n' +
-      `p=os.path.expanduser(${shq(candidate)})\n` +
-      'out=p\n' +
-      'try:\n' +
-      ' data=open(p,"r",encoding="utf-8",errors="ignore").read(4096)\n' +
-      ' for line in data.splitlines():\n' +
-      '  words=shlex.split(line)\n' +
-      '  if len(words)>1 and words[0]=="exec":\n' +
-      '   target=os.path.expanduser(words[1])\n' +
-      '   if os.path.isabs(target) and os.access(target,os.X_OK):out=target\n' +
-      '   break\n' +
-      'except (OSError,ValueError):pass\n' +
-      'print(out)'
-
-    const resolved = (await ssh.exec(`python3 -c ${shq(script)}`)).trim()
-
-    return resolved || candidate
-  }
+      // Return the candidate path directly. The hermes binary or wrapper script
+      // is executable and handles argument forwarding (e.g. `exec <python> <script> "$@"`)
+      // correctly on its own. Previously, this function followed `exec` wrappers and
+      // returned only the python interpreter, which broke:
+      //   - version checking: `<python> --version` printed "Python x.y.z" instead of
+      //     the Hermes version, and
+      //   - capability probing: `<python> serve --help` failed entirely.
+      // See https://github.com/NousResearch/hermes-agent/issues/74411
+      return candidate
+    }
 
   const isExecutable = async (candidate: string) => {
     try {


### PR DESCRIPTION
## Summary

Desktop SSH mode now probes and spawns the resolved `hermes` launcher itself instead of resolving exec-wrapper scripts down to their python interpreter — fixing the false "The remote Hermes install does not support --ssh-session-token-file and --ssh-owner-nonce" boot failure on fully up-to-date remote installs (#74411).

Root cause: `locateHermes()`'s `resolveLauncher` parsed the installer wrapper's `exec` line and returned `words[1]`. install.sh venv mode writes `exec "$HERMES_BIN" "$HERMES_ENTRYPOINT" "$@"` where `$HERMES_BIN` is the venv **python**, so every subsequent probe ran against the interpreter: `<python> --version` reported "Python 3.11" and `<python> serve --help` failed outright, tripping the update-required error. An explicit `remoteHermesPath` override was rewritten the same way, so it didn't help either.

## Changes

- `apps/desktop/electron/remote-lifecycle.ts`: `resolveLauncher` returns the candidate unchanged — the wrapper is executable and forwards args itself; canonicalizing past it also bypassed the venv interpreter the wrapper exists to force (salvaged from #74425 by @webtecnica, rebased onto current main)
- `apps/desktop/electron/remote-lifecycle.test.ts`: replaced the canonicalization test (which pinned the removed behavior) with wrapper-preservation coverage for auto-detection and explicit `remoteHermesPath`, both asserting no `python3 -c` parser call is issued

## Validation

| | Result |
|---|---|
| `vitest run electron/remote-lifecycle.test.ts` (with fix) | 66/66 passed |
| Same tests against pre-fix implementation (sabotage run) | 2 failed — exactly the new tests, on the intended assertions |

Compatibility: `pidIsOurDashboard` already accepts both direct (`args[0]==hermesPath`) and `python_entry` cmdline shapes, so ownership verification of backends spawned by older Desktop builds (which recorded the interpreter path) is unaffected.

Closes #74425. Fixes #74411.

## Infographic

![Desktop SSH: probe the wrapper, not python](https://v3b.fal.media/files/b/0aa5b20e/E9zMa1pHZgYpcjGKkXOxp_PpUSoQef.png)
