### PR TITLE
fix(desktop): keep react-router in one runtime chunk Fixes #82696

### DIFF
--- a/apps/desktop/scripts/assert-dist-built.mjs
+++ b/apps/desktop/scripts/assert-dist-built.mjs
@@ -11,7 +11,7 @@
 // inherits it. It fails loud and early instead of shipping a broken bundle.
 // See issues #39484 (renderer blank page) and #41327 / #39472 (dashboard 404).
 
-import { existsSync, statSync, readdirSync } from "fs"
+import { existsSync, statSync, readdirSync, readFileSync } from "fs"
 import { join, resolve } from "path"
 import { isMain } from "./utils.mjs"
 
@@ -33,12 +33,44 @@ export function checkDistBuilt(distDir) {
   // index.html alone isn't enough — vite emits hashed JS into dist/assets.
   // An index.html with no script bundle still blank-pages.
   const assetsDir = join(distDir, "assets")
-  const hasAssets =
-    existsSync(assetsDir) &&
-    statSync(assetsDir).isDirectory() &&
-    readdirSync(assetsDir).some(name => name.endsWith(".js"))
-  if (!hasAssets) {
+  let jsFiles = []
+  try {
+    if (existsSync(assetsDir) && statSync(assetsDir).isDirectory()) {
+      jsFiles = readdirSync(assetsDir).filter(name => name.endsWith(".js"))
+    }
+  } catch (err) {
+    return { ok: false, error: `failed reading assets directory at ${assetsDir}: ${err.message}` }
+  }
+
+  if (jsFiles.length === 0) {
     return { ok: false, error: `dist/assets has no built JS bundle (expected vite output under ${assetsDir})` }
+  }
+
+  // Packaging invariant: react-router must not be duplicated across multiple JS chunks (#82696).
+  // When react-router is split across chunks, non-entry chunks get an isolated Router context
+  // causing `useLocation()` to throw "may be used only in the context of a <Router> component".
+  const routerInvariant = "may be used only in the context of a"
+  const chunksWithRouter = jsFiles.filter(name => {
+    try {
+      const content = readFileSync(join(assetsDir, name), "utf8")
+      return content.includes(routerInvariant)
+    } catch {
+      return false
+    }
+  })
+
+  if (chunksWithRouter.length === 0) {
+    return {
+      ok: false,
+      error: `react-router context invariant not found in any JS chunk in dist/assets. Ensure the router invariant string is present in the built bundle (#82696)`
+    }
+  }
+
+  if (chunksWithRouter.length > 1) {
+    return {
+      ok: false,
+      error: `react-router context invariant emitted into ${chunksWithRouter.length} separate chunks (${chunksWithRouter.join(", ")}). Ensure react-router is in vendor-react and resolve.dedupe in vite.config.ts (#82696)`
+    }
   }
 
   return { ok: true }

--- a/apps/desktop/scripts/assert-dist-built.test.mjs
+++ b/apps/desktop/scripts/assert-dist-built.test.mjs
@@ -18,7 +18,11 @@ test('checkDistBuilt passes when index.html + an assets JS bundle exist', () => 
   const { tempRoot, distDir } = makeDist(d => {
     fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html><div id=root></div>', 'utf8')
     fs.mkdirSync(path.join(d, 'assets'))
-    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.js'), 'console.log(1)', 'utf8')
+    fs.writeFileSync(
+      path.join(d, 'assets', 'index-abc123.js'),
+      'function useLocation(){ throw new Error("may be used only in the context of a <Router> component") }',
+      'utf8'
+    )
   })
   try {
     assert.deepEqual(checkDistBuilt(distDir), { ok: true })
@@ -82,3 +86,64 @@ test('checkDistBuilt fails when assets/ has no JS bundle', () => {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
 })
+
+test('checkDistBuilt passes when react-router invariant is in exactly one JS bundle', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html><div id=root></div>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    fs.writeFileSync(
+      path.join(d, 'assets', 'vendor-react-123.js'),
+      'function useLocation(){ throw new Error("may be used only in the context of a <Router> component") }',
+      'utf8'
+    )
+    fs.writeFileSync(path.join(d, 'assets', 'command-456.js'), 'console.log("command")', 'utf8')
+  })
+  try {
+    assert.deepEqual(checkDistBuilt(distDir), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt fails when react-router invariant is emitted into multiple JS chunks', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html><div id=root></div>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    fs.writeFileSync(
+      path.join(d, 'assets', 'index-123.js'),
+      'function useLocation(){ throw new Error("may be used only in the context of a <Router> component") }',
+      'utf8'
+    )
+    fs.writeFileSync(
+      path.join(d, 'assets', 'command-456.js'),
+      'function useLocation(){ throw new Error("may be used only in the context of a <Router> component") }',
+      'utf8'
+    )
+  })
+  try {
+    const result = checkDistBuilt(distDir)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /react-router context invariant emitted into 2 separate chunks/)
+    assert.match(result.error, /command-456\.js/)
+    assert.match(result.error, /index-123\.js/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt fails when react-router context invariant is missing from JS bundles', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html><div id=root></div>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.js'), 'console.log(1)', 'utf8')
+  })
+  try {
+    const result = checkDistBuilt(distDir)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /react-router context invariant not found in any JS chunk/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -112,7 +112,10 @@ export default defineConfig(({ command }) => ({
             // the heavy chunk, and the entry then statically imports 19 MB of
             // shiki just to reach react/hast utils — putting the heavy chunk
             // right back on the boot path.
-            { name: 'vendor-react', test: /node_modules[\\/](react|react-dom|scheduler)[\\/]/ },
+            {
+              name: 'vendor-react',
+              test: /node_modules[\\/](react|react-dom|scheduler|react-router(-dom)?|@react-router)[\\/]/
+            },
             {
               name: 'vendor-md',
               test: /node_modules[\\/](property-information|hast-util-[^\\/]+|mdast-util-[^\\/]+|micromark[^\\/]*|unist-util-[^\\/]+|vfile[^\\/]*|unified|stringify-entities|space-separated-tokens|comma-separated-tokens|zwitch|html-void-elements|devlop|style-to-js|style-to-object|clsx)[\\/]/
@@ -152,7 +155,7 @@ export default defineConfig(({ command }) => ({
       'react/jsx-dev-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-dev-runtime.js'),
       'react/jsx-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-runtime.js')
     },
-    dedupe: ['react', 'react-dom']
+    dedupe: ['react', 'react-dom', 'react-router', 'react-router-dom']
   },
   server: {
     host: '127.0.0.1',

--- a/contributors/emails/StanleyStetson@users.noreply.github.com
+++ b/contributors/emails/StanleyStetson@users.noreply.github.com
@@ -1,0 +1,1 @@
+StanleyStetson


### PR DESCRIPTION
## What does this PR do?

Fixes a startup crash (P0) in Hermes Desktop where `react-router` is split into multiple separate JS chunks (`index-*.js`, `command-*.js`, `hooks-*.js`) during Vite code-splitting. 

Because `react-router` was instantiated separately in each chunk, non-entry chunks (such as the command palette) imported an isolated instance of `react-router` where `React.createContext` for the Router had `undefined` value, throwing `Error: useLocation() may be used only in the context of a <Router> component.` on boot.

This PR:
1. Adds `react-router`, `react-router-dom`, and `@react-router` to the `vendor-react` chunk group regex in `apps/desktop/vite.config.ts`.
2. Adds `react-router` and `react-router-dom` to `resolve.dedupe` in `apps/desktop/vite.config.ts`.
3. Hardens `apps/desktop/scripts/assert-dist-built.mjs` with a packaging regression guard that ensures the `react-router` context invariant exists in exactly 1 JS asset in `dist/assets/` (failing the build if 0 or >1 chunks match).
4. Adds unit tests in `apps/desktop/scripts/assert-dist-built.test.mjs` validating 1-chunk pass, >1-chunk failure, and 0-chunk failure behavior.

## Related Issue

Fixes #82696

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/vite.config.ts`: Updated `vendor-react` regex pattern to `/node_modules[\\/](react|react-dom|scheduler|react-router(-dom)?|@react-router)[\\/]/` and added `'react-router'` & `'react-router-dom'` to `resolve.dedupe`.
- `apps/desktop/scripts/assert-dist-built.mjs`: Added build-time check ensuring the router invariant string (`may be used only in the context of a`) is emitted into exactly 1 JS asset, with safe `readdirSync` error handling for Windows I/O locks.
- `apps/desktop/scripts/assert-dist-built.test.mjs`: Added unit tests verifying 1-chunk pass, >1-chunk failure, and 0-chunk failure behavior.

## How to Test

1. Run unit tests in `apps/desktop`:
   `npm test -- scripts/assert-dist-built.test.mjs` (8 passed).
2. Run `vite build` in `apps/desktop`:
   Verify that `react-router` resolves strictly to `dist/assets/vendor-react-*.js`.
3. Run post-build assertion:
   `node scripts/assert-dist-built.mjs` (passed).