### PR TITLE
fix(title): fall back to json_object response_format on provider rejection

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -392,17 +392,38 @@ def generate_title(
     ]
 
     try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
+        try:
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                # A title is a handful of tokens. The old 500-token ceiling let a
+                # chatty model burn seconds generating prose we then threw away.
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+                extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            )
+        except Exception as schema_err:
+            # Some providers (DeepSeek V4) reject the strict json_schema
+            # response_format with HTTP 400 ("This response_format type is
+            # unavailable now"). Retry with the looser json_object hint — the
+            # prompt already demands a single JSON object and
+            # _extract_title_text's loose scan tolerates non-compliant output.
+            logger.warning(
+                "Title generation with json_schema response_format failed (%s); "
+                "retrying with json_object",
+                schema_err,
+            )
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+                extra_body={"response_format": {"type": "json_object"}},
+            )
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))
     except Exception as e:


### PR DESCRIPTION
## Problem

Two-stage session titling (instant derived title, then an LLM "upgrade" to a short summary) fails for providers that reject the strict `json_schema` `response_format`. DeepSeek V4 returns HTTP 400 ("This response_format type is unavailable now"), the title task returns `None`, and the raw derived title (`[Display Name] first words…`) sticks forever.

## Root cause

`generate_title` sends `extra_body={"response_format": _TITLE_RESPONSE_FORMAT}` (json_schema) unconditionally. Some providers only support `json_object`. Because callers treat a `None` title as "keep the derived title", the failure is silent — no error surfaces to the user.

## Fix

Retry the title call with `{"type": "json_object"}` when the json_schema call raises. The prompt already demands a single JSON object and `_extract_title_text`'s loose scan tolerates non-compliant output, so the looser hint is safe.

## Verification

- Live deployment with DeepSeek V4 as the title provider: before → threads stuck with `[Name] <first words…>`; after → clean 3–7 word summaries land ~3s after thread creation.
- The json_schema path is still attempted first; the fallback only fires on provider rejection and is logged at warning level.
- Models that accept json_schema (e.g. openai-api) are unaffected.
