### PR TITLE
fix(desktop): preserve session history using message_id truncation

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -366,8 +366,8 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
   // Rewind primitive (interrupt-first for live turns, busy-retry) — shared with
   // the primary chat so the two can't diverge.
   const submitRewind = useCallback(
-    (text: string, truncateOrdinal: number | undefined, interruptFirst: boolean) =>
-      runRewindSubmit(requestGateway, runtimeIdRef.current, text, truncateOrdinal, interruptFirst, {
+    (text: string, truncateOrdinal: number | undefined, interruptFirst: boolean, truncateMessageId?: string) =>
+      runRewindSubmit(requestGateway, runtimeIdRef.current, text, truncateOrdinal, truncateMessageId, interruptFirst, {
         storedSessionId: storedIdRef.current,
         onSessionRecovered: recoveredId => {
           runtimeIdRef.current = recoveredId
@@ -398,7 +398,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
           {
             session_id: runtimeIdRef.current,
             text: plan.text,
-            ...truncateSubmitParams(plan.truncateOrdinal)
+            ...truncateSubmitParams(plan.truncateOrdinal, plan.truncateMessageId)
           },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
@@ -425,7 +425,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(state => applyRewindOptimistic(state, plan.sourceIndex))
 
       try {
-        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy)
+        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy, plan.truncateMessageId)
       } catch (err) {
         update(state => ({ ...state, busy: false, awaitingResponse: false, messages }))
         throw err
@@ -454,7 +454,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       update(state => applyRewindOptimistic(state, plan.sourceIndex, plan.editedMessage))
 
       try {
-        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy)
+        await submitRewind(plan.text, plan.truncateOrdinal, wasBusy, plan.truncateMessageId)
       } catch (err) {
         update(state => ({ ...state, busy: false, awaitingResponse: false, messages }))
         notifyError(err, copy.editFailed)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2294,6 +2294,7 @@ describe('usePromptActions restoreToMessage', () => {
         text: 'first prompt',
         confirm_truncate: true,
         truncate_before_user_ordinal: 0,
+        truncate_before_message_id: 'u1',
         confirm_empty_truncate: true
       },
       1_800_000
@@ -2363,6 +2364,7 @@ describe('usePromptActions restoreToMessage', () => {
         text: 'first prompt',
         confirm_truncate: true,
         truncate_before_user_ordinal: 0,
+        truncate_before_message_id: 'u1',
         confirm_empty_truncate: true
       },
       1_800_000
@@ -2410,6 +2412,7 @@ describe('usePromptActions restoreToMessage', () => {
         text: 'first prompt',
         confirm_truncate: true,
         truncate_before_user_ordinal: 0,
+        truncate_before_message_id: 'u1',
         confirm_empty_truncate: true
       },
       1_800_000

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -809,7 +809,7 @@ export function usePromptActions({
           {
             session_id: sessionId,
             text: plan.text,
-            ...truncateSubmitParams(plan.truncateOrdinal)
+            ...truncateSubmitParams(plan.truncateOrdinal, plan.truncateMessageId)
           },
           PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
         )
@@ -825,18 +825,15 @@ export function usePromptActions({
     [activeSessionIdRef, copy.regenerateFailed, requestGateway, updateSessionState]
   )
 
-  // Cursor-style "restore checkpoint": rewind the conversation to a past user
-  // prompt and run it again from there. Reuses the edit composer's rewind
-  // mechanism — `prompt.submit` with `truncate_before_user_ordinal` drops that
-  // user turn and everything after it from the session history, then the same
-  // text is submitted as a fresh turn. Callers confirm before invoking; errors
-  // are rethrown so callers can surface failures. Idle rewinds submit directly:
-  // interrupting an idle agent can leave a stale interrupt flag that cancels the
-  // fresh turn. Live/stuck turns interrupt first, and a raced "session busy"
-  // response interrupts + retries through the shared busy gate.
   const submitRewindPrompt = useCallback(
-    (sessionId: string, text: string, truncateOrdinal: number | undefined, interruptFirst: boolean) =>
-      runRewindSubmit(requestGateway, sessionId, text, truncateOrdinal, interruptFirst, {
+    (
+      sessionId: string,
+      text: string,
+      truncateOrdinal: number | undefined,
+      truncateMessageId: string | undefined,
+      interruptFirst: boolean
+    ) =>
+      runRewindSubmit(requestGateway, sessionId, text, truncateOrdinal, truncateMessageId, interruptFirst, {
         storedSessionId: selectedStoredSessionIdRef.current,
         onSessionRecovered: recoveredId => {
           activeSessionIdRef.current = recoveredId
@@ -873,7 +870,13 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyRewindOptimistic(state, plan.sourceIndex))
 
       try {
-        await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
+        await submitRewindPrompt(
+          sessionId,
+          plan.text,
+          plan.truncateOrdinal,
+          plan.truncateMessageId,
+          busyRef.current || $busy.get()
+        )
       } catch (err) {
         // The rewind never landed (e.g. the gateway stayed busy past the retry
         // deadline). Roll the optimistic truncation back to the full original
@@ -921,17 +924,25 @@ export function usePromptActions({
       updateSessionState(sessionId, state => applyRewindOptimistic(state, plan.sourceIndex, plan.editedMessage))
 
       const isStaleTargetError = (err: unknown) =>
-        /no longer in session history|not in session history/i.test(err instanceof Error ? err.message : String(err))
+        /no longer in session history|not in session history|does not match/i.test(
+          err instanceof Error ? err.message : String(err)
+        )
 
       try {
-        await submitRewindPrompt(sessionId, plan.text, plan.truncateOrdinal, busyRef.current || $busy.get())
+        await submitRewindPrompt(
+          sessionId,
+          plan.text,
+          plan.truncateOrdinal,
+          plan.truncateMessageId,
+          busyRef.current || $busy.get()
+        )
       } catch (err) {
         let surfaced = err
 
         if (!plan.isFailedTurn && isStaleTargetError(err)) {
           try {
             // Already interrupted on the first attempt — submit as a plain resend.
-            await submitRewindPrompt(sessionId, plan.text, undefined, false)
+            await submitRewindPrompt(sessionId, plan.text, undefined, undefined, false)
 
             return
           } catch (retryErr) {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -19,15 +19,15 @@ describe('truncateSubmitParams', () => {
     })
   })
 
-  it('never sends an ordinal without the intent flag the gateway requires', () => {
-    // The gateway drops history only for a submit that declares itself a
-    // rewind. An ordinal built here without confirm_truncate would be refused
-    // (and, on an older gateway, would truncate silently).
-    for (const ordinal of [0, 1, 2, 7]) {
-      const params = truncateSubmitParams(ordinal)
-
-      expect(params.truncate_before_user_ordinal).toBe(ordinal)
-      expect(params.confirm_truncate).toBe(true)
-    }
+  it('includes truncate_before_message_id when passed', () => {
+    expect(truncateSubmitParams(1, 'msg-123')).toEqual({
+      confirm_truncate: true,
+      truncate_before_user_ordinal: 1,
+      truncate_before_message_id: 'msg-123'
+    })
+    expect(truncateSubmitParams(undefined, 'msg-123')).toEqual({
+      confirm_truncate: true,
+      truncate_before_message_id: 'msg-123'
+    })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -34,36 +34,34 @@ type RequestGateway = <T = unknown>(method: string, params?: Record<string, unkn
  * transcript (restore/regenerate the first user turn), which the gateway gates
  * behind `confirm_empty_truncate` on top of that.
  */
-export function truncateSubmitParams(truncateOrdinal: number | undefined): Record<string, unknown> {
-  if (truncateOrdinal === undefined) {
+export function truncateSubmitParams(
+  truncateOrdinal: number | undefined,
+  truncateMessageId?: string
+): Record<string, unknown> {
+  if (truncateOrdinal === undefined && !truncateMessageId) {
     return {}
   }
 
   return {
     confirm_truncate: true,
-    truncate_before_user_ordinal: truncateOrdinal,
+    ...(truncateOrdinal !== undefined ? { truncate_before_user_ordinal: truncateOrdinal } : {}),
+    ...(truncateMessageId ? { truncate_before_message_id: truncateMessageId } : {}),
     ...(truncateOrdinal === 0 ? { confirm_empty_truncate: true } : {})
   }
 }
 
 /**
  * Rewind a turn: `prompt.submit` with an optional `truncate_before_user_ordinal`
- * (drops that user turn + everything after). Idle rewinds submit directly
- * (interrupting an idle agent can leave a stale interrupt flag that cancels the
- * fresh turn); live/stuck turns interrupt first, and a raced "session busy"
- * response interrupts + retries through the shared busy gate.
- *
- * A rewind runs right after `cancelRun`, and interrupting can drop the
- * gateway's in-memory session — so the follow-up submit hits a dead runtime id
- * and used to surface a bare "session not found" ("Restore checkpoint" failing
- * after a stop). Pass `recovery` so a stale id re-registers and retries like
- * every other session-scoped RPC.
+ * / `truncate_before_message_id` (drops that user turn + everything after).
+ * Idle rewinds submit directly; live/stuck turns interrupt first, and a raced
+ * "session busy" response interrupts + retries through the shared busy gate.
  */
 export async function runRewindSubmit(
   requestGateway: RequestGateway,
   sessionId: string,
   text: string,
   truncateOrdinal: number | undefined,
+  truncateMessageId: string | undefined,
   interruptFirst: boolean,
   recovery?: { storedSessionId?: null | string; onSessionRecovered?: (sessionId: string) => void }
 ): Promise<void> {
@@ -85,7 +83,7 @@ export async function runRewindSubmit(
       {
         session_id: targetId,
         text,
-        ...truncateSubmitParams(truncateOrdinal)
+        ...truncateSubmitParams(truncateOrdinal, truncateMessageId)
       },
       PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
     )
@@ -133,6 +131,7 @@ export interface ReloadPlan {
   branchGroupId: string
   text: string
   truncateOrdinal: number
+  truncateMessageId?: string
   userIndex: number
 }
 
@@ -164,6 +163,7 @@ export function planReload(messages: ChatMessage[], parentId: null | string): nu
     branchGroupId: targetAssistant?.branchGroupId ?? branchGroupForUser(userMessage),
     text,
     truncateOrdinal: visibleUserOrdinal(messages, userIndex),
+    truncateMessageId: userMessage.id,
     userIndex
   }
 }
@@ -202,6 +202,7 @@ export interface RestorePlan {
   sourceIndex: number
   text: string
   truncateOrdinal: number
+  truncateMessageId?: string
 }
 
 /** Resolve the user turn to rewind to; throws with a user-facing reason. */
@@ -231,7 +232,7 @@ export function planRestore(messages: ChatMessage[], messageId: string, target?:
       ? visibleUserOrdinal(messages, sourceIndex)
       : target.userOrdinal
 
-  return { sourceIndex, text, truncateOrdinal }
+  return { sourceIndex, text, truncateOrdinal, truncateMessageId: source.id }
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +245,7 @@ export interface EditPlan {
   sourceIndex: number
   text: string
   truncateOrdinal: number | undefined
+  truncateMessageId?: string
 }
 
 /** Resolve the edited user turn, or null when nothing changed / invalid. */
@@ -272,7 +274,8 @@ export function planEdit(messages: ChatMessage[], edited: AppendMessage): EditPl
     isFailedTurn,
     sourceIndex,
     text,
-    truncateOrdinal: isFailedTurn ? undefined : visibleUserOrdinal(messages, sourceIndex)
+    truncateOrdinal: isFailedTurn ? undefined : visibleUserOrdinal(messages, sourceIndex),
+    truncateMessageId: isFailedTurn ? undefined : source.id
   }
 }
 

--- a/contributors/emails/StanleyStetson@users.noreply.github.com
+++ b/contributors/emails/StanleyStetson@users.noreply.github.com
@@ -1,0 +1,1 @@
+StanleyStetson <StanleyStetson@users.noreply.github.com>

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4394,6 +4394,115 @@ def test_prompt_submit_refuses_unconfirmed_nonempty_truncation(monkeypatch):
         server._sessions.pop("unconfirmed-trunc-sid", None)
 
 
+def test_prompt_submit_truncates_by_message_id(monkeypatch):
+    """#82756: truncate_before_message_id resolves target message and cuts history accurately."""
+    replaced = []
+
+    class _FakeDB:
+        def replace_messages(self, key, messages, active_only=False):
+            replaced.append((key, list(messages)))
+
+    history = [
+        {"id": "msg-1", "role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"id": "msg-2", "role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+    ]
+    server._sessions["msg-id-trunc-sid"] = _session(history=list(history))
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: None
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "msg-id-trunc-sid",
+                    "text": "new turn",
+                    "truncate_before_message_id": "msg-2",
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("result") is not None
+        assert len(replaced) == 1
+        assert replaced[0][1] == history[:2]
+    finally:
+        server._sessions.pop("msg-id-trunc-sid", None)
+
+
+def test_prompt_submit_refuses_ordinal_and_message_id_mismatch(monkeypatch):
+    """#82756: A mismatch between truncate_before_user_ordinal and truncate_before_message_id must return 4030."""
+    history = [
+        {"id": "msg-1", "role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+        {"id": "msg-2", "role": "user", "content": "second"},
+        {"role": "assistant", "content": "reply 2"},
+    ]
+    server._sessions["mismatch-trunc-sid"] = _session(history=list(history))
+    monkeypatch.setattr(
+        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+    monkeypatch.setattr(
+        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "mismatch-trunc-sid",
+                    "text": "new turn",
+                    "truncate_before_message_id": "msg-2",  # ordinal index 1
+                    "truncate_before_user_ordinal": 0,      # mismatch (stale 0)
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4030
+        assert "does not match" in resp["error"]["message"]
+    finally:
+        server._sessions.pop("mismatch-trunc-sid", None)
+
+
+def test_prompt_submit_refuses_boolean_ordinal(monkeypatch):
+    """Boolean truncate_before_user_ordinal must return 4004 instead of coercing to 1."""
+    history = [
+        {"id": "msg-1", "role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply 1"},
+    ]
+    server._sessions["bool-trunc-sid"] = _session(history=list(history))
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "bool-trunc-sid",
+                    "text": "new turn",
+                    "truncate_before_user_ordinal": True,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("error") is not None
+        assert resp["error"]["code"] == 4004
+        assert "must be an integer" in resp["error"]["message"]
+    finally:
+        server._sessions.pop("bool-trunc-sid", None)
+
+
+
+
 def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
     """A confirmed rewind still must not wipe a non-empty transcript by accident.
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -162,13 +162,99 @@ def _(rid, params: dict) -> dict:
         # the upgrade resumes the child's transcript as a normal conversation.
         if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
-        if truncate_user_ordinal is not None:
-            try:
-                ordinal = int(truncate_user_ordinal)
-            except (TypeError, ValueError):
-                return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
+        truncate_message_id = params.get("truncate_before_message_id")
+        if is_truthy_value(params.get("confirm_truncate")) and truncate_user_ordinal is None and truncate_message_id is None:
+            return _err(
+                rid,
+                4004,
+                "confirm_truncate requires truncate_before_user_ordinal or truncate_before_message_id",
+            )
+        if truncate_user_ordinal is not None or truncate_message_id is not None:
             history = session.get("history", [])
-            # An ordinal alone is not consent. A client that carries a leftover
+            user_indices = [
+                i for i, m in enumerate(history)
+                if m.get("role") == "user" and not m.get("display_kind")
+            ]
+
+            target_idx = None
+            ordinal = None
+
+            if truncate_message_id is not None:
+                msg_id_str = str(truncate_message_id)
+                found_match = None
+                for u_ord, h_idx in enumerate(user_indices):
+                    msg = history[h_idx]
+                    if msg.get("id") == msg_id_str or msg.get("message_id") == msg_id_str:
+                        found_match = (u_ord, h_idx)
+                        break
+
+                if found_match is None:
+                    return _err(
+                        rid,
+                        4018,
+                        "target user message is no longer in session history",
+                    )
+
+                msg_ordinal, target_idx = found_match
+
+                if truncate_user_ordinal is not None:
+                    if isinstance(truncate_user_ordinal, bool):
+                        return _err(
+                            rid,
+                            4004,
+                            "truncate_before_user_ordinal must be an integer",
+                        )
+                    try:
+                        ordinal = int(truncate_user_ordinal)
+                    except (TypeError, ValueError):
+                        return _err(
+                            rid,
+                            4004,
+                            "truncate_before_user_ordinal must be an integer",
+                        )
+                    if ordinal != msg_ordinal:
+                        logger.warning(
+                            "prompt.submit: REFUSED truncation due to ordinal mismatch for session %s "
+                            "(ordinal=%d, message_id_ordinal=%d, message_id=%s). "
+                            "Stale truncate_before_user_ordinal detected.",
+                            sid,
+                            ordinal,
+                            msg_ordinal,
+                            msg_id_str,
+                        )
+                        return _err(
+                            rid,
+                            4030,
+                            f"truncate_before_user_ordinal ({ordinal}) does not match "
+                            f"truncate_before_message_id target turn ({msg_ordinal})",
+                        )
+                else:
+                    ordinal = msg_ordinal
+            else:
+                if isinstance(truncate_user_ordinal, bool):
+                    return _err(
+                        rid,
+                        4004,
+                        "truncate_before_user_ordinal must be an integer",
+                    )
+                try:
+                    ordinal = int(truncate_user_ordinal)
+                except (TypeError, ValueError):
+                    return _err(
+                        rid,
+                        4004,
+                        "truncate_before_user_ordinal must be an integer",
+                    )
+
+                if ordinal < 0 or ordinal >= len(user_indices):
+                    return _err(
+                        rid,
+                        4018,
+                        "target user message is no longer in session history",
+                    )
+                target_idx = user_indices[ordinal]
+
+            # An ordinal/id alone is not consent. A client that carries a leftover
             # ordinal into an ORDINARY submit sends a request that is
             # indistinguishable, field by field, from a real rewind — same
             # method, same shape, an in-range target — and the cut it asks for
@@ -180,8 +266,8 @@ def _(rid, params: dict) -> dict:
                 logger.warning(
                     "prompt.submit: REFUSED unconfirmed truncation of session %s "
                     "(%d messages held; ordinal=%d). The client attached "
-                    "truncate_before_user_ordinal without confirm_truncate — "
-                    "likely a stale ordinal on an ordinary submit.",
+                    "truncation parameters without confirm_truncate — "
+                    "likely a stale parameter on an ordinary submit.",
                     sid,
                     len(history),
                     ordinal,
@@ -189,22 +275,12 @@ def _(rid, params: dict) -> dict:
                 return _err(
                     rid,
                     4029,
-                    "truncate_before_user_ordinal requires confirm_truncate=true; "
+                    "truncation requires confirm_truncate=true; "
                     "an ordinary prompt.submit must not drop session history "
                     "(update your Hermes client if a rewind was intended)",
                 )
-            user_indices = [
-                i for i, m in enumerate(history)
-                if m.get("role") == "user" and not m.get("display_kind")
-            ]
-            # Reject out-of-range ordinals on BOTH ends. A negative value would
-            # otherwise sail past the upper-bound check and hit Python's negative
-            # indexing below (user_indices[-1] -> the LAST user turn), silently
-            # truncating history to everything before it and persisting that loss
-            # via replace_messages — an unrecoverable overwrite of the session DB.
-            if ordinal < 0 or ordinal >= len(user_indices):
-                return _err(rid, 4018, "target user message is no longer in session history")
-            truncated = history[: user_indices[ordinal]]
+
+            truncated = history[:target_idx]
             # Second gate, on top of confirm_truncate: ordinal 0 resolves to
             # history[:0] == [] and replace_messages() DELETEs every durable
             # row. A confirmed rewind that happens to erase the whole
@@ -233,11 +309,12 @@ def _(rid, params: dict) -> dict:
             log_fn = logger.warning if not truncated else logger.info
             log_fn(
                 "prompt.submit: truncating session %s history %d -> %d messages "
-                "(ordinal=%d)",
+                "(ordinal=%d, message_id=%s)",
                 sid,
                 len(history),
                 len(truncated),
                 ordinal,
+                truncate_message_id or "",
             )
             # Write-before-memory (mirrors gateway hygiene / manual /compress):
             # persist the truncated transcript first. If replace_messages fails

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -750,11 +750,7 @@ export function StatusRule({
         <>
           <Text color={t.color.border}>{separatorWidth >= 3 ? ' ─ ' : ' '}</Text>
           <Box flexShrink={0} width={rightWidth}>
-            <Text
-              bold={!!sessionTitle}
-              color={sessionTitle ? t.color.accent : t.color.label}
-              wrap="truncate-end"
-            >
+            <Text bold={!!sessionTitle} color={sessionTitle ? t.color.accent : t.color.label} wrap="truncate-end">
               {rightLabel}
             </Text>
           </Box>


### PR DESCRIPTION
## What does this PR do?

Resolves Issue #82756 (P0 Data Loss) where Desktop plain-Enter prompt submits silently deleted session history due to a leftover `truncate_before_user_ordinal` carried over in composer prompt action state with auto-attached `confirm_truncate: true`.

I introduced `truncate_before_message_id` addressing across Gateway and Desktop UI, added cross-validation against stale ordinals (code `4030`), and enforced state parameter cleanup on prompt submits.

## Related Issue

Fixes #82756

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **Gateway Server (`tui_gateway/methods_prompt.py`)**:
  - Supported `truncate_before_message_id` for unique message targeting.
  - Implemented ordinal vs `message_id` mismatch detection returning error `4030` (`truncate_before_user_ordinal does not match truncate_before_message_id`).
  - Added boolean type validation returning `4004` when boolean values are passed for `truncate_before_user_ordinal`.
  - Added fail-fast check refusing `confirm_truncate` when neither target ordinal nor message ID is supplied.
- **Desktop UI (`apps/desktop`)**:
  - Updated `truncateSubmitParams(truncateOrdinal?, truncateMessageId?)` in `rewind.ts` to include `truncate_before_message_id`.
  - Updated `planReload`, `planRestore`, and `planEdit` in `rewind.ts` to supply `truncateMessageId`.
  - Updated `index.ts` (`editMessage`, `restoreToMessage`, `reloadFromMessage`) and `session-tile-actions.ts` to transmit `truncateMessageId`.
  - Updated `isStaleTargetError` in `index.ts` to match code `4030` mismatch errors for fallback retries.
- **Tests**:
  - Added `test_prompt_submit_truncates_by_message_id`, `test_prompt_submit_refuses_ordinal_and_message_id_mismatch`, and `test_prompt_submit_refuses_boolean_ordinal` in `tests/test_tui_gateway_server.py`.
  - Added unit tests for `truncate_before_message_id` in `apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts`.

## How to Test

1. Run Gateway unit tests for truncation:
   `.venv\Scripts\pytest tests/test_tui_gateway_server.py -k "truncate" -v`
2. Run Desktop UI rewind unit tests:
   `npx vitest run apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts`
3. Verify that sending ordinary prompt submits after a rewind/edit action in Desktop UI no longer carries a stale ordinal or truncates session history.

