### PR TITLE
feat: add global daily LLM token budget

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1419,6 +1419,110 @@ def _notify_context_engine_turn_complete(
         )
 
 
+def _release_agent_budget_reservation(agent) -> None:
+    """Hand back an unsettled global daily-budget claim held by ``agent``.
+
+    A reservation is a *claim*, not a charge: releasing one never records
+    spend, so this may only run for an attempt that produced **no provider
+    response** — a transport exception, a denial, or a cancellation that never
+    got an answer.  An attempt that did get a response has already been settled
+    by :func:`_settle_agent_budget_reservation` the moment the response
+    arrived, which leaves nothing here to release; releasing a responded-to
+    attempt would book real provider spend as free.
+
+    Called at the top of every provider *attempt* (so a retry does not inherit
+    the previous attempt's claim), at the top of every loop iteration, after
+    the loop, and once more from ``AIAgent.run_conversation``'s ``finally`` —
+    which is what covers the early ``return`` and raise paths inside the loop.
+    Owner-release is the *only* way a claim comes back: ``token_budget``
+    deliberately runs no reclamation timer, so an attempt that dies without
+    releasing holds its tokens for the rest of the day.
+    """
+    held = getattr(agent, "_budget_reservation", None)
+    if held is None:
+        return
+    try:
+        from agent.token_budget import release as _budget_release
+
+        _budget_release(held)
+        # Retain the owner reference until SQLite accepted the release. A
+        # transient write failure can then be retried at the next boundary.
+        agent._budget_reservation = None
+    except Exception:
+        logger.debug("daily budget release failed (fail-open)", exc_info=True)
+
+
+def _settle_agent_budget_reservation(agent, response) -> None:
+    """Charge ``agent``'s global daily-budget claim for a provider response.
+
+    Runs the instant the provider answers, *before* the loop decides what to
+    do with that answer.  That ordering is the whole point: most of those
+    decisions leave the attempt without reaching the usage bookkeeping further
+    down — a redirect that crossed the response discards it, a truncated reply
+    re-loops for a continuation, a truncated tool call retries, a safety
+    refusal / thinking-budget exhaustion / rollback returns outright — and
+    every one of them is a response the provider already billed.  Settling
+    here is what stops those paths from handing the tokens back as if the
+    attempt had been free.
+
+    What gets charged:
+
+    * the response's canonical usage total, when the provider reported one;
+    * otherwise the reservation itself.  A response with no usage still burned
+      tokens, so its estimate is the honest floor — releasing it would record
+      a real call as costing nothing.
+
+    ``response is None`` means no answer exists (transport error, cancellation
+    before any response), so the claim is left outstanding for
+    :func:`_release_agent_budget_reservation` to hand back.
+    """
+    held = getattr(agent, "_budget_reservation", None)
+    if held is None or response is None:
+        return
+    # Conservative default; overridden below by the provider's real count.
+    actual = int(getattr(held, "tokens", 0) or 0)
+    usage = getattr(response, "usage", None)
+    if usage:
+        try:
+            reported = int(
+                normalize_usage(
+                    usage,
+                    provider=agent.provider,
+                    api_mode=agent.api_mode,
+                ).total_tokens
+                or 0
+            )
+            # A zero/absent total is "no usage supplied", not "free call".
+            if reported > 0:
+                actual = reported
+        except Exception:
+            logger.debug(
+                "daily budget usage normalization failed — charging the reservation",
+                exc_info=True,
+            )
+
+    try:
+        from agent.token_budget import (
+            settle as _budget_settle,
+            threshold_message as _budget_threshold_message,
+        )
+
+        # Swaps this attempt's estimate for ``actual`` in one transaction and
+        # returns whichever 50%/75% marks this settlement is responsible for.
+        # The ledger claims each mark atomically, so a mark is announced
+        # exactly once per day across every Hermes process. Keep the owner
+        # reference until SQLite accepts settlement: a transient write failure
+        # must remain retryable and must never be released as a free call.
+        _settle_outcome = _budget_settle(held, actual)
+        agent._budget_reservation = None
+        for _mark in _settle_outcome.crossed_marks:
+            agent._emit_status(
+                _budget_threshold_message(_settle_outcome.snapshot, _mark)
+            )
+    except Exception:
+        logger.debug("daily budget settle failed (fail-open)", exc_info=True)
+
+
 def run_conversation(
     agent,
     user_message: Any,
@@ -1603,6 +1707,17 @@ def run_conversation(
     # on the next loop iteration. This prevents a second advisor fan-out.
     pending_moa_prepared_request = None
 
+    # Outstanding global daily-budget claim for the provider attempt in flight
+    # (see agent/token_budget.py). Reserved per physical attempt, settled as
+    # soon as the provider answers (real token count when reported, the
+    # reservation otherwise), and released only on paths that never got an
+    # answer at all. Covers this loop's provider calls only — auxiliary calls
+    # (compression, summaries, memory, embeddings) go through
+    # agent/auxiliary_client.py and are not metered. Held on the agent (not a
+    # local) so AIAgent.run_conversation()'s ``finally`` can release it after
+    # the loop's early-return and exception paths too.
+    agent._budget_reservation = None
+
     # Per-turn tally of consecutive successful credential-pool token refreshes,
     # keyed by (provider, pool-entry-id). A persistent upstream 401 lets
     # ``try_refresh_current()`` "succeed" forever on a single-entry OAuth pool,
@@ -1632,6 +1747,12 @@ def run_conversation(
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        # Any claim still held here belongs to a previous iteration whose last
+        # attempt never got a provider response (transport failure, interrupt).
+        # An attempt that did get one settled on arrival, so there is nothing
+        # left to free. Give the unspent tokens back before reserving again.
+        _release_agent_budget_reservation(agent)
+
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:
             _apply_active_turn_redirect(agent, messages, _redirect_text)
@@ -2384,10 +2505,10 @@ def run_conversation(
                     request_pressure_tokens,
                     int(getattr(_compressor, "threshold_tokens", 0) or 0),
                 )
-        
+
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
-        
+
         if not agent.quiet_mode:
             agent._vprint(f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}...")
             agent._vprint(f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
@@ -2423,8 +2544,39 @@ def run_conversation(
         api_kwargs = None  # Guard against UnboundLocalError in except handler
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
+        # Set when the global daily ledger refuses an attempt; handled right
+        # after this retry loop, because the denial ends the whole turn.
+        _budget_denial = None
 
         while retry_count < max_retries:
+            # ── Global daily LLM budget: per-attempt reserve ───────────────
+            # Scoped to ONE physical provider attempt, not to this retry loop:
+            # every attempt that reaches the wire burns real tokens, so every
+            # attempt claims its own estimate (rough prompt estimate + tools +
+            # the response cap) and settles or releases it. Reserving once
+            # around the loop would let N retries spend against a single
+            # claim. The release below hands back the previous attempt's
+            # claim — an attempt that got a response already settled it, so
+            # this only ever frees an attempt that died before any answer.
+            # No budget configured → reserve() short-circuits without touching
+            # the ledger, so the default install pays nothing here.
+            _release_agent_budget_reservation(agent)
+            try:
+                from agent.token_budget import reserve as _budget_reserve
+
+                _budget_outcome = _budget_reserve(
+                    request_pressure_tokens + int(getattr(agent, "max_tokens", 0) or 0)
+                )
+            except Exception:
+                logger.debug("daily budget reserve skipped (fail-open)", exc_info=True)
+                _budget_outcome = None
+            if _budget_outcome is not None and _budget_outcome.denied:
+                _budget_denial = _budget_outcome.message
+                break
+            agent._budget_reservation = (
+                _budget_outcome.reservation if _budget_outcome is not None else None
+            )
+
             # ── Nous Portal rate limit guard ──────────────────────
             # If another session already recorded that Nous is rate-
             # limited, skip the API call entirely.  Each attempt
@@ -2751,6 +2903,19 @@ def run_conversation(
                         if _model_request_active is not None:
                             _model_request_active.clear()
                         _redirect_crossed_response = agent._has_pending_redirect()
+
+                # ── Global daily LLM budget: settle this attempt ───────────
+                # The provider answered, so this attempt's tokens are spent no
+                # matter what the loop does with the answer next. Settled HERE,
+                # ahead of every response-driven ``break`` / ``continue`` /
+                # ``return`` below (redirect discard, truncation continuation,
+                # refusal, tool-call retry, rollback), because those paths
+                # bypass the usage bookkeeping further down and would otherwise
+                # let the claim be released as zero spend. No usage reported →
+                # the reservation is charged rather than freed. A ``None``
+                # response is left to the release paths.
+                _settle_agent_budget_reservation(agent, response)
+
                 if _redirect_crossed_response:
                     # The response and redirect can cross on different threads:
                     # redirect() observed the request as active just before this
@@ -3659,6 +3824,12 @@ def run_conversation(
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+
+                    # (The global daily budget was already settled for this
+                    # attempt from the response's own usage, back where the
+                    # provider returned — see _settle_agent_budget_reservation.
+                    # It cannot be settled here: the truncation, refusal, and
+                    # retry paths above never reach this line.)
 
                     # Log API call details for debugging/observability
                     _cache_pct = ""
@@ -5985,6 +6156,26 @@ def run_conversation(
                     # stale request.
                     break
         
+        if _budget_denial is not None:
+            # The global daily budget has no room for this attempt, so nothing
+            # was sent. Refund the logical iteration (an attempt that never
+            # reached the provider must not consume one) and end the turn with
+            # the denial as the visible answer. Checked ahead of the restart /
+            # `response is None` branches below so the user gets the real
+            # reason instead of "all retries exhausted".
+            final_response = _budget_denial
+            failed = True
+            _turn_exit_reason = "daily_token_budget_exhausted"
+            messages.append({"role": "assistant", "content": final_response})
+            agent._emit_status(final_response)
+            api_call_count -= 1
+            agent._api_call_count = api_call_count
+            try:
+                agent.iteration_budget.refund()
+            except Exception:
+                pass
+            break
+
         if _retry.restart_with_redirected_messages:
             # The cancelled request produced no valid assistant item. Reuse the
             # same logical iteration after the outer loop appends the displayed
@@ -7714,6 +7905,12 @@ def run_conversation(
                 messages.append({"role": "assistant", "content": final_response})
                 break
     
+    # The turn is over: hand back any daily-budget claim whose attempt never
+    # got a provider response (interrupt, transport failure, budget denial).
+    # Nothing else will — the ledger runs no reclamation timer — so skipping
+    # this would park those tokens until midnight.
+    _release_agent_budget_reservation(agent)
+
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.

--- a/agent/token_budget.py
+++ b/agent/token_budget.py
@@ -1,0 +1,770 @@
+"""Global daily LLM token budget — reserve / settle ledger on ``state.db``.
+
+A daily **admission budget** for the tokens spent by the **main agent loop**
+(``agent/conversation_loop.run_conversation``), shared across every surface
+that runs that loop (CLI, TUI, desktop, gateway, cron, subagents) and across
+concurrent processes, because the ledger lives in the profile's ``state.db``
+rather than in memory.
+
+What it actually guarantees: no provider attempt is *admitted* unless its
+estimate still fits in the day. It is not an absolute ceiling on tokens spent,
+and cannot be — the spend of a call is only known once the provider answers,
+by which point the tokens are gone. So a day can finish over ``daily_tokens``
+by the amount the last admitted response exceeded its reservation: one API
+response's overshoot, not an unbounded one, since the overrun is charged in
+full and the next attempt is judged against the corrected total.
+
+Scope — what is *not* metered (see also the ``budget`` section of
+``website/docs/user-guide/configuration.md``): auxiliary provider calls that
+do not go through the agent loop. Context compression / summarisation, memory
+and curator passes, title generation, embeddings, and anything else built on
+``agent/auxiliary_client.py`` spend real tokens that this ledger never sees;
+so does a MoA advisor fan-out, whose per-advisor calls happen inside the
+client and are not the loop's own attempt. The budget therefore bounds
+admitted agent-loop attempts, not the process's total spend.
+
+Configuration (top level of ``config.yaml``)::
+
+    budget:
+      daily_tokens: 2000000   # 0 / null disables the feature entirely
+      timezone: "America/Sao_Paulo"   # empty → the global `timezone` setting
+
+Accounting model — reserve, then settle, once per *physical provider attempt*
+(a retried call reserves again, because a retry hits the wire again):
+
+1. **Reserve** (before the attempt): the caller reserves its *estimate*
+   (rough prompt estimate + the response cap). The reservation is a row, so a
+   second process racing the same remaining budget sees it immediately and is
+   denied. Reservations never count as spend.
+2. **Settle** (the provider answered): the reservation row is swapped for the
+   provider's *actual* token count in the same transaction. Over- and
+   under-estimates self-correct on every attempt. A response that reports no
+   usage is settled for the reservation amount instead — a real call charged
+   at its estimate, never at zero — because the alternative (releasing it)
+   would let unmetered responses run the day indefinitely.
+3. **Release** (no provider response at all): the reservation row is dropped
+   and nothing is charged. Reserved for attempts that raised or were cancelled
+   before any answer arrived; an attempt holding a response settles instead,
+   however the caller then disposes of that response (discarded on a redirect,
+   retried after truncation, returned as a refusal).
+
+Settle is exactly idempotent: it charges only when it is the call that removed
+the reservation row. Settling twice, settling a released reservation, or
+settling an unknown id records nothing, so no accounting bug can double-charge
+a day.
+
+Reservations are never reclaimed on a timer. Freeing a claim that cannot be
+proven finished defeats the point of admission control: the freed call would
+later settle into a row that no longer exists and, under exactly-once settle,
+its spend would vanish. Claims are released only by their owner (the agent
+loop releases at every retry, iteration, and turn boundary, including the
+``finally`` on abort paths). A SIGKILLed process therefore holds its claim for
+the remainder of that day — capacity lost, admission control intact. The rows
+are swept by :data:`ABANDONED_ROW_MAX_AGE_SECONDS` only once they belong to a
+past day *and* are a day old, which is pure table hygiene and can never touch
+a reservation counted against the current day.
+
+Threshold notifications (50% / 75%) are claimed inside the settle transaction,
+so exactly one process per day emits each one no matter how many are running.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# Table hygiene only — NOT budget reclamation. A reservation row is deleted as
+# abandoned once it is this old *and* belongs to a day other than the one being
+# written, so it is not counted against any live budget and cannot belong to a
+# call still in flight (no provider call spans a day). Never applied to the
+# current day: see the module docstring on why a timer must not free a claim.
+ABANDONED_ROW_MAX_AGE_SECONDS = 86400.0
+
+# Used-fraction marks that emit a one-time-per-day status notification.
+NOTIFY_MARKS: Tuple[int, ...] = (50, 75)
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS llm_budget_days (
+    day TEXT PRIMARY KEY,
+    used_tokens INTEGER NOT NULL DEFAULT 0,
+    notified_marks TEXT NOT NULL DEFAULT '',
+    updated_at REAL NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS llm_budget_reservations (
+    id TEXT PRIMARY KEY,
+    day TEXT NOT NULL,
+    tokens INTEGER NOT NULL,
+    created_at REAL NOT NULL,
+    owner_pid INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_budget_res_day
+    ON llm_budget_reservations(day, created_at);
+"""
+
+
+# ── Settings ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class BudgetSettings:
+    """Resolved ``budget:`` section of config.yaml."""
+
+    daily_tokens: int = 0
+    timezone: str = ""
+
+    @property
+    def enabled(self) -> bool:
+        return self.daily_tokens > 0
+
+
+def _coerce_daily_tokens(raw: Any) -> int:
+    """Parse ``budget.daily_tokens`` into a non-negative int (0 = disabled).
+
+    Accepts ints, floats, and numeric strings (``"2_000_000"``, ``"2000000"``)
+    so a hand-edited config.yaml with a quoted number still works. Anything
+    unparseable disables the feature rather than raising — a malformed budget
+    key must never block the agent loop.
+
+    Non-finite values (``.inf`` / ``.nan``, which YAML parses into real floats,
+    and their string spellings) disable the feature too: ``int(inf)`` raises
+    OverflowError and ``int(nan)`` raises ValueError, and "no limit" is spelled
+    ``0`` here, not infinity.
+    """
+    if raw is None or isinstance(raw, bool):
+        return 0
+    if isinstance(raw, int):
+        # Exact: an arbitrarily large int must not round-trip through float.
+        return raw if raw > 0 else 0
+    if isinstance(raw, (float, str)):
+        if isinstance(raw, str):
+            text = raw.strip().replace("_", "").replace(",", "")
+            if not text:
+                return 0
+        else:
+            text = raw
+        try:
+            number = float(text)
+        except (TypeError, ValueError, OverflowError):
+            logger.warning("Invalid budget.daily_tokens %r — budget disabled", raw)
+            return 0
+        # NaN fails every comparison, so this also rejects it.
+        if not (float("-inf") < number < float("inf")):
+            logger.warning(
+                "Non-finite budget.daily_tokens %r — budget disabled (use 0 for "
+                "no limit)",
+                raw,
+            )
+            return 0
+        try:
+            value = int(number)
+        except (ValueError, OverflowError):  # pragma: no cover - defensive
+            logger.warning("Invalid budget.daily_tokens %r — budget disabled", raw)
+            return 0
+    else:
+        logger.warning("Invalid budget.daily_tokens %r — budget disabled", raw)
+        return 0
+    return value if value > 0 else 0
+
+
+def load_budget_settings() -> BudgetSettings:
+    """Read the ``budget:`` section from config.yaml (fail-open to disabled).
+
+    Uses ``load_config_readonly()`` so both the CLI loader and the gateway see
+    the same merged defaults, and so the per-API-call read is a cache hit.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+    except Exception:
+        logger.debug("budget settings load failed (fail-open)", exc_info=True)
+        return BudgetSettings()
+
+    section = config.get("budget")
+    if not isinstance(section, dict):
+        return BudgetSettings()
+
+    tz = section.get("timezone", "")
+    return BudgetSettings(
+        daily_tokens=_coerce_daily_tokens(section.get("daily_tokens")),
+        timezone=tz.strip() if isinstance(tz, str) else "",
+    )
+
+
+def budget_now(settings: Optional[BudgetSettings] = None) -> datetime:
+    """Current wall-clock time in the budget's timezone.
+
+    ``budget.timezone`` wins; otherwise fall back to the global Hermes clock
+    (``HERMES_TIMEZONE`` → ``timezone:`` → server local), so a user who
+    already set their timezone once does not have to repeat it here.
+    """
+    settings = settings or load_budget_settings()
+    name = settings.timezone
+    if name:
+        try:
+            from zoneinfo import ZoneInfo
+
+            return datetime.now(ZoneInfo(name))
+        except Exception:
+            logger.warning(
+                "Invalid budget.timezone %r — falling back to the Hermes clock",
+                name,
+            )
+    from hermes_time import now as hermes_now
+
+    return hermes_now()
+
+
+def current_day(settings: Optional[BudgetSettings] = None) -> str:
+    """The ledger key for "today" (``YYYY-MM-DD``) in the budget timezone."""
+    return budget_now(settings).strftime("%Y-%m-%d")
+
+
+# ── Value objects ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Reservation:
+    """A held claim on part of today's budget. Settle or release it."""
+
+    id: str
+    day: str
+    tokens: int
+
+
+@dataclass(frozen=True)
+class BudgetSnapshot:
+    """Point-in-time view of one day's ledger."""
+
+    day: str
+    limit: int
+    used: int
+    reserved: int
+    timezone: str = ""
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.limit - self.used - self.reserved)
+
+    @property
+    def used_percent(self) -> float:
+        if self.limit <= 0:
+            return 0.0
+        return min(100.0, self.used / self.limit * 100.0)
+
+    @property
+    def exhausted(self) -> bool:
+        return self.remaining <= 0
+
+
+@dataclass
+class ReserveOutcome:
+    """Result of :meth:`DailyTokenBudget.reserve`.
+
+    ``status`` is ``"disabled"`` (no budget configured), ``"granted"``, or
+    ``"denied"``. Callers only need to block on ``"denied"``.
+    """
+
+    status: str
+    reservation: Optional[Reservation] = None
+    snapshot: Optional[BudgetSnapshot] = None
+    message: str = ""
+
+    @property
+    def denied(self) -> bool:
+        return self.status == "denied"
+
+
+@dataclass
+class SettleOutcome:
+    """Result of :meth:`DailyTokenBudget.settle`."""
+
+    snapshot: Optional[BudgetSnapshot] = None
+    crossed_marks: List[int] = field(default_factory=list)
+
+
+# ── Ledger ──────────────────────────────────────────────────────────────────
+
+
+def default_db_path() -> Path:
+    """Profile-scoped ledger location — the shared ``state.db``."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "state.db"
+
+
+class DailyTokenBudget:
+    """Atomic reserve/settle ledger backed by ``state.db``.
+
+    One connection is opened per operation and closed immediately: the
+    gateway calls this from many threads, and the ledger writes are tiny
+    compared with the provider call they guard.
+    """
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path) if db_path is not None else None
+        self._init_lock = threading.Lock()
+        self._initialized = False
+
+    # -- plumbing ----------------------------------------------------------
+
+    @property
+    def db_path(self) -> Path:
+        return self._db_path if self._db_path is not None else default_db_path()
+
+    def _connect(self) -> sqlite3.Connection:
+        path = self.db_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        from hermes_cli.sqlite_safe_read import connect_tracked
+
+        conn = connect_tracked(
+            path,
+            connect_fn=sqlite3.connect,
+            isolation_level=None,  # explicit BEGIN IMMEDIATE below
+            timeout=30.0,
+        )
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA busy_timeout=30000")
+            with self._init_lock:
+                if not self._initialized:
+                    from hermes_state import apply_wal_with_fallback
+
+                    apply_wal_with_fallback(conn, db_label="state.db")
+                    conn.executescript(_SCHEMA_SQL)
+                    self._initialized = True
+        except Exception:
+            conn.close()
+            raise
+        return conn
+
+    @staticmethod
+    def _sweep_abandoned(conn: sqlite3.Connection, day: str, now: float) -> None:
+        """Delete reservation rows that no live budget can ever depend on.
+
+        Both guards matter and neither is sufficient alone: ``day <> ?`` keeps
+        this from touching anything counted against the day being written, and
+        the age guard keeps it from touching a call that crossed midnight and
+        is still in flight. What is left is a row from a past day that is over
+        a day old — dead weight in the table, worth nothing to anyone.
+
+        This is deliberately *not* a reclamation timer. Freeing a claim whose
+        owner may still be talking to the provider would let that spend settle
+        into nothing, so the day would keep admitting attempts against budget
+        it had already spent.
+        """
+        conn.execute(
+            "DELETE FROM llm_budget_reservations WHERE day <> ? AND created_at < ?",
+            (day, now - ABANDONED_ROW_MAX_AGE_SECONDS),
+        )
+
+    @staticmethod
+    def _read_day(conn: sqlite3.Connection, day: str) -> Tuple[int, str]:
+        row = conn.execute(
+            "SELECT used_tokens, notified_marks FROM llm_budget_days WHERE day = ?",
+            (day,),
+        ).fetchone()
+        if row is None:
+            return 0, ""
+        return int(row["used_tokens"] or 0), str(row["notified_marks"] or "")
+
+    @staticmethod
+    def _read_reserved(conn: sqlite3.Connection, day: str) -> int:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(tokens), 0) AS total "
+            "FROM llm_budget_reservations WHERE day = ?",
+            (day,),
+        ).fetchone()
+        return int(row["total"] or 0) if row is not None else 0
+
+    # -- operations --------------------------------------------------------
+
+    def reserve(
+        self,
+        estimated_tokens: int,
+        *,
+        settings: Optional[BudgetSettings] = None,
+    ) -> ReserveOutcome:
+        """Claim ``estimated_tokens`` of today's budget before a provider call.
+
+        Denies when the estimate does not fit in what is left after committed
+        spend and other in-flight reservations. The whole read-decide-write
+        runs inside one ``BEGIN IMMEDIATE`` transaction, so two processes
+        cannot both be granted the last of the budget.
+        """
+        settings = settings or load_budget_settings()
+        if not settings.enabled:
+            return ReserveOutcome(status="disabled")
+
+        estimate = max(0, int(estimated_tokens or 0))
+        day = current_day(settings)
+        now = time.time()
+        reservation_id = uuid.uuid4().hex
+
+        try:
+            conn = self._connect()
+        except Exception:
+            # Ledger unavailable (locked / read-only / corrupt). Fail OPEN:
+            # a budget we cannot read must not brick the agent.
+            logger.warning("daily budget ledger unavailable — allowing call", exc_info=True)
+            return ReserveOutcome(status="disabled")
+
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._sweep_abandoned(conn, day, now)
+                used, _marks = self._read_day(conn, day)
+                reserved = self._read_reserved(conn, day)
+                snapshot = BudgetSnapshot(
+                    day=day,
+                    limit=settings.daily_tokens,
+                    used=used,
+                    reserved=reserved,
+                    timezone=settings.timezone,
+                )
+                if used + reserved + estimate > settings.daily_tokens:
+                    conn.execute("ROLLBACK")
+                    return ReserveOutcome(
+                        status="denied",
+                        snapshot=snapshot,
+                        message=denial_message(snapshot, estimate),
+                    )
+                conn.execute(
+                    "INSERT INTO llm_budget_reservations "
+                    "(id, day, tokens, created_at, owner_pid) VALUES (?, ?, ?, ?, ?)",
+                    (reservation_id, day, estimate, now, os.getpid()),
+                )
+                conn.execute("COMMIT")
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+        except Exception:
+            logger.warning("daily budget reserve failed — allowing call", exc_info=True)
+            return ReserveOutcome(status="disabled")
+        finally:
+            conn.close()
+
+        return ReserveOutcome(
+            status="granted",
+            reservation=Reservation(id=reservation_id, day=day, tokens=estimate),
+            snapshot=BudgetSnapshot(
+                day=day,
+                limit=settings.daily_tokens,
+                used=snapshot.used,
+                reserved=snapshot.reserved + estimate,
+                timezone=settings.timezone,
+            ),
+        )
+
+    def settle(
+        self,
+        reservation: Optional[Reservation],
+        actual_tokens: int,
+        *,
+        settings: Optional[BudgetSettings] = None,
+    ) -> SettleOutcome:
+        """Swap a reservation for the tokens the attempt actually cost.
+
+        ``actual_tokens`` is the provider's reported total when there is one;
+        callers that got a response *without* usage pass the reservation
+        amount, because an unmeasured response is still a charge (see the
+        module docstring). Only an attempt with no provider response at all
+        goes to :meth:`release`.
+
+        Exactly idempotent. The ``DELETE`` of the reservation row is the
+        permit: usage is added only by the call that removed the row, in the
+        same transaction. A second settle of the same reservation, a settle
+        after :meth:`release`, and a settle of an id that was never in the
+        table all find nothing to delete and therefore charge nothing — they
+        report the current ledger and announce no marks. Callers may retry
+        freely without inflating the day.
+
+        Returns the post-settlement snapshot plus any threshold marks this
+        call is responsible for announcing. A mark is claimed inside the same
+        transaction, so exactly one process ever emits it for a given day.
+        """
+        if reservation is None:
+            return SettleOutcome()
+        settings = settings or load_budget_settings()
+        actual = max(0, int(actual_tokens or 0))
+        day = reservation.day
+        now = time.time()
+
+        try:
+            conn = self._connect()
+        except Exception:
+            logger.warning("daily budget ledger unavailable — spend not recorded", exc_info=True)
+            return SettleOutcome()
+
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                charged = bool(
+                    conn.execute(
+                        "DELETE FROM llm_budget_reservations WHERE id = ?",
+                        (reservation.id,),
+                    ).rowcount
+                )
+                if charged:
+                    conn.execute(
+                        "INSERT INTO llm_budget_days (day, used_tokens, notified_marks, updated_at) "
+                        "VALUES (?, ?, '', ?) "
+                        "ON CONFLICT(day) DO UPDATE SET "
+                        "used_tokens = used_tokens + excluded.used_tokens, "
+                        "updated_at = excluded.updated_at",
+                        (day, actual, now),
+                    )
+                else:
+                    # Already settled or released. Charging here is how a
+                    # retried settle would double-bill a day, so don't.
+                    logger.debug(
+                        "budget reservation %s is not outstanding; settle is a no-op",
+                        reservation.id,
+                    )
+                used, marks_raw = self._read_day(conn, day)
+                reserved = self._read_reserved(conn, day)
+                snapshot = BudgetSnapshot(
+                    day=day,
+                    limit=settings.daily_tokens,
+                    used=used,
+                    reserved=reserved,
+                    timezone=settings.timezone,
+                )
+                claimed = {m for m in marks_raw.split(",") if m}
+                crossed: List[int] = []
+                if charged and settings.enabled:
+                    for mark in NOTIFY_MARKS:
+                        if snapshot.used_percent >= mark and str(mark) not in claimed:
+                            claimed.add(str(mark))
+                            crossed.append(mark)
+                if crossed:
+                    conn.execute(
+                        "UPDATE llm_budget_days SET notified_marks = ? WHERE day = ?",
+                        (",".join(sorted(claimed, key=int)), day),
+                    )
+                conn.execute("COMMIT")
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+        except Exception:
+            logger.warning("daily budget settle failed", exc_info=True)
+            return SettleOutcome()
+        finally:
+            conn.close()
+
+        return SettleOutcome(snapshot=snapshot, crossed_marks=crossed)
+
+    def release(self, reservation: Optional[Reservation]) -> None:
+        """Drop a reservation for an attempt that got no provider response.
+
+        Nothing is charged, so this is only correct when the attempt is known
+        to have produced no response (transport exception, cancellation before
+        an answer). Anything that did come back off the wire settles.
+        """
+        if reservation is None:
+            return
+        try:
+            conn = self._connect()
+        except Exception:
+            logger.debug("daily budget release skipped (ledger unavailable)", exc_info=True)
+            return
+        try:
+            conn.execute(
+                "DELETE FROM llm_budget_reservations WHERE id = ?",
+                (reservation.id,),
+            )
+        except Exception:
+            logger.debug("daily budget release failed", exc_info=True)
+        finally:
+            conn.close()
+
+    def snapshot(
+        self, *, settings: Optional[BudgetSettings] = None
+    ) -> Optional[BudgetSnapshot]:
+        """Today's ledger state, or ``None`` when no budget is configured."""
+        settings = settings or load_budget_settings()
+        if not settings.enabled:
+            return None
+        day = current_day(settings)
+        try:
+            conn = self._connect()
+        except Exception:
+            logger.debug("daily budget snapshot unavailable", exc_info=True)
+            return None
+        try:
+            # Read-only by construction: rendering ``/usage`` or a status line
+            # must never mutate the ledger, least of all by freeing someone
+            # else's in-flight claim.
+            used, _marks = self._read_day(conn, day)
+            reserved = self._read_reserved(conn, day)
+        except Exception:
+            logger.debug("daily budget snapshot failed", exc_info=True)
+            return None
+        finally:
+            conn.close()
+        return BudgetSnapshot(
+            day=day,
+            limit=settings.daily_tokens,
+            used=used,
+            reserved=reserved,
+            timezone=settings.timezone,
+        )
+
+
+# ── Process-wide accessor ───────────────────────────────────────────────────
+
+_LEDGER_LOCK = threading.Lock()
+_LEDGER: Optional[DailyTokenBudget] = None
+_LEDGER_PATH: Optional[str] = None
+
+
+def get_ledger() -> DailyTokenBudget:
+    """Return the ledger for the active profile.
+
+    Re-created when ``HERMES_HOME`` changes (profile switch, test isolation)
+    so a cached instance never writes into the previous profile's state.db.
+    """
+    global _LEDGER, _LEDGER_PATH
+    path = str(default_db_path())
+    with _LEDGER_LOCK:
+        if _LEDGER is None or _LEDGER_PATH != path:
+            _LEDGER = DailyTokenBudget()
+            _LEDGER_PATH = path
+        return _LEDGER
+
+
+def reset_ledger_cache() -> None:
+    """Drop the cached ledger (tests / profile switches)."""
+    global _LEDGER, _LEDGER_PATH
+    with _LEDGER_LOCK:
+        _LEDGER = None
+        _LEDGER_PATH = None
+
+
+# ── Rendering ───────────────────────────────────────────────────────────────
+
+
+def _reset_hint(snapshot: BudgetSnapshot) -> str:
+    tz = snapshot.timezone or ""
+    return f" • resets at midnight {tz}".rstrip() if tz else " • resets at midnight"
+
+
+def denial_message(snapshot: BudgetSnapshot, estimated_tokens: int) -> str:
+    """User-facing text for a request that does not fit in today's budget."""
+    return (
+        "🛑 Daily LLM token budget reached — this request needs about "
+        f"{estimated_tokens:,} tokens but only {snapshot.remaining:,} of the "
+        f"{snapshot.limit:,}-token daily budget remain "
+        f"({snapshot.used:,} used today{_reset_hint(snapshot)}). "
+        "Raise `budget.daily_tokens` in config.yaml or continue tomorrow."
+    )
+
+
+def threshold_message(snapshot: BudgetSnapshot, mark: int) -> str:
+    """One-time-per-day notification text for a crossed usage mark."""
+    return (
+        f"📉 Daily LLM budget {mark}% used — {snapshot.used:,} / "
+        f"{snapshot.limit:,} tokens today ({snapshot.remaining:,} remaining"
+        f"{_reset_hint(snapshot)})."
+    )
+
+
+def _gauge(percent: float, width: int = 20) -> str:
+    filled = max(0, min(width, int(round(percent / 100.0 * width))))
+    return "█" * filled + "░" * (width - filled)
+
+
+def daily_budget_lines(
+    *,
+    markdown: bool = False,
+    snapshot: Optional[BudgetSnapshot] = None,
+) -> List[str]:
+    """Render the global daily-budget block for ``/usage``.
+
+    Returns ``[]`` when no budget is configured, so both call sites can
+    unconditionally extend their output. Shared by the CLI and the gateway so
+    the two surfaces cannot drift.
+    """
+    if snapshot is None:
+        try:
+            snapshot = get_ledger().snapshot()
+        except Exception:
+            logger.debug("daily budget lines unavailable", exc_info=True)
+            return []
+    if snapshot is None:
+        return []
+
+    bold = "**" if markdown else ""
+    pct = snapshot.used_percent
+    lines = [f"🌐 {bold}Daily LLM Budget{bold} ({snapshot.day})"]
+    lines.append(
+        f"{_gauge(pct)} {pct:.0f}% — {snapshot.used:,} / {snapshot.limit:,} tokens"
+    )
+    lines.append(f"Remaining: {snapshot.remaining:,} tokens")
+    if snapshot.reserved:
+        lines.append(f"In flight (reserved): {snapshot.reserved:,} tokens")
+    if snapshot.timezone:
+        lines.append(f"Resets at midnight {snapshot.timezone}")
+    return lines
+
+
+# ── Convenience wrappers (module-level API used by the agent loop) ──────────
+
+
+def reserve(estimated_tokens: int) -> ReserveOutcome:
+    return get_ledger().reserve(estimated_tokens)
+
+
+def settle(reservation: Optional[Reservation], actual_tokens: int) -> SettleOutcome:
+    return get_ledger().settle(reservation, actual_tokens)
+
+
+def release(reservation: Optional[Reservation]) -> None:
+    get_ledger().release(reservation)
+
+
+def snapshot() -> Optional[BudgetSnapshot]:
+    return get_ledger().snapshot()
+
+
+__all__ = [
+    "BudgetSettings",
+    "BudgetSnapshot",
+    "DailyTokenBudget",
+    "ABANDONED_ROW_MAX_AGE_SECONDS",
+    "NOTIFY_MARKS",
+    "Reservation",
+    "ReserveOutcome",
+    "SettleOutcome",
+    "current_day",
+    "daily_budget_lines",
+    "default_db_path",
+    "denial_message",
+    "get_ledger",
+    "load_budget_settings",
+    "release",
+    "reserve",
+    "reset_ledger_cache",
+    "settle",
+    "snapshot",
+    "threshold_message",
+]

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -748,6 +748,46 @@ session_reset:
 # local runtime lease registry cannot be read or locked.
 max_concurrent_sessions: null
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Global Daily LLM Token Budget
+# ─────────────────────────────────────────────────────────────────────────────
+# One daily budget for AGENT-LOOP tokens, shared by every surface that runs
+# the agent loop in this profile (CLI, TUI, desktop, messaging gateway, cron
+# jobs, subagents) and by every concurrent Hermes process — the ledger lives in
+# the profile's state.db, not in memory.
+#
+# Each provider attempt reserves its estimated cost before the request and
+# settles the real token count afterwards, so estimates self-correct and two
+# processes can never both spend the last of the budget. Retries are metered
+# individually. A request that no longer fits is refused instead of being sent.
+#
+# WHAT THIS GUARANTEES: admission, not an absolute ceiling. A call's true cost
+# is only known once the provider has answered, so a day can end over
+# daily_tokens by however much the last admitted response overshot its
+# reservation — one API response's worth, charged in full so the next attempt
+# is judged against the corrected total.
+#
+# SCOPE: auxiliary provider calls are NOT counted — context compression and
+# summarisation, memory/curator passes, title generation, embeddings, and MoA
+# advisor fan-out all spend tokens this ledger never sees. daily_tokens bounds
+# the agent loop, not your whole provider bill; leave headroom accordingly.
+#
+# You get one-time notifications at 50% and 75% of the daily budget (once per
+# day across all processes, not once per session), and `/usage` shows the
+# current global figure in both the CLI and messaging platforms.
+#
+# A reservation is handed back only by the process holding it — there is no
+# reclamation timer, so a SIGKILLed process parks its claim until midnight.
+# That loses capacity rather than overspending it, which is the tradeoff this
+# feature exists to make.
+#
+# daily_tokens: 0 or null disables the feature entirely — no ledger reads and
+# no writes on the request path.
+budget:
+  daily_tokens: 0          # e.g. 2000000 for a 2M-token/day budget
+  timezone: ""             # IANA zone deciding when "today" rolls over;
+                           # empty falls back to the global `timezone` setting
+
 # When true, group/channel chats use one session per participant when the platform
 # provides a user ID. This is the secure default and prevents users in the same
 # room from sharing context, interrupts, and token costs. Set false only if you

--- a/cli.py
+++ b/cli.py
@@ -11526,11 +11526,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         with no live agent — important for the TUI, where /usage runs in a slash-worker
         subprocess that resumes the session WITHOUT building an agent (self.agent is None),
         which would otherwise early-return before any credits showed.
+
+        The global daily-budget block is agent-independent for the same reason,
+        but a stronger one: it reports the WHOLE profile's spend today (every
+        CLI, gateway, and cron process), so it is meaningful before this
+        session has made a single call.
         """
         if not self.agent:
+            printed_budget = self._print_daily_budget_block()
             if self._print_nous_credits_block():
                 self._print_usage_cta()
-            else:
+            elif not printed_budget:
                 print("(._.) No active agent -- send a message first.")
             return
 
@@ -11538,9 +11544,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         calls = agent.session_api_calls
 
         if calls == 0:
+            printed_budget = self._print_daily_budget_block()
             if self._print_nous_credits_block():
                 self._print_usage_cta()
-            else:
+            elif not printed_budget:
                 print("(._.) No API calls made yet in this session.")
             return
 
@@ -11608,6 +11615,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print()
             for line in account_lines:
                 print(line)
+
+        # Profile-wide daily token ceiling (agent-independent — see the
+        # docstring). Prints nothing when budget.daily_tokens is unset.
+        self._print_daily_budget_block()
 
         # Nous credits magnitudes + monthly-grant gauge (agent-independent — also
         # runs at the no-agent / no-calls early-returns above). See the helper.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5089,6 +5089,20 @@ class GatewaySlashCommandsMixin:
         except Exception:
             credits_lines = []  # fail-open: never break /usage
 
+        # ── Global daily LLM budget ─────────────────────────────────────
+        # Agent-independent: a read of the profile's shared state.db ledger,
+        # which every surface (CLI, TUI, cron, this gateway) settles into. It
+        # therefore renders on every /usage branch below, including the ones
+        # with no resident agent. Same renderer the CLI uses, so the two
+        # surfaces cannot drift. Off the event loop (SQLite I/O). Fail-open.
+        budget_lines: list[str] = []
+        try:
+            from agent.token_budget import daily_budget_lines
+
+            budget_lines = await asyncio.to_thread(daily_budget_lines, markdown=True)
+        except Exception:
+            budget_lines = []
+
         if agent and hasattr(agent, "session_total_tokens") and agent.session_api_calls > 0:
             lines = []
 
@@ -5130,6 +5144,9 @@ class GatewaySlashCommandsMixin:
                 lines.append("")
                 lines.extend(breakdown_lines)
 
+            if budget_lines:
+                lines.append("")
+                lines.extend(budget_lines)
             if account_lines:
                 lines.append("")
                 lines.extend(account_lines)
@@ -5152,6 +5169,9 @@ class GatewaySlashCommandsMixin:
                 t("gateway.usage.label_estimated_context", count=f"{approx:,}"),
                 t("gateway.usage.detailed_after_first"),
             ]
+            if budget_lines:
+                lines.append("")
+                lines.extend(budget_lines)
             if account_lines:
                 lines.append("")
                 lines.extend(account_lines)
@@ -5159,13 +5179,16 @@ class GatewaySlashCommandsMixin:
                 lines.append("")
                 lines.extend(credits_lines)
             return "\n".join(lines)
-        if account_lines or credits_lines:
-            # account-only, credits-only, or both — joined with a blank divider.
-            parts = list(account_lines)
-            if credits_lines:
+        if budget_lines or account_lines or credits_lines:
+            # budget-only, account-only, credits-only, or any mix — joined with
+            # blank dividers in the same order as the with-agent branch.
+            parts: list[str] = []
+            for block in (budget_lines, account_lines, credits_lines):
+                if not block:
+                    continue
                 if parts:
                     parts.append("")
-                parts.extend(credits_lines)
+                parts.extend(block)
             return "\n".join(parts)
         return t("gateway.usage.no_data")
 

--- a/hermes_cli/cli_billing_mixin.py
+++ b/hermes_cli/cli_billing_mixin.py
@@ -85,6 +85,27 @@ class CLIBillingMixin:
             print(f"  {line}")
         return True
 
+    def _print_daily_budget_block(self) -> bool:
+        """Print the global daily LLM token budget block. True if it printed.
+
+        Agent-independent (a read of the profile's shared state.db ledger), so
+        ``/usage`` shows today's global spend even with no live agent — the
+        budget is a property of the profile, not of this session. Returns
+        False when ``budget.daily_tokens`` is unset, which is the default.
+        """
+        try:
+            from agent.token_budget import daily_budget_lines
+
+            lines = daily_budget_lines()
+        except Exception:
+            return False
+        if not lines:
+            return False
+        print()
+        for line in lines:
+            print(f"  {line}")
+        return True
+
     def _print_usage_cta(self) -> None:
         """Print the `/usage` call-to-action pointing at /subscription + /topup.
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1941,6 +1941,24 @@ DEFAULT_CONFIG = {
     # Empty string means use server-local time.
     "timezone": "",
 
+    # Global daily budget for AGENT-LOOP tokens, shared by every surface that
+    # runs the loop (CLI, TUI, desktop, gateway, cron, subagents) and every
+    # concurrent process — the ledger lives in the profile's state.db. Each
+    # provider attempt reserves its estimate before the request and settles the
+    # real token count afterwards; a request that no longer fits is refused.
+    # It gates admission rather than capping spend absolutely: a day can end
+    # over by one response's overshoot of its reservation. Auxiliary calls
+    # (compression, summaries, memory, embeddings, MoA advisors) are NOT
+    # metered. See agent/token_budget.py.
+    "budget": {
+        # Tokens per calendar day. 0 / null disables the feature entirely
+        # (no ledger reads, no writes).
+        "daily_tokens": 0,
+        # IANA timezone deciding when "today" rolls over. Empty string falls
+        # back to the global `timezone` setting above (then server-local).
+        "timezone": "",
+    },
+
     # Slack platform settings (gateway mode)
     "slack": {
         "require_mention": True,       # Require @mention to respond in channels

--- a/run_agent.py
+++ b/run_agent.py
@@ -8046,6 +8046,21 @@ class AIAgent:
                         self._reset_activity_labels_after_turn()
                     except Exception:
                         pass
+                    # Hand back any global daily-budget claim whose provider
+                    # call never got a response (an attempt that did is settled
+                    # on arrival, leaving nothing here). The loop releases on
+                    # its own normal paths; this covers the turn dying by
+                    # exception or by an early return from inside the loop.
+                    # There is no reclamation timer, so a claim missed here
+                    # stays parked until midnight. See agent/token_budget.py.
+                    try:
+                        from agent.conversation_loop import (
+                            _release_agent_budget_reservation,
+                        )
+
+                        _release_agent_budget_reservation(self)
+                    except Exception:
+                        pass
                     if getattr(self, "_relay_pending_turn_id", None) == relay_turn_id:
                         self._relay_pending_turn_id = None
                     if acct_token is not None:

--- a/tests/agent/test_token_budget.py
+++ b/tests/agent/test_token_budget.py
@@ -1,0 +1,666 @@
+"""Behavior tests for the global daily LLM token budget ledger.
+
+Covers the reserve → settle / release contract on a real SQLite ``state.db``
+(no mocks — the whole point of the ledger is that it is shared across
+processes, so it is exercised through two independent ledger handles on the
+same file, which is what two Hermes processes look like from SQLite's side).
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent import token_budget as tb
+
+
+@pytest.fixture
+def settings():
+    return tb.BudgetSettings(daily_tokens=1000, timezone="UTC")
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    return tb.DailyTokenBudget(db_path=tmp_path / "state.db")
+
+
+# ── Settings resolution ─────────────────────────────────────────────────────
+
+
+def test_missing_budget_section_disables_the_feature(tmp_path, monkeypatch):
+    """No `budget:` in config.yaml → disabled, and disabled means untouched DB."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    resolved = tb.load_budget_settings()
+    assert resolved.enabled is False
+    assert resolved.daily_tokens == 0
+
+
+def test_settings_read_from_config_yaml(tmp_path, monkeypatch):
+    """`budget.daily_tokens` / `budget.timezone` come off config.yaml."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "budget:\n  daily_tokens: 2000000\n  timezone: 'America/Sao_Paulo'\n",
+        encoding="utf-8",
+    )
+    resolved = tb.load_budget_settings()
+    assert resolved.daily_tokens == 2_000_000
+    assert resolved.timezone == "America/Sao_Paulo"
+    assert resolved.enabled is True
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, 0),
+        (0, 0),
+        (-5, 0),
+        (True, 0),
+        ("2_000_000", 2_000_000),
+        ("1,500", 1_500),
+        ("not-a-number", 0),
+        ({"nested": 1}, 0),
+        (1500.9, 1500),
+        # Non-finite values: YAML's `.inf` / `.nan` parse into real floats, and
+        # int() raises OverflowError / ValueError on them. "No limit" is 0 here.
+        (float("inf"), 0),
+        (float("-inf"), 0),
+        (float("nan"), 0),
+        ("inf", 0),
+        ("-Infinity", 0),
+        ("nan", 0),
+        ("1e400", 0),  # overflows to inf while parsing
+    ],
+)
+def test_daily_tokens_coercion_never_raises(raw, expected):
+    """A malformed budget value disables the ceiling; it never breaks a turn."""
+    assert tb._coerce_daily_tokens(raw) == expected
+
+
+def test_a_huge_int_budget_is_not_rounded_through_float():
+    """An absurd-but-valid int must survive exactly, not overflow to disabled."""
+    huge = 10**30
+    assert tb._coerce_daily_tokens(huge) == huge
+
+
+def test_invalid_timezone_falls_back_to_the_hermes_clock():
+    """A bogus IANA zone must not crash the day-key computation."""
+    day = tb.current_day(tb.BudgetSettings(daily_tokens=10, timezone="Mars/Olympus"))
+    assert len(day) == 10 and day.count("-") == 2
+
+
+def test_day_key_follows_the_configured_timezone():
+    """Two zones on opposite sides of the date line get different day keys."""
+    a = tb.current_day(tb.BudgetSettings(daily_tokens=1, timezone="Pacific/Kiritimati"))
+    b = tb.current_day(tb.BudgetSettings(daily_tokens=1, timezone="Pacific/Niue"))
+    assert a >= b  # Kiritimati (+14) is never behind Niue (-11)
+
+
+# ── Reserve / settle / release ──────────────────────────────────────────────
+
+
+def test_disabled_budget_short_circuits_without_touching_the_db(tmp_path):
+    """The default install must pay nothing on the request path."""
+    db = tmp_path / "state.db"
+    ledger = tb.DailyTokenBudget(db_path=db)
+    outcome = ledger.reserve(500, settings=tb.BudgetSettings(daily_tokens=0))
+    assert outcome.status == "disabled"
+    assert outcome.reservation is None
+    assert not db.exists()
+
+
+def test_settle_charges_the_actual_not_the_estimate(ledger, settings):
+    """A generous estimate is corrected by the provider's real count."""
+    granted = ledger.reserve(900, settings=settings)
+    assert granted.status == "granted"
+
+    ledger.settle(granted.reservation, 120, settings=settings)
+
+    snap = ledger.snapshot(settings=settings)
+    assert snap.used == 120
+    assert snap.reserved == 0
+    assert snap.remaining == 880
+
+
+def test_settle_charges_an_underestimate_in_full(ledger, settings):
+    """Spending more than reserved is recorded honestly, even past the limit."""
+    granted = ledger.reserve(100, settings=settings)
+    ledger.settle(granted.reservation, 1400, settings=settings)
+
+    snap = ledger.snapshot(settings=settings)
+    assert snap.used == 1400
+    assert snap.remaining == 0
+    assert snap.exhausted is True
+
+
+def test_release_frees_the_claim_without_charging(ledger, settings):
+    """A failed call gives its tokens back — an unsettled reservation is not spend."""
+    granted = ledger.reserve(800, settings=settings)
+    assert ledger.snapshot(settings=settings).reserved == 800
+
+    ledger.release(granted.reservation)
+
+    snap = ledger.snapshot(settings=settings)
+    assert snap.used == 0
+    assert snap.reserved == 0
+    assert snap.remaining == 1000
+
+
+def test_reserve_is_denied_when_the_estimate_does_not_fit(ledger, settings):
+    granted = ledger.reserve(600, settings=settings)
+    ledger.settle(granted.reservation, 600, settings=settings)
+
+    denied = ledger.reserve(500, settings=settings)
+
+    assert denied.denied is True
+    assert denied.reservation is None
+    assert "600" in denied.message and "1,000" in denied.message
+    # A denial must not consume anything.
+    assert ledger.snapshot(settings=settings).reserved == 0
+
+
+def test_an_in_flight_reservation_blocks_a_concurrent_process(tmp_path, settings):
+    """Two handles on one state.db cannot both be granted the last tokens.
+
+    This is the cross-process invariant: the second Hermes process sees the
+    first one's outstanding reservation, not just its committed spend.
+    """
+    db = tmp_path / "state.db"
+    process_a = tb.DailyTokenBudget(db_path=db)
+    process_b = tb.DailyTokenBudget(db_path=db)
+
+    a = process_a.reserve(700, settings=settings)
+    b = process_b.reserve(700, settings=settings)
+
+    assert a.status == "granted"
+    assert b.denied is True
+
+    # Once A settles cheaply, B fits.
+    process_a.settle(a.reservation, 10, settings=settings)
+    assert process_b.reserve(700, settings=settings).status == "granted"
+
+
+def test_an_old_reservation_is_never_freed_by_a_timer(tmp_path, ledger, settings):
+    """No reclamation timer: an unreleased claim keeps holding today's budget.
+
+    This is the deliberate tradeoff. Freeing a claim we cannot prove is
+    finished would let that call settle into a row that no longer exists and,
+    with exactly-once settle, drop its spend — so the day would keep admitting
+    attempts against budget already gone. Losing capacity until midnight is
+    the safe failure.
+    """
+    import sqlite3
+
+    ledger.reserve(900, settings=settings)
+    # Backdate the row well past any plausible call duration.
+    conn = sqlite3.connect(tmp_path / "state.db")
+    conn.execute(
+        "UPDATE llm_budget_reservations SET created_at = ?",
+        (time.time() - tb.ABANDONED_ROW_MAX_AGE_SECONDS * 10,),
+    )
+    conn.commit()
+    conn.close()
+
+    assert ledger.snapshot(settings=settings).reserved == 900
+    assert ledger.reserve(900, settings=settings).denied is True
+    assert ledger.snapshot(settings=settings).reserved == 900
+
+
+def test_a_status_read_never_mutates_the_ledger(tmp_path, ledger, settings):
+    """`/usage` is a read. Rendering it must not free anyone's live claim."""
+    import sqlite3
+
+    granted = ledger.reserve(900, settings=settings)
+    conn = sqlite3.connect(tmp_path / "state.db")
+    conn.execute(
+        "UPDATE llm_budget_reservations SET created_at = ?",
+        (time.time() - tb.ABANDONED_ROW_MAX_AGE_SECONDS * 10,),
+    )
+    conn.commit()
+    conn.close()
+
+    for _ in range(3):
+        assert ledger.snapshot(settings=settings).reserved == 900
+        tb.daily_budget_lines(snapshot=ledger.snapshot(settings=settings))
+
+    # The claim is still settleable — the reads did not destroy it.
+    ledger.settle(granted.reservation, 300, settings=settings)
+    assert ledger.snapshot(settings=settings).used == 300
+
+
+def test_abandoned_rows_from_past_days_are_swept(tmp_path, ledger, settings):
+    """Table hygiene: a day-old row from another day is dropped on the next write.
+
+    It counts against no live budget (wrong day) and cannot be in flight (a
+    day old), so deleting it is free. Bounded growth without touching today.
+    """
+    import sqlite3
+
+    ledger.reserve(1, settings=settings)  # let the ledger create the schema
+
+    conn = sqlite3.connect(tmp_path / "state.db")
+    conn.execute(
+        "INSERT INTO llm_budget_reservations VALUES (?, ?, ?, ?, ?)",
+        ("ancient", "1999-12-31", 500, time.time() - tb.ABANDONED_ROW_MAX_AGE_SECONDS - 60, 1),
+    )
+    # Same past day, but recent — a call that just crossed midnight. Keep it.
+    conn.execute(
+        "INSERT INTO llm_budget_reservations VALUES (?, ?, ?, ?, ?)",
+        ("midnight-crosser", "1999-12-31", 500, time.time(), 1),
+    )
+    conn.commit()
+    conn.close()
+
+    ledger.reserve(100, settings=settings)  # a write path — sweeps
+
+    conn = sqlite3.connect(tmp_path / "state.db")
+    ids = {r[0] for r in conn.execute("SELECT id FROM llm_budget_reservations")}
+    conn.close()
+    assert "ancient" not in ids
+    assert "midnight-crosser" in ids
+
+
+def test_settle_is_exactly_idempotent(ledger, settings):
+    """Settling twice must charge once. This is the double-billing regression.
+
+    Every repeat shape is covered: the same reservation settled again, a
+    reservation that was released first, and an id that was never in the
+    table at all. Only the call that removes the claim row may add usage.
+    """
+    granted = ledger.reserve(400, settings=settings)
+
+    first = ledger.settle(granted.reservation, 300, settings=settings)
+    assert first.snapshot.used == 300
+
+    # Same reservation, settled again — and again with a different count.
+    second = ledger.settle(granted.reservation, 300, settings=settings)
+    third = ledger.settle(granted.reservation, 999, settings=settings)
+
+    assert ledger.snapshot(settings=settings).used == 300
+    assert second.snapshot.used == 300
+    assert third.snapshot.used == 300
+    # A no-op settle must not announce thresholds either.
+    assert second.crossed_marks == []
+    assert third.crossed_marks == []
+
+
+def test_settle_after_release_charges_nothing(ledger, settings):
+    """A released claim is spent-nothing by definition; settling it adds nothing."""
+    granted = ledger.reserve(100, settings=settings)
+    ledger.release(granted.reservation)
+
+    ledger.settle(granted.reservation, 250, settings=settings)
+
+    assert ledger.snapshot(settings=settings).used == 0
+
+
+def test_settle_of_an_unknown_reservation_id_charges_nothing(ledger, settings):
+    """A fabricated or stale id must never be able to inflate a day."""
+    ledger.settle(
+        tb.Reservation(id="never-existed", day=tb.current_day(settings), tokens=0),
+        5000,
+        settings=settings,
+    )
+    assert ledger.snapshot(settings=settings).used == 0
+
+
+def test_repeat_settles_cannot_be_used_to_inflate_a_day(tmp_path, settings):
+    """Cross-process: a re-settle from another process is a no-op there too."""
+    db = tmp_path / "state.db"
+    process_a = tb.DailyTokenBudget(db_path=db)
+    process_b = tb.DailyTokenBudget(db_path=db)
+
+    granted = process_a.reserve(500, settings=settings)
+    process_a.settle(granted.reservation, 500, settings=settings)
+
+    for _ in range(5):
+        process_b.settle(granted.reservation, 500, settings=settings)
+
+    assert process_b.snapshot(settings=settings).used == 500
+
+
+def test_ledger_survives_the_day_boundary(ledger, settings):
+    """Yesterday's spend does not eat today's budget."""
+    yesterday = tb.Reservation(id="old", day="1999-12-31", tokens=0)
+    ledger.settle(yesterday, 999, settings=settings)
+
+    snap = ledger.snapshot(settings=settings)
+    assert snap.used == 0
+    assert snap.remaining == 1000
+
+
+# ── Threshold notifications ─────────────────────────────────────────────────
+
+
+def test_thresholds_fire_once_per_day_across_processes(tmp_path, settings):
+    """50%/75% are claimed in the settle transaction — exactly one announcer."""
+    db = tmp_path / "state.db"
+    process_a = tb.DailyTokenBudget(db_path=db)
+    process_b = tb.DailyTokenBudget(db_path=db)
+
+    first = process_a.settle(
+        process_a.reserve(500, settings=settings).reservation, 500, settings=settings
+    )
+    assert first.crossed_marks == [50]
+
+    # A different process pushes past 75%: it announces 75, never 50 again.
+    second = process_b.settle(
+        process_b.reserve(300, settings=settings).reservation, 300, settings=settings
+    )
+    assert second.crossed_marks == [75]
+
+    third = process_a.settle(
+        process_a.reserve(50, settings=settings).reservation, 50, settings=settings
+    )
+    assert third.crossed_marks == []
+
+
+def test_a_single_jump_claims_every_mark_it_passed(ledger, settings):
+    """One big call that vaults from 0% to 80% still reports both marks."""
+    granted = ledger.reserve(800, settings=settings)
+    outcome = ledger.settle(granted.reservation, 800, settings=settings)
+    assert outcome.crossed_marks == [50, 75]
+
+
+def test_threshold_message_names_the_mark_and_the_remainder(settings):
+    snap = tb.BudgetSnapshot(day="2026-08-09", limit=1000, used=760, reserved=0, timezone="UTC")
+    msg = tb.threshold_message(snap, 75)
+    assert "75%" in msg
+    assert "760" in msg
+    assert "240" in msg
+
+
+# ── Rendering ───────────────────────────────────────────────────────────────
+
+
+def test_no_budget_configured_renders_nothing(tmp_path, monkeypatch):
+    """`/usage` surfaces extend unconditionally, so this must be empty."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    tb.reset_ledger_cache()
+    assert tb.daily_budget_lines() == []
+
+
+def test_rendered_block_reports_used_remaining_and_reset_zone():
+    snap = tb.BudgetSnapshot(
+        day="2026-08-09", limit=2000, used=500, reserved=100, timezone="America/Sao_Paulo"
+    )
+    lines = tb.daily_budget_lines(snapshot=snap)
+    body = "\n".join(lines)
+
+    assert "Daily LLM Budget" in lines[0] and "2026-08-09" in lines[0]
+    assert "25%" in body
+    assert "500" in body and "2,000" in body
+    assert "1,400" in body  # remaining excludes the in-flight reservation
+    assert "100" in body  # the in-flight figure is disclosed, not hidden
+    assert "America/Sao_Paulo" in body
+
+
+def test_markdown_rendering_only_changes_emphasis():
+    snap = tb.BudgetSnapshot(day="2026-08-09", limit=100, used=10, reserved=0)
+    plain = tb.daily_budget_lines(snapshot=snap)
+    md = tb.daily_budget_lines(snapshot=snap, markdown=True)
+    assert len(plain) == len(md)
+    assert "**Daily LLM Budget**" in md[0]
+    assert "**" not in plain[0]
+
+
+# ── Agent-loop wiring ───────────────────────────────────────────────────────
+
+
+def test_release_helper_frees_the_agents_claim(tmp_path, monkeypatch):
+    """``_release_agent_budget_reservation`` drops the claim and clears the slot.
+
+    This is the helper the loop calls at every attempt and iteration boundary
+    and that ``AIAgent.run_conversation``'s ``finally`` calls on abort paths.
+    Since the ledger runs no reclamation timer, owner-release is the only way
+    a dead turn's budget ever comes back before midnight.
+    """
+    from agent.conversation_loop import _release_agent_budget_reservation
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "budget:\n  daily_tokens: 1000\n  timezone: 'UTC'\n", encoding="utf-8"
+    )
+    tb.reset_ledger_cache()
+
+    class _Agent:
+        pass
+
+    agent = _Agent()
+    agent._budget_reservation = tb.reserve(400).reservation
+    assert tb.snapshot().reserved == 400
+
+    _release_agent_budget_reservation(agent)
+
+    assert agent._budget_reservation is None
+    assert tb.snapshot().reserved == 0
+    # Idempotent: a second release (loop boundary + turn end) is a no-op.
+    _release_agent_budget_reservation(agent)
+    assert tb.snapshot().used == 0
+    tb.reset_ledger_cache()
+
+
+def test_conversation_loop_reserves_before_the_call_and_settles_on_the_response():
+    """Wiring pin: reserve precedes the provider call, settle follows it."""
+    import inspect
+
+    import agent.conversation_loop as cl
+
+    src = inspect.getsource(cl.run_conversation)
+    reserve_idx = src.index("from agent.token_budget import reserve as _budget_reserve")
+    call_idx = src.index("api_kwargs = agent._build_api_kwargs(api_messages)")
+    settle_idx = src.index("_settle_agent_budget_reservation(agent, response)")
+    assert reserve_idx < call_idx < settle_idx
+    # Released at the attempt, iteration, and turn boundaries, so a call that
+    # never got a response cannot carry its claim into the next request.
+    assert src.count("_release_agent_budget_reservation(agent)") >= 3
+
+
+def test_the_settle_precedes_every_response_driven_exit():
+    """Wiring pin: the charge lands before the loop can bail on the response.
+
+    The truncation, refusal, invalid-response, and tool-call-retry branches all
+    ``return``/``continue``/``break`` out of the attempt. If settle sat after
+    them (it used to sit with the usage bookkeeping, far below), each of those
+    responses would reach a release instead and be booked as free.
+    """
+    import inspect
+
+    import agent.conversation_loop as cl
+
+    src = inspect.getsource(cl.run_conversation)
+    settle_idx = src.index("_settle_agent_budget_reservation(agent, response)")
+    for response_driven_branch in (
+        "if _redirect_crossed_response:",
+        "if response_invalid:",
+        'if finish_reason == "content_filter":',
+        'if finish_reason == "length":',
+        "if hasattr(response, 'usage') and response.usage:",
+    ):
+        assert settle_idx < src.index(response_driven_branch), response_driven_branch
+
+
+def test_the_reservation_is_scoped_to_each_physical_provider_attempt():
+    """Wiring pin: reserve/release sit INSIDE the retry loop, not around it.
+
+    A retry is another real request to the provider and burns real tokens.
+    Reserving once around ``while retry_count < max_retries`` would let N
+    attempts spend against a single claim, so the estimate must be re-taken
+    (and the previous claim released) on every pass.
+    """
+    import inspect
+
+    import agent.conversation_loop as cl
+
+    src = inspect.getsource(cl.run_conversation)
+    retry_loop_idx = src.index("while retry_count < max_retries:")
+    reserve_idx = src.index("from agent.token_budget import reserve as _budget_reserve")
+    # The per-attempt release must precede the reserve inside that loop.
+    release_idx = src.index("_release_agent_budget_reservation(agent)", retry_loop_idx)
+    assert retry_loop_idx < release_idx < reserve_idx
+
+    # And the reserve must be inside the loop body, i.e. indented deeper than
+    # the `while` itself — a same-level reserve would be after the loop.
+    reserve_line = src[: src.index("\n", reserve_idx)].rsplit("\n", 1)[-1]
+    while_line = src[: src.index("\n", retry_loop_idx)].rsplit("\n", 1)[-1]
+    indent = lambda line: len(line) - len(line.lstrip())  # noqa: E731
+    assert indent(reserve_line) > indent(while_line)
+
+
+@pytest.fixture
+def budget_profile(tmp_path, monkeypatch):
+    """A profile with a 10,000-token/day budget, addressed through the wrappers.
+
+    The loop helpers go through the module-level ``reserve``/``settle`` API,
+    which resolves the ledger from ``HERMES_HOME`` — so the wiring is exercised
+    exactly as the agent loop exercises it, on a real state.db.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "budget:\n  daily_tokens: 10000\n  timezone: 'UTC'\n", encoding="utf-8"
+    )
+    tb.reset_ledger_cache()
+    yield tmp_path
+    tb.reset_ledger_cache()
+
+
+class _LoopAgent:
+    """The slice of the agent that the budget helpers actually touch."""
+
+    provider = "openai"
+    api_mode = "chat_completions"
+
+    def __init__(self) -> None:
+        self._budget_reservation = None
+        self.status: list[str] = []
+
+    def _emit_status(self, message: str) -> None:
+        self.status.append(message)
+
+
+def _usage_response(prompt_tokens: int, completion_tokens: int):
+    """A provider response carrying OpenAI-shaped usage."""
+    return SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens, completion_tokens=completion_tokens
+        )
+    )
+
+
+def test_a_truncated_response_with_usage_is_charged_before_the_retry(budget_profile):
+    """A truncated answer is spend, and the continuation retry must not undo it.
+
+    ``finish_reason="length"`` sends the loop back for a continuation without
+    ever reaching the usage bookkeeping, so the charge has to land the moment
+    the response arrives. Otherwise the per-attempt release at the top of the
+    next attempt hands the truncated call's tokens back and a model that
+    truncates on every pass can run all day for free.
+    """
+    from agent.conversation_loop import (
+        _release_agent_budget_reservation,
+        _settle_agent_budget_reservation,
+    )
+
+    agent = _LoopAgent()
+
+    # Attempt 1 — reserve generously, get a truncated response reporting 1,000.
+    agent._budget_reservation = tb.reserve(4000).reservation
+    assert tb.snapshot().reserved == 4000
+    _settle_agent_budget_reservation(agent, _usage_response(900, 100))
+
+    assert agent._budget_reservation is None
+    assert tb.snapshot().used == 1000  # the actual, not the 4,000 estimate
+    assert tb.snapshot().reserved == 0
+
+    # Attempt 2 — the continuation. The loop's per-attempt release runs first
+    # and must find nothing to give back; the new claim stacks on real spend.
+    _release_agent_budget_reservation(agent)
+    assert tb.snapshot().used == 1000
+
+    agent._budget_reservation = tb.reserve(4000).reservation
+    _settle_agent_budget_reservation(agent, _usage_response(1500, 500))
+
+    assert tb.snapshot().used == 3000
+    assert tb.snapshot().reserved == 0
+
+
+def test_a_response_without_usage_is_charged_at_the_reservation(budget_profile):
+    """No usage reported is not a free call — charge the estimate, never zero.
+
+    Plenty of providers and streaming stubs answer without a usage block. If
+    those settled at zero (or were released), an unmetered provider would spend
+    the whole day unmetered.
+    """
+    from agent.conversation_loop import _settle_agent_budget_reservation
+
+    agent = _LoopAgent()
+
+    # A perfectly successful response that simply carries no usage block.
+    agent._budget_reservation = tb.reserve(2500).reservation
+    _settle_agent_budget_reservation(
+        agent, SimpleNamespace(choices=[SimpleNamespace(finish_reason="stop")])
+    )
+
+    assert agent._budget_reservation is None
+    assert tb.snapshot().used == 2500
+    assert tb.snapshot().reserved == 0
+
+    # A usage block that reports nothing is the same case, not a free call.
+    agent._budget_reservation = tb.reserve(1500).reservation
+    _settle_agent_budget_reservation(agent, _usage_response(0, 0))
+
+    assert tb.snapshot().used == 4000
+    assert tb.snapshot().reserved == 0
+
+
+def test_only_an_attempt_without_a_response_gives_its_tokens_back(budget_profile):
+    """``response is None`` is the one shape that leaves the claim releasable."""
+    from agent.conversation_loop import (
+        _release_agent_budget_reservation,
+        _settle_agent_budget_reservation,
+    )
+
+    agent = _LoopAgent()
+    agent._budget_reservation = tb.reserve(3000).reservation
+
+    # The transport raised / the request was cancelled before any answer.
+    _settle_agent_budget_reservation(agent, None)
+    assert agent._budget_reservation is not None  # still the owner's to release
+    assert tb.snapshot().used == 0
+
+    _release_agent_budget_reservation(agent)
+    assert tb.snapshot().used == 0
+    assert tb.snapshot().reserved == 0
+
+
+def test_agent_forwarder_releases_the_claim_on_abort_paths():
+    """Wiring pin: the turn's ``finally`` releases, covering raises/early returns."""
+    import inspect
+
+    import run_agent
+
+    src = inspect.getsource(run_agent.AIAgent.run_conversation)
+    assert "_release_agent_budget_reservation(self)" in src
+    assert src.index("finally:") < src.index("_release_agent_budget_reservation(self)")
+
+
+# ── Fail-open ───────────────────────────────────────────────────────────────
+
+
+def test_an_unusable_ledger_never_blocks_a_call(tmp_path, settings, monkeypatch):
+    """A budget we cannot read must fail OPEN — never brick the agent."""
+    ledger = tb.DailyTokenBudget(db_path=tmp_path / "state.db")
+
+    def _boom(*_a, **_kw):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(ledger, "_connect", _boom)
+
+    outcome = ledger.reserve(100, settings=settings)
+    assert outcome.status == "disabled"
+    assert outcome.denied is False
+    # Settle/release/snapshot degrade quietly rather than raising.
+    assert ledger.settle(tb.Reservation("x", "2026-08-09", 1), 5, settings=settings).snapshot is None
+    ledger.release(tb.Reservation("x", "2026-08-09", 1))
+    assert ledger.snapshot(settings=settings) is None

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2023,6 +2023,77 @@ group_sessions_per_user: true  # true = per-user isolation in groups/channels, f
 
 For the behavior details and examples, see [Sessions](/user-guide/sessions) and the [Discord guide](/user-guide/messaging/discord).
 
+## Global Daily LLM Token Budget
+
+Cap how many tokens the **agent loop** may spend per calendar day. The budget
+is shared by every surface that runs the agent loop — CLI, TUI, desktop,
+messaging gateway, cron jobs, and subagents — and by every concurrent Hermes
+process:
+
+```yaml
+budget:
+  daily_tokens: 2000000   # 0 / null = disabled (default)
+  timezone: "America/Sao_Paulo"   # empty = use the global `timezone` setting
+```
+
+The ledger lives in the profile's `state.db`, not in memory. Each provider
+attempt reserves its estimated cost before the request and settles the
+provider's real token count afterwards, so estimates self-correct and two
+processes can never both spend the last of the budget. Retries are metered
+individually, because each retry is a real request. A request that no longer
+fits is refused with a message instead of being sent, and the turn ends there.
+
+### What it guarantees
+
+`daily_tokens` is an **admission budget**, not an absolute ceiling: it decides
+whether the next provider attempt may be *sent*, using an estimate, because a
+call's real cost is only known once the provider has answered and the tokens
+are already spent. A day can therefore end slightly over `daily_tokens` — by
+however much the last admitted response exceeded its own reservation, i.e. at
+most one API response's overshoot. That overrun is charged in full, so the
+next attempt is judged against the corrected total and the gap does not
+compound.
+
+An attempt that gets a response is always charged: its reported usage when the
+provider sends one, and its reservation when the provider reports none. Only
+an attempt that never received a response at all (transport failure, a
+cancellation before any answer) gives its tokens back.
+
+### What is counted
+
+Only the agent loop's own model calls. Auxiliary provider calls do **not** go
+through this ledger and are not counted against the budget:
+
+- context compression and conversation summarisation
+- memory and curator passes
+- title generation, embeddings, and other background helpers
+- MoA advisor fan-out (the advisors' own calls, not the aggregator's)
+
+So `daily_tokens` bounds agent-loop spend, not the profile's total token spend.
+Leave headroom if you are budgeting against a provider bill.
+
+### Notifications and reporting
+
+You get one-time notifications at 50% and 75% of the daily budget — once per
+day across all processes, not once per session — and `/usage` shows the current
+global figure in both the CLI and messaging platforms. Reading `/usage` never
+mutates the ledger.
+
+### Failure behaviour
+
+The budget fails open: if the ledger cannot be read or written, calls proceed
+rather than being blocked. `daily_tokens: 0` (the default) disables the feature
+entirely, with no ledger reads or writes on the request path.
+
+Reservations are only ever handed back by the process that made them — there is
+no reclamation timer, because a timer that freed a call still in flight would
+lose that call's spend and keep admitting requests against budget that was
+already gone. Hermes releases its claim on every retry, iteration, and turn
+boundary, including abort paths, so this only bites if a process is `SIGKILL`ed
+mid-request: its reservation stays parked for the remainder of that day and the
+capacity is lost until midnight. That errs toward spending less than
+`daily_tokens`, never more.
+
 ## Unauthorized DM Behavior
 
 Control what Hermes does when an unknown user sends a direct message:


### PR DESCRIPTION
## Summary
- Add a profile-wide daily LLM token admission budget backed by the shared state database.
- Reserve each main `run_conversation` provider attempt before dispatch, settle actual usage (or the reservation when usage is unavailable), and release only attempts with no response.
- Add once-per-day 50% and 75% status notifications plus current budget status in CLI and gateway `/usage`.
- Document `budget.daily_tokens` and `budget.timezone`.

## Validation
- `HERMES_PYTHON=/opt/venv/bin/python scripts/run_tests.sh tests/agent/test_token_budget.py tests/agent/test_compression_attempt_telemetry.py tests/run_agent/test_compression_feasibility.py`
  - 62 passed
- `python -m py_compile agent/token_budget.py agent/conversation_loop.py cli.py gateway/slash_commands.py hermes_cli/cli_billing_mixin.py hermes_cli/config_defaults.py run_agent.py`

## Scope
This meters main `run_conversation` provider attempts across CLI, gateway, cron, delegation, and subagents sharing the profile state DB. Auxiliary/MoA fan-out calls remain explicitly unmetered in this first slice.