### PR TITLE
fix(agent): stop worker-loop churn from leaking async transports

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1819,6 +1819,9 @@ class AsyncCodexAuxiliaryClient:
         # gateway restarts.
         self._real_client = sync_wrapper._real_client
 
+    async def close(self):
+        await asyncio.to_thread(self._real_client.close)
+
 
 class _AnthropicCompletionsAdapter:
     """OpenAI-client-compatible adapter for Anthropic Messages API."""
@@ -2036,6 +2039,11 @@ class AsyncAnthropicAuxiliaryClient:
         # eviction on a poisoned underlying client also drops this entry.
         self._real_client = sync_wrapper._real_client
 
+    async def close(self):
+        close_fn = getattr(self._real_client, "close", None)
+        if callable(close_fn):
+            await asyncio.to_thread(close_fn)
+
 
 class _BedrockCompletionsAdapter:
     """Translates ``chat.completions.create(**kwargs)`` into Bedrock Converse."""
@@ -2125,6 +2133,10 @@ class AsyncBedrockAuxiliaryClient:
         self.chat = _AsyncBedrockChatShim(async_adapter)
         self.api_key = sync_wrapper.api_key
         self.base_url = sync_wrapper.base_url
+        self._sync_wrapper = sync_wrapper
+
+    async def close(self):
+        await asyncio.to_thread(self._sync_wrapper.close)
 
 
 def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
@@ -7170,6 +7182,7 @@ _client_cache: Dict[tuple, tuple] = {}
 _client_cache_lock = threading.Lock()
 _client_cache_owner_threads: Dict[tuple, threading.Thread] = {}
 _retired_async_clients: Dict[int, tuple] = {}
+_retired_async_close_tasks: Dict[int, asyncio.Task] = {}
 _CLIENT_CACHE_MAX_SIZE = 64  # safety belt — evict oldest when exceeded
 _ASYNC_CLIENT_CLOSE_TIMEOUT = 5.0
 
@@ -7333,16 +7346,23 @@ def neuter_async_httpx_del() -> None:
         pass  # Graceful degradation if the SDK changes its internals
 
 
-async def _await_cached_client_close(client: Any) -> None:
-    """Invoke a client's supported close API and await it when necessary."""
+async def _await_cached_client_close(client: Any) -> bool:
+    """Invoke a client's supported close API and report physical close support."""
     close_fn = getattr(client, "close", None)
     if not callable(close_fn):
         close_fn = getattr(client, "aclose", None)
     if not callable(close_fn):
-        return
+        return False
     result = close_fn()
     if inspect.isawaitable(result):
         await result
+    return True
+
+
+async def _await_close_result(result: Any) -> bool:
+    """Await a close result already produced by a synchronous close method."""
+    await result
+    return True
 
 
 def _close_cached_client(client: Any, bound_loop: Any = None) -> bool:
@@ -7353,7 +7373,7 @@ def _close_cached_client(client: Any, bound_loop: Any = None) -> bool:
     if not callable(close_fn):
         close_fn = getattr(client, "aclose", None)
     if not callable(close_fn):
-        return True
+        return bound_loop is None
     if not inspect.iscoroutinefunction(close_fn):
         try:
             result = close_fn()
@@ -7361,7 +7381,7 @@ def _close_cached_client(client: Any, bound_loop: Any = None) -> bool:
             return False
         if not inspect.isawaitable(result):
             return True
-        close_coro = result
+        close_coro = _await_close_result(result)
     else:
         close_coro = _await_cached_client_close(client)
 
@@ -7383,14 +7403,14 @@ def _close_cached_client(client: Any, bound_loop: Any = None) -> bool:
     try:
         if bound_loop.is_running():
             future = asyncio.run_coroutine_threadsafe(bounded_close, bound_loop)
-            future.result(timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT + 0.1)
-        elif running_loop is None:
-            bound_loop.run_until_complete(bounded_close)
-        else:
-            bounded_close.close()
-            close_coro.close()
-            return False
-        return True
+            return bool(
+                future.result(timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT + 0.1)
+            )
+        if running_loop is None:
+            return bool(bound_loop.run_until_complete(bounded_close))
+        bounded_close.close()
+        close_coro.close()
+        return False
     except Exception:
         if future is not None:
             future.cancel()
@@ -7406,6 +7426,45 @@ def _retire_async_client(client: Any, bound_loop: Any) -> None:
         _retired_async_clients[id(client)] = (client, bound_loop)
 
 
+async def _close_retired_async_client_on_owner_loop(
+    client: Any,
+    bound_loop: Any,
+) -> bool:
+    """Close one retired generation without blocking its running owner loop."""
+    client_id = id(client)
+    try:
+        closed = await asyncio.wait_for(
+            _await_cached_client_close(client),
+            timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT,
+        )
+    except asyncio.CancelledError:
+        closed = False
+    except Exception:
+        closed = False
+
+    with _client_cache_lock:
+        task = _retired_async_close_tasks.get(client_id)
+        if task is asyncio.current_task():
+            del _retired_async_close_tasks[client_id]
+        current = _retired_async_clients.get(client_id)
+        if closed and current is not None and current[0] is client:
+            del _retired_async_clients[client_id]
+    return closed
+
+
+def _schedule_retired_async_client_close(client: Any, bound_loop: Any) -> None:
+    """Schedule a same-loop close once while retaining the client strongly."""
+    client_id = id(client)
+    with _client_cache_lock:
+        existing = _retired_async_close_tasks.get(client_id)
+        if existing is not None and not existing.done():
+            return
+        task = bound_loop.create_task(
+            _close_retired_async_client_on_owner_loop(client, bound_loop)
+        )
+        _retired_async_close_tasks[client_id] = task
+
+
 def _retire_or_close_client(client: Any, bound_loop: Any) -> bool:
     """Close a removed entry or retain it for an owner-loop retry."""
     if bound_loop is None:
@@ -7414,6 +7473,13 @@ def _retire_or_close_client(client: Any, bound_loop: Any) -> bool:
         _retire_async_client(client, None)
         return False
     _retire_async_client(client, bound_loop)
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+    if running_loop is bound_loop and not bound_loop.is_closed():
+        _schedule_retired_async_client_close(client, bound_loop)
+        return False
     return _close_retired_async_client(client, bound_loop)
 
 
@@ -7443,22 +7509,43 @@ async def close_cached_async_clients_for_loop(bound_loop: Any = None) -> None:
                 if loop is owner_loop
             }
         )
+        pending_tasks = {
+            client_id: task
+            for client_id, task in _retired_async_close_tasks.items()
+            if client_id in candidates and not task.done()
+        }
 
-    results = await asyncio.gather(
+    direct_candidates = {
+        client_id: client
+        for client_id, client in candidates.items()
+        if client_id not in pending_tasks
+    }
+    direct_results = await asyncio.gather(
         *(
             asyncio.wait_for(
                 _await_cached_client_close(client),
                 timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT,
             )
-            for client in candidates.values()
+            for client in direct_candidates.values()
         ),
+        return_exceptions=True,
+    )
+    pending_results = await asyncio.gather(
+        *pending_tasks.values(),
         return_exceptions=True,
     )
     closed_ids = {
         client_id
-        for (client_id, _client), result in zip(candidates.items(), results)
-        if not isinstance(result, BaseException)
+        for (client_id, _client), result in zip(
+            direct_candidates.items(), direct_results
+        )
+        if result is True
     }
+    closed_ids.update(
+        client_id
+        for client_id, result in zip(pending_tasks, pending_results)
+        if result is True
+    )
 
     if not closed_ids:
         return
@@ -7472,18 +7559,74 @@ async def close_cached_async_clients_for_loop(bound_loop: Any = None) -> None:
                 del _retired_async_clients[client_id]
 
 
-def shutdown_cached_clients() -> None:
-    """Close all cached clients (sync and async) to prevent event-loop errors.
+def _drain_cached_async_client_loop(bound_loop: Any) -> None:
+    """Run one owner loop's concurrent drain from a shutdown worker."""
+    if bound_loop.is_closed():
+        return
+    close_coro = close_cached_async_clients_for_loop(bound_loop)
+    future = None
+    try:
+        if bound_loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(close_coro, bound_loop)
+            future.result(timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT + 0.1)
+        else:
+            bound_loop.run_until_complete(close_coro)
+    except Exception:
+        if future is not None:
+            future.cancel()
+        else:
+            close_coro.close()
 
-    Call this during CLI shutdown, *before* the event loop is closed, to
-    avoid ``AsyncHttpxClientWrapper.__del__`` raising on a dead loop.
-    """
+
+def shutdown_cached_clients() -> None:
+    """Close all cached clients without serializing per-generation timeouts."""
     with _client_cache_lock:
         active = list(_client_cache.items())
         retired = list(_retired_async_clients.values())
+
+    owner_loops = {
+        entry[2]
+        for _key, entry in active
+        if entry[2] is not None and not entry[2].is_closed()
+    }
+    owner_loops.update(
+        loop
+        for _client, loop in retired
+        if loop is not None and not loop.is_closed()
+    )
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+
+    if running_loop in owner_loops:
+        owner_loops.remove(running_loop)
+        running_loop.create_task(
+            close_cached_async_clients_for_loop(running_loop)
+        )
+
+    if owner_loops:
+        import concurrent.futures
+
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=min(len(owner_loops), 32),
+            thread_name_prefix="aux-client-close",
+        )
+        futures = [
+            executor.submit(_drain_cached_async_client_loop, loop)
+            for loop in owner_loops
+        ]
+        concurrent.futures.wait(
+            futures,
+            timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT + 0.2,
+        )
+        executor.shutdown(wait=False, cancel_futures=True)
+
     for key, entry in active:
         client, _default, bound_loop = entry
-        if client is None or not _close_cached_client(client, bound_loop):
+        if bound_loop is not None:
+            continue
+        if client is None or not _close_cached_client(client):
             continue
         with _client_cache_lock:
             current = _client_cache.get(key)
@@ -7491,7 +7634,8 @@ def shutdown_cached_clients() -> None:
                 del _client_cache[key]
                 _client_cache_owner_threads.pop(key, None)
     for client, bound_loop in retired:
-        _close_retired_async_client(client, bound_loop)
+        if bound_loop is None:
+            _close_retired_async_client(client, None)
 
 
 def cleanup_stale_async_clients() -> None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -44,6 +44,7 @@ Payment / credit exhaustion fallback:
   their OpenRouter balance but has Codex OAuth or another provider available.
 """
 
+import asyncio
 import contextlib
 import contextvars
 import copy
@@ -4255,16 +4256,19 @@ def _is_invalid_aux_response_error(exc: Exception) -> bool:
 def _evict_cached_clients(provider: str) -> None:
     """Drop cached auxiliary clients for a provider so fresh creds are used."""
     normalized = _normalize_aux_provider(provider)
+    stale_entries = []
     with _client_cache_lock:
         stale_keys = [
             key for key in _client_cache
             if _normalize_aux_provider(str(key[0])) == normalized
         ]
         for key in stale_keys:
-            client = _client_cache.get(key, (None, None, None))[0]
-            if client is not None:
-                _close_cached_client(client)
-            _client_cache.pop(key, None)
+            entry = _client_cache.pop(key, None)
+            _client_cache_owner_threads.pop(key, None)
+            if entry is not None and entry[0] is not None:
+                stale_entries.append((entry[0], entry[2]))
+    for client, bound_loop in stale_entries:
+        _retire_or_close_client(client, bound_loop)
 
 
 def _evict_cached_client_instance(target: Any) -> bool:
@@ -4286,7 +4290,7 @@ def _evict_cached_client_instance(target: Any) -> bool:
     """
     if target is None:
         return False
-    evicted = False
+    evicted_entries = []
     with _client_cache_lock:
         for key in list(_client_cache.keys()):
             entry = _client_cache.get(key)
@@ -4298,8 +4302,11 @@ def _evict_cached_client_instance(target: Any) -> bool:
             real = getattr(cached, "_real_client", None)
             if cached is target or real is target:
                 del _client_cache[key]
-                evicted = True
-    return evicted
+                _client_cache_owner_threads.pop(key, None)
+                evicted_entries.append((cached, entry[2]))
+    for client, bound_loop in evicted_entries:
+        _retire_or_close_client(client, bound_loop)
+    return bool(evicted_entries)
 
 
 def _pool_cache_hint(
@@ -7161,7 +7168,10 @@ def auxiliary_max_tokens_param(value: int, *, model: Optional[str] = None) -> di
 # caused unbounded fd accumulation in long-running gateway processes (#10200).
 _client_cache: Dict[tuple, tuple] = {}
 _client_cache_lock = threading.Lock()
+_client_cache_owner_threads: Dict[tuple, threading.Thread] = {}
+_retired_async_clients: Dict[int, tuple] = {}
 _CLIENT_CACHE_MAX_SIZE = 64  # safety belt — evict oldest when exceeded
+_ASYNC_CLIENT_CLOSE_TIMEOUT = 5.0
 
 
 class _CallableCacheDiscriminator:
@@ -7233,11 +7243,16 @@ def _client_cache_key(
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
+    old_entry = None
     with _client_cache_lock:
         old_entry = _client_cache.get(cache_key)
-        if old_entry is not None and old_entry[0] is not client:
-            _close_cached_client(old_entry[0])
         _client_cache[cache_key] = (client, default_model, bound_loop)
+        if bound_loop is not None:
+            _client_cache_owner_threads[cache_key] = threading.current_thread()
+        else:
+            _client_cache_owner_threads.pop(cache_key, None)
+    if old_entry is not None and old_entry[0] is not client:
+        _retire_or_close_client(old_entry[0], old_entry[2])
 
 
 def _refresh_nous_auxiliary_client(
@@ -7301,8 +7316,8 @@ def neuter_async_httpx_del() -> None:
     in event loop ... Press ENTER to continue...".
 
     Neutering ``__del__`` is safe because:
-    - Cached clients are explicitly cleaned via ``_force_close_async_httpx``
-      on stale-loop detection and ``shutdown_cached_clients`` on exit.
+    - Cached clients are explicitly closed through their public close API
+      while the owning loop is alive, before cache ownership is released.
     - Uncached clients' TCP connections are cleaned up by the OS when the
       process exits.
     - The OpenAI SDK itself marks this as a TODO (``# TODO(someday):
@@ -7318,37 +7333,143 @@ def neuter_async_httpx_del() -> None:
         pass  # Graceful degradation if the SDK changes its internals
 
 
-def _force_close_async_httpx(client: Any) -> None:
-    """Mark the httpx AsyncClient inside an AsyncOpenAI client as closed.
-
-    This prevents ``AsyncHttpxClientWrapper.__del__`` from scheduling
-    ``aclose()`` on a (potentially closed) event loop, which causes
-    ``RuntimeError: Event loop is closed`` → prompt_toolkit's
-    "Press ENTER to continue..." handler.
-
-    We intentionally do NOT run the full async close path — the
-    connections will be dropped by the OS when the process exits.
-    """
-    try:
-        from httpx._client import ClientState
-        inner = getattr(client, "_client", None)
-        if inner is not None and not getattr(inner, "is_closed", True):
-            inner._state = ClientState.CLOSED
-    except Exception:
-        pass
-
-
-def _close_cached_client(client: Any) -> None:
-    """Apply the canonical best-effort close policy to one cached client."""
-    if client is None:
+async def _await_cached_client_close(client: Any) -> None:
+    """Invoke a client's supported close API and await it when necessary."""
+    close_fn = getattr(client, "close", None)
+    if not callable(close_fn):
+        close_fn = getattr(client, "aclose", None)
+    if not callable(close_fn):
         return
-    _force_close_async_httpx(client)
+    result = close_fn()
+    if inspect.isawaitable(result):
+        await result
+
+
+def _close_cached_client(client: Any, bound_loop: Any = None) -> bool:
+    """Physically close one client, returning false when its loop is unavailable."""
+    if client is None:
+        return True
+    close_fn = getattr(client, "close", None)
+    if not callable(close_fn):
+        close_fn = getattr(client, "aclose", None)
+    if not callable(close_fn):
+        return True
+    if not inspect.iscoroutinefunction(close_fn):
+        try:
+            result = close_fn()
+        except Exception:
+            return False
+        if not inspect.isawaitable(result):
+            return True
+        close_coro = result
+    else:
+        close_coro = _await_cached_client_close(client)
+
+    if bound_loop is None or bound_loop.is_closed():
+        close_coro.close()
+        return False
     try:
-        close_fn = getattr(client, "close", None)
-        if callable(close_fn) and not inspect.iscoroutinefunction(close_fn):
-            close_fn()
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+    if running_loop is bound_loop:
+        close_coro.close()
+        return False
+    bounded_close = asyncio.wait_for(
+        close_coro,
+        timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT,
+    )
+    future = None
+    try:
+        if bound_loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(bounded_close, bound_loop)
+            future.result(timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT + 0.1)
+        elif running_loop is None:
+            bound_loop.run_until_complete(bounded_close)
+        else:
+            bounded_close.close()
+            close_coro.close()
+            return False
+        return True
     except Exception:
-        pass
+        if future is not None:
+            future.cancel()
+        else:
+            bounded_close.close()
+            close_coro.close()
+        return False
+
+
+def _retire_async_client(client: Any, bound_loop: Any) -> None:
+    """Keep a stale async generation strongly owned until physical close succeeds."""
+    with _client_cache_lock:
+        _retired_async_clients[id(client)] = (client, bound_loop)
+
+
+def _retire_or_close_client(client: Any, bound_loop: Any) -> bool:
+    """Close a removed entry or retain it for an owner-loop retry."""
+    if bound_loop is None:
+        if _close_cached_client(client):
+            return True
+        _retire_async_client(client, None)
+        return False
+    _retire_async_client(client, bound_loop)
+    return _close_retired_async_client(client, bound_loop)
+
+
+def _close_retired_async_client(client: Any, bound_loop: Any) -> bool:
+    if not _close_cached_client(client, bound_loop):
+        return False
+    with _client_cache_lock:
+        current = _retired_async_clients.get(id(client))
+        if current is not None and current[0] is client:
+            del _retired_async_clients[id(client)]
+    return True
+
+
+async def close_cached_async_clients_for_loop(bound_loop: Any = None) -> None:
+    """Close every cached generation owned by the running loop before it stops."""
+    owner_loop = bound_loop or asyncio.get_running_loop()
+    with _client_cache_lock:
+        candidates = {
+            id(entry[0]): entry[0]
+            for entry in _client_cache.values()
+            if entry[2] is owner_loop
+        }
+        candidates.update(
+            {
+                id(client): client
+                for client, loop in _retired_async_clients.values()
+                if loop is owner_loop
+            }
+        )
+
+    results = await asyncio.gather(
+        *(
+            asyncio.wait_for(
+                _await_cached_client_close(client),
+                timeout=_ASYNC_CLIENT_CLOSE_TIMEOUT,
+            )
+            for client in candidates.values()
+        ),
+        return_exceptions=True,
+    )
+    closed_ids = {
+        client_id
+        for (client_id, _client), result in zip(candidates.items(), results)
+        if not isinstance(result, BaseException)
+    }
+
+    if not closed_ids:
+        return
+    with _client_cache_lock:
+        for key, entry in list(_client_cache.items()):
+            if entry[2] is owner_loop and id(entry[0]) in closed_ids:
+                del _client_cache[key]
+                _client_cache_owner_threads.pop(key, None)
+        for client_id, (client, loop) in list(_retired_async_clients.items()):
+            if loop is owner_loop and client_id in closed_ids:
+                del _retired_async_clients[client_id]
 
 
 def shutdown_cached_clients() -> None:
@@ -7358,16 +7479,23 @@ def shutdown_cached_clients() -> None:
     avoid ``AsyncHttpxClientWrapper.__del__`` raising on a dead loop.
     """
     with _client_cache_lock:
-        for key, entry in list(_client_cache.items()):
-            client = entry[0]
-            if client is None:
-                continue
-            _close_cached_client(client)
-        _client_cache.clear()
+        active = list(_client_cache.items())
+        retired = list(_retired_async_clients.values())
+    for key, entry in active:
+        client, _default, bound_loop = entry
+        if client is None or not _close_cached_client(client, bound_loop):
+            continue
+        with _client_cache_lock:
+            current = _client_cache.get(key)
+            if current is not None and current[0] is client:
+                del _client_cache[key]
+                _client_cache_owner_threads.pop(key, None)
+    for client, bound_loop in retired:
+        _close_retired_async_client(client, bound_loop)
 
 
 def cleanup_stale_async_clients() -> None:
-    """Force-close cached async clients whose event loop is closed.
+    """Physically close stale async clients before releasing cache ownership.
 
     Call this after each agent turn to proactively clean up stale clients
     before GC can trigger ``AsyncHttpxClientWrapper.__del__`` on them.
@@ -7375,14 +7503,23 @@ def cleanup_stale_async_clients() -> None:
     which disables ``__del__`` entirely.
     """
     with _client_cache_lock:
-        stale_keys = []
+        stale_entries = []
         for key, entry in _client_cache.items():
             client, _default, cached_loop = entry
-            if cached_loop is not None and cached_loop.is_closed():
-                _force_close_async_httpx(client)
-                stale_keys.append(key)
-        for key in stale_keys:
-            del _client_cache[key]
+            owner = _client_cache_owner_threads.get(key)
+            if cached_loop is not None and (
+                cached_loop.is_closed() or (owner is not None and not owner.is_alive())
+            ):
+                stale_entries.append((key, client, cached_loop))
+
+    for key, client, cached_loop in stale_entries:
+        if not _close_cached_client(client, cached_loop):
+            continue
+        with _client_cache_lock:
+            current = _client_cache.get(key)
+            if current is not None and current[0] is client:
+                del _client_cache[key]
+                _client_cache_owner_threads.pop(key, None)
 
 
 def _is_openrouter_client(client: Any) -> bool:
@@ -7459,13 +7596,14 @@ def _get_cached_client(
         task=task,
         model=model,
     )
+    stale_entry = None
     with _client_cache_lock:
         if cache_key in _client_cache:
             cached_client, cached_default, cached_loop = _client_cache[cache_key]
             if async_mode:
                 # Validate: the cached client must be bound to the CURRENT,
                 # OPEN loop.  If the loop changed or was closed, the httpx
-                # transport inside is dead — force-close and replace.
+                # transport inside is dead — physically close and replace.
                 loop_ok = (
                     cached_loop is not None
                     and cached_loop is current_loop
@@ -7474,12 +7612,20 @@ def _get_cached_client(
                 if loop_ok:
                     effective = _compat_model(cached_client, model, cached_default)
                     return cached_client, effective
-                # Stale — evict and fall through to create a new client.
-                _force_close_async_httpx(cached_client)
+                # Preserve ownership while closing outside the cache lock. A
+                # failed/timeout close remains quarantined and retryable.
                 del _client_cache[cache_key]
+                _client_cache_owner_threads.pop(cache_key, None)
+                _retired_async_clients[id(cached_client)] = (
+                    cached_client,
+                    cached_loop,
+                )
+                stale_entry = (cached_client, cached_loop)
             else:
                 effective = _compat_model(cached_client, model, cached_default)
                 return cached_client, effective
+    if stale_entry is not None:
+        _close_retired_async_client(*stale_entry)
     # Build outside the lock.
     # For pool-backed api_key providers, derive the active API key from the
     # pool entry rather than from env vars.  resolve_api_key_provider_credentials
@@ -7508,24 +7654,34 @@ def _get_cached_client(
         # For async clients, remember which loop they were created on so we
         # can detect stale entries later.
         bound_loop = current_loop
+        evicted_entries = []
+        loser_entry = None
         with _client_cache_lock:
             if cache_key not in _client_cache:
                 # Safety belt: if the cache has grown beyond the max, evict
                 # the oldest entries (FIFO — dict preserves insertion order).
-                # Do not close an evicted client here: another caller may be
-                # mid-request with the object it obtained from this cache.
-                # Dropping the cache reference lets normal refcount/GC cleanup
-                # happen after in-flight users release it.
+                # Removed async generations stay quarantined until physical
+                # close succeeds; cache eviction never abandons ownership.
                 while len(_client_cache) >= _CLIENT_CACHE_MAX_SIZE:
                     evict_key = next(iter(_client_cache))
-                    del _client_cache[evict_key]
+                    evicted = _client_cache.pop(evict_key)
+                    _client_cache_owner_threads.pop(evict_key, None)
+                    evicted_entries.append((evicted[0], evicted[2]))
                 _client_cache[cache_key] = (client, default_model, bound_loop)
+                if bound_loop is not None:
+                    _client_cache_owner_threads[cache_key] = threading.current_thread()
+                else:
+                    _client_cache_owner_threads.pop(cache_key, None)
             else:
                 built_client = client
                 client, default_model, _ = _client_cache[cache_key]
-                # This concurrently built loser was never exposed to a caller,
-                # so it is safe to close immediately.
-                _close_cached_client(built_client)
+                loser_entry = (built_client, bound_loop)
+        for evicted_client, evicted_loop in evicted_entries:
+            _retire_or_close_client(evicted_client, evicted_loop)
+        if loser_entry is not None:
+            # This concurrently built loser was never exposed to a caller, but
+            # its async close still has to run on the loop that created it.
+            _retire_or_close_client(*loser_entry)
     return client, model or default_model
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13331,7 +13331,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # async httpx transports until they hit EMFILE on macOS's default
             # RLIMIT_NOFILE=256.  See #14210.
             try:
-                from agent.auxiliary_client import shutdown_cached_clients
+                from agent.auxiliary_client import (
+                    close_cached_async_clients_for_loop,
+                    shutdown_cached_clients,
+                )
+
+                # This coroutine still owns the gateway loop, so close its
+                # transports here rather than trying to hand work back to the
+                # loop synchronously after it has stopped.
+                await close_cached_async_clients_for_loop()
                 shutdown_cached_clients()
             except Exception as _e:
                 logger.debug("shutdown_cached_clients error: %s", _e)

--- a/model_tools.py
+++ b/model_tools.py
@@ -25,6 +25,7 @@ import json
 import re
 import asyncio
 import logging
+import sys
 import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
@@ -72,6 +73,18 @@ def _is_dispatcher_owned_worker() -> bool:
 _tool_loop = None          # persistent loop for the main (CLI) thread
 _tool_loop_lock = threading.Lock()
 _worker_thread_local = threading.local()  # per-worker-thread persistent loops
+
+
+def _drain_auxiliary_clients(loop) -> None:
+    """Physically close auxiliary transports while their owner loop still runs."""
+    module = sys.modules.get("agent.auxiliary_client")
+    if module is None:
+        return
+    try:
+        close_for_loop = module.close_cached_async_clients_for_loop
+        loop.run_until_complete(close_for_loop(loop))
+    except Exception:
+        logger.debug("Auxiliary client drain failed", exc_info=True)
 
 
 def _get_tool_loop():
@@ -155,6 +168,7 @@ def _run_async(coro):
                 asyncio.set_event_loop(worker_loop)
                 return worker_loop.run_until_complete(coro)
             finally:
+                _drain_auxiliary_clients(worker_loop)
                 try:
                     # Cancel anything still pending (e.g. task cancelled
                     # externally via call_soon_threadsafe on timeout).

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -80,12 +80,17 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
     with (
         patch("gateway.status.remove_pid_file"),
         patch("gateway.status.write_runtime_status"),
+        patch(
+            "agent.auxiliary_client.close_cached_async_clients_for_loop",
+            new_callable=AsyncMock,
+        ) as close_cached_async_clients_for_loop,
         patch("agent.auxiliary_client.shutdown_cached_clients") as shutdown_cached_clients,
     ):
         await runner.stop()
 
     running_agent.interrupt.assert_called_once_with("Gateway shutting down")
     disconnect_mock.assert_awaited_once()
+    close_cached_async_clients_for_loop.assert_awaited_once()
     shutdown_cached_clients.assert_called_once()
     assert runner.adapters == {}
     assert runner._running_agents == {}

--- a/tests/run_agent/test_async_httpx_del_neuter.py
+++ b/tests/run_agent/test_async_httpx_del_neuter.py
@@ -13,9 +13,39 @@ The three-layer defence:
 """
 
 import asyncio
+import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+class _AsyncCloseSentinelClient:
+    """Small async-client double whose close represents transport teardown."""
+
+    def __init__(self):
+        self._client = SimpleNamespace(is_closed=False)
+        self.transport_closed = threading.Event()
+
+    async def close(self):
+        self._client.is_closed = True
+        self.transport_closed.set()
+
+
+class _BlockingAsyncCloseClient(_AsyncCloseSentinelClient):
+    def __init__(self):
+        super().__init__()
+        self.release_close = threading.Event()
+
+    async def close(self):
+        while not self.release_close.is_set():
+            await asyncio.sleep(0.005)
+        await super().close()
+
+
+class _FailingAsyncCloseClient(_AsyncCloseSentinelClient):
+    async def close(self):
+        raise RuntimeError("transport close failed")
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +105,7 @@ class TestNeuterAsyncHttpxDel:
 # ---------------------------------------------------------------------------
 
 class TestCleanupStaleAsyncClients:
-    """Verify stale cache entries are evicted and force-closed."""
+    """Verify stale cache entries are evicted only after close succeeds."""
 
     def test_removes_stale_entries(self):
         """Entries with a closed loop should be evicted."""
@@ -90,7 +120,7 @@ class TestCleanupStaleAsyncClients:
         loop.close()
 
         mock_client = MagicMock()
-        # Give it _client attribute for _force_close_async_httpx
+        # Give it the same wrapper shape as an SDK client.
         mock_client._client = MagicMock()
         mock_client._client.is_closed = False
 
@@ -106,6 +136,48 @@ class TestCleanupStaleAsyncClients:
             # Clean up in case test fails
             with _client_cache_lock:
                 _client_cache.pop(key, None)
+
+    def test_dead_owner_thread_cleanup_physically_closes_transport_before_eviction(self):
+        """A stopped owner loop is drained before its cache owner is removed."""
+        from agent.auxiliary_client import (
+            _client_cache,
+            _client_cache_key,
+            _client_cache_lock,
+            _get_cached_client,
+            cleanup_stale_async_clients,
+        )
+
+        key = _client_cache_key("test_dead_owner", async_mode=True, model="m1")
+        client = _AsyncCloseSentinelClient()
+        owner_loop = asyncio.new_event_loop()
+
+        def build_on_owner_thread():
+            asyncio.set_event_loop(owner_loop)
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(client, "m1"),
+            ):
+                cached, _ = _get_cached_client(
+                    "test_dead_owner", "m1", async_mode=True
+                )
+            assert cached is client
+
+        owner = threading.Thread(target=build_on_owner_thread)
+        owner.start()
+        owner.join(timeout=5)
+        assert not owner.is_alive()
+        assert not owner_loop.is_closed()
+
+        try:
+            cleanup_stale_async_clients()
+
+            assert client.transport_closed.is_set()
+            with _client_cache_lock:
+                assert key not in _client_cache
+        finally:
+            with _client_cache_lock:
+                _client_cache.pop(key, None)
+            owner_loop.close()
 
     def test_keeps_live_entries(self):
         """Entries with an open loop should be preserved."""
@@ -205,6 +277,185 @@ class TestClientCacheBoundedGrowth:
         finally:
             with _client_cache_lock:
                 _client_cache.pop(key, None)
+
+    def test_close_timeout_does_not_mark_private_state_or_drop_owner(self):
+        """A timed-out owner-loop close keeps the old generation quarantined."""
+        import agent.auxiliary_client as aux
+
+        key = aux._client_cache_key("test_close_timeout", async_mode=True, model="m1")
+        old_client = _BlockingAsyncCloseClient()
+        new_client = _AsyncCloseSentinelClient()
+        owner_loop = asyncio.new_event_loop()
+        owner_ready = threading.Event()
+
+        def run_owner_loop():
+            asyncio.set_event_loop(owner_loop)
+            owner_ready.set()
+            owner_loop.run_forever()
+
+        owner = threading.Thread(target=run_owner_loop)
+        owner.start()
+        assert owner_ready.wait(timeout=5)
+
+        async def build_old():
+            with patch.object(
+                aux, "resolve_provider_client", return_value=(old_client, "m1")
+            ):
+                return aux._get_cached_client(
+                    "test_close_timeout", "m1", async_mode=True
+                )[0]
+
+        assert asyncio.run_coroutine_threadsafe(build_old(), owner_loop).result(timeout=5) is old_client
+
+        caller_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(caller_loop)
+        try:
+            with patch.object(aux, "_ASYNC_CLIENT_CLOSE_TIMEOUT", 0.05), patch.object(
+                aux, "resolve_provider_client", return_value=(new_client, "m1")
+            ):
+                resolved, _ = aux._get_cached_client(
+                    "test_close_timeout", "m1", async_mode=True
+                )
+
+            assert resolved is new_client
+            assert old_client._client.is_closed is False
+            assert any(
+                retired[0] is old_client
+                for retired in aux._retired_async_clients.values()
+            )
+            assert aux._client_cache[key][0] is new_client
+        finally:
+            old_client.release_close.set()
+            asyncio.run_coroutine_threadsafe(
+                aux.close_cached_async_clients_for_loop(owner_loop), owner_loop
+            ).result(timeout=5)
+            assert old_client.transport_closed.is_set()
+            assert not any(
+                retired[0] is old_client
+                for retired in aux._retired_async_clients.values()
+            )
+            owner_loop.call_soon_threadsafe(owner_loop.stop)
+            owner.join(timeout=5)
+            owner_loop.close()
+            caller_loop.close()
+            with aux._client_cache_lock:
+                aux._client_cache.pop(key, None)
+                aux._client_cache_owner_threads.pop(key, None)
+                if hasattr(aux, "_retired_async_clients"):
+                    aux._retired_async_clients.clear()
+
+    def test_repeated_worker_loop_turns_keep_fd_count_bounded(self):
+        """Each disposable loop closes its real HTTP keep-alive transport."""
+        import httpx
+
+        import agent.auxiliary_client as aux
+        from model_tools import _run_async
+
+        key = aux._client_cache_key("test_worker_http", async_mode=True, model="m1")
+        clients = []
+        peer_eofs = []
+
+        def build_client(*_args, **_kwargs):
+            client = httpx.AsyncClient(trust_env=False)
+            clients.append(client)
+            return client, "m1"
+
+        async def one_turn():
+            peer_eof = threading.Event()
+
+            async def handle(reader, writer):
+                try:
+                    await reader.readuntil(b"\r\n\r\n")
+                    writer.write(
+                        b"HTTP/1.1 200 OK\r\n"
+                        b"Content-Length: 0\r\n"
+                        b"Connection: keep-alive\r\n\r\n"
+                    )
+                    await writer.drain()
+                    await reader.read()
+                    peer_eof.set()
+                finally:
+                    writer.close()
+                    await writer.wait_closed()
+
+            server = await asyncio.start_server(handle, "127.0.0.1", 0)
+            port = server.sockets[0].getsockname()[1]
+            try:
+                client, _ = aux._get_cached_client(
+                    "test_worker_http", "m1", async_mode=True
+                )
+                response = await client.get(f"http://127.0.0.1:{port}/")
+                assert response.status_code == 200
+                return peer_eof
+            finally:
+                server.close()
+                await server.wait_closed()
+
+        async def run_turns():
+            for _ in range(5):
+                peer_eofs.append(_run_async(one_turn()))
+
+        try:
+            with patch.object(aux, "resolve_provider_client", side_effect=build_client):
+                asyncio.run(run_turns())
+
+            assert len(clients) == 5
+            assert all(client.is_closed for client in clients)
+            assert all(peer_eof.is_set() for peer_eof in peer_eofs)
+            with aux._client_cache_lock:
+                assert key not in aux._client_cache
+                assert not aux._retired_async_clients
+        finally:
+            with aux._client_cache_lock:
+                aux._client_cache.pop(key, None)
+                aux._client_cache_owner_threads.pop(key, None)
+                aux._retired_async_clients.clear()
+
+    def test_stopped_owner_loop_client_is_not_reused_or_silently_evicted(self):
+        """A failed close quarantines the stopped-loop client while replacing it."""
+        import agent.auxiliary_client as aux
+
+        key = aux._client_cache_key("test_stopped_owner", async_mode=True, model="m1")
+        old_client = _FailingAsyncCloseClient()
+        new_client = _AsyncCloseSentinelClient()
+        owner_loop = asyncio.new_event_loop()
+
+        def build_old():
+            asyncio.set_event_loop(owner_loop)
+            with patch.object(
+                aux, "resolve_provider_client", return_value=(old_client, "m1")
+            ):
+                aux._get_cached_client("test_stopped_owner", "m1", async_mode=True)
+
+        owner = threading.Thread(target=build_old)
+        owner.start()
+        owner.join(timeout=5)
+        assert not owner.is_alive()
+
+        caller_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(caller_loop)
+        try:
+            with patch.object(
+                aux, "resolve_provider_client", return_value=(new_client, "m1")
+            ):
+                resolved, _ = aux._get_cached_client(
+                    "test_stopped_owner", "m1", async_mode=True
+                )
+
+            assert resolved is new_client
+            assert old_client._client.is_closed is False
+            assert aux._client_cache[key][0] is new_client
+            assert any(
+                retired[0] is old_client
+                for retired in aux._retired_async_clients.values()
+            )
+        finally:
+            caller_loop.close()
+            owner_loop.close()
+            with aux._client_cache_lock:
+                aux._client_cache.pop(key, None)
+                aux._client_cache_owner_threads.pop(key, None)
+                aux._retired_async_clients.clear()
 
     def test_different_loops_do_not_grow_cache(self):
         """Multiple event loops for the same provider should NOT create multiple entries."""

--- a/tests/run_agent/test_async_httpx_del_neuter.py
+++ b/tests/run_agent/test_async_httpx_del_neuter.py
@@ -48,6 +48,23 @@ class _FailingAsyncCloseClient(_AsyncCloseSentinelClient):
         raise RuntimeError("transport close failed")
 
 
+class _CoordinatedAsyncCloseClient(_AsyncCloseSentinelClient):
+    def __init__(self, started, all_started, expected):
+        super().__init__()
+        self._started = started
+        self._all_started = all_started
+        self._expected = expected
+
+    async def close(self):
+        with self._started["lock"]:
+            self._started["count"] += 1
+            if self._started["count"] == self._expected:
+                self._all_started.set()
+        while not self._all_started.is_set():
+            await asyncio.sleep(0.005)
+        await super().close()
+
+
 # ---------------------------------------------------------------------------
 # Layer 1: neuter_async_httpx_del
 # ---------------------------------------------------------------------------
@@ -343,6 +360,141 @@ class TestClientCacheBoundedGrowth:
                 aux._client_cache_owner_threads.pop(key, None)
                 if hasattr(aux, "_retired_async_clients"):
                     aux._retired_async_clients.clear()
+
+    def test_same_loop_eviction_schedules_physical_close(self):
+        """A sync eviction on the owner loop must not defer close to shutdown."""
+        import agent.auxiliary_client as aux
+
+        client = _AsyncCloseSentinelClient()
+        key = aux._client_cache_key(
+            "test_same_loop_evict", async_mode=True, model="m1"
+        )
+
+        async def scenario():
+            loop = asyncio.get_running_loop()
+            with aux._client_cache_lock:
+                aux._client_cache[key] = (client, "m1", loop)
+            aux._evict_cached_clients("test_same_loop_evict")
+            for _ in range(20):
+                with aux._client_cache_lock:
+                    ownership_released = (
+                        id(client) not in aux._retired_async_clients
+                    )
+                if client.transport_closed.is_set() and ownership_released:
+                    break
+                await asyncio.sleep(0)
+
+            assert client.transport_closed.is_set()
+            with aux._client_cache_lock:
+                assert key not in aux._client_cache
+                assert id(client) not in aux._retired_async_clients
+
+        try:
+            asyncio.run(scenario())
+        finally:
+            with aux._client_cache_lock:
+                aux._client_cache.pop(key, None)
+                aux._retired_async_clients.pop(id(client), None)
+                aux._retired_async_close_tasks.pop(id(client), None)
+
+    def test_loop_drain_keeps_owner_when_client_has_no_close_api(self):
+        """Unsupported wrappers cannot be reported closed and discarded."""
+        import agent.auxiliary_client as aux
+
+        client = SimpleNamespace()
+        key = aux._client_cache_key(
+            "test_missing_close", async_mode=True, model="m1"
+        )
+
+        async def scenario():
+            loop = asyncio.get_running_loop()
+            with aux._client_cache_lock:
+                aux._client_cache[key] = (client, "m1", loop)
+
+            await aux.close_cached_async_clients_for_loop(loop)
+
+            with aux._client_cache_lock:
+                assert aux._client_cache[key][0] is client
+
+        try:
+            asyncio.run(scenario())
+        finally:
+            with aux._client_cache_lock:
+                aux._client_cache.pop(key, None)
+
+    def test_async_compatibility_wrappers_close_real_clients(self):
+        """Async shims expose close so loop drains reach their real transports."""
+        import agent.auxiliary_client as aux
+
+        class RealClient:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        def sync_wrapper(real_client):
+            return SimpleNamespace(
+                chat=SimpleNamespace(completions=MagicMock()),
+                api_key="key",
+                base_url="https://example.invalid",
+                _real_client=real_client,
+            )
+
+        async def scenario():
+            codex_real = RealClient()
+            anthropic_real = RealClient()
+            codex = aux.AsyncCodexAuxiliaryClient(sync_wrapper(codex_real))
+            anthropic = aux.AsyncAnthropicAuxiliaryClient(
+                sync_wrapper(anthropic_real)
+            )
+
+            assert await aux._await_cached_client_close(codex) is True
+            assert await aux._await_cached_client_close(anthropic) is True
+            assert codex_real.closed
+            assert anthropic_real.closed
+
+        asyncio.run(scenario())
+
+    def test_shutdown_closes_owner_loops_concurrently(self):
+        """One slow generation must not consume one timeout after another."""
+        import agent.auxiliary_client as aux
+
+        expected = 3
+        started = {"count": 0, "lock": threading.Lock()}
+        all_started = threading.Event()
+        loops = [asyncio.new_event_loop() for _ in range(expected)]
+        clients = [
+            _CoordinatedAsyncCloseClient(started, all_started, expected)
+            for _ in range(expected)
+        ]
+        keys = [
+            aux._client_cache_key(
+                f"test_parallel_shutdown_{index}", async_mode=True, model="m1"
+            )
+            for index in range(expected)
+        ]
+
+        with aux._client_cache_lock:
+            for key, client, loop in zip(keys, clients, loops):
+                aux._client_cache[key] = (client, "m1", loop)
+
+        try:
+            with patch.object(aux, "_ASYNC_CLIENT_CLOSE_TIMEOUT", 0.2):
+                aux.shutdown_cached_clients()
+
+            assert all_started.is_set()
+            assert all(client.transport_closed.is_set() for client in clients)
+            with aux._client_cache_lock:
+                assert all(key not in aux._client_cache for key in keys)
+        finally:
+            with aux._client_cache_lock:
+                for key in keys:
+                    aux._client_cache.pop(key, None)
+                aux._retired_async_clients.clear()
+            for loop in loops:
+                if not loop.is_closed():
+                    loop.close()
 
     def test_repeated_worker_loop_turns_keep_fd_count_bounded(self):
         """Each disposable loop closes its real HTTP keep-alive transport."""


### PR DESCRIPTION
## What does this PR do?

Long-running gateways and other async callers can now replace stale auxiliary clients without abandoning their underlying HTTP transports. Eviction closes each transport on its owner event loop before releasing ownership, while failed or timed-out closes remain strongly owned and retryable instead of being marked closed through private SDK state.

### Symptom

When an async auxiliary client outlives its worker event loop or is replaced from another loop, the cache entry disappears even though the underlying HTTP transport never receives its close call. Repeated worker-loop churn can therefore leave sockets and file descriptors alive until process exit.

### Impact

Affected long-running processes can accumulate transport resources across stale client generations despite the active cache remaining bounded. The exact blast radius depends on worker-loop churn, but sustained accumulation can exhaust the process file-descriptor budget and interrupt later network operations.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py:_get_cached_client()` and `cleanup_stale_async_clients()` when a cached async client belongs to a closed, stopped, or different owner loop.

**Causal chain:**
1. An async auxiliary client creates an HTTP transport bound to a worker event loop.
2. Cache cleanup or replacement encounters a dead or mismatched owner loop, marks the nested httpx client closed through private state, and removes the cache entry.
3. The public close path then becomes a no-op, the last strong owner disappears, and the physical transport remains open until process exit.

**Why it is wrong:** Cache eviction ended logical ownership without completing physical resource teardown. The disabled SDK destructor could not recover the resource afterward, and private `_state` mutation falsely reported a successful close.

**Working sibling / contrast:** Awaiting the supported client close API on a live owner loop closes the transport exactly once and lets the remote TCP peer observe EOF.

**Ruled out:** Cache-key growth is not the root cause. The active cache already keeps one entry per provider configuration; the leak came from discarded transport ownership across replaced generations.

### Fix

Retired async generations now stay in a strong quarantine until their supported close API succeeds. Same-loop evictions schedule bounded close tasks, cross-loop and shutdown drains execute on each owner loop, unsupported or timed-out closes remain retryable, and all owner loops drain concurrently within one global shutdown budget. Async compatibility wrappers expose their real transport close paths, disposable worker loops drain before closing, and gateway shutdown drains its currently running loop before the synchronous global sweep.

## Related Issue

Fixes #82690

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - physically close active and retired async generations on their owner loops, quarantine failed closes, and bound concurrent shutdown.
- `model_tools.py` - drain auxiliary transports before disposable async worker loops close.
- `gateway/run.py` - drain transports owned by the running gateway loop before global cache shutdown.
- `tests/run_agent/test_async_httpx_del_neuter.py` - cover dead owners, loop mismatch, same-loop retirement, close timeout, wrapper close paths, real transport EOF, and bounded multi-loop shutdown.
- `tests/gateway/test_gateway_shutdown.py` - verify gateway shutdown drains the running loop before the global sweep.

## How to Test

1. Create an actual async OpenAI/httpx client on a worker-owned event loop with an observable TCP peer.
2. Exercise dead-owner, same-loop, mismatched-loop, wrapper, timeout-and-retry, and multi-loop shutdown paths; verify peer EOF occurs before ownership is removed and all owner-loop drains share one bounded wait.
3. Run the focused repository tests:

```bash
scripts/run_tests.sh tests/run_agent/test_async_httpx_del_neuter.py tests/gateway/test_gateway_shutdown.py
```

Result: 23 tests passed. Additional real-environment verification passed all five transport-closure and bounded-shutdown contracts on the exact PR tip.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A
