### PR TITLE
fix(gateway): bind session context for plugin slash commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15870,9 +15870,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
-                    if asyncio.iscoroutine(result):
-                        result = await result
+                    # Bind THIS turn's session identity for the duration of the
+                    # handler. reset_session_vars() ran at handler entry and
+                    # _set_session_env() doesn't run until the agent path, so
+                    # without this every HERMES_SESSION_* var stays unset for
+                    # the whole handler: get_session_env() finds no ContextVar,
+                    # and nothing in the product mirrors these vars into
+                    # os.environ any more (see the deliberate non-mirroring of
+                    # HERMES_SESSION_KEY above), so the handler — and every
+                    # Hermes internal it calls, e.g. send_message_tool,
+                    # cronjob_tools, kanban_tools, approval — reads an empty
+                    # origin and stamps an empty platform/chat/user on whatever
+                    # it does. The handler gets no event/source argument, so
+                    # the bound context is its only view of the origin.
+                    # HERMES_SESSION_ID is the one var still mirrored process-
+                    # globally (agent_init), so resolve this key's real id
+                    # instead of binding "" over a possibly-foreign value.
+                    _plugin_session_id = await self._peek_bound_session_id(_quick_key)
+                    _plugin_env_tokens = self._set_session_env_from_source(
+                        source, _quick_key, session_id=_plugin_session_id
+                    )
+                    try:
+                        result = plugin_handler(user_args)
+                        if asyncio.iscoroutine(result):
+                            result = await result
+                    finally:
+                        # Clears to "" rather than restoring (these helpers are
+                        # not nestable). Only observable when the handler
+                        # raises and dispatch falls through to skill/agent
+                        # handling, which sees "" instead of the os.environ
+                        # fallback until _set_session_env binds properly —
+                        # stricter than before, not looser.
+                        self._clear_session_env(_plugin_env_tokens)
                     return str(result) if result else None
             except Exception as e:
                 logger.warning("Plugin command dispatch failed: %s", e)
@@ -21930,6 +21959,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Returns a list of reset tokens; pass them to ``_clear_session_env``
         in a ``finally`` block.
         """
+        return self._set_session_env_from_source(context.source, context.session_key)
+
+    async def _peek_bound_session_id(self, session_key: str) -> str:
+        """Best-effort persisted ``session_id`` for *session_key* (``""`` if none).
+
+        Dispatch paths that bind session context before the agent path runs
+        must carry the existing session id, or they replace it with ``""`` for
+        the duration of the handler — ``agent_init`` is what repopulates it on
+        the agent path, and it never runs for those paths.
+
+        Mirrors the store access in ``gateway/platforms/webhook.py``: the
+        public lock-held accessor, tolerant of stores and test doubles that
+        don't provide it. Never raises — an unresolvable id must not fail a
+        command.
+        """
+        peek = getattr(getattr(self, "session_store", None), "peek_session_id", None)
+        if not callable(peek):
+            return ""
+        try:
+            session_id = await asyncio.to_thread(peek, session_key)
+        except Exception:
+            return ""
+        # Only a real id counts: an unknown key yields None, and bare runners
+        # built via object.__new__ in tests carry a mock store whose call
+        # returns a mock object rather than a string.
+        return session_id if isinstance(session_id, str) else ""
+
+    def _set_session_env_from_source(
+        self, source: SessionSource, session_key: str, session_id: str = ""
+    ) -> list:
+        """Bind session context variables from a raw source + session key.
+
+        Same contract as :meth:`_set_session_env`, but usable from dispatch
+        paths that have the real ``SessionSource`` in hand before a
+        ``SessionContext`` is built (plugin slash commands). ``session_id``
+        defaults to ``""`` so :meth:`_set_session_env` keeps binding exactly
+        what it bound before this seam existed (the agent path gets its id
+        from ``agent_init`` a moment later); callers that bind outside the
+        agent path pass the session's real id.
+        """
         from gateway.session_context import set_session_vars
         # Propagate the adapter's async-delivery capability so async tools
         # (terminal notify_on_complete / watch_patterns, delegate_task
@@ -21939,27 +22008,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # bare runners built via object.__new__ (tests) without self.adapters
         # don't blow up — they simply default to supported.
         _adapters = getattr(self, "adapters", None) or {}
-        _adapter = _adapters.get(context.source.platform)
+        _adapter = _adapters.get(source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
         return set_session_vars(
-            platform=context.source.platform.value,
-            chat_id=context.source.chat_id,
-            chat_type=(
-                str(context.source.chat_type) if context.source.chat_type else ""
-            ),
-            chat_name=context.source.chat_name or "",
-            thread_id=str(context.source.thread_id) if context.source.thread_id else "",
-            user_id=str(context.source.user_id) if context.source.user_id else "",
-            user_name=str(context.source.user_name) if context.source.user_name else "",
-            session_key=context.session_key,
-            message_id=str(context.source.message_id) if context.source.message_id else "",
-            profile=getattr(context.source, "profile", "") or "",
+            platform=source.platform.value,
+            chat_id=source.chat_id,
+            chat_type=str(source.chat_type) if source.chat_type else "",
+            chat_name=source.chat_name or "",
+            thread_id=str(source.thread_id) if source.thread_id else "",
+            user_id=str(source.user_id) if source.user_id else "",
+            user_name=str(source.user_name) if source.user_name else "",
+            session_key=session_key,
+            session_id=session_id,
+            message_id=str(source.message_id) if source.message_id else "",
+            profile=getattr(source, "profile", "") or "",
             async_delivery=_async_delivery,
             cron_session="",
         )
 
     def _clear_session_env(self, tokens: list) -> None:
-        """Restore session context variables to their pre-handler values."""
+        """Mark session context variables as explicitly cleared.
+
+        ``clear_session_vars`` sets every var to ``""`` rather than restoring
+        the pre-handler values — the helpers are not nestable and the tokens
+        are accepted for API compatibility only. That distinction matters at
+        mid-turn call sites (plugin dispatch): after this, reads return ``""``
+        instead of falling back to ``os.environ``.
+        """
         from gateway.session_context import clear_session_vars
         clear_session_vars(tokens)
 

--- a/tests/gateway/test_plugin_command_context.py
+++ b/tests/gateway/test_plugin_command_context.py
@@ -1,0 +1,524 @@
+"""Plugin slash-command handlers must run inside the turn's bound session context.
+
+``_handle_message`` calls ``reset_session_vars()`` at handler entry (so a task
+that inherited a concurrent sibling's ContextVars starts clean) and only binds
+this turn's identity via ``_set_session_env`` much later, on the agent path.
+The plugin slash-command branch sits in between: it dispatches
+``plugin_handler(user_args)`` — a positional string, no ``event``, no
+``source`` — so every ``HERMES_SESSION_*`` ContextVar is unset for the whole
+handler.
+
+The defect that produces is an **empty ambient origin**: nothing in the product
+mirrors platform/chat/user/key into ``os.environ`` any more (the ContextVar
+migration removed those writes, and ``gateway/run.py`` deliberately stops
+mirroring ``HERMES_SESSION_KEY``), so ``get_session_env`` resolves through to
+the ``""`` default. The handler, and every Hermes internal it calls that reads
+the ambient context — ``tools/send_message_tool.py`` (platform + user_id for
+delivery), ``tools/cronjob_tools.py`` (origin stamped onto the job),
+``tools/kanban_tools.py``, ``tools/approval.py`` — sees no origin at all.
+
+``HERMES_SESSION_ID`` is the one session var still mirrored process-globally
+(``agent/agent_init.py``), so it is the one that can genuinely read as another
+session's value; the binding therefore carries this key's real session id
+rather than blanking it.
+
+These tests drive the real ``GatewayRunner._handle_message`` seam and assert
+the handler observes the identity of the event that invoked it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source(
+    *,
+    platform: Platform = Platform.TELEGRAM,
+    user_id: str = "u1",
+    user_name: str = "tester",
+    chat_id: str = "chat-1",
+    chat_type: str = "dm",
+    chat_name: str = "Chat One",
+    thread_id: str | None = None,
+    message_id: str | None = None,
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        user_name=user_name,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        chat_name=chat_name,
+        thread_id=thread_id,
+        message_id=message_id,
+    )
+
+
+def _make_event(
+    text: str, source: SessionSource, *, message_id: str = "m1"
+) -> MessageEvent:
+    return MessageEvent(text=text, source=source, message_id=message_id)
+
+
+def _make_runner(*platforms: Platform):
+    """A bare runner wired for the cold ``_handle_message`` dispatch path."""
+    from gateway.run import GatewayRunner
+
+    platforms = platforms or (Platform.TELEGRAM,)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={p: PlatformConfig(enabled=True, token="***") for p in platforms}
+    )
+    runner.adapters = {p: MagicMock(send=AsyncMock()) for p in platforms}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    session_entry = SessionEntry(
+        session_key="agent:main:stub",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=platforms[0],
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner.session_store = MagicMock()
+    # Real key derivation, so tests compare against the gateway's own answer
+    # instead of freezing a key format.
+    runner.session_store._generate_session_key = build_session_key
+    runner.session_store.get_or_create_session.return_value = session_entry
+    # The store already knows this key's session id; the plugin binding must
+    # carry it rather than blanking HERMES_SESSION_ID for the handler.
+    runner.session_store.peek_session_id.return_value = session_entry.session_id
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_sources = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._session_db.get_session.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *_a, **_kw: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    return runner
+
+
+def _install_plugin_commands(monkeypatch, handlers: dict) -> None:
+    """Register *handlers* (name → callable) as the process's plugin commands."""
+    from hermes_cli import plugins as plugins_mod
+
+    entries = {
+        name: {
+            "handler": handler,
+            "description": f"{name} command",
+            "plugin": "test-plugin",
+            "args_hint": "",
+        }
+        for name, handler in handlers.items()
+    }
+    monkeypatch.setattr(plugins_mod, "get_plugin_commands", lambda: entries)
+    monkeypatch.setattr(
+        plugins_mod,
+        "get_plugin_command_handler",
+        lambda name: entries[name]["handler"] if name in entries else None,
+    )
+
+
+_SESSION_VARS = (
+    "HERMES_SESSION_PLATFORM",
+    "HERMES_SESSION_CHAT_ID",
+    "HERMES_SESSION_CHAT_TYPE",
+    "HERMES_SESSION_CHAT_NAME",
+    "HERMES_SESSION_THREAD_ID",
+    "HERMES_SESSION_USER_ID",
+    "HERMES_SESSION_USER_NAME",
+    "HERMES_SESSION_KEY",
+    "HERMES_SESSION_MESSAGE_ID",
+    # Mirrored process-globally by agent_init — the one var whose pre-fix
+    # value could belong to another session rather than being merely empty.
+    "HERMES_SESSION_ID",
+)
+
+
+def _snapshot_session_env() -> dict:
+    from gateway.session_context import get_session_env
+
+    return {name: get_session_env(name) for name in _SESSION_VARS}
+
+
+def _pollute_process_env(monkeypatch, marker: str) -> None:
+    """Mirror a foreign session into process-global ``os.environ``.
+
+    Defense in depth, not the headline symptom. In a real gateway process
+    nothing writes the platform/chat/user/key vars to ``os.environ`` any more,
+    so the pre-fix handler simply saw *nothing* — the empty ambient origin
+    these tests assert against. Some hosts and wrappers do export them
+    (``HERMES_SESSION_ID`` is still mirrored by ``agent_init`` outright), and
+    ``get_session_env`` falls back to whatever is there whenever the ContextVar
+    is unset, so every test also pins the stronger property: the handler reads
+    its own turn even when the process environment is speaking for someone
+    else.
+    """
+    for name in _SESSION_VARS:
+        monkeypatch.setenv(name, f"{marker}-{name}")
+
+
+# ---------------------------------------------------------------------------
+# The handler must see ITS OWN turn — not an empty ambient context, and not
+# whatever the process environment happens to hold
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plugin_handler_sees_bound_origin_not_process_env(monkeypatch):
+    seen: dict = {}
+
+    def handler(args: str):
+        seen.update(_snapshot_session_env())
+        return "handled"
+
+    _install_plugin_commands(monkeypatch, {"probe": handler})
+    _pollute_process_env(monkeypatch, "FOREIGN")
+
+    runner = _make_runner(Platform.TELEGRAM)
+    source = _make_source(
+        platform=Platform.TELEGRAM,
+        user_id="tg-user",
+        user_name="tg-name",
+        chat_id="tg-chat",
+        chat_type="group",
+        chat_name="TG Group",
+        thread_id="tg-thread",
+        message_id="mid-9",
+    )
+
+    result = await runner._handle_message(
+        _make_event("/probe", source, message_id="mid-9")
+    )
+
+    assert result == "handled"
+    assert seen["HERMES_SESSION_PLATFORM"] == "telegram"
+    assert seen["HERMES_SESSION_CHAT_ID"] == "tg-chat"
+    assert seen["HERMES_SESSION_CHAT_TYPE"] == "group"
+    assert seen["HERMES_SESSION_CHAT_NAME"] == "TG Group"
+    assert seen["HERMES_SESSION_THREAD_ID"] == "tg-thread"
+    assert seen["HERMES_SESSION_USER_ID"] == "tg-user"
+    assert seen["HERMES_SESSION_USER_NAME"] == "tg-name"
+    assert seen["HERMES_SESSION_MESSAGE_ID"] == "mid-9"
+    assert seen["HERMES_SESSION_KEY"] == runner._session_key_for_source(source)
+    assert seen["HERMES_SESSION_ID"] == "sess-1"
+    # Nothing from the foreign process-global mirror survives.
+    assert not [v for v in seen.values() if "FOREIGN" in v]
+
+
+# ---------------------------------------------------------------------------
+# HERMES_SESSION_ID: the binding must carry the session that already exists
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_binding_carries_the_existing_session_id(monkeypatch):
+    """The turn already has a persisted session; the handler must see that id.
+
+    Binding without it would replace a correct value with "explicitly cleared"
+    for the handler's lifetime — ``agent_init`` is what repopulates
+    ``HERMES_SESSION_ID`` on the agent path, and the plugin branch returns long
+    before that runs.
+    """
+    seen: dict = {}
+    _install_plugin_commands(
+        monkeypatch, {"probe": lambda args: seen.update(_snapshot_session_env())}
+    )
+    _pollute_process_env(monkeypatch, "FOREIGN")
+
+    runner = _make_runner(Platform.TELEGRAM)
+    runner.session_store.peek_session_id.return_value = "sess-existing"
+    source = _make_source(platform=Platform.TELEGRAM, chat_id="tg-chat")
+
+    await runner._handle_message(_make_event("/probe", source))
+
+    assert seen["HERMES_SESSION_ID"] == "sess-existing"
+    # Resolved for THIS turn's key, via the store's public lock-held accessor.
+    runner.session_store.peek_session_id.assert_called_once_with(
+        runner._session_key_for_source(source)
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_persisted_session_binds_empty_id_not_a_foreign_one(monkeypatch):
+    """A first-contact chat has no session row yet. There is no correct id to
+    bind, so the handler sees ``""`` — never another session's id from the
+    process-global mirror ``agent_init`` writes."""
+    seen: dict = {}
+    _install_plugin_commands(
+        monkeypatch, {"probe": lambda args: seen.update(_snapshot_session_env())}
+    )
+    _pollute_process_env(monkeypatch, "FOREIGN")
+
+    runner = _make_runner(Platform.TELEGRAM)
+    runner.session_store.peek_session_id.return_value = None
+
+    await runner._handle_message(
+        _make_event("/probe", _make_source(platform=Platform.TELEGRAM))
+    )
+
+    assert seen["HERMES_SESSION_ID"] == ""
+    assert seen["HERMES_SESSION_PLATFORM"] == "telegram"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("store_defect", ["no_accessor", "raises"])
+async def test_unresolvable_session_id_never_fails_the_command(
+    monkeypatch, store_defect
+):
+    """Stores that predate ``peek_session_id`` (and stores that fail on it) must
+    still get the rest of the origin bound — resolving an id is best-effort,
+    not a precondition for running the command."""
+    seen: dict = {}
+    _install_plugin_commands(
+        monkeypatch,
+        {"probe": lambda args: seen.update(_snapshot_session_env()) or "handled"},
+    )
+
+    runner = _make_runner(Platform.TELEGRAM)
+    if store_defect == "no_accessor":
+        del runner.session_store.peek_session_id
+    else:
+        runner.session_store.peek_session_id.side_effect = RuntimeError("store down")
+
+    result = await runner._handle_message(
+        _make_event("/probe", _make_source(platform=Platform.TELEGRAM))
+    )
+
+    assert result == "handled"
+    assert seen["HERMES_SESSION_ID"] == ""
+    assert seen["HERMES_SESSION_PLATFORM"] == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_platform_sessions_do_not_leak_into_each_other(monkeypatch):
+    """Two plugin commands running concurrently on different platforms each see
+    their own origin — the property ``os.environ`` cannot provide."""
+    seen: dict = {}
+    both_inside = asyncio.Barrier(2)
+
+    async def handler(args: str):
+        # Force real overlap: neither handler may read its context until both
+        # are inside. A process-global mirror is last-writer-wins here.
+        await both_inside.wait()
+        snapshot = _snapshot_session_env()
+        seen[snapshot["HERMES_SESSION_CHAT_ID"]] = snapshot
+        return "handled"
+
+    _install_plugin_commands(monkeypatch, {"probe": handler})
+    _pollute_process_env(monkeypatch, "FOREIGN")
+
+    runner = _make_runner(Platform.TELEGRAM, Platform.DISCORD)
+    tg_source = _make_source(
+        platform=Platform.TELEGRAM, user_id="tg-user", chat_id="tg-chat"
+    )
+    dc_source = _make_source(
+        platform=Platform.DISCORD, user_id="dc-user", chat_id="dc-chat"
+    )
+
+    results = await asyncio.gather(
+        runner._handle_message(_make_event("/probe", tg_source)),
+        runner._handle_message(_make_event("/probe", dc_source)),
+    )
+
+    assert results == ["handled", "handled"]
+    assert set(seen) == {"tg-chat", "dc-chat"}
+    assert seen["tg-chat"]["HERMES_SESSION_PLATFORM"] == "telegram"
+    assert seen["tg-chat"]["HERMES_SESSION_USER_ID"] == "tg-user"
+    assert seen["dc-chat"]["HERMES_SESSION_PLATFORM"] == "discord"
+    assert seen["dc-chat"]["HERMES_SESSION_USER_ID"] == "dc-user"
+
+
+@pytest.mark.asyncio
+async def test_async_plugin_handler_also_sees_bound_origin(monkeypatch):
+    """Async handlers are supported (awaited at the dispatch site) and must get
+    the same binding as sync ones."""
+    seen: dict = {}
+
+    async def handler(args: str):
+        await asyncio.sleep(0)
+        seen.update(_snapshot_session_env())
+        return f"async:{args}"
+
+    _install_plugin_commands(monkeypatch, {"probe": handler})
+    _pollute_process_env(monkeypatch, "FOREIGN")
+
+    runner = _make_runner(Platform.DISCORD)
+    source = _make_source(
+        platform=Platform.DISCORD, chat_id="dc-chat", user_id="dc-user"
+    )
+
+    result = await runner._handle_message(_make_event("/probe now please", source))
+
+    assert result == "async:now please"
+    assert seen["HERMES_SESSION_PLATFORM"] == "discord"
+    assert seen["HERMES_SESSION_CHAT_ID"] == "dc-chat"
+
+
+@pytest.mark.asyncio
+async def test_session_context_is_released_after_the_handler(monkeypatch):
+    """The binding is scoped to the handler: once dispatch returns, the vars are
+    explicitly cleared, not left set for whatever runs next in this task."""
+    _install_plugin_commands(monkeypatch, {"probe": lambda args: "handled"})
+    _pollute_process_env(monkeypatch, "FOREIGN")
+
+    runner = _make_runner(Platform.TELEGRAM)
+    source = _make_source(platform=Platform.TELEGRAM, chat_id="tg-chat")
+
+    assert await runner._handle_message(_make_event("/probe", source)) == "handled"
+
+    after = _snapshot_session_env()
+    assert after["HERMES_SESSION_PLATFORM"] == ""
+    assert after["HERMES_SESSION_CHAT_ID"] == ""
+    # Cleared means cleared — the os.environ fallback must stay suppressed.
+    assert not [v for v in after.values() if "FOREIGN" in v]
+
+
+@pytest.mark.asyncio
+async def test_raising_handler_still_releases_the_binding(monkeypatch):
+    """A handler that raises is swallowed by the dispatch site's warning path;
+    it must not leave this turn's identity bound behind it."""
+
+    def handler(args: str):
+        raise RuntimeError("plugin blew up")
+
+    _install_plugin_commands(monkeypatch, {"probe": handler})
+    _pollute_process_env(monkeypatch, "FOREIGN")
+
+    runner = _make_runner(Platform.TELEGRAM)
+    runner._run_agent = AsyncMock(return_value=None)
+    source = _make_source(platform=Platform.TELEGRAM, chat_id="tg-chat")
+
+    await runner._handle_message(_make_event("/probe", source))
+
+    after = _snapshot_session_env()
+    assert after["HERMES_SESSION_PLATFORM"] == ""
+    assert not [v for v in after.values() if "FOREIGN" in v]
+
+
+# ---------------------------------------------------------------------------
+# Existing dispatch behaviour is preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("returned", [None, ""])
+async def test_falsy_handler_result_still_suppresses_the_echo(monkeypatch, returned):
+    _install_plugin_commands(monkeypatch, {"probe": lambda args: returned})
+
+    runner = _make_runner(Platform.TELEGRAM)
+    result = await runner._handle_message(
+        _make_event("/probe", _make_source(platform=Platform.TELEGRAM))
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_handler_receives_raw_args_and_result_is_stringified(monkeypatch):
+    got: list = []
+    _install_plugin_commands(
+        monkeypatch, {"probe": lambda args: got.append(args) or 42}
+    )
+
+    runner = _make_runner(Platform.TELEGRAM)
+    result = await runner._handle_message(
+        _make_event("/probe  10m  ", _make_source(platform=Platform.TELEGRAM))
+    )
+
+    assert got == ["10m"]
+    assert result == "42"
+
+
+@pytest.mark.asyncio
+async def test_underscored_form_still_reaches_a_hyphenated_command(monkeypatch):
+    """Telegram autocomplete sends /my_cmd for a command registered as my-cmd."""
+    _install_plugin_commands(monkeypatch, {"my-cmd": lambda args: "handled"})
+
+    runner = _make_runner(Platform.TELEGRAM)
+    result = await runner._handle_message(
+        _make_event("/my_cmd", _make_source(platform=Platform.TELEGRAM))
+    )
+
+    assert result == "handled"
+
+
+# ---------------------------------------------------------------------------
+# The extracted binding helper is the one _set_session_env itself uses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_session_env_delegates_to_the_source_helper():
+    """``_set_session_env(context)`` must be exactly
+    ``_set_session_env_from_source(context.source, context.session_key)`` — the
+    extraction carries no behaviour change of its own."""
+    from gateway.session import SessionContext
+
+    runner = _make_runner(Platform.TELEGRAM)
+    source = _make_source(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat",
+        chat_type="group",
+        chat_name="TG Group",
+        thread_id="t-9",
+        user_id="u-9",
+        user_name="name-9",
+    )
+
+    async def _bind_via_context():
+        context = SessionContext(
+            source=source,
+            connected_platforms=[Platform.TELEGRAM],
+            home_channels={},
+            session_key="key-from-context",
+        )
+        runner._set_session_env(context)
+        return _snapshot_session_env()
+
+    async def _bind_via_source():
+        runner._set_session_env_from_source(source, "key-from-context")
+        return _snapshot_session_env()
+
+    via_context, via_source = await asyncio.gather(
+        _bind_via_context(), _bind_via_source()
+    )
+
+    assert via_context == via_source
+    assert via_source["HERMES_SESSION_KEY"] == "key-from-context"
+    assert via_source["HERMES_SESSION_PLATFORM"] == "telegram"
+    # The agent path binds no session id — agent_init sets it via
+    # set_current_session_id immediately afterwards. The ``session_id`` kwarg
+    # defaults to "" precisely so this stays byte-identical to pre-change
+    # behaviour; only callers outside the agent path pass a real id.
+    assert via_context["HERMES_SESSION_ID"] == ""


### PR DESCRIPTION
## Summary

Bind the existing `HERMES_SESSION_*` ContextVars while a messaging gateway plugin slash-command handler runs.

Plugin handlers currently execute before the agent path binds session context. A handler itself—or Hermes code it calls, such as message delivery, cron scheduling, kanban, or approvals—therefore sees an empty platform/chat/thread origin. `HERMES_SESSION_ID` may also retain a process-level value unrelated to the current event.

## Fix

- Resolve the current persisted session ID from the event's session key.
- Bind the event source and session ID immediately before invoking the plugin handler.
- Clear the binding in `finally`, including when the handler raises.
- Keep the normal agent initialization path unchanged.

The handler API remains unchanged, so existing plugins benefit without opting into a new argument or registration mode.

## Scope and related work

This PR covers `GatewayRunner._handle_message`, the messaging gateway path where the bug was reproduced. TUI plugin dispatch uses separate host helpers and call sites and should be handled separately; the single-session CLI continues to use its process environment as the authoritative context.

This is complementary to #51596 and #56782. Those PRs propose an explicit context argument for plugin handlers; they do not bind the existing ambient ContextVars read by Hermes internals and existing handlers.

## Tests

- Added real gateway dispatch tests for platform, chat, thread, user, session key, and persisted session ID.
- Covered sequential events, handler exceptions, no persisted session, unavailable store access, and the unchanged agent path.
- Focused suite: 80 passed.
- Ruff and `git diff --check`: clean.
