### PR TITLE
fix(desktop): stream sync TTS by sentence

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
@@ -7,7 +7,9 @@ import { useVoiceConversation } from './use-voice-conversation'
 
 const mocks = vi.hoisted(() => {
   let deferStreamStart = false
+  let deferFallbackPlayback = false
   let onSilence: null | (() => void) = null
+  let resolveFallbackPlayback: null | ((played: boolean) => void) = null
   let resolveStreamStart: null | (() => void) = null
   let resolveSpeech: null | ((outcome: 'done' | 'fallback') => void) = null
   let streamAvailable = true
@@ -19,6 +21,12 @@ const mocks = vi.hoisted(() => {
 
   const playSpeechText = vi.fn(() => {
     stopVoicePlayback()
+
+    if (deferFallbackPlayback) {
+      return new Promise<boolean>(resolve => {
+        resolveFallbackPlayback = resolve
+      })
+    }
 
     return Promise.resolve(true)
   })
@@ -39,16 +47,25 @@ const mocks = vi.hoisted(() => {
       resolveStreamStart?.()
       resolveStreamStart = null
     },
+    deferFallbackPlayback() {
+      deferFallbackPlayback = true
+    },
     deferStreamStart() {
       deferStreamStart = true
     },
     finishSpeech(outcome: 'done' | 'fallback') {
       resolveSpeech?.(outcome)
     },
+    finishFallbackPlayback() {
+      resolveFallbackPlayback?.(true)
+      resolveFallbackPlayback = null
+    },
     handle,
     playSpeechText,
     resetSpeechMocks() {
+      deferFallbackPlayback = false
       deferStreamStart = false
+      resolveFallbackPlayback = null
       resolveStreamStart = null
       resolveSpeech = null
       streamAvailable = true
@@ -144,6 +161,36 @@ function renderRearmConversation(responseId: string, responseText: string) {
       }),
     { initialProps: { enabled: false } }
   )
+}
+
+function renderIncrementalFallbackConversation() {
+  let response: null | { id: string; pending: boolean; text: string } = null
+
+  const hook = renderHook(
+    ({ enabled }) =>
+      useVoiceConversation({
+        busy: false,
+        consumePendingResponse: vi.fn(),
+        enabled,
+        onSubmit: async () => {
+          response = { id: 'reply-edge', pending: true, text: 'The first sentence is ready. ' }
+        },
+        onTranscribeAudio: async () => 'Hello',
+        pendingResponse: () => response
+      }),
+    { initialProps: { enabled: false } }
+  )
+
+  return {
+    finishResponse() {
+      response = {
+        id: 'reply-edge',
+        pending: false,
+        text: 'The first sentence is ready. The second sentence is ready.'
+      }
+    },
+    hook
+  }
 }
 
 async function beginReply(hook: ReturnType<typeof renderRearmConversation>) {
@@ -254,5 +301,63 @@ describe('useVoiceConversation playback rearm', () => {
     )
     await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
     expect(hook.result.current.status).toBe('listening')
+  })
+
+  it('speaks completed fallback sentences before the response finishes', async () => {
+    mocks.useFallbackSpeech()
+    const { finishResponse, hook } = renderIncrementalFallbackConversation()
+
+    await beginReply(hook)
+
+    await waitFor(() =>
+      expect(mocks.playSpeechText).toHaveBeenCalledWith('The first sentence is ready.', {
+        source: 'voice-conversation'
+      })
+    )
+    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+
+    finishResponse()
+
+    await waitFor(() =>
+      expect(mocks.playSpeechText).toHaveBeenCalledWith('The second sentence is ready.', {
+        source: 'voice-conversation'
+      })
+    )
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
+    expect(hook.result.current.status).toBe('listening')
+  })
+
+  it('does not play the next fallback sentence or re-arm after Stop', async () => {
+    mocks.useFallbackSpeech()
+    mocks.deferFallbackPlayback()
+    const { finishResponse, hook } = renderIncrementalFallbackConversation()
+
+    await beginReply(hook)
+    await waitFor(() => expect(mocks.playSpeechText).toHaveBeenCalledTimes(1))
+    finishResponse()
+
+    mocks.stopVoicePlayback()
+    await act(async () => {
+      mocks.finishFallbackPlayback()
+    })
+
+    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    expect(mocks.playSpeechText).toHaveBeenCalledTimes(1)
+    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors Stop while waiting for the next fallback sentence', async () => {
+    mocks.useFallbackSpeech()
+    const { finishResponse, hook } = renderIncrementalFallbackConversation()
+
+    await beginReply(hook)
+    await waitFor(() => expect(mocks.playSpeechText).toHaveBeenCalledTimes(1))
+
+    mocks.stopVoicePlayback()
+    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    finishResponse()
+
+    expect(mocks.playSpeechText).toHaveBeenCalledTimes(1)
+    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
+import { IncrementalSpeechSentenceBuffer } from '@/lib/speech-text'
 import { startThinkingSound, stopThinkingSound } from '@/lib/thinking-sound'
 import { monitorSpeechDuringPlayback } from '@/lib/voice-barge-in'
 import {
@@ -433,46 +434,121 @@ export function useVoiceConversation({
     [pendingResponse]
   )
 
-  /** Whole-text fallback: wait for the reply to complete, then speak it. */
+  /** Non-streaming providers still speak completed sentences during generation. */
   const awaitFallbackSpeech = useCallback(
     (responseId: string) => {
+      const sentenceBuffer = new IncrementalSpeechSentenceBuffer()
+      const speechQueue: string[] = []
+      let sourceLength = 0
+      let responseFinished = false
+      let playing = false
+      let settled = false
+      let pollTimer: number | null = null
+      let ownedSequence = $voicePlayback.get().sequence
+
+      const finishFallback = (barged: boolean, stopped = false) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+
+        if (pollTimer !== null) {
+          window.clearTimeout(pollTimer)
+        }
+
+        awaitingSpokenResponseRef.current = false
+        settleAfterSpeech(barged, stopped)
+      }
+
+      const playNext = () => {
+        if (settled || playing || responseIdRef.current !== responseId) {
+          return
+        }
+
+        if ($voicePlayback.get().sequence > ownedSequence) {
+          finishFallback(false, true)
+
+          return
+        }
+
+        const sentence = speechQueue.shift()
+
+        if (!sentence) {
+          if (responseFinished) {
+            finishFallback(bargedRef.current)
+          }
+
+          return
+        }
+
+        ensureBargeMonitor()
+        playing = true
+
+        const playback = playSpeechText(sentence, { source: 'voice-conversation' })
+        const sentenceStartSequence = $voicePlayback.get().sequence
+        ownedSequence = sentenceStartSequence
+        speechStartSequenceRef.current = sentenceStartSequence
+        let playbackFailed = false
+
+        void playback
+          .catch(error => {
+            playbackFailed = true
+            notifyError(error, voiceCopy.playbackFailed)
+          })
+          .finally(() => {
+            if (settled || responseIdRef.current !== responseId) {
+              return
+            }
+
+            playing = false
+
+            if (playbackFailed) {
+              finishFallback(bargedRef.current)
+
+              return
+            }
+
+            const stopped = $voicePlayback.get().sequence > sentenceStartSequence
+
+            if (bargedRef.current || stopped) {
+              finishFallback(bargedRef.current, stopped && !bargedRef.current)
+
+              return
+            }
+
+            playNext()
+          })
+      }
+
       const poll = () => {
-        if (responseIdRef.current !== responseId) {
+        if (settled || responseIdRef.current !== responseId) {
           return
         }
 
         const response = pendingResponse()
 
         if (!response || response.id !== responseId) {
-          settleAfterSpeech(false)
+          finishFallback(false)
 
           return
         }
 
-        if (response.pending || busyRef.current) {
-          window.setTimeout(poll, 250)
-
-          return
+        if (response.text.length > sourceLength) {
+          speechQueue.push(...sentenceBuffer.append(response.text.slice(sourceLength)))
+          sourceLength = response.text.length
         }
 
-        // The full-duplex monitor is normally already live (armed at submit);
-        // this is a safety net for read-aloud-style entries into the loop.
-        ensureBargeMonitor()
+        if (!response.pending && !busyRef.current && !responseFinished) {
+          responseFinished = true
+          speechQueue.push(...sentenceBuffer.flush())
+        }
 
-        const playback = playSpeechText(response.text, { source: 'voice-conversation' })
-        // playSpeechText performs its normal cleanup synchronously before
-        // returning. Capture the sequence after that internal increment so
-        // only a later, external stop suppresses the next listen cycle.
-        speechStartSequenceRef.current = $voicePlayback.get().sequence
+        playNext()
 
-        void playback
-          .catch(error => notifyError(error, voiceCopy.playbackFailed))
-          .finally(() => {
-            if (responseIdRef.current === responseId) {
-              awaitingSpokenResponseRef.current = false
-              settleAfterSpeech(bargedRef.current)
-            }
-          })
+        if (!responseFinished) {
+          pollTimer = window.setTimeout(poll, 150)
+        }
       }
 
       poll()
@@ -487,6 +563,10 @@ export function useVoiceConversation({
    */
   const openLiveSpeech = useCallback(
     (responseId: string) => {
+      if (responseIdRef.current === responseId) {
+        return
+      }
+
       const sequenceBeforeStart = $voicePlayback.get().sequence
 
       responseIdRef.current = responseId

--- a/apps/desktop/src/lib/speech-text.test.ts
+++ b/apps/desktop/src/lib/speech-text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { sanitizeTextForSpeech } from './speech-text'
+import { IncrementalSpeechSentenceBuffer, sanitizeTextForSpeech } from './speech-text'
 
 describe('sanitizeTextForSpeech', () => {
   it('summarizes fenced code blocks instead of reading them literally', () => {
@@ -148,5 +148,28 @@ After the table.`
     Example A | 10`
 
     expect(sanitizeTextForSpeech(text)).toContain('Item | Value')
+  })
+})
+
+describe('IncrementalSpeechSentenceBuffer', () => {
+  it('emits completed sentences while retaining the unfinished tail', () => {
+    const buffer = new IncrementalSpeechSentenceBuffer()
+
+    expect(buffer.append('The first sentence is ready. The second')).toEqual(['The first sentence is ready.'])
+    expect(buffer.append(' sentence is ready too. ')).toEqual(['The second sentence is ready too.'])
+    expect(buffer.flush()).toEqual([])
+  })
+
+  it('keeps short fragments with the following sentence', () => {
+    const buffer = new IncrementalSpeechSentenceBuffer()
+
+    expect(buffer.append('Hi! This longer sentence is ready. ')).toEqual(['Hi! This longer sentence is ready.'])
+  })
+
+  it('does not emit a reasoning block split across deltas', () => {
+    const buffer = new IncrementalSpeechSentenceBuffer()
+
+    expect(buffer.append('<think>Private reason.')).toEqual([])
+    expect(buffer.append('</think> The public answer is ready. ')).toEqual(['The public answer is ready.'])
   })
 })

--- a/apps/desktop/src/lib/speech-text.ts
+++ b/apps/desktop/src/lib/speech-text.ts
@@ -12,6 +12,8 @@ const THINKING_PREFIX_RE =
   /^\s*(?:\([^)\n]{1,48}\)\s*)?(?:processing|thinking|reasoning|analyzing|pondering|contemplating|musing|cogitating|ruminating|deliberating|mulling|reflecting|computing|synthesizing|formulating|brainstorming)\.\.\.\s*/i
 
 const URL_RE = /\bhttps?:\/\/\S+/gi
+const CLOSED_THINK_BLOCK_RE = /<think[\s>][\s\S]*?<\/think>/g
+const SENTENCE_BOUNDARY_RE = /(?<=[.!?])(?:\s|\n)|(?:\n\n)/
 
 const MARKDOWN_TABLE_DELIMITER_CELL_RE = /^:?-{3,}:?$/
 
@@ -149,6 +151,53 @@ function normalizeLineBreaks(text: string): string {
     .replace(PUNCTUATED_PARAGRAPH_BREAK_RE, '$1$2 ')
     .replace(PARAGRAPH_BREAK_RE, '. ')
     .replace(SOFT_BREAK_RE, ' ')
+}
+
+export class IncrementalSpeechSentenceBuffer {
+  private buffer = ''
+
+  constructor(private readonly minLength = 20) {}
+
+  append(delta: string): string[] {
+    this.buffer = (this.buffer + delta).replace(CLOSED_THINK_BLOCK_RE, '')
+
+    if (this.buffer.includes('<think') && !this.buffer.includes('</think>')) {
+      return []
+    }
+
+    const sentences: string[] = []
+    let searchStart = 0
+
+    while (true) {
+      const match = SENTENCE_BOUNDARY_RE.exec(this.buffer.slice(searchStart))
+
+      if (!match || match.index === undefined) {
+        break
+      }
+
+      const end = searchStart + match.index + match[0].length
+      const head = this.buffer.slice(0, end).trim()
+
+      if (head.length < this.minLength) {
+        searchStart = end
+
+        continue
+      }
+
+      sentences.push(head)
+      this.buffer = this.buffer.slice(end)
+      searchStart = 0
+    }
+
+    return sentences
+  }
+
+  flush(): string[] {
+    const tail = this.buffer.replace(CLOSED_THINK_BLOCK_RE, '').trim()
+    this.buffer = ''
+
+    return tail ? [tail] : []
+  }
 }
 
 export function sanitizeTextForSpeech(text: string): string {


### PR DESCRIPTION
## Summary

- queue completed reply sentences through Desktop's existing sync TTS fallback while generation is still active
- keep short fragments and split `<think>` blocks buffered until they are safe to speak
- make one response ID own one speech session and preserve Stop/barge-in behavior between queued sentences

## Root cause

When `/api/audio/speak-stream` reported `fallback` for a provider without a chunked PCM adapter, `awaitFallbackSpeech` polled until both the pending response and the whole turn were complete. Edge is the default provider and has no chunked adapter, so Desktop deterministically waited for the full response before calling `/api/audio/speak`.

The fallback now tracks reply deltas, emits complete sentences with the same minimum-fragment and reasoning-block behavior as the backend sentence cutter, and serially plays them through the existing `playSpeechText` path. The unfinished tail flushes only when the response completes.

This does not change the WebSocket or provider protocol. It is complementary to #75014, whose versioned PCM transport deliberately retains fallback for providers without a cancellable PCM streamer.

Fixes #79314

## Regression coverage

- first fallback sentence starts while the response is still pending
- the final tail drains in order and the microphone re-arms once
- duplicate React scheduling cannot create two speech sessions for one response
- Stop during active fallback playback drops the queued sentence and does not re-arm
- Stop in the quiet gap before the next sentence is also retained
- `<think>` blocks split across deltas are never emitted

## Verification

- focused Desktop UI tests: 34 passed
- Desktop typecheck: passed
- changed-file ESLint and Prettier: passed
- production Desktop build and `assert-dist-built`: passed
- contribution publish gate and gitleaks: passed

The full Desktop UI run completed with 3,634 passing tests and one unrelated markdown property-test timeout under aggregate load. That exact file passes on this branch and untouched current main in fresh processes (6/6 on each).
