### PR TITLE
fix(desktop): isolate runtime plugin render hooks

### DIFF
--- a/apps/desktop/src/app/chat/route-tile.tsx
+++ b/apps/desktop/src/app/chat/route-tile.tsx
@@ -9,7 +9,7 @@
 
 import { lazy, type ReactNode, Suspense } from 'react'
 
-import { ContribBoundary } from '@/contrib/react/boundary'
+import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { $routeTiles, closeRouteTile, type RouteTile } from '@/store/route-tiles'
 
@@ -57,13 +57,19 @@ function RouteTilePane({ path }: { path: string }) {
   if (builtin) {
     return (
       <ContribBoundary id={path}>
-        <Suspense fallback={null}>{builtin.render()}</Suspense>
+        <Suspense fallback={null}>
+          <ContribRender render={builtin.render} />
+        </Suspense>
       </ContribBoundary>
     )
   }
 
   if (contrib) {
-    return <ContribBoundary id={path}>{contrib.render()}</ContribBoundary>
+    return (
+      <ContribBoundary id={path}>
+        <ContribRender render={contrib.render} />
+      </ContribBoundary>
+    )
   }
 
   return (

--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -18,7 +18,7 @@ import type { GroupSetter } from '@/app/shell/group-setter'
 import type { StatusbarItem } from '@/app/shell/statusbar-controls'
 import type { TitlebarTool } from '@/app/shell/titlebar-controls'
 import { DecodeText } from '@/components/ui/decode-text'
-import { ContribBoundary } from '@/contrib/react/boundary'
+import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { registry } from '@/contrib/registry'
 import { getLogs } from '@/hermes'
@@ -129,7 +129,7 @@ export function useStatusbarContributions(side: 'left' | 'right'): StatusbarItem
             id: c.id,
             render: () => (
               <ContribBoundary id={c.id} variant="chip">
-                {c.render!()}
+                <ContribRender render={c.render!} />
               </ContribBoundary>
             )
           } satisfies StatusbarItem)

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -11,7 +11,7 @@ import { useStore } from '@nanostores/react'
 import { type ComponentProps, lazy, memo, type ReactNode, Suspense, useMemo } from 'react'
 import { Navigate, Route, Routes, useParams } from 'react-router'
 
-import { ContribBoundary } from '@/contrib/react/boundary'
+import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $freshDraftReady, $gatewayState } from '@/store/session'
@@ -179,7 +179,11 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
           as every other contribution mount. */}
       {routeContributions.map(route => (
         <Route
-          element={page(<ContribBoundary id={route.key}>{route.render()}</ContribBoundary>)}
+          element={page(
+            <ContribBoundary id={route.key}>
+              <ContribRender render={route.render} />
+            </ContribBoundary>
+          )}
           key={route.key}
           path={route.path.slice(1)}
         />

--- a/apps/desktop/src/app/shell/statusbar-controls.tsx
+++ b/apps/desktop/src/app/shell/statusbar-controls.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/context-menu'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Tip, TipKeybindLabel, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { ContribRender } from '@/contrib/react/boundary'
 import { useI18n } from '@/i18n'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
@@ -209,7 +210,7 @@ const StatusbarItemView = memo(function StatusbarItemView({
 
   // Render escape hatch: the contribution owns its own chrome/state/tooltip.
   if (item.render) {
-    return <>{item.render()}</>
+    return <ContribRender render={item.render} />
   }
 
   const tooltipLabel = item.actionId ? <TipKeybindLabel actionId={item.actionId} text={item.title} /> : item.title

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -25,7 +25,7 @@ import {
   PaneTabLabel,
   PaneTabStrip
 } from '@/components/ui/pane-tab'
-import { ContribBoundary } from '@/contrib/react/boundary'
+import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
@@ -629,7 +629,7 @@ export function TreeGroup({
                     <PaneGroupContext.Provider value={node.id}>
                       <PaneVisibleContext.Provider value={isActive}>
                         <ContribBoundary id={pane.id} key={paneEpochs[paneId] ?? 0}>
-                          {pane.render()}
+                          <ContribRender render={pane.render} />
                         </ContribBoundary>
                       </PaneVisibleContext.Provider>
                     </PaneGroupContext.Provider>

--- a/apps/desktop/src/contrib/react/boundary.tsx
+++ b/apps/desktop/src/contrib/react/boundary.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { createElement, type ReactNode } from 'react'
 
 import { ErrorBoundary } from '@/components/error-boundary'
 import { Button } from '@/components/ui/button'
@@ -12,6 +12,16 @@ interface ContribBoundaryProps {
   id: string
   /** `chip` = inline bar item (tiny fallback); `pane` = zone body. */
   variant?: 'chip' | 'pane'
+}
+
+interface ContribRenderProps {
+  render: () => ReactNode
+}
+
+/** Mount a contribution callback as a component so its hooks and errors belong
+ * to the contribution, not to whichever host surface happened to call it. */
+export function ContribRender({ render }: ContribRenderProps) {
+  return createElement(render)
 }
 
 /**

--- a/apps/desktop/src/contrib/react/slot.test.tsx
+++ b/apps/desktop/src/contrib/react/slot.test.tsx
@@ -1,0 +1,74 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '../registry'
+
+import { Slot } from './slot'
+
+const disposers: Array<() => void> = []
+
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+  vi.restoreAllMocks()
+})
+
+describe('Slot contribution render boundary', () => {
+  it('hot-mounts and replaces hook-using plugin renders without changing the host hook order', () => {
+    const area = 'test.plugin-hook-boundary'
+    const id = 'stateful-plugin'
+
+    function FirstPluginRender() {
+      const [count, setCount] = useState(0)
+
+      return <button onClick={() => setCount(value => value + 1)}>first:{count}</button>
+    }
+
+    function ReloadedPluginRender() {
+      const [count, setCount] = useState(10)
+      const [suffix] = useState('ready')
+
+      return <button onClick={() => setCount(value => value + 1)}>reloaded:{count}:{suffix}</button>
+    }
+
+    render(<Slot area={area} />)
+
+    act(() => {
+      disposers.push(registry.register({ area, id, render: FirstPluginRender, source: 'disk' }))
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'first:0' }))
+    expect(screen.getByRole('button', { name: 'first:1' })).toBeTruthy()
+
+    act(() => {
+      disposers.push(registry.register({ area, id, render: ReloadedPluginRender, source: 'disk' }))
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'reloaded:10:ready' }))
+    expect(screen.getByRole('button', { name: 'reloaded:11:ready' })).toBeTruthy()
+  })
+
+  it('lets the contribution boundary contain a render-time plugin failure', () => {
+    const area = 'test.plugin-error-boundary'
+    const id = 'broken-plugin'
+
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    render(<Slot area={area} />)
+
+    act(() => {
+      disposers.push(
+        registry.register({
+          area,
+          id,
+          render: () => {
+            throw new Error('plugin render failed')
+          },
+          source: 'disk'
+        })
+      )
+    })
+
+    expect(screen.getByRole('button', { name: id })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/contrib/react/slot.tsx
+++ b/apps/desktop/src/contrib/react/slot.tsx
@@ -1,4 +1,4 @@
-import { ContribBoundary } from './boundary'
+import { ContribBoundary, ContribRender } from './boundary'
 import { useContributions } from './use-contributions'
 
 export interface SlotProps {
@@ -18,7 +18,7 @@ export function Slot({ area }: SlotProps) {
     <>
       {items.map(c => (
         <ContribBoundary id={c.id} key={`${c.source ?? 'core'}:${c.id}`} variant="chip">
-          {c.render?.()}
+          {c.render && <ContribRender render={c.render} />}
         </ContribBoundary>
       ))}
     </>


### PR DESCRIPTION
## Summary

- mount runtime contribution render callbacks as real React child components
- apply the boundary consistently to slots, chat routes, route tiles, panes, and statusbar contributions
- add hot-registration and render-failure regressions

## Root cause

Desktop hosts called plugin `render()` callbacks while rendering the host component. A hook used by a plugin therefore became a hook of the host. Loading or replacing a plugin changed the host's hook count and could trigger React error #310. It also meant a render-time plugin exception occurred before `ContribBoundary` received its child, so the boundary could not contain the failure.

`ContribRender` passes the callback to `createElement`, giving each contribution its own component boundary. Replacing a callback now remounts that child instead of changing the host's hook order, and plugin exceptions occur below `ContribBoundary`.

I audited every production `.render()` contribution call under `apps/desktop/src`; no direct callback invocation remains.

Fixes #80560

## Verification

- `npx vitest run --project ui src/contrib/react/slot.test.tsx` - 2 passed
- `npm run typecheck` - passed
- `npm run lint` - 0 errors (89 pre-existing warnings)
- `npm run build` - passed, including `assert-dist-built`
- `git diff --check origin/main...HEAD` - passed
- contribution publish gate and gitleaks - passed

The full Desktop UI run completed with 3,624 passing tests and 8 aggregate timeout/order failures in four unrelated existing files. Each affected file passes in a fresh process (19/19 total); the intermittent messaging file also passes on untouched exact-base `main` (7/7).
