### PR TITLE
fix(desktop): restore first-chat profile-build onboarding in tui_gateway

### DIFF
--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -167,6 +167,43 @@ def profile_build_mode(config: Mapping[str, Any]) -> str:
     return "ask"
 
 
+PLAIN_INTRO_NOTE = (
+    "[System note: This is the user's very first message ever. "
+    "Briefly introduce yourself and mention that /help shows available commands. "
+    "Keep the introduction concise -- one or two sentences max.]"
+)
+
+
+def first_contact_turn_note(
+    config: Mapping[str, Any],
+    config_path: Path,
+    *,
+    session_history_empty: bool,
+    install_has_prior_sessions: bool,
+) -> Optional[str]:
+    """Return a one-shot sidecar note for the install's first-ever message.
+
+    Matches the gateway first-contact path: when ``profile_build`` is ``ask``
+    and the offer has not been latched yet, return the opt-in profile-build
+    directive and persist ``onboarding.seen.profile_build_offered``. Otherwise
+    return the plain intro note. Returns ``None`` when this is not the first
+    contact (non-empty session history or prior sessions exist on the install).
+    """
+    if not session_history_empty or install_has_prior_sessions:
+        return None
+    try:
+        if (
+            profile_build_mode(config) == "ask"
+            and not is_seen(config, PROFILE_BUILD_FLAG)
+        ):
+            mark_seen(config_path, PROFILE_BUILD_FLAG)
+            return profile_build_directive().strip()
+        return PLAIN_INTRO_NOTE
+    except Exception as e:
+        logger.debug("first_contact_turn_note failed, using plain intro: %s", e)
+        return PLAIN_INTRO_NOTE
+
+
 def profile_build_directive() -> str:
     """System-note directive appended to the very first message ever.
 
@@ -253,6 +290,8 @@ __all__ = [
     "TOOL_PROGRESS_FLAG",
     "OPENCLAW_RESIDUE_FLAG",
     "PROFILE_BUILD_FLAG",
+    "PLAIN_INTRO_NOTE",
+    "first_contact_turn_note",
     "busy_input_hint_gateway",
     "busy_input_hint_cli",
     "tool_progress_hint_gateway",

--- a/tests/agent/test_onboarding.py
+++ b/tests/agent/test_onboarding.py
@@ -225,3 +225,48 @@ class TestProfileBuildConfigDefault:
         from hermes_cli.config import DEFAULT_CONFIG
 
         assert DEFAULT_CONFIG["onboarding"]["profile_build"] == "ask"
+
+
+class TestFirstContactTurnNote:
+    def test_returns_profile_directive_and_marks_seen(self, tmp_path):
+        from agent.onboarding import (
+            PROFILE_BUILD_FLAG,
+            first_contact_turn_note,
+            profile_build_directive,
+        )
+
+        cfg_path = tmp_path / "config.yaml"
+        cfg = {"onboarding": {"profile_build": "ask"}}
+        note = first_contact_turn_note(
+            cfg,
+            cfg_path,
+            session_history_empty=True,
+            install_has_prior_sessions=False,
+        )
+        assert note == profile_build_directive().strip()
+        loaded = yaml.safe_load(cfg_path.read_text())
+        assert loaded["onboarding"]["seen"][PROFILE_BUILD_FLAG] is True
+
+    def test_returns_none_when_not_first_contact(self, tmp_path):
+        from agent.onboarding import first_contact_turn_note
+
+        cfg_path = tmp_path / "config.yaml"
+        assert (
+            first_contact_turn_note(
+                {},
+                cfg_path,
+                session_history_empty=False,
+                install_has_prior_sessions=False,
+            )
+            is None
+        )
+        assert (
+            first_contact_turn_note(
+                {},
+                cfg_path,
+                session_history_empty=True,
+                install_has_prior_sessions=True,
+            )
+            is None
+        )
+        assert not cfg_path.exists()

--- a/tests/tui_gateway/test_first_contact_onboarding.py
+++ b/tests/tui_gateway/test_first_contact_onboarding.py
@@ -1,0 +1,154 @@
+"""Desktop/TUI first-contact profile-build onboarding via tui_gateway."""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+import yaml
+
+from agent.onboarding import PROFILE_BUILD_FLAG, profile_build_directive
+from tui_gateway import server
+
+
+class _InlineThread:
+    def __init__(self, target=None, daemon=None, args=(), kwargs=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+def _session(agent=None, **extra):
+    return {
+        "agent": agent if agent is not None else types.SimpleNamespace(),
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "inflight_turn": None,
+        **extra,
+    }
+
+
+@pytest.fixture()
+def emits(monkeypatch):
+    captured: list = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: captured.append((event, sid, payload)),
+    )
+    return captured
+
+
+@pytest.fixture()
+def marker_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture()
+def turn_env(monkeypatch, tmp_path, marker_home):
+    monkeypatch.setattr(server.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda sid: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda sid, session: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
+    monkeypatch.setattr(server, "_tts_stream_begin", lambda: None)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_usage", lambda agent: {})
+    monkeypatch.setattr(server, "_load_interim_assistant_messages", lambda: False)
+    monkeypatch.setattr(server, "_pending_reaction_notes", lambda _s: "")
+
+
+def test_run_prompt_submit_stages_profile_build_on_first_contact(
+    monkeypatch, tmp_path, emits, turn_env, marker_home
+):
+    """Fresh install + empty history must stage the opt-in profile-build note."""
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({"onboarding": {"profile_build": "ask"}}))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_install_has_prior_sessions", lambda _s: False)
+
+    staged: list[str] = []
+
+    def _run(message, **kwargs):
+        staged.append(getattr(agent, "_gateway_turn_context_notes", ""))
+        return {"final_response": "done"}
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(agent=agent, running=True)
+
+    server._run_prompt_submit("rid", "sid", session, "hello there")
+
+    assert staged == [profile_build_directive().strip()]
+    loaded = yaml.safe_load(cfg_path.read_text())
+    assert loaded["onboarding"]["seen"][PROFILE_BUILD_FLAG] is True
+
+
+def test_run_prompt_submit_skips_first_contact_when_prior_sessions_exist(
+    emits, turn_env, marker_home, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_install_has_prior_sessions", lambda _s: True)
+
+    staged: list[str] = []
+
+    def _run(message, **kwargs):
+        staged.append(getattr(agent, "_gateway_turn_context_notes", ""))
+        return {"final_response": "done"}
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(agent=agent, running=True)
+
+    server._run_prompt_submit("rid", "sid", session, "hello again")
+
+    assert staged == [""]
+
+
+def test_run_prompt_submit_skips_first_contact_when_history_not_empty(
+    emits, turn_env, marker_home, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_install_has_prior_sessions", lambda _s: False)
+
+    staged: list[str] = []
+
+    def _run(message, **kwargs):
+        staged.append(getattr(agent, "_gateway_turn_context_notes", ""))
+        return {"final_response": "done"}
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(
+        agent=agent,
+        running=True,
+        history=[{"role": "user", "content": "prior"}],
+    )
+
+    server._run_prompt_submit("rid", "sid", session, "follow up")
+
+    assert staged == [""]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2856,6 +2856,41 @@ def _ensure_session_db_row(session: dict) -> None:
                 pass
 
 
+def _install_has_prior_sessions(session: dict) -> bool:
+    """True when this install already has session rows beyond the current one.
+
+    Mirrors ``gateway.session.SessionStore.has_any_sessions``: the current
+    session row is persisted before ``_run_prompt_submit``, so a fresh install
+    with its first-ever message has exactly one row and this returns False.
+    """
+    profile_home = session.get("profile_home")
+    close_db = False
+    if profile_home:
+        from hermes_state import SessionDB
+
+        try:
+            db = SessionDB(db_path=Path(profile_home) / "state.db")
+            close_db = True
+        except Exception:
+            logger.debug("failed to open profile db for session count", exc_info=True)
+            return False
+    else:
+        db = _get_db()
+    if db is None:
+        return False
+    try:
+        return db.session_count_ge(2)
+    except Exception:
+        logger.debug("session_count_ge failed for first-contact check", exc_info=True)
+        return False
+    finally:
+        if close_db:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
 def _persist_branch_seed(session: dict) -> None:
     """First-turn persist of a branch's copied transcript.
 
@@ -9845,6 +9880,31 @@ def _run_prompt_submit(
             # Which window the message was typed into. HUD mode is per-turn
             # state, so it cannot live in the (byte-stable) system prompt.
             run_message = _prepend_note(run_message, _hud_surface_note(session))
+
+            # First-message onboarding (gateway parity): on the install's very
+            # first message ever, stage a one-shot sidecar note offering opt-in
+            # profile setup (or a plain intro when profile_build is off/already
+            # offered). Delivered via agent._gateway_turn_context_notes so the
+            # ephemeral system prompt stays byte-stable.
+            if not history:
+                try:
+                    from agent.onboarding import first_contact_turn_note
+                    from hermes_cli.config import load_config as _onb_load_config
+                    from hermes_constants import get_hermes_home
+
+                    _onb_cfg = _onb_load_config()
+                    _fc_note = first_contact_turn_note(
+                        _onb_cfg,
+                        get_hermes_home() / "config.yaml",
+                        session_history_empty=True,
+                        install_has_prior_sessions=_install_has_prior_sessions(session),
+                    )
+                    if _fc_note:
+                        agent._gateway_turn_context_notes = _fc_note
+                except Exception as _fc_err:
+                    logger.debug(
+                        "first-contact onboarding note failed: %s", _fc_err
+                    )
 
             def _stream(delta):
                 with session["history_lock"]:


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where Hermes Desktop skipped the opt-in first-chat profile-build onboarding on a fresh install. Messaging gateway already staged the profile-build system note on the install's first message; Desktop goes through `tui_gateway`, which never applied that path, so the agent answered the first prompt without introducing itself or offering profile setup and `onboarding.seen.profile_build_offered` stayed unset.

This PR adds a shared `first_contact_turn_note()` helper in `agent/onboarding.py` and wires it into `tui_gateway/server.py::_run_prompt_submit` so Desktop/TUI first-ever messages stage the same one-shot sidecar note via `agent._gateway_turn_context_notes`.

## Related Issue

Fixes #82750

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/onboarding.py`: add `first_contact_turn_note()` and `PLAIN_INTRO_NOTE` shared by gateway and TUI paths
- `tui_gateway/server.py`: detect first-ever install message and stage profile-build/intro sidecar notes; add `_install_has_prior_sessions()`
- `tests/tui_gateway/test_first_contact_onboarding.py`: integration tests for the Desktop/TUI submit path
- `tests/agent/test_onboarding.py`: unit tests for the shared helper

## How to Test

1. Start from a fresh profile with `onboarding.profile_build: ask` and no prior sessions.
2. Complete Desktop provider setup, open Hermes Desktop, and send the first chat message.
3. Confirm the assistant introduces itself and offers opt-in profile setup; verify `onboarding.seen.profile_build_offered: true` is written to config after the turn.
4. Run `scripts/run_tests.sh tests/tui_gateway/test_first_contact_onboarding.py tests/agent/test_onboarding.py::TestFirstContactTurnNote -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Cloud Agent); issue reporter env Windows 10 / Hermes Desktop v0.20.0

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reporter debug dump (issue #82750): first Desktop turn logged `history=0` with no profile-build sidecar; `onboarding.seen.profile_build_offered` remained unset. Automated repro: `tests/tui_gateway/test_first_contact_onboarding.py` fails on current main without this patch and passes with it.