### PR TITLE
feat(tools): past-EOF and empty-file notes in read_file (name the dead end)

### DIFF
--- a/tests/tools/test_read_past_eof_note.py
+++ b/tests/tools/test_read_past_eof_note.py
@@ -1,0 +1,44 @@
+"""Tests for the past-EOF and empty-file notes in read_file.
+
+An empty content string is ambiguous from inside the model (empty file?
+bad offset? broken tool?) — the tool names the dead end and the recovery.
+"""
+
+import json
+
+from tools.file_tools import read_file_tool
+
+
+class TestPastEofNote:
+    def test_offset_beyond_eof_names_recovery(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "r.txt"
+        p.write_text("\n".join(f"l{i}" for i in range(1, 51)) + "\n")
+        result = json.loads(read_file_tool(str(p), offset=900, limit=50))
+        hint = result.get("hint") or ""
+        assert "beyond the end" in hint
+        assert "50" in hint  # states actual line count
+        assert not result.get("error"), "a fact about the file is not an error"
+
+    def test_offset_at_last_line_still_reads(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "r.txt"
+        p.write_text("a\nb\nc\n")
+        result = json.loads(read_file_tool(str(p), offset=3, limit=10))
+        assert "c" in result.get("content", "")
+        assert "beyond" not in (result.get("hint") or "")
+
+    def test_empty_file_says_so(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "e.txt"
+        p.write_text("")
+        result = json.loads(read_file_tool(str(p)))
+        assert "empty" in (result.get("hint") or "").lower()
+        assert not result.get("error")
+
+    def test_normal_pagination_hint_unchanged(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "r.txt"
+        p.write_text("\n".join(f"l{i}" for i in range(1, 300)) + "\n")
+        result = json.loads(read_file_tool(str(p), offset=1, limit=100))
+        assert "offset=101" in (result.get("hint") or "")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1331,7 +1331,30 @@ class ShellFileOperations(FileOperations):
         hint = None
         if truncated:
             hint = f"Use offset={end_line + 1} to continue reading (showing {offset}-{end_line} of {total_lines} lines)"
-        
+
+        # Ambiguous-silence guards: an empty content string is
+        # indistinguishable, from inside the model, from a broken tool —
+        # it re-reads, widens the window, tries another path. Name the
+        # dead end and its recovery instead.
+        if file_size == 0:
+            return ReadResult(
+                content="",
+                total_lines=0,
+                file_size=0,
+                hint="File is empty (0 bytes).",
+            )
+        if offset > total_lines > 0:
+            return ReadResult(
+                content="",
+                total_lines=total_lines,
+                file_size=file_size,
+                hint=(
+                    f"Note: offset {offset} is beyond the end of the file "
+                    f"({total_lines} lines total). Retry with offset <= "
+                    f"{total_lines}."
+                ),
+            )
+
         return ReadResult(
             content=self._add_line_numbers(read_output, offset),
             total_lines=total_lines,


### PR DESCRIPTION
## Summary

A `read_file` past EOF returned `content: "900|"` — a phantom line-number prefix that looks like a real (empty) line 900 — and an empty file returned `"1|"`. Both are ambiguous silence: from inside the model they're indistinguishable from a broken tool, so it re-reads, widens the window, and burns turns learning what one sentence could have said. This PR names the dead end and its recovery.

- Past-EOF → `Note: offset 900 is beyond the end of the file (412 lines total). Retry with offset <= 412.`
- Empty file → `File is empty (0 bytes).`

Notes, not `Error:` — a fact about the file is not a failure.

Measured (file-only arm, 3 reps, control = #82800 stack vs feature, `past_eof` + `empty_config` tasks):

| | control | feature | delta |
|---|---|---|---|
| qwen3.8-max tokens | 22.8k | 18.6k | −18% |
| qwen3.8-max tool calls | 6 | 4 | −26% |
| qwen3.8-max turns | 5 | 4 | −17% |
| opus-4.8 tokens | 35.7k | 32.3k | −10% (turns flat) |
| accuracy (both) | 1.00 | 1.00 | held |

Honest read: qwen's gain is consistent across both tasks; opus is within rep noise on turns (it already recovered cheaply). The change also fixes the phantom-line content bug regardless of efficiency.

## Changes

- `tools/file_operations.py`: in `ShellFileOperations.read_file`, after the line count is known — empty file and offset-past-EOF return early with explanatory hints instead of a bare numbered-nothing. Boundary pinned: `offset == total_lines` still reads (an off-by-one in a resume hint is a silently corrupted read, the one class worse than a wasted turn).
- `tests/tools/test_read_past_eof_note.py`: 4 tests — past-EOF note with real line count, boundary read at last line, empty-file note, normal pagination hint unchanged.

## Validation

| | Before | After |
|---|---|---|
| `read_file(report.txt, offset=900)` | `content: "900|"` (phantom line) | note naming 412-line reality + retry bound |
| `read_file(empty.yaml)` | `content: "1|"` | `File is empty (0 bytes).` |
| targeted tests | — | 58/58 (new + existing file_tools + unicode suites) |

Stacked on #82800 → #82792. Merge order: 82792, 82800, then this reduces to one commit.

## Infographic

![past-EOF note](https://v3b.fal.media/files/b/0aa5b4fd/_WcSAHh9Qw8PuTB_lrE9__RTsM8Z9n.png)
