### PR TITLE
fix(cron): keep blueprint skills and no-source fallbacks reachable

### DIFF
--- a/cron/blueprint_catalog.py
+++ b/cron/blueprint_catalog.py
@@ -96,6 +96,9 @@ class AutomationBlueprint:
     slots: List[BlueprintSlot] = field(default_factory=list)
     deliver_default: str = "origin"
     skills: tuple = ()        # skills the job loads before running
+    # Let a prompt with an explicit no-source path run even when an attached
+    # integration skill still needs setup. Ordinary jobs stay fail-before-run.
+    allow_unready_skills: bool = False
     tags: tuple = ()
 
 
@@ -136,6 +139,7 @@ CATALOG: List[AutomationBlueprint] = [
         ),
         slots=[_TIME("08:00"), _DELIVER],
         skills=("google-workspace",),
+        allow_unready_skills=True,
         tags=("daily", "briefing"),
     ),
     AutomationBlueprint(
@@ -794,6 +798,8 @@ def fill_blueprint(
     }
     if blueprint.skills:
         spec["skills"] = list(blueprint.skills)
+    if blueprint.allow_unready_skills:
+        spec["allow_unready_skills"] = True
     if origin is not None:
         spec["origin"] = origin
     return spec

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1584,6 +1584,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    allow_unready_skills: bool = False,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -1630,6 +1631,9 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        allow_unready_skills: When True, let the agent run even if an attached
+                skill reports incomplete setup. Use only when the prompt has an
+                explicit fallback that does not require that setup.
         monitor_script: Optional path to a cheap monitor source script (same
                 resolution/containment rules as ``script``: relative to
                 ~/.hermes/scripts/, .sh/.bash via bash, else Python). Each
@@ -1675,6 +1679,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_allow_unready_skills = bool(allow_unready_skills)
     normalized_monitor_script = str(monitor_script).strip() if isinstance(monitor_script, str) else None
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
@@ -1783,6 +1788,8 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    if normalized_allow_unready_skills:
+        job["allow_unready_skills"] = True
 
     with _jobs_lock():
         jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3082,6 +3082,9 @@ def _preflight_check_skills(job: dict) -> Optional[str]:
     the skill exists but its required environment is missing — a run that
     is guaranteed to misfire.
     """
+    if job.get("allow_unready_skills"):
+        return None
+
     skills = job.get("skills")
     if skills is None:
         legacy = job.get("skill")

--- a/hermes_cli/blueprint_cmd.py
+++ b/hermes_cli/blueprint_cmd.py
@@ -186,6 +186,16 @@ def build_blueprint_seed(blueprint) -> str:
             bits.append(f" — {s.help}")
         lines.append("".join(bits))
 
+    create_options: List[str] = []
+    if blueprint.skills:
+        create_options.append(f"skills={list(blueprint.skills)!r}")
+    if blueprint.allow_unready_skills:
+        create_options.append("allow_unready_skills=True")
+    create_suffix = (
+        f" Include these exact create options: {', '.join(create_options)}."
+        if create_options else ""
+    )
+
     lines.append("")
     lines.append(
         "Once you have my answers, create the job by calling the cronjob tool "
@@ -195,6 +205,7 @@ def build_blueprint_seed(blueprint) -> str:
         f"choice using {dict(WEEKDAY_PRESETS)}, {{interval_min}} from any "
         "interval). Use this exact prompt for the job (substituting my "
         f"answers into any {{slot}} placeholders): \"{blueprint.prompt_template}\". "
+        f"{create_suffix} "
         "Confirm the schedule and what it will do before you create it."
     )
     return "\n".join(lines)

--- a/tests/cron/test_blueprint_catalog.py
+++ b/tests/cron/test_blueprint_catalog.py
@@ -168,6 +168,8 @@ class TestCommandHandler:
         assert res.agent_seed is not None
         assert "morning-brief" in res.agent_seed
         assert "cronjob tool" in res.agent_seed
+        assert "skills=['google-workspace']" in res.agent_seed
+        assert "allow_unready_skills=True" in res.agent_seed
         # the schedule template is handed to the agent to build the cron expr
         assert "* * *" in res.agent_seed
 
@@ -182,6 +184,8 @@ class TestCommandHandler:
         assert len(jobs) == 1
         assert (jobs[0].get("schedule_display") or jobs[0].get("schedule")) == "30 7 * * *"
         assert jobs[0].get("deliver") == "telegram"
+        assert jobs[0].get("skills") == ["google-workspace"]
+        assert jobs[0].get("allow_unready_skills") is True
 
 
 class TestDocsGenerator:

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -313,6 +313,34 @@ class TestSkillReadiness:
         assert success is True
         assert agent_constructed is True
 
+    def test_explicit_fallback_allows_unready_skill_to_run(self, tmp_path):
+        """A useful no-source fallback may opt out of readiness blocking."""
+        payload = json.dumps(
+            {
+                "success": True,
+                "content": "# optional integration\nUse it when configured.",
+                "readiness_status": "setup_needed",
+                "setup_needed": True,
+                "missing_credential_files": ["integration_token.json"],
+            }
+        )
+
+        def fake_skill_view(name, *args, **kwargs):
+            return payload
+
+        job = _job(
+            skills=["optional-integration"],
+            allow_unready_skills=True,
+            prompt="Use the integration when ready; otherwise provide the fallback.",
+        )
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            success, output, final_response, error, agent_constructed = \
+                _run_job_patched(job, tmp_path, skill_view=fake_skill_view)
+
+        assert success is True
+        assert agent_constructed is True
+
 
 class TestDeliveryPlatform:
     def test_unknown_delivery_platform_blocks(self, tmp_path):

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,22 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_persists_explicit_unready_skill_fallback(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Use the integration when ready; otherwise use the fallback.",
+                schedule="every 1h",
+                skills=["optional-integration"],
+                allow_unready_skills=True,
+            )
+        )
+
+        assert created["success"] is True
+        assert created["job"]["allow_unready_skills"] is True
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["allow_unready_skills"] is True
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -590,6 +590,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["monitor_state"] = job["monitor_state"]
     if job.get("no_agent"):
         result["no_agent"] = True
+    if job.get("allow_unready_skills"):
+        result["allow_unready_skills"] = True
     if job.get("enabled_toolsets"):
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
@@ -1050,6 +1052,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    allow_unready_skills: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     task_id: str = None,
@@ -1138,6 +1141,7 @@ def cronjob(
                     workdir=_normalize_optional_job_value(workdir),
                     no_agent=_no_agent,
                     attach_to_session=attach_to_session,
+                    allow_unready_skills=bool(allow_unready_skills),
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
                 )
@@ -1395,6 +1399,8 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if allow_unready_skills is not None:
+                updates["allow_unready_skills"] = bool(allow_unready_skills)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1495,6 +1501,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Optional ordered list of skill names to load before executing the cron prompt. On update, pass an empty array to clear attached skills."
+            },
+            "allow_unready_skills": {
+                "type": "boolean",
+                "description": "Default: False. When True, an attached skill that still needs setup does not block the run. Use only when the prompt explicitly defines a useful fallback that does not require that setup."
             },
             "script": {
                 "type": "string",
@@ -1609,6 +1619,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        allow_unready_skills=args.get("allow_unready_skills"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
         task_id=kw.get("task_id"),


### PR DESCRIPTION
## What does this PR do?

Cron automation blueprints now preserve their attached skills across conversational and direct creation paths. The `morning-brief` blueprint can also reach its documented no-source response when Google Workspace still needs setup, while readiness preflight remains strict by default for every other job.

### Symptom

`/blueprint morning-brief` could seed a cron create call without `google-workspace`, so the resulting job lost the procedure it was meant to follow. Directly filled morning-brief jobs kept the skill but were rejected by readiness preflight before their explicit no-source fallback could run.

### Impact

Users could receive a degraded briefing without the connected-data procedure or no briefing at all when Google Workspace was not configured. The opt-out is limited to jobs whose prompt explicitly defines a useful fallback.

### Bug Cause

**Trigger:** `build_blueprint_seed()` omitted blueprint create options, while `_preflight_check_skills()` treated every attached unready skill as an unconditional block.

**Causal chain:**
1. A blueprint declares attached skills and may define a no-source prompt path.
2. Conversational creation drops the skills; direct creation retains them but strict preflight blocks incomplete setup.
3. The scheduled agent either lacks its procedure or never runs the fallback.

**Why it is wrong:** The blueprint contract was not propagated consistently, and the scheduler had no explicit per-job fallback policy.

**Working sibling / contrast:** Direct `fill_blueprint()` already persisted skill lists. Ordinary jobs without an explicit fallback should and still do fail before running when required setup is missing.

**Ruled out:** Skill discovery is not the cause; the referenced bundled skills resolve. Focused tests isolate the missing create options and unconditional readiness block.

### Fix

- Carry exact `skills` and fallback options in conversational blueprint seeds.
- Persist and expose `allow_unready_skills` through cron create, update, list, storage, and scheduler paths.
- Opt only `morning-brief` into the policy because its prompt already defines a no-source response.
- Keep strict skill readiness as the global default.

## Related Issue

Fixes #82754

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/blueprint_catalog.py` - model the explicit fallback policy and apply it to morning briefings.
- `hermes_cli/blueprint_cmd.py` - include blueprint skill and fallback options in conversational create instructions.
- `cron/jobs.py`, `cron/scheduler.py`, and `tools/cronjob_tools.py` - persist, expose, and enforce the policy consistently.
- `tests/cron/` and `tests/tools/test_cronjob_tools.py` - cover seed propagation, storage, and strict-versus-fallback preflight behavior.

## How to Test

1. Run the focused cron, blueprint, skill, and tool tests.
2. Verify a conversational morning-brief seed includes `skills=['google-workspace']` and `allow_unready_skills=True`.
3. Verify an opted-in job constructs the agent with an unready optional integration while an ordinary job remains blocked.

```bash
scripts/run_tests.sh -j 2 tests/cron/test_blueprint_catalog.py tests/cron/test_preflight_config.py tests/cron/test_cronjob_schema.py tests/skills/test_weekly_review_planning_skill.py tests/tools/test_cronjob_tools.py
```

Result: 113 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all 113 tests pass
- [x] I've added regression tests for the changed behavior
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant behavior is documented in docstrings and the cronjob tool schema
- [x] `cli-config.yaml.example` update is not applicable because this is persisted per-job state, not user config
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable because no architecture or workflow contract changed
- [x] Cross-platform impact was considered; the change uses platform-neutral job metadata
- [x] The cronjob tool description and schema include the new option

## Screenshots / Logs

Not applicable. Automated behavior tests and lint checks cover the changed paths.
