### PR TITLE
docs(cron): warn self-sending no_agent scripts to use deliver: local

### DIFF
--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -149,6 +149,28 @@ That's the whole thing. No prompt, no skill, no model.
 
 The "silent when empty" behavior is the key to the classic watchdog pattern: the script is free to run every minute, but the channel only sees a message when something actually needs attention.
 
+### Scripts that already send messages themselves
+
+Some scripts call a platform API directly (for example uploading files via a
+Weixin / Telegram helper, or posting a multi-part report). In that case the
+script has already delivered the user-facing content.
+
+If the job still uses `deliver: origin` (or another chat target), Hermes will
+**also** deliver the script's stdout after the run. That second push is usually
+unwanted: it can look like a duplicate message, and on platforms with session
+tokens (notably Weixin) it can fail with a misleading `prepare failed` /
+"rate limited" error even though the script's own sends already succeeded.
+
+For self-sending scripts, use:
+
+```bash
+--deliver local
+```
+
+Stdout is still saved under `~/.hermes/cron/output/` for audit, but Hermes will
+not post it again to chat. Keep `deliver: origin` / platform targets for the
+common case where **stdout is the message**.
+
 ## Script Rules
 
 Scripts must live in `~/.hermes/scripts/`. This is enforced at both job-creation time and run time — absolute paths, `~/` expansion, and path-traversal patterns (`../`) are rejected. The same directory is shared with the pre-check script gate used by LLM jobs.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -642,6 +642,7 @@ Semantics:
 - Non-zero exit or timeout → an error alert is delivered, so a broken watchdog can't fail silently.
 - `{"wakeAgent": false}` on the last line → silent tick (same gate LLM jobs use).
 - No tokens, no model, no provider fallback — the job never touches the inference layer.
+- **Self-sending scripts** (scripts that call a messaging API themselves for files/multi-part reports): set `deliver: local`. Otherwise Hermes will also deliver stdout to the chat target after the script finishes, which can duplicate the user-facing message or fail independently of the script's own sends. See the [Script-Only Cron Jobs guide](/guides/cron-script-only#scripts-that-already-send-messages-themselves).
 
 `.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. Subprocess env is sanitized (`_sanitize_subprocess_env`): provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -506,6 +506,7 @@ Semantics:
 - Non-zero exit or timeout → an error alert is delivered, so a broken watchdog can't fail silently.
 - `{"wakeAgent": false}` on the last line → silent tick (same gate LLM jobs use).
 - No tokens, no model, no provider fallback — the job never touches the inference layer.
+- **Self-sending scripts** (scripts that call a messaging API themselves for files/multi-part reports): set `deliver: local`. Otherwise Hermes will also deliver stdout to the chat target after the script finishes, which can duplicate the user-facing message or fail independently of the script's own sends. See the [Script-Only Cron Jobs guide](/guides/cron-script-only#scripts-that-already-send-messages-themselves).
 
 `.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. Subprocess env is sanitized (`_sanitize_subprocess_env`): provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
 


### PR DESCRIPTION
## Summary
- Document that `no_agent` scripts which already call a messaging API themselves must use `deliver: local`, otherwise Hermes also posts script stdout to the chat target after the run.
- Cross-link the Script-Only guide from the cron feature reference.

## Why
In production we had a Weixin daily-report script that already sent text + Excel via `send_weixin_direct`. The cron job still used `deliver: origin`, so after a successful script run Hermes attempted a second stdout delivery. That second push failed with iLink `ret=-2 errmsg=prepare failed` (often mislabeled as rate limit; see #80125 / #80426) and polluted `last_delivery_error`, even though the user-facing report had already been delivered.

This is not a scheduler bug — `deliver: origin` is working as designed for the common case where **stdout is the message**. The missing piece was docs for the self-sending script pattern.

## Test plan
- [ ] Docs render locally / on the site preview
- [ ] Anchor `#scripts-that-already-send-messages-themselves` resolves from the cron feature page link


Made with [Cursor](https://cursor.com)