### PR TITLE
fix(whatsapp): resolve canonical delivery JIDs

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -7,6 +7,7 @@
  *
  * Endpoints (matches gateway/platforms/whatsapp.py expectations):
  *   GET  /messages       - Long-poll for new incoming messages
+ *   POST /resolve        - Validate a phone number and return its WhatsApp JID
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
@@ -33,6 +34,7 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { resolveWhatsAppNumber } from './phone-resolver.js';
 import {
   buildPollPayload,
   createReconnectScheduler,
@@ -817,6 +819,23 @@ app.use((req, res, next) => {
 app.get('/messages', (req, res) => {
   const msgs = messageQueue.splice(0, messageQueue.length);
   res.json(msgs);
+});
+
+// Resolve a phone number through WhatsApp before storing it in an allowlist
+// or using it as a delivery target. WhatsApp numbers are not reliably inferred
+// from a national-format number because some countries have optional/mobile
+// prefixes; callers must use the returned JID.
+app.post('/resolve', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  try {
+    res.json(await resolveWhatsAppNumber(sock, req.body?.number));
+  } catch (err) {
+    const status = err instanceof TypeError ? 400 : 500;
+    res.status(status).json({ error: err.message });
+  }
 });
 
 // Send a message

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bridge.js"
+    "start": "node bridge.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",

--- a/scripts/whatsapp-bridge/phone-resolver.js
+++ b/scripts/whatsapp-bridge/phone-resolver.js
@@ -1,0 +1,16 @@
+/**
+ * Resolve a user-supplied phone number through WhatsApp.
+ *
+ * The returned JID is canonical for the connected account and must be used
+ * for allowlists and delivery targets instead of inferring national prefixes.
+ */
+export async function resolveWhatsAppNumber(sock, value) {
+  const number = String(value || '').replace(/\D/g, '');
+  if (!number) {
+    throw new TypeError('number must contain digits');
+  }
+
+  const results = await sock.onWhatsApp(number);
+  const matches = (results || []).filter(item => item?.exists && item?.jid);
+  return { number, exists: matches.length > 0, matches };
+}

--- a/scripts/whatsapp-bridge/test/phone-resolver.test.js
+++ b/scripts/whatsapp-bridge/test/phone-resolver.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveWhatsAppNumber } from '../phone-resolver.js';
+
+test('resolves a national-format input to WhatsApp canonical JIDs', async () => {
+  const calls = [];
+  const sock = {
+    onWhatsApp: async (number) => {
+      calls.push(number);
+      return [
+        { jid: '557199258283@s.whatsapp.net', exists: true },
+        { jid: 'ignored@s.whatsapp.net', exists: false },
+      ];
+    },
+  };
+
+  const result = await resolveWhatsAppNumber(sock, '+55 (71) 99925-8283');
+
+  assert.deepEqual(calls, ['5571999258283']);
+  assert.deepEqual(result, {
+    number: '5571999258283',
+    exists: true,
+    matches: [{ jid: '557199258283@s.whatsapp.net', exists: true }],
+  });
+});
+
+test('rejects inputs without digits before calling WhatsApp', async () => {
+  let called = false;
+  const sock = { onWhatsApp: async () => { called = true; } };
+
+  await assert.rejects(
+    () => resolveWhatsAppNumber(sock, 'not a number'),
+    { message: 'number must contain digits' },
+  );
+  assert.equal(called, false);
+});


### PR DESCRIPTION
## Summary
- Add a bridge `/resolve` endpoint backed by Baileys `onWhatsApp`.
- Return the canonical WhatsApp JID instead of inferring it from a phone number.
- Add Node regression tests for normalization and invalid input.

## Why
National-format phone inputs can contain optional/mobile prefixes. Inferring an `@s.whatsapp.net` JID can route delivery to the wrong chat even when the bridge accepts the send request.

## Verification
- `npm test` — 24 passing.
- Live bridge contract against a paired WhatsApp account: national-format input resolved to the canonical JID.
- `scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py -q` — 12 passing.
