### PR TITLE
fix(a2a): declare SUPPORTS_MESSAGE_EDITING = False

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -338,6 +338,14 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
 class A2AAdapter(BasePlatformAdapter):
     """Inbound A2A server adapter."""
 
+    # A2A is request/response — there is no edit API for an already-delivered
+    # reply. Declaring this False makes the gateway skip the stream consumer
+    # for A2A sessions entirely (run.py _build_stream_consumer_config raises
+    # for non-editable platforms), so a reply can never be mangled by
+    # preview/tail-send racing (observed: streamed replies arriving truncated
+    # or empty while the full text had been generated).
+    SUPPORTS_MESSAGE_EDITING = False
+
     def __init__(self, config, **kwargs):
         platform = Platform("a2a")
         super().__init__(config=config, platform=platform)


### PR DESCRIPTION
## Problem

A2A is a request/response protocol — there is no edit API for an already-delivered reply. The adapter did not declare this, so the gateway's stream consumer (built for editable platforms) ran for A2A sessions and could race preview/tail-send against delivery. Observed result: streamed replies arrived prefix-truncated or empty while the agent had generated the full text.

## Fix

Declare `SUPPORTS_MESSAGE_EDITING = False` on `A2AAdapter`. The gateway already handles this flag — `run.py::_build_stream_consumer_config` raises for non-editable platforms, so the stream consumer is skipped entirely for A2A sessions and a delivered reply can never be mangled.

## Verification

- Live agent-to-agent A2A sessions: full replies delivered, no truncation.
