### PR TITLE
fix(tool-call): salvage gateway {}-prefixed tool-call arguments

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -284,6 +284,38 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
 
 
 
+def _salvage_double_serialized_arguments(arguments: str) -> Optional[str]:
+    """Recover real tool-call arguments when a provider corrupts them by
+    prefixing an extra empty ``{}`` object (double serialization).
+
+    Observed live on DeepSeek-V4-Flash via the MARVIN OpenAI-compatible
+    proxy (and MiniMax via NVIDIA NIM): the model streams a leading ``{}``
+    chunk before the real JSON arguments, so the accumulated value becomes
+    ``'{}{"path": "/tmp/foo"}'`` — not valid JSON on its own.  Stripping the
+    leading ``{}`` recovers the actual tool intent.
+
+    Returns the recovered arguments text (verbatim, preserving the real
+    JSON) or ``None`` when nothing is recoverable — i.e. the string does not
+    begin with ``{}``, the remainder is empty, or the remainder is not a
+    JSON object (only object-valued arguments are salvageable; arrays,
+    scalars and fragments fall through to the drop-and-marker path)."""
+    if not isinstance(arguments, str):
+        return None
+    s = arguments.lstrip()
+    if not s.startswith("{}"):
+        return None
+    rest = s[2:].lstrip()
+    if not rest:
+        return None
+    try:
+        parsed = json.loads(rest)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return rest
+
+
 def sanitize_tool_call_arguments(
     messages: list,
     *,
@@ -378,6 +410,26 @@ def sanitize_tool_call_arguments(
             try:
                 json.loads(arguments)
             except json.JSONDecodeError:
+                # Provider corruption like ``'{}{"path": "/tmp"}`` (a leading
+                # ``{}`` chunk streamed before the real arguments) discards the
+                # actual tool intent if we nuke the whole string.  Try to
+                # recover the real object first; only fall through to the
+                # drop-and-marker path when nothing is salvageable.
+                salvaged = _salvage_double_serialized_arguments(arguments)
+                if salvaged is not None and salvaged != "{}":
+                    function["arguments"] = salvaged
+                    log.warning(
+                        "Corrupted tool_call arguments recovered from "
+                        "double-serialization (session=%s, message_index=%s, "
+                        "function=%s, preview=%r)",
+                        session_id or "-",
+                        message_index,
+                        function.get("name", "?"),
+                        arguments[:80],
+                    )
+                    repaired += 1
+                    continue
+
                 # Use the canonical ``call_id || id`` precedence so both the
                 # scan for an existing tool result and any inserted stub key
                 # on the same id the rest of the pipeline uses. Keying on bare

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6472,6 +6472,19 @@ def run_conversation(
                     try:
                         json.loads(args)
                     except json.JSONDecodeError as e:
+                        # Repair before flagging: gateway proxies prepend a
+                        # complete JSON value to the arguments (e.g.
+                        # `{}{"city": "Paris"}`), which json.loads rejects as
+                        # "Extra data". _repair_tool_call_arguments recovers
+                        # that (and other common malformations); only fall
+                        # through to the whole-turn retry/recovery machinery
+                        # when the args are genuinely unrepairable.
+                        repaired = _repair_tool_call_arguments(
+                            args, tc.function.name
+                        )
+                        if repaired != "{}":
+                            tc.function.arguments = repaired
+                            continue
                         if (
                             _mixed_invalid_batch
                             and tc.function.name not in agent.valid_tool_names

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -192,6 +192,35 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
 _FULL_ARGS_LOG_BOUND = 100_000
 
 
+def _strip_leading_json_value(raw: str) -> str:
+    """Strip a complete JSON value prefix if the suffix parses standalone.
+
+    Some OpenAI-compatible gateway proxies (one-api/new-api style) prepend
+    an empty value to tool-call arguments, e.g. ``{}{"city": "Paris"}``.
+    ``json.loads`` rejects that as "Extra data"; the trailing repair passes
+    do not handle it, so the args would be replaced with ``{}`` and the tool
+    would run with no arguments.  When a clean prefix (``{}``/``[]``/scalar)
+    is present and the suffix parses on its own, return the suffix.
+    """
+    if not raw or not raw.strip():
+        return raw
+    text = raw.strip()
+    try:
+        _, end = json.JSONDecoder().raw_decode(text)
+    except json.JSONDecodeError:
+        return raw  # doesn't start with a complete JSON value
+    remainder = text[end:].strip()
+    if not remainder:
+        return raw  # whole string is a single value — normal args
+    try:
+        parsed = json.loads(remainder)
+    except json.JSONDecodeError:
+        return raw  # suffix alone isn't valid → not this bug
+    if not isinstance(parsed, dict):
+        return raw  # tool args must be a JSON object, not an array/scalar
+    return remainder
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -229,6 +258,18 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
         return reserialised
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
+
+    # Repair pass 0.5: gateway proxies prepend a complete JSON value
+    # (typically an empty object) to the real arguments, e.g.
+    # `{}{"city": "Paris"}`. The trailing repairs below can't fix that
+    # ("Extra data"), so recover the standalone suffix here.
+    stripped = _strip_leading_json_value(raw_stripped)
+    if stripped != raw_stripped:
+        logger.warning(
+            "Repaired leading-value-prefixed tool_call arguments for %s: %s → %s",
+            tool_name, raw_stripped[:80], stripped[:80],
+        )
+        return stripped
 
     # Attempt common JSON repairs
     fixed = raw_stripped

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -18,6 +18,8 @@ class TestRepairToolCallArguments:
     # -- Stage 2: Python None literal --
 
 
+    def test_none_literal_returns_empty_object(self):
+        assert _repair_tool_call_arguments("None", "t") == "{}"
 
     # -- Stage 3: trailing comma repair --
 
@@ -26,6 +28,7 @@ class TestRepairToolCallArguments:
         result = _repair_tool_call_arguments('{"a": [1, 2,]}', "t")
         parsed = json.loads(result)
         assert parsed == {"a": [1, 2]}
+
 
 
     # -- Stage 4: unclosed brackets --
@@ -43,21 +46,32 @@ class TestRepairToolCallArguments:
         # Truncated in the middle of a string key — bracket closing won't help
         assert _repair_tool_call_arguments('{"truncated": "val', "t") == "{}"
 
-    # -- Valid JSON passthrough (this path is via except, but still works) --
+    # -- Stage 0.5: gateway leading-value prefix (e.g. `{}{"city": "Paris"}`) --
 
+    def test_leading_empty_object_prefix_salvaged(self):
+        # one-api/new-api gateways prepend a complete JSON value (usually an
+        # empty object) to the real arguments. The remainder must be
+        # recovered, not discarded to "{}".
+        result = _repair_tool_call_arguments('{}{"city": "Paris"}', "t")
+        assert json.loads(result) == {"city": "Paris"}
 
-    # -- Combined repairs --
+    def test_leading_empty_object_prefix_with_whitespace_salvaged(self):
+        result = _repair_tool_call_arguments('  {}  {"mode": "tail"}', "t")
+        assert json.loads(result) == {"mode": "tail"}
 
+    def test_leading_array_prefix_salvaged(self):
+        result = _repair_tool_call_arguments('[]{"a": [1, 2]}', "t")
+        assert json.loads(result) == {"a": [1, 2]}
 
+    def test_double_empty_object_prefix_unrepairable(self):
+        # '{}{}' has no recoverable args — must fall back to empty object.
+        assert _repair_tool_call_arguments("{}", "t") == "{}"
 
-    # -- Stage 0: strict=False (literal control chars in strings) --
-    # llama.cpp backends sometimes emit literal tabs/newlines inside JSON
-    # string values. strict=False accepts these; we re-serialise to the
-    # canonical wire form (#12068).
+    def test_non_object_suffix_not_salvaged(self):
+        # Suffix is an array, not a tool-args object — falls to last resort.
+        assert _repair_tool_call_arguments("{}[1, 2]", "t") == "{}"
 
-
-
-
-    # -- Stage 4: control-char escape fallback --
-
-
+    def test_plain_prefixless_args_passthrough(self):
+        # No leading value to strip — original JSON still parses.
+        result = _repair_tool_call_arguments('{"city": "Paris"}', "t")
+        assert json.loads(result) == {"city": "Paris"}

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -144,6 +144,67 @@ def test_empty_string_arguments_treated_as_empty_object(caplog):
     assert caplog.records == []
 
 
+def test_double_serialized_arguments_salvaged():
+    # DeepSeek-V4-Flash via MARVIN proxy streams a leading "{}" chunk before
+    # the real arguments: '{}{"path": "/tmp/foo"}'. The real args must be
+    # recovered, not discarded to "{}".
+    messages = [
+        _assistant_message(_tool_call(arguments='{}{"path": "/tmp/foo"}')),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == '{"path": "/tmp/foo"}'
+    # No marker tool message inserted — arguments were recovered, not dropped.
+    assert len(messages) == 1
+
+
+def test_double_serialized_with_whitespace_salvaged():
+    messages = [
+        _assistant_message(_tool_call(arguments='  {}  {"mode": "tail"}')),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == '{"mode": "tail"}'
+
+
+def test_double_empty_object_not_salvaged_falls_back_to_marker():
+    # '{}{}' has no recoverable args — must fall through to drop-and-marker.
+    marker = AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
+    messages = [
+        _assistant_message(_tool_call(arguments="{}")),  # valid, untouched
+        _assistant_message(_tool_call(arguments="{}{}")),
+        _tool_message(content="existing"),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1  # only the '{}{}' one
+    # First tool call (valid "{}") left as-is.
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    # Second ones reset to "{}" with marker prepended on the existing tool msg.
+    assert messages[1]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert messages[2]["content"].startswith(marker)
+
+
+def test_non_object_suffix_not_salvaged():
+    # '{}[...]' — suffix is an array, not object args → fall back.
+    marker = AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
+    messages = [
+        _assistant_message(_tool_call(arguments='{}[1, 2, 3]')),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert messages[1]["role"] == "tool"
+    assert messages[1]["content"] == marker
+
+
 def test_non_assistant_messages_ignored():
     messages = [
         {"role": "user", "content": "hello", "tool_calls": [_tool_call(arguments='{"bad":')]},


### PR DESCRIPTION
## Summary

Fixes loss of the real tool-call intent when an OpenAI-compatible gateway proxy prefixes tool-call arguments with a stray empty value — the MARVIN `{}` corruption bug (`{}{\"city\": \"Paris\"}`).

Two paths were losing the args:

1. **Send path** (`_salvage_double_serialized_arguments` in `agent_runtime_helpers.py`): when the provider streams a leading `{}` chunk before the real JSON, the accumulated arguments become `{}{\"path\": \"/tmp/foo\"}`. `sanitize_tool_call_arguments` now recovers the real object instead of nuking the whole string to `{}`.

2. **Receive paths**:
   - `conversation_loop.run_conversation` (non-streaming): `json.loads(args)` failed → 3 whole-turn API retries + a recovery loop that re-fed the same mangled args. Now it first attempts `_repair_tool_call_arguments` and keeps the recovered args.
   - `_repair_tool_call_arguments` (message_sanitization, streaming + send canonicalize fallback): hit the last-resort `{}`, discarding the intent. Added `_strip_leading_json_value` which strips a complete leading JSON value (usually `{}`) when the suffix parses as a JSON object.

## Verification

- `tests/run_agent/test_tool_call_args_sanitizer.py` — new salvage cases
- `tests/run_agent/test_repair_tool_call_arguments.py` — 7 new cases covering the leading-value prefix and the fall-through behavior

Run locally:
```
.venv/Scripts/python.exe -m pytest tests/run_agent/test_tool_call_args_sanitizer.py tests/run_agent/test_repair_tool_call_arguments.py -q
# 20 passed
```

*This was generated by AI, Review is declarative*
