### PR TITLE
fix(gateway): session recovery honors reset boundaries and real idle time (#68617 + #78618 salvage)

### DIFF
--- a/contributors/emails/hill.chitsanupong@gmail.com
+++ b/contributors/emails/hill.chitsanupong@gmail.com
@@ -1,0 +1,1 @@
+hillimited

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1903,18 +1903,37 @@ class SessionStore:
     ) -> SessionEntry:
         started_at = row.get("started_at")
         try:
-            created_at = datetime.fromtimestamp(float(started_at)) if started_at else now
+            created_at = datetime.fromtimestamp(float(started_at))
         except (TypeError, ValueError, OSError):
-            created_at = now
+            # An invalid durable timestamp must look old, never freshly active.
+            created_at = datetime.fromtimestamp(0)
+        # The finder already returns the row's durable recency
+        # (last_activity_at is what it ranks candidates by), so no extra DB
+        # round-trip is needed: derive updated_at straight from the row.
+        last_activity = row.get("last_activity_at")
+        try:
+            updated_at = (
+                datetime.fromtimestamp(float(last_activity))
+                if last_activity is not None
+                else created_at
+            )
+        except (TypeError, ValueError, OSError):
+            updated_at = created_at
+        had_activity = row.get("_has_messages")
+        if had_activity is None:
+            had_activity = bool(row.get("message_count") or 0) or (
+                last_activity is not None
+            )
         return SessionEntry(
             session_key=session_key,
             session_id=str(row["id"]),
             created_at=created_at,
-            updated_at=now,
+            updated_at=updated_at,
             origin=source,
             display_name=source.chat_name,
             platform=source.platform,
             chat_type=source.chat_type,
+            reset_had_activity=bool(had_activity),
         )
 
     def _find_gateway_session_row(
@@ -1964,7 +1983,13 @@ class SessionStore:
         now: datetime,
         raise_on_lookup_error: bool = False,
     ) -> Optional[SessionEntry]:
-        """Rebuild a missing session-key mapping from durable state.db data."""
+        """Rebuild a missing session-key mapping from durable state.db data.
+
+        Returns ``None`` when no row is recoverable, or when the recovered
+        session is already overdue under the configured reset policy — the
+        row is then durably promoted to a reset boundary instead of being
+        resurrected as freshly active.
+        """
         legacy_key = self._legacy_slack_session_key(source)
         recovered = self._find_gateway_session_row(
             session_key=session_key,
@@ -2001,16 +2026,31 @@ class SessionStore:
                 session_key,
             )
             return None
-        try:
-            self._db.reopen_session(str(recovered["id"]))
-        except Exception as exc:
-            logger.debug("Gateway session DB reopen failed for %s: %s", session_key, exc)
         entry = self._create_entry_from_recovered_row(
             row=recovered,
             session_key=session_key,
             source=source,
             now=now,
         )
+        reset_reason = self._should_reset(entry, source)
+        if reset_reason:
+            try:
+                promote = getattr(self._db, "promote_to_session_reset", None)
+                if callable(promote):
+                    promote(entry.session_id, reset_reason)
+                else:
+                    self._db.end_session(entry.session_id, reset_reason)
+            except Exception as exc:
+                logger.debug(
+                    "Gateway recovered-session reset promotion failed for %s: %s",
+                    session_key,
+                    exc,
+                )
+            return None
+        try:
+            self._db.reopen_session(entry.session_id)
+        except Exception as exc:
+            logger.debug("Gateway session DB reopen failed for %s: %s", session_key, exc)
         if migrated_legacy:
             self._record_gateway_session_peer(
                 entry.session_id,
@@ -2026,6 +2066,8 @@ class SessionStore:
         """DB-only half of _recover_session_from_db (no lock needed).
 
         Returns a SessionEntry or None.  Caller assigns _entries[key] under lock.
+        The returned entry's session row is NOT reopened here: the caller
+        evaluates the reset policy first and decides reset vs resume.
         """
         legacy_key = self._legacy_slack_session_key(source)
         recovered = self._find_gateway_session_row(
@@ -2061,11 +2103,9 @@ class SessionStore:
                 session_key,
             )
             return None
-        try:
-            self._db.reopen_session(str(recovered["id"]))
-        except Exception as exc:
-            logger.debug("Gateway session DB reopen failed for %s: %s",
-                         session_key, exc)
+        # Reopen only after the caller evaluates reset policy against durable
+        # last activity.  An agent_close/ws_orphan row may need promotion to a
+        # real reset boundary instead.
         entry = self._create_entry_from_recovered_row(
             row=recovered, session_key=session_key, source=source, now=now,
         )
@@ -2638,13 +2678,29 @@ class SessionStore:
                 session_key=session_key, source=source, now=now,
             )
             if recovered is not None:
-                with self._lock:
-                    published = self._entries.get(session_key)
-                    if published is None:
-                        self._entries[session_key] = recovered
-                        published = recovered
-                entry = published
-                _needs_save = True
+                recovered_reset_reason = self._should_reset(recovered, source)
+                if recovered_reset_reason:
+                    was_auto_reset = True
+                    auto_reset_reason = recovered_reset_reason
+                    reset_had_activity = recovered.reset_had_activity
+                    db_end_session_id = recovered.session_id
+                    prev_session_id = recovered.session_id
+                else:
+                    try:
+                        self._db.reopen_session(recovered.session_id)
+                    except Exception as exc:
+                        logger.debug(
+                            "Gateway session DB reopen failed for %s: %s",
+                            session_key,
+                            exc,
+                        )
+                    with self._lock:
+                        published = self._entries.get(session_key)
+                        if published is None:
+                            self._entries[session_key] = recovered
+                            published = recovered
+                    entry = published
+                    _needs_save = True
 
         if entry is None:
             # Create a candidate outside the lock, then publish only if another

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4019,6 +4019,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         returning ``None`` mints a brand-new session id, which is a worse
         outcome than resuming an empty-but-correctly-keyed row (and "empty"
         may just mean the transcript lives under a compression child).
+
+        Reset boundaries fence recovery (#68539): an intentional boundary
+        such as ``session_reset`` (or any explicit non-recoverable
+        end_reason) must block fallback to an *older* row for the same
+        peer. Without the fence, the has-messages ranking above could reach
+        behind a /new reset and silently restore the exact context the user
+        reset. Each candidate is therefore rejected when a boundary row for
+        the peer ended *after* the candidate's last activity — if the
+        conversation's most recent event is an intentional reset, recovery
+        returns nothing rather than reaching behind it.
         """
         if not session_key:
             return None
@@ -4036,6 +4046,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 WHERE s.session_key = ?
                   AND s.source = ?
                   AND (s.ended_at IS NULL OR s.end_reason IN ('agent_close', 'ws_orphan_reap'))
+                  AND NOT EXISTS (
+                      SELECT 1 FROM sessions b
+                      WHERE b.session_key = s.session_key
+                        AND b.source = s.source
+                        AND b.ended_at IS NOT NULL
+                        AND b.end_reason IN ('session_reset', 'session_switch',
+                                             'idle', 'daily', 'suspended',
+                                             'resume_pending_expired')
+                        AND b.ended_at
+                            > COALESCE(s.last_activity_at, s.started_at)
+                  )
                 ORDER BY _has_messages DESC,
                          COALESCE(s.last_activity_at, s.started_at) DESC
                 LIMIT 1
@@ -4069,6 +4090,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND (COALESCE(s.message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = s.id LIMIT 1
                   ))
+                  AND NOT EXISTS (
+                      SELECT 1 FROM sessions b
+                      WHERE b.source = s.source
+                        AND COALESCE(b.user_id, '') = COALESCE(s.user_id, '')
+                        AND COALESCE(b.chat_id, '') = COALESCE(s.chat_id, '')
+                        AND COALESCE(b.chat_type, '') = COALESCE(s.chat_type, '')
+                        AND COALESCE(b.thread_id, '') = COALESCE(s.thread_id, '')
+                        AND b.ended_at IS NOT NULL
+                        AND b.end_reason IN ('session_reset', 'session_switch',
+                                             'idle', 'daily', 'suspended',
+                                             'resume_pending_expired')
+                        AND b.ended_at
+                            > COALESCE(s.last_activity_at, s.started_at)
+                  )
                 ORDER BY COALESCE(s.last_activity_at, s.started_at) DESC
                 LIMIT 1
                 """,

--- a/tests/gateway/test_session_store_runtime_stale_guard.py
+++ b/tests/gateway/test_session_store_runtime_stale_guard.py
@@ -165,6 +165,111 @@ class TestRuntimeStaleGuard:
         db.create_session.assert_called_once()
 
 
+class TestRecoveredSessionResetPolicy:
+    """Recovery must not resurrect sessions as freshly active.
+
+    ``_create_entry_from_recovered_row`` used to stamp ``updated_at=now`` on
+    the rebuilt entry, so an opt-in idle/daily ``session_reset`` policy could
+    never fire across a gateway restart: the recovered session always looked
+    freshly active, and every subsequent message bumped ``updated_at`` again
+    — a recovered stale session could never age out. The entry now carries
+    the durable ``last_activity_at`` the finder already returns on the row
+    and the recovery paths evaluate ``_should_reset`` before resuming.
+    """
+
+    def test_recovered_entry_carries_durable_last_activity(self, tmp_path):
+        """A recovered mapping reports the DB's last message time, not now()."""
+        source = _source()
+        started = (datetime.now() - timedelta(hours=3)).timestamp()
+        last_activity = (datetime.now() - timedelta(hours=2)).timestamp()
+        db = _db_returning({})
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_recovered",
+            "started_at": started,
+            "last_activity_at": last_activity,
+        }
+        store = _make_store_with_db(tmp_path, db)  # default mode="none"
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id == "sid_recovered"
+        assert result.created_at == datetime.fromtimestamp(started)
+        assert result.updated_at == datetime.fromtimestamp(last_activity)
+        assert result.reset_had_activity is True
+
+    def test_recovered_session_past_idle_policy_resets_instead_of_resuming(
+        self, tmp_path,
+    ):
+        """Lost mapping + overdue recoverable row → reset, not silent resume."""
+        source = _source()
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=60),
+        )
+        db = _db_returning({})
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_idle",
+            "started_at": (datetime.now() - timedelta(hours=3)).timestamp(),
+            "last_activity_at": (
+                datetime.now() - timedelta(hours=2)
+            ).timestamp(),
+        }
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+        # No in-memory entry: the mapping was lost (e.g. crash before save).
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id != "sid_idle"
+        assert result.was_auto_reset is True
+        assert result.auto_reset_reason == "idle"
+        assert result.reset_had_activity is True
+        assert result.prev_session_id == "sid_idle"
+        db.reopen_session.assert_not_called()
+        db.promote_to_session_reset.assert_called_once_with("sid_idle", "idle")
+        db.end_session.assert_not_called()
+        db.create_session.assert_called_once()
+
+    def test_default_none_policy_recovery_resumes_unchanged(self, tmp_path):
+        """mode="none" (the default) still resumes recoverable rows as before."""
+        source = _source()
+        db = _db_returning({})
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_recovered",
+            "started_at": (datetime.now() - timedelta(days=30)).timestamp(),
+            "last_activity_at": (
+                datetime.now() - timedelta(days=30)
+            ).timestamp(),
+        }
+        store = _make_store_with_db(tmp_path, db)  # default mode="none"
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id == "sid_recovered"
+        db.reopen_session.assert_called_once_with("sid_recovered")
+        db.promote_to_session_reset.assert_not_called()
+        db.end_session.assert_not_called()
+        db.create_session.assert_not_called()
+
+    def test_recovery_tolerates_row_without_last_activity(self, tmp_path):
+        """A row lacking last_activity_at falls back to created_at."""
+        source = _source()
+        started = (datetime.now() - timedelta(hours=3)).timestamp()
+        db = _db_returning({})
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_recovered",
+            "started_at": started,
+        }
+        store = _make_store_with_db(tmp_path, db)
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id == "sid_recovered"
+        assert result.updated_at == datetime.fromtimestamp(started)
+        assert result.reset_had_activity is False
+
+
 class TestAdvanceCompressionSession:
     def test_cas_advances_route_without_reopening_rows(self, tmp_path):
         db = _db_returning({})

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -170,6 +170,75 @@ class TestPruneStaleSessionsLocked:
 
 
 # ---------------------------------------------------------------------------
+# Startup recovery honours the reset policy
+# ---------------------------------------------------------------------------
+
+class TestStartupRecoveryResetPolicy:
+    """Startup repoint must not resurrect an overdue session as fresh.
+
+    The startup pruner repoints a stale entry to the recovered row via
+    ``_recover_session_from_db``. The rebuilt entry used to be stamped
+    ``updated_at=now``, so an opt-in idle/daily ``session_reset`` policy was
+    silently skipped across every gateway restart. Recovery now evaluates
+    ``_should_reset`` against the durable last message timestamp and promotes
+    an overdue session to a durable reset boundary instead of reopening it.
+    """
+
+    def test_overdue_recovered_session_promoted_to_reset_and_pruned(self, tmp_path):
+        key = "agent:main:telegram:dm:5140768830"
+        db = _db_returning(
+            {"sid_parent": {"end_reason": "agent_close", "id": "sid_parent"}}
+        )
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_child",
+            "started_at": (datetime.now() - timedelta(hours=5)).timestamp(),
+            "last_activity_at": (
+                datetime.now() - timedelta(hours=4)
+            ).timestamp(),
+        }
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=60),
+        )
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+        store._entries[key] = _make_entry_with_origin(key, "sid_parent")
+
+        with patch.object(store, "_save"):
+            store._prune_stale_sessions_locked()
+
+        assert key not in store._entries
+        db.promote_to_session_reset.assert_called_once_with("sid_child", "idle")
+        db.reopen_session.assert_not_called()
+
+    def test_none_policy_startup_repoint_unchanged(self, tmp_path):
+        """mode="none" (the default) still repoints to the recovered row."""
+        key = "agent:main:telegram:dm:5140768830"
+        db = _db_returning(
+            {"sid_parent": {"end_reason": "compression", "id": "sid_parent"}}
+        )
+        last_activity = (datetime.now() - timedelta(hours=4)).timestamp()
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_child",
+            "started_at": (datetime.now() - timedelta(hours=5)).timestamp(),
+            "last_activity_at": last_activity,
+        }
+        store = _make_store_with_db(tmp_path, db)  # default mode="none"
+        store._entries[key] = _make_entry_with_origin(key, "sid_parent")
+
+        with patch.object(store, "_save"):
+            store._prune_stale_sessions_locked()
+
+        assert store._entries[key].session_id == "sid_child"
+        assert store._entries[key].updated_at == datetime.fromtimestamp(
+            last_activity
+        )
+        db.reopen_session.assert_called_once_with("sid_child")
+        db.promote_to_session_reset.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Integration: _ensure_loaded_locked calls _prune_stale_sessions_locked
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -126,6 +126,48 @@ class TestPruneStaleSessionsLocked:
             store._prune_stale_sessions_locked()
             mock_save.assert_called_once()
 
+    def test_reset_boundary_does_not_recover_older_session_for_peer(self, tmp_path):
+        """Startup pruning must not search past an intentional reset boundary.
+
+        The durable recovery query deliberately excludes ``session_reset``
+        rows — and a newer reset row must also fence any *older* still-open
+        row for the same peer. If startup pruning invokes recovery for a
+        routing entry that points at such a row, the query must not return
+        an older live session for the same peer and silently restore the
+        context that the user reset. Exercise the real SessionDB query here
+        rather than mocking its result.
+        """
+        from hermes_state import SessionDB
+
+        key = "agent:main:telegram:dm:5140768830"
+        db = SessionDB(tmp_path / "state.db")
+        peer = {
+            "user_id": "5140768830",
+            "session_key": key,
+            "chat_id": "5140768830",
+            "chat_type": "dm",
+        }
+        db.create_session("sid_before_reset", "telegram", **peer)
+        db.append_message("sid_before_reset", "user", "private old context")
+        db.create_session("sid_reset", "telegram", **peer)
+        db.append_message("sid_reset", "user", "/new")
+        db.end_session("sid_reset", "session_reset")
+
+        store = _make_store_with_db(tmp_path / "sessions", db)
+        stale_entry = _make_entry_with_origin(key, "sid_reset")
+        store._entries[key] = stale_entry
+
+        # Model restart startup followed by the peer's first incoming message.
+        store._prune_stale_sessions_locked()
+        assert stale_entry.origin is not None
+        current = store.get_or_create_session(stale_entry.origin)
+
+        assert current.session_id not in {"sid_before_reset", "sid_reset"}
+        assert store._entries[key].session_id == current.session_id
+        reset_row = db.get_session("sid_reset")
+        assert reset_row is not None
+        assert reset_row["end_reason"] == "session_reset"
+
 
 # ---------------------------------------------------------------------------
 # Integration: _ensure_loaded_locked calls _prune_stale_sessions_locked

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3496,6 +3496,41 @@ def test_gateway_session_peer_round_trip_and_recovery(db):
     assert recovered["id"] == "gw-session"
 
 
+@pytest.mark.parametrize(
+    "persisted_session_key",
+    ["agent:main:telegram:dm:chat-1", None],
+    ids=["exact-key", "peer-fallback"],
+)
+def test_gateway_session_recovery_does_not_cross_newer_reset_boundary(
+    db, persisted_session_key
+):
+    """A newer session_reset row fences recovery for the peer (#68539).
+
+    Recovery must never reach *behind* an intentional /new boundary and
+    resurrect an older still-open row — if the newest boundary row for the
+    peer is reset-ended, recovery returns nothing.
+    """
+    peer = {
+        "user_id": "user-1",
+        "session_key": persisted_session_key,
+        "chat_id": "chat-1",
+        "chat_type": "dm",
+    }
+    db.create_session("gw-before-reset", "telegram", **peer)
+    db.append_message("gw-before-reset", "user", "old context")
+    db.create_session("gw-reset", "telegram", **peer)
+    db.append_message("gw-reset", "user", "/new")
+    db.end_session("gw-reset", "session_reset")
+
+    assert db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    ) is None
+
+
 
 
 


### PR DESCRIPTION
## Summary

Gateway session recovery now honors `/new` reset boundaries and real idle time: a newer reset-ended row fences the finder from resurrecting older rows behind it, and recovered sessions keep their true `last_activity_at` instead of being stamped `updated_at=now` (which made every recovered session look zero-seconds idle to reset policy).

Combined salvage of #68617 (@Tranquil-Flow, Jul 21 — earliest submitter) and #78618 (@hillimited, Aug 4), cherry-picked with both authors preserved; the two PRs fix complementary halves of the same recovery flow and were composed onto #82633's rewritten finder.

## Changes

- `hermes_state.py` (`find_latest_gateway_session_for_peer`): NOT EXISTS fence on both the exact-key and peer-fallback queries — a candidate is rejected when a boundary row for the same peer (reset/switch/idle/daily/suspended/resume_pending_expired) ended more recently than the candidate's last activity (@Tranquil-Flow, intent re-expressed inside the rewritten query)
- `gateway/session.py`: recovered entries carry their real `created_at`/`updated_at` from the row (no more `now` stamps), and both recovery paths consult reset policy before reopening (@hillimited; simplified to reuse the `last_activity_at` the finder already returns — the PR's separate `get_last_activity` DB method was unnecessary post-#82633)
- Tests from both PRs adapted; dropped #68617's `ORDER BY started_at` hunk and its "newer empty session hides history" test (both contradict #82616's deliberate has-messages ranking / empty-keyed-row semantics)

## Validation

| | Result |
|---|---|
| Both PRs' adapted tests + session-continuity regression file (incl. reset-boundary + recency tests) | pass |
| tests/state/ + tests/test_hermes_state.py | 259 passed |
| Full tests/gateway/ + tests/state/ via canonical runner | green (9 plain-pytest failures reproduced identically on unmodified base — pre-existing cross-file isolation flakes, pass under the per-file runner) |
| Sabotage run (fence removed) | both fence tests fail |

Closes #68617 (credit @Tranquil-Flow) and #78618 (credit @hillimited). Part of #82616; also the surviving half of #71530's diagnosis (@FrendoWu).

## Infographic

![The past stays past](https://v3b.fal.media/files/b/0aa5b20e/CcUm8SD6NGNNhEC4c-IfZ_cc7ZH59u.png)
