### PR TITLE
fix: surface openrouter/fusion in the model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -95,6 +95,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
+    ("openrouter/fusion",                      "multi-model deliberation panel + analyst; ~4-5x cost when invoked"),
+    ("openrouter/fusion-flash",                "fusion with latency-tuned general-fast preset"),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
     ("poolside/laguna-m.1:free",               "free"),
@@ -1490,13 +1492,21 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     so the picker doesn't silently empty for those users. Only hide models
     whose ``supported_parameters`` is an explicit list that omits ``tools``.
 
+    **Permissive when the list is empty.** OpenRouter's meta-routers (e.g.
+    ``openrouter/fusion``) publish ``supported_parameters: []`` because the
+    concrete model is resolved per-request, yet they fully support tool
+    calling (verified against the live endpoint). An empty list carries no
+    capability information, so treat it like a missing field rather than an
+    explicit "no tools" declaration.
+
     Ported from Kilo-Org/kilocode#9068.
     """
     if not isinstance(item, dict):
         return True
     params = item.get("supported_parameters")
-    if not isinstance(params, list):
-        # Field absent / malformed / None — be permissive.
+    if not isinstance(params, list) or not params:
+        # Field absent / malformed / None / empty — carries no capability
+        # information, so be permissive.
         return True
     return "tools" in params
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -113,11 +113,23 @@ class TestOpenRouterToolSupportHelper:
         ) is True
 
 
-    def test_empty_supported_parameters_list_drops_model(self):
-        """Explicit empty list → no tools → drop."""
+    def test_empty_supported_parameters_list_is_permissive(self):
+        """Empty list carries no capability info → allow (openrouter/fusion).
+
+        OpenRouter meta-routers (e.g. ``openrouter/fusion``) publish
+        ``supported_parameters: []`` because the concrete model is resolved
+        per-request, yet they support tool calling. Treat empty like missing.
+        """
         from hermes_cli.models import _openrouter_model_supports_tools
         assert _openrouter_model_supports_tools(
-            {"id": "x", "supported_parameters": []}
+            {"id": "openrouter/fusion", "supported_parameters": []}
+        ) is True
+
+    def test_explicit_list_without_tools_drops_model(self):
+        """Non-empty list that omits 'tools' → drop."""
+        from hermes_cli.models import _openrouter_model_supports_tools
+        assert _openrouter_model_supports_tools(
+            {"id": "x", "supported_parameters": ["temperature", "response_format"]}
         ) is False
 
 


### PR DESCRIPTION
## Summary

OpenRouter's meta-routers (`openrouter/fusion`, `openrouter/fusion-flash`) publish `supported_parameters: []` in the `/api/v1/models` catalog because the concrete model is resolved per-request. They **do** support tool calling — verified against the live `chat/completions` endpoint with a function tool: the outer model (resolved to `anthropic/claude-opus-5`) returned `finish_reason: tool_calls` with a well-formed call.

`_openrouter_model_supports_tools()` treated the empty list as an explicit "no tools" declaration, so these routers were silently dropped from the model picker even though they work fine as the agent's driving model.

## Changes

- `_openrouter_model_supports_tools`: treat an **empty** `supported_parameters` list like a missing field (permissive). Only a non-empty list that omits `tools` hides a model. An empty list carries no capability information.
- Add `openrouter/fusion` and `openrouter/fusion-flash` to the curated `OPENROUTER_MODELS` fallback list with short descriptions (including the ~4-5x cost caveat when the fusion panel is invoked).
- Tests: replaced `test_empty_supported_parameters_list_drops_model` with `test_empty_supported_parameters_list_is_permissive` (documents the fusion case) and added `test_explicit_list_without_tools_drops_model` to keep the original protection covered.

## Test Plan

- [x] `tests/hermes_cli/test_models.py` — 31 passed
- [x] Live verification: `POST /chat/completions` with `model: openrouter/fusion` + a `get_weather` function tool returns `tool_calls`

## Notes

The image-only-model protection from Kilo-Org/kilocode#9068 remains intact — those models advertise a *non-empty* parameter list without `tools` (e.g. `google/gemini-3-pro-image-preview`) and are still filtered.