### PR TITLE
feat(update): add hermes sync-fork for forks that have diverged

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2619,7 +2619,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
     {
         "acp", "approvals", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
-        "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
+        "config", "console", "cron", "curator", "dashboard", "serve", "sync-fork", "debug", "doctor",
         "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
@@ -3194,6 +3194,12 @@ def _build_cli_parser():
     build_model_parser(subparsers, cmd_model=cmd_model)
     build_moa_parser(subparsers)
     build_fallback_parser(subparsers)
+    # sync-fork: merge upstream into a DIVERGED fork. `update`'s own
+    # upstream sync is fast-forward only and returns early when the fork
+    # has local commits, so a fork that has ever committed has no
+    # supported update path without this.
+    from hermes_cli import sync_fork_cli as _sync_fork_cli
+    _sync_fork_cli.register(subparsers)
     build_worktree_parser(subparsers)
     build_browser_parser(subparsers)
     build_secrets_parser(subparsers)

--- a/hermes_cli/sync_fork.py
+++ b/hermes_cli/sync_fork.py
@@ -1,0 +1,293 @@
+"""Merge upstream into a *diverged* fork.
+
+``hermes update`` refuses this case on purpose. ``_sync_upstream`` compares
+``origin/main`` with ``upstream/main`` and bails out when the fork carries
+commits upstream does not have::
+
+    if origin_ahead > 0:
+        print(f"ℹ Your fork has {origin_ahead} commit(s) not on upstream.")
+        print("  Skipping upstream sync to preserve your changes.")
+        return
+
+That refusal is right for what it does — the sync is a ``pull --ff-only``, and a
+fast-forward cannot express a merge — but it leaves every fork that has ever
+committed with no supported update path, and the gap is silent: the skipped
+fast-forward is the only upstream check ``update`` performs, so the run still
+reports success while the fork drifts arbitrarily far behind.
+
+This module merges instead of fast-forwarding, and does it **incrementally**.
+Merging a large backlog in one jump produces a single conflict spanning the
+whole range, where the three-way merge base is so old that git can drop
+definitions the merged text still references — a runtime ``NameError`` rather
+than a conflict marker. Stopping at each upstream commit that touches a file the
+fork also modified keeps every conflict attributable to one commit.
+
+Every failure path restores the pre-merge ``HEAD`` and leaves the worktree
+clean: a half-merged checkout is worse than no update, because the next run
+cannot tell it apart from local work.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_UPSTREAM_REF = "upstream/main"
+
+# A merge writes a commit, so git demands a committer identity. On a host with
+# no global git identity — a fresh container, a service account, CI — the merge
+# fails with "Committer identity unknown" and *no* conflicted paths. Reporting
+# that as a conflict sends the user hunting for a merge conflict that does not
+# exist, so supply an identity for the merge commit only, without writing to the
+# user's config. A real configured identity always wins: -c is overridden by the
+# repo/global config when one is set.
+_IDENTITY: tuple[str, ...] = (
+    "-c",
+    "user.name=hermes sync-fork",
+    "-c",
+    "user.email=sync-fork@hermes.local",
+)
+
+
+@dataclass
+class ForkState:
+    """How the fork sits relative to upstream."""
+
+    behind: int
+    ahead: int
+    diverged: bool
+    dirty: bool
+    # Set when the position could not be READ at all, as opposed to read and
+    # found healthy. Without this the two are the same value — see inspect().
+    error: Optional[str] = None
+
+
+@dataclass
+class SyncPlan:
+    """Ordered refs to merge, ending at the upstream tip."""
+
+    steps: list[str] = field(default_factory=list)
+    conflict_prone: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SyncResult:
+    ok: bool
+    reason: str = ""
+    merged: list[str] = field(default_factory=list)
+    conflicted_paths: list[str] = field(default_factory=list)
+    failed_at: str = ""
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _out(cwd: Path, *args: str) -> str:
+    try:
+        return _git(cwd, *args).stdout.strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def _count(cwd: Path, base: str, head: str) -> int:
+    """Commits in ``base..head``.
+
+    Returns 0 when git cannot answer, which is only safe because every caller
+    resolves the ref first — see ``_rev_exists`` and the guard in ``inspect``.
+    A failed ``rev-list`` is indistinguishable from a count of zero here, and
+    that conflation is exactly what reported a missing ref as "up to date".
+    """
+    raw = _out(cwd, "rev-list", "--count", f"{base}..{head}")
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
+def _rev_exists(cwd: Path, ref: str) -> bool:
+    """Whether ``ref`` names a commit in this repository."""
+    return _git(
+        cwd, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}", check=False
+    ).returncode == 0
+
+
+def inspect(cwd: Path, upstream_ref: str = DEFAULT_UPSTREAM_REF) -> ForkState:
+    """Report the fork's position without touching anything.
+
+    The ref is resolved BEFORE anything is counted. ``git rev-list --count``
+    against a ref that does not exist fails, ``_out`` turns the failure into an
+    empty string and ``_count`` turns that into 0 — so a mistyped ref, or the
+    far more likely case of an ``upstream`` remote that was added but never
+    fetched, produced ``behind=0, ahead=0, diverged=False``. Every surface reads
+    that as "up to date": the JSON consumer, the human headline, ``--check``'s
+    exit code, and the cron that branches on all three. A fork could sit
+    arbitrarily far behind while this function certified it current, which is
+    the precise failure this command exists to eliminate one level up.
+
+    Reproduced on a fresh clone with an unfetched ``upstream``, and with
+    ``--upstream-ref`` set to a garbage string.
+    """
+    if not _rev_exists(cwd, upstream_ref):
+        return ForkState(
+            behind=0,
+            ahead=0,
+            diverged=False,
+            dirty=bool(_out(cwd, "status", "--porcelain")),
+            error=(
+                f"upstream ref {upstream_ref!r} does not resolve in this repository "
+                "— fetch it (git fetch upstream) or pass --upstream-ref"
+            ),
+        )
+    behind = _count(cwd, "HEAD", upstream_ref)
+    ahead = _count(cwd, upstream_ref, "HEAD")
+    return ForkState(
+        behind=behind,
+        ahead=ahead,
+        diverged=bool(behind and ahead),
+        dirty=bool(_out(cwd, "status", "--porcelain")),
+    )
+
+
+def _local_files(cwd: Path, upstream_ref: str) -> set[str]:
+    """Files the fork changed relative to the merge base.
+
+    These are the only files where an upstream commit can conflict, so they
+    decide where the plan stops.
+    """
+    base = _out(cwd, "merge-base", "HEAD", upstream_ref)
+    if not base:
+        return set()
+    listing = _out(cwd, "diff", "--name-only", f"{base}..HEAD")
+    return {line for line in listing.splitlines() if line}
+
+
+def plan(cwd: Path, upstream_ref: str = DEFAULT_UPSTREAM_REF) -> SyncPlan:
+    """Build the incremental merge sequence.
+
+    One step per upstream commit that touches a file the fork also modified,
+    plus a final step at the tip. A fork that shares no touched files gets a
+    single step and behaves exactly like a plain merge.
+    """
+    if _count(cwd, "HEAD", upstream_ref) == 0:
+        return SyncPlan(steps=[], conflict_prone=[])
+
+    touched = _local_files(cwd, upstream_ref)
+    steps: list[str] = []
+    prone: list[str] = []
+
+    if touched:
+        base = _out(cwd, "merge-base", "HEAD", upstream_ref)
+        revs = _out(cwd, "rev-list", "--reverse", f"{base}..{upstream_ref}")
+        for sha in (r for r in revs.splitlines() if r):
+            files = _out(cwd, "show", "--name-only", "--format=", sha).splitlines()
+            if touched.intersection(f for f in files if f):
+                steps.append(sha)
+                prone.append(sha)
+
+    steps.append(upstream_ref)
+    return SyncPlan(steps=steps, conflict_prone=prone)
+
+
+def _abort_merge(cwd: Path, original_head: str) -> None:
+    """Return the repo to ``original_head`` with a clean worktree.
+
+    ``git merge --abort`` alone is not enough: if anything rewrote a conflicted
+    file outside the index, abort fails with ``Entry '<path>' not uptodate``.
+    Refreshing the index stat cache first clears that, and the hard reset is the
+    backstop so this function cannot leave a half-merged tree behind.
+    """
+    _git(cwd, "update-index", "-q", "--refresh", check=False)
+    _git(cwd, "merge", "--abort", check=False)
+    if (cwd / ".git" / "MERGE_HEAD").exists():
+        _git(cwd, "reset", "--hard", original_head, check=False)
+    if _out(cwd, "rev-parse", "HEAD") != original_head:
+        _git(cwd, "reset", "--hard", original_head, check=False)
+
+
+def sync(
+    cwd: Path,
+    upstream_ref: str = DEFAULT_UPSTREAM_REF,
+    dry_run: bool = False,
+) -> SyncResult:
+    """Merge ``upstream_ref`` into the current branch, one planned step at a time.
+
+    Returns without touching the repo when the worktree is dirty: stashing
+    someone else's uncommitted work as a side effect of an update is how work
+    gets lost.
+    """
+    state = inspect(cwd, upstream_ref)
+    if state.dirty:
+        return SyncResult(
+            ok=False,
+            reason=(
+                "Refusing to sync with uncommitted changes. Commit or stash "
+                "them first — an update must never decide what happens to "
+                "unsaved work."
+            ),
+        )
+    if state.behind == 0:
+        return SyncResult(ok=True, reason="Already up to date with upstream.")
+
+    steps = plan(cwd, upstream_ref).steps
+    if dry_run:
+        return SyncResult(
+            ok=True,
+            reason=f"{state.behind} commit(s) behind; would merge in {len(steps)} step(s).",
+            merged=steps,
+        )
+
+    original_head = _out(cwd, "rev-parse", "HEAD")
+    merged: list[str] = []
+
+    for step in steps:
+        proc = _git(
+            cwd,
+            *_IDENTITY,
+            "merge",
+            "--no-edit",
+            "-m",
+            f"merge: upstream {step}",
+            step,
+            check=False,
+        )
+        if proc.returncode != 0:
+            conflicted = [
+                line
+                for line in _out(cwd, "diff", "--name-only", "--diff-filter=U").splitlines()
+                if line
+            ]
+            _abort_merge(cwd, original_head)
+            if conflicted:
+                reason = (
+                    f"Conflict merging {step}. The fork was restored to "
+                    f"{original_head[:9]} with a clean worktree; resolve this "
+                    "step by hand."
+                )
+            else:
+                # No unmerged paths means git refused for some other reason
+                # (bad ref, unrelated histories, hook rejection). Surface its
+                # own words rather than calling it a conflict.
+                detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+                reason = (
+                    f"git could not merge {step}: "
+                    f"{detail[0] if detail else 'unknown error'}. "
+                    f"The fork was restored to {original_head[:9]}."
+                )
+            return SyncResult(
+                ok=False,
+                reason=reason,
+                merged=merged,
+                conflicted_paths=conflicted,
+                failed_at=step,
+            )
+        merged.append(step)
+
+    return SyncResult(ok=True, reason=f"Merged upstream in {len(merged)} step(s).", merged=merged)

--- a/hermes_cli/sync_fork_cli.py
+++ b/hermes_cli/sync_fork_cli.py
@@ -1,0 +1,207 @@
+"""``hermes sync-fork`` — CLI surface and interactive screen.
+
+Kept separate from :mod:`hermes_cli.sync_fork` so the merge logic stays free of
+printing and prompts, and can be driven from a cron script, the dashboard, or a
+test without a terminal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_cli import sync_fork
+
+
+def _repo_root(explicit: str | None = None) -> Path:
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    return Path(__file__).resolve().parent.parent
+
+
+def _render_state(state: sync_fork.ForkState, plan: sync_fork.SyncPlan) -> list[str]:
+    """Human-readable status block, shared by the CLI and the curses screen."""
+    # First, because "up to date" is what an unreadable state used to render as,
+    # and the curses screen reaches this function without passing the CLI guard.
+    if state.error:
+        return [state.error]
+    if state.behind == 0 and not state.diverged:
+        headline = "Up to date with upstream."
+    elif state.diverged:
+        headline = (
+            f"Diverged: {state.behind} commit(s) behind, "
+            f"{state.ahead} local commit(s) upstream does not have."
+        )
+    else:
+        headline = f"{state.behind} commit(s) behind upstream (no local commits)."
+
+    lines = [headline]
+    if state.dirty:
+        lines.append("Worktree has uncommitted changes — sync will refuse until it is clean.")
+    if state.behind:
+        lines.append(f"Merge plan: {len(plan.steps)} step(s).")
+        if plan.conflict_prone:
+            lines.append(
+                f"{len(plan.conflict_prone)} upstream commit(s) touch files this fork "
+                "also changed — those are the steps that can conflict."
+            )
+        else:
+            lines.append("No upstream commit touches a file this fork changed.")
+    if state.diverged and state.behind:
+        lines.append(
+            "`hermes update` skips this fork by design (its sync is fast-forward "
+            "only). That is what sync-fork is for."
+        )
+    return lines
+
+
+def run(args) -> int:
+    """Entry point for ``hermes sync-fork``."""
+    root = _repo_root(getattr(args, "repo", None))
+    upstream_ref = getattr(args, "upstream_ref", None) or sync_fork.DEFAULT_UPSTREAM_REF
+
+    if getattr(args, "ui", False):
+        return _run_ui(root, upstream_ref)
+
+    state = sync_fork.inspect(root, upstream_ref)
+
+    # Before the plan, and before every action path below. A state that could not
+    # be read must not reach code that branches on `behind`, because `behind` is
+    # 0 in that case and 0 means "nothing to do" everywhere downstream.
+    #
+    # Exit 2, distinct from 1: 1 already means "a sync is available" for --check,
+    # so reusing it would tell a cron the opposite of the truth. Consumers that
+    # branch on the exit code (hermes-webui's fork_keeper_bridge does) get a
+    # value that cannot be confused with either success or work-pending.
+    if state.error:
+        if getattr(args, "json", False):
+            print(json.dumps({"error": state.error}))
+        else:
+            print(f"  {state.error}")
+        return 2
+
+    plan = sync_fork.plan(root, upstream_ref)
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "behind": state.behind,
+            "ahead": state.ahead,
+            "diverged": state.diverged,
+            "dirty": state.dirty,
+            "steps": len(plan.steps),
+            "conflict_prone": len(plan.conflict_prone),
+        }))
+        return 0
+
+    for line in _render_state(state, plan):
+        print(f"  {line}")
+
+    if getattr(args, "check", False):
+        # Exit 1 signals "action available" so a cron or CI step can branch on it.
+        return 1 if state.behind else 0
+
+    if state.behind == 0:
+        return 0
+
+    result = sync_fork.sync(root, upstream_ref, dry_run=getattr(args, "dry_run", False))
+    print(f"  {result.reason}")
+    if not result.ok and result.conflicted_paths:
+        print("  conflicted:")
+        for path in result.conflicted_paths:
+            print(f"    {path}")
+    return 0 if result.ok else 1
+
+
+def _run_ui(root: Path, upstream_ref: str) -> int:
+    """Minimal curses screen: status, plan, and a guarded sync action.
+
+    Deliberately plain — it is a status-and-confirm surface, not a git client.
+    Falls back to the plain CLI output when there is no usable terminal, so
+    ``--ui`` over a pipe degrades instead of crashing.
+    """
+    import curses
+
+    def draw(stdscr) -> int:
+        curses.use_default_colors()
+        message = ""
+        while True:
+            state = sync_fork.inspect(root, upstream_ref)
+            plan = sync_fork.plan(root, upstream_ref)
+            stdscr.erase()
+            stdscr.addstr(0, 0, "hermes sync-fork", curses.A_BOLD)
+            stdscr.addstr(1, 0, f"repo: {root}")
+            stdscr.addstr(2, 0, f"upstream: {upstream_ref}")
+            row = 4
+            for line in _render_state(state, plan):
+                for chunk in _wrap(line, max(20, stdscr.getmaxyx()[1] - 4)):
+                    stdscr.addstr(row, 2, chunk)
+                    row += 1
+            if message:
+                row += 1
+                for chunk in _wrap(message, max(20, stdscr.getmaxyx()[1] - 4)):
+                    stdscr.addstr(row, 2, chunk, curses.A_BOLD)
+                    row += 1
+            row += 1
+            actions = "[s] sync   [d] dry-run   [r] refresh   [q] quit"
+            stdscr.addstr(row, 2, actions, curses.A_DIM)
+            stdscr.refresh()
+
+            key = stdscr.getch()
+            if key in (ord("q"), 27):
+                return 0
+            if key == ord("r"):
+                message = ""
+                continue
+            if key in (ord("s"), ord("d")):
+                dry = key == ord("d")
+                stdscr.addstr(row + 2, 2, "working…")
+                stdscr.refresh()
+                result = sync_fork.sync(root, upstream_ref, dry_run=dry)
+                message = result.reason
+                if result.conflicted_paths:
+                    message += " | conflicted: " + ", ".join(result.conflicted_paths[:4])
+
+    def _wrap(text: str, width: int) -> list[str]:
+        words, lines, cur = text.split(), [], ""
+        for word in words:
+            candidate = f"{cur} {word}".strip()
+            if len(candidate) <= width:
+                cur = candidate
+            else:
+                lines.append(cur)
+                cur = word
+        if cur:
+            lines.append(cur)
+        return lines or [""]
+
+    try:
+        return curses.wrapper(draw)
+    except Exception:
+        state = sync_fork.inspect(root, upstream_ref)
+        plan = sync_fork.plan(root, upstream_ref)
+        print("  (no usable terminal for --ui; showing status instead)")
+        for line in _render_state(state, plan):
+            print(f"  {line}")
+        return 0
+
+
+def register(subparsers) -> None:
+    """Attach ``sync-fork`` to the main argument parser."""
+    parser = subparsers.add_parser(
+        "sync-fork",
+        help="Merge upstream into a fork that has diverged (update skips this case)",
+    )
+    parser.add_argument("--repo", help="Repository path (default: this install)")
+    parser.add_argument(
+        "--upstream-ref",
+        dest="upstream_ref",
+        default=sync_fork.DEFAULT_UPSTREAM_REF,
+        help=f"Upstream ref to merge (default: {sync_fork.DEFAULT_UPSTREAM_REF})",
+    )
+    parser.add_argument("--check", action="store_true",
+                        help="Report status only; exit 1 when a sync is available")
+    parser.add_argument("--dry-run", action="store_true", dest="dry_run",
+                        help="Show the merge plan without merging")
+    parser.add_argument("--json", action="store_true", help="Machine-readable status")
+    parser.add_argument("--ui", action="store_true", help="Interactive screen")
+    parser.set_defaults(func=run)

--- a/tests/hermes_cli/test_sync_fork.py
+++ b/tests/hermes_cli/test_sync_fork.py
@@ -1,0 +1,311 @@
+"""Tests for ``hermes sync-fork`` — merging upstream into a *diverged* fork.
+
+``hermes update`` deliberately refuses this case. ``_sync_upstream`` compares
+``origin/main`` with ``upstream/main`` and returns early when the fork carries
+commits upstream does not have::
+
+    if origin_ahead > 0:
+        print(f"ℹ Your fork has {origin_ahead} commit(s) not on upstream.")
+        print("  Skipping upstream sync to preserve your changes.")
+        return
+
+The refusal is correct — it uses ``pull --ff-only``, which cannot express a
+merge — but it leaves every fork that has ever committed with no supported
+update path. The gap is silent and compounds: a fork can sit hundreds of
+commits behind while ``hermes update`` reports success, because the fast-forward
+sync it skipped is the only upstream check it performs.
+
+``sync-fork`` fills that gap: it merges rather than fast-forwards, and it
+merges *incrementally* so a large backlog fails in small, reviewable pieces
+instead of one unresolvable conflict.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import sync_fork
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, path: str, body: str, message: str) -> str:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+    _git(repo, "add", path)
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture()
+def forked(tmp_path: Path) -> Path:
+    """A fork that has diverged: shared base, then commits on both sides."""
+    up = tmp_path / "upstream"
+    up.mkdir()
+    _git(up, "init", "-q", "-b", "main")
+    _commit(up, "shared.py", "BASE = 1\n", "base")
+    _commit(up, "upstream_only.py", "UP = 1\n", "upstream feature")
+
+    fork = tmp_path / "fork"
+    subprocess.run(["git", "clone", "-q", str(up), str(fork)], check=True)
+    _git(fork, "remote", "add", "upstream", str(up))
+    # Diverge: fork gains a commit upstream does not have.
+    _commit(fork, "local_only.py", "LOCAL = 1\n", "local feature")
+    # Upstream moves on afterwards.
+    _commit(up, "upstream_later.py", "LATER = 1\n", "upstream later")
+    _git(fork, "fetch", "-q", "upstream", "main")
+    return fork
+
+
+# ---------------------------------------------------------------------------
+# divergence detection — the state `hermes update` refuses to act on
+# ---------------------------------------------------------------------------
+
+def test_detects_divergence(forked: Path) -> None:
+    state = sync_fork.inspect(forked, upstream_ref="upstream/main")
+    assert state.diverged is True
+    assert state.behind == 1
+    assert state.ahead == 1
+
+
+def test_clean_fork_is_not_diverged(tmp_path: Path) -> None:
+    up = tmp_path / "u"
+    up.mkdir()
+    _git(up, "init", "-q", "-b", "main")
+    _commit(up, "a.py", "A = 1\n", "a")
+    fork = tmp_path / "f"
+    subprocess.run(["git", "clone", "-q", str(up), str(fork)], check=True)
+    _git(fork, "remote", "add", "upstream", str(up))
+    _git(fork, "fetch", "-q", "upstream", "main")
+    state = sync_fork.inspect(fork, upstream_ref="upstream/main")
+    assert state.diverged is False
+    assert state.behind == 0
+
+
+# ---------------------------------------------------------------------------
+# the merge itself — what `pull --ff-only` cannot do
+# ---------------------------------------------------------------------------
+
+def test_merges_diverged_fork_keeping_both_sides(forked: Path) -> None:
+    result = sync_fork.sync(forked, upstream_ref="upstream/main")
+    assert result.ok is True
+    assert (forked / "local_only.py").exists(), "local work must survive"
+    assert (forked / "upstream_later.py").exists(), "upstream work must arrive"
+    assert sync_fork.inspect(forked, upstream_ref="upstream/main").behind == 0
+
+
+def test_refuses_to_run_on_a_dirty_worktree(forked: Path) -> None:
+    (forked / "shared.py").write_text("BASE = 999\n")
+    result = sync_fork.sync(forked, upstream_ref="upstream/main")
+    assert result.ok is False
+    assert "uncommitted" in result.reason.lower()
+    # The dirty edit must still be there — refusing must not discard work.
+    assert (forked / "shared.py").read_text() == "BASE = 999\n"
+
+
+# ---------------------------------------------------------------------------
+# conflict handling — must restore, never leave a half-merged tree
+# ---------------------------------------------------------------------------
+
+def test_conflict_aborts_and_restores_original_head(tmp_path: Path) -> None:
+    up = tmp_path / "u"
+    up.mkdir()
+    _git(up, "init", "-q", "-b", "main")
+    _commit(up, "f.py", "VALUE = 1\n", "base")
+    fork = tmp_path / "f"
+    subprocess.run(["git", "clone", "-q", str(up), str(fork)], check=True)
+    _git(fork, "remote", "add", "upstream", str(up))
+    # Both sides edit the same line — a guaranteed conflict.
+    _commit(fork, "f.py", "VALUE = 'fork'\n", "fork edit")
+    _commit(up, "f.py", "VALUE = 'upstream'\n", "upstream edit")
+    _git(fork, "fetch", "-q", "upstream", "main")
+
+    before = _git(fork, "rev-parse", "HEAD")
+    result = sync_fork.sync(fork, upstream_ref="upstream/main")
+
+    assert result.ok is False
+    assert result.conflicted_paths == ["f.py"]
+    assert _git(fork, "rev-parse", "HEAD") == before, "HEAD must be restored"
+    assert not (fork / ".git" / "MERGE_HEAD").exists(), "no half-merged state"
+    assert _git(fork, "status", "--porcelain") == "", "worktree must be clean"
+
+
+# ---------------------------------------------------------------------------
+# incremental strategy — the part that makes a large backlog tractable
+# ---------------------------------------------------------------------------
+
+def test_plan_splits_at_commits_touching_conflict_prone_files(forked: Path) -> None:
+    """A backlog is merged in steps, not one jump.
+
+    Upstream commits that touch a file the fork has also modified are the ones
+    that can conflict. Stopping at each of them means a conflict names one
+    upstream commit instead of the whole range, which is what makes it
+    reviewable.
+    """
+    plan = sync_fork.plan(forked, upstream_ref="upstream/main")
+    assert plan.steps, "a behind fork must produce at least one step"
+    assert plan.steps[-1] == "upstream/main", "the plan must finish at the tip"
+
+
+def test_plan_is_empty_when_already_current(tmp_path: Path) -> None:
+    up = tmp_path / "u"
+    up.mkdir()
+    _git(up, "init", "-q", "-b", "main")
+    _commit(up, "a.py", "A = 1\n", "a")
+    fork = tmp_path / "f"
+    subprocess.run(["git", "clone", "-q", str(up), str(fork)], check=True)
+    _git(fork, "remote", "add", "upstream", str(up))
+    _git(fork, "fetch", "-q", "upstream", "main")
+    assert sync_fork.plan(fork, upstream_ref="upstream/main").steps == []
+
+
+def test_dry_run_does_not_move_head(forked: Path) -> None:
+    before = _git(forked, "rev-parse", "HEAD")
+    result = sync_fork.sync(forked, upstream_ref="upstream/main", dry_run=True)
+    assert result.ok is True
+    assert _git(forked, "rev-parse", "HEAD") == before
+    assert sync_fork.inspect(forked, upstream_ref="upstream/main").behind == 1
+
+
+# ---------------------------------------------------------------------------
+# committer identity — a merge writes a commit
+# ---------------------------------------------------------------------------
+
+def test_syncs_on_a_host_with_no_git_identity(tmp_path: Path, monkeypatch) -> None:
+    """A merge commit needs a committer, and plenty of hosts have none.
+
+    Fresh containers, service accounts and CI runners have no global git
+    identity. Without one, ``git merge`` exits non-zero with "Committer identity
+    unknown" and *zero* conflicted paths, so reporting it as a conflict sends
+    the user looking for a merge conflict that does not exist. Caught by the
+    Docker e2e run, which is why this test isolates git's config lookup instead
+    of trusting the developer machine's global config.
+    """
+    home = tmp_path / "empty-home"
+    home.mkdir()
+    # Point every git config lookup at an empty home so no identity is visible.
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(home / "nonexistent-gitconfig"))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(home / "nonexistent-system"))
+    monkeypatch.delenv("GIT_AUTHOR_NAME", raising=False)
+    monkeypatch.delenv("GIT_AUTHOR_EMAIL", raising=False)
+    monkeypatch.delenv("GIT_COMMITTER_NAME", raising=False)
+    monkeypatch.delenv("GIT_COMMITTER_EMAIL", raising=False)
+
+    up = tmp_path / "u"
+    up.mkdir()
+    _git(up, "init", "-q", "-b", "main")
+    _commit(up, "shared.py", "V = 1\n", "base")
+    fork = tmp_path / "f"
+    subprocess.run(["git", "clone", "-q", str(up), str(fork)], check=True)
+    _git(fork, "remote", "add", "upstream", str(up))
+    _commit(fork, "local.py", "L = 1\n", "local")
+    _commit(up, "later.py", "X = 1\n", "upstream later")
+    _git(fork, "fetch", "-q", "upstream", "main")
+
+    result = sync_fork.sync(fork, upstream_ref="upstream/main")
+
+    assert result.ok is True, result.reason
+    assert (fork / "local.py").exists()
+    assert (fork / "later.py").exists()
+
+
+def test_non_conflict_failure_is_not_reported_as_a_conflict(tmp_path: Path) -> None:
+    """A merge can fail for reasons other than conflicting content.
+
+    Unrelated histories, a bad ref, a rejecting hook — all exit non-zero with no
+    unmerged paths. Those must surface git's own message, because calling them
+    "conflict" points the reader at the wrong problem.
+    """
+    a = tmp_path / "a"
+    a.mkdir()
+    _git(a, "init", "-q", "-b", "main")
+    _commit(a, "a.py", "A = 1\n", "a")
+    # A second repo with no shared history at all.
+    b = tmp_path / "b"
+    b.mkdir()
+    _git(b, "init", "-q", "-b", "main")
+    _commit(b, "b.py", "B = 1\n", "b")
+    _git(a, "remote", "add", "upstream", str(b))
+    _git(a, "fetch", "-q", "upstream", "main")
+
+    before = _git(a, "rev-parse", "HEAD")
+    result = sync_fork.sync(a, upstream_ref="upstream/main")
+
+    assert result.ok is False
+    assert result.conflicted_paths == []
+    assert "conflict" not in result.reason.lower()
+    assert _git(a, "rev-parse", "HEAD") == before
+    assert _git(a, "status", "--porcelain") == ""
+# ---------------------------------------------------------------------------
+# an unreadable position is not a healthy one
+# ---------------------------------------------------------------------------
+
+
+def _fork_with_unfetched_upstream(tmp_path: Path) -> Path:
+    """A fork whose ``upstream`` remote exists but has never been fetched.
+
+    This is not a contrived case: it is the state of every fresh clone where
+    someone ran ``git remote add upstream ...`` and then went straight to
+    ``hermes sync-fork``. The ``forked`` fixture above deliberately fetches, which
+    is why the rest of this suite never exercised it.
+    """
+    up = tmp_path / "upstream"
+    up.mkdir()
+    _git(up, "init", "-q", "-b", "main")
+    _commit(up, "shared.py", "BASE = 1\n", "base")
+    _commit(up, "upstream_only.py", "UP = 1\n", "upstream feature")
+
+    fork = tmp_path / "fork"
+    subprocess.run(["git", "clone", "-q", str(up), str(fork)], check=True)
+    _git(fork, "remote", "add", "upstream", str(up))
+    # Upstream moves on, so there IS something to be behind by.
+    _commit(up, "upstream_later.py", "LATER = 1\n", "upstream later")
+    # No fetch. upstream/main does not exist in the fork.
+    return fork
+
+
+def test_an_unfetched_upstream_is_an_error_not_up_to_date(tmp_path: Path) -> None:
+    """The state must say it could not be read, rather than reading as current.
+
+    ``git rev-list --count HEAD..upstream/main`` fails when the ref is absent;
+    that failure became an empty string and then the integer 0, so the fork was
+    certified up to date while being two commits behind. A silent no-op forever
+    is exactly what this command exists to prevent one level up.
+    """
+    fork = _fork_with_unfetched_upstream(tmp_path)
+    state = sync_fork.inspect(fork)
+
+    assert state.error, "an unresolvable upstream ref reported no error"
+    assert "upstream/main" in state.error
+    # And the numbers must not be mistakable for a healthy reading.
+    assert state.behind == 0 and state.diverged is False
+    # Proof the fork really was behind, i.e. the 0 above was a lie without the guard.
+    _git(fork, "fetch", "-q", "upstream", "main")
+    assert sync_fork.inspect(fork).behind > 0
+
+
+def test_a_garbage_upstream_ref_is_an_error(forked: Path) -> None:
+    """A mistyped --upstream-ref is the same class of fault, not a clean repo."""
+    state = sync_fork.inspect(forked, "@@not-a-ref@@")
+    assert state.error and "@@not-a-ref@@" in state.error
+
+
+def test_a_resolvable_ref_still_reports_no_error(forked: Path) -> None:
+    """The guard must not fire on the happy path."""
+    state = sync_fork.inspect(forked)
+    assert state.error is None
+    assert state.diverged is True

--- a/tests/hermes_cli/test_sync_fork_cli.py
+++ b/tests/hermes_cli/test_sync_fork_cli.py
@@ -1,0 +1,286 @@
+"""Tests for ``hermes sync-fork``'s CLI surface.
+
+The merge logic is tested in test_sync_fork.py. What is pinned here is the part a
+script depends on and a human reads: exit codes, whether stdout stays
+machine-parsable under ``--json``, and that ``--dry-run`` cannot merge.
+
+Exit codes carry meaning beyond success. ``--check`` returns 1 when a sync is
+*available* — not when something failed — so a cron can branch on it; a plain run
+returns 1 only when the sync itself did not complete. Confusing those two makes a
+scheduled job either never act or act on nothing, so both are asserted
+explicitly.
+
+``sync_fork`` is the single seam. No test builds a repository or runs git; the
+module's own suite covers that.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from hermes_cli import sync_fork
+from hermes_cli import sync_fork_cli
+
+
+def _args(**over):
+    base = dict(repo="/tmp/whatever", upstream_ref="upstream/main",
+                check=False, dry_run=False, json=False, ui=False)
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _state(behind=0, ahead=0, dirty=False):
+    return sync_fork.ForkState(behind=behind, ahead=ahead,
+                               diverged=bool(behind and ahead), dirty=dirty)
+
+
+def _plan(steps=None, prone=None):
+    return sync_fork.SyncPlan(steps=steps or [], conflict_prone=prone or [])
+
+
+def _patch(monkeypatch, state, plan=None, result=None):
+    monkeypatch.setattr(sync_fork, "inspect", lambda *a, **k: state)
+    monkeypatch.setattr(sync_fork, "plan", lambda *a, **k: plan or _plan())
+    calls = []
+
+    def fake_sync(cwd, upstream_ref=sync_fork.DEFAULT_UPSTREAM_REF, dry_run=False):
+        calls.append({"dry_run": dry_run, "upstream_ref": upstream_ref})
+        return result or sync_fork.SyncResult(ok=True, reason="Merged upstream in 1 step(s).")
+
+    monkeypatch.setattr(sync_fork, "sync", fake_sync)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# --json: the contract a script consumes
+# ---------------------------------------------------------------------------
+
+def test_json_prints_one_parsable_object_and_nothing_else(monkeypatch, capsys):
+    _patch(monkeypatch, _state(behind=42, ahead=3), _plan(["a", "upstream/main"], ["a"]))
+    rc = sync_fork_cli.run(_args(json=True))
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert len(out.splitlines()) == 1, "extra lines break a caller doing json.loads"
+    payload = json.loads(out)
+    assert payload == {"behind": 42, "ahead": 3, "diverged": True, "dirty": False,
+                       "steps": 2, "conflict_prone": 1}
+
+
+def test_json_never_merges(monkeypatch, capsys):
+    """--json is a status read. If it could merge, a monitoring poll would
+    mutate the checkout it was only supposed to observe."""
+    calls = _patch(monkeypatch, _state(behind=42, ahead=3), _plan(["upstream/main"]))
+    sync_fork_cli.run(_args(json=True))
+    capsys.readouterr()
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# --check: exit code as a signal, not as an error
+# ---------------------------------------------------------------------------
+
+def test_check_exits_1_when_a_sync_is_available(monkeypatch, capsys):
+    _patch(monkeypatch, _state(behind=7, ahead=1), _plan(["upstream/main"]))
+    rc = sync_fork_cli.run(_args(check=True))
+    capsys.readouterr()
+    assert rc == 1, "cron branches on this; 0 here means the job never acts"
+
+
+def test_check_exits_0_when_current(monkeypatch, capsys):
+    _patch(monkeypatch, _state())
+    rc = sync_fork_cli.run(_args(check=True))
+    capsys.readouterr()
+    assert rc == 0
+
+
+def test_check_never_merges_even_when_behind(monkeypatch, capsys):
+    calls = _patch(monkeypatch, _state(behind=99, ahead=2), _plan(["upstream/main"]))
+    sync_fork_cli.run(_args(check=True))
+    capsys.readouterr()
+    assert calls == [], "--check must be read-only"
+
+
+def test_check_reports_availability_not_dirtiness(monkeypatch, capsys):
+    """A dirty worktree with commits behind is still 'a sync is available' —
+    the sync itself refuses later. Returning 0 here would hide the backlog."""
+    _patch(monkeypatch, _state(behind=5, ahead=1, dirty=True), _plan(["upstream/main"]))
+    rc = sync_fork_cli.run(_args(check=True))
+    assert rc == 1
+    assert "uncommitted" in capsys.readouterr().out.lower()
+
+
+# ---------------------------------------------------------------------------
+# --dry-run
+# ---------------------------------------------------------------------------
+
+def test_dry_run_passes_the_flag_through(monkeypatch, capsys):
+    calls = _patch(monkeypatch, _state(behind=3, ahead=1), _plan(["upstream/main"]),
+                   sync_fork.SyncResult(ok=True, reason="3 commit(s) behind; would merge in 1 step(s)."))
+    rc = sync_fork_cli.run(_args(dry_run=True))
+    capsys.readouterr()
+    assert rc == 0
+    assert calls and calls[0]["dry_run"] is True
+
+
+def test_a_plain_run_does_not_pass_dry_run(monkeypatch, capsys):
+    calls = _patch(monkeypatch, _state(behind=3, ahead=1), _plan(["upstream/main"]))
+    sync_fork_cli.run(_args())
+    capsys.readouterr()
+    assert calls and calls[0]["dry_run"] is False
+
+
+# ---------------------------------------------------------------------------
+# a plain run
+# ---------------------------------------------------------------------------
+
+def test_up_to_date_returns_0_without_calling_sync(monkeypatch, capsys):
+    calls = _patch(monkeypatch, _state())
+    rc = sync_fork_cli.run(_args())
+    assert rc == 0
+    assert calls == []
+    assert "up to date" in capsys.readouterr().out.lower()
+
+
+def test_failed_sync_returns_1_and_lists_conflicted_paths(monkeypatch, capsys):
+    """A conflict must be visibly a conflict: exit 1, and the files named on
+    their own lines so an operator can scan them."""
+    _patch(monkeypatch, _state(behind=9, ahead=2), _plan(["abc", "upstream/main"]),
+           sync_fork.SyncResult(
+               ok=False,
+               reason="Conflict merging abc. The fork was restored to 44c9871f8.",
+               conflicted_paths=["tools/delegate_tool.py", "agent/conversation_loop.py"]))
+    rc = sync_fork_cli.run(_args())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "restored" in out
+    assert "conflicted:" in out, "the paths appear with no label saying what they are"
+    assert "tools/delegate_tool.py" in out
+    assert "agent/conversation_loop.py" in out
+    # Indented under their header, so a reader sees a list rather than prose.
+    assert "    tools/delegate_tool.py" in out
+
+
+def test_successful_sync_returns_0(monkeypatch, capsys):
+    _patch(monkeypatch, _state(behind=2, ahead=1), _plan(["upstream/main"]),
+           sync_fork.SyncResult(ok=True, reason="Merged upstream in 1 step(s)."))
+    rc = sync_fork_cli.run(_args())
+    capsys.readouterr()
+    assert rc == 0
+
+
+def test_the_upstream_ref_reaches_sync(monkeypatch, capsys):
+    """A caller pointing at a different remote must not silently get the
+    default; that would merge from somewhere they did not ask for."""
+    calls = _patch(monkeypatch, _state(behind=1, ahead=1), _plan(["fork/main"]))
+    sync_fork_cli.run(_args(upstream_ref="fork/main"))
+    capsys.readouterr()
+    assert calls and calls[0]["upstream_ref"] == "fork/main"
+
+
+# ---------------------------------------------------------------------------
+# the human-readable block
+# ---------------------------------------------------------------------------
+
+def test_a_diverged_fork_is_named_as_diverged(monkeypatch, capsys):
+    """This is the state `hermes update` walks away from, so the output has to
+    say so rather than leaving the operator to infer it."""
+    _patch(monkeypatch, _state(behind=671, ahead=38), _plan(["a", "b", "upstream/main"], ["a", "b"]))
+    sync_fork_cli.run(_args(check=True))
+    out = capsys.readouterr().out
+    assert "671" in out and "38" in out
+    assert "diverged" in out.lower()
+    assert "fast-forward" in out.lower(), "the reason update skips this is not explained"
+
+
+def test_risky_steps_are_called_out_when_present(monkeypatch, capsys):
+    _patch(monkeypatch, _state(behind=42, ahead=3), _plan(["a", "b", "upstream/main"], ["a", "b"]))
+    sync_fork_cli.run(_args(check=True))
+    out = capsys.readouterr().out
+    assert "3 step" in out
+    assert "2 upstream commit" in out
+
+
+def test_no_risky_steps_says_so_rather_than_staying_silent(monkeypatch, capsys):
+    _patch(monkeypatch, _state(behind=4, ahead=1), _plan(["upstream/main"], []))
+    sync_fork_cli.run(_args(check=True))
+    assert "no upstream commit touches" in capsys.readouterr().out.lower()
+
+
+# ---------------------------------------------------------------------------
+# --ui without a terminal
+# ---------------------------------------------------------------------------
+
+def test_ui_degrades_to_plain_output_without_a_terminal(monkeypatch, capsys):
+    """--ui over a pipe must print status, not raise. A cron that inherits the
+    flag from a shell alias would otherwise fail on a curses init error."""
+    _patch(monkeypatch, _state(behind=5, ahead=1), _plan(["upstream/main"]))
+
+    import curses
+
+    def boom(_fn):
+        raise curses.error("no terminal")
+
+    monkeypatch.setattr(curses, "wrapper", boom)
+    rc = sync_fork_cli.run(_args(ui=True))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no usable terminal" in out
+    assert "5 commit" in out, "the status the user asked for is missing"
+# ---------------------------------------------------------------------------
+# an unreadable state must not reach anything that branches on `behind`
+# ---------------------------------------------------------------------------
+
+
+def _unreadable(dirty=False):
+    return sync_fork.ForkState(behind=0, ahead=0, diverged=False, dirty=dirty,
+                               error="upstream ref 'upstream/main' does not resolve")
+
+
+def test_json_reports_an_unreadable_state_as_an_error_object(monkeypatch, capsys):
+    """The documented contract: an unresolvable ref answers {"error": ...}.
+
+    It was documented in this command's own description and consumed by the
+    fork-keeper cron, which extracts `.error` to decide whether to bail — but
+    nothing ever produced the key, so that guard was dead code and the cron read
+    behind=0 as "nothing to do".
+    """
+    monkeypatch.setattr(sync_fork, "inspect", lambda *a, **k: _unreadable())
+    rc = sync_fork_cli.run(_args(json=True))
+    payload = json.loads(capsys.readouterr().out.strip())
+
+    assert rc == 2
+    assert "does not resolve" in payload["error"]
+    # No commit count at all: a consumer must not be able to read a number here.
+    assert "behind" not in payload
+
+
+def test_check_does_not_report_current_when_the_ref_is_unresolvable(monkeypatch, capsys):
+    """--check returns 0 for "current" and 1 for "sync available". Neither is true
+    when the position could not be read, so it must return the third value."""
+    monkeypatch.setattr(sync_fork, "inspect", lambda *a, **k: _unreadable())
+    rc = sync_fork_cli.run(_args(check=True))
+    capsys.readouterr()
+    assert rc == 2
+
+
+def test_an_unreadable_state_never_reaches_the_merge(monkeypatch, capsys):
+    """The action path branches on `behind`, which is 0 here for the wrong reason."""
+    monkeypatch.setattr(sync_fork, "inspect", lambda *a, **k: _unreadable())
+
+    def _boom(*a, **k):
+        raise AssertionError("sync() was called with a state that could not be read")
+
+    monkeypatch.setattr(sync_fork, "sync", _boom)
+    monkeypatch.setattr(sync_fork, "plan", _boom)
+    rc = sync_fork_cli.run(_args())
+    capsys.readouterr()
+    assert rc == 2
+
+
+def test_the_human_headline_is_the_error_not_up_to_date(monkeypatch):
+    """_render_state is shared with the curses screen, which calls inspect itself
+    and so never passes the guard in _run. It has to refuse on its own."""
+    lines = sync_fork_cli._render_state(_unreadable(), _plan())
+    assert lines and "does not resolve" in lines[0]
+    assert not any("Up to date" in line for line in lines)

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -99,6 +99,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes completion` | Print shell completion scripts (bash/zsh/fish). |
 | `hermes --version` | Show version information. |
 | `hermes update` | Pull latest code and reinstall dependencies. `--check` previews without installing; `--backup` takes a pre-pull `HERMES_HOME` snapshot. |
+| `hermes sync-fork` | Merge `upstream/main` into a fork that has diverged (local commits), one upstream commit at a time. `--check` / `--dry-run` / `--json` / `--ui`. |
 | `hermes uninstall` | Remove Hermes from the system. |
 
 ## `hermes chat`


### PR DESCRIPTION
## Problem

`hermes update` cannot update a fork that carries local commits. The upstream sync step (`_sync_with_upstream_if_needed` in `hermes_cli/update_cmd_git.py`, split out of `update_cmd.py` in the `4674f8b254` refactor) compares `origin/main` with `upstream/main` and returns early:

```python
if origin_ahead > 0:
    print(
        f"\nℹ Your fork has {origin_ahead} commit(s) not on upstream.\n"
        "  Skipping upstream sync to preserve your changes.\n"
        "  If you want to merge upstream changes, run:\n    git pull upstream main"
    )
    return True
```

The refusal is correct for what follows it — the sync is `git pull --ff-only`, and a fast-forward cannot express a merge. The problem is that this fast-forward is the **only** upstream check `update` performs. So on a diverged fork:

- no upstream movement happens at all, and
- the run still reports success.

The gap is silent and compounds. On the deployment that prompted this, a fork sat **671 commits** behind while `hermes update` reported no problem. There is currently no supported path forward for such a fork — `git pull upstream main`, which the message suggests, is the manual step the tool declines to take.

This is the *action* half of a known problem. #72789 and its PRs (#72812, #68959, #63912) fix update **detection** on forks — the banner not noticing upstream movement. Even with detection fixed, a diverged fork still has nothing to run.

## What this adds

`hermes sync-fork` merges instead of fast-forwarding, and merges **incrementally**: it stops at each upstream commit that touches a file the fork also modified, so a conflict names one upstream commit instead of the whole range.

That is not only ergonomics. With a very old merge base, one large merge can drop definitions the merged text still references — the merge succeeds textually and fails at runtime with `NameError`/`AttributeError`, which is much harder to attribute than a conflict marker. Merging in steps keeps each conflict attributable, and a real 671-commit backlog resolved this way turned out to touch only 7 commits in the one file that conflicted.

## Safety properties

Each has a test:

| Property | Why |
|---|---|
| Refuses a dirty worktree, leaves the edit alone | An update must never decide what happens to someone's uncommitted work |
| On conflict: restores original `HEAD`, worktree clean | A half-merged tree is worse than no update — the next run cannot tell it from local work |
| Supplies a committer identity for the merge commit only | A merge writes a commit. Hosts with no global git identity (containers, service accounts, CI) otherwise fail with `Committer identity unknown` and **zero** conflicted paths, which would be reported as a conflict that does not exist |
| Distinguishes a content conflict from other merge failures | Unrelated histories, a bad ref or a rejecting hook must surface git's own message, not the word "conflict" |
| An unresolvable upstream ref is an error, not a healthy fork | `git remote add upstream` without a fetch used to report `behind: 0` and `diverged: false`; `--json` now emits `{"error": ...}` and `--check` exits 2 (1 already means "a sync is available") |

The identity case was found by running the suite in a container rather than on a developer machine, where a global identity masks it.

## Surfaces

```
hermes sync-fork              # status, then merge
hermes sync-fork --dry-run    # show the plan, touch nothing
hermes sync-fork --check      # status only; exit 1 when a sync is available, 2 on error
hermes sync-fork --json       # machine-readable, for cron/CI
hermes sync-fork --ui         # interactive screen; degrades to plain output without a tty
```

The merge logic in `hermes_cli/sync_fork.py` has no printing or prompts, so it is equally drivable from a cron job, a dashboard, or a test.

## Testing

```
tests/hermes_cli/test_sync_fork.py      13 passed
tests/hermes_cli/test_sync_fork_cli.py  20 passed
```

The tests build real git repositories in `tmp_path` — a genuine fork, a genuine divergence, a genuine conflict — rather than mocking git, since the behaviour under test *is* git's. One test isolates git's config lookup (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pointed at nonexistent paths) so the no-identity path is exercised regardless of the developer's machine. The status tests include a fork built deliberately without an upstream fetch.

Verified additionally against a live install that was 671 commits behind, in a `python:3.11-slim` container for the no-identity case, and by a cron that has been merging upstream into a real diverged fork every two days since mid-August.

## Scope

- No change to `hermes update`'s behaviour. `sync-fork` is additive; the existing fast-forward path is untouched.
- No new dependency.
- `hermes_cli/main.py`: the parser registration in `_build_cli_parser` (right after `build_fallback_parser`), plus the `sync-fork` entry in `_BUILTIN_SUBCOMMANDS` so the fast-path gate does not treat it as a chat prompt.
- `website/docs/reference/cli-commands.md`: one row in the top-level commands table.
