### PR TITLE
feat(compression): keep native compaction stable across transient failures

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2093,8 +2093,8 @@ def init_agent(
     # Native OpenAI Responses server-side compaction (opt-in). Only ever
     # engages for gpt-5.6-family models on api.openai.com or the ChatGPT
     # Codex backend — the per-request gate lives in agent/native_compaction.py.
-    codex_responses_native_compaction = bool(
-        _compression_cfg.get("codex_responses_native", False)
+    codex_responses_native_compaction = is_truthy_value(
+        _compression_cfg.get("codex_responses_native"), default=False
     )
     _native_threshold_raw = _compression_cfg.get(
         "codex_responses_compact_threshold", 200_000

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4494,7 +4494,9 @@ def run_conversation(
                     and bool(getattr(agent, "codex_responses_native_compaction", False))
                 ):
                     from agent.native_compaction import is_native_compaction_rejection
-                    if is_native_compaction_rejection(api_error):
+                    if is_native_compaction_rejection(
+                        api_error, status_code=status_code
+                    ):
                         _retry.native_compaction_reject_retry_attempted = True
                         agent.codex_responses_native_compaction = False
                         agent._vprint(

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -144,16 +144,38 @@ def native_compaction_context_management(
     return [{"type": "compaction", "compact_threshold": threshold}]
 
 
-def is_native_compaction_rejection(error: Any) -> bool:
-    """True when a provider error names the context_management field.
+def is_native_compaction_rejection(
+    error: Any,
+    *,
+    status_code: Optional[int] = None,
+) -> bool:
+    """True when a provider explicitly rejects the context_management field.
 
     Used by the conversation loop's one-shot recovery: strip the field,
     disable native compaction for the rest of the session, retry. Matching
     is deliberately narrow — generic 4xx/5xx/timeouts must NOT permanently
     downgrade native compaction, they take the normal retry path.
     """
+    if status_code is not None and status_code != 400:
+        return False
     text = str(error or "").lower()
-    return "context_management" in text or "compact_threshold" in text
+    if "context_management" not in text and "compact_threshold" not in text:
+        return False
+    return any(
+        marker in text
+        for marker in (
+            "unknown parameter",
+            "unknown field",
+            "unrecognized parameter",
+            "unrecognized field",
+            "unsupported parameter",
+            "unsupported field",
+            "not supported",
+            "invalid parameter",
+            "invalid value",
+            "extra inputs are not permitted",
+        )
+    )
 
 
 def merge_interim_reasoning_items(

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -171,6 +171,11 @@ class TestRejectionMatcher:
             "invalid value for compact_threshold"
         )
 
+    def test_non_400_status_never_matches_explicit_rejection_text(self):
+        assert not is_native_compaction_rejection(
+            "Unknown parameter: context_management", status_code=500
+        )
+
     def test_generic_errors_do_not_match(self):
         # Generic failures must take the normal retry path — a transient
         # 500 or timeout must never permanently disable native compaction.
@@ -182,6 +187,17 @@ class TestRejectionMatcher:
             None,
         ):
             assert not is_native_compaction_rejection(err)
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            "Error code: 500 - failed while processing context_management",
+            "Request timed out while sending compact_threshold",
+            "Connection reset while serializing context_management",
+        ],
+    )
+    def test_transient_errors_that_name_fields_do_not_match(self, error):
+        assert not is_native_compaction_rejection(error)
 
 
 class TestWirePlumbing:
@@ -352,6 +368,33 @@ class TestAgentInitConfig:
         )
         assert agent.codex_responses_native_compaction is False
         assert agent.codex_responses_compact_threshold == 200_000
+
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [("false", False), ("off", False), ("true", True), ("yes", True)],
+    )
+    def test_native_opt_in_uses_config_boolean_semantics(
+        self, monkeypatch, configured, expected
+    ):
+        from hermes_cli import config as config_mod
+        from run_agent import AIAgent
+
+        config = {"compression": {"codex_responses_native": configured}}
+        monkeypatch.setattr(config_mod, "load_config", lambda: config)
+        monkeypatch.setattr(config_mod, "load_config_readonly", lambda: config)
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.openai.com/v1",
+            api_mode="codex_responses",
+            model="gpt-5.6",
+            provider="openai-api",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=[],
+        )
+        assert agent.codex_responses_native_compaction is expected
 
     def test_kwargs_have_no_context_management_by_default(self):
         from run_agent import AIAgent


### PR DESCRIPTION
## What does this PR do?

Native OpenAI Responses server-side compaction now remains enabled across transient provider failures that merely mention its request fields. Hermes only uses the one-shot field-removal fallback for explicit 400 parameter rejections, and false-like string configuration values no longer enable the default-off feature unexpectedly.

## Related Issue

Closes #82777

## Type of Change

- [x] New feature

## Changes Made

- `agent/native_compaction.py` - require explicit rejection language and reject non-400 responses before downgrading native compaction.
- `agent/conversation_loop.py` - pass the parsed provider status into the rejection predicate.
- `agent/agent_init.py` - parse the native compaction opt-in with shared config boolean semantics.
- `tests/run_agent/test_native_compaction.py` - cover transient field-naming failures, non-400 responses, and string boolean values.

## How to Test

1. Configure `compression.codex_responses_native` with true-like and false-like string values and verify the opt-in follows shared config semantics.
2. Feed explicit 400 parameter rejections and transient field-naming failures through the rejection predicate and verify only explicit rejections trigger the fallback.
3. Run the focused regression suite (42 passed locally):

```bash
scripts/run_tests.sh -j 1 tests/run_agent/test_native_compaction.py tests/agent/test_turn_retry_state.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings remain accurate; no user-facing docs change is required
- [x] `cli-config.yaml.example` is N/A because no config key was added or changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because architecture and workflows are unchanged
- [x] I've considered cross-platform impact; the changed logic is platform-independent
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

N/A - automated behavior tests cover the affected configuration and retry paths.
