### PR TITLE
fix(tools): preserve POSIX paths for Docker vision

### DIFF
--- a/tests/tools/test_image_source_windows_path.py
+++ b/tests/tools/test_image_source_windows_path.py
@@ -1,0 +1,76 @@
+import asyncio
+import base64
+from pathlib import PureWindowsPath
+
+from tools import image_source
+
+
+# Valid 1x1 PNG. Small enough to keep the test self-contained.
+_PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+class _FakeSandboxEnv:
+    """Minimal sandbox environment that records executed commands."""
+
+    def __init__(self):
+        self.commands = []
+
+    def execute(self, command):
+        self.commands.append(command)
+        return {
+            "returncode": 0,
+            "output": base64.b64encode(_PNG_1X1).decode("ascii"),
+        }
+
+
+def test_container_fallback_preserves_posix_path_on_windows_host(monkeypatch):
+    """POSIX sandbox paths must remain POSIX when Hermes runs on Windows."""
+
+    # Simulate pathlib behavior on a native Windows Hermes host.
+    monkeypatch.setattr(image_source, "Path", PureWindowsPath)
+
+    # Force this path down the non-local/sandbox resolution path.
+    monkeypatch.setattr(
+        image_source,
+        "_permitted_host_read_target",
+        lambda p, ctx: None,
+    )
+    monkeypatch.setattr(
+        image_source,
+        "_is_local_terminal_backend",
+        lambda: False,
+    )
+
+    # Exercise the real _resolve_container_fallback implementation, but replace
+    # the actual Docker environment with a deterministic fake.
+    sandbox = _FakeSandboxEnv()
+    monkeypatch.setattr(
+        image_source,
+        "_get_active_env",
+        lambda task_id: sandbox,
+    )
+
+    resolved = asyncio.run(
+        image_source.resolve_image_source(
+            "/workspace/input/image.png",
+            image_source.ResolveContext(task_id="default"),
+        )
+    )
+
+    assert len(sandbox.commands) == 1
+
+    command = sandbox.commands[0]
+
+    # The Linux container path must cross the host -> sandbox boundary unchanged.
+    assert "/workspace/input/image.png" in command
+
+    # Regression check: Path(...) on Windows must not turn it into this.
+    assert "\\workspace\\input\\image.png" not in command
+
+    # Verify the real sandbox fallback successfully decoded/finalized the image.
+    assert resolved.data == _PNG_1X1
+    assert resolved.mime == "image/png"
+    assert resolved.origin == "container"

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -120,7 +120,10 @@ async def resolve_image_source(
     # Everything else is a filesystem path — including bare relative names
     # like "pic.png" (accepted on main; a path-shape gate here regressed them).
     candidate = s[len("file://"):] if s.lower().startswith("file://") else s
-    p = Path(os.path.expanduser(candidate))
+    # Preserve the original path string for non-local backends; converting a
+    # POSIX container path to Path on Windows changes its separators.
+    expanded_candidate = os.path.expanduser(candidate)
+    p = Path(expanded_candidate)
     # Confinement decision (see module docstring). Under a non-local backend
     # a path is host-readable ONLY if it lands in a media cache (after
     # translating a container-visible cache path back to its host mount);
@@ -153,7 +156,7 @@ async def resolve_image_source(
     # Not a permitted host read (or the host file is absent) -> read the
     # bytes inside the sandbox. Under a sandbox this reads the container's
     # filesystem, never the host's.
-    return await _resolve_container_fallback(p, ctx, s, permitted)
+    return await _resolve_container_fallback(expanded_candidate, ctx, s, permitted)
 
 
 def _resolve_data_url(s: str) -> tuple[bytes, str]:
@@ -302,7 +305,7 @@ def _ensure_container_env(task_id: Optional[str]) -> None:
 
 
 async def _resolve_container_fallback(
-    p: Path, ctx: ResolveContext, src: str, permitted: tuple = ("image",)
+    p: str | Path, ctx: ResolveContext, src: str, permitted: tuple = ("image",)
 ) -> ResolvedImage:
     """Read the image bytes inside the sandbox (fail-closed when none exists).
 


### PR DESCRIPTION
## What does this PR do?

Fixes local image analysis when Hermes Agent runs natively on Windows with a non-local Linux terminal backend such as Docker.

`resolve_image_source()` converts filesystem paths to a host-native `pathlib.Path` for host-side checks. On Windows, this changes a POSIX container path such as:

```text
/workspace/input/image.png
```

into a Windows-style path:

```text
\workspace\input\image.png
```

That transformed path was then passed to the Linux sandbox, causing `vision_analyze` to fail when reading images that were valid and accessible inside the container.

This change preserves the original expanded path string for the container fallback while continuing to use `Path` for host-side filesystem checks.

A regression test simulates Windows `pathlib` behavior and verifies that a POSIX sandbox path crosses the host-to-sandbox boundary unchanged.

## Related Issue

Fixes #82757

Related: #32709

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 🔒 Security fix
* [ ] 📝 Documentation update
* [x] ✅ Tests (adding or improving test coverage)
* [ ] ♻️ Refactor (no behavior change)
* [ ] 🎯 New skill (bundled or hub)

## Changes Made

* Updated `tools/image_source.py` to preserve the original expanded filesystem path string before creating a host-native `Path`.
* Continue using `Path` for host-side path and confinement checks.
* Pass the unmodified path string to `_resolve_container_fallback()` for non-local terminal backends.
* Updated `_resolve_container_fallback()` to accept `str | Path`.
* Added `tests/tools/test_image_source_windows_path.py` to reproduce Windows path semantics and verify that POSIX container paths are not converted to Windows-style paths before sandbox execution.
* The regression test exercises the real container fallback command construction, base64 decoding, and image finalization while using a fake sandbox environment.

## How to Test

1. Run the regression test:

   ```bash
   pytest tests/tools/test_image_source_windows_path.py -q
   ```

   Or using the repository test wrapper:

   ```bash
   HERMES_PYTHON="$VIRTUAL_ENV/Scripts/python.exe" \
     scripts/run_tests.sh tests/tools/test_image_source_windows_path.py -q
   ```

2. On Windows, configure Hermes to use a Linux Docker terminal backend and place a valid image at a container-visible path such as:

   ```text
   /workspace/input/image.png
   ```

3. Verify the image is readable from the Hermes terminal, then call `vision_analyze` using that POSIX path.

   Before this fix, the path is converted to a Windows-style path and the tool fails with an error similar to:

   ```text
   Error analyzing image: sandbox returned non-image data for '\\workspace\\input\\image.png': Only base64 data is allowed
   ```

   After this fix, the original POSIX path is passed to the Linux sandbox unchanged and `vision_analyze` successfully reads and analyzes the image.

## Checklist

### Code

* [x] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
* [x] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
* [x] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
* [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
* [x] I've run `pytest tests/ -q` and all tests pass
* [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
* [x] I've tested on my platform: Windows 11 Pro, Hermes running natively on Windows, Docker Desktop with WSL2 backend

### Documentation & Housekeeping

* [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
* [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
* [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
* [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
* [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before the fix, a valid container-local image path:

```text
/tmp/hermes-vision-test.png
```

failed as:

```text
Error analyzing image: sandbox returned non-image data for '\\tmp\\hermes-vision-test.png': Only base64 data is allowed
```

The backslash-normalized path shows that the POSIX sandbox path was converted using Windows host path semantics before being sent to the Linux container.

After preserving the original expanded path string for the container fallback, the same local-image workflow succeeds.

Regression test result:

```text
tests/tools/test_image_source_windows_path.py ... passed
```

The regression test also passes through `scripts/run_tests.sh`.