### PR TITLE
feat(skills-hub): fall back to live repo for optional skills missing from local checkout

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -797,6 +797,129 @@ class TestOptionalSkillSourceBinaryAssets:
         assert bundle is None
 
 
+class TestOptionalSkillSourceLiveRepoFallback:
+    """Skills merged to main after the local install was cut must still be
+    searchable and installable without `hermes update` (live-repo fallback)."""
+
+    def _make_source(self, tmp_path, remote_dirs):
+        optional_root = tmp_path / "optional-skills"
+        optional_root.mkdir(exist_ok=True)
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+        src._remote_dirs = dict.fromkeys(remote_dirs, True)
+        return src
+
+    @staticmethod
+    def _fake_github_with_tree(remote_dirs, extra_files=()):
+        """MagicMock GitHubSource whose repo tree contains each skill dir's
+        SKILL.md plus any extra files, served byte-exact by _fetch_file_bytes."""
+        entries = []
+        contents = {}
+        for rel_dir in remote_dirs:
+            p = f"optional-skills/{rel_dir}/SKILL.md"
+            entries.append({"type": "blob", "path": p, "mode": "100644"})
+            contents[p] = b"---\nname: " + rel_dir.rsplit("/", 1)[-1].encode() + b"\n---\nBody"
+        for rel_path, data in extra_files:
+            entries.append({"type": "blob", "path": rel_path, "mode": "100644"})
+            contents[rel_path] = data
+        fake = MagicMock()
+        fake._get_repo_tree.return_value = ("main", entries)
+        fake._fetch_file_bytes.side_effect = lambda repo, path: contents.get(path)
+        return fake
+
+    def test_fetch_falls_back_to_live_repo_when_missing_locally(self, tmp_path):
+        src = self._make_source(tmp_path, ["software-development/ast-grep"])
+        src._github = self._fake_github_with_tree(
+            ["software-development/ast-grep"],
+            extra_files=[
+                ("optional-skills/software-development/ast-grep/install.sh", b"#!/bin/sh\n"),
+                ("optional-skills/software-development/ast-grep/LICENSE", b"MIT"),
+            ],
+        )
+
+        bundle = src.fetch("official/software-development/ast-grep")
+
+        assert bundle is not None
+        # Provenance is rewritten to official/builtin
+        assert bundle.source == "official"
+        assert bundle.identifier == "official/software-development/ast-grep"
+        assert bundle.trust_level == "builtin"
+        # FULL directory arrives — including root-level files GitHubSource.fetch drops
+        assert bundle.files["install.sh"] == b"#!/bin/sh\n"
+        assert bundle.files["LICENSE"] == b"MIT"
+
+    def test_fetch_bare_name_resolves_via_remote_tree(self, tmp_path):
+        src = self._make_source(tmp_path, ["software-development/ast-grep"])
+        src._github = self._fake_github_with_tree(["software-development/ast-grep"])
+
+        bundle = src.fetch("official/ast-grep")
+
+        assert bundle is not None
+        assert bundle.identifier == "official/software-development/ast-grep"
+
+    def test_fetch_ambiguous_bare_name_refuses(self, tmp_path):
+        src = self._make_source(
+            tmp_path, ["security/scanner", "devops/scanner"]
+        )
+        fake_github = MagicMock()
+        src._github = fake_github
+
+        assert src.fetch("official/scanner") is None
+        fake_github.fetch.assert_not_called()
+
+    def test_local_checkout_wins_over_remote(self, tmp_path):
+        src = self._make_source(tmp_path, ["research/local-skill"])
+        skill_dir = src._optional_dir / "research" / "local-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: local-skill\ndescription: local\n---\nBody",
+            encoding="utf-8",
+        )
+        fake_github = MagicMock()
+        src._github = fake_github
+
+        bundle = src.fetch("official/research/local-skill")
+
+        assert bundle is not None
+        fake_github.fetch.assert_not_called()
+
+    def test_fallback_rejects_traversal_rel(self, tmp_path):
+        src = self._make_source(tmp_path, ["security/whatever"])
+        fake_github = MagicMock()
+        src._github = fake_github
+
+        assert src._fetch_from_live_repo("../../etc/passwd") is None
+        fake_github.fetch.assert_not_called()
+
+    def test_search_surfaces_remote_only_skills(self, tmp_path):
+        src = self._make_source(tmp_path, ["software-development/ast-grep"])
+
+        results = src.search("ast-grep")
+
+        assert any(
+            r.identifier == "official/software-development/ast-grep"
+            and r.trust_level == "builtin"
+            for r in results
+        )
+
+    def test_inspect_surfaces_remote_only_skill(self, tmp_path):
+        src = self._make_source(tmp_path, ["software-development/ast-grep"])
+
+        meta = src.inspect("official/software-development/ast-grep")
+
+        assert meta is not None
+        assert meta.repo == "NousResearch/hermes-agent"
+        assert meta.path == "optional-skills/software-development/ast-grep"
+
+    def test_offline_degrades_to_local_only(self, tmp_path):
+        src = self._make_source(tmp_path, [])
+        fake_github = MagicMock()
+        src._github = fake_github
+
+        assert src.fetch("official/never-heard-of-it") is None
+        assert src.search("never-heard-of-it") == []
+
+
 class TestQuarantineBundleBinaryAssets:
     def test_quarantine_bundle_writes_binary_files(self, tmp_path):
         import tools.skills_hub as hub

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3274,13 +3274,21 @@ class OptionalSkillSource(SkillSource):
     """
 
     OFFICIAL_REPO = "NousResearch/hermes-agent"
+    OPTIONAL_SKILLS_PREFIX = "optional-skills"
 
-    def __init__(self):
+    def __init__(self, auth: Optional[GitHubAuth] = None):
         from hermes_constants import get_optional_skills_dir
 
         self._optional_dir = get_optional_skills_dir(
             Path(__file__).parent.parent / "optional-skills"
         )
+        self._auth = auth
+        # Lazily created GitHubSource for the live-repo fallback — only
+        # instantiated when a skill is missing from the local checkout.
+        self._github: Optional[GitHubSource] = None
+        # rel_path ("category/skill") -> True, from the live repo tree.
+        # None = not fetched yet this process.
+        self._remote_dirs: Optional[Dict[str, bool]] = None
 
     def source_id(self) -> str:
         return "official"
@@ -3294,12 +3302,37 @@ class OptionalSkillSource(SkillSource):
         results: List[SkillMeta] = []
         query_lower = query.lower()
 
+        local_rels: set = set()
         for meta in self._scan_all():
+            rel = meta.identifier.split("/", 1)[-1] if meta.identifier else ""
+            local_rels.add(rel)
             searchable = f"{meta.name} {meta.description} {' '.join(meta.tags)}".lower()
             if query_lower in searchable:
                 results.append(meta)
             if len(results) >= limit:
                 break
+
+        # Also surface skills that landed on live main after this install was
+        # cut (missing from the local optional-skills/ checkout).
+        if len(results) < limit:
+            for rel_dir in sorted(self._list_remote_skill_dirs()):
+                if rel_dir in local_rels:
+                    continue
+                name = rel_dir.rsplit("/", 1)[-1]
+                if query_lower and query_lower not in rel_dir.lower():
+                    continue
+                results.append(SkillMeta(
+                    name=name,
+                    description="Official optional skill (from live repo; run install to fetch)",
+                    source="official",
+                    identifier=f"official/{rel_dir}",
+                    trust_level="builtin",
+                    repo=self.OFFICIAL_REPO,
+                    path=f"{self.OPTIONAL_SKILLS_PREFIX}/{rel_dir}",
+                    tags=[],
+                ))
+                if len(results) >= limit:
+                    break
 
         return results
 
@@ -3324,7 +3357,9 @@ class OptionalSkillSource(SkillSource):
             skill_name = rel.rsplit("/", 1)[-1]
             skill_dir = self._find_skill_dir(skill_name)
             if not skill_dir:
-                return None
+                # Not in the local checkout — the skill may have landed on
+                # main after this install was cut. Fall back to the live repo.
+                return self._fetch_from_live_repo(rel)
         else:
             skill_dir = resolved
 
@@ -3365,9 +3400,143 @@ class OptionalSkillSource(SkillSource):
         for meta in self._scan_all():
             if meta.name == skill_name:
                 return meta
+
+        # Not in the local checkout — check live main.
+        remote_dirs = self._list_remote_skill_dirs()
+        matches = [d for d in remote_dirs if d.rsplit("/", 1)[-1] == skill_name]
+        if len(matches) == 1:
+            rel_dir = matches[0]
+            return SkillMeta(
+                name=skill_name,
+                description="Official optional skill (from live repo; run install to fetch)",
+                source="official",
+                identifier=f"official/{rel_dir}",
+                trust_level="builtin",
+                repo=self.OFFICIAL_REPO,
+                path=f"{self.OPTIONAL_SKILLS_PREFIX}/{rel_dir}",
+                tags=[],
+            )
         return None
 
     # -- internal helpers -------------------------------------------------
+
+    def _get_github(self) -> "GitHubSource":
+        if self._github is None:
+            self._github = GitHubSource(auth=self._auth or GitHubAuth())
+        return self._github
+
+    def _fetch_from_live_repo(self, rel: str) -> Optional[SkillBundle]:
+        """Fetch an optional skill straight from the live repo on GitHub.
+
+        Local installs lag `main` — a freshly merged optional skill isn't in
+        the user's `optional-skills/` checkout until they run
+        ``hermes update``. Rather than telling them to update first, resolve
+        the skill against the live default branch.
+
+        ``rel`` is the identifier without the ``official/`` prefix — either
+        ``category/skill`` (used verbatim) or a bare skill name (located via
+        the repo tree).
+        """
+        rel = rel.strip("/")
+        if not rel:
+            return None
+        # Reject traversal before it ever becomes a GitHub path.
+        parts = [p for p in rel.split("/") if p not in ("", ".")]
+        if not parts or any(p == ".." for p in parts):
+            return None
+        rel = "/".join(parts)
+
+        github = self._get_github()
+        remote_dirs = self._list_remote_skill_dirs()
+
+        if rel in remote_dirs:
+            repo_path = f"{self.OPTIONAL_SKILLS_PREFIX}/{rel}"
+        else:
+            # Bare name (or stale category) — locate by final path segment.
+            name = parts[-1]
+            matches = [d for d in remote_dirs if d.rsplit("/", 1)[-1] == name]
+            if len(matches) != 1:
+                return None
+            repo_path = f"{self.OPTIONAL_SKILLS_PREFIX}/{matches[0]}"
+            rel = matches[0]
+
+        # Download the FULL skill directory (byte-exact, including root-level
+        # install scripts, LICENSE, tests/). GitHubSource.fetch() would only
+        # pull SKILL.md + referenced support dirs, silently dropping files the
+        # local-checkout path preserves.
+        tree = github._get_repo_tree(self.OFFICIAL_REPO)
+        if tree is None:
+            return None
+        _branch, entries = tree
+        prefix = f"{repo_path}/"
+        files: Dict[str, Union[str, bytes]] = {}
+        for item in entries:
+            if item.get("type") != "blob" or item.get("mode") == "120000":
+                continue
+            item_path = item.get("path", "")
+            if not item_path.startswith(prefix):
+                continue
+            rel_file = item_path[len(prefix):]
+            base = rel_file.rsplit("/", 1)[-1]
+            if base.startswith(".") or base.endswith(".pyc") or "__pycache__" in rel_file.split("/"):
+                continue
+            content = github._fetch_file_bytes(self.OFFICIAL_REPO, item_path)
+            if content is None:
+                logger.warning("Live-repo optional skill fetch failed for %s", item_path)
+                return None
+            files[rel_file] = content
+
+        if "SKILL.md" not in files:
+            return None
+
+        logger.info("Optional skill '%s' fetched from live repo (not in local checkout)", rel)
+        return SkillBundle(
+            name=rel.rsplit("/", 1)[-1],
+            files=files,
+            source="official",
+            identifier=f"official/{rel}",
+            trust_level="builtin",
+        )
+
+    def _list_remote_skill_dirs(self) -> Dict[str, bool]:
+        """Map of ``category/skill`` dirs under optional-skills/ on live main.
+
+        Derived from the repo tree (single API call, cached per-process by
+        GitHubSource, plus the shared on-disk index cache). Returns {} when
+        the network/API is unavailable — callers degrade to local-only.
+        """
+        if self._remote_dirs is not None:
+            return self._remote_dirs
+
+        cache_key = "official_optional_dirs"
+        cached = _read_index_cache(cache_key)
+        if isinstance(cached, dict) and cached:
+            self._remote_dirs = cached
+            return cached
+
+        dirs: Dict[str, bool] = {}
+        tree = self._get_github()._get_repo_tree(self.OFFICIAL_REPO)
+        if tree is not None:
+            _branch, entries = tree
+            prefix = f"{self.OPTIONAL_SKILLS_PREFIX}/"
+            suffix = "/SKILL.md"
+            for item in entries:
+                path = item.get("path", "")
+                if (
+                    item.get("type") == "blob"
+                    and path.startswith(prefix)
+                    and path.endswith(suffix)
+                ):
+                    rel_dir = path[len(prefix):-len(suffix)]
+                    if rel_dir and not is_excluded_skill_path(
+                        PurePosixPath(rel_dir + suffix)
+                    ):
+                        dirs[rel_dir] = True
+            if dirs:
+                _write_index_cache(cache_key, dirs)
+
+        self._remote_dirs = dirs
+        return dirs
 
     def _find_skill_dir(self, name: str) -> Optional[Path]:
         """Find a skill directory by name anywhere in optional-skills/."""
@@ -4272,7 +4441,7 @@ def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]
     extra_taps = taps_mgr.list_taps()
 
     sources: List[SkillSource] = [
-        OptionalSkillSource(),        # Official optional skills (highest priority)
+        OptionalSkillSource(auth=auth),  # Official optional skills (highest priority)
         HermesIndexSource(auth=auth), # Centralized index (search + resolved install paths)
         SkillsShSource(auth=auth),
         WellKnownSkillSource(),


### PR DESCRIPTION
## Summary
`hermes skills install official/<category>/<skill>` (and search/inspect) now resolves optional skills against the live repo's default branch when they're missing from the local checkout — a freshly merged optional skill is installable immediately, without waiting for `hermes update`.

Root cause: `OptionalSkillSource` only scanned the local `optional-skills/` directory, which lags `main` by however long since the user's last update. First hit: users couldn't install `official/software-development/ast-grep` minutes after it merged (#80892).

## Changes
- `tools/skills_hub.py`:
  - `OptionalSkillSource.fetch()` — on local miss, resolves the identifier against live `main` via one Trees API call (dir listing cached through the shared on-disk index cache, 1h TTL), then downloads the full skill directory byte-exact — including root-level `install.sh`/`LICENSE`/`tests/`, which the generic `GitHubSource.fetch()` path drops (it only pulls SKILL.md + referenced support dirs).
  - `search()` / `inspect()` — surface remote-only skills so discovery works pre-update too (labelled as fetched from the live repo).
  - Guards: local checkout always wins; offline/rate-limited degrades to old local-only behavior; traversal segments refused before any GitHub path is built; ambiguous bare names refused; provenance pinned to `official`/`builtin`.
- `tests/tools/test_skills_hub.py`: 8 new tests (`TestOptionalSkillSourceLiveRepoFallback`).

## Validation
| | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_skills_hub.py` | 68/68 pass |
| Live E2E (empty local dir, real GitHub) | `official/software-development/ast-grep` → search hit, inspect hit, fetch = all 14 files byte-exact incl. install.sh/LICENSE/tests |
| Bare-name fetch `official/ast-grep` | resolves to `official/software-development/ast-grep` |
| Unknown skill | clean `None`, no crash |

## Infographic

![Optional skills live-repo fallback](https://v3b.fal.media/files/b/0aa5b3b0/bRHUyLZ-Bt8ewl3m9dH9h_HHNpk7Pu.png)
