### PR TITLE
fix(desktop): make un-highlighted code readable while streaming in light theme

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -422,6 +422,12 @@ const MARKDOWN_CONTAINER_CLASS_NAME = cn(
   'aui-md prose w-full max-w-none overflow-hidden text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground',
   'prose-p:leading-(--dt-line-height) prose-li:leading-(--dt-line-height)',
   'prose-headings:text-foreground prose-strong:text-foreground',
+  // Typography styles `pre` as a dark slab: light text (`--tw-prose-pre-code`,
+  // gray-200) on a dark bg. We strip its bg for our own light code card but its
+  // near-white foreground survives — invisible under Shiki's opaque token
+  // spans, but it's what un-highlighted text inherits (streaming delay,
+  // Suspense fallback, budget-exceeded blocks): unreadable in light mode.
+  'prose-pre:text-foreground',
   'prose-a:break-words prose-p:[overflow-wrap:anywhere]',
   'prose-li:marker:text-muted-foreground/70',
   'prose-code:rounded-[0.25rem] prose-code:px-[0.1875rem] prose-code:py-px prose-code:font-mono prose-code:text-[0.9em] prose-code:font-normal prose-code:before:content-none prose-code:after:content-none',


### PR DESCRIPTION
## What does this PR do?

Fixes unreadable code blocks in the desktop app's light theme while a reply streams.

Code renders near-white text on the white code card until Shiki's highlight lands, then snaps to normal colors.

### why?
`@tailwindcss/typography` styles `pre` as a dark card with light text. Our code card strips typography's `pre` background but not the light foreground. Shiki's colors normally hide it, so it shows through exactly where text renders without Shiki:
- the streaming window before a (delayed/throttled) highlight pass lands
- the Suspense fallback while the lazy shiki chunk loads
- over-budget blocks (>150k chars / >3000 lines) that never highlight
- 
### Fix
`prose-pre:text-foreground` on the markdown container class, so every un-highlighted fenced path inherits the transcript foreground.

Dark mode is unaffected in practice (gray-200 on the dark card was readable), but the same rule applies there for consistency.

## Related Issue

None

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/markdown-text.tsx` — add `prose-pre:text-foreground` to `MARKDOWN_CONTAINER_CLASS_NAME`, with a comment stating why typography's `pre` foreground must be overridden.

## How to Test

1. Run the desktop app with the light theme (default).
2. Ask the agent to stream a long fenced code block (or a ```text fence, which never gets token spans).
3. Before: the code text is near-white on the white card while streaming, then darkens when highlighting lands. After: it streams in at the normal transcript foreground.
4. Devtools check: computed `color` on the `pre` inside a code card is the theme foreground, not `oklch(0.928 0.006 264.531)`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only change, no Python touched; ran `npx tsc --noEmit` and `npx vitest run src/components/assistant-ui/markdown-text.artifacts.test.tsx` (3 passed) in `apps/desktop`
- [ ] I've added tests for my changes — no test: the fix is one Tailwind utility in a class string; asserting on the class string would be a source-text test, and computed-style cascade isn't exercised by jsdom
- [x] I've tested on my platform: NixOS (traced live via CDP on the running renderer)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (visual bug fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (CSS only, platform-independent)
