### PR TITLE
fix(hooks): rate-limit outbound webhook deliveries

### DIFF
--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -18,6 +18,13 @@ Design notes
   loop, so callbacks must never block on network I/O — they serialize,
   enqueue, and return ``None`` immediately.  Outbound targets can never
   block a tool call, inject context, or otherwise influence agent flow.
+* Every physical HTTP attempt, including retries, consumes a token from a
+  process-local bucket keyed by the exact validated URL.  The default is
+  10 attempts/second with burst capacity 10.  Accepted above-limit
+  deliveries wait in the existing worker; duplicate entries for a URL
+  share the strictest configured rate seen by that bucket.  The bounded
+  queue's existing full-warning/drop behavior is unchanged, so delivery
+  remains best-effort.
 * Payloads are signed with HMAC-SHA256 (GitHub-style
   ``X-Hermes-Signature-256: sha256=<hexdigest>`` over the raw body) when
   a secret is configured.  Receivers verify exactly like they verify
@@ -40,6 +47,7 @@ Config schema (``~/.hermes/config.yaml``)::
           # optional regex, honored for pre/post_tool_call only:
           matcher: "terminal|delegate_task"
           timeout: 10       # per-attempt seconds, clamped to [1, 60]
+          rate_limit_per_second: 10  # clamped to [0.1, 1000], burst 10
           name: ci-notify   # optional label for logs / `hermes hooks list`
 
 Wire format (POST body)::
@@ -71,6 +79,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import os
 import queue
 import re
@@ -88,6 +97,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 10
 MAX_TIMEOUT_SECONDS = 60
+DEFAULT_RATE_LIMIT_PER_SECOND = 10.0
+MIN_RATE_LIMIT_PER_SECOND = 0.1
+MAX_RATE_LIMIT_PER_SECOND = 1000.0
+RATE_LIMIT_BURST_CAPACITY = 10.0
 MAX_DELIVERY_ATTEMPTS = 2
 RETRY_BACKOFF_SECONDS = 1.0
 QUEUE_MAX_SIZE = 256
@@ -107,6 +120,15 @@ _delivery_queue: "queue.Queue[Optional[Dict[str, Any]]]" = queue.Queue(
 )
 _worker_lock = threading.Lock()
 _worker: Optional[threading.Thread] = None
+_rate_limit_lock = threading.Lock()
+_rate_limit_buckets: Dict[str, "_TokenBucket"] = {}
+
+
+@dataclass
+class _TokenBucket:
+    tokens: float
+    updated_at: float
+    rate_per_second: float
 
 
 @dataclass
@@ -119,6 +141,7 @@ class WebhookTarget:
     secret: Optional[str] = None
     matcher: Optional[str] = None
     timeout: int = DEFAULT_TIMEOUT_SECONDS
+    rate_limit_per_second: float = DEFAULT_RATE_LIMIT_PER_SECOND
     compiled_matcher: Optional[re.Pattern] = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
@@ -235,6 +258,8 @@ def reset_for_tests() -> None:
     """Clear the idempotence set and drain the queue.  Test-only helper."""
     with _registered_lock:
         _registered.clear()
+    with _rate_limit_lock:
+        _rate_limit_buckets.clear()
     try:
         while True:
             _delivery_queue.get_nowait()
@@ -262,6 +287,15 @@ def _parse_outbound_block(raw: Any) -> List[WebhookTarget]:
         target = _parse_single_target(i, entry)
         if target is not None:
             targets.append(target)
+
+    strictest_rates: Dict[str, float] = {}
+    for target in targets:
+        strictest_rates[target.url] = min(
+            strictest_rates.get(target.url, target.rate_limit_per_second),
+            target.rate_limit_per_second,
+        )
+    for target in targets:
+        target.rate_limit_per_second = strictest_rates[target.url]
     return targets
 
 
@@ -339,6 +373,28 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
         timeout = DEFAULT_TIMEOUT_SECONDS
     timeout = max(1, min(timeout, MAX_TIMEOUT_SECONDS))
 
+    rate_limit_raw = raw.get(
+        "rate_limit_per_second", DEFAULT_RATE_LIMIT_PER_SECOND,
+    )
+    valid_rate_limit = (
+        isinstance(rate_limit_raw, (int, float))
+        and not isinstance(rate_limit_raw, bool)
+        and (isinstance(rate_limit_raw, int) or math.isfinite(rate_limit_raw))
+        and rate_limit_raw > 0
+    )
+    if not valid_rate_limit:
+        logger.warning(
+            "hooks.outbound[%d].rate_limit_per_second must be a positive "
+            "finite int or float (got %r); using default %g/s",
+            index, rate_limit_raw, DEFAULT_RATE_LIMIT_PER_SECOND,
+        )
+        rate_limit_per_second = DEFAULT_RATE_LIMIT_PER_SECOND
+    else:
+        rate_limit_per_second = float(max(
+            MIN_RATE_LIMIT_PER_SECOND,
+            min(rate_limit_raw, MAX_RATE_LIMIT_PER_SECOND),
+        ))
+
     secret = _resolve_secret(index, raw)
 
     name = raw.get("name")
@@ -352,6 +408,7 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
         secret=secret,
         matcher=matcher,
         timeout=timeout,
+        rate_limit_per_second=rate_limit_per_second,
     )
 
 
@@ -452,6 +509,7 @@ def _build_delivery(
         "body": body,
         "headers": headers,
         "timeout": target.timeout,
+        "rate_limit_per_second": target.rate_limit_per_second,
     }
 
 
@@ -517,6 +575,44 @@ class _NoRedirectHandler(urlrequest.HTTPRedirectHandler):
 _opener = urlrequest.build_opener(_NoRedirectHandler)
 
 
+def _acquire_rate_limit_token(delivery: Dict[str, Any]) -> None:
+    """Wait until one physical request token is available for the target URL."""
+    configured_rate = delivery["rate_limit_per_second"]
+    now = time.monotonic()
+    with _rate_limit_lock:
+        bucket = _rate_limit_buckets.get(delivery["url"])
+        if bucket is None:
+            bucket = _TokenBucket(
+                tokens=RATE_LIMIT_BURST_CAPACITY,
+                updated_at=now,
+                rate_per_second=configured_rate,
+            )
+            _rate_limit_buckets[delivery["url"]] = bucket
+        else:
+            bucket.rate_per_second = min(
+                bucket.rate_per_second, configured_rate,
+            )
+            elapsed = max(0.0, now - bucket.updated_at)
+            bucket.tokens = min(
+                RATE_LIMIT_BURST_CAPACITY,
+                bucket.tokens + (elapsed * bucket.rate_per_second),
+            )
+            bucket.updated_at = now
+
+        effective_rate = bucket.rate_per_second
+        wait_seconds = max(0.0, (1.0 - bucket.tokens) / effective_rate)
+        bucket.tokens -= 1.0
+
+    if wait_seconds > 0:
+        logger.info(
+            "outbound webhook throttled: target=%s rate=%g/s wait=%.3fs "
+            "queue_depth=%d",
+            delivery["label"], effective_rate, wait_seconds,
+            _delivery_queue.qsize(),
+        )
+        time.sleep(wait_seconds)
+
+
 def _deliver(delivery: Dict[str, Any]) -> None:
     """POST with bounded retries.  Retries on connection errors and 5xx;
     4xx is the receiver telling us the request itself is wrong — no retry.
@@ -530,6 +626,7 @@ def _deliver(delivery: Dict[str, Any]) -> None:
             method="POST",
         )
         try:
+            _acquire_rate_limit_token(delivery)
             with _opener.open(req, timeout=delivery["timeout"]) as resp:
                 status = getattr(resp, "status", 200)
             if 200 <= status < 300:

--- a/tests/agent/test_outbound_webhooks.py
+++ b/tests/agent/test_outbound_webhooks.py
@@ -101,6 +101,55 @@ def _cfg(*entries):
     return {"hooks": {"outbound": list(entries)}}
 
 
+class _FakeClock:
+    def __init__(self):
+        self.now = 100.0
+        self.sleeps = []
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class _Response:
+    def __init__(self, status):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _RecordingOpener:
+    def __init__(self, clock, statuses=None):
+        self.clock = clock
+        self.statuses = list(statuses or [200])
+        self.attempts = []
+
+    def open(self, request, timeout):
+        attempt_index = len(self.attempts)
+        status = self.statuses[min(attempt_index, len(self.statuses) - 1)]
+        headers = {key.lower(): value for key, value in request.header_items()}
+        self.attempts.append(
+            {
+                "url": request.full_url,
+                "time": self.clock.monotonic(),
+                "timeout": timeout,
+                "body": request.data,
+                "delivery_id": headers["x-hermes-delivery"],
+            }
+        )
+        return _Response(status)
+
+
 # ── config parsing ────────────────────────────────────────────────────────
 
 
@@ -194,6 +243,66 @@ class TestParseConfig:
             )
         )
         assert targets[0].timeout == outbound_webhooks.DEFAULT_TIMEOUT_SECONDS
+
+    def test_rate_limit_defaults_and_accepts_positive_int_or_float(self):
+        default_target, int_target, float_target = (
+            outbound_webhooks.iter_configured_targets(
+                _cfg(
+                    {"url": f"https://example.com/{index}",
+                     "events": ["on_session_end"], **extra},
+                )
+            )[0]
+            for index, extra in enumerate((
+                {},
+                {"rate_limit_per_second": 25},
+                {"rate_limit_per_second": 2.5},
+            ))
+        )
+
+        assert default_target.rate_limit_per_second == 10.0
+        assert int_target.rate_limit_per_second == 25.0
+        assert float_target.rate_limit_per_second == 2.5
+
+    @pytest.mark.parametrize(
+        "configured",
+        [True, False, float("nan"), float("inf"), float("-inf"), 0, -1, "5", None],
+    )
+    def test_malformed_rate_limit_warns_and_falls_back_to_default(
+        self, configured, caplog,
+    ):
+        targets = outbound_webhooks.iter_configured_targets(
+            _cfg(
+                {
+                    "url": "https://example.com",
+                    "events": ["on_session_end"],
+                    "rate_limit_per_second": configured,
+                }
+            )
+        )
+
+        assert targets[0].rate_limit_per_second == 10.0
+        assert "rate_limit_per_second" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            (0.01, 0.1),
+            (10_000, 1000.0),
+            pytest.param(10**1000, 1000.0, id="huge-int"),
+        ],
+    )
+    def test_positive_rate_limit_is_clamped(self, configured, expected):
+        targets = outbound_webhooks.iter_configured_targets(
+            _cfg(
+                {
+                    "url": "https://example.com",
+                    "events": ["on_session_end"],
+                    "rate_limit_per_second": configured,
+                }
+            )
+        )
+
+        assert targets[0].rate_limit_per_second == expected
 
     def test_matcher_dropped_for_non_tool_events(self):
         targets = outbound_webhooks.iter_configured_targets(
@@ -349,6 +458,256 @@ class TestRegistration:
 
 
 class TestDelivery:
+    def test_default_destination_rate_limit_waits_after_ten_attempts(
+        self, monkeypatch,
+    ):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        target = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook", events=["on_session_end"],
+        )
+        delivery = outbound_webhooks._build_delivery(
+            "on_session_end", target, b"{}", "did_rate_limit",
+        )
+
+        for _ in range(11):
+            outbound_webhooks._deliver(delivery)
+
+        assert len(opener.attempts) == 11
+        assert clock.sleeps == [pytest.approx(0.1)]
+
+    def test_at_limit_traffic_does_not_sleep(self, monkeypatch):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        target = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook", events=["on_session_end"],
+        )
+        delivery = outbound_webhooks._build_delivery(
+            "on_session_end", target, b"{}", "did_at_limit",
+        )
+
+        for _ in range(10):
+            outbound_webhooks._deliver(delivery)
+
+        assert len(opener.attempts) == 10
+        assert clock.sleeps == []
+
+    def test_above_limit_queue_waits_without_losing_deliveries(
+        self, monkeypatch,
+    ):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        target = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook", events=["on_session_end"],
+        )
+        callback = outbound_webhooks._make_callback("on_session_end", target)
+
+        for index in range(11):
+            assert callback(session_id=f"session-{index}") is None
+        outbound_webhooks._delivery_queue.join()
+
+        assert len(opener.attempts) == 11
+        assert clock.sleeps == [pytest.approx(0.1)]
+        assert len({attempt["delivery_id"] for attempt in opener.attempts}) == 11
+        assert [
+            json.loads(attempt["body"])["session_id"]
+            for attempt in opener.attempts
+        ] == [f"session-{index}" for index in range(11)]
+
+    def test_destination_urls_have_independent_buckets(self, monkeypatch):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        target_a = outbound_webhooks.WebhookTarget(
+            url="https://a.example.com/hook", events=["on_session_end"],
+        )
+        target_b = outbound_webhooks.WebhookTarget(
+            url="https://b.example.com/hook", events=["on_session_end"],
+        )
+        delivery_a = outbound_webhooks._build_delivery(
+            "on_session_end", target_a, b"{}", "did_a",
+        )
+        delivery_b = outbound_webhooks._build_delivery(
+            "on_session_end", target_b, b"{}", "did_b",
+        )
+
+        for _ in range(10):
+            outbound_webhooks._deliver(delivery_a)
+        outbound_webhooks._deliver(delivery_b)
+
+        assert clock.sleeps == []
+
+        outbound_webhooks._deliver(delivery_a)
+        assert clock.sleeps == [pytest.approx(0.1)]
+
+    def test_same_url_across_events_shares_one_bucket(self, monkeypatch):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        session_start = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook", events=["on_session_start"],
+        )
+        session_end = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook", events=["on_session_end"],
+        )
+        start_delivery = outbound_webhooks._build_delivery(
+            "on_session_start", session_start, b"{}", "did_start",
+        )
+        end_delivery = outbound_webhooks._build_delivery(
+            "on_session_end", session_end, b"{}", "did_end",
+        )
+
+        for _ in range(10):
+            outbound_webhooks._deliver(start_delivery)
+        outbound_webhooks._deliver(end_delivery)
+
+        assert clock.sleeps == [pytest.approx(0.1)]
+
+    def test_conflicting_same_url_rates_keep_strictest_effective_rate(
+        self, monkeypatch, caplog,
+    ):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        fast_target, strict_target = outbound_webhooks.iter_configured_targets(
+            _cfg(
+                {
+                    "url": "https://example.com/hook",
+                    "events": ["on_session_start"],
+                    "rate_limit_per_second": 100.0,
+                },
+                {
+                    "url": "https://example.com/hook",
+                    "events": ["on_session_end"],
+                    "rate_limit_per_second": 0.5,
+                },
+            )
+        )
+        fast_delivery = outbound_webhooks._build_delivery(
+            "on_session_start", fast_target, b"{}", "did_fast",
+        )
+        strict_delivery = outbound_webhooks._build_delivery(
+            "on_session_end", strict_target, b"{}", "did_strict",
+        )
+
+        assert fast_target.rate_limit_per_second == 0.5
+        assert strict_target.rate_limit_per_second == 0.5
+
+        with caplog.at_level("INFO", logger=outbound_webhooks.__name__):
+            for _ in range(10):
+                outbound_webhooks._deliver(fast_delivery)
+            outbound_webhooks._deliver(fast_delivery)
+            outbound_webhooks._deliver(strict_delivery)
+
+        assert clock.sleeps == [pytest.approx(2.0), pytest.approx(2.0)]
+        assert caplog.text.count("rate=0.5/s") == 2
+
+    def test_destination_bucket_recovers_with_monotonic_time(
+        self, monkeypatch,
+    ):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        target = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook", events=["on_session_end"],
+        )
+        delivery = outbound_webhooks._build_delivery(
+            "on_session_end", target, b"{}", "did_refill",
+        )
+
+        for _ in range(10):
+            outbound_webhooks._deliver(delivery)
+        clock.advance(0.2)
+        outbound_webhooks._deliver(delivery)
+        outbound_webhooks._deliver(delivery)
+
+        assert clock.sleeps == []
+
+        outbound_webhooks._deliver(delivery)
+        assert clock.sleeps == [pytest.approx(0.1)]
+
+    def test_retry_attempt_is_rate_limited_after_existing_backoff(
+        self, monkeypatch,
+    ):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock, statuses=[200] * 9 + [500, 200])
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        target = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook",
+            events=["on_session_end"],
+            rate_limit_per_second=0.5,
+        )
+        delivery = outbound_webhooks._build_delivery(
+            "on_session_end", target, b"{}", "did_retry",
+        )
+
+        for _ in range(9):
+            outbound_webhooks._deliver(delivery)
+        outbound_webhooks._deliver(delivery)
+
+        assert len(opener.attempts) == 11
+        assert clock.sleeps == [
+            pytest.approx(outbound_webhooks.RETRY_BACKOFF_SECONDS),
+            pytest.approx(1.0),
+        ]
+
+    def test_reset_for_tests_clears_destination_buckets(self, monkeypatch):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        target = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook", events=["on_session_end"],
+        )
+        delivery = outbound_webhooks._build_delivery(
+            "on_session_end", target, b"{}", "did_reset",
+        )
+
+        for _ in range(10):
+            outbound_webhooks._deliver(delivery)
+        outbound_webhooks.reset_for_tests()
+        outbound_webhooks._deliver(delivery)
+
+        assert clock.sleeps == []
+
+    def test_throttle_info_log_is_emitted_only_when_waiting(
+        self, monkeypatch, caplog,
+    ):
+        clock = _FakeClock()
+        opener = _RecordingOpener(clock)
+        monkeypatch.setattr(outbound_webhooks, "time", clock)
+        monkeypatch.setattr(outbound_webhooks, "_opener", opener)
+        target = outbound_webhooks.WebhookTarget(
+            url="https://example.com/hook",
+            events=["on_session_end"],
+            name="named-target",
+        )
+        delivery = outbound_webhooks._build_delivery(
+            "on_session_end", target, b"{}", "did_log",
+        )
+
+        with caplog.at_level("INFO", logger=outbound_webhooks.__name__):
+            for _ in range(10):
+                outbound_webhooks._deliver(delivery)
+            assert "outbound webhook throttled" not in caplog.text
+            outbound_webhooks._deliver(delivery)
+
+        assert "target=named-target" in caplog.text
+        assert "rate=10/s" in caplog.text
+        assert "wait=0.100s" in caplog.text
+        assert "queue_depth=" in caplog.text
+
     def test_delivery_with_hmac_signature(self, http_server):
         secret = "s3cret"
         cfg = _cfg(

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1620,6 +1620,7 @@ hooks:
       events: [on_session_end, subagent_stop]
       secret_env: HERMES_OUTBOUND_WEBHOOK_SECRET   # env var holding the HMAC secret
       timeout: 10                           # per-attempt seconds (1–60)
+      rate_limit_per_second: 10             # optional, 0.1–1000; burst is always 10
 
     - name: tool-monitor
       url: https://metrics.example.com/hooks/hermes
@@ -1677,6 +1678,8 @@ Because `delivery_id` and `timestamp` live **inside the signed body**, a verifie
 - **Fire-and-forget, off the hot path.** Events are serialized and queued instantly; a single background thread performs the HTTP POSTs. A slow or dead endpoint can never stall a tool call or an agent turn.
 - **Notify-only.** Unlike shell hooks, outbound webhooks cannot block tool calls or inject context — the response body is ignored. They observe, never steer.
 - **Bounded retries.** Connection errors and 5xx responses are retried once with backoff; 4xx responses are not retried (the receiver said the request itself is wrong). Failures are logged and dropped — delivery is best-effort, not guaranteed.
+- **Per-destination rate limit.** Each exact configured URL has a process-local token bucket. The default is 10 HTTP attempts per second with a burst of 10; `rate_limit_per_second` accepts a positive number clamped to `0.1`–`1000`. Retries consume tokens too. Duplicate entries for the same URL share one bucket and use the strictest configured rate seen for that URL.
+- **Above-limit deliveries wait.** Accepted events remain in the existing worker queue until a token is available, then are delivered with their original body and delivery id. Rate limiting does not introduce another drop path; only the bounded queue can reject a new event when full.
 - **Redirects are never followed.** A 3xx response is treated as a misconfiguration and logged — following a redirected POST would silently drop the signed payload. Point the `url` at the final endpoint.
 - **Bounded queue.** If the queue backs up (dead endpoint, event storm), new events are dropped with a warning rather than consuming unbounded memory.
 - **No consent prompt.** Outbound targets execute no code on your machine — they receive data at a URL you configured. `HERMES_SAFE_MODE=1` still skips registration, same as plugins and shell hooks. Note that payloads include tool inputs and event metadata, so only point targets at endpoints you trust, and prefer `https://`.


### PR DESCRIPTION
## Summary
- enforce a process-local token bucket immediately before each outbound webhook HTTP attempt
- default to 10 requests/second per exact destination URL with burst 10 and optional bounded configuration
- pace retries and queue accepted above-limit deliveries without introducing a limiter drop path

## Verification
- scripts/run_tests.sh tests/agent/test_outbound_webhooks.py (54 passed)
- scripts/run_tests.sh tests/hermes_cli/test_hooks_cli.py tests/cli/test_session_boundary_hooks.py tests/gateway/test_session_boundary_hooks.py (14 passed)
- ruff check agent/outbound_webhooks.py tests/agent/test_outbound_webhooks.py
- git diff --check

Independent review: approved with no blocking findings.