### PR TITLE
feat(skills): bind refinement candidates and prevent retry loops

### DIFF
--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -38,6 +38,9 @@ def _fmt_pending_list(subsystem: str) -> str:
     for r in records:
         origin = r.get("origin", "foreground")
         tag = " [auto]" if origin == "background_review" else ""
+        candidate = r.get("refinement_candidate")
+        if isinstance(candidate, dict) and candidate.get("id"):
+            tag += f" [candidate {str(candidate['id'])[:8]}]"
         lines.append(f"  {r['id']}{tag}  {r.get('summary', '')}")
     where = "/{s} approve <id>".format(s=subsystem)
     lines.append("")
@@ -122,16 +125,32 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
             return f"No pending {subsystem} write with id '{target}'."
         targets = [rec]
 
-    applied, failed = 0, []
+    applied, failed, details = 0, [], []
     for rec in targets:
-        ok, msg = _apply_one(subsystem, rec, memory_store)
+        candidate = rec.get("refinement_candidate")
+        try:
+            if subsystem == wa.SKILLS and isinstance(candidate, dict):
+                with wa.refinement_candidate_transaction(rec) as latest:
+                    ok, msg = _apply_one(subsystem, latest, memory_store)
+                    if ok and not wa.discard_pending(subsystem, latest["id"]):
+                        ok, msg = False, "Applied candidate could not be removed from pending state."
+            else:
+                ok, msg = _apply_one(subsystem, rec, memory_store)
+                if ok:
+                    wa.discard_pending(subsystem, rec["id"])
+        except Exception as exc:
+            ok, msg = False, str(exc)
         if ok:
-            wa.discard_pending(subsystem, rec["id"])
             applied += 1
+            if msg:
+                details.append(f"{rec['id']}: {msg}")
         else:
             failed.append(f"{rec['id']}: {msg}")
 
     out = [f"Approved {applied} {subsystem} write(s)."]
+    if details:
+        out.append("Applied:")
+        out.extend(f"  {detail}" for detail in details)
     if failed:
         out.append("Failed:")
         out.extend(f"  {f}" for f in failed)
@@ -140,6 +159,17 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
 
 def _apply_one(subsystem: str, rec, memory_store):
     payload = rec.get("payload", {})
+    candidate = rec.get("refinement_candidate") if subsystem == wa.SKILLS else None
+
+    def _record_failure(message: str) -> str:
+        if isinstance(candidate, dict):
+            stored, guard_error = wa.record_refinement_candidate_outcome(
+                rec, "failed"
+            )
+            if not stored:
+                return f"{message} ({guard_error})"
+        return message
+
     try:
         if subsystem == wa.MEMORY:
             if memory_store is None:
@@ -148,11 +178,58 @@ def _apply_one(subsystem: str, rec, memory_store):
             result = apply_memory_pending(payload, memory_store)
             return bool(result.get("success")), result.get("error", "")
         else:
+            snapshot = None
+            if isinstance(candidate, dict):
+                ok, message = wa.can_attempt_refinement_apply(rec)
+                if not ok:
+                    return False, message
+                ok, message = wa.validate_refinement_candidate_base(rec)
+                if not ok:
+                    return False, _record_failure(message)
+                from agent.curator_backup import snapshot_skills
+
+                snapshot = snapshot_skills(
+                    reason=f"pre-refinement {candidate.get('id', '')}"
+                )
+                if snapshot is None:
+                    return False, _record_failure(
+                        "Required Curator snapshot failed or is disabled; "
+                        "the refinement was not applied."
+                    )
+
             from tools.skill_manager_tool import apply_skill_pending
-            result = json.loads(apply_skill_pending(payload))
-            return bool(result.get("success")), result.get("error", "")
+            result = json.loads(
+                apply_skill_pending(payload, refinement_candidate=candidate)
+            )
+            if not result.get("success"):
+                message = result.get("error", "")
+                if snapshot is not None:
+                    message = f"{message} (recovery snapshot: {snapshot.name})"
+                return False, _record_failure(message)
+
+            if isinstance(candidate, dict):
+                ok, message = wa.validate_refinement_candidate_result(rec)
+                if not ok:
+                    return False, _record_failure(
+                        f"{message} (recovery snapshot: {snapshot.name})"
+                    )
+                stored, guard_error = wa.record_refinement_candidate_outcome(
+                    rec, "applied"
+                )
+                if not stored:
+                    retained = dict(rec)
+                    retained["refinement_apply_state"] = "applied_guard_error"
+                    retained["refinement_apply_error"] = guard_error
+                    wa.replace_pending_record(wa.SKILLS, retained)
+                    return False, (
+                        "Refinement write was applied, but the loop-guard outcome "
+                        f"failed and the pending record was retained: {guard_error}"
+                    )
+                detail = f"refinement applied; recovery snapshot: {snapshot.name}"
+                return True, detail
+            return True, ""
     except Exception as e:
-        return False, str(e)
+        return False, _record_failure(str(e))
 
 
 def _reject(subsystem: str, rest: List[str]) -> str:
@@ -160,11 +237,46 @@ def _reject(subsystem: str, rest: List[str]) -> str:
     if err or target is None:
         return err or f"Usage: /{subsystem} reject <id>"
     if target.lower() == "all":
-        n = 0
+        n, failed = 0, []
         for rec in wa.list_pending(subsystem):
-            if wa.discard_pending(subsystem, rec["id"]):
+            if isinstance(rec.get("refinement_candidate"), dict):
+                try:
+                    with wa.refinement_candidate_transaction(rec) as latest:
+                        stored, message = wa.record_refinement_candidate_outcome(
+                            latest, "rejected"
+                        )
+                        if not stored:
+                            failed.append(f"{rec['id']}: {message}")
+                            continue
+                        if wa.discard_pending(subsystem, latest["id"]):
+                            n += 1
+                except Exception as exc:
+                    failed.append(f"{rec['id']}: {exc}")
+                    continue
+            elif wa.discard_pending(subsystem, rec["id"]):
                 n += 1
-        return f"Rejected {n} pending {subsystem} write(s)."
+        out = [f"Rejected {n} pending {subsystem} write(s)."]
+        if failed:
+            out.append("Failed:")
+            out.extend(f"  {item}" for item in failed)
+        return "\n".join(out)
+
+    rec = wa.get_pending(subsystem, target)
+    if not rec:
+        return f"No pending {subsystem} write with id '{target}'."
+    if isinstance(rec.get("refinement_candidate"), dict):
+        try:
+            with wa.refinement_candidate_transaction(rec) as latest:
+                stored, message = wa.record_refinement_candidate_outcome(
+                    latest, "rejected"
+                )
+                if not stored:
+                    return f"Could not reject refinement candidate '{target}': {message}"
+                if wa.discard_pending(subsystem, target):
+                    return f"Rejected pending {subsystem} write '{target}'."
+        except Exception as exc:
+            return f"Could not reject refinement candidate '{target}': {exc}"
+        return f"No pending {subsystem} write with id '{target}'."
     if wa.discard_pending(subsystem, target):
         return f"Rejected pending {subsystem} write '{target}'."
     return f"No pending {subsystem} write with id '{target}'."
@@ -178,6 +290,19 @@ def _diff(rest: List[str]) -> str:
         return f"No pending skill write with id '{rest[0]}'."
     diff = wa.skill_pending_diff(rec)
     header = f"# Pending skill write {rec['id']}: {rec.get('summary', '')}\n"
+    candidate = rec.get("refinement_candidate")
+    if isinstance(candidate, dict):
+        evidence = candidate.get("evidence", {})
+        base = candidate.get("base", {})
+        proposed = candidate.get("proposed", {})
+        header += (
+            f"Candidate: {candidate.get('id', '')}\n"
+            f"Evidence: origin={evidence.get('origin', '')} "
+            f"session={evidence.get('session_id', '')} "
+            f"task={evidence.get('task_id', '')}\n"
+            f"Base: {base.get('state', '')} {base.get('sha256', '')}\n"
+            f"Proposed: {proposed.get('state', '')} {proposed.get('sha256', '')}\n"
+        )
     return header + "\n" + diff
 
 

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -11,6 +11,8 @@ import json
 import os
 import tempfile
 import shutil
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -255,6 +257,525 @@ def test_memory_invalid_params_rejected_before_staging(hermes_home):
     r = json.loads(memory_tool("add", "memory", None, store=store))
     assert r["success"] is False
     assert wa.pending_count("memory") == 0
+
+
+def _background_skill_patch_result(
+    hermes_home, tmp_path, *, reset_skill=True, new_string="improved body"
+):
+    """Run one real background-review patch attempt against a temp skill."""
+    from tools.skill_manager_tool import skill_manage
+    from tools.skill_provenance import set_current_write_origin, reset_current_write_origin
+
+    _set_approval("skills", True)
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    if reset_skill:
+        skill_md.write_text(_SKILL, encoding="utf-8")
+
+    token = set_current_write_origin("background_review")
+    try:
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+             patch("tools.skill_manager_tool._background_review_preflight", return_value=None):
+            result = json.loads(skill_manage(
+                action="patch",
+                name="test-skill",
+                old_string="body",
+                new_string=new_string,
+                task_id="task-123",
+                session_id="session-456",
+            ))
+    finally:
+        reset_current_write_origin(token)
+    return result, skill_md
+
+
+def _stage_background_skill_patch(hermes_home, tmp_path):
+    """Stage one real background-review patch against an existing temp skill."""
+    from tools import write_approval as wa
+
+    result, skill_md = _background_skill_patch_result(hermes_home, tmp_path)
+    assert result["success"] is True
+    assert result["staged"] is True
+    record = wa.get_pending(wa.SKILLS, result["pending_id"])
+    assert record is not None
+    return result, record, skill_md
+
+
+def test_background_skill_patch_stages_frozen_refinement_candidate(
+    hermes_home, tmp_path
+):
+    from tools import write_approval as wa
+
+    result, record, skill_md = _stage_background_skill_patch(hermes_home, tmp_path)
+    candidate = record["refinement_candidate"]
+
+    assert result["candidate_id"] == candidate["id"]
+    assert len(candidate["id"]) == 32
+    assert candidate["schema_version"] == 1
+    assert candidate["target"]["skill"] == "test-skill"
+    assert candidate["target"]["file"] == "SKILL.md"
+    assert Path(candidate["target"]["root"]) == tmp_path / "test-skill"
+    assert candidate["evidence"] == {
+        "origin": "background_review",
+        "task_id": "task-123",
+        "session_id": "session-456",
+    }
+    assert candidate["base"]["state"] == "present"
+    assert candidate["proposed"]["state"] == "present"
+    assert candidate["base"]["sha256"] != candidate["proposed"]["sha256"]
+    assert "-body" in candidate["diff"]
+    assert "+improved body" in candidate["diff"]
+    assert skill_md.read_text(encoding="utf-8") == _SKILL
+
+    frozen = wa.skill_pending_diff(record)
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    rendered = handle_pending_subcommand(
+        wa.SKILLS, ["diff", result["pending_id"]]
+    )
+    assert candidate["id"] in rendered
+    assert "session-456" in rendered
+    assert candidate["base"]["sha256"] in rendered
+
+    skill_md.write_text(_SKILL.replace("body", "unrelated drift"), encoding="utf-8")
+    assert wa.skill_pending_diff(record) == frozen
+
+
+def test_refinement_approval_rejects_stale_base_before_snapshot(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, _record, skill_md = _stage_background_skill_patch(hermes_home, tmp_path)
+    skill_md.write_text(_SKILL.replace("body", "newer user edit"), encoding="utf-8")
+    snapshots = []
+    monkeypatch.setattr(
+        "agent.curator_backup.snapshot_skills",
+        lambda **kwargs: snapshots.append(kwargs) or Path("unused"),
+    )
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        out = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    assert "base changed" in out.lower()
+    assert snapshots == []
+    assert wa.pending_count(wa.SKILLS) == 1
+    assert "newer user edit" in skill_md.read_text(encoding="utf-8")
+
+
+def test_refinement_approval_requires_snapshot_and_keeps_pending_on_failure(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, _record, skill_md = _stage_background_skill_patch(hermes_home, tmp_path)
+    snapshot_calls = []
+    monkeypatch.setattr(
+        "agent.curator_backup.snapshot_skills",
+        lambda **kwargs: snapshot_calls.append(kwargs) or None,
+    )
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        out = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+        immediate_retry = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    assert "snapshot" in out.lower()
+    assert "failed" in out.lower()
+    assert "cooldown" in immediate_retry.lower()
+    assert len(snapshot_calls) == 1
+    assert wa.pending_count(wa.SKILLS) == 1
+    assert skill_md.read_text(encoding="utf-8") == _SKILL
+
+
+def test_refinement_approval_snapshots_applies_and_verifies_result(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, record, skill_md = _stage_background_skill_patch(hermes_home, tmp_path)
+    candidate_id = record["refinement_candidate"]["id"]
+    snapshot = Path(hermes_home) / "skills" / ".curator_backups" / "snap-123"
+    calls = []
+
+    def _snapshot(*, reason, **kwargs):
+        calls.append(reason)
+        return snapshot
+
+    monkeypatch.setattr("agent.curator_backup.snapshot_skills", _snapshot)
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        out = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    assert calls == [f"pre-refinement {candidate_id}"]
+    assert "Approved 1" in out
+    assert "snap-123" in out
+    assert wa.pending_count(wa.SKILLS) == 0
+    assert "improved body" in skill_md.read_text(encoding="utf-8")
+
+
+def test_refinement_approval_creates_real_curator_snapshot(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    skills_root = Path(hermes_home) / "skills"
+    result, record, skill_md = _stage_background_skill_patch(
+        hermes_home, skills_root
+    )
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", skills_root), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_root]):
+        out = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    backups = skills_root / ".curator_backups"
+    manifests = list(backups.glob("*/manifest.json"))
+    assert len(manifests) == 1
+    manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+    assert manifest["reason"] == (
+        f"pre-refinement {record['refinement_candidate']['id']}"
+    )
+    assert manifest["skill_files"] == 1
+    assert manifests[0].parent.name in out
+    assert "improved body" in skill_md.read_text(encoding="utf-8")
+    assert wa.pending_count(wa.SKILLS) == 0
+
+
+def test_refinement_guard_allows_only_one_active_candidate_per_skill(
+    hermes_home, tmp_path
+):
+    from tools import write_approval as wa
+
+    _stage_background_skill_patch(hermes_home, tmp_path)
+    second, _skill_md = _background_skill_patch_result(
+        hermes_home, tmp_path, reset_skill=False
+    )
+
+    assert second["success"] is False
+    assert "active refinement candidate" in second["error"].lower()
+    assert wa.pending_count(wa.SKILLS) == 1
+
+
+def test_rejected_refinement_candidate_enters_cooldown(
+    hermes_home, tmp_path
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, _record, _skill_md = _stage_background_skill_patch(
+        hermes_home, tmp_path
+    )
+    rejected = handle_pending_subcommand(
+        wa.SKILLS, ["reject", result["pending_id"]]
+    )
+    assert "Rejected" in rejected
+
+    retry, _skill_md = _background_skill_patch_result(
+        hermes_home,
+        tmp_path,
+        reset_skill=False,
+        new_string="differently improved body",
+    )
+    assert retry["success"] is False
+    assert "cooldown" in retry["error"].lower()
+    assert wa.pending_count(wa.SKILLS) == 0
+
+
+def test_exact_duplicate_remains_blocked_after_cooldown(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    now = [1_000_000.0]
+    monkeypatch.setattr(wa.time, "time", lambda: now[0])
+    result, _record, _skill_md = _stage_background_skill_patch(
+        hermes_home, tmp_path
+    )
+    handle_pending_subcommand(wa.SKILLS, ["reject", result["pending_id"]])
+    now[0] += wa.REFINEMENT_COOLDOWN_SECONDS + 1
+
+    duplicate, _skill_md = _background_skill_patch_result(
+        hermes_home, tmp_path, reset_skill=False
+    )
+    assert duplicate["success"] is False
+    assert "duplicate refinement candidate" in duplicate["error"].lower()
+
+
+def test_refinement_guard_caps_same_candidate_at_three_attempts_per_window(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    now = [1_000_000.0]
+    monkeypatch.setattr(wa.time, "time", lambda: now[0])
+
+    for attempt in range(wa.REFINEMENT_MAX_ATTEMPTS):
+        result, _skill_md = _background_skill_patch_result(
+            hermes_home,
+            tmp_path,
+            new_string=f"improved body variant {attempt}",
+        )
+        assert result["success"] is True
+        handle_pending_subcommand(
+            wa.SKILLS, ["reject", result["pending_id"]]
+        )
+        now[0] += wa.REFINEMENT_COOLDOWN_SECONDS + 1
+
+    blocked, _skill_md = _background_skill_patch_result(
+        hermes_home, tmp_path, reset_skill=False
+    )
+    assert blocked["success"] is False
+    assert "attempt limit" in blocked["error"].lower()
+    assert wa.pending_count(wa.SKILLS) == 0
+
+
+def test_corrupt_refinement_guard_blocks_new_candidate(hermes_home, tmp_path):
+    from tools import write_approval as wa
+
+    guard = Path(hermes_home) / "pending" / "refinement_guard.json"
+    guard.parent.mkdir(parents=True, exist_ok=True)
+    guard.write_text("not valid json", encoding="utf-8")
+
+    result, _skill_md = _background_skill_patch_result(hermes_home, tmp_path)
+    assert result["success"] is False
+    assert "loop guard" in result["error"].lower()
+    assert wa.pending_count(wa.SKILLS) == 0
+
+
+def test_semantically_corrupt_refinement_guard_blocks_new_candidate(
+    hermes_home, tmp_path
+):
+    from tools import write_approval as wa
+
+    guard = Path(hermes_home) / "pending" / "refinement_guard.json"
+    guard.parent.mkdir(parents=True, exist_ok=True)
+    guard.write_text(json.dumps({
+        "schema_version": 1,
+        "fingerprints": {},
+        "skills": {"test-skill": {"attempts": "corrupt", "failures": []}},
+    }), encoding="utf-8")
+
+    result, _skill_md = _background_skill_patch_result(hermes_home, tmp_path)
+    assert result["success"] is False
+    assert "loop guard" in result["error"].lower()
+    assert wa.pending_count(wa.SKILLS) == 0
+
+
+def test_refinement_candidate_is_bound_to_exact_skill_root(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    result, _record, skill_a = _stage_background_skill_patch(
+        hermes_home, root_a
+    )
+    skill_b_dir = root_b / "test-skill"
+    skill_b_dir.mkdir(parents=True)
+    skill_b = skill_b_dir / "SKILL.md"
+    skill_b.write_text(_SKILL, encoding="utf-8")
+    snapshots = []
+    monkeypatch.setattr(
+        "agent.curator_backup.snapshot_skills",
+        lambda **kwargs: snapshots.append(kwargs) or Path("unused"),
+    )
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", root_b), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[root_b, root_a]):
+        out = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    assert "target root changed" in out.lower()
+    assert snapshots == []
+    assert skill_a.read_text(encoding="utf-8") == _SKILL
+    assert skill_b.read_text(encoding="utf-8") == _SKILL
+    assert wa.pending_count(wa.SKILLS) == 1
+
+
+def test_refinement_apply_rechecks_base_inside_skill_writer(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, _record, skill_md = _stage_background_skill_patch(
+        hermes_home, tmp_path
+    )
+
+    def _snapshot_then_user_edit(**kwargs):
+        skill_md.write_text(
+            _SKILL.replace("body", "concurrent user edit"), encoding="utf-8"
+        )
+        return Path("snap")
+
+    monkeypatch.setattr(
+        "agent.curator_backup.snapshot_skills", _snapshot_then_user_edit
+    )
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        out = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    assert "changed during apply" in out.lower()
+    assert "concurrent user edit" in skill_md.read_text(encoding="utf-8")
+    assert wa.pending_count(wa.SKILLS) == 1
+
+
+def test_parallel_refinement_approvals_apply_only_once(
+    hermes_home, tmp_path, monkeypatch
+):
+    from concurrent.futures import ThreadPoolExecutor
+    import threading
+    import time
+
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, _record, skill_md = _stage_background_skill_patch(
+        hermes_home, tmp_path
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    apply_calls = []
+
+    def _apply_once(payload, refinement_candidate=None):
+        apply_calls.append(payload)
+        entered.set()
+        release.wait(timeout=2)
+        skill_md.write_text(_SKILL.replace("body", "improved body"), encoding="utf-8")
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr(
+        "agent.curator_backup.snapshot_skills", lambda **kwargs: Path("snap")
+    )
+    monkeypatch.setattr("tools.skill_manager_tool.apply_skill_pending", _apply_once)
+
+    def _approve():
+        return handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+         ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(_approve)
+        ready = entered.wait(timeout=2)
+        assert ready, first.result(timeout=1)
+        second = pool.submit(_approve)
+        time.sleep(0.05)
+        release.set()
+        outputs = [first.result(timeout=2), second.result(timeout=2)]
+
+    assert len(apply_calls) == 1
+    assert sum("Approved 1" in output for output in outputs) == 1
+    assert wa.pending_count(wa.SKILLS) == 0
+
+
+def test_applied_candidate_with_guard_failure_is_retained_and_not_retried(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, _record, skill_md = _stage_background_skill_patch(
+        hermes_home, tmp_path
+    )
+    original_record_outcome = wa.record_refinement_candidate_outcome
+    snapshots = []
+
+    def _record_outcome(record, outcome):
+        if outcome == "applied":
+            return False, "simulated guard write failure"
+        return original_record_outcome(record, outcome)
+
+    monkeypatch.setattr(wa, "record_refinement_candidate_outcome", _record_outcome)
+    monkeypatch.setattr(
+        "agent.curator_backup.snapshot_skills",
+        lambda **kwargs: snapshots.append(kwargs) or Path("snap"),
+    )
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        first = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+        second = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    retained = wa.get_pending(wa.SKILLS, result["pending_id"])
+    assert "retained" in first.lower()
+    assert "must not be retried" in second.lower()
+    assert retained["refinement_apply_state"] == "applied_guard_error"
+    assert len(snapshots) == 1
+    assert "improved body" in skill_md.read_text(encoding="utf-8")
+
+
+def test_tampered_refinement_candidate_can_still_be_rejected(
+    hermes_home, tmp_path
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, record, _skill_md = _stage_background_skill_patch(
+        hermes_home, tmp_path
+    )
+    record["refinement_candidate"]["diff"] += "\nforged"
+    wa.replace_pending_record(wa.SKILLS, record)
+
+    out = handle_pending_subcommand(
+        wa.SKILLS, ["reject", result["pending_id"]]
+    )
+    assert "Rejected" in out
+    assert wa.pending_count(wa.SKILLS) == 0
+
+
+def test_refinement_candidate_integrity_tampering_blocks_apply(
+    hermes_home, tmp_path, monkeypatch
+):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    result, record, skill_md = _stage_background_skill_patch(hermes_home, tmp_path)
+    record["refinement_candidate"]["diff"] += "\nforged"
+    wa.replace_pending_record(wa.SKILLS, record)
+    snapshots = []
+    monkeypatch.setattr(
+        "agent.curator_backup.snapshot_skills",
+        lambda **kwargs: snapshots.append(kwargs) or Path("unused"),
+    )
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        out = handle_pending_subcommand(
+            wa.SKILLS, ["approve", result["pending_id"]]
+        )
+
+    assert "integrity" in out.lower()
+    assert snapshots == []
+    assert wa.pending_count(wa.SKILLS) == 1
+    assert skill_md.read_text(encoding="utf-8") == _SKILL
 
 
 class TestSkillGist:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -32,6 +32,7 @@ Directory layout for user skills:
             └── SKILL.md
 """
 
+import hashlib
 import json
 import logging
 import re
@@ -54,6 +55,9 @@ logger = logging.getLogger(__name__)
 
 _background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
     "background_review_read_paths", default=frozenset()
+)
+_skill_apply_contract: "_ctxvars.ContextVar[Optional[Dict[str, Any]]]" = (
+    _ctxvars.ContextVar("skill_apply_contract", default=None)
 )
 
 
@@ -651,6 +655,19 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     {"path": Path} or None.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+
+    contract = _skill_apply_contract.get()
+    if isinstance(contract, dict) and contract.get("skill") == name:
+        bound_root = Path(str(contract.get("root") or ""))
+        skill_md = bound_root / "SKILL.md"
+        if (
+            bound_root.name == name
+            and skill_md.exists()
+            and not is_excluded_skill_path(skill_md)
+        ):
+            return {"path": bound_root}
+        return None
+
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
@@ -1120,6 +1137,17 @@ def _patch_skill(
         return read_guard
 
     content = target.read_text(encoding="utf-8")
+    contract = _skill_apply_contract.get()
+    if isinstance(contract, dict) and contract.get("skill") == name:
+        expected_file = str(contract.get("file") or "SKILL.md")
+        actual_file = str(target.relative_to(skill_dir)).replace("\\", "/")
+        expected_file = expected_file.replace("\\", "/")
+        current_sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        if actual_file != expected_file or current_sha != contract.get("base_sha256"):
+            return {
+                "success": False,
+                "error": "Refinement base or target changed during apply.",
+            }
 
     # Use the same fuzzy matching engine as the file patch tool.
     # This handles whitespace normalization, indentation differences,
@@ -1161,6 +1189,15 @@ def _patch_skill(
             }
 
     original_content = content  # for rollback
+    if (
+        isinstance(contract, dict)
+        and contract.get("skill") == name
+        and target.read_text(encoding="utf-8") != content
+    ):
+        return {
+            "success": False,
+            "error": "Refinement target changed while the approved patch was prepared.",
+        }
     atomic_write_text(target, new_content)
 
     # Security scan — roll back on block
@@ -1422,7 +1459,6 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
 
 # ContextVar bypass: set while replaying an already-approved staged skill write
 # so skill_manage() does not re-gate (and re-stage) it.
-import contextvars as _ctxvars
 _skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
     "skill_gate_bypass", default=False
 )
@@ -1459,19 +1495,64 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
         old_string=payload_kwargs.get("old_string") or "",
         new_string=payload_kwargs.get("new_string") or "",
     )
-    record = wa.stage_write(wa.SKILLS, payload, summary=gist, origin=wa.current_origin())
-    return json.dumps(
-        {"success": True, "staged": True, "pending_id": record["id"],
-         "gist": gist, "message": decision.message},
-        ensure_ascii=False,
-    )
+    origin = wa.current_origin()
+    try:
+        candidate = wa.build_skill_refinement_candidate(payload, origin=origin)
+    except Exception as exc:
+        return tool_error(
+            f"Could not stage a safe refinement candidate: {exc}", success=False
+        )
+    if candidate is not None:
+        try:
+            record, guard_error = wa.stage_refinement_write(
+                payload,
+                summary=gist,
+                origin=origin,
+                candidate=candidate,
+            )
+        except Exception as exc:
+            return tool_error(
+                f"Refinement loop guard is unavailable: {exc}", success=False
+            )
+        if record is None:
+            return tool_error(guard_error, success=False)
+    else:
+        record = wa.stage_write(
+            wa.SKILLS,
+            payload,
+            summary=gist,
+            origin=origin,
+        )
+    result = {
+        "success": True,
+        "staged": True,
+        "pending_id": record["id"],
+        "gist": gist,
+        "message": decision.message,
+    }
+    if candidate is not None:
+        result["candidate_id"] = candidate["id"]
+    return json.dumps(result, ensure_ascii=False)
 
 
-def apply_skill_pending(payload: Dict[str, Any]) -> str:
+def apply_skill_pending(
+    payload: Dict[str, Any], refinement_candidate: Optional[Dict[str, Any]] = None
+) -> str:
     """Replay a staged skill write, bypassing the gate. Returns the tool result
     JSON string. Called by the /skills approve handler.
     """
-    token = _skill_gate_bypass.set(True)
+    contract = None
+    if isinstance(refinement_candidate, dict):
+        target = refinement_candidate.get("target", {})
+        base = refinement_candidate.get("base", {})
+        contract = {
+            "skill": str(target.get("skill") or ""),
+            "file": str(target.get("file") or "SKILL.md"),
+            "root": str(target.get("root") or ""),
+            "base_sha256": str(base.get("sha256") or ""),
+        }
+    bypass_token = _skill_gate_bypass.set(True)
+    contract_token = _skill_apply_contract.set(contract)
     try:
         return skill_manage(
             action=payload.get("action", ""),
@@ -1484,9 +1565,12 @@ def apply_skill_pending(payload: Dict[str, Any]) -> str:
             new_string=payload.get("new_string"),
             replace_all=payload.get("replace_all", False),
             absorbed_into=payload.get("absorbed_into"),
+            task_id=payload.get("task_id"),
+            session_id=payload.get("session_id"),
         )
     finally:
-        _skill_gate_bypass.reset(token)
+        _skill_apply_contract.reset(contract_token)
+        _skill_gate_bypass.reset(bypass_token)
 
 
 # Debounce state for the sync push hook. A burst of skill_manage writes
@@ -1571,6 +1655,7 @@ def skill_manage(
         file_path=file_path, file_content=file_content,
         old_string=old_string, new_string=new_string,
         replace_all=replace_all, absorbed_into=absorbed_into,
+        task_id=task_id, session_id=session_id,
     )
     if gate_result is not None:
         return gate_result

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -42,11 +42,16 @@ web dashboard.
 
 from __future__ import annotations
 
+import difflib
+import hashlib
 import json
 import logging
+import math
 import os
+import threading
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -65,6 +70,15 @@ _SUBSYSTEMS = (MEMORY, SKILLS)
 # "block all writes" state — to disable a subsystem entirely use its own
 # enable flag (e.g. ``memory.memory_enabled: false``).
 CONFIG_KEY = "write_approval"
+
+# Hard safety bounds for repeated background-review proposals. These are
+# intentionally fixed rather than configurable in the first slice: changing
+# policy must be an explicit code review, not an autonomous config mutation.
+REFINEMENT_COOLDOWN_SECONDS = 24 * 60 * 60
+REFINEMENT_ATTEMPT_WINDOW_SECONDS = 7 * 24 * 60 * 60
+REFINEMENT_MAX_ATTEMPTS = 3
+_refinement_guard_lock = threading.RLock()
+_refinement_guard_state = threading.local()
 
 
 # ---------------------------------------------------------------------------
@@ -112,7 +126,8 @@ def _pending_dir(subsystem: str) -> Path:
 
 
 def stage_write(subsystem: str, payload: Dict[str, Any],
-                *, summary: str, origin: str) -> Dict[str, Any]:
+                *, summary: str, origin: str,
+                refinement_candidate: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Persist a pending write and return a short record describing it.
 
     Args:
@@ -124,6 +139,8 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
             For skills this is the LLM/heuristic gist; for memory it can be the
             entry text itself.
         origin: ``foreground`` or ``background_review`` — recorded for audit.
+        refinement_candidate: optional immutable proposal envelope for a
+            background-review mutation of an existing skill.
 
     Returns a dict with ``id`` and metadata. Best-effort: on disk failure it
     logs and still returns a record (the write is simply lost, which is the
@@ -139,16 +156,30 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
         "created_at": time.time(),
         "payload": payload,
     }
+    if refinement_candidate is not None:
+        record["refinement_candidate"] = refinement_candidate
     try:
-        d = _pending_dir(subsystem)
-        d.mkdir(parents=True, exist_ok=True)
-        path = d / f"{pid}.json"
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        replace_pending_record(subsystem, record)
     except Exception as e:  # pragma: no cover - disk failure path
         logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
     return record
+
+
+def replace_pending_record(subsystem: str, record: Dict[str, Any]) -> None:
+    """Atomically replace one pending record after validating its identity."""
+    if subsystem not in _SUBSYSTEMS:
+        raise ValueError(f"invalid pending subsystem: {subsystem}")
+    pending_id = str(record.get("id") or "")
+    if len(pending_id) != 8 or any(ch not in "0123456789abcdef" for ch in pending_id):
+        raise ValueError("invalid pending record id")
+    if record.get("subsystem") != subsystem:
+        raise ValueError("pending record subsystem mismatch")
+    d = _pending_dir(subsystem)
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{pending_id}.json"
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
 
 
 def list_pending(subsystem: str) -> List[Dict[str, Any]]:
@@ -382,8 +413,549 @@ def _prompt_inline_memory_approval(summary: str, detail: str) -> Optional[bool]:
 
 
 # ---------------------------------------------------------------------------
-# Skill-specific helpers (gist + diff for the review affordances)
+# Skill-specific helpers (refinement candidate + review affordances)
 # ---------------------------------------------------------------------------
+
+_REFINEMENT_ACTIONS = {"patch"}
+
+
+def _canonical_sha256(value: Any) -> str:
+    raw = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _text_state(path: Path) -> Dict[str, str]:
+    if not path.exists():
+        return {"state": "missing", "sha256": ""}
+    content = path.read_text(encoding="utf-8")
+    return {
+        "state": "present",
+        "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    }
+
+
+def _resolve_refinement_target(payload: Dict[str, Any]):
+    """Return (skill root, target path, display label, error)."""
+    from tools.skill_manager_tool import _find_skill, _resolve_skill_target
+
+    name = str(payload.get("name") or "")
+    existing = _find_skill(name)
+    if not existing:
+        return None, None, "", f"Skill '{name}' is not an existing skill."
+    skill_dir = existing["path"]
+    rel = str(payload.get("file_path") or "SKILL.md")
+    target, error = _resolve_skill_target(skill_dir, rel)
+    return skill_dir, target, rel, error
+
+
+def build_skill_refinement_candidate(
+    payload: Dict[str, Any], *, origin: str
+) -> Optional[Dict[str, Any]]:
+    """Freeze a background-review proposal against one existing skill file.
+
+    New-skill creation and whole-skill deletion deliberately remain ordinary
+    pending writes. This first native refinement slice only covers bounded
+    improvements to an existing skill.
+    """
+    action = str(payload.get("action") or "")
+    if origin != "background_review" or action not in _REFINEMENT_ACTIONS:
+        return None
+
+    skill_dir, target, target_label, error = _resolve_refinement_target(payload)
+    if error or skill_dir is None or target is None:
+        raise ValueError(error or "Could not resolve refinement target.")
+
+    current = target.read_text(encoding="utf-8") if target.exists() else ""
+    if not target.exists():
+        raise ValueError(f"Refinement target does not exist: {target_label}")
+    from tools.fuzzy_match import fuzzy_find_and_replace
+
+    proposed, _count, _strategy, match_error = fuzzy_find_and_replace(
+        current,
+        str(payload.get("old_string") or ""),
+        payload.get("new_string"),
+        bool(payload.get("replace_all", False)),
+    )
+    if match_error:
+        raise ValueError(match_error)
+
+    before_lines = current.splitlines(keepends=True)
+    after_lines = [] if proposed is None else proposed.splitlines(keepends=True)
+    frozen_diff = "".join(difflib.unified_diff(
+        before_lines,
+        after_lines,
+        fromfile=f"a/{target_label}",
+        tofile=f"b/{target_label}",
+    )) or "(no textual change)"
+
+    proposed_state = (
+        {"state": "missing", "sha256": ""}
+        if proposed is None
+        else {
+            "state": "present",
+            "sha256": hashlib.sha256(proposed.encode("utf-8")).hexdigest(),
+        }
+    )
+    candidate = {
+        "schema_version": 1,
+        "id": uuid.uuid4().hex,
+        "action": action,
+        "target": {
+            "skill": str(payload.get("name") or ""),
+            "file": target_label,
+            "root": str(skill_dir.resolve()),
+        },
+        "evidence": {
+            "origin": origin,
+            "task_id": str(payload.get("task_id") or ""),
+            "session_id": str(payload.get("session_id") or ""),
+        },
+        "base": _text_state(target),
+        "proposed": proposed_state,
+        "payload_sha256": _canonical_sha256(payload),
+        "diff": frozen_diff,
+    }
+    candidate["fingerprint"] = _canonical_sha256({
+        "action": candidate["action"],
+        "target": candidate["target"],
+        "base": candidate["base"],
+        "proposed": candidate["proposed"],
+        "diff": candidate["diff"],
+    })
+    candidate["integrity_sha256"] = _canonical_sha256(candidate)
+    return candidate
+
+
+def _validate_candidate_integrity(record: Dict[str, Any]):
+    candidate = record.get("refinement_candidate")
+    if not isinstance(candidate, dict):
+        return True, ""
+    expected = str(candidate.get("integrity_sha256") or "")
+    unsigned = dict(candidate)
+    unsigned.pop("integrity_sha256", None)
+    if not expected or _canonical_sha256(unsigned) != expected:
+        return False, "Refinement candidate integrity check failed."
+    if candidate.get("payload_sha256") != _canonical_sha256(record.get("payload", {})):
+        return False, "Refinement candidate payload integrity check failed."
+    return True, ""
+
+
+def _refinement_guard_path() -> Path:
+    return get_hermes_home() / "pending" / "refinement_guard.json"
+
+
+def _refinement_guard_lock_path() -> Path:
+    return get_hermes_home() / "pending" / ".refinement_guard.lock"
+
+
+@contextmanager
+def _locked_refinement_guard():
+    """Serialize guard decisions across threads and Hermes processes."""
+    with _refinement_guard_lock:
+        depth = int(getattr(_refinement_guard_state, "depth", 0))
+        if depth:
+            _refinement_guard_state.depth = depth + 1
+            try:
+                yield
+            finally:
+                _refinement_guard_state.depth = depth
+            return
+
+        lock_path = _refinement_guard_lock_path()
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as handle:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            _refinement_guard_state.depth = 1
+            try:
+                yield
+            finally:
+                _refinement_guard_state.depth = 0
+                handle.seek(0)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def refinement_candidate_transaction(record: Dict[str, Any]):
+    """Hold the lifecycle lock from final validation through pending removal."""
+    with _locked_refinement_guard():
+        pending_id = str(record.get("id") or "")
+        latest = get_pending(SKILLS, pending_id)
+        if latest is None:
+            raise RuntimeError(
+                f"Refinement candidate '{pending_id}' is no longer pending."
+            )
+        if (
+            _canonical_sha256(latest.get("payload"))
+            != _canonical_sha256(record.get("payload"))
+            or _canonical_sha256(latest.get("refinement_candidate"))
+            != _canonical_sha256(record.get("refinement_candidate"))
+        ):
+            raise RuntimeError(
+                f"Refinement candidate '{pending_id}' changed during approval."
+            )
+        yield latest
+
+
+def _validate_guard_entry(entry: Any, *, label: str) -> None:
+    if not isinstance(entry, dict):
+        raise RuntimeError(f"Refinement loop guard entry '{label}' is invalid.")
+    for field in ("attempts", "failures"):
+        values = entry.get(field, [])
+        if not isinstance(values, list):
+            raise RuntimeError(
+                f"Refinement loop guard field '{label}.{field}' is invalid."
+            )
+        for value in values:
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+                or float(value) < 0
+            ):
+                raise RuntimeError(
+                    f"Refinement loop guard timestamp '{label}.{field}' is invalid."
+                )
+    outcome = entry.get("last_outcome")
+    if outcome is not None and outcome not in {"staged", "rejected", "failed", "applied"}:
+        raise RuntimeError(
+            f"Refinement loop guard outcome '{label}' is invalid."
+        )
+    outcome_at = entry.get("last_outcome_at")
+    if outcome_at is not None and (
+        isinstance(outcome_at, bool)
+        or not isinstance(outcome_at, (int, float))
+        or not math.isfinite(float(outcome_at))
+        or float(outcome_at) < 0
+    ):
+        raise RuntimeError(
+            f"Refinement loop guard outcome timestamp '{label}' is invalid."
+        )
+
+
+def _validate_refinement_guard(data: Any, path: Path) -> Dict[str, Any]:
+    if not isinstance(data, dict) or data.get("schema_version") != 1:
+        raise RuntimeError(f"Refinement loop guard has an invalid schema: {path}")
+    for bucket_name in ("fingerprints", "skills"):
+        bucket = data.get(bucket_name)
+        if not isinstance(bucket, dict):
+            raise RuntimeError(f"Refinement loop guard has an invalid schema: {path}")
+        for key, entry in bucket.items():
+            if not isinstance(key, str) or not key:
+                raise RuntimeError(
+                    f"Refinement loop guard key in '{bucket_name}' is invalid."
+                )
+            _validate_guard_entry(entry, label=f"{bucket_name}.{key}")
+    return data
+
+
+def _load_refinement_guard() -> Dict[str, Any]:
+    path = _refinement_guard_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"schema_version": 1, "fingerprints": {}, "skills": {}}
+    except Exception as exc:
+        raise RuntimeError(f"Refinement loop guard is unreadable: {path}") from exc
+
+    return _validate_refinement_guard(data, path)
+
+
+def _save_refinement_guard(data: Dict[str, Any]) -> None:
+    _validate_refinement_guard(data, _refinement_guard_path())
+    now = time.time()
+    cutoff = now - REFINEMENT_ATTEMPT_WINDOW_SECONDS
+    for bucket_name in ("skills", "fingerprints"):
+        bucket = data.setdefault(bucket_name, {})
+        for key, entry in list(bucket.items()):
+            entry["attempts"] = _recent_timestamps(entry.get("attempts"), now)
+            entry["failures"] = _recent_timestamps(entry.get("failures"), now)
+            try:
+                last_outcome_at = float(entry.get("last_outcome_at") or 0)
+            except (TypeError, ValueError):
+                last_outcome_at = 0
+            if (
+                not entry["attempts"]
+                and not entry["failures"]
+                and last_outcome_at < cutoff
+            ):
+                bucket.pop(key, None)
+
+    path = _refinement_guard_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _recent_timestamps(values: Any, now: float) -> List[float]:
+    cutoff = now - REFINEMENT_ATTEMPT_WINDOW_SECONDS
+    recent = []
+    for value in values if isinstance(values, list) else []:
+        try:
+            timestamp = float(value)
+        except (TypeError, ValueError):
+            continue
+        if timestamp >= cutoff:
+            recent.append(timestamp)
+    return recent
+
+
+def _guard_entry(data: Dict[str, Any], candidate: Dict[str, Any]) -> Dict[str, Any]:
+    fingerprint = str(candidate.get("fingerprint") or "")
+    entries = data.setdefault("fingerprints", {})
+    entry = entries.setdefault(fingerprint, {})
+    entry["skill"] = str(candidate.get("target", {}).get("skill") or "")
+    return entry
+
+
+def _skill_guard_entry(data: Dict[str, Any], skill: str) -> Dict[str, Any]:
+    skills = data.setdefault("skills", {})
+    return skills.setdefault(skill, {})
+
+
+def stage_refinement_write(
+    payload: Dict[str, Any], *, summary: str, origin: str,
+    candidate: Dict[str, Any]
+):
+    """Atomically enforce anti-loop policy and stage one refinement proposal."""
+    ok, message = _validate_candidate_integrity({
+        "payload": payload,
+        "refinement_candidate": candidate,
+    })
+    if not ok:
+        return None, message
+
+    skill = str(candidate.get("target", {}).get("skill") or "")
+    fingerprint = str(candidate.get("fingerprint") or "")
+    if not skill or not fingerprint:
+        return None, "Refinement candidate is missing its loop-guard identity."
+
+    with _locked_refinement_guard():
+        for pending in list_pending(SKILLS):
+            active = pending.get("refinement_candidate")
+            if not isinstance(active, dict):
+                continue
+            active_skill = str(active.get("target", {}).get("skill") or "")
+            if active_skill == skill:
+                return None, (
+                    f"Skill '{skill}' already has an active refinement candidate "
+                    f"({pending.get('id', '')})."
+                )
+
+        now = time.time()
+        try:
+            data = _load_refinement_guard()
+        except RuntimeError as exc:
+            return None, str(exc)
+        fingerprint_entry = _guard_entry(data, candidate)
+        skill_entry = _skill_guard_entry(data, skill)
+        attempts = _recent_timestamps(skill_entry.get("attempts"), now)
+        failures = _recent_timestamps(skill_entry.get("failures"), now)
+        skill_entry["attempts"] = attempts
+        skill_entry["failures"] = failures
+
+        fingerprint_attempts = _recent_timestamps(
+            fingerprint_entry.get("attempts"), now
+        )
+        fingerprint_entry["attempts"] = fingerprint_attempts
+        if (
+            fingerprint_attempts
+            and fingerprint_entry.get("last_outcome")
+            in {"rejected", "failed", "applied"}
+        ):
+            return None, (
+                f"Duplicate refinement candidate blocked for skill '{skill}'; "
+                "the same base and diff were already decided in this guard window."
+            )
+
+        if len(attempts) >= REFINEMENT_MAX_ATTEMPTS:
+            return None, (
+                f"Refinement attempt limit reached for skill '{skill}' "
+                f"({REFINEMENT_MAX_ATTEMPTS} per 7 days)."
+            )
+
+        last_outcome = str(skill_entry.get("last_outcome") or "")
+        try:
+            last_outcome_at = float(skill_entry.get("last_outcome_at") or 0)
+        except (TypeError, ValueError):
+            last_outcome_at = 0
+        if (
+            last_outcome in {"rejected", "failed"}
+            and now - last_outcome_at < REFINEMENT_COOLDOWN_SECONDS
+        ):
+            return None, (
+                f"Refinement cooldown is active for skill '{skill}' after "
+                f"{last_outcome}."
+            )
+
+        record = stage_write(
+            SKILLS,
+            payload,
+            summary=summary,
+            origin=origin,
+            refinement_candidate=candidate,
+        )
+        if get_pending(SKILLS, record["id"]) is None:
+            return None, "Refinement candidate could not be persisted safely."
+
+        for entry in (skill_entry, fingerprint_entry):
+            own_attempts = _recent_timestamps(entry.get("attempts"), now)
+            entry["attempts"] = own_attempts + [now]
+            entry["last_outcome"] = "staged"
+            entry["last_outcome_at"] = now
+        try:
+            _save_refinement_guard(data)
+        except Exception as exc:
+            discard_pending(SKILLS, record["id"])
+            return None, f"Refinement loop guard could not be persisted: {exc}"
+        return record, ""
+
+
+def can_attempt_refinement_apply(record: Dict[str, Any]):
+    """Block immediate retries and cap failed applies for one candidate."""
+    candidate = record.get("refinement_candidate")
+    if not isinstance(candidate, dict):
+        return True, ""
+    if record.get("refinement_apply_state") == "applied_guard_error":
+        return False, (
+            "Refinement write was already applied but its guard outcome failed; "
+            "the pending record is retained and must not be retried."
+        )
+    ok, message = _validate_candidate_integrity(record)
+    if not ok:
+        return False, message
+
+    with _locked_refinement_guard():
+        now = time.time()
+        data = _load_refinement_guard()
+        skill = str(candidate.get("target", {}).get("skill") or "")
+        entry = _skill_guard_entry(data, skill)
+        failures = _recent_timestamps(entry.get("failures"), now)
+        if len(failures) >= REFINEMENT_MAX_ATTEMPTS:
+            return False, (
+                "Refinement apply attempt limit reached; reject this candidate "
+                "and create a corrected proposal after the guard window."
+            )
+        if failures:
+            try:
+                last_outcome_at = float(entry.get("last_outcome_at") or 0)
+            except (TypeError, ValueError):
+                last_outcome_at = 0
+            if (
+                entry.get("last_outcome") == "failed"
+                and now - last_outcome_at < REFINEMENT_COOLDOWN_SECONDS
+            ):
+                return False, "Refinement apply cooldown is active after the last failure."
+    return True, ""
+
+
+def record_refinement_candidate_outcome(
+    record: Dict[str, Any], outcome: str
+):
+    """Persist rejected/failed/applied outcomes for anti-loop enforcement."""
+    if outcome not in {"rejected", "failed", "applied"}:
+        return False, f"Unsupported refinement outcome: {outcome}"
+    candidate = record.get("refinement_candidate")
+    if not isinstance(candidate, dict):
+        return True, ""
+    integrity_ok, message = _validate_candidate_integrity(record)
+    if not integrity_ok and outcome != "rejected":
+        return False, message
+
+    try:
+        with _locked_refinement_guard():
+            now = time.time()
+            data = _load_refinement_guard()
+            payload = record.get("payload", {})
+            skill = str(
+                payload.get("name")
+                or candidate.get("target", {}).get("skill")
+                or ""
+            )
+            entries = [_skill_guard_entry(data, skill)]
+            if integrity_ok:
+                entries.append(_guard_entry(data, candidate))
+            for entry in entries:
+                entry["attempts"] = _recent_timestamps(
+                    entry.get("attempts"), now
+                )
+                failures = _recent_timestamps(entry.get("failures"), now)
+                if outcome == "failed":
+                    failures.append(now)
+                entry["failures"] = failures
+                entry["last_outcome"] = outcome
+                entry["last_outcome_at"] = now
+            _save_refinement_guard(data)
+        return True, ""
+    except Exception as exc:
+        return False, f"Refinement loop guard update failed: {exc}"
+
+
+def validate_refinement_candidate_base(record: Dict[str, Any]):
+    """Fail closed when the approved candidate no longer matches its base."""
+    ok, message = _validate_candidate_integrity(record)
+    if not ok:
+        return ok, message
+    candidate = record.get("refinement_candidate")
+    if not isinstance(candidate, dict):
+        return True, ""
+    try:
+        skill_dir, target, label, error = _resolve_refinement_target(
+            record.get("payload", {})
+        )
+    except Exception as exc:
+        return False, f"Refinement candidate target check failed: {exc}"
+    if error or skill_dir is None or target is None:
+        return False, f"Refinement candidate base changed: {error or label}"
+    bound_root = str(candidate.get("target", {}).get("root") or "")
+    if str(skill_dir.resolve()) != bound_root:
+        return False, "Refinement target root changed; create a new candidate."
+    if _text_state(target) != candidate.get("base"):
+        return False, "Refinement candidate base changed; create and approve a new candidate."
+    return True, ""
+
+
+def validate_refinement_candidate_result(record: Dict[str, Any]):
+    """Verify that the approved skill write produced the frozen result."""
+    candidate = record.get("refinement_candidate")
+    if not isinstance(candidate, dict):
+        return True, ""
+    try:
+        skill_dir, target, label, error = _resolve_refinement_target(
+            record.get("payload", {})
+        )
+    except Exception as exc:
+        return False, f"Refinement result check failed: {exc}"
+    if error or skill_dir is None or target is None:
+        return False, f"Refinement result target missing: {error or label}"
+    bound_root = str(candidate.get("target", {}).get("root") or "")
+    if str(skill_dir.resolve()) != bound_root:
+        return False, "Refinement target root changed after apply."
+    if _text_state(target) != candidate.get("proposed"):
+        return False, "Refinement result hash did not match the approved candidate."
+    return True, ""
+
 
 def skill_gist(action: str, name: str, *, content: str = "",
                file_path: str = "", old_string: str = "",
@@ -427,14 +999,18 @@ def _frontmatter_description(content: str) -> str:
 
 
 def skill_pending_diff(record: Dict[str, Any]) -> str:
-    """Build a full unified diff (or full content) for a staged skill write.
+    """Build the review diff for a staged skill write.
 
-    Used by /skills diff <id> on a surface that can render it (CLI pager, web
-    dashboard, or by opening the pending JSON file). For create this is the new
-    file content; for edit/patch it is a unified diff against the current
-    on-disk skill.
+    Refinement candidates return the integrity-bound frozen diff captured at
+    staging. Ordinary pending writes retain the legacy live-diff behaviour.
     """
-    import difflib
+    candidate = record.get("refinement_candidate")
+    if isinstance(candidate, dict):
+        ok, message = _validate_candidate_integrity(record)
+        if not ok:
+            return f"({message})"
+        return str(candidate.get("diff") or "(no textual change)")
+
     payload = record.get("payload", {})
     action = payload.get("action", "")
     name = payload.get("name", "")


### PR DESCRIPTION
## Summary

Adds a narrowly scoped native refinement-candidate contract to the existing Hermes skill write-approval path.

- Binds refinement candidates to the exact skill root, target file, base state, payload, and frozen diff.
- Revalidates the approved base immediately before applying the patch.
- Requires a successful Curator snapshot before an approved refinement write.
- Keeps `skill_manage` as the only skill writer.
- Serializes candidate approve/reject operations.
- Retains fail-closed pending state when the final guard outcome cannot be persisted.
- Rejects semantically corrupted guard state.
- Limits refinement candidates to targeted patch operations.

## Loop protection

- At most one active candidate per skill.
- Exact duplicate candidates are blocked.
- 24-hour cooldown after rejection or apply failure.
- At most three distinct attempts per skill within seven days.
- No scheduler.
- No autonomous retry.
- No automatic approval or re-apply.
- No recursive refinement or new background loop.

## Compatibility

Legacy pending skill writes continue to use the existing approval and replay behavior. The stricter contract applies only to refinement candidates created by background review.

## Verification

- 88 tests passed
- 3 tests skipped
- 1 Windows symlink-permission test deselected
- Python compilation passed
- `git diff --check` passed
- No new scheduler, retry loop, auto-approve, or re-apply control path detected

## Scope exclusions

This change does not add probation, promotion, causal outcome measurement, automated rollback, a new agent, plugin, scheduler, or skill.
