### PR TITLE
fix(agent): classify empty-bodied 400 from local llama.cpp as transient and free-retry

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4177,6 +4177,29 @@ def run_conversation(
                 )
 
                 if (
+                    classified.reason == FailoverReason.llama_cpp_transient
+                    and _retry.llama_cpp_transient_retries < 10
+                ):
+                    _retry.llama_cpp_transient_retries += 1
+                    _free_n = _retry.llama_cpp_transient_retries
+                    # The failed attempt's stream-error cleanup already
+                    # closed the cached wire client, so the next attempt
+                    # opens a fresh TCP connection onto the healthy server.
+                    agent._buffer_vprint(
+                        f"llama.cpp transient 400 (free retry {_free_n}/10) — "
+                        "sleeping 1.5s"
+                    )
+                    logger.warning(
+                        "%sllama.cpp transient 400 (free retry %d/10) — "
+                        "recycling dead pooled connection",
+                        agent.log_prefix, _free_n,
+                    )
+                    time.sleep(1.5)
+                    if retry_count >= max_retries:
+                        retry_count = max_retries - 1
+                    continue
+
+                if (
                     classified.reason == FailoverReason.billing
                     and _is_nous_inference_route(
                         getattr(agent, "provider", "") or "",

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -67,6 +67,12 @@ class FailoverReason(enum.Enum):
     long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate
     oauth_long_context_beta_forbidden = "oauth_long_context_beta_forbidden"  # Anthropic OAuth subscription rejects 1M context beta — disable beta and retry
     llama_cpp_grammar_pattern = "llama_cpp_grammar_pattern"  # llama.cpp json-schema-to-grammar rejects regex escapes in `pattern` / `format` — strip from tools and retry
+    # Local llama.cpp closes the connection after every SSE reply; a pooled
+    # httpx client then lands the next request on the dead socket and gets
+    # an empty-bodied 400.  The request and server are fine — retry on a
+    # fresh connection (Hermes-only: curl and other harnesses open fresh
+    # sockets and never see it).
+    llama_cpp_transient = "llama_cpp_transient"
 
     # Catch-all
     unknown = "unknown"                  # Unclassifiable — retry with backoff
@@ -819,6 +825,37 @@ def classify_api_error(
             FailoverReason.llama_cpp_grammar_pattern,
             retryable=True,
             should_compress=False,
+        )
+
+    # Transient empty-bodied 400 from a local llama.cpp / OAI-compatible
+    # server.  llama.cpp closes the connection after every SSE reply; a
+    # pooled httpx client (only Hermes pools connections on localhost) can
+    # reuse that dead socket for the next request and receive a 400 whose
+    # body is lost on the half-closed connection (SDK falls back to the
+    # bare "Error code: 400").  No `message`/body text at all is the
+    # signature — real validation errors always carry one.  Keep it on the
+    # same local server with a fresh connection instead of aborting the
+    # turn as a non-retryable client error.
+    if (
+        status_code == 400
+        and not _body_msg
+        and not _metadata_msg
+        and provider_lower
+        in {
+            "custom",
+            "local",
+            "ollama",
+            "lmstudio",
+            "vllm",
+            "koboldcpp",
+            "openwebui",
+        }
+    ):
+        return _result(
+            FailoverReason.llama_cpp_transient,
+            retryable=True,
+            should_compress=False,
+            should_fallback=False,
         )
 
     # xAI Grok subscription entitlement errors.

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -67,6 +67,11 @@ class TurnRetryState:
     # ── Transport / rate-limit recovery ──────────────────────────────────
     primary_recovery_attempted: bool = False
     has_retried_429: bool = False
+    # Free-retry budget for local llama.cpp "transient 400" (dead pooled
+    # socket after an SSE reply).  These retries are not charged against
+    # the normal api_max_retries budget: the request itself is fine, only
+    # the connection was recycled by the server.
+    llama_cpp_transient_retries: int = 0
 
     # ── Auth-failure provider failover ───────────────────────────────────
     # Set once we've escalated a persistent 401/403 (after the per-provider

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -65,6 +65,7 @@ class TestFailoverReason:
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
+            "llama_cpp_transient",
             "unknown",
         }
         actual = {r.value for r in FailoverReason}
@@ -292,6 +293,44 @@ class TestClassifyApiError:
         non-retryable format_error and must not be swept up by the 408 branch."""
         e = MockAPIError("Bad Request", status_code=400)
         result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_400_empty_body_local_llama_cpp_is_transient(self):
+        """An empty-bodied 400 from a local llama.cpp server is the dead
+        pooled-socket signature (the server closed the connection after its
+        SSE reply, so the next call lands on a closed socket and the body is
+        lost). Treat it as transient with free retries, not an abort."""
+        e = MockAPIError("Error code: 400", status_code=400, body=None)
+        result = classify_api_error(e, provider="custom", model="local")
+        assert result.reason == FailoverReason.llama_cpp_transient
+        assert result.retryable is True
+        assert result.should_fallback is False
+
+    def test_400_empty_body_cloud_provider_stays_format_error(self):
+        """Empty-bodied 400s on cloud providers keep the existing
+        non-retryable format_error classification — only local endpoints
+        get the transient treatment."""
+        e = MockAPIError("Error code: 400", status_code=400, body=None)
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_400_with_real_message_local_stays_format_error(self):
+        """A 400 that carries a real message (validation error, etc.) from a
+        local server is still a genuine client error — it must not be swept
+        up by the empty-bodied transient branch."""
+        e = MockAPIError(
+            "Bad request: invalid messages payload",
+            status_code=400,
+            body={
+                "error": {
+                    "message": "Bad request: invalid messages payload",
+                    "type": "invalid_request_error",
+                }
+            },
+        )
+        result = classify_api_error(e, provider="custom")
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
 

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -30,6 +30,7 @@ EXPECTED_FIELDS = {
     "llama_cpp_grammar_retry_attempted",
     "primary_recovery_attempted",
     "has_retried_429",
+    "llama_cpp_transient_retries",
     "auth_failover_attempted",
     "restart_with_compressed_messages",
     "restart_with_length_continuation",


### PR DESCRIPTION
## What does this PR do?

Hermes intermittently fails against a local llama.cpp server with `HTTP 400: Error code: 400` (empty body), then aborts the turn as a non-retryable client error. It usually happens a few calls in, right after a successful streamed reply.

Root cause: the local server closes the TCP connection immediately after each SSE reply. Hermes is the only harness that pools HTTP connections against localhost (per-session httpx client), so the next call can be written to the now-dead socket. The connection rejects it with a 400 whose body is lost on the half-closed connection, which surfaces as the SDK's bare `"Error code: 400"`. The request never enters the inference queue (no llama-server log entry, no task id), and replays of the identical request over fresh connections (curl, plain openai-SDK) return 200 every time. Other harnesses (opencode, Qwen Code) against the same server never see it.

This PR classifies that signature (status_code 400, empty body, local provider slug) as transient and retryable, and free-retries it up to 10 times with a 1.5s backoff instead of aborting. Each retry already rebuilds the wire client, so it reconnects on a fresh socket. No request content, config, or cloud-provider behavior changes: real 400s that carry a message, and cloud 400s, keep the existing non-retryable `format_error` classification.

Environment note: reproduced against a local llama.cpp server running BeeLlama, Anbeeld's performance-oriented llama.cpp fork, tag `preview-v0.4.3` (commit `32040e79d2227fdef9248df3cc6746d231d66f9f`, "Keep KVarN AMD decode on supported routes"). The connection-close-after-SSE behavior was observed on that fork (confirmed via raw socket test: the server sends EOF immediately after the final `[DONE]` chunk). The fix is intentionally server-agnostic; Hermes should survive a recycled connection regardless of which llama.cpp flavor does it.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/82805

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: new `FailoverReason.llama_cpp_transient`. Classifies HTTP 400 with no body message on local providers (`custom`, `local`, `ollama`, `lmstudio`, `vllm`, `koboldcpp`, `openwebui`) as retryable, no fallback, inserted ahead of the generic-400 `format_error` classification. Empty-body 400s on cloud providers and message-bearing 400s on local providers are untouched.
- `agent/turn_retry_state.py`: `llama_cpp_transient_retries: int = 0` free-retry budget (not charged against `api_max_retries`).
- `agent/conversation_loop.py`: in the turn-loop error handler, when classified as `llama_cpp_transient` and the budget is below 10, retry with `llama.cpp transient 400 (free retry N/10) - sleeping 1.5s` instead of hitting the non-retryable abort. Resets `retry_count` to the cap so the loop re-enters, and the existing `stream_error_cleanup` closes the poisoned client so the next attempt reconnects.
- `tests/agent/test_error_classifier.py`: 3 new tests (local empty-body 400 to transient; cloud empty-body 400 still `format_error`; local 400 with real message still `format_error`). Enum contract test updated.
- `tests/agent/test_turn_retry_state.py`: field-contract test updated for the new budget field.

## How to Test

1. Start a local llama.cpp OAI server (e.g. `llama-server -m <gguf> --port 1234`). Environment used here: BeeLlama fork `preview-v0.4.3` with `Qwen3.6-35B-A3B-MTP-UD-IQ4_NL.gguf`.
2. Configure Hermes: `provider: custom`, `base_url: http://localhost:1234/v1`, `model: local`.
3. Send several turns back to back. Before: after a streamed completion the next call intermittently dies with the empty-bodied 400 and the turn aborts ("Non-retryable client error"). After: the turn logs `llama.cpp transient 400 (free retry N/10) - sleeping 1.5s` and completes on the next attempt.
4. `./venv/bin/python -m pytest tests/agent/test_error_classifier.py tests/agent/test_turn_retry_state.py -q` -> 78 passed.
5. Full suite: `venv/bin/python scripts/run_tests_parallel.py -q` (the repo's per-file parallel runner, 32 workers). My touched suites pass (`tests/agent/test_error_classifier.py` 75 passed incl. the 3 new tests; `tests/agent/test_turn_retry_state.py` 3 passed). Full parallel runs of this branch and a clean `origin/main` worktree yield the same pre-existing, environment-dependent failures (nous portal auth, fal/video/image generation, daytona/modal, hindsight, browser hardening, etc.). The only observed delta was two source-scanning guard tests (`tests/test_managed_runtime_resolution.py`, `tests/hermes_cli/test_config_read_guard.py`) failing when a stale local `build/` artifact directory was present in the checkout; removed, and they pass. Zero failures are attributable to this PR.
6. Regression guards: see the new unit tests for the empty-body boundary.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass: does not fully pass in this environment. Full parallel runs (`scripts/run_tests_parallel.py`, 32 workers) of this branch and a clean `origin/main` worktree yield the same pre-existing, environment-dependent failures (nous portal auth, fal/video/image-gen, daytona/modal, hindsight, browser hardening). This PR's touched suites all pass (error_classifier 75, turn_retry_state 3, test_models 30). No failures are attributable to this PR.
- [x] I've added tests for my changes (3 new unit tests + contract updates)
- [x] I've tested on my platform: Linux (Ubuntu 24.04-based, X870E AORUS, AMD GPU)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): N/A (docstrings updated in new code; no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): N/A (pure error-classification/retry change; macOS test intended as follow-up)
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

## Screenshots / Logs

Before (turn aborts on the recycled connection):

```
  API call failed (attempt 1/3): BadRequestError [HTTP 400]
     Elapsed: 0.01s  Context: 4 msgs, ~5,989 tokens
  Non-retryable client error (HTTP 400). Aborting.
```

Captured error payload: `{"type": "BadRequestError", "message": "Error code: 400", "status_code": 400, "body": "", "response_status": 400, "response_text": ""}`

Raw-socket confirmation that the BeeLlama server closes the connection after a streamed reply:

```
== REQ 1 (streamed) ==
  socket CLOSED by server (EOF)
== REQ 2 (same socket reuse) ==
  socket CLOSED by server (EOF)
  got 0 bytes
```

After (free retries reconnect on a fresh socket):

```
llama.cpp transient 400 (free retry N/10) - sleeping 1.5s
```
