### PR TITLE
fix(desktop): route session windows to their owning profile

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -34,6 +34,7 @@ import {
   pathWithGlobalRemoteProfile,
   profileHasRemoteConnection,
   profileRemoteOverride,
+  profileScopedConnection,
   profileSshOverride,
   resolveAuthMode,
   resolveProfileBackendRoute,
@@ -276,6 +277,29 @@ test('resolveProfileBackendRoute only tags a descriptor when the backend is shar
     assert.equal(Boolean(resolved.descriptorProfile), resolved.scopePath)
     assert.ok(!resolved.descriptorProfile || resolved.backend === 'primary')
   }
+})
+
+test('profileScopedConnection stamps the effective named primary when the raw descriptor omits it', () => {
+  const connection = { baseUrl: 'http://127.0.0.1:3000', token: 'token' }
+
+  const scoped = profileScopedConnection(connection, 'life', {
+    backend: 'primary',
+    descriptorProfile: null,
+    scopePath: false
+  })
+
+  assert.deepEqual(scoped, { ...connection, profile: 'life' })
+  assert.equal('profile' in connection, false)
+})
+
+test('profileScopedConnection preserves a shared-backend alias over the effective primary', () => {
+  const scoped = profileScopedConnection({ baseUrl: 'https://remote.example.com' }, 'default', {
+    backend: 'primary',
+    descriptorProfile: 'life',
+    scopePath: true
+  })
+
+  assert.equal(scoped.profile, 'life')
 })
 
 // --- pathWithGlobalRemoteProfile ---

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -427,6 +427,13 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
   return { backend: 'pool', descriptorProfile: null, scopePath: false }
 }
 
+/** Stamp the desktop profile scope on a backend connection descriptor. */
+function profileScopedConnection(connection, effectiveProfile, route: ProfileBackendRoute) {
+  const profile = connectionScopeKey(route.descriptorProfile) || connectionScopeKey(effectiveProfile) || 'default'
+
+  return { ...connection, profile }
+}
+
 /**
  * Add renderer-side `request.profile` to a REST path when the route says the
  * serving backend is not already scoped to that profile.
@@ -579,6 +586,7 @@ export {
   PRIVY_SESSION_COOKIE_VARIANTS,
   profileHasRemoteConnection,
   profileRemoteOverride,
+  profileScopedConnection,
   profileSshOverride,
   resolveAuthMode,
   resolveProfileBackendRoute,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8871,9 +8871,9 @@ function wireWindowReveal(win, { show, onRevealed }: { show?: () => void; onReve
 
 // Secondary "session windows" — one extra OS window per chat so a user can
 // work with multiple chats side by side. The registry guarantees one window
-// per sessionId (re-opening focuses the existing window) and self-cleans on
-// close. The primary mainWindow is never tracked here. Pure logic + the URL
-// builder live in session-windows.ts so they stay unit-testable.
+// per profile + sessionId (re-opening focuses the existing window) and
+// self-cleans on close. The primary mainWindow is never tracked here. Pure
+// logic + the URL builder live in session-windows.ts so they stay unit-testable.
 const sessionWindows = createSessionWindowRegistry()
 
 function focusWindow(win) {
@@ -8892,7 +8892,11 @@ function focusWindow(win) {
   win.focus()
 }
 
-function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
+function spawnSecondaryWindow({
+  profile,
+  sessionId,
+  watch
+}: { profile?: null | string; sessionId?: string; watch?: boolean } = {}) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -8952,6 +8956,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     win,
     buildSessionWindowUrl(sessionId, {
       devServer: DEV_SERVER,
+      profile,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
       watch
     }),
@@ -8962,8 +8967,8 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
+function createSessionWindow(sessionId, { profile = null, watch = false } = {}) {
+  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ profile, sessionId, watch }), profile)
 }
 
 // Additional full "instance" windows — peers of the primary that render the
@@ -10123,7 +10128,13 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
     return { ok: false, error: 'invalid-session-id' }
   }
 
-  createSessionWindow(sessionId.trim(), { watch: opts?.watch === true })
+  const profile = typeof opts?.profile === 'string' ? opts.profile.trim() : ''
+
+  if (profile && profile !== 'default' && !PROFILE_NAME_RE.test(profile)) {
+    return { ok: false, error: 'invalid-profile' }
+  }
+
+  createSessionWindow(sessionId.trim(), { profile: profile || null, watch: opts?.watch === true })
 
   return { ok: true }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -163,9 +163,13 @@ import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
-import { createPrimaryProfileOwner, resolveEffectivePrimaryProfile } from './primary-profile'
+import {
+  createPrimaryProfileOwner,
+  parseDesktopProfilePreference,
+  resolveEffectivePrimaryProfile
+} from './primary-profile'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
-import { normalizeDesktopProfile, PROFILE_NAME_RE } from './profile-name'
+import { normalizeDesktopProfile } from './profile-name'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
@@ -6916,7 +6920,9 @@ function sanitizeConnectionProfiles(raw: Record<string, any>) {
       continue
     }
 
-    if (name !== 'default' && !PROFILE_NAME_RE.test(name)) {
+    const profile = normalizeDesktopProfile(name)
+
+    if (!profile) {
       continue
     }
 
@@ -6928,7 +6934,7 @@ function sanitizeConnectionProfiles(raw: Record<string, any>) {
           ssh.token = entry.token
         }
 
-        out[name] = ssh
+        out[profile] = ssh
       }
 
       continue
@@ -6975,7 +6981,7 @@ function sanitizeConnectionProfiles(raw: Record<string, any>) {
       }
     }
 
-    out[name] = cleaned
+    out[profile] = cleaned
   }
 
   return out
@@ -7041,30 +7047,31 @@ function writeDesktopConnectionConfig(config) {
 function readActiveDesktopProfile() {
   try {
     const raw = fs.readFileSync(DESKTOP_PROFILE_CONFIG_PATH, 'utf8')
-    const parsed = JSON.parse(raw)
-    const name = parsed && typeof parsed.profile === 'string' ? parsed.profile.trim() : ''
 
-    if (name && (name === 'default' || PROFILE_NAME_RE.test(name))) {
-      return name
+    return parseDesktopProfilePreference(raw)
+  } catch (error) {
+    // A missing file means no preference. Malformed persisted state must fail
+    // visibly rather than retargeting the primary backend to another profile.
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null
     }
-  } catch {
-    // Missing or malformed → no preference.
-  }
 
-  return null
+    throw error
+  }
 }
 
 function writeActiveDesktopProfile(name) {
   const value = typeof name === 'string' ? name.trim() : ''
+  const profile = value ? normalizeDesktopProfile(value) : null
 
-  if (value && value !== 'default' && !PROFILE_NAME_RE.test(value)) {
+  if (value && !profile) {
     throw new Error(`Invalid profile name: ${value}`)
   }
 
   fs.mkdirSync(path.dirname(DESKTOP_PROFILE_CONFIG_PATH), { recursive: true })
-  writeFileAtomic(DESKTOP_PROFILE_CONFIG_PATH, JSON.stringify({ profile: value || null }, null, 2))
+  writeFileAtomic(DESKTOP_PROFILE_CONFIG_PATH, JSON.stringify({ profile }, null, 2))
 
-  return value || null
+  return profile
 }
 
 // Sanitize a connection config into the renderer-facing shape. With no
@@ -8466,7 +8473,7 @@ async function prepareProfileDeleteRequest(request) {
 
   const decision = decideProfileDeleteAction(profile, {
     isDefaultProfile: p => p === 'default',
-    isValidProfileName: p => PROFILE_NAME_RE.test(p),
+    isValidProfileName: p => normalizeDesktopProfile(p) !== null,
     primaryProfileKey
   })
 
@@ -9572,7 +9579,12 @@ function restoreMainWindowFromHud() {
 }
 
 function openHudWindow(sessionId, profile) {
-  const profileKey = typeof profile === 'string' && profile.trim() ? profile.trim() : null
+  const rawProfile = typeof profile === 'string' ? profile.trim() : ''
+  const profileKey = rawProfile ? normalizeDesktopProfile(rawProfile) : null
+
+  if (rawProfile && !profileKey) {
+    throw new Error(`Invalid profile name: ${rawProfile}`)
+  }
 
   if (hudWindow && !hudWindow.isDestroyed()) {
     // Pointed at another PROFILE: the live renderer is bound to the old
@@ -10305,10 +10317,14 @@ ipcMain.on('hermes:pet-overlay:control', (_event, payload) => {
 
 // --- HUD mode (chrome-free floating chat) -----------------------------------
 ipcMain.handle('hermes:hud:open', async (_event, request) => {
-  openHudWindow(
-    typeof request?.sessionId === 'string' ? request.sessionId : null,
-    typeof request?.profile === 'string' ? request.profile : null
-  )
+  const rawProfile = typeof request?.profile === 'string' ? request.profile.trim() : ''
+  const profile = rawProfile ? normalizeDesktopProfile(rawProfile) : null
+
+  if (rawProfile && !profile) {
+    return { ok: false, error: 'invalid-profile' }
+  }
+
+  openHudWindow(typeof request?.sessionId === 'string' ? request.sessionId : null, profile)
 
   return { ok: true }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -69,6 +69,7 @@ import {
   pathWithGlobalRemoteProfile,
   profileHasRemoteConnection,
   profileRemoteOverride,
+  profileScopedConnection,
   profileSshOverride,
   resolveAuthMode,
   resolveProfileBackendRoute,
@@ -8136,9 +8137,10 @@ async function ensureBackend(profile) {
   if (route.backend === 'primary') {
     const connection = await startHermes()
 
-    // A shared backend still owes the caller its profile scope, so renderer-side
-    // WebSocket, filesystem, and cache routing target the selected profile.
-    return route.descriptorProfile ? { ...connection, profile: route.descriptorProfile } : connection
+    // Every connection owes the renderer its effective desktop profile. The raw
+    // primary descriptor predates profiles and omits it, while a shared remote
+    // route can override it with the selected alias.
+    return profileScopedConnection(connection, key, route)
   }
 
   const existing = backendPool.get(key)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -163,6 +163,7 @@ import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import { normalizeDesktopProfile, PROFILE_NAME_RE } from './profile-name'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
@@ -628,9 +629,6 @@ const DESKTOP_WINDOW_STATE_PATH = path.join(app.getPath('userData'), 'window-sta
 // ~/.hermes/active_profile file. Unset (null) preserves the legacy behavior:
 // no --profile flag, so the backend honors active_profile / default.
 const DESKTOP_PROFILE_CONFIG_PATH = path.join(app.getPath('userData'), 'active-profile.json')
-// Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never hand the backend a
-// value its profile resolver would reject and exit on.
-const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
 // Branch we track for self-update. The GUI work has merged to main, so this
 // tracks main. User can also override at runtime via
 // hermesDesktop.updates.setBranch().
@@ -8129,7 +8127,10 @@ function profileRouteOptions(profile) {
 // resolveProfileBackendRoute(). An empty / unknown profile resolves to the
 // primary, so legacy callers are unchanged.
 async function ensureBackend(profile) {
-  const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
+  // All renderer-provided profile values converge here (`hermes:connection`,
+  // REST, and fresh WS tickets). Malformed URL/query input is treated as an
+  // absent hint and cannot become a pool key or `--profile` child argument.
+  const key = normalizeDesktopProfile(profile) ?? primaryProfileKey()
   const route = resolveProfileBackendRoute(key, profileRouteOptions(key))
 
   if (route.backend === 'primary') {
@@ -10128,13 +10129,17 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
     return { ok: false, error: 'invalid-session-id' }
   }
 
-  const profile = typeof opts?.profile === 'string' ? opts.profile.trim() : ''
+  const requestedProfile = typeof opts?.profile === 'string' ? opts.profile.trim() : ''
+  const profile = normalizeDesktopProfile(requestedProfile)
 
-  if (profile && profile !== 'default' && !PROFILE_NAME_RE.test(profile)) {
+  if (requestedProfile && !profile) {
     return { ok: false, error: 'invalid-profile' }
   }
 
-  createSessionWindow(sessionId.trim(), { profile: profile || null, watch: opts?.watch === true })
+  createSessionWindow(sessionId.trim(), {
+    profile: profile ?? primaryProfileKey(),
+    watch: opts?.watch === true
+  })
 
   return { ok: true }
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -163,6 +163,7 @@ import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
+import { createPrimaryProfileOwner, resolveEffectivePrimaryProfile } from './primary-profile'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { normalizeDesktopProfile, PROFILE_NAME_RE } from './profile-name'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
@@ -8016,6 +8017,15 @@ function stopBackendChild(child) {
   stopBackendChildImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS })
 }
 
+// Frozen identity of the primary backend for its lifetime. The legacy
+// `active_profile` file is launch input, not a live routing signal.
+const primaryProfileOwner = createPrimaryProfileOwner(() =>
+  resolveEffectivePrimaryProfile({
+    desktopProfile: readActiveDesktopProfile(),
+    hermesHome: HERMES_HOME
+  })
+)
+
 // Soft gateway-mode apply: tear down the primary without resetting boot UI or
 // reloading the renderer. The shell stays up; the renderer wipes session lists
 // (so skeletons retrigger) and re-dials. Distinct from hard re-home (profile
@@ -8024,6 +8034,7 @@ function resetHermesConnection({ soft = false } = {}) {
   backendStartFailure = null
   remoteReauthFailure = null
   remoteLiveness.clear()
+  primaryProfileOwner.reset()
   const hermesProcess = backendConnectionState.invalidate()
   stopBackendChild(hermesProcess)
 
@@ -8108,11 +8119,12 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
   })
 }
 
-// The profile the primary (window) backend runs as. readActiveDesktopProfile()
-// returns the desktop's stored preference, or null when unset (legacy launch
-// that defers to active_profile / default).
+// The profile the primary (window) backend actually runs as. An explicit
+// Desktop preference wins; otherwise mirror the CLI's profile-scoped
+// HERMES_HOME → legacy active_profile → default precedence. Freeze the result
+// until teardown so an external sticky-file edit cannot relabel a live backend.
 function primaryProfileKey() {
-  return readActiveDesktopProfile() || 'default'
+  return primaryProfileOwner.get()
 }
 
 // Options describing the current connection setup for `resolveProfileBackendRoute`.
@@ -10686,7 +10698,7 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   return sanitizeDesktopConnectionConfig(config, payload?.profile)
 })
 
-ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
+ipcMain.handle('hermes:profile:get', async () => ({ profile: primaryProfileKey() }))
 ipcMain.handle('hermes:profile:set', async (_event, name) => {
   const next = writeActiveDesktopProfile(name)
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -33,7 +33,7 @@ import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
-import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
+import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
 import { isReauthRequiredError, waitForHermesReady } from './backend-health'
@@ -8562,18 +8562,10 @@ async function startHermes() {
     // Resolve for the desktop's primary profile so a per-profile remote
     // override on the active profile is honored (falls back to env / global).
     const token = crypto.randomBytes(32).toString('base64url')
-    // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
-    const backendArgs = ['serve', '--host', '127.0.0.1', '--port', '0']
-    // Pin the desktop's chosen profile via the global --profile flag. This is
-    // deterministic (it wins over the sticky ~/.hermes/active_profile file) and
-    // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
-    // unset preference keeps the legacy launch so existing installs are
-    // unaffected.
-    const activeProfile = readActiveDesktopProfile()
-
-    if (activeProfile) {
-      backendArgs.unshift('--profile', activeProfile)
-    }
+    // Pin every local launch to the frozen owner. Without this, a crash respawn
+    // could follow a changed legacy active_profile file while Electron kept
+    // routing and labeling the connection as the prior owner.
+    const backendArgs = serveBackendArgs(primaryProfileKey())
 
     const setup = await runPrimaryBackendStartup({
       connectRemote,

--- a/apps/desktop/electron/primary-profile.test.ts
+++ b/apps/desktop/electron/primary-profile.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test, vi } from 'vitest'
+
+import { createPrimaryProfileOwner, resolveEffectivePrimaryProfile } from './primary-profile'
+
+const ROOT = path.join(path.parse(process.cwd()).root, 'tmp', 'hermes-home')
+
+test('explicit desktop preference wins without reading legacy state', () => {
+  const readFile = vi.fn(() => 'legacy')
+
+  assert.equal(resolveEffectivePrimaryProfile({ desktopProfile: ' life ', hermesHome: ROOT, readFile }), 'life')
+  assert.equal(readFile.mock.calls.length, 0)
+})
+
+test('profile-scoped HERMES_HOME mirrors the CLI profile override', () => {
+  const readFile = vi.fn(() => 'legacy')
+  const hermesHome = path.join(ROOT, 'profiles', 'coder')
+
+  assert.equal(resolveEffectivePrimaryProfile({ desktopProfile: null, hermesHome, readFile }), 'coder')
+  assert.equal(readFile.mock.calls.length, 0)
+})
+
+test('legacy active_profile owns an unpinned root launch', () => {
+  const readFile = vi.fn(() => ' life\n')
+
+  assert.equal(resolveEffectivePrimaryProfile({ desktopProfile: null, hermesHome: ROOT, readFile }), 'life')
+  assert.deepEqual(readFile.mock.calls, [[path.join(ROOT, 'active_profile'), 'utf8']])
+})
+
+test('missing or malformed legacy state falls back to default', () => {
+  assert.equal(
+    resolveEffectivePrimaryProfile({
+      desktopProfile: null,
+      hermesHome: ROOT,
+      readFile: () => {
+        throw new Error('missing')
+      }
+    }),
+    'default'
+  )
+  assert.equal(
+    resolveEffectivePrimaryProfile({ desktopProfile: null, hermesHome: ROOT, readFile: () => '../bad' }),
+    'default'
+  )
+})
+
+test('primary owner stays frozen until the backend lifecycle resets', () => {
+  let resolved = 'life'
+  const owner = createPrimaryProfileOwner(() => resolved)
+
+  assert.equal(owner.get(), 'life')
+  resolved = 'work'
+  assert.equal(owner.get(), 'life')
+
+  owner.reset()
+  assert.equal(owner.get(), 'work')
+})

--- a/apps/desktop/electron/primary-profile.test.ts
+++ b/apps/desktop/electron/primary-profile.test.ts
@@ -4,7 +4,11 @@ import path from 'node:path'
 import { test, vi } from 'vitest'
 
 import { serveBackendArgs } from './backend-command'
-import { createPrimaryProfileOwner, resolveEffectivePrimaryProfile } from './primary-profile'
+import {
+  createPrimaryProfileOwner,
+  parseDesktopProfilePreference,
+  resolveEffectivePrimaryProfile
+} from './primary-profile'
 
 const ROOT = path.join(path.parse(process.cwd()).root, 'tmp', 'hermes-home')
 
@@ -15,12 +19,41 @@ test('explicit desktop preference wins without reading legacy state', () => {
   assert.equal(readFile.mock.calls.length, 0)
 })
 
+test('invalid explicit desktop preference fails without reading legacy state', () => {
+  const readFile = vi.fn(() => 'life')
+
+  assert.throws(
+    () => resolveEffectivePrimaryProfile({ desktopProfile: 'root', hermesHome: ROOT, readFile }),
+    /Invalid profile name in Desktop preference/
+  )
+  assert.equal(readFile.mock.calls.length, 0)
+})
+
+test('malformed or wrongly typed persisted Desktop preferences fail closed', () => {
+  assert.throws(() => parseDesktopProfilePreference('{'), SyntaxError)
+  assert.throws(() => parseDesktopProfilePreference('{"profile":42}'), /Invalid profile name in Desktop preference/)
+  assert.equal(parseDesktopProfilePreference('{"profile":null}'), null)
+  assert.equal(parseDesktopProfilePreference('{"profile":"  "}'), null)
+})
+
 test('profile-scoped HERMES_HOME mirrors the CLI profile override', () => {
   const readFile = vi.fn(() => 'legacy')
   const hermesHome = path.join(ROOT, 'profiles', 'coder')
 
   assert.equal(resolveEffectivePrimaryProfile({ desktopProfile: null, hermesHome, readFile }), 'coder')
   assert.equal(readFile.mock.calls.length, 0)
+})
+
+test('invalid profile-scoped HERMES_HOME fails before backend spawn', () => {
+  assert.throws(
+    () =>
+      resolveEffectivePrimaryProfile({
+        desktopProfile: null,
+        hermesHome: path.join(ROOT, 'profiles', 'sudo'),
+        readFile: vi.fn(() => 'life')
+      }),
+    /Invalid profile name in HERMES_HOME/
+  )
 })
 
 test('legacy active_profile owns an unpinned root launch', () => {
@@ -30,20 +63,52 @@ test('legacy active_profile owns an unpinned root launch', () => {
   assert.deepEqual(readFile.mock.calls, [[path.join(ROOT, 'active_profile'), 'utf8']])
 })
 
-test('missing or malformed legacy state falls back to default', () => {
+test('missing or empty legacy state falls back to default', () => {
+  const missing = Object.assign(new Error('missing'), { code: 'ENOENT' })
+
   assert.equal(
     resolveEffectivePrimaryProfile({
       desktopProfile: null,
       hermesHome: ROOT,
       readFile: () => {
-        throw new Error('missing')
+        throw missing
       }
     }),
     'default'
   )
   assert.equal(
-    resolveEffectivePrimaryProfile({ desktopProfile: null, hermesHome: ROOT, readFile: () => '../bad' }),
+    resolveEffectivePrimaryProfile({ desktopProfile: null, hermesHome: ROOT, readFile: () => '  ' }),
     'default'
+  )
+})
+
+test('non-missing active_profile read failures surface to desktop boot', () => {
+  const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+
+  assert.throws(
+    () =>
+      resolveEffectivePrimaryProfile({
+        desktopProfile: null,
+        hermesHome: ROOT,
+        readFile: () => {
+          throw denied
+        }
+      }),
+    error => error === denied
+  )
+})
+
+test('non-empty invalid legacy state fails instead of silently booting default', () => {
+  assert.throws(
+    () => resolveEffectivePrimaryProfile({ desktopProfile: null, hermesHome: ROOT, readFile: () => '../bad' }),
+    /Invalid profile name in active_profile/
+  )
+})
+
+test('reserved legacy state fails instead of reaching backend spawn', () => {
+  assert.throws(
+    () => resolveEffectivePrimaryProfile({ desktopProfile: null, hermesHome: ROOT, readFile: () => 'root' }),
+    /Invalid profile name in active_profile/
   )
 })
 

--- a/apps/desktop/electron/primary-profile.test.ts
+++ b/apps/desktop/electron/primary-profile.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { test, vi } from 'vitest'
 
+import { serveBackendArgs } from './backend-command'
 import { createPrimaryProfileOwner, resolveEffectivePrimaryProfile } from './primary-profile'
 
 const ROOT = path.join(path.parse(process.cwd()).root, 'tmp', 'hermes-home')
@@ -56,4 +57,14 @@ test('primary owner stays frozen until the backend lifecycle resets', () => {
 
   owner.reset()
   assert.equal(owner.get(), 'work')
+})
+
+test('local respawns stay pinned when the legacy sticky profile changes', () => {
+  let stickyProfile = 'life'
+  const owner = createPrimaryProfileOwner(() => stickyProfile)
+
+  assert.deepEqual(serveBackendArgs(owner.get()), ['--profile', 'life', 'serve', '--host', '127.0.0.1', '--port', '0'])
+
+  stickyProfile = 'work'
+  assert.deepEqual(serveBackendArgs(owner.get()), ['--profile', 'life', 'serve', '--host', '127.0.0.1', '--port', '0'])
 })

--- a/apps/desktop/electron/primary-profile.ts
+++ b/apps/desktop/electron/primary-profile.ts
@@ -9,6 +9,41 @@ interface EffectivePrimaryProfileOptions {
   readFile?: (file: string, encoding: BufferEncoding) => string
 }
 
+function resolveConfiguredProfile(value: unknown, source: string): null | string {
+  if (value == null) {
+    return null
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid profile name in ${source}: ${JSON.stringify(value)}`)
+  }
+
+  const raw = value.trim()
+
+  if (!raw) {
+    return null
+  }
+
+  const profile = normalizeDesktopProfile(raw)
+
+  if (!profile) {
+    throw new Error(`Invalid profile name in ${source}: ${JSON.stringify(raw)}`)
+  }
+
+  return profile
+}
+
+/** Parse the persisted Desktop preference without hiding malformed state. */
+export function parseDesktopProfilePreference(raw: string): null | string {
+  const parsed: unknown = JSON.parse(raw)
+
+  if (!parsed || typeof parsed !== 'object' || !('profile' in parsed)) {
+    return null
+  }
+
+  return resolveConfiguredProfile((parsed as { profile: unknown }).profile, 'Desktop preference')
+}
+
 /** Keep the resolved owner stable until the primary backend is torn down. */
 export function createPrimaryProfileOwner(resolve: () => string) {
   let current: null | string = null
@@ -31,7 +66,7 @@ export function resolveEffectivePrimaryProfile({
   hermesHome,
   readFile = (file, encoding) => fs.readFileSync(file, encoding)
 }: EffectivePrimaryProfileOptions): string {
-  const explicit = normalizeDesktopProfile(desktopProfile)
+  const explicit = resolveConfiguredProfile(desktopProfile, 'Desktop preference')
 
   if (explicit) {
     return explicit
@@ -40,12 +75,19 @@ export function resolveEffectivePrimaryProfile({
   const resolvedHome = path.resolve(hermesHome)
 
   if (path.basename(path.dirname(resolvedHome)) === 'profiles') {
-    return normalizeDesktopProfile(path.basename(resolvedHome)) ?? 'default'
+    return resolveConfiguredProfile(path.basename(resolvedHome), 'HERMES_HOME') ?? 'default'
   }
 
   try {
-    return normalizeDesktopProfile(readFile(path.join(resolvedHome, 'active_profile'), 'utf8')) ?? 'default'
-  } catch {
-    return 'default'
+    return (
+      resolveConfiguredProfile(readFile(path.join(resolvedHome, 'active_profile'), 'utf8'), 'active_profile') ??
+      'default'
+    )
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return 'default'
+    }
+
+    throw error
   }
 }

--- a/apps/desktop/electron/primary-profile.ts
+++ b/apps/desktop/electron/primary-profile.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { normalizeDesktopProfile } from './profile-name'
+
+interface EffectivePrimaryProfileOptions {
+  desktopProfile: unknown
+  hermesHome: string
+  readFile?: (file: string, encoding: BufferEncoding) => string
+}
+
+/** Keep the resolved owner stable until the primary backend is torn down. */
+export function createPrimaryProfileOwner(resolve: () => string) {
+  let current: null | string = null
+
+  return {
+    get() {
+      current ??= resolve()
+
+      return current
+    },
+    reset() {
+      current = null
+    }
+  }
+}
+
+/** Mirror the CLI's profile precedence for an unpinned Desktop backend launch. */
+export function resolveEffectivePrimaryProfile({
+  desktopProfile,
+  hermesHome,
+  readFile = (file, encoding) => fs.readFileSync(file, encoding)
+}: EffectivePrimaryProfileOptions): string {
+  const explicit = normalizeDesktopProfile(desktopProfile)
+
+  if (explicit) {
+    return explicit
+  }
+
+  const resolvedHome = path.resolve(hermesHome)
+
+  if (path.basename(path.dirname(resolvedHome)) === 'profiles') {
+    return normalizeDesktopProfile(path.basename(resolvedHome)) ?? 'default'
+  }
+
+  try {
+    return normalizeDesktopProfile(readFile(path.join(resolvedHome, 'active_profile'), 'utf8')) ?? 'default'
+  } catch {
+    return 'default'
+  }
+}

--- a/apps/desktop/electron/profile-name.test.ts
+++ b/apps/desktop/electron/profile-name.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { normalizeDesktopProfile } from './profile-name'
+
+test('normalizeDesktopProfile accepts canonical desktop profile names', () => {
+  assert.equal(normalizeDesktopProfile(' life_2 '), 'life_2')
+  assert.equal(normalizeDesktopProfile('default'), 'default')
+})
+
+test('normalizeDesktopProfile rejects malformed and absent values', () => {
+  assert.equal(normalizeDesktopProfile('../life'), null)
+  assert.equal(normalizeDesktopProfile('bad profile'), null)
+  assert.equal(normalizeDesktopProfile(''), null)
+  assert.equal(normalizeDesktopProfile(undefined), null)
+})

--- a/apps/desktop/electron/profile-name.test.ts
+++ b/apps/desktop/electron/profile-name.test.ts
@@ -9,9 +9,20 @@ test('normalizeDesktopProfile accepts canonical desktop profile names', () => {
   assert.equal(normalizeDesktopProfile('default'), 'default')
 })
 
+test('normalizeDesktopProfile canonicalizes mixed-case CLI profile input', () => {
+  assert.equal(normalizeDesktopProfile(' Life_2 '), 'life_2')
+  assert.equal(normalizeDesktopProfile('Default'), 'default')
+})
+
 test('normalizeDesktopProfile rejects malformed and absent values', () => {
   assert.equal(normalizeDesktopProfile('../life'), null)
   assert.equal(normalizeDesktopProfile('bad profile'), null)
   assert.equal(normalizeDesktopProfile(''), null)
   assert.equal(normalizeDesktopProfile(undefined), null)
+})
+
+test('normalizeDesktopProfile rejects every non-default CLI reserved name', () => {
+  for (const profile of ['hermes', 'test', 'tmp', 'root', 'sudo', 'Hermes', 'SUDO']) {
+    assert.equal(normalizeDesktopProfile(profile), null, profile)
+  }
 })

--- a/apps/desktop/electron/profile-name.ts
+++ b/apps/desktop/electron/profile-name.ts
@@ -1,10 +1,17 @@
 // Mirrors hermes_cli.profiles._PROFILE_ID_RE so the desktop never routes or
 // spawns a backend with a profile name the Python resolver would reject.
-export const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+// Keep this in lockstep with hermes_cli.profiles._RESERVED_NAMES. `default`
+// remains the one valid built-in alias; the other names are refused before a
+// route or child-process argv can carry them into the CLI.
+const RESERVED_PROFILE_NAMES = new Set(['hermes', 'test', 'tmp', 'root', 'sudo'])
 
 /** Return a canonical desktop profile name, or null for absent/malformed input. */
 export function normalizeDesktopProfile(value: unknown): null | string {
-  const profile = typeof value === 'string' ? value.trim() : ''
+  const profile = typeof value === 'string' ? value.trim().toLowerCase() : ''
 
-  return profile && (profile === 'default' || PROFILE_NAME_RE.test(profile)) ? profile : null
+  return profile && (profile === 'default' || (PROFILE_NAME_RE.test(profile) && !RESERVED_PROFILE_NAMES.has(profile)))
+    ? profile
+    : null
 }

--- a/apps/desktop/electron/profile-name.ts
+++ b/apps/desktop/electron/profile-name.ts
@@ -1,0 +1,10 @@
+// Mirrors hermes_cli.profiles._PROFILE_ID_RE so the desktop never routes or
+// spawns a backend with a profile name the Python resolver would reject.
+export const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+/** Return a canonical desktop profile name, or null for absent/malformed input. */
+export function normalizeDesktopProfile(value: unknown): null | string {
+  const profile = typeof value === 'string' ? value.trim() : ''
+
+  return profile && (profile === 'default' || PROFILE_NAME_RE.test(profile)) ? profile : null
+}

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -88,6 +88,22 @@ test('buildSessionWindowUrl adds the watch flag for spectator windows, before th
   assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1#/abc')
 })
 
+test('buildSessionWindowUrl carries the owning profile before the hash', () => {
+  const url = buildSessionWindowUrl('abc', {
+    devServer: 'http://localhost:5173',
+    profile: ' research-lab ',
+    watch: true
+  })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1&profile=research-lab#/abc')
+})
+
+test('buildSessionWindowUrl omits a blank profile hint', () => {
+  const url = buildSessionWindowUrl('abc', { devServer: 'http://localhost:5173', profile: '   ' })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary#/abc')
+})
+
 test('instanceWindowBounds cascades a new window off its source bounds', () => {
   const bounds = instanceWindowBounds({ x: 100, y: 120, width: 1400, height: 900 }, { width: 1, height: 1 })
 
@@ -118,6 +134,24 @@ test('registry opens one window per session and focuses on re-open', () => {
   assert.equal(first, second)
   assert.equal(registry.size, 1)
   assert.equal(win.calls.focus, 1, 'second open focuses the existing window')
+})
+
+test('registry treats the same session id in different profiles as different windows', () => {
+  const registry = createSessionWindowRegistry()
+  let built = 0
+
+  const factory = () => {
+    built += 1
+
+    return makeFakeWindow()
+  }
+
+  registry.openOrFocus('s1', factory, 'default')
+  registry.openOrFocus('s1', factory, 'life')
+  registry.openOrFocus('s1', factory, 'life')
+
+  assert.equal(built, 2)
+  assert.equal(registry.size, 2)
 })
 
 test('registry restores + shows a minimized/hidden window on re-open', () => {

--- a/apps/desktop/electron/session-windows.test.ts
+++ b/apps/desktop/electron/session-windows.test.ts
@@ -154,6 +154,40 @@ test('registry treats the same session id in different profiles as different win
   assert.equal(registry.size, 2)
 })
 
+test('registry treats an omitted profile as default ownership', () => {
+  const registry = createSessionWindowRegistry()
+  let built = 0
+
+  const factory = () => {
+    built += 1
+
+    return makeFakeWindow()
+  }
+
+  registry.openOrFocus('s1', factory)
+  registry.openOrFocus('s1', factory, 'default')
+
+  assert.equal(built, 1)
+  assert.equal(registry.size, 1)
+})
+
+test('registry tuple keys do not collide with delimiter text in session ids', () => {
+  const registry = createSessionWindowRegistry()
+  let built = 0
+
+  const factory = () => {
+    built += 1
+
+    return makeFakeWindow()
+  }
+
+  registry.openOrFocus('b\u0000c', factory, 'a')
+  registry.openOrFocus('c', factory, 'a\u0000b')
+
+  assert.equal(built, 2)
+  assert.equal(registry.size, 2)
+})
+
 test('registry restores + shows a minimized/hidden window on re-open', () => {
   const registry = createSessionWindowRegistry()
   const win = makeFakeWindow()

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -108,17 +108,31 @@ function instanceWindowBounds(base: { x: number; y: number; width: number; heigh
 function createSessionWindowRegistry() {
   const windows = new Map()
 
-  function openOrFocus(sessionId, factory, profile = null) {
+  const registryKey = (sessionId, profile = null) => {
     const id = typeof sessionId === 'string' ? sessionId.trim() : ''
 
     if (!id) {
       return null
     }
 
-    const profileKey = typeof profile === 'string' ? profile.trim() : ''
-    // Session ids are profile-scoped. Keep the legacy key for unhinted windows,
-    // but do not let equal ids in two profiles focus the wrong renderer.
-    const key = profileKey ? `${profileKey}\u0000${id}` : id
+    // Main resolves an omitted hint to the effective primary profile before it
+    // reaches the registry. Keep `default` as the pure-helper fallback so
+    // legacy/test callers share identity with an explicit default window.
+    const profileKey = (typeof profile === 'string' ? profile.trim() : '') || 'default'
+
+    // JSON encodes the tuple unambiguously even if a session id contains the
+    // delimiter text an ad-hoc concatenation would confuse.
+    return JSON.stringify([profileKey, id])
+  }
+
+  function openOrFocus(sessionId, factory, profile = null) {
+    const key = registryKey(sessionId, profile)
+
+    if (!key) {
+      return null
+    }
+
+    const id = sessionId.trim()
 
     const existing = windows.get(key)
 
@@ -157,8 +171,8 @@ function createSessionWindowRegistry() {
 
   return {
     openOrFocus,
-    get: key => windows.get(key),
-    has: key => windows.has(key),
+    get: (sessionId, profile = null) => windows.get(registryKey(sessionId, profile)),
+    has: (sessionId, profile = null) => windows.has(registryKey(sessionId, profile)),
     get size() {
       return windows.size
     }

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -56,9 +56,17 @@ function chatWindowWebPreferences(preloadPath: string) {
 // renderer reads the flag from window.location.search to suppress the install /
 // onboarding overlays and the global session sidebar. `watch=1` marks a
 // spectator window (e.g. a running subagent's session): the renderer resumes it
-// lazily so the gateway never builds an agent just to stream into it.
-function buildSessionWindowUrl(sessionId: string, { devServer, rendererIndexPath, watch }: any = {}) {
-  const query = `?win=secondary${watch ? '&watch=1' : ''}`
+// lazily so the gateway never builds an agent just to stream into it. `profile`
+// tells the fresh renderer which profile backend owns the routed session before
+// its first gateway connection; without it, auxiliary windows adopt the primary
+// backend and cross-profile session ids miss.
+function buildSessionWindowUrl(sessionId: string, { devServer, profile, rendererIndexPath, watch }: any = {}) {
+  const profileKey = typeof profile === 'string' ? profile.trim() : ''
+
+  const query = `?win=secondary${watch ? '&watch=1' : ''}${
+    profileKey ? `&profile=${encodeURIComponent(profileKey)}` : ''
+  }`
+
   const route = `#/${encodeURIComponent(sessionId)}`
 
   if (devServer) {
@@ -92,20 +100,25 @@ function instanceWindowBounds(base: { x: number; y: number; width: number; heigh
   }
 }
 
-// A small registry keyed by sessionId that guarantees one window per chat:
-// opening a session that already has a live window focuses it instead of
-// spawning a duplicate, and a window removes itself from the registry when it
-// closes. The actual BrowserWindow construction is injected (the `factory`) so
-// this module stays free of Electron and is unit-testable.
+// A small registry keyed by profile + sessionId that guarantees one window per
+// profile-scoped chat: opening a session that already has a live window focuses
+// it instead of spawning a duplicate, and a window removes itself from the
+// registry when it closes. The actual BrowserWindow construction is injected
+// (the `factory`) so this module stays free of Electron and is unit-testable.
 function createSessionWindowRegistry() {
   const windows = new Map()
 
-  function openOrFocus(sessionId, factory) {
-    const key = typeof sessionId === 'string' ? sessionId.trim() : ''
+  function openOrFocus(sessionId, factory, profile = null) {
+    const id = typeof sessionId === 'string' ? sessionId.trim() : ''
 
-    if (!key) {
+    if (!id) {
       return null
     }
+
+    const profileKey = typeof profile === 'string' ? profile.trim() : ''
+    // Session ids are profile-scoped. Keep the legacy key for unhinted windows,
+    // but do not let equal ids in two profiles focus the wrong renderer.
+    const key = profileKey ? `${profileKey}\u0000${id}` : id
 
     const existing = windows.get(key)
 
@@ -124,7 +137,7 @@ function createSessionWindowRegistry() {
       return existing
     }
 
-    const win = factory(key)
+    const win = factory(id)
 
     if (!win) {
       return null

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router'
 
 import { blurComposerInput } from '@/app/chat/composer/focus'
+import { useSessionOwnerProfile } from '@/app/chat/use-session-owner-profile'
 import { AGENTS_ROUTE } from '@/app/routes'
 import { BillingBanner } from '@/components/billing-banner'
 import { composerDockCard } from '@/components/chat/composer-dock'
@@ -84,6 +85,7 @@ interface ComposerStatusStackProps {
 export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackProps) {
   const { t } = useI18n()
   const navigate = useNavigate()
+  const sessionProfile = useSessionOwnerProfile()
   // Subscribe to THIS session's slice only. Both maps churn on other
   // sessions' activity (subagent ticks, background polls, preview updates in
   // any tile); a whole-map `useStore` re-rendered every mounted stack — one
@@ -125,7 +127,9 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   const openAgents = () => navigate(AGENTS_ROUTE)
 
   const openSubagent = (item: ComposerStatusItem) =>
-    item.sessionId ? void openSessionInNewWindow(item.sessionId, { watch: true }) : openAgents()
+    item.sessionId
+      ? void openSessionInNewWindow(item.sessionId, { profile: sessionProfile, watch: true })
+      : openAgents()
 
   // Preview links live as child rows of the background group — a localhost dev
   // server and its preview are the same thing — so they no longer float as an

--- a/apps/desktop/src/app/chat/composer/status-stack/profile-window.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/profile-window.test.tsx
@@ -4,10 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $activeSessionId, $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
 import { $subagentsBySession, type SubagentProgress } from '@/store/subagents'
 import type * as WindowsStore from '@/store/windows'
-import type { SessionInfo } from '@/types/hermes'
 
 import { ComposerStatusStack } from './index'
 
@@ -57,10 +56,9 @@ function renderStack() {
 describe('ComposerStatusStack subagent windows', () => {
   beforeEach(() => {
     openSessionInNewWindow.mockReset()
-    $activeGatewayProfile.set('default')
+    $activeGatewayProfile.set('life')
     $activeSessionId.set(RUNTIME)
     $selectedStoredSessionId.set(STORED)
-    $sessions.set([{ id: STORED, profile: 'life' } as SessionInfo])
     $subagentsBySession.set({ [RUNTIME]: [subagent()] })
   })
 
@@ -69,7 +67,6 @@ describe('ComposerStatusStack subagent windows', () => {
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
-    $sessions.set([])
     $subagentsBySession.set({})
   })
 

--- a/apps/desktop/src/app/chat/composer/status-stack/profile-window.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/profile-window.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $activeSessionId, $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $subagentsBySession, type SubagentProgress } from '@/store/subagents'
+import type * as WindowsStore from '@/store/windows'
+import type { SessionInfo } from '@/types/hermes'
+
+import { ComposerStatusStack } from './index'
+
+const openSessionInNewWindow = vi.fn()
+
+vi.mock('@/store/windows', async importOriginal => ({
+  ...(await importOriginal<typeof WindowsStore>()),
+  openSessionInNewWindow: (...args: unknown[]) => openSessionInNewWindow(...args)
+}))
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+const RUNTIME = 'parent-runtime'
+const STORED = 'parent-stored'
+
+const subagent = (): SubagentProgress => ({
+  filesRead: [],
+  filesWritten: [],
+  goal: 'Research docs',
+  id: 'sub-1',
+  parentId: null,
+  sessionId: 'child-stored',
+  startedAt: 0,
+  status: 'running',
+  stream: [],
+  taskCount: 1,
+  taskIndex: 0,
+  updatedAt: 0
+})
+
+function renderStack() {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null} initialLocale="en">
+        <ComposerStatusStack queue={null} sessionId={RUNTIME} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('ComposerStatusStack subagent windows', () => {
+  beforeEach(() => {
+    openSessionInNewWindow.mockReset()
+    $activeGatewayProfile.set('default')
+    $activeSessionId.set(RUNTIME)
+    $selectedStoredSessionId.set(STORED)
+    $sessions.set([{ id: STORED, profile: 'life' } as SessionInfo])
+    $subagentsBySession.set({ [RUNTIME]: [subagent()] })
+  })
+
+  afterEach(() => {
+    cleanup()
+    $activeGatewayProfile.set('default')
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+    $subagentsBySession.set({})
+  })
+
+  it('opens a child watch window against the parent session profile', () => {
+    renderStack()
+
+    fireEvent.click(screen.getByText('1 Subagent'))
+    fireEvent.click(screen.getByText('Research docs'))
+
+    expect(openSessionInNewWindow).toHaveBeenCalledWith('child-stored', { profile: 'life', watch: true })
+  })
+})

--- a/apps/desktop/src/app/chat/index.test.tsx
+++ b/apps/desktop/src/app/chat/index.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
+import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
   $awaitingResponse,
@@ -21,6 +22,7 @@ import {
 } from '@/store/session'
 
 const threadRenderCount = vi.hoisted(() => ({ current: 0 }))
+const sessionActionsMenuProps = vi.hoisted(() => ({ current: null as null | { profile?: string } }))
 
 vi.mock('@/components/assistant-ui/thread', async () => {
   const React = await import('react')
@@ -56,8 +58,11 @@ vi.mock('./sidebar/session-actions-menu', async () => {
   const React = await import('react')
 
   return {
-    SessionActionsMenu: ({ children }: { children: React.ReactNode }) =>
-      React.createElement('div', { 'data-testid': 'session-actions-menu' }, children)
+    SessionActionsMenu: ({ children, profile }: { children: React.ReactNode; profile?: string }) => {
+      sessionActionsMenuProps.current = { profile }
+
+      return React.createElement('div', { 'data-testid': 'session-actions-menu' }, children)
+    }
   }
 })
 
@@ -71,9 +76,38 @@ function assistantMessage(id: string, text: string): ChatMessage {
   }
 }
 
+function chatViewProps() {
+  return {
+    gateway: null,
+    maxVoiceRecordingSeconds: 120,
+    onAddContextRef: vi.fn(),
+    onAddUrl: vi.fn(),
+    onAttachDroppedItems: vi.fn(),
+    onAttachImageBlob: vi.fn(),
+    onBranchInNewChat: vi.fn(),
+    onCancel: vi.fn(),
+    onDeleteSelectedSession: vi.fn(),
+    onEdit: vi.fn(),
+    onPasteClipboardImage: vi.fn(),
+    onPickFiles: vi.fn(),
+    onPickFolders: vi.fn(),
+    onPickImages: vi.fn(),
+    onReload: vi.fn(),
+    onRemoveAttachment: vi.fn(),
+    onRetryResume: vi.fn(),
+    onSteer: vi.fn(),
+    onSubmit: vi.fn(),
+    onThreadMessagesChange: vi.fn(),
+    onToggleSelectedPin: vi.fn(),
+    onTranscribeAudio: vi.fn()
+  }
+}
+
 describe('ChatView render isolation', () => {
   beforeEach(() => {
     threadRenderCount.current = 0
+    sessionActionsMenuProps.current = null
+    $activeGatewayProfile.set('life')
     $activeSessionId.set('runtime-1')
     $awaitingResponse.set(false)
     $busy.set(false)
@@ -85,13 +119,14 @@ describe('ChatView render isolation', () => {
     $gatewayState.set('closed')
     $messages.set([assistantMessage('assistant-1', 'Stable historical answer')])
     $selectedStoredSessionId.set('stored-1')
-    $sessions.set([{ id: 'stored-1', message_count: 1, title: 'Stable chat' } as never])
+    $sessions.set([{ id: 'stored-1', message_count: 1, profile: 'life', title: 'Stable chat' } as never])
   })
 
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
     $activeSessionId.set(null)
+    $activeGatewayProfile.set('default')
     $awaitingResponse.set(false)
     $busy.set(false)
     $contextSuggestions.set([])
@@ -106,30 +141,7 @@ describe('ChatView render isolation', () => {
   })
 
   it('does not re-render chat history when an unrelated parent idle tick updates', () => {
-    const props = {
-      gateway: null,
-      maxVoiceRecordingSeconds: 120,
-      onAddContextRef: vi.fn(),
-      onAddUrl: vi.fn(),
-      onAttachDroppedItems: vi.fn(),
-      onAttachImageBlob: vi.fn(),
-      onBranchInNewChat: vi.fn(),
-      onCancel: vi.fn(),
-      onDeleteSelectedSession: vi.fn(),
-      onEdit: vi.fn(),
-      onPasteClipboardImage: vi.fn(),
-      onPickFiles: vi.fn(),
-      onPickFolders: vi.fn(),
-      onPickImages: vi.fn(),
-      onReload: vi.fn(),
-      onRemoveAttachment: vi.fn(),
-      onRetryResume: vi.fn(),
-      onSteer: vi.fn(),
-      onSubmit: vi.fn(),
-      onThreadMessagesChange: vi.fn(),
-      onToggleSelectedPin: vi.fn(),
-      onTranscribeAudio: vi.fn()
-    }
+    const props = chatViewProps()
 
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } }
@@ -160,5 +172,19 @@ describe('ChatView render isolation', () => {
     // memo(ChatView) with stable props must absorb the parent's idle tick —
     // the transcript (Thread) must not re-render. This is PR #38470's contract.
     expect(threadRenderCount.current).toBe(1)
+  })
+
+  it('passes the active session owner to the chat-header window action', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/stored-1']}>
+          <ChatView {...chatViewProps()} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    expect(sessionActionsMenuProps.current).toEqual({ profile: 'life' })
   })
 })

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -65,6 +65,7 @@ import { useSessionView } from './session-view'
 import { SessionActionsMenu } from './sidebar/session-actions-menu'
 import { threadLoadingState } from './thread-loading'
 import { advanceTranscriptWindow, type TranscriptWindowState } from './transcript-window'
+import { useSessionOwnerProfile } from './use-session-owner-profile'
 
 interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   gateway: HermesGateway | null
@@ -112,6 +113,7 @@ function ChatHeader({
   const sessions = useStore($sessions)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const profiles = useStore($profiles)
+  const sessionProfile = useSessionOwnerProfile()
 
   const activeStoredSession =
     (selectedSessionId && sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))) || null
@@ -154,6 +156,7 @@ function ChatHeader({
           onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
           onPin={selectedSessionId ? onToggleSelectedPin : undefined}
           pinned={selectedIsPinned}
+          profile={sessionProfile}
           sessionId={selectedSessionId || activeSessionId || ''}
           sideOffset={8}
           title={title}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -225,7 +225,7 @@ function useSessionActions({
             label: r.newWindow,
             onSelect: () => {
               triggerHaptic('selection')
-              openSession(sessionId, () => undefined, 'window')
+              openSession(sessionId, () => undefined, 'window', profile)
             }
           })
         ]

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -300,7 +300,7 @@ function SidebarSessionRowImpl({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              openSession(session.id, () => undefined, 'window')
+              openSession(session.id, () => undefined, 'window', session.profile)
 
               return
             }

--- a/apps/desktop/src/app/chat/use-session-owner-profile.ts
+++ b/apps/desktop/src/app/chat/use-session-owner-profile.ts
@@ -1,23 +1,15 @@
 import { useStore } from '@nanostores/react'
 
-import { useStoreSelector } from '@/lib/use-session-slice'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { $sessions, rememberedSessionProfile } from '@/store/session'
-
-import { useSessionView } from './session-view'
 
 /**
  * The profile that owns the chat surface currently rendering this component.
  *
- * Session tiles can remain mounted while another profile is active, so the
- * global gateway profile is only a fallback for fresh sessions that do not yet
- * have a stored row. The stored session's stamped owner is authoritative.
+ * The renderer adopts the connected backend profile before the gateway opens,
+ * and session tiles are persisted and swapped per active profile. Do not infer
+ * ownership from the bounded recent-session cache: the parent may be older than
+ * that cache, while the live gateway remains the source of truth.
  */
 export function useSessionOwnerProfile(): string {
-  const storedSessionId = useStore(useSessionView().$storedId)
-  const activeProfile = useStore($activeGatewayProfile)
-
-  return useStoreSelector($sessions, sessions =>
-    normalizeProfileKey(rememberedSessionProfile(sessions, storedSessionId, activeProfile))
-  )
+  return normalizeProfileKey(useStore($activeGatewayProfile))
 }

--- a/apps/desktop/src/app/chat/use-session-owner-profile.ts
+++ b/apps/desktop/src/app/chat/use-session-owner-profile.ts
@@ -1,0 +1,23 @@
+import { useStore } from '@nanostores/react'
+
+import { useStoreSelector } from '@/lib/use-session-slice'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
+import { $sessions, rememberedSessionProfile } from '@/store/session'
+
+import { useSessionView } from './session-view'
+
+/**
+ * The profile that owns the chat surface currently rendering this component.
+ *
+ * Session tiles can remain mounted while another profile is active, so the
+ * global gateway profile is only a fallback for fresh sessions that do not yet
+ * have a stored row. The stored session's stamped owner is authoritative.
+ */
+export function useSessionOwnerProfile(): string {
+  const storedSessionId = useStore(useSessionView().$storedId)
+  const activeProfile = useStore($activeGatewayProfile)
+
+  return useStoreSelector($sessions, sessions =>
+    normalizeProfileKey(rememberedSessionProfile(sessions, storedSessionId, activeProfile))
+  )
+}

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -84,7 +84,6 @@ import { luminance } from '@/themes/color'
 import { type ThemeMode, useTheme } from '@/themes/context'
 import { isUserTheme, resolveTheme } from '@/themes/user-themes'
 
-import { openSession, openSessionIntentFromModifiers } from '../open-session'
 import {
   AGENTS_ROUTE,
   ARTIFACTS_ROUTE,
@@ -105,6 +104,7 @@ import { prettyName } from '../settings/helpers'
 import { usePaletteContributions } from './contrib'
 import { MarketplaceThemePage } from './marketplace-theme-page'
 import { PetInlineToggle, PetPalettePage } from './pet-palette-page'
+import { openCommandPaletteSession } from './session-open'
 
 interface PaletteItem {
   /** Keybind action id — its live combo renders as a hotkey hint. */
@@ -159,6 +159,7 @@ interface SessionEntry {
   git_branch?: null | string
   id: string
   preview?: string
+  profile?: string
   title: string
 }
 
@@ -379,6 +380,7 @@ const toSessionEntry = (session: SessionRow): SessionEntry => ({
   git_branch: session.git_branch ?? null,
   id: session.id,
   preview: session.preview ?? undefined,
+  profile: session.profile ?? undefined,
   title: sessionTitle(session)
 })
 
@@ -647,8 +649,8 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   // ⌘/⌃-select / ⌘-Enter = force a new tab; ⇧⌘ = own window. Same door as the
   // sidebar, minus the sidebar's licence to spend main.
   const goSession = useCallback(
-    (sessionId: string) => (event?: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }) => {
-      openSession(sessionId, navigate, openSessionIntentFromModifiers(event, 'stack'))
+    (sessionId: string, profile?: string) => (event?: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }) => {
+      void openCommandPaletteSession(sessionId, profile, event, navigate)
     },
     [navigate]
   )
@@ -1079,7 +1081,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
             ...(session.git_branch ? [session.git_branch] : [])
           ],
           label: session.title,
-          runWithEvent: goSession(session.id)
+          runWithEvent: goSession(session.id, session.profile)
         }))
       })
     }

--- a/apps/desktop/src/app/command-palette/session-open.test.ts
+++ b/apps/desktop/src/app/command-palette/session-open.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { openSession, resolveSessionProfile } = vi.hoisted(() => ({
+  openSession: vi.fn(),
+  resolveSessionProfile: vi.fn()
+}))
+
+vi.mock('../open-session', async () => ({
+  ...(await vi.importActual<Record<string, unknown>>('../open-session')),
+  openSession
+}))
+
+vi.mock('../session/hooks/use-session-actions/utils', () => ({ resolveSessionProfile }))
+
+import { openCommandPaletteSession } from './session-open'
+
+describe('openCommandPaletteSession', () => {
+  const navigate = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes a listed session owner to a modifier-opened window', async () => {
+    await openCommandPaletteSession('session-1', 'life', { metaKey: true, shiftKey: true }, navigate)
+
+    expect(resolveSessionProfile).not.toHaveBeenCalled()
+    expect(openSession).toHaveBeenCalledWith('session-1', navigate, 'window', 'life')
+  })
+
+  it('resolves a direct session id owner before opening a window', async () => {
+    resolveSessionProfile.mockResolvedValue('life')
+
+    await openCommandPaletteSession('session-2', undefined, { metaKey: true, shiftKey: true }, navigate)
+
+    expect(resolveSessionProfile).toHaveBeenCalledWith('session-2')
+    expect(openSession).toHaveBeenCalledWith('session-2', navigate, 'window', 'life')
+  })
+
+  it('does not delay an in-workspace open for profile discovery', async () => {
+    await openCommandPaletteSession('session-3', undefined, undefined, navigate)
+
+    expect(resolveSessionProfile).not.toHaveBeenCalled()
+    expect(openSession).toHaveBeenCalledWith('session-3', navigate, 'stack', undefined)
+  })
+})

--- a/apps/desktop/src/app/command-palette/session-open.ts
+++ b/apps/desktop/src/app/command-palette/session-open.ts
@@ -1,0 +1,23 @@
+import type { NavigateFunction } from 'react-router'
+
+import { openSession, openSessionIntentFromModifiers } from '../open-session'
+import { resolveSessionProfile } from '../session/hooks/use-session-actions/utils'
+
+interface SessionOpenModifiers {
+  ctrlKey?: boolean
+  metaKey?: boolean
+  shiftKey?: boolean
+}
+
+/** Open a palette session while preserving ownership for window intents. */
+export async function openCommandPaletteSession(
+  sessionId: string,
+  profile: string | undefined,
+  event: SessionOpenModifiers | undefined,
+  navigate: NavigateFunction
+): Promise<void> {
+  const intent = openSessionIntentFromModifiers(event, 'stack')
+  const owner = profile?.trim() || (intent === 'window' ? await resolveSessionProfile(sessionId) : undefined)
+
+  openSession(sessionId, navigate, intent, owner)
+}

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot-secondary-window.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot-secondary-window.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url":"http://localhost/?win=secondary&profile=life#/session-123"}
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useGatewayBoot } from './use-gateway-boot'
+
+function Harness() {
+  useGatewayBoot({
+    beforeConnectionSwitch: () => undefined,
+    handleGatewayEvent: () => undefined,
+    onConnectionReady: () => undefined,
+    onGatewayReady: () => undefined,
+    refreshHermesConfig: async () => undefined,
+    refreshSessions: async () => undefined
+  })
+
+  return null
+}
+
+describe('useGatewayBoot secondary-window profile routing', () => {
+  afterEach(() => {
+    cleanup()
+    delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('selects the backend profile encoded in the secondary-window URL', () => {
+    // Keep the connection pending: this covers the first boot hop from the real
+    // window URL parser through useGatewayBoot to the Electron bridge.
+    const getConnection = vi.fn(() => new Promise<never>(() => undefined))
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+      getConnection,
+      getBootProgress: vi.fn(() => new Promise<never>(() => undefined)),
+      onBackendExit: vi.fn(() => () => undefined),
+      onBootProgress: vi.fn(() => () => undefined)
+    }
+
+    render(<Harness />)
+
+    expect(getConnection).toHaveBeenCalledOnce()
+    expect(getConnection).toHaveBeenCalledWith('life')
+  })
+})

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -281,6 +281,22 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     }
   })
 
+  it('reconnects the primary socket with its frozen owner after the foreground profile changes', async () => {
+    const desktop = fakeDesktop('life')
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    render(<Harness />)
+    await flushAsync()
+
+    expect($gatewayState.get()).toBe('open')
+    $activeGatewayProfile.set('other')
+    act(() => FakeWebSocket.instances[0].drop())
+    await flushAsync()
+    await advanceBackoff()
+
+    expect(desktop.getConnection).toHaveBeenLastCalledWith('life')
+  })
+
   it('INITIAL boot against a dead VPS: getConnection hangs (waitForHermes) → app sits in the connecting combo, then fails', async () => {
     // The report's actual path: a fresh launch pointed at an unreachable VPS.
     // startHermes()'s remote branch awaits waitForHermes() for 45s before it

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $currentCwd, $gatewayState } from '@/store/session'
+import { $connection, $currentCwd, $gatewayState, setConnection } from '@/store/session'
 
-import { takeGatewaySurvivor } from './gateway-hmr-survivor'
+import { stashGatewaySurvivor, takeGatewaySurvivor } from './gateway-hmr-survivor'
 import { useGatewayBoot } from './use-gateway-boot'
 
 // End-to-end-ish repro of the "remote VPS → stuck on CONNECTING, no Settings"
@@ -117,6 +117,20 @@ function fakeDesktop(profile: null | string = 'default', storedProfile = profile
     onWindowStateChanged: vi.fn(() => () => undefined),
     touchBackend: vi.fn(async () => undefined),
     profile: { get: vi.fn(async () => ({ profile: storedProfile })) }
+  }
+}
+
+function storedConnection(profile: string) {
+  return {
+    baseUrl: `https://${profile}.example.com`,
+    isFullscreen: false,
+    logs: [],
+    mode: 'remote' as const,
+    nativeOverlayWidth: 0,
+    profile,
+    token: `${profile}-token`,
+    windowButtonPosition: null,
+    wsUrl: `wss://${profile}.example.com/api/ws?token=${profile}-token`
   }
 }
 
@@ -290,6 +304,48 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($gatewayState.get()).toBe('open')
     $activeGatewayProfile.set('other')
+    act(() => FakeWebSocket.instances[0].drop())
+    await flushAsync()
+    await advanceBackoff()
+
+    expect(desktop.getConnection).toHaveBeenLastCalledWith('life')
+  })
+
+  it('parks and re-adopts the primary owner across HMR after a secondary profile becomes active', async () => {
+    const desktop = fakeDesktop('life')
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    const first = render(<Harness />)
+    await flushAsync()
+
+    expect($gatewayState.get()).toBe('open')
+    const primaryConnection = $connection.get()
+    expect(primaryConnection?.profile).toBe('life')
+
+    $activeGatewayProfile.set('other')
+    setConnection(storedConnection('other'))
+
+    first.unmount()
+    const survivor = takeGatewaySurvivor()
+
+    expect(survivor?.profile).toBe('life')
+    expect(survivor?.connection).toBe(primaryConnection)
+
+    if (!survivor) {
+      throw new Error('expected HMR survivor')
+    }
+
+    stashGatewaySurvivor(survivor)
+    const handleGatewayEvent = vi.fn()
+    render(<Harness handleGatewayEvent={handleGatewayEvent} />)
+    await flushAsync()
+
+    expect($activeGatewayProfile.get()).toBe('life')
+    FakeWebSocket.instances[0].sendEvent({ type: 'session.updated' })
+    expect(handleGatewayEvent).toHaveBeenCalledWith(expect.objectContaining({ profile: 'life' }))
+
+    $activeGatewayProfile.set('other')
+    setConnection(storedConnection('other'))
     act(() => FakeWebSocket.instances[0].drop())
     await flushAsync()
     await advanceBackoff()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -70,6 +70,12 @@ class FakeWebSocket {
     this.emit('close', {})
   }
 
+  sendEvent(params: Record<string, unknown>) {
+    this.emit('message', {
+      data: JSON.stringify({ jsonrpc: '2.0', method: 'event', params })
+    })
+  }
+
   private emit(type: string, ev: unknown) {
     for (const fn of this.listeners[type] ?? []) {
       fn(ev)
@@ -77,11 +83,11 @@ class FakeWebSocket {
   }
 }
 
-function fakeDesktop() {
+function fakeDesktop(profile = 'default') {
   const conn = {
     authMode: 'token' as const,
     baseUrl: 'https://vps.example.com',
-    profile: 'default',
+    profile,
     token: 't',
     wsUrl: 'wss://vps.example.com/api/ws?token=t'
   }
@@ -116,11 +122,16 @@ function fakeDesktop() {
 
 function Harness({
   beforeConnectionSwitch = () => undefined,
+  handleGatewayEvent = () => undefined,
   refreshSessions
-}: { beforeConnectionSwitch?: () => void; refreshSessions?: () => Promise<void> } = {}) {
+}: {
+  beforeConnectionSwitch?: () => void
+  handleGatewayEvent?: Parameters<typeof useGatewayBoot>[0]['handleGatewayEvent']
+  refreshSessions?: () => Promise<void>
+} = {}) {
   useGatewayBoot({
     beforeConnectionSwitch,
-    handleGatewayEvent: () => undefined,
+    handleGatewayEvent,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
     refreshHermesConfig: async () => undefined,
@@ -225,6 +236,47 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     } finally {
       stop()
       window.history.replaceState({}, '', '/')
+      $activeGatewayProfile.set('default')
+    }
+  })
+
+  it('publishes the named primary connection profile before open when the URL has no hint', async () => {
+    window.history.replaceState({}, '', '/')
+    $activeGatewayProfile.set('default')
+    const desktop = fakeDesktop('life')
+    let profileAtFirstOpen: string | null = null
+    const eventProfiles: string[] = []
+
+    const stop = $gatewayState.listen(state => {
+      if (state === 'open' && profileAtFirstOpen === null) {
+        profileAtFirstOpen = $activeGatewayProfile.get()
+      }
+    })
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    try {
+      render(<Harness handleGatewayEvent={event => eventProfiles.push(event.profile ?? '')} />)
+      await flushAsync()
+
+      act(() => {
+        FakeWebSocket.instances[0]?.sendEvent({ type: 'session.updated' })
+        $activeGatewayProfile.set('other')
+        FakeWebSocket.instances[0]?.sendEvent({ type: 'session.updated' })
+        $activeGatewayProfile.set('life')
+      })
+
+      expect(desktop.getConnection).toHaveBeenCalledWith(undefined)
+      const connection = await desktop.getConnection.mock.results[0]?.value
+
+      expect({
+        connectionProfile: connection?.profile,
+        current: $activeGatewayProfile.get(),
+        profileAtFirstOpen
+      }).toEqual({ connectionProfile: 'life', current: 'life', profileAtFirstOpen: 'life' })
+      expect(eventProfiles).toEqual(['life', 'life'])
+    } finally {
+      stop()
       $activeGatewayProfile.set('default')
     }
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
+import { $activeGatewayProfile } from '@/store/profile'
 import { $currentCwd, $gatewayState } from '@/store/session'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
@@ -201,6 +202,33 @@ async function advanceBackoff() {
 }
 
 describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => {
+  it('publishes a secondary-window profile before the first gateway open event', async () => {
+    window.history.replaceState({}, '', '/?win=secondary&profile=life#/session-123')
+    $activeGatewayProfile.set('default')
+    const desktop = fakeDesktop()
+    let profileAtFirstOpen: string | null = null
+
+    const stop = $gatewayState.listen(state => {
+      if (state === 'open' && profileAtFirstOpen === null) {
+        profileAtFirstOpen = $activeGatewayProfile.get()
+      }
+    })
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    try {
+      render(<Harness />)
+      await flushAsync()
+
+      expect(desktop.getConnection).toHaveBeenCalledWith('life')
+      expect(profileAtFirstOpen).toBe('life')
+    } finally {
+      stop()
+      window.history.replaceState({}, '', '/')
+      $activeGatewayProfile.set('default')
+    }
+  })
+
   it('INITIAL boot against a dead VPS: getConnection hangs (waitForHermes) → app sits in the connecting combo, then fails', async () => {
     // The report's actual path: a fresh launch pointed at an unreachable VPS.
     // startHermes()'s remote branch awaits waitForHermes() for 45s before it

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -83,11 +83,11 @@ class FakeWebSocket {
   }
 }
 
-function fakeDesktop(profile = 'default') {
+function fakeDesktop(profile: null | string = 'default', storedProfile = profile ?? 'default') {
   const conn = {
     authMode: 'token' as const,
     baseUrl: 'https://vps.example.com',
-    profile,
+    ...(profile === null ? {} : { profile }),
     token: 't',
     wsUrl: 'wss://vps.example.com/api/ws?token=t'
   }
@@ -116,7 +116,7 @@ function fakeDesktop(profile = 'default') {
     onPowerResume: vi.fn(() => () => undefined),
     onWindowStateChanged: vi.fn(() => () => undefined),
     touchBackend: vi.fn(async () => undefined),
-    profile: { get: vi.fn(async () => ({ profile: 'default' })) }
+    profile: { get: vi.fn(async () => ({ profile: storedProfile })) }
   }
 }
 
@@ -243,7 +243,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
   it('publishes the named primary connection profile before open when the URL has no hint', async () => {
     window.history.replaceState({}, '', '/')
     $activeGatewayProfile.set('default')
-    const desktop = fakeDesktop('life')
+    const desktop = fakeDesktop(null, 'life')
     let profileAtFirstOpen: string | null = null
     const eventProfiles: string[] = []
 
@@ -273,7 +273,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
         connectionProfile: connection?.profile,
         current: $activeGatewayProfile.get(),
         profileAtFirstOpen
-      }).toEqual({ connectionProfile: 'life', current: 'life', profileAtFirstOpen: 'life' })
+      }).toEqual({ connectionProfile: undefined, current: 'life', profileAtFirstOpen: 'life' })
       expect(eventProfiles).toEqual(['life', 'life'])
     } finally {
       stop()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -95,6 +95,7 @@ export function useGatewayBoot({
   useEffect(() => {
     let cancelled = false
     let connectionProfile: null | string = null
+    let primaryConnection: HermesConnection | null = null
     const desktop = window.hermesDesktop
     const profileOverride = windowProfileOverride()
 
@@ -180,6 +181,7 @@ export function useGatewayBoot({
           return
         }
 
+        primaryConnection = conn
         publish(conn)
         // Re-mint the WS URL before reconnecting. OAuth tickets are single-use
         // with a short TTL, so the ticket baked into the cached conn.wsUrl is
@@ -293,6 +295,7 @@ export function useGatewayBoot({
       )
 
       connectionProfile = key
+      primaryConnection = connection
       $activeGatewayProfile.set(key)
       setPrimaryGateway(gateway, key)
     }
@@ -420,6 +423,11 @@ export function useGatewayBoot({
     const survivor = import.meta.hot ? takeGatewaySurvivor() : null
     const adoptedFromHmr = Boolean(survivor && !survivorIsStale(survivor))
 
+    if (adoptedFromHmr) {
+      connectionProfile = normalizeProfileKey(survivor!.profile)
+      primaryConnection = survivor!.connection
+    }
+
     if (survivor && !adoptedFromHmr) {
       // Parked socket died between edits (e.g. backend restart) — release it.
       try {
@@ -432,7 +440,7 @@ export function useGatewayBoot({
     const gateway = adoptedFromHmr ? survivor!.gateway : new HermesGateway()
 
     callbacksRef.current.onGatewayReady(gateway)
-    setPrimaryGateway(gateway, survivor?.profile ?? normalizeProfileKey($activeGatewayProfile.get()))
+    setPrimaryGateway(gateway, connectionProfile ?? normalizeProfileKey($activeGatewayProfile.get()))
     // Secondary (background-profile) sockets funnel into the same handler.
     configureGatewayRegistry({ onEvent: event => callbacksRef.current.handleGatewayEvent(event) })
 
@@ -639,11 +647,14 @@ export function useGatewayBoot({
       bootCompleted = true
       completeDesktopBoot()
 
-      if (survivor?.connection) {
-        publish(survivor.connection)
+      const profile = connectionProfile ?? normalizeProfileKey(survivor?.profile ?? $activeGatewayProfile.get())
+      connectionProfile = profile
+      primaryConnection = survivor?.connection ?? primaryConnection
+
+      if (primaryConnection) {
+        publish(primaryConnection)
       }
 
-      const profile = survivor?.profile ?? $activeGatewayProfile.get()
       $activeGatewayProfile.set(profile)
       void ensureGatewayForProfile(profile)
 
@@ -694,8 +705,8 @@ export function useGatewayBoot({
       if (import.meta.hot && gateway.connectionState === 'open') {
         stashGatewaySurvivor({
           gateway,
-          profile: survivor?.profile ?? $activeGatewayProfile.get(),
-          connection: $connection.get()
+          profile: connectionProfile ?? survivor?.profile ?? normalizeProfileKey($activeGatewayProfile.get()),
+          connection: primaryConnection ?? survivor?.connection ?? null
         })
 
         return

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -95,6 +95,15 @@ export function useGatewayBoot({
   useEffect(() => {
     let cancelled = false
     const desktop = window.hermesDesktop
+    const profileOverride = windowProfileOverride()
+
+    // A profile-pinned helper window must publish its ownership before the
+    // gateway can emit `open`: route resume is gated on that event and scopes
+    // its first REST lookup through $activeGatewayProfile. Adopting only after
+    // connect lets a fast wrong-profile 404 reset the routed watch session.
+    if (profileOverride) {
+      $activeGatewayProfile.set(profileOverride)
+    }
 
     const publish = (next: HermesConnection | null) => {
       callbacksRef.current.onConnectionReady(next)
@@ -256,14 +265,13 @@ export function useGatewayBoot({
     // Best-effort: a missing preference means "default". Shared by boot + soft
     // switch.
     //
-    // Helper windows (the HUD) can carry an explicit profile override in their
-    // URL: the HUD is opened ON a conversation, and when that conversation
-    // belongs to a non-primary profile, adopting the primary here resolves the
-    // session id against the wrong backend — the HUD then falls back to the
-    // default profile's last session (#82285). The override wins over the
-    // stored preference; absent, behavior is unchanged.
+    // Helper windows (the HUD and session popouts) can carry an explicit
+    // profile override in their URL. When the routed conversation belongs to a
+    // non-primary profile, adopting the primary here resolves its session id
+    // against the wrong backend. The override wins over the stored preference;
+    // absent, behavior is unchanged (#82285).
     async function adoptPrimaryProfile() {
-      const override = windowProfileOverride()
+      const override = profileOverride
 
       try {
         const profileKey = override ?? (await desktop.profile?.get?.())?.profile ?? ''
@@ -310,7 +318,7 @@ export function useGatewayBoot({
 
         // Same override rule as boot(): a profile-pinned helper window stays
         // on its pinned profile's backend across a soft switch.
-        const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
+        const conn = await desktop.getConnection(profileOverride ?? undefined)
 
         if (cancelled) {
           return
@@ -500,10 +508,10 @@ export function useGatewayBoot({
 
     async function boot() {
       try {
-        // A profile-pinned helper window (the HUD) dials its target profile's
-        // backend directly — ensureBackend spawns/reuses it from the pool.
+        // A profile-pinned helper window (HUD or session popout) dials its target
+        // profile's backend directly — ensureBackend spawns/reuses it from the pool.
         // Everything else keeps dialing the primary.
-        const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
+        const conn = await desktop.getConnection(profileOverride ?? undefined)
 
         if (cancelled) {
           return

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -94,6 +94,7 @@ export function useGatewayBoot({
 
   useEffect(() => {
     let cancelled = false
+    let connectionProfile: null | string = null
     const desktop = window.hermesDesktop
     const profileOverride = windowProfileOverride()
 
@@ -270,17 +271,29 @@ export function useGatewayBoot({
     // non-primary profile, adopting the primary here resolves its session id
     // against the wrong backend. The override wins over the stored preference;
     // absent, behavior is unchanged (#82285).
+    function adoptConnectionProfile(connection: HermesConnection) {
+      const key = normalizeProfileKey(profileOverride ?? connection.profile ?? $activeGatewayProfile.get())
+
+      connectionProfile = key
+      $activeGatewayProfile.set(key)
+      setPrimaryGateway(gateway, key)
+    }
+
     async function adoptPrimaryProfile() {
       const override = profileOverride
 
       try {
-        const profileKey = override ?? (await desktop.profile?.get?.())?.profile ?? ''
+        const profileKey =
+          override ?? connectionProfile ?? (await desktop.profile?.get?.())?.profile ?? $activeGatewayProfile.get()
+
         const key = normalizeProfileKey(profileKey)
         $activeGatewayProfile.set(key)
         setPrimaryGateway(gateway, key)
         void ensureGatewayForProfile(key)
       } catch {
-        $activeGatewayProfile.set(normalizeProfileKey(override))
+        if (override) {
+          $activeGatewayProfile.set(normalizeProfileKey(override))
+        }
       }
     }
 
@@ -324,6 +337,7 @@ export function useGatewayBoot({
           return
         }
 
+        adoptConnectionProfile(conn)
         publish(conn)
         const wsUrl = await resolveGatewayWsUrl(desktop, conn)
         await gateway.connect(wsUrl)
@@ -431,10 +445,11 @@ export function useGatewayBoot({
       }
     })
 
-    const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
-
     const offEvent = gateway.onEvent(event =>
-      callbacksRef.current.handleGatewayEvent({ ...event, profile: sourceProfile })
+      callbacksRef.current.handleGatewayEvent({
+        ...event,
+        profile: connectionProfile ?? normalizeProfileKey($activeGatewayProfile.get())
+      })
     )
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
@@ -517,6 +532,7 @@ export function useGatewayBoot({
           return
         }
 
+        adoptConnectionProfile(conn)
         setDesktopBootStep({
           phase: 'renderer.gateway.connect',
           message: translateNow('boot.steps.connectingGateway'),

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -271,8 +271,23 @@ export function useGatewayBoot({
     // non-primary profile, adopting the primary here resolves its session id
     // against the wrong backend. The override wins over the stored preference;
     // absent, behavior is unchanged (#82285).
-    function adoptConnectionProfile(connection: HermesConnection) {
-      const key = normalizeProfileKey(profileOverride ?? connection.profile ?? $activeGatewayProfile.get())
+    async function adoptConnectionProfile(connection: HermesConnection) {
+      let storedProfile: null | string = null
+
+      // Older primary descriptors omit `profile`. Resolve the stored desktop
+      // preference before opening the socket so the first event and REST route
+      // still inherit the backend's actual scope.
+      if (!profileOverride && !connection.profile) {
+        try {
+          storedProfile = (await desktop.profile?.get?.())?.profile ?? null
+        } catch {
+          // Fall through to the live atom for legacy/single-profile installs.
+        }
+      }
+
+      const key = normalizeProfileKey(
+        profileOverride ?? connection.profile ?? storedProfile ?? $activeGatewayProfile.get()
+      )
 
       connectionProfile = key
       $activeGatewayProfile.set(key)
@@ -337,7 +352,7 @@ export function useGatewayBoot({
           return
         }
 
-        adoptConnectionProfile(conn)
+        await adoptConnectionProfile(conn)
         publish(conn)
         const wsUrl = await resolveGatewayWsUrl(desktop, conn)
         await gateway.connect(wsUrl)
@@ -532,7 +547,7 @@ export function useGatewayBoot({
           return
         }
 
-        adoptConnectionProfile(conn)
+        await adoptConnectionProfile(conn)
         setDesktopBootStep({
           phase: 'renderer.gateway.connect',
           message: translateNow('boot.steps.connectingGateway'),

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -171,7 +171,10 @@ export function useGatewayBoot({
         // "Starting Hermes…". The probe is a no-op for a healthy or local backend.
         await desktop.revalidateConnection?.().catch(() => undefined)
 
-        const conn = await desktop.getConnection($activeGatewayProfile.get())
+        // This gateway is the window's primary socket. A foreground profile
+        // switch may activate a secondary socket, but it must not retarget this
+        // reconnect or relabel the primary connection.
+        const conn = await desktop.getConnection(connectionProfile ?? profileOverride ?? undefined)
 
         if (cancelled) {
           return

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -184,9 +184,9 @@ describe('openSession', () => {
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 
-  it('window pops out when the bridge supports it', () => {
-    openSession('s1', navigate, 'window')
-    expect(openSessionInNewWindow).toHaveBeenCalledWith('s1')
+  it('window pops out against the session owner when the bridge supports it', () => {
+    openSession('s1', navigate, 'window', 'life')
+    expect(openSessionInNewWindow).toHaveBeenCalledWith('s1', { profile: 'life' })
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -68,11 +68,13 @@ export function openSessionIntentFromModifiers(
 /**
  * @param navigate Required for `in-place` (route into main when not on screen).
  *   `tab` / `window` ignore it — pass a no-op when you don't have a router handle.
+ * @param profile Owning profile for `window`; ignored by the other intents.
  */
 export function openSession(
   storedSessionId: string,
   navigate: OpenSessionNavigate,
-  intent: OpenSessionIntent = 'in-place'
+  intent: OpenSessionIntent = 'in-place',
+  profile?: null | string
 ): void {
   if (!storedSessionId) {
     return
@@ -82,7 +84,7 @@ export function openSession(
 
   if (resolved === 'window') {
     if (canOpenSessionWindow()) {
-      void openSessionInNewWindow(storedSessionId)
+      void openSessionInNewWindow(storedSessionId, profile ? { profile } : undefined)
 
       return
     }

--- a/apps/desktop/src/app/profiles/create-profile-dialog.test.ts
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { isValidProfileName } from './create-profile-dialog'
+
+describe('isValidProfileName', () => {
+  it('accepts canonical named profiles and the default alias', () => {
+    expect(isValidProfileName('life_2')).toBe(true)
+    expect(isValidProfileName(' default ')).toBe(true)
+  })
+
+  it('rejects malformed and non-default CLI reserved names', () => {
+    for (const profile of ['../life', 'bad profile', 'hermes', 'test', 'tmp', 'root', 'sudo']) {
+      expect(isValidProfileName(profile), profile).toBe(false)
+    }
+  })
+})

--- a/apps/desktop/src/app/profiles/create-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.tsx
@@ -17,13 +17,12 @@ import { Textarea } from '@/components/ui/textarea'
 import { createProfile, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
+import { normalizeDesktopProfile } from '@/lib/profile-name'
 import { slug } from '@/lib/sanitize'
 import type { ProfileInfo } from '@/types/hermes'
 
-const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
-
 export function isValidProfileName(name: string): boolean {
-  return PROFILE_NAME_RE.test(name.trim())
+  return normalizeDesktopProfile(name) !== null
 }
 
 // Self-contained create flow (name + clone toggle + optional SOUL.md). Owns the

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -42,6 +42,11 @@ import type { ClientSessionState } from '../../types'
 
 import { useSessionActions } from './use-session-actions'
 
+const { mockIsWatchWindow, mockWindowProfileOverride } = vi.hoisted(() => ({
+  mockIsWatchWindow: vi.fn(() => false),
+  mockWindowProfileOverride: vi.fn<() => null | string>(() => null)
+}))
+
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   deleteSession: vi.fn(),
@@ -56,6 +61,12 @@ vi.mock('@/hermes', async importOriginal => ({
 vi.mock('@/store/profile', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   ensureGatewayProfile: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('@/store/windows', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isWatchWindow: mockIsWatchWindow,
+  windowProfileOverride: mockWindowProfileOverride
 }))
 
 vi.mock('@/components/pane-shell/tree/store', async importOriginal => ({
@@ -651,6 +662,8 @@ describe('resumeSession failure recovery', () => {
     setResumeFailedSessionId(null)
     setMessages([])
     setSessions([])
+    mockIsWatchWindow.mockReturnValue(false)
+    mockWindowProfileOverride.mockReturnValue(null)
     vi.restoreAllMocks()
   })
 
@@ -923,6 +936,29 @@ describe('resumeSession failure recovery', () => {
     expect(resumeParams).not.toHaveProperty('lazy')
     expect(resumeParams).not.toHaveProperty('eager_build')
     expect(resumeParams).toMatchObject({ source: 'desktop', omit_messages: true })
+  })
+
+  it('uses the pinned profile for a lazy watch resume before the child row exists', async () => {
+    mockIsWatchWindow.mockReturnValue(true)
+    mockWindowProfileOverride.mockReturnValue('life')
+    vi.mocked(getSession).mockRejectedValue(new Error('404: Session not found'))
+    vi.mocked(ensureGatewayProfile).mockClear()
+    let resumeParams: Record<string, unknown> | undefined
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        resumeParams = params
+
+        return { session_id: 'runtime-child', resumed: params?.session_id, messages: [], info: {} } as never
+      }
+
+      return {} as never
+    })
+
+    await runResume(requestGateway)
+
+    expect(ensureGatewayProfile).toHaveBeenCalledWith('life')
+    expect(resumeParams).toMatchObject({ lazy: true, profile: 'life', source: 'desktop' })
   })
 
   it('arms the failure latch when resume succeeds with an empty transcript for a non-empty stored session', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -653,11 +653,12 @@ export function useSessionActions({
       // gateway call (no-op when it's already on that profile / single-profile).
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
-      const storedForProfile = await resolveStoredSession(storedSessionId)
+      const pinnedWindowProfile = windowProfileOverride() ?? undefined
+      const storedForProfile = await resolveStoredSession(storedSessionId, pinnedWindowProfile)
       // A fresh subagent watch can open before the child has flushed its first
       // stored row. The validated window hint is authoritative for that narrow
       // race and keeps shared-remote resume/REST requests on the owning profile.
-      const sessionProfile = storedForProfile?.profile ?? windowProfileOverride() ?? undefined
+      const sessionProfile = storedForProfile?.profile ?? pinnedWindowProfile
 
       if (resumeRequestRef.current !== requestId) {
         return

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -67,7 +67,7 @@ import {
   type TileDock
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
-import { isWatchWindow } from '@/store/windows'
+import { isWatchWindow, windowProfileOverride } from '@/store/windows'
 import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
 
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
@@ -654,7 +654,10 @@ export function useSessionActions({
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
       const storedForProfile = await resolveStoredSession(storedSessionId)
-      const sessionProfile = storedForProfile?.profile
+      // A fresh subagent watch can open before the child has flushed its first
+      // stored row. The validated window hint is authoritative for that narrow
+      // race and keeps shared-remote resume/REST requests on the owning profile.
+      const sessionProfile = storedForProfile?.profile ?? windowProfileOverride() ?? undefined
 
       if (resumeRequestRef.current !== requestId) {
         return

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -127,6 +127,20 @@ describe('resolveStoredSession profile ownership', () => {
     ])
   })
 
+  it('prefers the active owner when an unhinted id exists in multiple profiles', async () => {
+    $activeGatewayProfile.set('default')
+    $sessions.set([
+      session({ id: 's1', profile: 'meta', title: 'Meta copy' }),
+      session({ id: 's1', profile: 'default', title: 'Default copy' })
+    ])
+
+    await expect(resolveStoredSession('s1')).resolves.toMatchObject({
+      profile: 'default',
+      title: 'Default copy'
+    })
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
   it('resolveSessionProfile routes a default-profile session from a non-default gateway', async () => {
     mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
     mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'default' }))

--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesModule from '@/hermes'
-import { getSession } from '@/hermes'
+import { getProfiles, getSession } from '@/hermes'
 import { $activeGatewayProfile, $profiles } from '@/store/profile'
 import { $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
@@ -10,9 +10,11 @@ import { resolveSessionProfile, resolveStoredSession } from './utils'
 
 vi.mock('@/hermes', async importActual => ({
   ...(await importActual<typeof HermesModule>()),
+  getProfiles: vi.fn(),
   getSession: vi.fn()
 }))
 
+const mockGetProfiles = vi.mocked(getProfiles)
 const mockGetSession = vi.mocked(getSession)
 
 const session = (over: Partial<SessionInfo>): SessionInfo => over as SessionInfo
@@ -24,6 +26,8 @@ describe('resolveStoredSession profile ownership', () => {
     $sessions.set([])
     $profiles.set(profiles('default', 'meta'))
     $activeGatewayProfile.set('meta')
+    mockGetProfiles.mockReset()
+    mockGetProfiles.mockResolvedValue({ profiles: profiles('default', 'meta') })
     mockGetSession.mockReset()
   })
 
@@ -98,6 +102,29 @@ describe('resolveStoredSession profile ownership', () => {
     expect(resolved?.profile).toBe('default')
     // the cached row is owned too — no unowned row is ever re-cached
     expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('default')
+  })
+
+  it('refreshes an empty profile catalog before probing an uncached direct id', async () => {
+    $profiles.set([])
+    mockGetSession.mockRejectedValueOnce(new Error('404: Session not found'))
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'default' }))
+
+    await expect(resolveSessionProfile('s1')).resolves.toBe('default')
+
+    expect(mockGetProfiles).toHaveBeenCalledTimes(1)
+    expect(mockGetSession).toHaveBeenNthCalledWith(2, 's1', 'default')
+  })
+
+  it('keeps a same-id row from another profile when a scoped lookup fills the cache', async () => {
+    $sessions.set([session({ id: 's1', profile: 'default', title: 'Default copy' })])
+    mockGetSession.mockResolvedValueOnce(session({ id: 's1', profile: 'meta', title: 'Meta copy' }))
+
+    await expect(resolveStoredSession('s1', 'meta')).resolves.toMatchObject({ profile: 'meta' })
+
+    expect($sessions.get().map(row => [row.profile, row.title])).toEqual([
+      ['meta', 'Meta copy'],
+      ['default', 'Default copy']
+    ])
   })
 
   it('resolveSessionProfile routes a default-profile session from a non-default gateway', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -852,14 +852,14 @@ export async function resolveStoredSession(
   profileHint?: null | string
 ): Promise<SessionInfo | undefined> {
   const hintedProfile = profileHint?.trim() ? normalizeProfileKey(profileHint) : null
+  const activeKey = normalizeProfileKey($activeGatewayProfile.get())
+  const cachedMatches = $sessions.get().filter(session => sessionMatchesStoredId(session, storedSessionId))
+  const ownedMatches = cachedMatches.filter(session => session.profile?.trim())
 
-  const cached = $sessions
-    .get()
-    .find(
-      session =>
-        sessionMatchesStoredId(session, storedSessionId) &&
-        (!hintedProfile || normalizeProfileKey(session.profile) === hintedProfile)
-    )
+  const cached = hintedProfile
+    ? ownedMatches.find(session => normalizeProfileKey(session.profile) === hintedProfile)
+    : (ownedMatches.find(session => normalizeProfileKey(session.profile) === activeKey) ??
+      (ownedMatches.length === 1 ? ownedMatches[0] : cachedMatches.length === 1 ? cachedMatches[0] : undefined))
 
   // A row with no owning profile can't route a resume when more than one
   // profile exists — a resume without a profile lands on whichever gateway is
@@ -909,8 +909,6 @@ export async function resolveStoredSession(
   // Multi-profile only: probe each other profile by id (still one cheap lookup
   // each) rather than pulling every profile's recent sessions. The first hit
   // carries its owning `profile`, which routes the resume to the right backend.
-  const activeKey = normalizeProfileKey($activeGatewayProfile.get())
-
   let profiles = $profiles.get()
 
   // The profile rail is loaded lazily and can also be stale after an external

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -5,7 +5,7 @@ import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
-import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
+import { $activeGatewayProfile, $profiles, normalizeProfileKey, refreshProfiles } from '@/store/profile'
 import {
   $currentCwd,
   $sessions,
@@ -829,10 +829,15 @@ export function sessionShouldHaveTranscript(session: SessionInfo | undefined): b
 
 function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
   const lineage = session._lineage_root_id ?? session.id
+  const owner = normalizeProfileKey(session.profile)
 
   setSessions(prev => [
     session,
     ...prev.filter(existing => {
+      if (normalizeProfileKey(existing.profile) !== owner) {
+        return true
+      }
+
       if (sessionMatchesStoredId(existing, storedSessionId)) {
         return false
       }
@@ -842,8 +847,19 @@ function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
   ])
 }
 
-export async function resolveStoredSession(storedSessionId: string): Promise<SessionInfo | undefined> {
-  const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+export async function resolveStoredSession(
+  storedSessionId: string,
+  profileHint?: null | string
+): Promise<SessionInfo | undefined> {
+  const hintedProfile = profileHint?.trim() ? normalizeProfileKey(profileHint) : null
+
+  const cached = $sessions
+    .get()
+    .find(
+      session =>
+        sessionMatchesStoredId(session, storedSessionId) &&
+        (!hintedProfile || normalizeProfileKey(session.profile) === hintedProfile)
+    )
 
   // A row with no owning profile can't route a resume when more than one
   // profile exists — a resume without a profile lands on whichever gateway is
@@ -853,6 +869,22 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
 
   if (cached && (cached.profile?.trim() || !multiProfile)) {
     return cached
+  }
+
+  // A profile-pinned auxiliary window already knows the authoritative owner.
+  // Probe that scope directly so a cloned/same-id row from another profile in
+  // the all-profile cache cannot hijack the resume.
+  if (hintedProfile) {
+    try {
+      const session = await getSession(storedSessionId, hintedProfile)
+
+      session.profile = hintedProfile
+      upsertResolvedSession(session, storedSessionId)
+
+      return session
+    } catch {
+      return undefined
+    }
   }
 
   // Direct by-id on the live backend — one row lookup, no list scan. Covers
@@ -879,10 +911,18 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
   // carries its owning `profile`, which routes the resume to the right backend.
   const activeKey = normalizeProfileKey($activeGatewayProfile.get())
 
-  const otherProfiles = $profiles
-    .get()
-    .map(profile => normalizeProfileKey(profile.name))
-    .filter(key => key !== activeKey)
+  let profiles = $profiles.get()
+
+  // The profile rail is loaded lazily and can also be stale after an external
+  // create/delete. A direct-id miss is rare and needs an authoritative catalog
+  // before deciding the session does not exist elsewhere.
+  try {
+    profiles = await refreshProfiles()
+  } catch {
+    // Best effort: retain the cached catalog when the profile endpoint is down.
+  }
+
+  const otherProfiles = profiles.map(profile => normalizeProfileKey(profile.name)).filter(key => key !== activeKey)
 
   for (const profile of otherProfiles) {
     try {

--- a/apps/desktop/src/components/assistant-ui/tool/delegate-profile-window.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/delegate-profile-window.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $activeSessionId, $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $subagentsBySession, type SubagentProgress } from '@/store/subagents'
+import type * as WindowsStore from '@/store/windows'
+import type { SessionInfo } from '@/types/hermes'
+
+import { DelegateTool } from './delegate'
+
+const openSessionInNewWindow = vi.fn()
+
+vi.mock('@/store/windows', async importOriginal => ({
+  ...(await importOriginal<typeof WindowsStore>()),
+  openSessionInNewWindow: (...args: unknown[]) => openSessionInNewWindow(...args)
+}))
+
+const RUNTIME = 'parent-runtime'
+const STORED = 'parent-stored'
+
+const subagent = (): SubagentProgress => ({
+  filesRead: [],
+  filesWritten: [],
+  goal: 'Research docs',
+  id: 'sub-1',
+  parentId: null,
+  sessionId: 'child-stored',
+  startedAt: 0,
+  status: 'running',
+  stream: [],
+  taskCount: 1,
+  taskIndex: 0,
+  updatedAt: 0
+})
+
+describe('DelegateTool subagent windows', () => {
+  beforeEach(() => {
+    openSessionInNewWindow.mockReset()
+    $activeGatewayProfile.set('default')
+    $activeSessionId.set(RUNTIME)
+    $selectedStoredSessionId.set(STORED)
+    $sessions.set([{ id: STORED, profile: 'life' } as SessionInfo])
+    $subagentsBySession.set({ [RUNTIME]: [subagent()] })
+  })
+
+  afterEach(() => {
+    cleanup()
+    $activeGatewayProfile.set('default')
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+    $subagentsBySession.set({})
+  })
+
+  it('opens a child watch window against the transcript session profile', () => {
+    render(
+      <I18nProvider configClient={null} initialLocale="en">
+        <DelegateTool args={{ tasks: [{ goal: 'Research docs' }] }} result={undefined} toolCallId="call-1" />
+      </I18nProvider>
+    )
+
+    fireEvent.click(screen.getByText('Research docs'))
+
+    expect(openSessionInNewWindow).toHaveBeenCalledWith('child-stored', { profile: 'life', watch: true })
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/delegate-profile-window.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/delegate-profile-window.test.tsx
@@ -3,10 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $activeSessionId, $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
 import { $subagentsBySession, type SubagentProgress } from '@/store/subagents'
 import type * as WindowsStore from '@/store/windows'
-import type { SessionInfo } from '@/types/hermes'
 
 import { DelegateTool } from './delegate'
 
@@ -38,10 +37,9 @@ const subagent = (): SubagentProgress => ({
 describe('DelegateTool subagent windows', () => {
   beforeEach(() => {
     openSessionInNewWindow.mockReset()
-    $activeGatewayProfile.set('default')
+    $activeGatewayProfile.set('life')
     $activeSessionId.set(RUNTIME)
     $selectedStoredSessionId.set(STORED)
-    $sessions.set([{ id: STORED, profile: 'life' } as SessionInfo])
     $subagentsBySession.set({ [RUNTIME]: [subagent()] })
   })
 
@@ -50,7 +48,6 @@ describe('DelegateTool subagent windows', () => {
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
-    $sessions.set([])
     $subagentsBySession.set({})
   })
 

--- a/apps/desktop/src/components/assistant-ui/tool/delegate.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/delegate.tsx
@@ -4,6 +4,7 @@ import { useStore } from '@nanostores/react'
 import { type FC, type ReactNode, useMemo } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
+import { useSessionOwnerProfile } from '@/app/chat/use-session-owner-profile'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { SCAFFOLD_LABEL_CLASS, SCAFFOLD_META_CLASS } from '@/components/chat/scaffold-row'
@@ -63,7 +64,7 @@ function statusGlyph(status: DelegateRowStatus, label: string): ReactNode {
  * activity, so a fan-out of five children costs ten lines of transcript
  * whatever they get up to.
  */
-function DelegateRowView({ row }: { row: DelegateRow }) {
+function DelegateRowView({ profile, row }: { profile: string; row: DelegateRow }) {
   const { t } = useI18n()
   const copy = t.assistant.tool
   const { sessionId } = row
@@ -83,7 +84,7 @@ function DelegateRowView({ row }: { row: DelegateRow }) {
   ].filter(Boolean)
 
   // Only a child that reported its own session id has somewhere to go.
-  const open = sessionId ? () => void openSessionInNewWindow(sessionId, { watch: true }) : undefined
+  const open = sessionId ? () => void openSessionInNewWindow(sessionId, { profile, watch: true }) : undefined
 
   return (
     <div className="grid min-w-0 max-w-full gap-0.5" data-conversation-scaffold="">
@@ -137,6 +138,7 @@ function DelegateRowView({ row }: { row: DelegateRow }) {
  */
 export const DelegateTool: FC<Pick<ToolPart, 'args' | 'result' | 'toolCallId'>> = ({ args, result, toolCallId }) => {
   const sessionId = useStore(useSessionView().$runtimeId)
+  const sessionProfile = useSessionOwnerProfile()
   const live = useSessionSlice($subagentsBySession, sessionId)
 
   const rows = useMemo(
@@ -151,7 +153,7 @@ export const DelegateTool: FC<Pick<ToolPart, 'args' | 'result' | 'toolCallId'>> 
   return (
     <div className="grid min-w-0 gap-(--tool-row-gap)" data-delegate-card="" data-slot="tool-block">
       {rows.map(row => (
-        <DelegateRowView key={row.id} row={row} />
+        <DelegateRowView key={row.id} profile={sessionProfile} row={row} />
       ))}
     </div>
   )

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -31,10 +31,14 @@ declare global {
       getGatewayWsUrl: (profile?: null | string) => Promise<GatewayWsUrlResult>
       // Open (or focus) a standalone OS window for a single chat session so
       // the user can work with multiple chats side by side. Returns ok:false
-      // with an error code when the sessionId is empty/invalid. `watch` opens
-      // a spectator window (lazy resume — no agent build) for live-streaming
-      // a running subagent's session.
-      openSessionWindow: (sessionId: string, opts?: { watch?: boolean }) => Promise<{ ok: boolean; error?: string }>
+      // with an error code when the sessionId or profile is invalid. `watch`
+      // opens a spectator window (lazy resume — no agent build) for
+      // live-streaming a running subagent's session. `profile` selects the
+      // owning backend before the auxiliary renderer's first gateway dial.
+      openSessionWindow: (
+        sessionId: string,
+        opts?: { profile?: null | string; watch?: boolean }
+      ) => Promise<{ ok: boolean; error?: string }>
       // Open a new full-chrome app window — a peer instance of the primary that
       // renders the complete app against the shared backend, so the user can run
       // multiple GUI windows at once.

--- a/apps/desktop/src/lib/profile-name.ts
+++ b/apps/desktop/src/lib/profile-name.ts
@@ -1,0 +1,11 @@
+// Mirrors hermes_cli.profiles.validate_profile_name at renderer ingress points.
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const RESERVED_PROFILE_NAMES = new Set(['hermes', 'test', 'tmp', 'root', 'sudo'])
+
+export function normalizeDesktopProfile(value: unknown): null | string {
+  const profile = typeof value === 'string' ? value.trim().toLowerCase() : ''
+
+  return profile && (profile === 'default' || (PROFILE_NAME_RE.test(profile) && !RESERVED_PROFILE_NAMES.has(profile)))
+    ? profile
+    : null
+}

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -19,7 +19,7 @@ import type { ProfileInfo } from '@/types/hermes'
 // Canonical key for a profile: trimmed, empty → "default". Used everywhere we
 // compare a session's owning profile against the live gateway's profile.
 export function normalizeProfileKey(name: string | null | undefined): string {
-  const value = (name ?? '').trim()
+  const value = (name ?? '').trim().toLowerCase()
 
   return value || 'default'
 }

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -79,13 +79,13 @@ describe('openSessionInNewWindow', () => {
     expect(notifyError).not.toHaveBeenCalled()
   })
 
-  it('forwards the watch flag for spectator (subagent) windows', async () => {
+  it('forwards the watch flag and owning profile for spectator (subagent) windows', async () => {
     const open = vi.fn().mockResolvedValue({ ok: true })
     installBridge(open)
 
-    await openSessionInNewWindow('s1', { watch: true })
+    await openSessionInNewWindow('s1', { profile: 'life', watch: true })
 
-    expect(open).toHaveBeenCalledWith('s1', { watch: true })
+    expect(open).toHaveBeenCalledWith('s1', { profile: 'life', watch: true })
     expect(notifyError).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { canOpenNewWindow, canOpenSessionWindow, openNewWindow, openSessionInNewWindow } from './windows'
+import {
+  canOpenNewWindow,
+  canOpenSessionWindow,
+  openNewWindow,
+  openSessionInNewWindow,
+  windowProfileOverride
+} from './windows'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
@@ -26,11 +32,27 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  window.history.replaceState({}, '', '/')
+
   if (initialHermesDesktop) {
     desktopWindow.hermesDesktop = initialHermesDesktop
   } else {
     delete desktopWindow.hermesDesktop
   }
+})
+
+describe('windowProfileOverride', () => {
+  it('returns a valid decoded profile hint', () => {
+    window.history.replaceState({}, '', '/?profile=life_2')
+
+    expect(windowProfileOverride()).toBe('life_2')
+  })
+
+  it('treats malformed profile hints as absent', () => {
+    window.history.replaceState({}, '', '/?profile=..%2Flife')
+
+    expect(windowProfileOverride()).toBeNull()
+  })
 })
 
 describe('canOpenSessionWindow', () => {

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -48,10 +48,23 @@ describe('windowProfileOverride', () => {
     expect(windowProfileOverride()).toBe('life_2')
   })
 
+  it('canonicalizes mixed-case profile hints like the CLI', () => {
+    window.history.replaceState({}, '', '/?profile=Life_2')
+
+    expect(windowProfileOverride()).toBe('life_2')
+  })
+
   it('treats malformed profile hints as absent', () => {
     window.history.replaceState({}, '', '/?profile=..%2Flife')
 
     expect(windowProfileOverride()).toBeNull()
+  })
+
+  it('treats every non-default CLI reserved profile hint as absent', () => {
+    for (const profile of ['hermes', 'test', 'tmp', 'root', 'sudo']) {
+      window.history.replaceState({}, '', `/?profile=${profile}`)
+      expect(windowProfileOverride(), profile).toBeNull()
+    }
   })
 })
 

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -1,3 +1,5 @@
+import { normalizeDesktopProfile } from '@/lib/profile-name'
+
 import { notifyError } from './notifications'
 
 // Window flag set by the Electron main process when it opens a standalone
@@ -91,13 +93,11 @@ export const isAuxiliaryWindow = (): boolean => isSecondaryWindow() || isHudWind
 // before, so ordinary windows and single-profile users are untouched.
 // Not cached: it is read a handful of times per boot and staying cache-free
 // keeps it honest under test.
-const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
-
 export function windowProfileOverride(): null | string {
   try {
     const profile = new URLSearchParams(window.location.search).get('profile')?.trim() ?? ''
 
-    return PROFILE_NAME_RE.test(profile) ? profile : null
+    return normalizeDesktopProfile(profile)
   } catch {
     return null
   }

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -91,9 +91,13 @@ export const isAuxiliaryWindow = (): boolean => isSecondaryWindow() || isHudWind
 // before, so ordinary windows and single-profile users are untouched.
 // Not cached: it is read a handful of times per boot and staying cache-free
 // keeps it honest under test.
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
 export function windowProfileOverride(): null | string {
   try {
-    return new URLSearchParams(window.location.search).get('profile')?.trim() || null
+    const profile = new URLSearchParams(window.location.search).get('profile')?.trim() ?? ''
+
+    return PROFILE_NAME_RE.test(profile) ? profile : null
   } catch {
     return null
   }

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -129,7 +129,10 @@ async function runWindowOpen(call: () => Promise<WindowOpenResult>, failMessage:
 // Open (or focus) a standalone OS window for a single chat session. No-ops
 // gracefully outside Electron so callers can wire it unconditionally.
 // `watch: true` opens a spectator window (lazy resume, live-mirror stream).
-export async function openSessionInNewWindow(sessionId: string, opts?: { watch?: boolean }): Promise<void> {
+export async function openSessionInNewWindow(
+  sessionId: string,
+  opts?: { profile?: null | string; watch?: boolean }
+): Promise<void> {
   if (!sessionId || !canOpenSessionWindow()) {
     return
   }

--- a/contributors/emails/hello@mysticmages.xyz
+++ b/contributors/emails/hello@mysticmages.xyz
@@ -1,0 +1,1 @@
+DomGrieco


### PR DESCRIPTION
## Summary

Fix Desktop session popouts that open against the primary backend instead of the profile that owns the routed session.

This fixes the blank subagent watch window reported in #82768 and the ordinary cross-profile popout variant tracked by #61286.

## Root cause

A session popout URL carried the session ID and optional watch flag, but not the owning profile. Each auxiliary renderer therefore adopted the primary Desktop backend before route resume. When the target session existed only in another profile, the first lookup returned 404 and the watch window reset to an empty draft.

Follow-up review exposed more ownership gaps. The primary backend descriptor omitted its effective named profile, a new child watch could resume before its first stored row existed, reconnect followed the mutable foreground profile, direct ID probing trusted a lazy profile catalog, invalid Desktop profile state could silently select `default`, and HMR could relabel the primary socket as the active secondary profile.

## Changes

- resolve the parent transcript profile once for both subagent entry points
- carry `profile` through renderer callers, the preload bridge, Electron IPC, and the query string before the hash route
- preserve ownership for sidebar, chat header, and command palette popouts, including direct session ID opens
- validate profile hints at renderer and Electron boundaries before routing or spawning a backend
- align Desktop profile validation with the Python validator, including reserved names while retaining the built in `default` alias
- fail closed for malformed or unreadable nonempty Desktop and legacy `active_profile` state while preserving the missing or empty default behavior
- stamp every primary connection descriptor with its effective profile and recover older unscoped descriptors before the first gateway open
- keep the primary gateway profile and connection immutable across foreground profile switches, HMR stash and adoption, events, and reconnects
- fall back to the validated window profile when a new child watch resumes before its stored session row exists
- use authoritative window profile hints during resume so a same ID row from another profile cannot hijack the route
- refresh the profile catalog before an uncached cross-profile direct ID probe and preserve same ID cache rows owned by other profiles
- key the session window registry by an encoded profile and session ID tuple, with omitted and explicit default ownership sharing one identity
- mirror the CLI preference, profile scoped `HERMES_HOME`, legacy `active_profile`, then default precedence and freeze that owner for the primary backend lifecycle
- pin every local crash respawn to the frozen effective owner

## Safety and compatibility

Malformed URL profile hints remain absent and cannot become backend pool keys or `--profile` arguments. Malformed nonempty persisted profile state now fails visibly instead of silently opening the default profile. Reserved backend profile names are rejected at each changed Desktop ingress point. An unhinted window still resolves to the effective primary profile.

Named primary connections remain authoritative when stored state is stale. A background profile switch cannot retarget or relabel the primary socket, including across HMR and reconnect. Profile pinned resumes only replace cache rows from the same owner.

## Tests

Current rebased head `a19512a396244c22d169627f523b69ff7f35f21d`:

- `npm run test:ui`: 418 files passed, 3,701 tests passed
- `npm run test:desktop:platforms`: 90 files passed, 1 skipped, 1,058 tests passed, 2 skipped
- focused review regressions: 82 tests passed
- `npm run lint`: 0 errors, 88 existing warnings
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run test:desktop:all`: passed, including macOS arm64 app and DMG packaging
- Prettier check: passed
- `git diff --check`: passed

Regression coverage includes invalid, reserved, mixed-case, missing, empty, and unreadable profile state; renderer profile creation, HUD, and window hints; primary connection event provenance; HMR stash and adoption after a secondary profile becomes active; reconnect ownership; crash respawn pinning; missing row watch resume; same ID active-owner selection and profile hints; direct ID resolution; chat header ownership; command palette popouts; both subagent entry points; and collision safe native window identity.

The review regressions were verified to fail before their fixes and pass after them. All tests and builds ran in an isolated worktree. The installed Hermes app and user profile data were not modified.

## Prior work and coordination

This current main salvage carries forward the profile through window design from #48473 by @necoweb3 and #61323 by @giggling-ginger. Their authorship is preserved with commit trailers. It addresses the spectator path gap called out in reviews of #59608 and #59904 and uses the auxiliary profile boot seam merged in #82325.

The broader work in #83219 overlaps with these files but uses a different authority contract. Compatibility requirements for the session owner, header, palette, direct ID, missing row, same ID, and watch window paths are documented there.

Closes #82768
Closes #61286
