### PR TITLE
fix(gateway): gate plugin commands on their registered name

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15385,6 +15385,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _cmd_def = _resolve_cmd(command) if command else None
                         canonical = _cmd_def.name if _cmd_def else command
 
+        # Resolve a plugin command typed in Telegram's underscored spelling to
+        # the hyphenated name it was registered under. The Bot API permits only
+        # [a-z0-9_], so ``_sanitize_telegram_name`` renders a plugin command
+        # registered as ``my-cmd`` in the command menu as ``/my_cmd``, and that
+        # is the spelling the adapter sends back. Plugin dispatch already folds
+        # it, but the access gate and the ``command:<canonical>`` hook below
+        # both key off ``canonical`` — so without this they saw a name that
+        # resolves to nothing, skipped, and let a command run that neither the
+        # policy nor a deny hook had approved. Resolving once, here, keeps every
+        # downstream decision on the name dispatch will actually use.
+        # Built-ins are untouched: ``_resolve_cmd`` has already mapped their
+        # aliases, including the ``reload_mcp``-style separator pairs.
+        if command and _cmd_def is None and "_" in canonical:
+            _plugin_canonical = canonical.replace("_", "-")
+            try:
+                from hermes_cli.plugins import get_plugin_command_handler
+                if get_plugin_command_handler(_plugin_canonical):
+                    canonical = _plugin_canonical
+            except Exception as _plugin_lookup_err:
+                logger.debug(
+                    "Plugin command canonicalization failed (non-fatal): %s",
+                    _plugin_lookup_err,
+                )
+
         # Per-platform slash command access control. Only kicks in when the
         # operator has set ``allow_admin_from`` for the source's scope (DM
         # vs group). When unset → backward-compat: every allowed user can
@@ -15866,9 +15890,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from hermes_cli.plugins import get_plugin_command_handler
                 # Normalize underscores to hyphens so Telegram's underscored
                 # autocomplete form matches plugin commands registered with
-                # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
+                # hyphens. See hermes_cli/commands.py:_sanitize_telegram_name.
+                plugin_command = command.replace("_", "-")
+                plugin_handler = get_plugin_command_handler(plugin_command)
                 if plugin_handler:
+                    # Defense in depth. The cold gate above now decides on the
+                    # canonicalized name and denies first for both spellings,
+                    # but this sink runs arbitrary plugin code in the gateway
+                    # process and stays reachable by routes that recompute
+                    # ``canonical`` without that resolution — a ``rewrite``
+                    # hook naming an underscored plugin command, for one. Check
+                    # the name we are about to dispatch, mirroring the
+                    # quick-command sink gate above.
+                    _denied = self._check_slash_access(source, plugin_command)
+                    if _denied is not None:
+                        return _denied
                     user_args = event.get_command_args().strip()
                     result = plugin_handler(user_args)
                     if asyncio.iscoroutine(result):

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -53,6 +53,30 @@ _ALWAYS_ALLOWED_FOR_USERS: FrozenSet[str] = frozenset({
 })
 
 
+def _fold_command_name(name: str) -> str:
+    """Canonicalize a slash command name for allowlist comparison.
+
+    ``_`` and ``-`` are interchangeable in slash dispatch, so they must be
+    interchangeable here too. Two independent reasons, both generic:
+
+      - Plugin dispatch normalizes the typed name to hyphens before it looks
+        a handler up (``gateway/run.py``), because Telegram's command menu
+        renders a hyphenated plugin command as ``/my_cmd`` and sends that
+        underscored form back. The gate therefore sees ``my-cmd`` while the
+        operator, copying what the menu showed them, wrote ``my_cmd``.
+      - Several built-ins register both spellings as aliases of one command
+        (``reload-mcp``/``reload_mcp``, ``reload-skills``/``reload_skills``,
+        ``codex-runtime``/``codex_runtime``), but the gate only ever sees the
+        canonical name — so listing the alias would silently fail to grant the
+        command it names.
+
+    Folding is applied to both sides of the comparison, so the allowlist
+    grants exactly the commands it names and no others: only spellings that
+    differ solely in these two separators are treated as one name.
+    """
+    return name.replace("_", "-")
+
+
 @dataclass(frozen=True)
 class SlashAccessPolicy:
     """Resolved access policy for a single (platform, scope) pair.
@@ -83,9 +107,12 @@ class SlashAccessPolicy:
             return True
         if not canonical_cmd:
             return False
-        if canonical_cmd in _ALWAYS_ALLOWED_FOR_USERS:
+        folded = _fold_command_name(canonical_cmd)
+        if folded in _ALWAYS_ALLOWED_FOR_USERS:
             return True
-        return canonical_cmd in self.user_allowed_commands
+        # ``user_allowed_commands`` is already folded on ingest, so this
+        # compares like for like — see _fold_command_name.
+        return folded in self.user_allowed_commands
 
 
 _DM_CHAT_TYPES = frozenset({"dm", "direct", "private", ""})
@@ -119,7 +146,10 @@ def _coerce_command_list(raw: Any) -> FrozenSet[str]:
 
     Strips leading slashes so YAML can read either ``["help", "status"]``
     or ``["/help", "/status"]``. Lowercase canonicalization matches how
-    ``resolve_command()`` stores names.
+    ``resolve_command()`` stores names, and ``_`` folds to ``-`` so an
+    operator can list whichever spelling their platform showed them (see
+    :func:`_fold_command_name`). The folded form is what gets stored, so
+    ``/whoami`` and the denial message quote the canonical name.
     """
     if raw is None:
         return frozenset()
@@ -131,7 +161,7 @@ def _coerce_command_list(raw: Any) -> FrozenSet[str]:
         items = (raw,)
     out: list[str] = []
     for it in items:
-        s = str(it).strip().lstrip("/").lower()
+        s = _fold_command_name(str(it).strip().lstrip("/").lower())
         if s:
             out.append(s)
     return frozenset(out)

--- a/tests/gateway/test_plugin_command_access.py
+++ b/tests/gateway/test_plugin_command_access.py
@@ -1,0 +1,430 @@
+"""Plugin slash commands must obey the same per-platform slash-access policy
+as built-in and quick commands.
+
+The cold-path gate in ``_handle_message`` resolves access on the name the user
+typed. Plugin dispatch, however, normalizes underscores to hyphens before
+looking the handler up — Telegram's command menu surfaces a hyphenated plugin
+command as ``/my_cmd``, and that underscored form is what the adapter sends
+back. So for every hyphenated plugin command the typed name (``my_cmd``) is not
+a known command while the dispatched name (``my-cmd``) is, and the command runs
+unchecked: with ``allow_admin_from`` configured, a non-admin can invoke it.
+
+These tests drive the real ``GatewayRunner._handle_message`` seam and mirror the
+expectations already pinned for built-ins and quick commands in
+``test_slash_access_dispatch.py``: gate off unless the operator configured it,
+admins unrestricted, ``user_allowed_commands`` honoured, everyone else denied
+before the handler runs.
+
+The ``command:<canonical>`` hook is the second decision point keyed off the same
+resolved name — it can return ``{"decision": "deny"}`` — so it had the identical
+bypass, and the last section here pins both spellings through it.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+
+ADMIN = "111"
+NON_ADMIN = "999"
+
+
+def _make_source(
+    *,
+    platform: Platform = Platform.TELEGRAM,
+    user_id: str = NON_ADMIN,
+    chat_type: str = "dm",
+    chat_id: str = "chat-1",
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name=f"name-{user_id}",
+        chat_type=chat_type,
+    )
+
+
+def _make_event(text: str, source: SessionSource) -> MessageEvent:
+    return MessageEvent(text=text, source=source, message_id="m1")
+
+
+def _make_runner(*, platform_extra: dict | None = None,
+                 platform: Platform = Platform.TELEGRAM):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra=platform_extra or {},
+            )
+        }
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {platform: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    runner.session_store = MagicMock()
+    session_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:chat-1",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=platform,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_sources = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._session_db.get_session.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    # A denied command must never reach the agent either.
+    runner._run_agent = AsyncMock(return_value=None)
+    return runner
+
+
+def _install_plugin_command(monkeypatch, name: str) -> list:
+    """Register *name* as a plugin slash command; return its invocation log."""
+    from hermes_cli import plugins as plugins_mod
+
+    invocations: list = []
+
+    def handler(args: str):
+        invocations.append(args)
+        return "PLUGIN-COMMAND-RAN"
+
+    entries = {
+        name: {
+            "handler": handler,
+            "description": f"{name} command",
+            "plugin": "test-plugin",
+            "args_hint": "",
+        }
+    }
+    monkeypatch.setattr(plugins_mod, "get_plugin_commands", lambda: entries)
+    monkeypatch.setattr(
+        plugins_mod,
+        "get_plugin_command_handler",
+        lambda n: entries[n]["handler"] if n in entries else None,
+    )
+    return invocations
+
+
+# ---------------------------------------------------------------------------
+# Denial — the gate applies, and applies before the handler runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_admin_denied_for_hyphenated_plugin_command_typed_underscored(
+    monkeypatch,
+):
+    """The Telegram-menu form of a hyphenated plugin command is the live
+    bypass: the typed name never resolves, so nothing gated it."""
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner(
+        platform_extra={"allow_admin_from": [ADMIN], "user_allowed_commands": []}
+    )
+
+    result = await runner._handle_message(
+        _make_event("/my_cmd", _make_source(user_id=NON_ADMIN))
+    )
+
+    assert result is not None
+    assert "⛔" in result
+    assert "/my-cmd is admin-only here" in result
+    assert invocations == []
+    assert "PLUGIN-COMMAND-RAN" not in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_denied_for_plugin_command_typed_exactly(monkeypatch):
+    """The exactly-typed form must stay denied too."""
+    invocations = _install_plugin_command(monkeypatch, "mycmd")
+    runner = _make_runner(
+        platform_extra={"allow_admin_from": [ADMIN], "user_allowed_commands": []}
+    )
+
+    result = await runner._handle_message(
+        _make_event("/mycmd", _make_source(user_id=NON_ADMIN))
+    )
+
+    assert result is not None
+    assert "⛔" in result
+    assert invocations == []
+
+
+@pytest.mark.asyncio
+async def test_denial_holds_when_the_plugin_command_takes_arguments(monkeypatch):
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner(
+        platform_extra={"allow_admin_from": [ADMIN], "user_allowed_commands": []}
+    )
+
+    result = await runner._handle_message(
+        _make_event("/my_cmd 10m", _make_source(user_id=NON_ADMIN))
+    )
+
+    assert "⛔" in result
+    assert invocations == []
+
+
+# ---------------------------------------------------------------------------
+# Allow — admins, listed users, and the un-configured default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed", ["/my_cmd", "/my-cmd"])
+async def test_admin_runs_plugin_command_when_gating_enabled(monkeypatch, typed):
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner(
+        platform_extra={"allow_admin_from": [ADMIN], "user_allowed_commands": []}
+    )
+
+    result = await runner._handle_message(
+        _make_event(typed, _make_source(user_id=ADMIN))
+    )
+
+    assert result == "PLUGIN-COMMAND-RAN"
+    assert invocations == [""]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed", ["/my_cmd", "/my-cmd"])
+@pytest.mark.parametrize("listed", ["my-cmd", "my_cmd"])
+async def test_non_admin_runs_plugin_command_listed_in_user_allowed(
+    monkeypatch, typed, listed
+):
+    """Either spelling of the allowlist entry admits either typed form.
+
+    The registration is hyphenated, but Telegram's command menu shows the
+    command as ``/my_cmd`` — so that underscored form is what an operator
+    copies into ``user_allowed_commands``. The policy folds ``_`` to ``-`` on
+    both sides, so the four combinations of listed × typed all resolve to the
+    same command.
+    """
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": [ADMIN],
+            "user_allowed_commands": [listed],
+        }
+    )
+
+    result = await runner._handle_message(
+        _make_event(typed, _make_source(user_id=NON_ADMIN))
+    )
+
+    assert result == "PLUGIN-COMMAND-RAN"
+    assert invocations == [""]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed", ["/my_cmd", "/my-cmd"])
+async def test_underscored_allowlist_entry_does_not_admit_other_commands(
+    monkeypatch, typed
+):
+    """Folding must not widen the allowlist beyond the command it names."""
+    invocations = _install_plugin_command(monkeypatch, "other-cmd")
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": [ADMIN],
+            "user_allowed_commands": ["my_cmd"],
+        }
+    )
+
+    result = await runner._handle_message(
+        _make_event(typed.replace("my", "other"), _make_source(user_id=NON_ADMIN))
+    )
+
+    assert "⛔" in result
+    assert invocations == []
+
+
+@pytest.mark.asyncio
+async def test_backward_compat_no_admin_list_means_no_gating(monkeypatch):
+    """Unless the operator configured ``allow_admin_from`` for the scope, the
+    policy is disabled and every authorized user runs every plugin command."""
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner(platform_extra={})
+
+    result = await runner._handle_message(
+        _make_event("/my_cmd", _make_source(user_id="anyone"))
+    )
+
+    assert result == "PLUGIN-COMMAND-RAN"
+    assert invocations == [""]
+
+
+@pytest.mark.asyncio
+async def test_group_only_gating_leaves_dm_plugin_commands_unrestricted(monkeypatch):
+    """Admin lists are scope-specific: a group-scoped list must not gate DMs."""
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner(platform_extra={"group_allow_admin_from": [ADMIN]})
+
+    result = await runner._handle_message(
+        _make_event("/my_cmd", _make_source(user_id="anyone", chat_type="dm"))
+    )
+
+    assert result == "PLUGIN-COMMAND-RAN"
+    assert invocations == [""]
+
+
+@pytest.mark.asyncio
+async def test_group_scope_gating_denies_non_admin_plugin_command(monkeypatch):
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner(
+        platform_extra={
+            "group_allow_admin_from": [ADMIN],
+            "group_user_allowed_commands": [],
+        }
+    )
+
+    result = await runner._handle_message(
+        _make_event(
+            "/my_cmd",
+            _make_source(user_id=NON_ADMIN, chat_type="group", chat_id="g-1"),
+        )
+    )
+
+    assert "⛔" in result
+    assert invocations == []
+
+
+# ---------------------------------------------------------------------------
+# command:<canonical> hook — the second decision point on the same name
+# ---------------------------------------------------------------------------
+#
+# The hook fires only ``if is_gateway_known_command(canonical)``, the same
+# predicate the access gate used, so the underscored spelling skipped it too:
+# a handler returning ``{"decision": "deny"}`` was silently ignored for
+# /my_cmd while it was honoured for /my-cmd. Both spellings must now reach it,
+# and must reach it under the *registered* name so one hook registration works
+# regardless of which spelling the platform sends.
+
+
+def _hook_returns(runner, *results):
+    """Make the ``command:`` hook return *results*; return the emit_collect mock."""
+    emit_collect = AsyncMock(return_value=list(results))
+    runner.hooks.emit_collect = emit_collect
+    return emit_collect
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed", ["/my_cmd", "/my-cmd"])
+async def test_command_hook_deny_blocks_the_plugin_command(monkeypatch, typed):
+    """A deny hook must stop dispatch for either spelling."""
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner()
+    _hook_returns(runner, {"decision": "deny", "message": "HOOK-DENIED"})
+
+    result = await runner._handle_message(_make_event(typed, _make_source()))
+
+    assert result == "HOOK-DENIED"
+    assert invocations == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed", ["/my_cmd", "/my-cmd"])
+async def test_command_hook_deny_without_message_still_blocks(monkeypatch, typed):
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner()
+    _hook_returns(runner, {"decision": "deny"})
+
+    result = await runner._handle_message(_make_event(typed, _make_source()))
+
+    assert "blocked by a hook" in result
+    assert invocations == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed", ["/my_cmd", "/my-cmd"])
+async def test_command_hook_handled_short_circuits_plugin_dispatch(monkeypatch, typed):
+    """``handled`` means the hook did the work — core dispatch must not."""
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner()
+    _hook_returns(runner, {"decision": "handled", "message": "HOOK-HANDLED"})
+
+    result = await runner._handle_message(_make_event(typed, _make_source()))
+
+    assert result == "HOOK-HANDLED"
+    assert invocations == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed", ["/my_cmd", "/my-cmd"])
+async def test_command_hook_fires_under_the_registered_name(monkeypatch, typed):
+    """One registration, ``command:my-cmd``, serves both spellings.
+
+    The hook name and ``ctx["command"]`` carry the registered (hyphenated)
+    name so a handler need not know which spelling the platform sent, while
+    ``ctx["raw_command"]`` preserves what the user actually typed.
+    """
+    _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner()
+    emit_collect = _hook_returns(runner)
+
+    await runner._handle_message(_make_event(f"{typed} 10m", _make_source()))
+
+    hook_names = [call.args[0] for call in emit_collect.await_args_list]
+    assert "command:my-cmd" in hook_names
+
+    ctx = next(
+        call.args[1]
+        for call in emit_collect.await_args_list
+        if call.args[0] == "command:my-cmd"
+    )
+    assert ctx["command"] == "my-cmd"
+    assert ctx["raw_command"] == typed.lstrip("/")
+    assert ctx["args"] == "10m"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("typed", ["/my_cmd", "/my-cmd"])
+async def test_hook_without_a_decision_leaves_dispatch_alone(monkeypatch, typed):
+    """Telemetry-style hooks that return nothing must not change behaviour."""
+    invocations = _install_plugin_command(monkeypatch, "my-cmd")
+    runner = _make_runner()
+    _hook_returns(runner, {}, {"decision": "allow"}, "not-a-dict")
+
+    result = await runner._handle_message(_make_event(typed, _make_source()))
+
+    assert result == "PLUGIN-COMMAND-RAN"
+    assert invocations == [""]

--- a/tests/gateway/test_slash_access.py
+++ b/tests/gateway/test_slash_access.py
@@ -52,6 +52,20 @@ class TestPolicyFromExtra:
         assert p.user_allowed_commands == frozenset({"status", "model", "help"})
 
 
+    def test_command_coercion_folds_underscores_to_hyphens(self):
+        # Telegram's command menu surfaces a hyphenated command as /my_cmd and
+        # sends that form back, so operators reasonably write the underscored
+        # spelling in their allowlist. Both spellings name the same command.
+        p = policy_from_extra(
+            {
+                "allow_admin_from": ["111"],
+                "user_allowed_commands": ["my_cmd", "/Reload_MCP"],
+            },
+            "dm",
+        )
+        assert p.user_allowed_commands == frozenset({"my-cmd", "reload-mcp"})
+
+
     def test_dm_admin_does_not_imply_group_admin(self):
         # Admin lists are scope-specific. DM admin must not auto-promote in groups.
         extra = {"allow_admin_from": ["111"]}
@@ -69,6 +83,80 @@ class TestPolicyFromExtra:
         gp2 = policy_from_extra(extra2, "group")
         assert gp2.is_admin("111") is False
         assert gp2.is_admin("222") is True
+
+
+# ---------------------------------------------------------------------------
+# can_run — underscore/hyphen equivalence
+# ---------------------------------------------------------------------------
+
+
+class TestCanRunSeparatorFolding:
+    """``_`` and ``-`` are the same character to slash dispatch, so they must
+    be the same character to the allowlist.
+
+    Plugin dispatch normalizes the typed name (``my_cmd``) to the registered
+    one (``my-cmd``) before looking a handler up, and the gate runs on that
+    normalized name. Built-ins go further and register both spellings as
+    aliases of one command (``reload-mcp`` / ``reload_mcp``). An operator
+    cannot be expected to know which spelling the gate will see, so the
+    policy folds both sides of the comparison.
+    """
+
+    @staticmethod
+    def _policy(listed):
+        return policy_from_extra(
+            {"allow_admin_from": ["111"], "user_allowed_commands": listed}, "dm"
+        )
+
+
+    def test_underscored_listing_admits_the_hyphenated_command(self):
+        # The operator wrote the form Telegram's menu shows.
+        p = self._policy(["my_cmd"])
+        assert p.can_run("999", "my-cmd") is True
+
+
+    def test_hyphenated_listing_admits_the_underscored_command(self):
+        # The mirror image — a quick command or plugin registered with an
+        # underscore, gated on the raw typed name.
+        p = self._policy(["my-cmd"])
+        assert p.can_run("999", "my_cmd") is True
+
+
+    def test_both_spellings_keep_working_for_the_exact_form(self):
+        for listed in (["my_cmd"], ["my-cmd"]):
+            p = self._policy(listed)
+            assert p.can_run("999", listed[0]) is True
+
+
+    def test_builtin_alias_pair_is_allowed_under_either_spelling(self):
+        # ``reload-mcp`` and ``reload_mcp`` are aliases of one built-in, but
+        # the gate only ever sees the canonical name.
+        for listed in ("reload_mcp", "reload-mcp"):
+            p = self._policy([listed])
+            assert p.can_run("999", "reload-mcp") is True
+            assert p.can_run("999", "reload_mcp") is True
+
+
+    def test_folding_does_not_admit_unrelated_commands(self):
+        p = self._policy(["my_cmd"])
+        assert p.can_run("999", "mycmd") is False
+        assert p.can_run("999", "my cmd") is False
+        assert p.can_run("999", "other-cmd") is False
+        assert p.can_run("999", "my-cmd-2") is False
+
+
+    def test_non_allowlisted_user_stays_denied_for_either_spelling(self):
+        # Nothing here is a way in: an empty allowlist denies both forms.
+        p = self._policy([])
+        assert p.can_run("999", "my-cmd") is False
+        assert p.can_run("999", "my_cmd") is False
+
+
+    def test_admin_and_disabled_gating_are_unaffected(self):
+        p = self._policy([])
+        assert p.can_run("111", "my_cmd") is True  # admin
+        off = policy_from_extra({}, "dm")
+        assert off.can_run("999", "my_cmd") is True  # gating not configured
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Normalize recognized plugin command names before slash-access and command-hook decisions, and retain a policy check at the plugin dispatch sink.

Telegram renders a plugin command registered as `my-cmd` as `/my_cmd`. Dispatch already converts that spelling back to `my-cmd`, but the earlier access gate and `command:<name>` hook looked up `my_cmd`, treated it as unknown, and skipped both checks.

## Reproduction

With a plugin command `my-cmd`, a configured non-admin command policy, and no user grant:

- `/my-cmd` is denied
- `/my_cmd` reaches the plugin handler on current `main`

A deny result from `command:my-cmd` is skipped in the same way for `/my_cmd`.

## Fix

- Resolve the Telegram-safe underscore spelling to the registered plugin name before the access gate and command hook.
- Fold `_` and `-` consistently in `user_allowed_commands`, so operators can use the spelling shown by Telegram.
- Re-check policy immediately before invoking plugin code as defense in depth, including hook rewrite paths.

The fold has no collisions across distinct built-in commands. When `allow_admin_from` is not configured, slash access remains disabled as before. Command hooks now fire consistently under the registered name for both spellings.

Skill and bundle command paths are intentionally unchanged: they rewrite into normal chat/agent handling rather than invoking a plugin handler directly.

## Tests

- Added gateway dispatch coverage for both spellings, admin/user policy behavior, allowlists, and DM/group scopes.
- Added deny/handled/no-decision command-hook coverage for both spellings.
- Added unit coverage for allowlist normalization.
- Focused suite: 95 passed.
- Ruff and `git diff --check`: clean.
