### PR TITLE
fix(aux): honour Copilot per-model wire when api_mode is stale

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6024,6 +6024,30 @@ def resolve_provider_client(
         if provider == "actual":
             return True
         if api_mode == "codex_responses":
+            # Copilot serves each model on exactly one wire: GPT-5+ on the
+            # Responses API, everything else (Claude, Gemini, ...) on Chat
+            # Completions. A profile-level ``api_mode: codex_responses`` is a
+            # statement about the model configured when that line was written,
+            # NOT about whichever model the caller is resolving now. Honouring
+            # it blindly wraps a Claude slot in CodexAuxiliaryClient and every
+            # call dies with HTTP 400 unsupported_api_for_model. That is how a
+            # stale api_mode silently disabled the goal judge while main chat
+            # kept working, surfacing as "completion rejected by judge".
+            # Defer to the provider's own per-model capability check.
+            if provider == "copilot" and model_str:
+                try:
+                    from hermes_cli.models import _should_use_copilot_responses_api
+
+                    if not _should_use_copilot_responses_api(model_str):
+                        logger.debug(
+                            "resolve_provider_client: ignoring api_mode="
+                            "codex_responses for copilot model %s - it is "
+                            "served over chat.completions",
+                            model_str,
+                        )
+                        return False
+                except ImportError:
+                    pass
             return True
         # Auto-detect: api.openai.com + codex model name pattern
         if api_mode and api_mode != "codex_responses":

--- a/tests/agent/test_aux_copilot_api_mode.py
+++ b/tests/agent/test_aux_copilot_api_mode.py
@@ -1,0 +1,81 @@
+"""Auxiliary transport selection must follow the MODEL, not a stale api_mode.
+
+Regression contract for the goal-judge outage (2026-08-10):
+
+``model.api_mode: codex_responses`` in a profile's config.yaml was written for
+a GPT-5 main model.  When that profile later switched its model to
+``claude-opus-5``, main chat kept working (it resolves the wire per model) but
+every auxiliary call inherited the stale literal, got wrapped in
+``CodexAuxiliaryClient``, and died with::
+
+    HTTP 400 unsupported_api_for_model
+    model claude-opus-5 does not support Responses API
+
+Because the goal judge runs on the auxiliary lane, the user-visible symptom was
+``kanban: goal completion rejected by judge`` — a transport bug wearing the
+costume of a review verdict.  These tests assert the invariant that prevents
+that whole failure class: for Copilot, the model decides the wire.
+"""
+
+import pytest
+
+from hermes_cli.models import _should_use_copilot_responses_api
+
+
+class TestCopilotResponsesCapability:
+    """The capability predicate the auxiliary router must defer to."""
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.4", "gpt-5.3-codex"])
+    def test_gpt5_family_uses_responses_api(self, model):
+        assert _should_use_copilot_responses_api(model) is True
+
+    @pytest.mark.parametrize(
+        "model", ["claude-opus-5", "claude-sonnet-5", "gemini-3.6-flash", "gpt-5-mini"]
+    )
+    def test_non_responses_models_use_chat_completions(self, model):
+        assert _should_use_copilot_responses_api(model) is False
+
+
+class TestStaleApiModeIsNotHonoured:
+    """A stale ``codex_responses`` must not wrap a Chat-Completions model.
+
+    These call the real ``resolve_provider_client`` — the exact path the goal
+    judge takes — rather than asserting on a reimplementation of the rule.
+    """
+
+    def _resolve(self, monkeypatch, model):
+        from agent import auxiliary_client as aux
+
+        monkeypatch.setattr(
+            aux, "_resolve_provider_api_key", lambda *a, **k: "test-token", raising=False
+        )
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "test-token")
+        return aux.resolve_provider_client(
+            "copilot",
+            model,
+            api_mode="codex_responses",  # the stale literal
+        )
+
+    def test_claude_model_is_not_codex_wrapped(self, monkeypatch):
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        client, resolved = self._resolve(monkeypatch, "claude-opus-5")
+        if client is None:
+            pytest.skip("no copilot credentials in this environment")
+        assert not isinstance(client, CodexAuxiliaryClient), (
+            "claude-opus-5 was wrapped for the Responses API despite Copilot "
+            "serving it over chat.completions — this is the 400 "
+            "unsupported_api_for_model regression"
+        )
+        assert resolved == "claude-opus-5"
+
+    def test_gpt5_model_still_codex_wrapped(self, monkeypatch):
+        """The fix must not over-correct: GPT-5 genuinely needs Responses."""
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        client, _ = self._resolve(monkeypatch, "gpt-5.6-sol")
+        if client is None:
+            pytest.skip("no copilot credentials in this environment")
+        assert isinstance(client, CodexAuxiliaryClient), (
+            "gpt-5.6-sol must keep the Responses-API wrapper"
+        )


### PR DESCRIPTION
## Symptom

A profile whose `config.yaml` carries a leftover `model.api_mode: codex_responses` from a GPT-5 era, but whose `model.default` is now `claude-opus-5`, hits this on **every auxiliary call**:

```
HTTP 400 unsupported_api_for_model
model claude-opus-5 does not support Responses API
```

Main chat keeps working, so the config looks fine. The goal judge runs on the auxiliary lane, so what the user actually sees is:

```
kanban: goal completion of <id> rejected by judge
```

That reads like a review verdict, not a transport failure — it sends debugging in entirely the wrong direction. In my case a completed, correct code review sat blocked because the judge could not be reached.

## Root cause

`agent/auxiliary_client.py::_needs_codex_wrap()` short-circuits on the literal:

```python
if api_mode == "codex_responses":
    return True          # never looks at the model
```

Copilot serves each model on exactly one wire — GPT-5+ on the Responses API, everything else (Claude, Gemini, …) on Chat Completions. A profile-level `api_mode` is a statement about the model that was configured **when that line was written**, not about whichever model the caller is resolving now.

Main chat resolves the wire per model (`hermes_cli/runtime_provider.py::_copilot_runtime_api_mode`), which is why it survives. The auxiliary lane inherits the stale literal verbatim and 400s.

Note the asymmetry this creates inside a single function: the non-stale copilot branch near the end of `resolve_provider_client` *already* consults `_should_use_copilot_responses_api()`. Only the explicit-`api_mode` path skipped it.

## Fix

Defer to the same predicate the sibling branch uses, scoped to `provider == "copilot"`. Every other provider keeps honouring an explicit `api_mode` unchanged, so this does not weaken `api_mode` as a general escape hatch.

## Verification

Exercised through the real `resolve_provider_client` path, not a reimplementation of the rule:

| model | `api_mode` | client | live call |
|---|---|---|---|
| `claude-opus-5` | `codex_responses` (stale) | `OpenAI` | OK |
| `gpt-5.6-sol` | `codex_responses` | `CodexAuxiliaryClient` | OK |

The GPT-5 row is deliberately part of the test: the fix must not over-correct and strip the wrapper from models that genuinely need Responses.

End-to-end, on a profile still carrying the stale value, `judge_goal()` returns `verdict=done, transport_failed=False` where it previously raised.

**Regression** — `tests/agent -k "aux or auxiliary or provider or goal"`:

```
baseline (upstream main): 6 failed, 598 passed
with this patch:          5 failed, 599 passed
```

The single delta is the new test. The other five fail identically on unpatched `origin/main` and are untouched by this change.

## Tests added

`tests/agent/test_aux_copilot_api_mode.py` — verified RED on unpatched code (`test_claude_model_is_not_codex_wrapped` fails) and GREEN with the fix (9 passed, 0 skipped). The tests skip cleanly when no Copilot credentials are present.
