### PR TITLE
fix(plugins): enforce mandatory provider preflight

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1331,11 +1331,14 @@ class _CodexCompletionsAdapter:
     """Drop-in shim that accepts chat.completions.create() kwargs and
     routes them through the Codex Responses streaming API."""
 
+    _handles_provider_preflight = True
+
     def __init__(self, real_client: OpenAI, model: str):
         self._client = real_client
         self._model = model
 
     def create(self, **kwargs) -> Any:
+        provider_preflight = kwargs.pop("_hermes_provider_preflight", None)
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
 
@@ -1634,6 +1637,16 @@ class _CodexCompletionsAdapter:
             stream_kwargs = dict(resp_kwargs)
             stream_kwargs["stream"] = True
 
+            if provider_preflight is not None:
+                provider_preflight(stream_kwargs)
+            else:
+                _enforce_auxiliary_provider_preflight(
+                    self._client,
+                    stream_kwargs,
+                    provider="openai-codex",
+                    api_mode="codex_responses",
+                )
+
             def _on_each_event(_event: Any) -> None:
                 # Re-check timeout/cancellation per event, matching the
                 # cadence the old in-line ``_check_cancelled()`` used.
@@ -1787,6 +1800,8 @@ class _AsyncCodexCompletionsAdapter:
     (web_tools, session_search) can await it as normal.
     """
 
+    _handles_provider_preflight = True
+
     def __init__(self, sync_adapter: _CodexCompletionsAdapter):
         self._sync = sync_adapter
 
@@ -1822,6 +1837,8 @@ class AsyncCodexAuxiliaryClient:
 class _AnthropicCompletionsAdapter:
     """OpenAI-client-compatible adapter for Anthropic Messages API."""
 
+    _handles_provider_preflight = True
+
     def __init__(
         self,
         real_client: Any,
@@ -1853,6 +1870,7 @@ class _AnthropicCompletionsAdapter:
         from agent.anthropic_adapter import build_anthropic_kwargs, create_anthropic_message
         from agent.transports import get_transport
 
+        provider_preflight = kwargs.pop("_hermes_provider_preflight", None)
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
         tools = kwargs.get("tools")
@@ -1937,6 +1955,16 @@ class _AnthropicCompletionsAdapter:
                 if not isinstance(existing, dict):
                     existing = {}
                 anthropic_kwargs["extra_body"] = {**existing, **passthrough}
+
+        if provider_preflight is not None:
+            provider_preflight(anthropic_kwargs)
+        else:
+            _enforce_auxiliary_provider_preflight(
+                self._client,
+                anthropic_kwargs,
+                provider="anthropic",
+                api_mode="anthropic_messages",
+            )
 
         response = create_anthropic_message(
             self._client,
@@ -3100,27 +3128,127 @@ def _relay_auxiliary_metadata(
     }
 
 
+def _sanitize_auxiliary_hook_value(value: Any) -> Any:
+    """Copy an auxiliary request for hooks without exposing credentials."""
+    if isinstance(value, dict):
+        sanitized: Dict[str, Any] = {}
+        for key, item in value.items():
+            normalized = str(key).lower().replace("-", "_")
+            if normalized in {
+                "api_key",
+                "authorization",
+                "proxy_authorization",
+                "cookie",
+                "set_cookie",
+            } or normalized.endswith("_api_key"):
+                sanitized[str(key)] = "<redacted>"
+            else:
+                sanitized[str(key)] = _sanitize_auxiliary_hook_value(item)
+        return sanitized
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_auxiliary_hook_value(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _enforce_auxiliary_provider_preflight(
+    client: Any,
+    request: dict[str, Any],
+    *,
+    provider: str | None,
+    api_mode: str | None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Run mandatory guards and observers at the auxiliary egress boundary."""
+    from hermes_cli.plugins import has_mandatory_hook
+
+    # Auxiliary calls historically had no provider-request observer surface.
+    # Preserve that zero-overhead path unless a fail-closed contract is
+    # explicitly configured; mandatory mode then owns the full hook sequence.
+    if not has_mandatory_hook("pre_api_request"):
+        return
+
+    from hermes_cli import lifecycle as _lifecycle
+
+    body = {
+        key: value
+        for key, value in request.items()
+        if key not in {"timeout", "http_client"}
+    }
+    hook_request = {
+        "method": "POST",
+        "body": _sanitize_auxiliary_hook_value(body),
+    }
+    context = _RELAY_AUX_CALL_CONTEXT.get() or {}
+    hook_metadata = metadata or {}
+    _lifecycle.invoke_hook_enforced(
+        "pre_api_request",
+        task_id=str(context.get("task") or "auxiliary"),
+        turn_id="",
+        api_request_id=str(hook_metadata.get("api_request_id") or ""),
+        session_id="",
+        platform="auxiliary",
+        provider=str(provider or context.get("provider") or "auxiliary"),
+        base_url=str(getattr(client, "base_url", "") or ""),
+        model=str(request.get("model") or context.get("model") or ""),
+        api_mode=str(api_mode or context.get("api_mode") or "chat_completions"),
+        api_call_count=int(hook_metadata.get("retry_count") or 0),
+        request=hook_request,
+        request_messages=hook_request["body"].get("messages", []),
+        call_role=str(hook_metadata.get("call_role") or "auxiliary"),
+        retry_count=int(hook_metadata.get("retry_count") or 0),
+        middleware_trace=[],
+    )
+
+
 def _relay_sync_completion(
     client: Any,
     kwargs: dict[str, Any],
     *,
     provider: str | None = None,
     api_mode: str | None = None,
-    create: Callable[[dict[str, Any]], Any] | None = None,
+    create: Callable[..., Any] | None = None,
+    create_handles_preflight: bool = False,
 ) -> Any:
     callback = create or (lambda request: client.chat.completions.create(**request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
+    metadata = route[2] if route is not None else None
+
+    def guarded_callback(request: dict[str, Any]) -> Any:
+        def preflight(final_request: dict[str, Any]) -> None:
+            _enforce_auxiliary_provider_preflight(
+                client,
+                final_request,
+                provider=provider,
+                api_mode=api_mode,
+                metadata=metadata,
+            )
+
+        if create_handles_preflight:
+            return _run_protected_sync_provider_call(
+                lambda final_request: callback(final_request, preflight), request
+            )
+        if create is None and getattr(
+            client.chat.completions, "_handles_provider_preflight", False
+        ):
+            final_request = dict(request)
+            final_request["_hermes_provider_preflight"] = preflight
+            return _run_protected_sync_provider_call(callback, final_request)
+        preflight(request)
+        return _run_protected_sync_provider_call(callback, request)
+
     # Protected compression calls isolate only the provider callback and stream
     # aggregation.  The owning thread remains free to unwind its lease/DB
     # transaction on hard cancel without touching the process-shared client.
     if route is None:
-        return _run_protected_sync_provider_call(callback, kwargs)
+        return guarded_callback(kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
 
     return relay_llm.execute_current(
         kwargs,
-        lambda request: _run_protected_sync_provider_call(callback, request),
+        guarded_callback,
         name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
         metadata=metadata,
@@ -3134,18 +3262,41 @@ async def _relay_async_completion(
     *,
     provider: str | None = None,
     api_mode: str | None = None,
-    create: Callable[[dict[str, Any]], Any] | None = None,
+    create: Callable[..., Any] | None = None,
+    create_handles_preflight: bool = False,
 ) -> Any:
     callback = create or (lambda request: client.chat.completions.create(**request))
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
+
+    async def guarded_callback(request: dict[str, Any]) -> Any:
+        def preflight(final_request: dict[str, Any]) -> None:
+            _enforce_auxiliary_provider_preflight(
+                client,
+                final_request,
+                provider=provider,
+                api_mode=api_mode,
+                metadata=route[2] if route is not None else None,
+            )
+
+        if create_handles_preflight:
+            return await callback(request, preflight)
+        if create is None and getattr(
+            client.chat.completions, "_handles_provider_preflight", False
+        ):
+            final_request = dict(request)
+            final_request["_hermes_provider_preflight"] = preflight
+            return await callback(final_request)
+        preflight(request)
+        return await callback(request)
+
     if route is None:
-        return await callback(kwargs)
+        return await guarded_callback(kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
 
     return await relay_llm.execute_current_async(
         kwargs,
-        callback,
+        guarded_callback,
         name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
         metadata=metadata,
@@ -3161,14 +3312,32 @@ def _relay_sync_stream(
     api_mode: str | None = None,
 ) -> Any:
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
+
+    def guarded_callback(request: dict[str, Any]) -> Any:
+        def preflight(final_request: dict[str, Any]) -> None:
+            _enforce_auxiliary_provider_preflight(
+                client,
+                final_request,
+                provider=provider,
+                api_mode=api_mode,
+                metadata=route[2] if route is not None else None,
+            )
+
+        if getattr(client.chat.completions, "_handles_provider_preflight", False):
+            final_request = dict(request)
+            final_request["_hermes_provider_preflight"] = preflight
+            return client.chat.completions.create(**final_request)
+        preflight(request)
+        return client.chat.completions.create(**request)
+
     if route is None:
-        return client.chat.completions.create(**kwargs)
+        return guarded_callback(kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
 
     return relay_llm.stream_current(
         kwargs,
-        lambda request: client.chat.completions.create(**request),
+        guarded_callback,
         name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
         finalizer=dict,
@@ -8541,6 +8710,7 @@ def _create_with_progress(
     task: Optional[str] = None,
     *,
     force_stream: bool = False,
+    preflight: Optional[Callable[[Dict[str, Any]], None]] = None,
 ) -> Any:
     """chat.completions.create() that streams when a progress hook is active
     or the provider only accepts streamed requests.
@@ -8559,15 +8729,25 @@ def _create_with_progress(
     original error is surfaced to the normal recovery chains instead.
     """
     _notify_aux_progress()  # request dispatched counts as progress
+    completion_api = client.chat.completions
+    if getattr(completion_api, "_handles_provider_preflight", False):
+        final_request = dict(kwargs)
+        if preflight is not None:
+            final_request["_hermes_provider_preflight"] = preflight
+        return completion_api.create(**final_request)
     if (not _aux_progress_active() and not force_stream) or _client_streams_internally(client):
-        return client.chat.completions.create(**kwargs)
+        if preflight is not None:
+            preflight(kwargs)
+        return completion_api.create(**kwargs)
 
     total_ceiling = _aux_stream_total_ceiling(kwargs.get("timeout"))
     stream_kwargs = dict(kwargs)
     stream_kwargs["stream"] = True
     stream_kwargs["stream_options"] = {"include_usage": True}
     try:
-        chunks = client.chat.completions.create(**stream_kwargs)
+        if preflight is not None:
+            preflight(stream_kwargs)
+        chunks = completion_api.create(**stream_kwargs)
     except Exception as exc:
         # Genuine provider failures (auth, credit, rate limit, network) are
         # not streaming's fault — surface them unchanged so the existing
@@ -8589,7 +8769,9 @@ def _create_with_progress(
             "Auxiliary %s: streamed request failed (%s); retrying "
             "non-streaming", task or "call", exc,
         )
-        return client.chat.completions.create(**kwargs)
+        if preflight is not None:
+            preflight(kwargs)
+        return completion_api.create(**kwargs)
 
     # Some shims (MoA virtual provider under quiet mode, defensive adapters)
     # return a complete response even when stream=True was requested.
@@ -8761,6 +8943,7 @@ async def _acreate_with_stream(
     client: Any,
     kwargs: Dict[str, Any],
     task: Optional[str] = None,
+    preflight: Optional[Callable[[Dict[str, Any]], None]] = None,
 ) -> Any:
     """Async chat.completions.create() for stream-only providers.
 
@@ -8772,6 +8955,8 @@ async def _acreate_with_stream(
     stream_kwargs = dict(kwargs)
     stream_kwargs["stream"] = True
     stream_kwargs["stream_options"] = {"include_usage": True}
+    if preflight is not None:
+        preflight(stream_kwargs)
     chunks = await client.chat.completions.create(**stream_kwargs)
     # Defensive: shims may hand back a complete response despite stream=True.
     if hasattr(chunks, "choices"):
@@ -9054,7 +9239,12 @@ def _call_llm_impl(
             # Return the provider call directly; the MoA facade converts a
             # completed response into a one-chunk delta iterator at its
             # boundary.
-            return client.chat.completions.create(**kwargs)
+            return _relay_sync_completion(
+                client,
+                kwargs,
+                provider=request_provider,
+                api_mode=resolved_api_mode,
+            )
         return _relay_sync_stream(
             client,
             kwargs,
@@ -9088,14 +9278,16 @@ def _call_llm_impl(
                     kwargs,
                     provider=request_provider,
                     api_mode=resolved_api_mode,
-                    create=lambda request: _create_with_progress(
+                    create=lambda request, preflight: _create_with_progress(
                         client,
                         request,
                         task,
                         force_stream=_provider_requires_stream(
                             request_provider, _base_info or resolved_base_url,
                         ),
+                        preflight=preflight,
                     ),
+                    create_handles_preflight=True,
                 ),
                 task,
                 provider=request_provider, base_url=_base_info)
@@ -9135,7 +9327,7 @@ def _call_llm_impl(
                             kwargs,
                             provider=request_provider,
                             api_mode=resolved_api_mode,
-                            create=lambda request: _create_with_progress(
+                            create=lambda request, preflight: _create_with_progress(
                                 client,
                                 request,
                                 task,
@@ -9143,7 +9335,9 @@ def _call_llm_impl(
                                     request_provider,
                                     _base_info or resolved_base_url,
                                 ),
+                                preflight=preflight,
                             ),
+                            create_handles_preflight=True,
                         ),
                         task)
                 except Exception as retry_transient:
@@ -9813,9 +10007,15 @@ async def _async_call_llm_impl(
             ))
         )
 
-        async def _acreate(_kwargs: Dict[str, Any]) -> Any:
+        async def _acreate(
+            _kwargs: Dict[str, Any],
+            preflight: Callable[[Dict[str, Any]], None],
+        ) -> Any:
             if _force_stream_async:
-                return await _acreate_with_stream(client, _kwargs, task)
+                return await _acreate_with_stream(
+                    client, _kwargs, task, preflight=preflight
+                )
+            preflight(_kwargs)
             return await client.chat.completions.create(**_kwargs)
 
         try:
@@ -9826,6 +10026,7 @@ async def _async_call_llm_impl(
                     provider=request_provider,
                     api_mode=resolved_api_mode,
                     create=_acreate,
+                    create_handles_preflight=True,
                 ),
                 task,
                 provider=request_provider, base_url=_client_base)
@@ -9854,6 +10055,7 @@ async def _async_call_llm_impl(
                     provider=request_provider,
                     api_mode=resolved_api_mode,
                     create=_acreate,
+                    create_handles_preflight=True,
                 ),
                 task)
     except Exception as first_err:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2318,12 +2318,33 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     summary_api_request_id = f"iteration-summary:{uuid.uuid4()}"
     summary_call_outcome = "failed"
 
+    def _summary_preflight(request: dict, *, retry_count: int) -> None:
+        from agent.auxiliary_client import _enforce_auxiliary_provider_preflight
+
+        _enforce_auxiliary_provider_preflight(
+            agent,
+            request,
+            provider=str(getattr(agent, "provider", "") or "provider"),
+            api_mode=str(
+                getattr(agent, "api_mode", "") or "chat_completions"
+            ),
+            metadata={
+                "api_request_id": summary_api_request_id,
+                "call_role": "iteration_summary",
+                "retry_count": retry_count,
+            },
+        )
+
     def _managed_summary_call(request, callback, *, retry_count: int):
         from agent import relay_llm
 
+        def guarded_callback(final_request):
+            _summary_preflight(final_request, retry_count=retry_count)
+            return callback(final_request)
+
         return relay_llm.execute_current(
             request,
-            callback,
+            guarded_callback,
             name=str(getattr(agent, "provider", "") or "provider"),
             model_name=str(getattr(agent, "model", "") or ""),
             metadata={
@@ -2336,6 +2357,17 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             },
             defer_logical_completion=True,
         )
+
+    def _managed_codex_summary_call(request, *, retry_count: int):
+        transport = agent._get_transport()
+        final_request = transport.preflight_kwargs(
+            request,
+            allow_stream=False,
+            is_github_responses=agent._is_copilot_url(),
+            sanitize_harmony_tokens=agent._is_codex_backend(),
+        )
+        _summary_preflight(final_request, retry_count=retry_count)
+        return agent._run_codex_stream(final_request)
 
     # Shared constant so compaction recognizers can identify this runtime nudge
     # by its stable content after SessionDB projection strips metadata flags
@@ -2454,7 +2486,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         if agent.api_mode == "codex_responses":
             codex_kwargs = agent._build_api_kwargs(api_messages)
             codex_kwargs.pop("tools", None)
-            summary_response = agent._run_codex_stream(codex_kwargs)
+            summary_response = _managed_codex_summary_call(
+                codex_kwargs, retry_count=0
+            )
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
             final_response = (_cnr_sum.content or "").strip()
@@ -2566,7 +2600,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "codex_responses":
                 codex_kwargs = agent._build_api_kwargs(api_messages)
                 codex_kwargs.pop("tools", None)
-                retry_response = agent._run_codex_stream(codex_kwargs)
+                retry_response = _managed_codex_summary_call(
+                    codex_kwargs, retry_count=1
+                )
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)
                 final_response = (_cnr_retry.content or "").strip()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2558,9 +2558,11 @@ def run_conversation(
                 try:
                     from hermes_cli.lifecycle import (
                         has_hook,
-                        invoke_hook as _invoke_hook,
+                        has_mandatory_hook,
+                        invoke_hook_enforced as _invoke_hook,
                     )
-                    if has_hook("pre_api_request"):
+                    from hermes_cli.plugins import MandatoryHookError
+                    if has_hook("pre_api_request") or has_mandatory_hook("pre_api_request"):
                         request_messages = api_kwargs.get("messages")
                         if not isinstance(request_messages, list):
                             request_messages = api_kwargs.get("input")
@@ -2610,6 +2612,26 @@ def run_conversation(
                             middleware_trace=list(_llm_middleware_trace),
                             request=_request_payload,
                         )
+                except MandatoryHookError as exc:
+                    if thinking_spinner:
+                        thinking_spinner.stop("")
+                        thinking_spinner = None
+                    if agent.thinking_callback:
+                        agent.thinking_callback("")
+                    agent.iteration_budget.refund()
+                    api_call_count -= 1
+                    agent._api_call_count = api_call_count
+                    final_response = str(exc)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": final_response,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": final_response,
+                        "failure_reason": exc.code,
+                    }
                 except Exception:
                     pass
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1536,13 +1536,15 @@ def _invoke_provider_preflight(
 def _mandatory_preflight_failure_result(
     exc: Exception,
     messages: List[Dict[str, Any]],
+    *,
+    api_calls: int = 1,
 ) -> Dict[str, Any]:
     """Build the deterministic local failure returned by every transport path."""
     final_response = str(exc)
     return {
         "final_response": final_response,
         "messages": messages,
-        "api_calls": 0,
+        "api_calls": api_calls,
         "completed": False,
         "failed": True,
         "error": final_response,
@@ -1754,30 +1756,81 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        from hermes_cli.middleware import (
+            apply_llm_request_middleware,
+            run_llm_execution_middleware,
+        )
         from hermes_cli.plugins import MandatoryHookError
 
+        request_kwargs = {
+            "messages": list(messages),
+            "user_message": user_message,
+        }
         try:
-            _invoke_provider_preflight(
-                agent,
-                request_kwargs={"messages": list(messages)},
-                api_messages=list(messages),
-                conversation_messages=messages,
-                original_user_message=original_user_message,
-                effective_task_id=effective_task_id,
+            middleware_result = apply_llm_request_middleware(
+                request_kwargs,
+                task_id=effective_task_id,
                 turn_id=turn_id,
                 api_request_id=f"{turn_id}:api:1",
+                session_id=agent.session_id or "",
+                platform=agent.platform or "",
+                model=agent.model,
+                provider=agent.provider,
+                base_url=agent.base_url,
+                api_mode=agent.api_mode,
                 api_call_count=1,
+            )
+
+            def _dispatch_codex_app_server(final_request):
+                final_messages = final_request.get("messages")
+                if not isinstance(final_messages, list):
+                    final_messages = list(messages)
+                final_user_message = final_request.get("user_message", user_message)
+                for message in reversed(final_messages):
+                    if isinstance(message, dict) and message.get("role") == "user":
+                        final_user_message = message.get("content", final_user_message)
+                        break
+                _invoke_provider_preflight(
+                    agent,
+                    request_kwargs=final_request,
+                    api_messages=final_messages,
+                    conversation_messages=messages,
+                    original_user_message=original_user_message,
+                    effective_task_id=effective_task_id,
+                    turn_id=turn_id,
+                    api_request_id=f"{turn_id}:api:1",
+                    api_call_count=1,
+                    middleware_trace=middleware_result.trace,
+                )
+                return agent._run_codex_app_server_turn(
+                    user_message=final_user_message,
+                    original_user_message=original_user_message,
+                    messages=final_messages,
+                    effective_task_id=effective_task_id,
+                    should_review_memory=_should_review_memory,
+                )
+
+            return run_llm_execution_middleware(
+                middleware_result.payload,
+                _dispatch_codex_app_server,
+                original_request=middleware_result.original_payload,
+                task_id=effective_task_id,
+                turn_id=turn_id,
+                api_request_id=f"{turn_id}:api:1",
+                session_id=agent.session_id or "",
+                platform=agent.platform or "",
+                model=agent.model,
+                provider=agent.provider,
+                base_url=agent.base_url,
+                api_mode=agent.api_mode,
+                api_call_count=1,
+                middleware_trace=list(middleware_result.trace),
             )
         except MandatoryHookError as exc:
             agent._persist_session(messages, conversation_history)
-            return _mandatory_preflight_failure_result(exc, messages)
-        return agent._run_codex_app_server_turn(
-            user_message=user_message,
-            original_user_message=original_user_message,
-            messages=messages,
-            effective_task_id=effective_task_id,
-            should_review_memory=_should_review_memory,
-        )
+            return _mandatory_preflight_failure_result(
+                exc, messages, api_calls=0
+            )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         _redirect_text = agent._drain_pending_redirect()
@@ -2665,37 +2718,11 @@ def run_conversation(
                 _sanitize_structure_surrogates(api_kwargs)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
-                try:
-                    from hermes_cli.plugins import MandatoryHookError
-
-                    _mandatory_preflight_plugins = _invoke_provider_preflight(
-                        agent,
-                        request_kwargs=api_kwargs,
-                        api_messages=api_messages,
-                        conversation_messages=messages,
-                        original_user_message=original_user_message,
-                        effective_task_id=effective_task_id,
-                        turn_id=turn_id,
-                        api_request_id=api_request_id,
-                        api_call_count=api_call_count,
-                        retry_count=retry_count,
-                        approx_input_tokens=approx_tokens,
-                        request_char_count=total_chars,
-                        started_at=api_start_time,
-                        phase="mandatory",
-                    )
-                except MandatoryHookError as exc:
-                    if thinking_spinner:
-                        thinking_spinner.stop("")
-                        thinking_spinner = None
-                    if agent.thinking_callback:
-                        agent.thinking_callback("")
-                    agent.iteration_budget.refund()
-                    api_call_count -= 1
-                    agent._api_call_count = api_call_count
-                    agent._persist_session(messages, conversation_history)
-                    return _mandatory_preflight_failure_result(exc, messages)
                 if agent.api_mode == "codex_responses":
+                    # Normalize provider-reserved wire tokens before request
+                    # middleware sees the payload. Middleware may rewrite it,
+                    # so the dispatch chokepoint repeats this transport
+                    # preflight immediately before mandatory policy approval.
                     api_kwargs = agent._get_transport().preflight_kwargs(
                         api_kwargs,
                         allow_stream=False,
@@ -2732,48 +2759,6 @@ def run_conversation(
                 except Exception:
                     _original_api_kwargs = dict(api_kwargs)
                     _llm_middleware_trace = []
-
-                try:
-                    from hermes_cli.plugins import MandatoryHookError
-
-                    _invoke_provider_preflight(
-                        agent,
-                        request_kwargs=api_kwargs,
-                        api_messages=api_messages,
-                        conversation_messages=messages,
-                        original_user_message=original_user_message,
-                        effective_task_id=effective_task_id,
-                        turn_id=turn_id,
-                        api_request_id=api_request_id,
-                        api_call_count=api_call_count,
-                        retry_count=retry_count,
-                        approx_input_tokens=approx_tokens,
-                        request_char_count=total_chars,
-                        started_at=api_start_time,
-                        middleware_trace=_llm_middleware_trace,
-                        phase="observers",
-                        mandatory_plugins=_mandatory_preflight_plugins,
-                    )
-                except MandatoryHookError as exc:
-                    if thinking_spinner:
-                        thinking_spinner.stop("")
-                        thinking_spinner = None
-                    if agent.thinking_callback:
-                        agent.thinking_callback("")
-                    agent.iteration_budget.refund()
-                    api_call_count -= 1
-                    agent._api_call_count = api_call_count
-                    agent._persist_session(messages, conversation_history)
-                    return _mandatory_preflight_failure_result(exc, messages)
-
-                if env_var_enabled("HERMES_DUMP_REQUESTS"):
-                    agent._dump_api_request_debug(api_kwargs, reason="preflight")
-
-                # This object is private to the in-process MoA facade.  Add it
-                # only after middleware, hooks, and debug dumps so none of them
-                # attempts to serialize it as part of the provider payload.
-                if _moa_prepared_request is not None and agent.provider == "moa":
-                    api_kwargs["_moa_prepared_request"] = _moa_prepared_request
 
                 # Always prefer the streaming path — even without stream
                 # consumers.  Streaming gives us fine-grained health
@@ -2837,6 +2822,30 @@ def run_conversation(
                             is_github_responses=agent._is_copilot_url(),
                             sanitize_harmony_tokens=agent._is_codex_backend(),
                         )
+                    _invoke_provider_preflight(
+                        agent,
+                        request_kwargs=next_api_kwargs,
+                        api_messages=api_messages,
+                        conversation_messages=messages,
+                        original_user_message=original_user_message,
+                        effective_task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        retry_count=retry_count,
+                        approx_input_tokens=approx_tokens,
+                        request_char_count=total_chars,
+                        started_at=api_start_time,
+                        middleware_trace=_llm_middleware_trace,
+                    )
+                    if env_var_enabled("HERMES_DUMP_REQUESTS"):
+                        agent._dump_api_request_debug(
+                            next_api_kwargs, reason="preflight"
+                        )
+                    # Private to the in-process MoA facade: add only after the
+                    # final provider-bound payload passes policy inspection.
+                    if _moa_prepared_request is not None and agent.provider == "moa":
+                        next_api_kwargs["_moa_prepared_request"] = _moa_prepared_request
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
@@ -2865,6 +2874,7 @@ def run_conversation(
                     )
 
                 from hermes_cli.middleware import run_llm_execution_middleware
+                from hermes_cli.plugins import MandatoryHookError
 
                 _model_request_active = getattr(agent, "_model_request_active", None)
                 _redirect_lock = getattr(agent, "_pending_redirect_lock", None)
@@ -2876,22 +2886,38 @@ def run_conversation(
                     _model_request_active.set()
                 _redirect_crossed_response = False
                 try:
-                    response = run_llm_execution_middleware(
-                        api_kwargs,
-                        _perform_api_call,
-                        original_request=_original_api_kwargs,
-                        task_id=effective_task_id,
-                        turn_id=turn_id,
-                        api_request_id=api_request_id,
-                        session_id=agent.session_id or "",
-                        platform=agent.platform or "",
-                        model=agent.model,
-                        provider=agent.provider,
-                        base_url=agent.base_url,
-                        api_mode=agent.api_mode,
-                        api_call_count=api_call_count,
-                        middleware_trace=list(_llm_middleware_trace),
-                    )
+                    try:
+                        response = run_llm_execution_middleware(
+                            api_kwargs,
+                            _perform_api_call,
+                            original_request=_original_api_kwargs,
+                            task_id=effective_task_id,
+                            turn_id=turn_id,
+                            api_request_id=api_request_id,
+                            session_id=agent.session_id or "",
+                            platform=agent.platform or "",
+                            model=agent.model,
+                            provider=agent.provider,
+                            base_url=agent.base_url,
+                            api_mode=agent.api_mode,
+                            api_call_count=api_call_count,
+                            middleware_trace=list(_llm_middleware_trace),
+                        )
+                    except MandatoryHookError as exc:
+                        if thinking_spinner:
+                            thinking_spinner.stop("")
+                            thinking_spinner = None
+                        if agent.thinking_callback:
+                            agent.thinking_callback("")
+                        agent.iteration_budget.refund()
+                        api_call_count -= 1
+                        agent._api_call_count = api_call_count
+                        agent._persist_session(messages, conversation_history)
+                        return _mandatory_preflight_failure_result(
+                            exc,
+                            messages,
+                            api_calls=api_call_count,
+                        )
                 finally:
                     if _redirect_lock is not None:
                         with _redirect_lock:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1419,6 +1419,109 @@ def _notify_context_engine_turn_complete(
         )
 
 
+def _invoke_provider_preflight(
+    agent,
+    *,
+    request_kwargs: Dict[str, Any],
+    api_messages: List[Dict[str, Any]],
+    conversation_messages: List[Dict[str, Any]],
+    original_user_message: Any,
+    effective_task_id: str,
+    turn_id: str,
+    api_request_id: str,
+    api_call_count: int,
+    retry_count: int = 0,
+    approx_input_tokens: int = 0,
+    request_char_count: int = 0,
+    started_at: Optional[float] = None,
+    middleware_trace: Optional[List[Dict[str, Any]]] = None,
+) -> None:
+    """Run the single provider preflight gate before any transport dispatch."""
+    from hermes_cli.lifecycle import (
+        has_hook,
+        has_mandatory_hook,
+        invoke_hook_enforced,
+    )
+    from hermes_cli.plugins import MandatoryHookError
+
+    try:
+        mandatory = has_mandatory_hook("pre_api_request")
+    except MandatoryHookError:
+        raise
+    except Exception:
+        raise MandatoryHookError(
+            "mandatory_hook_config_invalid", "pre_api_request", "config"
+        ) from None
+
+    try:
+        observed = has_hook("pre_api_request")
+    except Exception:
+        if mandatory:
+            raise MandatoryHookError(
+                "mandatory_hook_exception", "pre_api_request", "runtime"
+            ) from None
+        return
+    if not (observed or mandatory):
+        return
+
+    try:
+        request_messages = request_kwargs.get("messages")
+        if not isinstance(request_messages, list):
+            request_messages = request_kwargs.get("input")
+        if not isinstance(request_messages, list):
+            request_messages = api_messages
+        request_payload = agent._api_request_payload_for_hook(request_kwargs)
+        invoke_hook_enforced(
+            "pre_api_request",
+            task_id=effective_task_id,
+            turn_id=turn_id,
+            api_request_id=api_request_id,
+            session_id=agent.session_id or "",
+            user_message=original_user_message,
+            conversation_history=list(conversation_messages),
+            platform=agent.platform or "",
+            model=agent.model,
+            provider=agent.provider,
+            base_url=agent.base_url,
+            api_mode=agent.api_mode,
+            api_call_count=api_call_count,
+            retry_count=retry_count,
+            request_messages=list(request_messages),
+            message_count=len(api_messages),
+            tool_count=len(agent.tools or []),
+            approx_input_tokens=approx_input_tokens,
+            request_char_count=request_char_count,
+            max_tokens=agent.max_tokens,
+            started_at=started_at if started_at is not None else time.time(),
+            middleware_trace=list(middleware_trace or []),
+            request=request_payload,
+        )
+    except MandatoryHookError:
+        raise
+    except Exception:
+        if mandatory:
+            raise MandatoryHookError(
+                "mandatory_hook_exception", "pre_api_request", "runtime"
+            ) from None
+
+
+def _mandatory_preflight_failure_result(
+    exc: Exception,
+    messages: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build the deterministic local failure returned by every transport path."""
+    final_response = str(exc)
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "api_calls": 0,
+        "completed": False,
+        "failed": True,
+        "error": final_response,
+        "failure_reason": getattr(exc, "code", "mandatory_hook_exception"),
+    }
+
+
 def run_conversation(
     agent,
     user_message: Any,
@@ -1623,6 +1726,23 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        from hermes_cli.plugins import MandatoryHookError
+
+        try:
+            _invoke_provider_preflight(
+                agent,
+                request_kwargs={"messages": list(messages)},
+                api_messages=list(messages),
+                conversation_messages=messages,
+                original_user_message=original_user_message,
+                effective_task_id=effective_task_id,
+                turn_id=turn_id,
+                api_request_id=f"{turn_id}:api:1",
+                api_call_count=1,
+            )
+        except MandatoryHookError as exc:
+            agent._persist_session(messages, conversation_history)
+            return _mandatory_preflight_failure_result(exc, messages)
         return agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
@@ -2556,62 +2676,24 @@ def run_conversation(
                     _llm_middleware_trace = []
 
                 try:
-                    from hermes_cli.lifecycle import (
-                        has_hook,
-                        has_mandatory_hook,
-                        invoke_hook_enforced as _invoke_hook,
-                    )
                     from hermes_cli.plugins import MandatoryHookError
-                    if has_hook("pre_api_request") or has_mandatory_hook("pre_api_request"):
-                        request_messages = api_kwargs.get("messages")
-                        if not isinstance(request_messages, list):
-                            request_messages = api_kwargs.get("input")
-                        if not isinstance(request_messages, list):
-                            request_messages = api_messages
-                        # Shallow-copy the outer list so plugins that retain the
-                        # reference for async snapshotting don't observe later
-                        # mutations of api_messages.  The inner dicts are not
-                        # mutated by the agent loop, so a shallow copy is
-                        # sufficient; a deepcopy would walk every tool result
-                        # and base64 image on every API call.
-                        #
-                        # The ``request_messages`` and ``conversation_history``
-                        # kwargs below are pre-existing raw passthroughs
-                        # consumed by the bundled langfuse plugin
-                        # (``plugins/observability/langfuse/__init__.py:_coerce_request_messages``).
-                        # They predate ``request`` and are intentionally NOT
-                        # sanitised — secrets are not expected here because
-                        # ``api_kwargs`` is the same object passed to the
-                        # provider client.  New consumers should read the
-                        # sanitised view from ``request["body"]["messages"]``.
-                        _request_payload = agent._api_request_payload_for_hook(api_kwargs)
-                        _invoke_hook(
-                            "pre_api_request",
-                            task_id=effective_task_id,
-                            turn_id=turn_id,
-                            api_request_id=api_request_id,
-                            session_id=agent.session_id or "",
-                            user_message=original_user_message,
-                            conversation_history=list(messages),
-                            platform=agent.platform or "",
-                            model=agent.model,
-                            provider=agent.provider,
-                            base_url=agent.base_url,
-                            api_mode=agent.api_mode,
-                            api_call_count=api_call_count,
-                            retry_count=retry_count,
-                            request_messages=list(request_messages)
-                            if isinstance(request_messages, list)
-                            else [],
-                            message_count=len(api_messages),
-                            tool_count=len(agent.tools or []),
-                            approx_input_tokens=approx_tokens,
-                            request_char_count=total_chars,
-                            max_tokens=agent.max_tokens,
-                            started_at=api_start_time,
-                            middleware_trace=list(_llm_middleware_trace),
-                            request=_request_payload,
-                        )
+
+                    _invoke_provider_preflight(
+                        agent,
+                        request_kwargs=api_kwargs,
+                        api_messages=api_messages,
+                        conversation_messages=messages,
+                        original_user_message=original_user_message,
+                        effective_task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        retry_count=retry_count,
+                        approx_input_tokens=approx_tokens,
+                        request_char_count=total_chars,
+                        started_at=api_start_time,
+                        middleware_trace=_llm_middleware_trace,
+                    )
                 except MandatoryHookError as exc:
                     if thinking_spinner:
                         thinking_spinner.stop("")
@@ -2621,19 +2703,8 @@ def run_conversation(
                     agent.iteration_budget.refund()
                     api_call_count -= 1
                     agent._api_call_count = api_call_count
-                    final_response = str(exc)
                     agent._persist_session(messages, conversation_history)
-                    return {
-                        "final_response": final_response,
-                        "messages": messages,
-                        "api_calls": api_call_count,
-                        "completed": False,
-                        "failed": True,
-                        "error": final_response,
-                        "failure_reason": exc.code,
-                    }
-                except Exception:
-                    pass
+                    return _mandatory_preflight_failure_result(exc, messages)
 
                 if env_var_enabled("HERMES_DUMP_REQUESTS"):
                     agent._dump_api_request_debug(api_kwargs, reason="preflight")

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1435,34 +1435,42 @@ def _invoke_provider_preflight(
     request_char_count: int = 0,
     started_at: Optional[float] = None,
     middleware_trace: Optional[List[Dict[str, Any]]] = None,
-) -> None:
-    """Run the single provider preflight gate before any transport dispatch."""
+    phase: str = "all",
+    mandatory_plugins: Optional[List[str]] = None,
+) -> List[str]:
+    """Run mandatory and observer provider-preflight phases in strict order."""
     from hermes_cli.lifecycle import (
         has_hook,
         has_mandatory_hook,
+        invoke_hook_observers,
         invoke_hook_enforced,
+        invoke_mandatory_hook,
     )
     from hermes_cli.plugins import MandatoryHookError
 
-    try:
-        mandatory = has_mandatory_hook("pre_api_request")
-    except MandatoryHookError:
-        raise
-    except Exception:
-        raise MandatoryHookError(
-            "mandatory_hook_config_invalid", "pre_api_request", "config"
-        ) from None
+    mandatory = bool(mandatory_plugins)
+    if phase != "observers":
+        try:
+            mandatory = has_mandatory_hook("pre_api_request")
+        except MandatoryHookError:
+            raise
+        except Exception:
+            raise MandatoryHookError(
+                "mandatory_hook_config_invalid", "pre_api_request", "config"
+            ) from None
+        if phase == "mandatory" and not mandatory:
+            return []
 
     try:
         observed = has_hook("pre_api_request")
     except Exception:
-        if mandatory:
+        if mandatory and phase != "observers":
             raise MandatoryHookError(
                 "mandatory_hook_exception", "pre_api_request", "runtime"
             ) from None
-        return
+        return list(mandatory_plugins or [])
     if not (observed or mandatory):
-        return
+        return []
 
     try:
         request_messages = request_kwargs.get("messages")
@@ -1471,8 +1479,7 @@ def _invoke_provider_preflight(
         if not isinstance(request_messages, list):
             request_messages = api_messages
         request_payload = agent._api_request_payload_for_hook(request_kwargs)
-        invoke_hook_enforced(
-            "pre_api_request",
+        hook_kwargs = dict(
             task_id=effective_task_id,
             turn_id=turn_id,
             api_request_id=api_request_id,
@@ -1496,13 +1503,34 @@ def _invoke_provider_preflight(
             middleware_trace=list(middleware_trace or []),
             request=request_payload,
         )
+        if phase == "mandatory":
+            _, required = invoke_mandatory_hook(
+                "pre_api_request", **hook_kwargs
+            )
+            return required
+        if phase == "observers":
+            if mandatory_plugins:
+                invoke_hook_observers(
+                    "pre_api_request",
+                    list(mandatory_plugins),
+                    **hook_kwargs,
+                )
+            else:
+                # Preserve the public observer seam (including callers/tests
+                # patching lifecycle.invoke_hook) when no mandatory contract
+                # is configured.
+                invoke_hook_enforced("pre_api_request", **hook_kwargs)
+            return list(mandatory_plugins or [])
+        invoke_hook_enforced("pre_api_request", **hook_kwargs)
+        return []
     except MandatoryHookError:
         raise
     except Exception:
-        if mandatory:
+        if mandatory and phase != "observers":
             raise MandatoryHookError(
                 "mandatory_hook_exception", "pre_api_request", "runtime"
             ) from None
+        return list(mandatory_plugins or [])
 
 
 def _mandatory_preflight_failure_result(
@@ -2637,6 +2665,36 @@ def run_conversation(
                 _sanitize_structure_surrogates(api_kwargs)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
+                try:
+                    from hermes_cli.plugins import MandatoryHookError
+
+                    _mandatory_preflight_plugins = _invoke_provider_preflight(
+                        agent,
+                        request_kwargs=api_kwargs,
+                        api_messages=api_messages,
+                        conversation_messages=messages,
+                        original_user_message=original_user_message,
+                        effective_task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        retry_count=retry_count,
+                        approx_input_tokens=approx_tokens,
+                        request_char_count=total_chars,
+                        started_at=api_start_time,
+                        phase="mandatory",
+                    )
+                except MandatoryHookError as exc:
+                    if thinking_spinner:
+                        thinking_spinner.stop("")
+                        thinking_spinner = None
+                    if agent.thinking_callback:
+                        agent.thinking_callback("")
+                    agent.iteration_budget.refund()
+                    api_call_count -= 1
+                    agent._api_call_count = api_call_count
+                    agent._persist_session(messages, conversation_history)
+                    return _mandatory_preflight_failure_result(exc, messages)
                 if agent.api_mode == "codex_responses":
                     api_kwargs = agent._get_transport().preflight_kwargs(
                         api_kwargs,
@@ -2693,6 +2751,8 @@ def run_conversation(
                         request_char_count=total_chars,
                         started_at=api_start_time,
                         middleware_trace=_llm_middleware_trace,
+                        phase="observers",
+                        mandatory_plugins=_mandatory_preflight_plugins,
                     )
                 except MandatoryHookError as exc:
                     if thinking_spinner:

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -47,13 +47,22 @@ def has_mandatory_hook(hook_name: str) -> bool:
     return plugins.has_mandatory_hook(hook_name)
 
 
-def invoke_hook_enforced(hook_name: str, **kwargs: Any) -> List[Any]:
-    """Notify observers and enforce configured mandatory plugin callbacks."""
-    if not has_mandatory_hook(hook_name):
-        # Preserve the public observer seam (including callers/tests that patch
-        # module-level invoke_hook) when no mandatory contract is configured.
-        return invoke_hook(hook_name, **kwargs)
+def invoke_mandatory_hook(
+    hook_name: str,
+    **kwargs: Any,
+) -> tuple[List[Any], List[str]]:
+    """Run the mandatory security phase without invoking observers."""
+    from hermes_cli import plugins
 
+    return plugins.invoke_mandatory_hook(hook_name, **kwargs)
+
+
+def invoke_hook_observers(
+    hook_name: str,
+    mandatory_plugins: List[str],
+    **kwargs: Any,
+) -> List[Any]:
+    """Notify first-party and compatibility observers after mandatory allow."""
     try:
         from hermes_cli.observability import observe_lifecycle
 
@@ -66,7 +75,23 @@ def invoke_hook_enforced(hook_name: str, **kwargs: Any) -> List[Any]:
 
     from hermes_cli import plugins
 
-    return plugins.invoke_hook_enforced(hook_name, **kwargs)
+    return plugins.invoke_hook_observers(
+        hook_name, mandatory_plugins, **kwargs
+    )
+
+
+def invoke_hook_enforced(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Enforce mandatory callbacks before any lifecycle observer side effect."""
+    if not has_mandatory_hook(hook_name):
+        # Preserve the public observer seam (including callers/tests that patch
+        # module-level invoke_hook) when no mandatory contract is configured.
+        return invoke_hook(hook_name, **kwargs)
+
+    mandatory_results, required = invoke_mandatory_hook(hook_name, **kwargs)
+    observer_results = invoke_hook_observers(
+        hook_name, required, **kwargs
+    )
+    return mandatory_results + observer_results
 
 
 def finalize_session(**kwargs: Any) -> List[Any]:

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -37,6 +37,32 @@ def has_hook(hook_name: str) -> bool:
     return plugins.has_hook(hook_name)
 
 
+def has_mandatory_hook(hook_name: str) -> bool:
+    """Return whether a plugin hook has a fail-closed contract configured."""
+    from hermes_cli import plugins
+
+    return plugins.has_mandatory_hook(hook_name)
+
+
+def invoke_hook_enforced(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Notify observers and enforce configured mandatory plugin callbacks."""
+    if not has_mandatory_hook(hook_name):
+        # Preserve the public observer seam (including callers/tests that patch
+        # module-level invoke_hook) when no mandatory contract is configured.
+        return invoke_hook(hook_name, **kwargs)
+
+    try:
+        from hermes_cli.observability import observe_lifecycle
+
+        observe_lifecycle(hook_name, **kwargs)
+    except Exception:
+        logger.warning("Built-in observability hook failed", exc_info=True)
+
+    from hermes_cli import plugins
+
+    return plugins.invoke_hook_enforced(hook_name, **kwargs)
+
+
 def finalize_session(**kwargs: Any) -> List[Any]:
     """Notify observers and hard-close one core-owned Relay conversation."""
     try:

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -15,7 +15,10 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
         observe_lifecycle(hook_name, **kwargs)
     except Exception:
-        logger.warning("Built-in observability hook failed", exc_info=True)
+        logger.warning(
+            "Built-in observability hook failed",
+            exc_info=hook_name != "pre_api_request",
+        )
 
     from hermes_cli import plugins
 
@@ -56,7 +59,10 @@ def invoke_hook_enforced(hook_name: str, **kwargs: Any) -> List[Any]:
 
         observe_lifecycle(hook_name, **kwargs)
     except Exception:
-        logger.warning("Built-in observability hook failed", exc_info=True)
+        logger.warning(
+            "Built-in observability hook failed",
+            exc_info=hook_name != "pre_api_request",
+        )
 
     from hermes_cli import plugins
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -309,9 +309,19 @@ def _get_mandatory_hook_plugins(hook_name: str) -> List[str]:
     """
     from hermes_cli.config import load_config_readonly
 
-    configured = cfg_get(
-        load_config_readonly(), "plugins", "mandatory_hooks", default={}
-    )
+    config = load_config_readonly()
+    if not isinstance(config, dict):
+        raise MandatoryHookError(
+            "mandatory_hook_config_invalid", hook_name, "config"
+        )
+    plugins_config = config.get("plugins", {})
+    if plugins_config in (None, {}):
+        return []
+    if not isinstance(plugins_config, dict):
+        raise MandatoryHookError(
+            "mandatory_hook_config_invalid", hook_name, "config"
+        )
+    configured = plugins_config.get("mandatory_hooks", {})
     if configured in (None, {}):
         return []
     if not isinstance(configured, dict):
@@ -385,6 +395,28 @@ def _audit_mandatory_hook(
             },
             sort_keys=True,
         )
+    )
+
+
+def _log_hook_callback_failure(
+    hook_name: str,
+    callback: Callable,
+    exc: Exception,
+) -> None:
+    """Log observer failure without exposing provider-request payloads."""
+    callback_name = getattr(callback, "__name__", type(callback).__name__)
+    if hook_name == "pre_api_request":
+        logger.warning(
+            "Hook '%s' callback %s raised; details suppressed",
+            hook_name,
+            callback_name,
+        )
+        return
+    logger.warning(
+        "Hook '%s' callback %s raised: %s",
+        hook_name,
+        callback_name,
+        exc,
     )
 
 
@@ -2247,12 +2279,7 @@ class PluginManager:
                 if ret is not None:
                     results.append(ret)
             except Exception as exc:
-                logger.warning(
-                    "Hook '%s' callback %s raised: %s",
-                    hook_name,
-                    getattr(cb, "__name__", repr(cb)),
-                    exc,
-                )
+                _log_hook_callback_failure(hook_name, cb, exc)
         return results
 
     def invoke_hook_enforced(self, hook_name: str, **kwargs: Any) -> List[Any]:
@@ -2300,12 +2327,7 @@ class PluginManager:
                     if ret is not None:
                         results.append(ret)
                 except Exception as exc:
-                    logger.warning(
-                        "Hook '%s' callback %s raised: %s",
-                        hook_name,
-                        getattr(cb, "__name__", repr(cb)),
-                        exc,
-                    )
+                    _log_hook_callback_failure(hook_name, cb, exc)
                 continue
 
             try:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -38,8 +38,10 @@ import hashlib
 import importlib.metadata
 import importlib.util
 import inspect
+import json
 import logging
 import os
+import re
 import sys
 import threading
 import types
@@ -75,6 +77,27 @@ class PluginToolOverrideError(PermissionError):
     """Raised when a plugin attempts to override a built-in tool without
     operator opt-in via ``plugins.entries.<plugin_id>.allow_tool_override``.
     """
+
+
+class MandatoryHookError(RuntimeError):
+    """Fail-closed result from a configured mandatory plugin hook."""
+
+    def __init__(
+        self,
+        code: str,
+        hook_name: str,
+        plugin_id: str,
+        reason: str = "",
+    ) -> None:
+        self.code = code
+        self.hook_name = hook_name
+        self.plugin_id = plugin_id
+        self.reason = reason
+        detail = f": {reason}" if reason else ""
+        super().__init__(
+            f"Provider request blocked by mandatory preflight "
+            f"({hook_name}/{plugin_id}){detail}"
+        )
 
 
 logger = logging.getLogger(__name__)
@@ -272,6 +295,97 @@ def _get_enabled_plugins() -> Optional[set]:
         return set(enabled)
     except Exception:
         return None
+
+
+_MANDATORY_PLUGIN_ID_RE = re.compile(r"^[A-Za-z0-9_.\-/]+$")
+
+
+def _get_mandatory_hook_plugins(hook_name: str) -> List[str]:
+    """Return configured plugin ids that must enforce *hook_name*.
+
+    The contract is ``plugins.mandatory_hooks.<hook>: [plugin-id, ...]``.
+    Absence is backward-compatible and leaves all hooks observer-only. Once a
+    hook is configured, malformed configuration is itself fail-closed.
+    """
+    from hermes_cli.config import load_config_readonly
+
+    configured = cfg_get(
+        load_config_readonly(), "plugins", "mandatory_hooks", default={}
+    )
+    if configured in (None, {}):
+        return []
+    if not isinstance(configured, dict):
+        raise MandatoryHookError(
+            "mandatory_hook_config_invalid", hook_name, "config"
+        )
+    required = configured.get(hook_name, [])
+    if required in (None, []):
+        return []
+    if not isinstance(required, list):
+        raise MandatoryHookError(
+            "mandatory_hook_config_invalid", hook_name, "config"
+        )
+
+    normalized: List[str] = []
+    for plugin_id in required:
+        if (
+            not isinstance(plugin_id, str)
+            or not plugin_id
+            or not _MANDATORY_PLUGIN_ID_RE.fullmatch(plugin_id)
+        ):
+            raise MandatoryHookError(
+                "mandatory_hook_config_invalid", hook_name, "config"
+            )
+        if plugin_id not in normalized:
+            normalized.append(plugin_id)
+    return normalized
+
+
+def has_mandatory_hook(hook_name: str) -> bool:
+    """Return whether *hook_name* has a mandatory contract configured.
+
+    Invalid configuration returns ``True`` so the enforced invocation path can
+    surface its deterministic fail-closed error instead of skipping the hook.
+    """
+    try:
+        return bool(_get_mandatory_hook_plugins(hook_name))
+    except MandatoryHookError:
+        return True
+
+
+def _sanitize_mandatory_hook_reason(value: Any) -> str:
+    """Return a bounded, secret-redacted reason safe for local display."""
+    if not isinstance(value, str):
+        return ""
+    try:
+        from agent.redact import redact_sensitive_text
+
+        cleaned = redact_sensitive_text(value, force=True)
+    except Exception:
+        return "Policy blocked the provider request."
+    cleaned = re.sub(r"https?://\S+", "[endpoint]", cleaned)
+    cleaned = re.sub(r"\b[A-Za-z0-9_-]{18,}\b", "[redacted]", cleaned)
+    cleaned = " ".join(cleaned.split())
+    return cleaned[:240]
+
+
+def _audit_mandatory_hook(
+    hook_name: str,
+    plugin_id: str,
+    outcome: str,
+) -> None:
+    """Emit a payload-free, key-allowlisted mandatory-hook audit event."""
+    logger.warning(
+        json.dumps(
+            {
+                "event": "mandatory_hook_preflight",
+                "hook": hook_name,
+                "outcome": outcome,
+                "plugin": plugin_id,
+            },
+            sort_keys=True,
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1226,6 +1340,8 @@ class PluginContext:
                 ", ".join(sorted(VALID_HOOKS)),
             )
         self._manager._hooks.setdefault(hook_name, []).append(callback)
+        plugin_id = self.manifest.key or self.manifest.name
+        self._manager._hook_owners.setdefault(hook_name, []).append(plugin_id)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
     # -- middleware registration -------------------------------------------
@@ -1312,6 +1428,7 @@ class PluginManager:
     def __init__(self) -> None:
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
+        self._hook_owners: Dict[str, List[Optional[str]]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
@@ -1354,6 +1471,7 @@ class PluginManager:
         if force:
             self._plugins.clear()
             self._hooks.clear()
+            self._hook_owners.clear()
             self._middleware.clear()
             self._plugin_tool_names.clear()
             self._plugin_platform_names.clear()
@@ -2137,6 +2255,94 @@ class PluginManager:
                 )
         return results
 
+    def invoke_hook_enforced(self, hook_name: str, **kwargs: Any) -> List[Any]:
+        """Invoke a hook with fail-closed semantics for configured plugins.
+
+        Non-mandatory callbacks retain :meth:`invoke_hook`'s isolated observer
+        behavior. Configured mandatory callbacks must be present, must not
+        raise, and may return ``None`` or ``{"action": "allow"}`` to proceed.
+        Any other result is malformed; ``{"action": "block"}`` vetoes the
+        provider request with a sanitized local reason.
+        """
+        required = _get_mandatory_hook_plugins(hook_name)
+        if not required:
+            return self.invoke_hook(hook_name, **kwargs)
+
+        callbacks = self._hooks.get(hook_name, [])
+        owners = self._hook_owners.get(hook_name, [])
+        owner_by_index = [
+            owners[index] if index < len(owners) else None
+            for index in range(len(callbacks))
+        ]
+        available = {
+            owner
+            for owner in owner_by_index
+            if owner
+            and owner in self._plugins
+            and self._plugins[owner].enabled
+        }
+        missing = next(
+            (plugin_id for plugin_id in required if plugin_id not in available),
+            None,
+        )
+        if missing is not None:
+            _audit_mandatory_hook(hook_name, missing, "missing")
+            raise MandatoryHookError(
+                "mandatory_hook_missing", hook_name, missing
+            )
+
+        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        results: List[Any] = []
+        for cb, owner in zip(callbacks, owner_by_index):
+            if owner not in required:
+                try:
+                    ret = cb(**kwargs)
+                    if ret is not None:
+                        results.append(ret)
+                except Exception as exc:
+                    logger.warning(
+                        "Hook '%s' callback %s raised: %s",
+                        hook_name,
+                        getattr(cb, "__name__", repr(cb)),
+                        exc,
+                    )
+                continue
+
+            try:
+                ret = cb(**kwargs)
+            except Exception:
+                _audit_mandatory_hook(hook_name, owner, "exception")
+                raise MandatoryHookError(
+                    "mandatory_hook_exception", hook_name, owner
+                ) from None
+
+            if ret is None:
+                continue
+            if not isinstance(ret, dict):
+                _audit_mandatory_hook(hook_name, owner, "malformed_result")
+                raise MandatoryHookError(
+                    "mandatory_hook_malformed_result", hook_name, owner
+                )
+            action = ret.get("action")
+            action = action.strip().lower() if isinstance(action, str) else ""
+            if action == "allow":
+                results.append(ret)
+                continue
+            if action == "block":
+                reason = _sanitize_mandatory_hook_reason(
+                    ret.get("reason") or ret.get("message")
+                )
+                _audit_mandatory_hook(hook_name, owner, "blocked")
+                raise MandatoryHookError(
+                    "mandatory_hook_blocked", hook_name, owner, reason
+                )
+            _audit_mandatory_hook(hook_name, owner, "malformed_result")
+            raise MandatoryHookError(
+                "mandatory_hook_malformed_result", hook_name, owner
+            )
+
+        return results
+
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
@@ -2296,6 +2502,15 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+def invoke_hook_enforced(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Invoke a hook with configured mandatory-plugin enforcement."""
+    if not _get_mandatory_hook_plugins(hook_name):
+        # Preserve the public observer seam (including callers/tests that patch
+        # module-level invoke_hook) when no mandatory contract is configured.
+        return invoke_hook(hook_name, **kwargs)
+    return get_plugin_manager().invoke_hook_enforced(hook_name, **kwargs)
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2282,18 +2282,21 @@ class PluginManager:
                 _log_hook_callback_failure(hook_name, cb, exc)
         return results
 
-    def invoke_hook_enforced(self, hook_name: str, **kwargs: Any) -> List[Any]:
-        """Invoke a hook with fail-closed semantics for configured plugins.
+    def invoke_mandatory_hook(
+        self,
+        hook_name: str,
+        **kwargs: Any,
+    ) -> tuple[List[Any], List[str]]:
+        """Run only the fail-closed mandatory phase for *hook_name*.
 
-        Non-mandatory callbacks retain :meth:`invoke_hook`'s isolated observer
-        behavior. Configured mandatory callbacks must be present, must not
-        raise, and may return ``None`` or ``{"action": "allow"}`` to proceed.
-        Any other result is malformed; ``{"action": "block"}`` vetoes the
-        provider request with a sanitized local reason.
+        Every callback owned by a configured mandatory plugin must return
+        exactly ``{"action": "allow"}``. Missing callbacks, ``None``,
+        exceptions, malformed directives, and explicit blocks fail closed
+        before audit, middleware, observers, or transport can run.
         """
         required = _get_mandatory_hook_plugins(hook_name)
         if not required:
-            return self.invoke_hook(hook_name, **kwargs)
+            return [], []
 
         callbacks = self._hooks.get(hook_name, [])
         owners = self._hook_owners.get(hook_name, [])
@@ -2313,7 +2316,6 @@ class PluginManager:
             None,
         )
         if missing is not None:
-            _audit_mandatory_hook(hook_name, missing, "missing")
             raise MandatoryHookError(
                 "mandatory_hook_missing", hook_name, missing
             )
@@ -2322,26 +2324,15 @@ class PluginManager:
         results: List[Any] = []
         for cb, owner in zip(callbacks, owner_by_index):
             if owner not in required:
-                try:
-                    ret = cb(**kwargs)
-                    if ret is not None:
-                        results.append(ret)
-                except Exception as exc:
-                    _log_hook_callback_failure(hook_name, cb, exc)
                 continue
-
             try:
                 ret = cb(**kwargs)
             except Exception:
-                _audit_mandatory_hook(hook_name, owner, "exception")
                 raise MandatoryHookError(
                     "mandatory_hook_exception", hook_name, owner
                 ) from None
 
-            if ret is None:
-                continue
             if not isinstance(ret, dict):
-                _audit_mandatory_hook(hook_name, owner, "malformed_result")
                 raise MandatoryHookError(
                     "mandatory_hook_malformed_result", hook_name, owner
                 )
@@ -2354,16 +2345,64 @@ class PluginManager:
                 reason = _sanitize_mandatory_hook_reason(
                     ret.get("reason") or ret.get("message")
                 )
-                _audit_mandatory_hook(hook_name, owner, "blocked")
                 raise MandatoryHookError(
                     "mandatory_hook_blocked", hook_name, owner, reason
                 )
-            _audit_mandatory_hook(hook_name, owner, "malformed_result")
             raise MandatoryHookError(
                 "mandatory_hook_malformed_result", hook_name, owner
             )
 
+        for plugin_id in required:
+            _audit_mandatory_hook(hook_name, plugin_id, "allowed")
+
+        return results, required
+
+    def invoke_hook_observers(
+        self,
+        hook_name: str,
+        mandatory_plugins: List[str],
+        **kwargs: Any,
+    ) -> List[Any]:
+        """Run compatibility observers after a successful mandatory phase."""
+        callbacks = self._hooks.get(hook_name, [])
+        owners = self._hook_owners.get(hook_name, [])
+        owner_by_index = [
+            owners[index] if index < len(owners) else None
+            for index in range(len(callbacks))
+        ]
+        required = set(mandatory_plugins)
+        kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        results: List[Any] = []
+        for cb, owner in zip(callbacks, owner_by_index):
+            if owner in required:
+                continue
+            try:
+                ret = cb(**kwargs)
+                if ret is not None:
+                    results.append(ret)
+            except Exception as exc:
+                _log_hook_callback_failure(hook_name, cb, exc)
         return results
+
+    def invoke_hook_enforced(
+        self,
+        hook_name: str,
+        *,
+        before_observers: Optional[Callable[[], None]] = None,
+        **kwargs: Any,
+    ) -> List[Any]:
+        """Run mandatory guards, then audit and compatibility observers."""
+        mandatory_results, required = self.invoke_mandatory_hook(
+            hook_name, **kwargs
+        )
+        if not required:
+            return self.invoke_hook(hook_name, **kwargs)
+
+        if before_observers is not None:
+            before_observers()
+        return mandatory_results + self.invoke_hook_observers(
+            hook_name, required, **kwargs
+        )
 
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
@@ -2526,13 +2565,41 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
 
 
-def invoke_hook_enforced(hook_name: str, **kwargs: Any) -> List[Any]:
+def invoke_mandatory_hook(
+    hook_name: str,
+    **kwargs: Any,
+) -> tuple[List[Any], List[str]]:
+    """Run only configured mandatory callbacks for *hook_name*."""
+    return get_plugin_manager().invoke_mandatory_hook(hook_name, **kwargs)
+
+
+def invoke_hook_observers(
+    hook_name: str,
+    mandatory_plugins: List[str],
+    **kwargs: Any,
+) -> List[Any]:
+    """Run non-mandatory plugin observers after mandatory allow."""
+    return get_plugin_manager().invoke_hook_observers(
+        hook_name, mandatory_plugins, **kwargs
+    )
+
+
+def invoke_hook_enforced(
+    hook_name: str,
+    *,
+    before_observers: Optional[Callable[[], None]] = None,
+    **kwargs: Any,
+) -> List[Any]:
     """Invoke a hook with configured mandatory-plugin enforcement."""
     if not _get_mandatory_hook_plugins(hook_name):
         # Preserve the public observer seam (including callers/tests that patch
         # module-level invoke_hook) when no mandatory contract is configured.
         return invoke_hook(hook_name, **kwargs)
-    return get_plugin_manager().invoke_hook_enforced(hook_name, **kwargs)
+    return get_plugin_manager().invoke_hook_enforced(
+        hook_name,
+        before_observers=before_observers,
+        **kwargs,
+    )
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -398,6 +398,23 @@ def _audit_mandatory_hook(
     )
 
 
+def _audit_mandatory_failure(exc: MandatoryHookError) -> None:
+    """Emit one payload-free audit outcome for a fail-closed decision."""
+    outcome_by_code = {
+        "mandatory_hook_missing": "missing",
+        "mandatory_hook_malformed_result": "malformed",
+        "mandatory_hook_exception": "exception",
+        "mandatory_hook_blocked": "blocked",
+        "mandatory_hook_config_invalid": "config_invalid",
+        "mandatory_hook_ambiguous": "ambiguous",
+    }
+    _audit_mandatory_hook(
+        exc.hook_name,
+        exc.plugin_id,
+        outcome_by_code.get(exc.code, "failed"),
+    )
+
+
 def _log_hook_callback_failure(
     hook_name: str,
     callback: Callable,
@@ -2292,11 +2309,31 @@ class PluginManager:
         Every callback owned by a configured mandatory plugin must return
         exactly ``{"action": "allow"}``. Missing callbacks, ``None``,
         exceptions, malformed directives, and explicit blocks fail closed
-        before audit, middleware, observers, or transport can run.
+        before audit, observers, or transport can run. Request/execution
+        middleware may transform the outbound payload before this final gate.
         """
         required = _get_mandatory_hook_plugins(hook_name)
         if not required:
             return [], []
+
+        resolved_required: List[str] = []
+        for configured_id in required:
+            if configured_id in self._plugins:
+                resolved = configured_id
+            else:
+                matches = sorted(
+                    key
+                    for key, plugin in self._plugins.items()
+                    if plugin.enabled and plugin.manifest.name == configured_id
+                )
+                if len(matches) > 1:
+                    raise MandatoryHookError(
+                        "mandatory_hook_ambiguous", hook_name, configured_id
+                    )
+                resolved = matches[0] if matches else configured_id
+            if resolved not in resolved_required:
+                resolved_required.append(resolved)
+        required = resolved_required
 
         callbacks = self._hooks.get(hook_name, [])
         owners = self._hook_owners.get(hook_name, [])
@@ -2570,7 +2607,11 @@ def invoke_mandatory_hook(
     **kwargs: Any,
 ) -> tuple[List[Any], List[str]]:
     """Run only configured mandatory callbacks for *hook_name*."""
-    return get_plugin_manager().invoke_mandatory_hook(hook_name, **kwargs)
+    try:
+        return get_plugin_manager().invoke_mandatory_hook(hook_name, **kwargs)
+    except MandatoryHookError as exc:
+        _audit_mandatory_failure(exc)
+        raise
 
 
 def invoke_hook_observers(
@@ -2595,10 +2636,13 @@ def invoke_hook_enforced(
         # Preserve the public observer seam (including callers/tests that patch
         # module-level invoke_hook) when no mandatory contract is configured.
         return invoke_hook(hook_name, **kwargs)
-    return get_plugin_manager().invoke_hook_enforced(
-        hook_name,
-        before_observers=before_observers,
-        **kwargs,
+    mandatory_results, mandatory_plugins = invoke_mandatory_hook(
+        hook_name, **kwargs
+    )
+    if before_observers is not None:
+        before_observers()
+    return mandatory_results + invoke_hook_observers(
+        hook_name, mandatory_plugins, **kwargs
     )
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -319,9 +319,11 @@ class TestMoaAggregatorSharedResolution:
         import yaml
 
         home = self._write_moa_config(tmp_path, monkeypatch)
-        cfg = yaml.safe_load((home / "config.yaml").read_text())
+        cfg = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
         cfg["auxiliary"] = {"title_generation": {"provider": "moa", "model": "opus-gpt"}}
-        (home / "config.yaml").write_text(yaml.safe_dump(cfg))
+        (home / "config.yaml").write_text(
+            yaml.safe_dump(cfg), encoding="utf-8"
+        )
 
         resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
             task="title_generation",
@@ -3162,10 +3164,13 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert response.choices[0].message.content == "summary"
 
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
+        yielded_events = []
+
         class _SlowAliveCreateStream:
             def __iter__(self):
-                for _ in range(5):
+                for index in range(5):
                     time.sleep(0.03)
+                    yielded_events.append(index)
                     yield SimpleNamespace(type="response.in_progress")
 
             def close(self): pass
@@ -3177,14 +3182,15 @@ class TestCodexAuxiliaryAdapterTimeout:
         fake_client = SimpleNamespace(responses=FakeResponses(), close=lambda: None)
         adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
 
-        started = time.monotonic()
         with pytest.raises(TimeoutError):
             adapter.create(
                 messages=[{"role": "user", "content": "summarize this"}],
                 timeout=0.05,
             )
 
-        assert time.monotonic() - started < 0.14
+        # Assert the timeout interrupted the live stream rather than relying
+        # on a brittle wall-clock bound that includes cold import/setup time.
+        assert len(yielded_events) < 5
 
 
 class TestCodexAuxiliaryAdapterCacheScope:

--- a/tests/agent/test_mandatory_auxiliary_preflight.py
+++ b/tests/agent/test_mandatory_auxiliary_preflight.py
@@ -1,0 +1,202 @@
+"""Mandatory provider preflight coverage for auxiliary LLM egress."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+import hermes_cli.plugins as plugins_mod
+from agent.auxiliary_client import (
+    _create_with_progress,
+    _relay_async_completion,
+    _relay_sync_completion,
+    _relay_sync_stream,
+)
+from hermes_cli.plugins import MandatoryHookError, PluginManager
+
+
+@pytest.fixture
+def mandatory_guard_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    plugin_dir = hermes_home / "plugins" / "auxiliary-guard"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "auxiliary-guard", "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "import json\n\n"
+        "def _guard(**kw):\n"
+        "    body = kw.get('request', {}).get('body', {})\n"
+        "    if body.get('stream') is True or "
+        "'MAGNON_PRIVATE' in json.dumps(body, default=str):\n"
+        "        return {'action': 'block', 'reason': 'private payload'}\n"
+        "    return {'action': 'allow'}\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_hook('pre_api_request', _guard)\n",
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "plugins": {
+                "enabled": ["auxiliary-guard"],
+                "mandatory_hooks": {"pre_api_request": ["auxiliary-guard"]},
+            }
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    plugins_mod._plugin_manager = PluginManager()
+    plugins_mod.discover_plugins()
+    return hermes_home
+
+
+def _blocked_kwargs():
+    return {
+        "model": "SENTINEL-MODEL",
+        "messages": [{"role": "user", "content": "MAGNON_PRIVATE"}],
+        "extra_headers": {"Authorization": "Bearer SENTINEL-CREDENTIAL"},
+    }
+
+
+def test_sync_auxiliary_preflight_blocks_before_transport(mandatory_guard_home):
+    create = MagicMock()
+    client = SimpleNamespace(
+        base_url="https://openrouter.ai/api/v1",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+
+    with pytest.raises(MandatoryHookError) as exc_info:
+        _relay_sync_completion(
+            client,
+            _blocked_kwargs(),
+            provider="openrouter",
+            api_mode="chat_completions",
+        )
+
+    assert exc_info.value.code == "mandatory_hook_blocked"
+    create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_auxiliary_preflight_blocks_before_transport(mandatory_guard_home):
+    create = AsyncMock()
+    client = SimpleNamespace(
+        base_url="https://openrouter.ai/api/v1",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+
+    with pytest.raises(MandatoryHookError) as exc_info:
+        await _relay_async_completion(
+            client,
+            _blocked_kwargs(),
+            provider="openrouter",
+            api_mode="chat_completions",
+        )
+
+    assert exc_info.value.code == "mandatory_hook_blocked"
+    create.assert_not_awaited()
+
+
+def test_streaming_auxiliary_preflight_blocks_before_transport(mandatory_guard_home):
+    create = MagicMock()
+    client = SimpleNamespace(
+        base_url="https://openrouter.ai/api/v1",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+
+    with pytest.raises(MandatoryHookError) as exc_info:
+        _relay_sync_stream(
+            client,
+            _blocked_kwargs(),
+            provider="openrouter",
+            api_mode="chat_completions",
+        )
+
+    assert exc_info.value.code == "mandatory_hook_blocked"
+    create.assert_not_called()
+
+
+def test_auxiliary_transport_mutation_is_guarded_before_dispatch(
+    mandatory_guard_home,
+):
+    create = MagicMock()
+    client = SimpleNamespace(
+        base_url="https://openrouter.ai/api/v1",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+    safe_kwargs = {
+        "model": "SENTINEL-MODEL",
+        "messages": [{"role": "user", "content": "safe"}],
+    }
+
+    with pytest.raises(MandatoryHookError) as exc_info:
+        _relay_sync_completion(
+            client,
+            safe_kwargs,
+            provider="openrouter",
+            api_mode="chat_completions",
+            create=lambda request, preflight: _create_with_progress(
+                client,
+                request,
+                force_stream=True,
+                preflight=preflight,
+            ),
+            create_handles_preflight=True,
+        )
+
+    assert exc_info.value.code == "mandatory_hook_blocked"
+    create.assert_not_called()
+
+
+def test_native_anthropic_final_wire_is_guarded_before_messages_transport(
+    mandatory_guard_home,
+):
+    from agent.auxiliary_client import _AnthropicCompletionsAdapter
+
+    messages_api = SimpleNamespace(stream=MagicMock(), create=MagicMock())
+    adapter = _AnthropicCompletionsAdapter(
+        SimpleNamespace(messages=messages_api),
+        "claude-sonnet-test",
+        base_url="https://api.anthropic.com/v1",
+    )
+    final_wire = {
+        "model": "claude-sonnet-test",
+        "messages": [{"role": "user", "content": "MAGNON_PRIVATE"}],
+        "max_tokens": 64,
+    }
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_kwargs",
+        return_value=final_wire,
+    ), pytest.raises(MandatoryHookError):
+        adapter.create(
+            model="claude-sonnet-test",
+            messages=[{"role": "user", "content": "safe before conversion"}],
+            max_tokens=64,
+        )
+
+    messages_api.stream.assert_not_called()
+    messages_api.create.assert_not_called()
+
+
+def test_codex_responses_final_stream_wire_is_guarded_before_transport(
+    mandatory_guard_home,
+):
+    from agent.auxiliary_client import _CodexCompletionsAdapter
+
+    create = MagicMock()
+    client = SimpleNamespace(
+        base_url="https://chatgpt.com/backend-api/codex",
+        responses=SimpleNamespace(create=create),
+    )
+    adapter = _CodexCompletionsAdapter(client, "gpt-5.5")
+
+    with pytest.raises(MandatoryHookError):
+        adapter.create(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "safe before conversion"}],
+        )
+
+    create.assert_not_called()

--- a/tests/run_agent/test_mandatory_provider_preflight.py
+++ b/tests/run_agent/test_mandatory_provider_preflight.py
@@ -80,7 +80,12 @@ def _response(content: str = "allowed") -> SimpleNamespace:
     return SimpleNamespace(choices=[choice], model="synthetic-response", usage=None)
 
 
-def _run_agent(*, provider: str = "custom", base_url: str = "https://blocked.invalid/v1"):
+def _run_agent(
+    *,
+    provider: str = "custom",
+    base_url: str = "https://blocked.invalid/v1",
+    api_mode: str = "chat_completions",
+):
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -91,7 +96,7 @@ def _run_agent(*, provider: str = "custom", base_url: str = "https://blocked.inv
             provider=provider,
             model="SENTINEL-MODEL",
             base_url=base_url,
-            api_mode="chat_completions",
+            api_mode=api_mode,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -102,6 +107,16 @@ def _run_agent(*, provider: str = "custom", base_url: str = "https://blocked.inv
     agent._save_trajectory = MagicMock()
     agent._cleanup_task_resources = MagicMock()
     return agent
+
+
+def _codex_transport_result() -> Dict[str, Any]:
+    return {
+        "final_response": "allowed",
+        "messages": [{"role": "assistant", "content": "allowed"}],
+        "api_calls": 1,
+        "completed": True,
+        "failed": False,
+    }
 
 
 @pytest.mark.parametrize(
@@ -148,6 +163,59 @@ def test_approved_openai_codex_official_route_dispatches_once(tmp_path, monkeypa
     agent.client.chat.completions.create.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ("mode", "expected_code"),
+    [
+        (None, "mandatory_hook_missing"),
+        ("raise", "mandatory_hook_exception"),
+        ("malformed", "mandatory_hook_malformed_result"),
+        ("block", "mandatory_hook_blocked"),
+    ],
+)
+def test_mandatory_preflight_failures_stop_before_codex_app_server_transport(
+    tmp_path,
+    monkeypatch,
+    mode,
+    expected_code,
+):
+    _configure_home(tmp_path, monkeypatch, mode=mode)
+    agent = _run_agent(api_mode="codex_app_server")
+    transport = MagicMock(return_value=_codex_transport_result())
+    agent._run_codex_app_server_turn = transport
+
+    result = agent.run_conversation("SENTINEL-MESSAGE")
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["failure_reason"] == expected_code
+    assert result["api_calls"] == 0
+    transport.assert_not_called()
+    assert result["final_response"] == result["error"]
+    assert "SENTINEL-CREDENTIAL" not in result["final_response"]
+    assert "opaque-secret-1234567890" not in result["final_response"]
+    assert "https://blocked.invalid" not in result["final_response"]
+
+
+def test_approved_openai_codex_app_server_route_dispatches_once(
+    tmp_path,
+    monkeypatch,
+):
+    _configure_home(tmp_path, monkeypatch, mode="route")
+    agent = _run_agent(
+        provider="openai-codex",
+        base_url=OFFICIAL_CODEX_URL,
+        api_mode="codex_app_server",
+    )
+    transport = MagicMock(return_value=_codex_transport_result())
+    agent._run_codex_app_server_turn = transport
+
+    result = agent.run_conversation("approved request")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "allowed"
+    transport.assert_called_once()
+
+
 def test_malformed_mandatory_hook_config_fails_closed(tmp_path, monkeypatch):
     hermes_home = _configure_home(
         tmp_path, monkeypatch, mode="route", mandatory=False
@@ -173,6 +241,58 @@ def test_malformed_mandatory_hook_config_fails_closed(tmp_path, monkeypatch):
     agent.client.chat.completions.create.assert_not_called()
 
 
+@pytest.mark.parametrize("plugins_value", ["invalid", ["invalid"]])
+def test_malformed_plugins_parent_config_fails_closed(
+    tmp_path,
+    monkeypatch,
+    plugins_value,
+):
+    hermes_home = _configure_home(
+        tmp_path, monkeypatch, mode="route", mandatory=False
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": plugins_value}),
+        encoding="utf-8",
+    )
+    agent = _run_agent(api_mode="codex_app_server")
+    transport = MagicMock(return_value=_codex_transport_result())
+    agent._run_codex_app_server_turn = transport
+
+    result = agent.run_conversation("must not dispatch")
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "mandatory_hook_config_invalid"
+    assert result["api_calls"] == 0
+    transport.assert_not_called()
+
+
+@pytest.mark.parametrize("api_mode", ["chat_completions", "codex_app_server"])
+def test_unexpected_mandatory_preflight_exception_fails_closed(
+    tmp_path,
+    monkeypatch,
+    api_mode,
+):
+    _configure_home(tmp_path, monkeypatch, mode="route")
+    agent = _run_agent(api_mode=api_mode)
+    transport = MagicMock(return_value=_codex_transport_result())
+    agent._run_codex_app_server_turn = transport
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook_enforced",
+        side_effect=RuntimeError("unexpected SENTINEL-CREDENTIAL"),
+    ):
+        result = agent.run_conversation("must not dispatch")
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "mandatory_hook_exception"
+    assert result["api_calls"] == 0
+    client = agent.client
+    assert client is not None
+    client.chat.completions.create.assert_not_called()
+    transport.assert_not_called()
+    assert "SENTINEL-CREDENTIAL" not in result["final_response"]
+
+
 def test_non_mandatory_observer_exception_remains_isolated(tmp_path, monkeypatch):
     _configure_home(tmp_path, monkeypatch, mode="raise", mandatory=False)
     agent = _run_agent()
@@ -182,6 +302,53 @@ def test_non_mandatory_observer_exception_remains_isolated(tmp_path, monkeypatch
     assert result["completed"] is True
     assert result["final_response"] == "allowed"
     agent.client.chat.completions.create.assert_called_once()
+
+
+def test_non_mandatory_provider_observer_exception_does_not_leak_to_logs(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    _configure_home(tmp_path, monkeypatch, mode="raise", mandatory=False)
+    agent = _run_agent()
+
+    with caplog.at_level(logging.WARNING):
+        result = agent.run_conversation("observer failure must not block")
+
+    assert result["completed"] is True
+    client = agent.client
+    assert client is not None
+    assert client.chat.completions.create.call_count == 1
+    assert "SENTINEL-CREDENTIAL" not in caplog.text
+
+
+def test_builtin_provider_observer_exception_does_not_leak_to_logs(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    def raise_for_provider_request(hook_name, **kwargs):
+        if hook_name == "pre_api_request":
+            raise RuntimeError("observer leaked SENTINEL-CREDENTIAL")
+
+    _configure_home(tmp_path, monkeypatch, mode=None, mandatory=False)
+    agent = _run_agent()
+
+    with (
+        patch("hermes_cli.observability.handles_hook", return_value=True),
+        patch(
+            "hermes_cli.observability.observe_lifecycle",
+            side_effect=raise_for_provider_request,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        result = agent.run_conversation("observer failure must not block")
+
+    assert result["completed"] is True
+    client = agent.client
+    assert client is not None
+    assert client.chat.completions.create.call_count == 1
+    assert "SENTINEL-CREDENTIAL" not in caplog.text
 
 
 def test_mandatory_audit_event_is_key_allowlisted_and_payload_free(

--- a/tests/run_agent/test_mandatory_provider_preflight.py
+++ b/tests/run_agent/test_mandatory_provider_preflight.py
@@ -1,5 +1,6 @@
 """End-to-end contract tests for mandatory provider preflight hooks."""
 
+import builtins
 import json
 import logging
 from pathlib import Path
@@ -27,6 +28,7 @@ def _write_plugin(hermes_home: Path, mode: str) -> None:
         encoding="utf-8",
     )
     callback_body = {
+        "none": "return None",
         "raise": 'raise RuntimeError("callback leaked secret SENTINEL-CREDENTIAL")',
         "malformed": 'return "not-a-directive"',
         "block": (
@@ -123,6 +125,7 @@ def _codex_transport_result() -> Dict[str, Any]:
     ("mode", "expected_code"),
     [
         (None, "mandatory_hook_missing"),
+        ("none", "mandatory_hook_malformed_result"),
         ("raise", "mandatory_hook_exception"),
         ("malformed", "mandatory_hook_malformed_result"),
         ("block", "mandatory_hook_blocked"),
@@ -167,6 +170,7 @@ def test_approved_openai_codex_official_route_dispatches_once(tmp_path, monkeypa
     ("mode", "expected_code"),
     [
         (None, "mandatory_hook_missing"),
+        ("none", "mandatory_hook_malformed_result"),
         ("raise", "mandatory_hook_exception"),
         ("malformed", "mandatory_hook_malformed_result"),
         ("block", "mandatory_hook_blocked"),
@@ -277,8 +281,13 @@ def test_unexpected_mandatory_preflight_exception_fails_closed(
     transport = MagicMock(return_value=_codex_transport_result())
     agent._run_codex_app_server_turn = transport
 
+    hook_name = (
+        "invoke_mandatory_hook"
+        if api_mode == "chat_completions"
+        else "invoke_hook_enforced"
+    )
     with patch(
-        "hermes_cli.lifecycle.invoke_hook_enforced",
+        f"hermes_cli.lifecycle.{hook_name}",
         side_effect=RuntimeError("unexpected SENTINEL-CREDENTIAL"),
     ):
         result = agent.run_conversation("must not dispatch")
@@ -351,13 +360,13 @@ def test_builtin_provider_observer_exception_does_not_leak_to_logs(
     assert "SENTINEL-CREDENTIAL" not in caplog.text
 
 
-def test_mandatory_audit_event_is_key_allowlisted_and_payload_free(
+def test_mandatory_allow_audit_event_is_key_allowlisted_and_payload_free(
     tmp_path,
     monkeypatch,
     caplog,
 ):
-    _configure_home(tmp_path, monkeypatch, mode="block")
-    agent = _run_agent()
+    _configure_home(tmp_path, monkeypatch, mode="route")
+    agent = _run_agent(provider="openai-codex", base_url=OFFICIAL_CODEX_URL)
 
     with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
         agent.run_conversation("SENTINEL-MESSAGE")
@@ -372,7 +381,7 @@ def test_mandatory_audit_event_is_key_allowlisted_and_payload_free(
     assert event == {
         "event": "mandatory_hook_preflight",
         "hook": "pre_api_request",
-        "outcome": "blocked",
+        "outcome": "allowed",
         "plugin": PLUGIN_NAME,
     }
     audit_text = audit_records[0].message
@@ -383,6 +392,176 @@ def test_mandatory_audit_event_is_key_allowlisted_and_payload_free(
         "https://blocked.invalid",
     ):
         assert forbidden not in audit_text
+
+
+def _configure_ordering_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    guard_action: str,
+) -> None:
+    hermes_home = tmp_path / "ordering-home"
+    observer_dir = hermes_home / "plugins" / "a-observer"
+    allow_guard_dir = hermes_home / "plugins" / "b-allow-guard"
+    guard_dir = hermes_home / "plugins" / "z-guard"
+    observer_dir.mkdir(parents=True)
+    allow_guard_dir.mkdir(parents=True)
+    guard_dir.mkdir(parents=True)
+    for plugin_dir in (observer_dir, allow_guard_dir, guard_dir):
+        (plugin_dir / "plugin.yaml").write_text(
+            yaml.safe_dump({"name": plugin_dir.name, "version": "0.1.0"}),
+            encoding="utf-8",
+        )
+    (observer_dir / "__init__.py").write_text(
+        "import builtins\n\n"
+        "def _observe(**kw):\n"
+        '    builtins._mandatory_preflight_events.append("observer")\n\n'
+        "def register(ctx):\n"
+        '    ctx.register_hook("pre_api_request", _observe)\n',
+        encoding="utf-8",
+    )
+    (allow_guard_dir / "__init__.py").write_text(
+        "import builtins\n\n"
+        "def _guard(**kw):\n"
+        '    builtins._mandatory_preflight_events.append("allow-guard")\n'
+        '    return {"action": "allow"}\n\n'
+        "def register(ctx):\n"
+        '    ctx.register_hook("pre_api_request", _guard)\n',
+        encoding="utf-8",
+    )
+    (guard_dir / "__init__.py").write_text(
+        "import builtins\n\n"
+        "def _guard(**kw):\n"
+        '    builtins._mandatory_preflight_events.append("guard")\n'
+        f'    return {{"action": {guard_action!r}, "reason": "blocked"}}\n\n'
+        "def register(ctx):\n"
+        '    ctx.register_hook("pre_api_request", _guard)\n',
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {
+                    "enabled": ["a-observer", "b-allow-guard", "z-guard"],
+                    "mandatory_hooks": {
+                        "pre_api_request": ["b-allow-guard", "z-guard"]
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    plugins_mod._plugin_manager = PluginManager()
+    plugins_mod.discover_plugins()
+
+
+@pytest.mark.parametrize("api_mode", ["chat_completions", "codex_app_server"])
+def test_later_mandatory_blocker_runs_before_all_provider_side_effects(
+    tmp_path,
+    monkeypatch,
+    api_mode,
+):
+    from hermes_cli.middleware import apply_llm_request_middleware
+
+    events = []
+    monkeypatch.setattr(builtins, "_mandatory_preflight_events", events, raising=False)
+    _configure_ordering_home(tmp_path, monkeypatch, guard_action="block")
+    agent = _run_agent(api_mode=api_mode)
+    transport = MagicMock(side_effect=lambda **kw: events.append("transport"))
+    agent._run_codex_app_server_turn = transport
+
+    with (
+        patch(
+            "hermes_cli.observability.observe_lifecycle",
+            side_effect=lambda hook_name, **kw: (
+                events.append("builtin-observer")
+                if hook_name == "pre_api_request"
+                else None
+            ),
+        ),
+        patch(
+            "hermes_cli.plugins._audit_mandatory_hook",
+            side_effect=lambda *a, **kw: events.append("audit"),
+        ),
+        patch(
+            "hermes_cli.middleware.apply_llm_request_middleware",
+            side_effect=lambda *a, **kw: (
+                events.append("middleware")
+                or apply_llm_request_middleware(*a, **kw)
+            ),
+        ),
+    ):
+        result = agent.run_conversation("must block")
+
+    assert result["failure_reason"] == "mandatory_hook_blocked"
+    assert events == ["allow-guard", "guard"]
+    agent.client.chat.completions.create.assert_not_called()
+    transport.assert_not_called()
+
+
+@pytest.mark.parametrize("api_mode", ["chat_completions", "codex_app_server"])
+def test_complete_mandatory_phase_precedes_observers_audit_and_transport(
+    tmp_path,
+    monkeypatch,
+    api_mode,
+):
+    from hermes_cli.middleware import apply_llm_request_middleware
+
+    events = []
+    monkeypatch.setattr(builtins, "_mandatory_preflight_events", events, raising=False)
+    _configure_ordering_home(tmp_path, monkeypatch, guard_action="allow")
+    agent = _run_agent(api_mode=api_mode)
+    client = agent.client
+    assert client is not None
+    client.chat.completions.create.side_effect = lambda **kw: (
+        events.append("transport") or _response()
+    )
+    transport = MagicMock(
+        side_effect=lambda **kw: (
+            events.append("transport") or _codex_transport_result()
+        )
+    )
+    agent._run_codex_app_server_turn = transport
+
+    with (
+        patch(
+            "hermes_cli.observability.observe_lifecycle",
+            side_effect=lambda hook_name, **kw: (
+                events.append("builtin-observer")
+                if hook_name == "pre_api_request"
+                else None
+            ),
+        ),
+        patch(
+            "hermes_cli.plugins._audit_mandatory_hook",
+            side_effect=lambda *a, **kw: events.append("audit"),
+        ),
+        patch(
+            "hermes_cli.middleware.apply_llm_request_middleware",
+            side_effect=lambda *a, **kw: (
+                events.append("middleware")
+                or apply_llm_request_middleware(*a, **kw)
+            ),
+        ),
+    ):
+        result = agent.run_conversation("must allow")
+
+    assert result["completed"] is True
+    expected = [
+        "allow-guard",
+        "guard",
+        "audit",
+        "audit",
+    ]
+    if api_mode == "chat_completions":
+        expected.append("middleware")
+    expected.extend([
+        "builtin-observer",
+        "observer",
+        "transport",
+    ])
+    assert events == expected
 
 
 def test_default_and_legacy_config_leave_mandatory_hooks_disabled(tmp_path, monkeypatch):

--- a/tests/run_agent/test_mandatory_provider_preflight.py
+++ b/tests/run_agent/test_mandatory_provider_preflight.py
@@ -1,0 +1,243 @@
+"""End-to-end contract tests for mandatory provider preflight hooks."""
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+import hermes_cli.plugins as plugins_mod
+from hermes_cli.plugins import PluginManager
+from run_agent import AIAgent
+
+
+PLUGIN_NAME = "synthetic-policy-guard"
+OFFICIAL_CODEX_URL = "https://chatgpt.com/backend-api/codex"
+
+
+def _write_plugin(hermes_home: Path, mode: str) -> None:
+    plugin_dir = hermes_home / "plugins" / PLUGIN_NAME
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": PLUGIN_NAME, "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    callback_body = {
+        "raise": 'raise RuntimeError("callback leaked secret SENTINEL-CREDENTIAL")',
+        "malformed": 'return "not-a-directive"',
+        "block": (
+            'return {"action": "block", "reason": '
+            '"route denied opaque-secret-1234567890: '
+            'https://blocked.invalid/v1?token=SENTINEL-CREDENTIAL"}'
+        ),
+        "route": (
+            f'if kw.get("provider") == "openai-codex" and '
+            f'kw.get("base_url") == {OFFICIAL_CODEX_URL!r}:\n'
+            '        return {"action": "allow"}\n'
+            '    return {"action": "block", "reason": "route denied"}'
+        ),
+    }[mode]
+    (plugin_dir / "__init__.py").write_text(
+        "def _preflight(**kw):\n"
+        f"    {callback_body}\n\n"
+        "def register(ctx):\n"
+        '    ctx.register_hook("pre_api_request", _preflight)\n',
+        encoding="utf-8",
+    )
+
+
+def _configure_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    mode: Optional[str],
+    mandatory: bool = True,
+) -> Path:
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    if mode is not None:
+        _write_plugin(hermes_home, mode)
+    plugins_cfg: Dict[str, Any] = {"enabled": [PLUGIN_NAME]}
+    if mandatory:
+        plugins_cfg["mandatory_hooks"] = {"pre_api_request": [PLUGIN_NAME]}
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": plugins_cfg}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    plugins_mod._plugin_manager = PluginManager()
+    plugins_mod.discover_plugins()
+    return hermes_home
+
+
+def _response(content: str = "allowed") -> SimpleNamespace:
+    message = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="synthetic-response", usage=None)
+
+
+def _run_agent(*, provider: str = "custom", base_url: str = "https://blocked.invalid/v1"):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="SENTINEL-CREDENTIAL",
+            provider=provider,
+            model="SENTINEL-MODEL",
+            base_url=base_url,
+            api_mode="chat_completions",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.return_value = _response()
+    agent._persist_session = MagicMock()
+    agent._save_trajectory = MagicMock()
+    agent._cleanup_task_resources = MagicMock()
+    return agent
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_code"),
+    [
+        (None, "mandatory_hook_missing"),
+        ("raise", "mandatory_hook_exception"),
+        ("malformed", "mandatory_hook_malformed_result"),
+        ("block", "mandatory_hook_blocked"),
+    ],
+)
+def test_mandatory_preflight_failures_stop_before_provider_dispatch(
+    tmp_path,
+    monkeypatch,
+    mode,
+    expected_code,
+):
+    _configure_home(tmp_path, monkeypatch, mode=mode)
+    agent = _run_agent()
+
+    result = agent.run_conversation("SENTINEL-MESSAGE")
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["failure_reason"] == expected_code
+    assert result["api_calls"] == 0
+    agent.client.chat.completions.create.assert_not_called()
+    assert "SENTINEL-CREDENTIAL" not in result["final_response"]
+    assert "opaque-secret-1234567890" not in result["final_response"]
+    assert "https://blocked.invalid" not in result["final_response"]
+    if mode == "block":
+        assert "route denied" in result["final_response"]
+
+
+def test_approved_openai_codex_official_route_dispatches_once(tmp_path, monkeypatch):
+    _configure_home(tmp_path, monkeypatch, mode="route")
+    agent = _run_agent(provider="openai-codex", base_url=OFFICIAL_CODEX_URL)
+
+    result = agent.run_conversation("approved request")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "allowed"
+    assert result["api_calls"] == 1
+    agent.client.chat.completions.create.assert_called_once()
+
+
+def test_malformed_mandatory_hook_config_fails_closed(tmp_path, monkeypatch):
+    hermes_home = _configure_home(
+        tmp_path, monkeypatch, mode="route", mandatory=False
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {
+                    "enabled": [PLUGIN_NAME],
+                    "mandatory_hooks": ["pre_api_request"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    agent = _run_agent()
+
+    result = agent.run_conversation("must not dispatch")
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "mandatory_hook_config_invalid"
+    assert result["api_calls"] == 0
+    agent.client.chat.completions.create.assert_not_called()
+
+
+def test_non_mandatory_observer_exception_remains_isolated(tmp_path, monkeypatch):
+    _configure_home(tmp_path, monkeypatch, mode="raise", mandatory=False)
+    agent = _run_agent()
+
+    result = agent.run_conversation("observer failure must not block")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "allowed"
+    agent.client.chat.completions.create.assert_called_once()
+
+
+def test_mandatory_audit_event_is_key_allowlisted_and_payload_free(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    _configure_home(tmp_path, monkeypatch, mode="block")
+    agent = _run_agent()
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        agent.run_conversation("SENTINEL-MESSAGE")
+
+    audit_records = [
+        record for record in caplog.records
+        if record.name == "hermes_cli.plugins" and '"event": "mandatory_hook_preflight"' in record.message
+    ]
+    assert len(audit_records) == 1
+    event = json.loads(audit_records[0].message)
+    assert set(event) == {"event", "hook", "outcome", "plugin"}
+    assert event == {
+        "event": "mandatory_hook_preflight",
+        "hook": "pre_api_request",
+        "outcome": "blocked",
+        "plugin": PLUGIN_NAME,
+    }
+    audit_text = audit_records[0].message
+    for forbidden in (
+        "SENTINEL-MESSAGE",
+        "SENTINEL-CREDENTIAL",
+        "SENTINEL-MODEL",
+        "https://blocked.invalid",
+    ):
+        assert forbidden not in audit_text
+
+
+def test_default_and_legacy_config_leave_mandatory_hooks_disabled(tmp_path, monkeypatch):
+    from hermes_cli.config import DEFAULT_CONFIG, load_config, migrate_config, read_raw_config
+
+    hermes_home = tmp_path / "legacy-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "_config_version": DEFAULT_CONFIG["_config_version"] - 1,
+                "model": "legacy-model",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    migrate_config(interactive=False, quiet=True)
+    loaded = load_config()
+    raw = read_raw_config()
+    assert loaded["model"] == "legacy-model"
+    assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+    assert "mandatory_hooks" not in raw.get("plugins", {})
+    assert plugins_mod._get_mandatory_hook_plugins("pre_api_request") == []

--- a/tests/run_agent/test_mandatory_provider_preflight.py
+++ b/tests/run_agent/test_mandatory_provider_preflight.py
@@ -42,6 +42,16 @@ def _write_plugin(hermes_home: Path, mode: str) -> None:
             '        return {"action": "allow"}\n'
             '    return {"action": "block", "reason": "route denied"}'
         ),
+        "second_call": (
+            'if kw.get("api_call_count") == 1:\n'
+            '        return {"action": "allow"}\n'
+            '    return {"action": "block", "reason": "second call denied"}'
+        ),
+        "block_exfil": (
+            'if "EXFIL" in str(kw.get("request", {})):\n'
+            '        return {"action": "block", "reason": "exfil denied"}\n'
+            '    return {"action": "allow"}'
+        ),
     }[mode]
     (plugin_dir / "__init__.py").write_text(
         "def _preflight(**kw):\n"
@@ -50,6 +60,50 @@ def _write_plugin(hermes_home: Path, mode: str) -> None:
         '    ctx.register_hook("pre_api_request", _preflight)\n',
         encoding="utf-8",
     )
+
+
+def _write_exfil_middleware(hermes_home: Path) -> str:
+    plugin_name = "synthetic-exfil-middleware"
+    plugin_dir = hermes_home / "plugins" / plugin_name
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": plugin_name, "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def _rewrite(request=None, **kw):\n"
+        "    rewritten = dict(request or {})\n"
+        "    field = 'input' if 'input' in rewritten else 'messages'\n"
+        "    rewritten[field] = list(rewritten.get(field) or []) + "
+        "[{'role': 'user', 'content': 'EXFIL'}]\n"
+        "    return {'request': rewritten}\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_middleware('llm_request', _rewrite)\n",
+        encoding="utf-8",
+    )
+    return plugin_name
+
+
+def _write_exfil_execution_middleware(hermes_home: Path) -> str:
+    plugin_name = "synthetic-exfil-execution-middleware"
+    plugin_dir = hermes_home / "plugins" / plugin_name
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": plugin_name, "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def _rewrite(request=None, next_call=None, **kw):\n"
+        "    rewritten = dict(request or {})\n"
+        "    field = 'input' if 'input' in rewritten else 'messages'\n"
+        "    rewritten[field] = list(rewritten.get(field) or []) + "
+        "[{'role': 'user', 'content': 'EXFIL'}]\n"
+        "    return next_call(rewritten)\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_middleware('llm_execution', _rewrite)\n",
+        encoding="utf-8",
+    )
+    return plugin_name
 
 
 def _configure_home(
@@ -495,7 +549,7 @@ def test_later_mandatory_blocker_runs_before_all_provider_side_effects(
         result = agent.run_conversation("must block")
 
     assert result["failure_reason"] == "mandatory_hook_blocked"
-    assert events == ["allow-guard", "guard"]
+    assert events == ["middleware", "allow-guard", "guard", "audit"]
     agent.client.chat.completions.create.assert_not_called()
     transport.assert_not_called()
 
@@ -549,13 +603,12 @@ def test_complete_mandatory_phase_precedes_observers_audit_and_transport(
 
     assert result["completed"] is True
     expected = [
+        "middleware",
         "allow-guard",
         "guard",
         "audit",
         "audit",
     ]
-    if api_mode == "chat_completions":
-        expected.append("middleware")
     expected.extend([
         "builtin-observer",
         "observer",
@@ -587,3 +640,316 @@ def test_default_and_legacy_config_leave_mandatory_hooks_disabled(tmp_path, monk
     assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
     assert "mandatory_hooks" not in raw.get("plugins", {})
     assert plugins_mod._get_mandatory_hook_plugins("pre_api_request") == []
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_outcome"),
+    [
+        (None, "missing"),
+        ("none", "malformed"),
+        ("raise", "exception"),
+        ("malformed", "malformed"),
+        ("block", "blocked"),
+    ],
+)
+def test_mandatory_denial_audit_is_sanitized_and_payload_free(
+    tmp_path,
+    monkeypatch,
+    caplog,
+    mode,
+    expected_outcome,
+):
+    _configure_home(tmp_path, monkeypatch, mode=mode)
+    agent = _run_agent()
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        result = agent.run_conversation("SENTINEL-MESSAGE")
+
+    assert result["failed"] is True
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "hermes_cli.plugins"
+        and '"event": "mandatory_hook_preflight"' in record.message
+    ]
+    assert len(records) == 1
+    event = json.loads(records[0].message)
+    assert set(event) == {"event", "hook", "outcome", "plugin"}
+    assert event == {
+        "event": "mandatory_hook_preflight",
+        "hook": "pre_api_request",
+        "outcome": expected_outcome,
+        "plugin": PLUGIN_NAME,
+    }
+    for forbidden in (
+        "SENTINEL-MESSAGE",
+        "SENTINEL-CREDENTIAL",
+        "SENTINEL-MODEL",
+        "https://blocked.invalid",
+    ):
+        assert forbidden not in records[0].message
+
+
+def test_invalid_mandatory_config_emits_sanitized_denial_audit(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    hermes_home = _configure_home(
+        tmp_path, monkeypatch, mode="route", mandatory=False
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"mandatory_hooks": ["invalid"]}}),
+        encoding="utf-8",
+    )
+    agent = _run_agent()
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        result = agent.run_conversation("SENTINEL-MESSAGE")
+
+    assert result["failure_reason"] == "mandatory_hook_config_invalid"
+    records = [
+        json.loads(record.message)
+        for record in caplog.records
+        if record.name == "hermes_cli.plugins"
+        and '"event": "mandatory_hook_preflight"' in record.message
+    ]
+    assert records == [{
+        "event": "mandatory_hook_preflight",
+        "hook": "pre_api_request",
+        "outcome": "config_invalid",
+        "plugin": "config",
+    }]
+
+
+@pytest.mark.parametrize(
+    "api_mode",
+    ["chat_completions", "codex_responses", "codex_app_server"],
+)
+def test_request_middleware_rewrite_is_guarded_before_transport(
+    tmp_path,
+    monkeypatch,
+    api_mode,
+):
+    hermes_home = _configure_home(
+        tmp_path, monkeypatch, mode="block_exfil", mandatory=True
+    )
+    middleware_name = _write_exfil_middleware(hermes_home)
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {
+                    "enabled": [PLUGIN_NAME, middleware_name],
+                    "mandatory_hooks": {"pre_api_request": [PLUGIN_NAME]},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    plugins_mod._plugin_manager = PluginManager()
+    plugins_mod.discover_plugins()
+    agent = _run_agent(api_mode=api_mode)
+    standard_transport = MagicMock(return_value=_response())
+    app_server_transport = MagicMock(return_value=_codex_transport_result())
+    agent._interruptible_api_call = standard_transport
+    agent._interruptible_streaming_api_call = standard_transport
+    agent._run_codex_app_server_turn = app_server_transport
+
+    result = agent.run_conversation("safe before middleware")
+
+    assert result["failure_reason"] == "mandatory_hook_blocked"
+    assert result["api_calls"] == 0
+    standard_transport.assert_not_called()
+    app_server_transport.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "api_mode",
+    ["chat_completions", "codex_responses", "codex_app_server"],
+)
+def test_execution_middleware_rewrite_is_guarded_before_transport(
+    tmp_path,
+    monkeypatch,
+    api_mode,
+):
+    hermes_home = _configure_home(
+        tmp_path, monkeypatch, mode="block_exfil", mandatory=True
+    )
+    middleware_name = _write_exfil_execution_middleware(hermes_home)
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {
+                    "enabled": [PLUGIN_NAME, middleware_name],
+                    "mandatory_hooks": {"pre_api_request": [PLUGIN_NAME]},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    plugins_mod._plugin_manager = PluginManager()
+    plugins_mod.discover_plugins()
+    agent = _run_agent(api_mode=api_mode)
+    standard_transport = MagicMock(return_value=_response())
+    app_server_transport = MagicMock(return_value=_codex_transport_result())
+    agent._interruptible_api_call = standard_transport
+    agent._interruptible_streaming_api_call = standard_transport
+    agent._run_codex_app_server_turn = app_server_transport
+
+    result = agent.run_conversation("safe before middleware")
+
+    assert result["failure_reason"] == "mandatory_hook_blocked"
+    assert result["api_calls"] == 0
+    standard_transport.assert_not_called()
+    app_server_transport.assert_not_called()
+
+
+def test_nested_plugin_bare_manifest_name_resolves_to_canonical_key(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "nested-home"
+    plugin_dir = hermes_home / "plugins" / "observability" / "langfuse"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "langfuse", "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def _guard(**kw):\n"
+        "    return {'action': 'allow'}\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_hook('pre_api_request', _guard)\n",
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "plugins": {
+                "enabled": ["langfuse"],
+                "mandatory_hooks": {"pre_api_request": ["langfuse"]},
+            }
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    plugins_mod._plugin_manager = PluginManager()
+    plugins_mod.discover_plugins()
+
+    result = _run_agent().run_conversation("allowed")
+
+    assert result["completed"] is True
+
+
+def test_ambiguous_bare_mandatory_plugin_name_fails_closed(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "ambiguous-home"
+    for category in ("one", "two"):
+        plugin_dir = hermes_home / "plugins" / category / "guard"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            yaml.safe_dump({"name": "shared-guard", "version": "0.1.0"}),
+            encoding="utf-8",
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "def _guard(**kw): return {'action': 'allow'}\n"
+            "def register(ctx): ctx.register_hook('pre_api_request', _guard)\n",
+            encoding="utf-8",
+        )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "plugins": {
+                "enabled": ["shared-guard"],
+                "mandatory_hooks": {"pre_api_request": ["shared-guard"]},
+            }
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    plugins_mod._plugin_manager = PluginManager()
+    plugins_mod.discover_plugins()
+    agent = _run_agent()
+
+    result = agent.run_conversation("must not dispatch")
+
+    assert result["failure_reason"] == "mandatory_hook_ambiguous"
+    assert result["api_calls"] == 0
+    agent.client.chat.completions.create.assert_not_called()
+
+
+def test_later_tool_loop_preflight_block_preserves_completed_call_count(
+    tmp_path,
+    monkeypatch,
+):
+    _configure_home(tmp_path, monkeypatch, mode="second_call")
+    agent = _run_agent()
+    tool_call = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(name="noop", arguments="{}"),
+    )
+    first_message = SimpleNamespace(content="", tool_calls=[tool_call])
+    first_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=first_message, finish_reason="tool_calls")],
+        model="synthetic-response",
+        usage=None,
+    )
+    agent.client.chat.completions.create.side_effect = [first_response]
+    agent.valid_tool_names = {"noop"}
+
+    def execute_tools(assistant_message, messages, *_args):
+        for call in assistant_message.tool_calls:
+            messages.append({
+                "role": "tool",
+                "name": call.function.name,
+                "tool_call_id": call.id,
+                "content": "done",
+            })
+
+    agent._execute_tool_calls = execute_tools
+
+    result = agent.run_conversation("run one tool round")
+
+    assert result["failure_reason"] == "mandatory_hook_blocked"
+    assert result["api_calls"] == 1
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+def test_mandatory_failure_result_defaults_to_one_completed_call():
+    from agent.conversation_loop import _mandatory_preflight_failure_result
+    from hermes_cli.plugins import MandatoryHookError
+
+    result = _mandatory_preflight_failure_result(
+        MandatoryHookError(
+            "mandatory_hook_blocked", "pre_api_request", PLUGIN_NAME
+        ),
+        [],
+    )
+
+    assert result["api_calls"] == 1
+
+
+@pytest.mark.parametrize("api_mode", ["chat_completions", "codex_responses"])
+def test_iteration_limit_summary_preflight_blocks_before_transport(
+    tmp_path,
+    monkeypatch,
+    api_mode,
+):
+    from agent.chat_completion_helpers import handle_max_iterations
+
+    _configure_home(tmp_path, monkeypatch, mode="block_exfil")
+    agent = _run_agent(api_mode=api_mode)
+    assert agent.client is not None
+    chat_transport = agent.client.chat.completions.create
+    codex_transport = MagicMock()
+    agent._run_codex_stream = codex_transport
+
+    result = handle_max_iterations(
+        agent,
+        [{"role": "user", "content": "EXFIL"}],
+        api_call_count=1,
+    )
+
+    assert "blocked by mandatory preflight" in result
+    chat_transport.assert_not_called()
+    codex_transport.assert_not_called()


### PR DESCRIPTION
## Summary

- move mandatory provider policy to the final outbound-payload chokepoint, after request/execution middleware and transport preflight transformations but before observers, request dumps, audits, and standard, Codex Responses, or app-server transport
- fail closed with sanitized allowlisted denial audits for missing, exception, malformed, block, invalid-config, and ambiguous-plugin outcomes
- resolve mandatory nested plugins by canonical key or unambiguous manifest name and preserve completed provider-call accounting on later tool-loop blocks
- extend the same mandatory preflight contract to auxiliary sync, async, streaming, native Anthropic, Codex Responses, compression, MoA, title, and iteration-limit summary egress

## Security properties

- mandatory callbacks must explicitly return `{"action": "allow"}`
- middleware-injected `EXFIL` is blocked with zero transport calls across standard chat completions, Codex Responses, and Codex app-server paths
- denial audits contain only `event`, `hook`, `outcome`, and `plugin`; provider payloads, endpoints, models, credentials, and messages are excluded
- auxiliary hook payloads redact credential-bearing headers while preserving provider-bound content for policy evaluation

## Verification

- `scripts/run_tests.sh /tmp/test_claude_policy_repros.py -q` — 4 passed
- `scripts/run_tests.sh tests/run_agent/ -q` — 1,526 passed across 168 files
- targeted provider-preflight + auxiliary suites — 230 passed
- affected plugin/lifecycle/transport suites — 496 passed across 15 files
- broad auxiliary/compression/MoA/summary suites — 642 passed across 69 files
- staged copy of the real Magnon guard in temporary `HERMES_HOME` — 2 passed (approved official Codex route dispatched; blocked route stopped before transport)
- `python -m py_compile ...` — passed
- `ruff check ...` — passed
- Windows-footgun scan — passed
- `git diff --check` and private-value scan — passed
- `git merge-tree --write-tree HEAD FETCH_HEAD` against current upstream `main` — clean
- remote branch tip verified equal to exact commit `74f1fa8e8ea08f0914bf8f5b882401cad7e70c92`

## Safety

No live Nova profile, plugin, config, process, provider, connector, credential, gateway, mailbox, tenant, or production state was changed. The real guard was copied into a temporary test home only. This remains a draft pending fresh independent Forge and Claude exact-commit review; activation and merge remain separately gated.
