### PR TITLE
fix(oneshot): attest effective reasoning identity

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -140,6 +140,7 @@ def _run_and_exit_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: object = None,
+    reasoning: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -151,6 +152,7 @@ def _run_and_exit_oneshot(
             toolsets=toolsets,
             skills=skills,
             usage_file=usage_file,
+            reasoning=reasoning,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -2884,6 +2886,7 @@ def _run_oneshot_from_args(args) -> None:
         toolsets=getattr(args, "toolsets", None),
         skills=getattr(args, "skills", None),
         usage_file=getattr(args, "usage_file", None),
+        reasoning=getattr(args, "reasoning", None),
     )
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -180,6 +180,7 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    reasoning: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -190,6 +191,7 @@ def _run_and_exit_oneshot(
             provider=provider,
             toolsets=toolsets,
             usage_file=usage_file,
+            reasoning=reasoning,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -10967,6 +10969,7 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            reasoning=getattr(args, "reasoning", None),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -12638,6 +12641,7 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            reasoning=getattr(args, "reasoning", None),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -28,7 +28,7 @@ _ALL_TOOLSETS = {"all", "*"}
 _USAGE_KEYS = (
     "estimated_cost_usd", "cost_status", "cost_source", "input_tokens", "output_tokens",
     "cache_read_tokens", "cache_write_tokens", "reasoning_tokens", "total_tokens", "api_calls",
-    "model", "provider", "session_id", "completed",
+    "model", "provider", "session_id", "completed", "reasoning_effort",
 )
 
 
@@ -167,6 +167,7 @@ def run_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: Optional[str] = None,
+    reasoning: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -177,6 +178,14 @@ def run_oneshot(
     # Silence every stdlib logger: AIAgent, tools and provider adapters log to stderr through the
     # root logger. File handlers from setup_logging() keep working (level-independent).
     logging.disable(logging.CRITICAL)
+
+    from hermes_constants import parse_reasoning_effort
+
+    if reasoning is not None and parse_reasoning_effort(reasoning) is None:
+        sys.stderr.write(
+            f"hermes -z: invalid --reasoning: unrecognized effort {reasoning!r}\n"
+        )
+        return 2
 
     # --provider without --model is ambiguous (the provider may not host the configured model, and
     # picking its catalog default hides the mismatch). Validate BEFORE the stderr redirect.
@@ -220,6 +229,8 @@ def run_oneshot(
                 toolsets=explicit_toolsets,
                 use_config_toolsets=use_config_toolsets,
                 skills=skills,
+                reasoning=reasoning,
+                run_metadata=result,
             )
         except BaseException as exc:  # noqa: BLE001
             # Capture anything escaping the agent (OSError from prompt_toolkit on a non-TTY pipe,
@@ -347,6 +358,8 @@ def _run_agent(
     toolsets: object = None,
     use_config_toolsets: bool = True,
     skills: object = None,
+    reasoning: Optional[str] = None,
+    run_metadata: Optional[dict] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn, run one conversation, and return
     ``(final_response, run_result)``. Imports are local to keep CLI startup cheap."""
@@ -354,9 +367,28 @@ def _run_agent(
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
     from run_agent import AIAgent
+    from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
 
     cfg = load_config()
     choice = _resolve_model_and_provider(cfg, model, provider)
+    # Resolve reasoning the same way an interactive turn would (CLI override → per-model override
+    # → agent.reasoning_effort) and attest the EFFECTIVE effort up front, so the usage report can
+    # prove which identity was requested even when the provider fails before the run completes.
+    reasoning_config = (
+        parse_reasoning_effort(reasoning)
+        if reasoning is not None
+        else resolve_reasoning_config(cfg, choice.model)
+    )
+    effective_reasoning_effort = (
+        "none"
+        if reasoning_config == {"enabled": False}
+        else reasoning_config.get("effort")
+        if reasoning_config
+        else None
+    )
+    if run_metadata is not None:
+        run_metadata["reasoning_effort"] = effective_reasoning_effort
+
     runtime = resolve_runtime_provider(
         requested=choice.provider,
         target_model=choice.model or None,
@@ -400,6 +432,7 @@ def _run_agent(
             credential_pool=runtime.get("credential_pool"),
             fallback_model=get_fallback_chain(cfg) or None,
             ephemeral_system_prompt=skills_prompt,
+            reasoning_config=reasoning_config,
             # The only interactive callback wired: no user sits at a terminal. Sudo prompts gate on
             # HERMES_INTERACTIVE (never set), hook approval via HERMES_ACCEPT_HOOKS=1, dangerous
             # commands via HERMES_YOLO_MODE=1, skill secret capture degrades gracefully.
@@ -411,6 +444,7 @@ def _run_agent(
         agent.tool_gen_callback = None
 
         result = agent.run_conversation(prompt)
+        result["reasoning_effort"] = effective_reasoning_effort
         return (result.get("final_response") or "", result)
     finally:
         _close_agent(agent, session_db)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -157,6 +157,7 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
             # paying for actually went out on the wire (July 2026 incident:
             # a config-matching bug silently dropped flex -> 2.3x billing).
             "service_tier": result.get("service_tier"),
+            "reasoning_effort": result.get("reasoning_effort"),
         }
         if failure is not None:
             report["failure"] = failure
@@ -173,6 +174,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    reasoning: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -196,6 +198,14 @@ def run_oneshot(
     # the root logger's handler list, not affected by level), but no
     # bytes reach the terminal.
     logging.disable(logging.CRITICAL)
+
+    from hermes_constants import parse_reasoning_effort
+
+    if reasoning is not None and parse_reasoning_effort(reasoning) is None:
+        sys.stderr.write(
+            f"hermes -z: invalid --reasoning: unrecognized effort {reasoning!r}\n"
+        )
+        return 2
 
     # --provider without --model is ambiguous: carrying the user's configured
     # model across to a different provider is usually wrong (that provider may
@@ -248,6 +258,8 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    reasoning=reasoning,
+                    run_metadata=result,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -325,6 +337,8 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    reasoning: Optional[str] = None,
+    run_metadata: Optional[dict] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -335,6 +349,7 @@ def _run_agent(
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
     from run_agent import AIAgent
+    from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
 
     cfg = load_config()
 
@@ -391,6 +406,21 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
+    reasoning_config = (
+        parse_reasoning_effort(reasoning)
+        if reasoning is not None
+        else resolve_reasoning_config(cfg, effective_model)
+    )
+    effective_reasoning_effort = (
+        "none"
+        if reasoning_config == {"enabled": False}
+        else reasoning_config.get("effort")
+        if reasoning_config
+        else None
+    )
+    if run_metadata is not None:
+        run_metadata["reasoning_effort"] = effective_reasoning_effort
+
     runtime = resolve_runtime_provider(
         requested=effective_provider,
         target_model=effective_model or None,
@@ -443,6 +473,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            reasoning_config=reasoning_config,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction
@@ -464,6 +495,7 @@ def _run_agent(
         agent.tool_gen_callback = None
 
         result = agent.run_conversation(prompt)
+        result["reasoning_effort"] = effective_reasoning_effort
         return (result.get("final_response") or "", result)
     finally:
         # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,

--- a/tests/hermes_cli/test_oneshot_reasoning_identity.py
+++ b/tests/hermes_cli/test_oneshot_reasoning_identity.py
@@ -1,0 +1,134 @@
+"""Contract tests for reasoning identity in non-interactive one-shot runs."""
+
+import json
+
+import pytest
+
+from hermes_cli import oneshot
+
+
+def _stub_runtime(monkeypatch, tmp_path, *, configured_effort=None):
+    import hermes_cli.config as config_mod
+    import run_agent
+    from hermes_cli import mcp_startup, runtime_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    cfg = {"model": {"default": "test-model", "provider": "openai-api"}}
+    if configured_effort is not None:
+        cfg["agent"] = {"reasoning_effort": configured_effort}
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(
+        mcp_startup, "ensure_mcp_discovery_before_agent_build", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "test",
+            "base_url": "http://provider.invalid/v1",
+            "provider": "openai-api",
+            "requested_provider": "openai-api",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    observed = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            observed.update(kwargs)
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, _prompt):
+            return {"final_response": "ok", "completed": True, "failed": False}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent, "AIAgent", FakeAgent)
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    return observed
+
+
+@pytest.mark.parametrize(
+    ("reasoning", "expected_config", "expected_effort"),
+    [
+        ("low", {"enabled": True, "effort": "low"}, "low"),
+        ("xhigh", {"enabled": True, "effort": "xhigh"}, "xhigh"),
+        ("none", {"enabled": False}, "none"),
+    ],
+)
+def test_explicit_reasoning_is_passed_and_attested(
+    monkeypatch, tmp_path, reasoning, expected_config, expected_effort
+):
+    observed = _stub_runtime(monkeypatch, tmp_path)
+    response, result = oneshot._run_agent(
+        "identity", model="test-model", provider="openai-api", reasoning=reasoning
+    )
+    assert response == "ok"
+    assert observed["reasoning_config"] == expected_config
+    assert result["reasoning_effort"] == expected_effort
+
+
+def test_absent_cli_override_preserves_configured_reasoning(monkeypatch, tmp_path):
+    observed = _stub_runtime(monkeypatch, tmp_path, configured_effort="high")
+    _response, result = oneshot._run_agent(
+        "identity", model="test-model", provider="openai-api", reasoning=None
+    )
+    assert observed["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert result["reasoning_effort"] == "high"
+
+
+def test_invalid_reasoning_fails_before_agent_or_provider(monkeypatch, capsys):
+    monkeypatch.setattr(
+        oneshot,
+        "_run_agent",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("agent/provider reached")
+        ),
+    )
+    assert oneshot.run_oneshot("identity", reasoning="turbo") == 2
+    assert "invalid --reasoning" in capsys.readouterr().err
+
+
+def test_failure_usage_keeps_resolved_reasoning_identity(monkeypatch, tmp_path):
+    import run_agent
+
+    usage_path = tmp_path / "usage.json"
+    _stub_runtime(monkeypatch, tmp_path)
+
+    class FailingAgent:
+        def __init__(self, **_kwargs):
+            raise RuntimeError("provider failed")
+
+    monkeypatch.setattr(run_agent, "AIAgent", FailingAgent)
+    assert oneshot.run_oneshot(
+        "identity",
+        model="test-model",
+        provider="openai-api",
+        reasoning="high",
+        usage_file=str(usage_path),
+    ) == 1
+    report = json.loads(usage_path.read_text())
+    assert report["failed"] is True
+    assert report["reasoning_effort"] == "high"
+
+
+def test_main_oneshot_wrapper_forwards_reasoning(monkeypatch):
+    from hermes_cli import main
+
+    observed = {}
+    monkeypatch.setattr(
+        oneshot,
+        "run_oneshot",
+        lambda *_args, **kwargs: observed.update(kwargs) or 0,
+    )
+    monkeypatch.setattr(main, "_cleanup_oneshot_runtime", lambda: None)
+    monkeypatch.setattr(
+        main, "_exit_after_oneshot", lambda rc: observed.update(exit_code=rc)
+    )
+    main._run_and_exit_oneshot("identity", reasoning="low")
+    assert observed["reasoning"] == "low"
+    assert observed["exit_code"] == 0


### PR DESCRIPTION
## Summary

- propagate the explicit `--reasoning` override through both one-shot CLI dispatch paths
- resolve configured/per-model reasoning when no CLI override is present
- pass the effective config to `AIAgent` and attest it in `--usage-file`, including failure paths
- reject unrecognized explicit efforts before provider resolution

## Context

This overlaps with #70023 on configured fallback resolution. It extends that contract with explicit CLI precedence and a machine-readable effective identity for batch/audit callers. The branches currently conflict in `hermes_cli/oneshot.py`; the intended combined behavior is covered by this PR tests and should be resolved semantically rather than by choosing either side wholesale.

## Validation

- 21 targeted tests passed across one-shot identity, usage, agent one-shot, and startup fast guards
- independent exact-SHA review approved `27f9bc618f4a7d0d75f48d0799669112931380aa`
- compile and `git diff --check` passed
- no provider call is made by the tests

Closes the one-shot identity gap where `model_config.reasoning_config` was null despite an explicit CLI effort.