### PR TITLE
fix(telegram): keep remote bridge sends working after rolling upgrades

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -707,8 +707,17 @@ _TOOL_ERROR_CDATA_RE = re.compile(r'<!\[CDATA\[.*?\]\]>', re.DOTALL)
 # Single home for the tool-error context cap: tools/registry.py. Both this
 # sanitizer (exception paths) and the dispatch-boundary bounding
 # (tool_error / _bound_json_error_result) trim to the same budget so text
-# never passes two different caps with two different markers.
-from tools.registry import _MAX_TOOL_ERROR_CHARS as _TOOL_ERROR_MAX_LEN
+# never passes two different caps with two different markers. During an
+# in-process upgrade, however, a pre-cap registry module can remain cached
+# while this newer module is imported lazily. Preserve the old sanitizer cap
+# in that mixed-version window instead of failing the entire tool import.
+import tools.registry as _tool_registry_module
+
+_TOOL_ERROR_MAX_LEN = getattr(
+    _tool_registry_module,
+    "_MAX_TOOL_ERROR_CHARS",
+    2000,
+)
 
 
 def _sanitize_tool_error(error_msg: str) -> str:

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -809,6 +809,54 @@ class TestE2EMessagesSend:
         assert call_args["action"] == "send"
         assert call_args["target"] == "telegram:123456"
 
+    def test_send_survives_legacy_loaded_tool_registry(
+        self, mcp_server_e2e, _event_loop, monkeypatch
+    ):
+        """A rolling upgrade must not fail before reaching the platform sender."""
+        import sys
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from gateway.config import Platform
+        import tools.registry as registry_module
+        import tools.send_message_tool as send_message_module
+
+        server, _ = mcp_server_e2e
+        telegram_config = SimpleNamespace(enabled=True, token="test-token", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.TELEGRAM: telegram_config},
+            get_home_channel=lambda _platform: None,
+        )
+        sender = AsyncMock(
+            return_value={"success": True, "platform": "telegram", "message_id": "1"}
+        )
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+        monkeypatch.setattr(send_message_module, "_send_to_platform", sender)
+        monkeypatch.setattr("gateway.mirror.mirror_to_session", lambda *_args, **_kwargs: False)
+
+        # Reproduce a long-lived bridge that retained the registry module from
+        # before the shared error cap existed, then lazily imports model_tools.
+        monkeypatch.delitem(sys.modules, "model_tools", raising=False)
+        monkeypatch.delattr(registry_module, "_MAX_TOOL_ERROR_CHARS")
+
+        result = _run_tool(
+            server,
+            "messages_send",
+            {"target": "telegram:123456", "message": "Hello!"},
+        )
+
+        assert result["success"] is True
+        sender.assert_awaited_once_with(
+            Platform.TELEGRAM,
+            telegram_config,
+            "123456",
+            "Hello!",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
+
 
 class TestE2EChannelsList:
     def test_channels_from_sessions(self, mcp_server_e2e, _event_loop):


### PR DESCRIPTION
## What does this PR do?

Remote MCP bridges can discover Telegram channels but fail every send before delivery when a rolling upgrade leaves an older `tools.registry` module loaded and lazily imports the newer `model_tools.py`. This change keeps that mixed-version window importable while preserving the unified error-length cap on coherent installs.

### Symptom

`channels_list` succeeds, but `messages_send` returns `cannot import name _MAX_TOOL_ERROR_CHARS from tools.registry` before the Telegram transport is reached.

### Impact

Remote bridge users affected by this mixed-version runtime cannot send messages to any configured Telegram target until the process is fully restarted. The same lazy `model_tools._run_async` dependency is shared by other bridge send and reaction paths, so the import failure can block those paths before transport as well.

### Bug Cause

**Trigger:** `model_tools.py:711` during the lazy `model_tools` import reached from MCP `messages_send`

**Causal chain:**
1. A long-lived remote bridge retains the pre-cap `tools.registry` module during a rolling upgrade.
2. `messages_send` enters `tools.send_message_tool`, which lazily imports the newer `model_tools.py` for `_run_async`.
3. The newer module directly imports `_MAX_TOOL_ERROR_CHARS`, which does not exist on the retained registry module, so delivery fails before `_send_to_platform` runs.

**Why it is wrong:** A lazy cross-module import made bridge delivery depend on two modules having been loaded from exactly the same release, even though long-lived processes can temporarily retain the older registry module.

**Working sibling / contrast:** `channels_list` does not import `model_tools` and remains functional. Coherent old/old and new/new module pairs also import successfully.

**Ruled out:** Telegram target selection and credentials are not the cause because the failure occurs before transport, reproduces across targets, and a real-environment FastMCP verification reaches a no-I/O Telegram transport sentinel after this fix.

### Fix

Import the registry module and read its shared cap with a historical 2000-character fallback. Coherent installs still use `_MAX_TOOL_ERROR_CHARS`, while mixed-version bridge send and reaction paths remain importable. Add an MCP regression that removes the constant from the loaded registry module and verifies `messages_send` reaches the Telegram sender.

## Related Issue

Closes #82687

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `model_tools.py` - preserve the historical sanitizer cap when the loaded registry module predates the shared constant.
- `tests/test_mcp_serve.py` - exercise the real MCP `messages_send` path with a retained legacy registry module and verify Telegram transport dispatch.

## How to Test

1. Start the FastMCP bridge with a retained pre-cap `tools.registry` module, call `channels_list`, then call `messages_send` for a configured Telegram target.
2. Verify the send reaches the platform transport instead of returning the registry import error.
3. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/test_mcp_serve.py -k TestE2EMessagesSend
scripts/run_tests.sh tests/test_sanitize_tool_error.py
ruff check model_tools.py tests/test_mcp_serve.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test files and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with the FastMCP bridge harness

### Documentation & Housekeeping

- [x] Documentation update - N/A, behavior and configuration are unchanged
- [x] `cli-config.yaml.example` update - N/A, no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update - N/A, architecture and workflows are unchanged
- [x] Cross-platform impact considered - the fallback uses standard Python module lookup and preserves coherent-install behavior
- [x] Tool descriptions/schemas update - N/A, tool behavior and schemas are unchanged

## Screenshots / Logs

Real-environment FastMCP verification reproduced the original mixed-version import failure before the fix and reached a no-I/O Telegram transport sentinel after the fix. Focused test results: 3 MCP send tests passed, 9 sanitizer tests passed, and Ruff reported no errors.
