### PR TITLE
fix(desktop): give the HUD window a distinct, stable title

### DIFF
--- a/apps/desktop/electron/hud-title.test.ts
+++ b/apps/desktop/electron/hud-title.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { HUD_WINDOW_TITLE, wireHudWindowTitle } from './hud-title'
+
+test('wireHudWindowTitle sets the distinct HUD title', () => {
+  let title: string | null = null
+  const win = {
+    setTitle: (t: string) => {
+      title = t
+    },
+    on: () => {}
+  }
+
+  wireHudWindowTitle(win)
+
+  assert.equal(title, 'Hermes HUD')
+  assert.equal(title, HUD_WINDOW_TITLE)
+})
+
+test('wireHudWindowTitle guards the title against the page overwriting it', () => {
+  let handler: ((event: { preventDefault(): void }) => void) | null = null
+  const win = {
+    setTitle: () => {},
+    on: (name: string, listener: (event: { preventDefault(): void }) => void) => {
+      if (name === 'page-title-updated') {
+        handler = listener
+      }
+    }
+  }
+
+  wireHudWindowTitle(win)
+
+  let prevented = false
+  handler?.({ preventDefault: () => (prevented = true) })
+  assert.equal(prevented, true)
+})

--- a/apps/desktop/electron/hud-title.test.ts
+++ b/apps/desktop/electron/hud-title.test.ts
@@ -6,6 +6,7 @@ import { HUD_WINDOW_TITLE, wireHudWindowTitle } from './hud-title'
 
 test('wireHudWindowTitle sets the distinct HUD title', () => {
   let title: string | null = null
+
   const win = {
     setTitle: (t: string) => {
       title = t
@@ -21,6 +22,7 @@ test('wireHudWindowTitle sets the distinct HUD title', () => {
 
 test('wireHudWindowTitle guards the title against the page overwriting it', () => {
   let handler: ((event: { preventDefault(): void }) => void) | null = null
+
   const win = {
     setTitle: () => {},
     on: (name: string, listener: (event: { preventDefault(): void }) => void) => {

--- a/apps/desktop/electron/hud-title.ts
+++ b/apps/desktop/electron/hud-title.ts
@@ -1,0 +1,31 @@
+// HUD mode's window title, plus the guard that keeps it stable.
+//
+// The pure, Electron-typed piece lives here so it can be unit-tested (same
+// split as hud-url.ts). The HUD is chrome-free, so its title is invisible to
+// the user — but it is the one stable handle a tiling window manager
+// (Hyprland, i3, sway, …) can match on. Without a distinct title the HUD is
+// indistinguishable from the main app window, which shares its class/app-id;
+// window rules aimed at the HUD would hit both.
+
+/** The HUD window's title — distinct from the main window's "Hermes". */
+export const HUD_WINDOW_TITLE = 'Hermes HUD'
+
+/** The minimal window surface this helper needs, kept structural so tests
+ *  don't have to construct a real BrowserWindow. */
+interface HudTitleWindow {
+  setTitle(title: string): void
+  on(event: 'page-title-updated', listener: (event: { preventDefault(): void }) => void): void
+}
+
+/**
+ * Make sure the HUD window's title stays `HUD_WINDOW_TITLE`.
+ *
+ * The renderer's `<title>Hermes</title>` would otherwise overwrite the window
+ * title the moment the page loads, silently destroying the handle window
+ * managers match on. The guard is attached before the URL is loaded, so the
+ * compositor never sees the generic title.
+ */
+export function wireHudWindowTitle(win: HudTitleWindow): void {
+  win.setTitle(HUD_WINDOW_TITLE)
+  win.on('page-title-updated', event => event.preventDefault())
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -137,6 +137,7 @@ import {
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
 import { cursorPointInWindow } from './hud-cursor'
+import { HUD_WINDOW_TITLE, wireHudWindowTitle } from './hud-title'
 import { buildHudWindowUrl } from './hud-url'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
@@ -9326,6 +9327,9 @@ function broadcastHudState(open) {
 function spawnHudWindow(sessionId, profile) {
   const win = new BrowserWindow({
     ...hudBounds(),
+    // Distinct from the main window's "Hermes": the one handle tiling window
+    // managers can match on to keep the HUD floating/pinned (see hud-title.ts).
+    title: HUD_WINDOW_TITLE,
     minWidth: 380,
     minHeight: 160,
     frame: false,
@@ -9375,6 +9379,9 @@ function spawnHudWindow(sessionId, profile) {
   // every chat window does.
   streamThrottle.register(win)
   wireCommonWindowHandlers(win, zoomWiringForWindowKind('chat'))
+
+  // Re-assert the title and stop the page's <title> from overwriting it.
+  wireHudWindowTitle(win)
 
   // Remember where the user parks and sizes it (debounced — these fire many
   // times mid-drag).


### PR DESCRIPTION
## What does this PR do?

The HUD window (chrome-free floating chat) shares its class/app-id **and** its `Hermes` page title with the main app window. On tiling window managers (Hyprland, i3, sway, …) that makes the HUD impossible to target with window rules: a rule written for the HUD matches the main window too, and a rule for the app hits both — so the HUD can't be floated, pinned, or kept above everything, which is exactly what HUD mode is designed for. Electron's own always-on-top / visible-on-all-workspaces hints don't reach most Linux compositors on native Wayland, so the compositor-side rule is the only reliable mechanism.

This PR gives the HUD a distinct, stable window title (`Hermes HUD`) and freezes it against the renderer's `<title>` overwriting it, so window managers have a stable handle to match on. The HUD is frameless and skip-taskbar, so the title is invisible to users — no UX change.

Example Hyprland rule this unlocks:

```lua
hl.window_rule({
  name = "hermes-hud-popover",
  match = { class = "^hermes$", title = "^Hermes HUD$" },
  float = true,
  pin = true,
})
```

## Related Issue

No issue filed — small, self-contained fix. Happy to file one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/hud-title.ts` (new) — `HUD_WINDOW_TITLE` constant + `wireHudWindowTitle()` helper (re-asserts the title and guards `page-title-updated`, keeping the title stable once the renderer loads)
- `apps/desktop/electron/hud-title.test.ts` (new) — unit tests for both behaviors
- `apps/desktop/electron/main.ts` — `spawnHudWindow` sets `title: HUD_WINDOW_TITLE` on the BrowserWindow and wires the guard

## How to Test

1. Open HUD mode (titlebar toggle in the desktop app)
2. Inspect the window: `hyprctl clients` shows the HUD with `title: Hermes HUD` while the main window stays `Hermes`
3. With the example rule above, the HUD opens floating and pinned (visible on all workspaces); the main app window is unaffected
4. `npm run check:test:desktop:platforms` — new tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)