### PR TITLE
fix(gateway/state): fix the truncate ordinal address space and make a mis-aimed rewind recoverable (#82756)

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -324,16 +324,30 @@ describe('toChatMessages', () => {
         content: '[System note: Your previous turn was interrupted mid-run…]\n\noriginal prompt',
         display_kind: 'auto_continue',
         timestamp: 6
+      },
+      {
+        role: 'user',
+        content: "[System: The user has changed the assistant's personality…]",
+        display_kind: 'personality_switch',
+        timestamp: 7
       }
     ])
 
-    expect(messages.map(message => message.role)).toEqual(['user', 'assistant', 'system', 'system', 'system'])
+    expect(messages.map(message => message.role)).toEqual([
+      'user',
+      'assistant',
+      'system',
+      'system',
+      'system',
+      'system'
+    ])
     expect(messages.map(chatMessageText)).toEqual([
       'real user turn',
       'real assistant reply',
       'model changed',
       'background agent work finished',
-      'resumed interrupted turn'
+      'resumed interrupted turn',
+      'personality changed'
     ])
   })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -387,6 +387,10 @@ function timelineDisplayContent(message: SessionMessage, content: string): strin
     return 'resumed interrupted turn'
   }
 
+  if (message.display_kind === 'personality_switch') {
+    return 'personality changed'
+  }
+
   if (message.display_kind === 'async_delegation_complete') {
     const count = timelineTaskCount(message.display_metadata)
 
@@ -993,7 +997,8 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
     const displayRole =
       message.display_kind === 'model_switch' ||
       message.display_kind === 'async_delegation_complete' ||
-      message.display_kind === 'auto_continue'
+      message.display_kind === 'auto_continue' ||
+      message.display_kind === 'personality_switch'
         ? 'system'
         : message.role
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -555,7 +555,13 @@ export interface SessionMessage {
   reasoning?: null | string
   reasoning_content?: null | string
   reasoning_details?: unknown
-  display_kind?: 'async_delegation_complete' | 'auto_continue' | 'hidden' | 'model_switch' | string
+  display_kind?:
+    | 'async_delegation_complete'
+    | 'auto_continue'
+    | 'hidden'
+    | 'model_switch'
+    | 'personality_switch'
+    | string
   /**
    * A backend older than this app can still serve this as unparsed JSON text,
    * so readers must narrow before indexing into it.

--- a/contributors/emails/joaomarcosdias444@gmail.com
+++ b/contributors/emails/joaomarcosdias444@gmail.com
@@ -1,0 +1,1 @@
+JoaoMarcos44 # fix(gateway): personality pivot must not consume a truncate ordinal slot (#82756)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7974,6 +7974,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         messages: List[Dict[str, Any]],
         active_only: bool = False,
+        archive_dropped: bool = False,
     ) -> None:
         """Atomically replace the stored messages for a session.
 
@@ -7994,6 +7995,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         full-history rewrite doesn't wipe the rows the agent deliberately
         archived. ``message_count``/``tool_call_count`` then track the live set,
         matching :meth:`archive_and_compact`.
+
+        Pass ``archive_dropped=True`` to SOFT-archive the live rows instead of
+        DELETEing them: the replaced turns stay on disk with ``active = 0``,
+        ``compacted = 0`` — the same "the user took it back" marking
+        :meth:`rewind_to_message` applies — and stay readable via
+        :meth:`get_messages` with ``include_inactive=True``. This is the mode a
+        rewind/edit/regenerate must use: those flows overwrite a transcript the
+        user may not have meant to drop, and a plain DELETE also evicts the rows
+        from the FTS index, leaving nothing to recover from (#82756). It implies
+        active-only handling — already-archived rows are never touched — so
+        ``active_only`` is redundant with it. The rewritten set is inserted as
+        fresh active rows exactly as in the destructive path, so the live view
+        is identical either way; only the durability of the dropped turns
+        differs.
         """
 
         active_clause = " AND active = 1" if active_only else ""
@@ -8009,10 +8024,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 and session["end_reason"] == "compression"
             ):
                 raise CompressionSessionClosedError(session_id)
-            conn.execute(
-                f"DELETE FROM messages WHERE session_id = ?{active_clause}",
-                (session_id,),
-            )
+            if archive_dropped:
+                # Content-preserving UPDATE: the rows keep their FTS entries
+                # (the messages_fts triggers index on INSERT / drop on DELETE
+                # and don't key on active), so the replaced turns stay both
+                # readable and searchable-by-id after the rewrite.
+                conn.execute(
+                    "UPDATE messages SET active = 0 "
+                    "WHERE session_id = ? AND active = 1",
+                    (session_id,),
+                )
+            else:
+                conn.execute(
+                    f"DELETE FROM messages WHERE session_id = ?{active_clause}",
+                    (session_id,),
+                )
             conn.execute(
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
                 (session_id,),

--- a/tests/hermes_state/test_replace_messages_archive_siblings.py
+++ b/tests/hermes_state/test_replace_messages_archive_siblings.py
@@ -157,3 +157,104 @@ class TestTuiPromptTruncationPreservesArchives:
             if m.get("role") in ("user", "assistant")
         ]
         assert [m["content"] for m in live] == ["kept head"]
+
+
+class TestArchiveDroppedIsRecoverable:
+    """`active_only=True` protects rows archived EARLIER; it still DELETEs the
+    live ones it replaces.
+
+    That is the last write standing between a mis-aimed rewind and permanent
+    loss, and all three reported incidents (#70516, #80763, #82756) ended
+    there with an empty WAL, no `active=0` rows and an FTS entry dropped in
+    sync. `archive_dropped=True` keeps the replaced turns on disk under the
+    same "the user took it back" marking `rewind_to_message` uses.
+    """
+
+    def test_dropped_turns_survive_as_inactive_rows(self, state_db):
+        sid = "archive-dropped"
+        state_db.create_session(sid, "test")
+        state_db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "first reply"},
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "second reply"},
+            ],
+        )
+
+        state_db.replace_messages(
+            sid,
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "first reply"},
+            ],
+            active_only=True,
+            archive_dropped=True,
+        )
+
+        # The live transcript is exactly what a destructive replace would leave.
+        live = [
+            m for m in state_db.get_messages_as_conversation(sid)
+            if m.get("role") in ("user", "assistant")
+        ]
+        assert [m["content"] for m in live] == ["first", "first reply"]
+
+        # …but the dropped turns are still readable instead of gone.
+        recovered = [
+            m["content"]
+            for m in state_db.get_messages(sid, include_inactive=True)
+            if not m["active"]
+        ]
+        assert "second" in recovered
+        assert "second reply" in recovered
+
+    def test_archived_rows_use_rewind_marking_not_compaction(self, state_db):
+        """compacted=0 keeps abandoned turns out of session search results.
+
+        `archive_and_compact` marks its rows compacted=1 precisely so they stay
+        discoverable; a rewound turn is one the user took back, so it must
+        carry the `rewind_to_message` marking instead.
+        """
+        sid = "archive-marking"
+        state_db.create_session(sid, "test")
+        state_db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": "keep"},
+                {"role": "assistant", "content": "drop me"},
+            ],
+        )
+
+        state_db.replace_messages(
+            sid,
+            [{"role": "user", "content": "keep"}],
+            active_only=True,
+            archive_dropped=True,
+        )
+
+        archived = [
+            m for m in state_db.get_messages(sid, include_inactive=True)
+            if not m["active"]
+        ]
+        assert archived, "the replaced rows must still be on disk"
+        assert all(not m.get("compacted") for m in archived)
+
+    def test_default_stays_destructive(self, state_db):
+        """The other three callers must be untouched by the new parameter."""
+        sid = "archive-default"
+        state_db.create_session(sid, "test")
+        state_db.append_messages_batch(
+            sid,
+            [
+                {"role": "user", "content": "gone"},
+                {"role": "assistant", "content": "also gone"},
+            ],
+        )
+
+        state_db.replace_messages(sid, [{"role": "user", "content": "fresh"}])
+
+        assert not [
+            m for m in state_db.get_messages(sid, include_inactive=True)
+            if not m["active"]
+        ]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4352,7 +4352,7 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False):
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
             replaced.append((key, list(messages)))
 
     history = [
@@ -4406,7 +4406,7 @@ def test_prompt_submit_refuses_unconfirmed_nonempty_truncation(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages):
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
             replaced.append((key, list(messages)))
 
     history = [
@@ -4469,7 +4469,7 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
     replaced = []
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False):
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
             replaced.append((key, list(messages)))
 
     history = [
@@ -4556,7 +4556,7 @@ def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
             self._target()
 
     class _FakeDB:
-        def replace_messages(self, key, messages, active_only=False):
+        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
             replaced.append((key, list(messages)))
 
     history = [
@@ -9535,7 +9535,7 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def replace_messages(self, session_id, messages, active_only=False):
+        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
             self.replaced.append((session_id, list(messages)))
 
     stub_db = _StubDb()
@@ -9592,7 +9592,7 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
     server._sessions["trunc-fail-sid"] = sess
 
     class _FailDb:
-        def replace_messages(self, session_id, messages, active_only=False):
+        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
             raise OSError("disk full")
 
     monkeypatch.setattr(server, "_get_db", lambda: _FailDb())
@@ -9684,7 +9684,7 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def replace_messages(self, session_id, messages, active_only=False):
+        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
             self.replaced.append((session_id, list(messages)))
 
     stub_db = _StubDb()
@@ -16759,7 +16759,7 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def replace_messages(self, session_id, messages, active_only=False):
+        def replace_messages(self, session_id, messages, active_only=False, archive_dropped=False):
             self.replaced.append((session_id, list(messages)))
 
     session = _session(
@@ -16832,4 +16832,83 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
         )
     finally:
         server._sessions.pop("personality-ordinal-sid", None)
+
+
+def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
+    """The rewind write must be recoverable, not a hard DELETE.
+
+    #70516 / #80763 / #82756 all ended at this one call, and all three were
+    unrecoverable for the same reason: `replace_messages` DELETEs the rows and
+    the FTS entry goes with them. Guarding the *aim* of a rewind still leaves
+    every other way of aiming it wrong terminal, so the write itself has to
+    stop destroying. The storage-layer contract this relies on is pinned in
+    tests/hermes_state/test_replace_messages_archive_siblings.py.
+    """
+
+    captured = {}
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            return {
+                "final_response": "reply",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "reply"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    class _StubDb:
+        def replace_messages(
+            self, session_id, messages, active_only=False, archive_dropped=False
+        ):
+            captured["active_only"] = active_only
+            captured["archive_dropped"] = archive_dropped
+
+    server._sessions["archive-trunc-sid"] = _session(
+        agent=_Agent(),
+        history=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "first reply"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "second reply"},
+        ],
+    )
+
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_get_db", lambda: _StubDb())
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "archive-trunc-sid",
+                    "text": "second, reworded",
+                    "truncate_before_user_ordinal": 1,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assert captured.get("archive_dropped") is True, (
+            "a rewind must soft-archive the turns it drops, not DELETE them"
+        )
+        # #80216: still must not touch rows archived by an earlier compaction.
+        assert captured.get("active_only") is True
+    finally:
+        server._sessions.pop("archive-trunc-sid", None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16720,3 +16720,116 @@ def test_save_cfg_keeps_unicode_personalities_readable(tmp_path, monkeypatch):
     assert "(=^･ω･^=)" in text
     assert "\\u4f60" not in text
 
+
+def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
+    """A personality pivot must not occupy a slot in the ordinal address space.
+
+    ``_apply_personality_to_session`` injects its pivot as ``role=user`` so
+    strict OpenAI-compatible providers accept it mid-conversation. Untagged, the
+    ordinal filter (``role == "user" and not display_kind``) counted it as a
+    real user turn while no client renders it as one, so every rewind issued
+    after a personality change resolved one turn too early and
+    ``replace_messages()`` hard-deleted the extra span (#82756, third occurrence
+    after #70516 / #80763).
+
+    The sibling ``test_prompt_submit_truncate_ordinal_skips_display_kind_rows``
+    pins the filter itself; this one pins the producer, which is where the
+    invariant was actually broken.
+    """
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            return {
+                "final_response": "reply",
+                "messages": [
+                    *(conversation_history or []),
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "reply"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    class _StubDb:
+        def __init__(self):
+            self.replaced = []
+
+        def replace_messages(self, session_id, messages, active_only=False):
+            self.replaced.append((session_id, list(messages)))
+
+    session = _session(
+        agent=_Agent(),
+        history=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "first reply"},
+        ],
+    )
+    server._sessions["personality-ordinal-sid"] = session
+    stub_db = _StubDb()
+
+    try:
+        monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+        monkeypatch.setattr(server, "_emit", lambda *a: None)
+
+        # Real production injection point — not a hand-written marker dict.
+        server._apply_personality_to_session(
+            "personality-ordinal-sid", session, "talk like a pirate", "pirate"
+        )
+
+        marker = session["history"][-1]
+        assert marker["role"] == "user", "provider compatibility: pivot rides as a user turn"
+
+        # Two more real turns land after the personality change.
+        session["history"].extend(
+            [
+                {"role": "user", "content": "second"},
+                {"role": "assistant", "content": "second reply"},
+                {"role": "user", "content": "third"},
+                {"role": "assistant", "content": "third reply"},
+            ]
+        )
+        history_before = list(session["history"])
+        third_index = history_before.index({"role": "user", "content": "third"})
+
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_get_db", lambda: stub_db)
+
+        # The client counts three user bubbles (first=0, second=1, third=2) —
+        # it never sees the pivot. Rewinding to "third" must cut exactly there.
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "personality-ordinal-sid",
+                    "text": "third, reworded",
+                    "truncate_before_user_ordinal": 2,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+
+        expected = history_before[:third_index]
+        assert stub_db.replaced == [("session-key", expected)], (
+            "the pivot shifted the ordinal: the cut landed at "
+            f"{len(stub_db.replaced[0][1]) if stub_db.replaced else None} instead of {third_index}"
+        )
+        # The turn before the target must survive — that is the span the three
+        # reported incidents lost.
+        assert {"role": "user", "content": "second"} in expected
+        # And the mechanism that keeps it out of the address space, so a future
+        # producer cannot regress this by dropping the tag.
+        assert marker.get("display_kind"), (
+            "an untagged role=user pivot silently consumes a truncate ordinal slot"
+        )
+    finally:
+        server._sessions.pop("personality-ordinal-sid", None)
+

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -257,8 +257,18 @@ def _(rid, params: dict) -> dict:
                     # class #80216 fixed for /retry. On an uncompacted session
                     # all rows are active=1, so this is behaviorally identical
                     # to the full replace.
+                    # archive_dropped: a rewind overwrites turns the user may
+                    # not have meant to drop, and this write is the last step
+                    # before they are gone — three reported incidents ended
+                    # here with nothing to restore from (#70516, #80763,
+                    # #82756). Soft-archiving keeps them on disk (active=0) and
+                    # in the FTS index, so a mis-aimed cut is recoverable
+                    # instead of terminal. The live transcript is unchanged.
                     db.replace_messages(
-                        session["session_key"], truncated, active_only=True
+                        session["session_key"],
+                        truncated,
+                        active_only=True,
+                        archive_dropped=True,
                     )
                 except Exception as exc:
                     logger.error(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6065,8 +6065,17 @@ def _apply_personality_to_session(
                 "[System: The user has cleared the personality overlay. "
                 "From this point forward, respond in your normal default style.]"
             )
+        # Tagged like the model-switch marker (`_append_model_switch_marker`):
+        # the marker rides as role=user so strict OpenAI-compatible providers
+        # accept it mid-conversation, but `display_kind` keeps it out of the
+        # `truncate_before_user_ordinal` addressing space. Untagged, it counts
+        # as a real user turn on the gateway side while no client counts it, so
+        # every later rewind resolves one turn too early and `replace_messages`
+        # hard-deletes the difference (#82756).
         with session["history_lock"]:
-            session["history"].append({"role": "user", "content": marker})
+            session["history"].append(
+                {"role": "user", "content": marker, "display_kind": "personality_switch"}
+            )
             session["history_version"] = int(session.get("history_version", 0)) + 1
         info = _session_info(agent)
         _emit("session.info", sid, info)


### PR DESCRIPTION
Fixes #82756.

Two commits, two independent findings, each verified against the real code path before it was written:

| # | Commit | Claim | How it was verified |
|---|---|---|---|
| 1 | keep the personality pivot out of the ordinal space | An untagged `role=user` marker shifts every later rewind | Failing test on the real injection point: `the cut landed at 3 instead of 5` |
| 2 | make a rewind truncation recoverable | The rewind write is a hard DELETE with no archive | Storage test: dropped turns readable via `include_inactive=True` after the rewrite |

## 1. The addressing defect

`truncate_before_user_ordinal` is an index into the list of **real** user turns. The gateway builds that list with `role == "user" and not display_kind`, and the repo already states the invariant, in `test_prompt_submit_truncate_ordinal_skips_display_kind_rows`:

> `display_kind` timeline rows (model_switch, async_delegation_complete, …) are role=user but no client counts them as user turns. **Without the filter, a trailing marker shifts the ordinal so the wrong message is targeted for truncation.**

`_apply_personality_to_session` broke that invariant **at the producer**. Its pivot rides as `role=user` on purpose — strict OpenAI-compatible providers reject system messages that are not first in the list (#48338), the same reason `_append_model_switch_marker` does it — but unlike the model-switch marker it carried **no `display_kind`**:

```python
# tui_gateway/server.py — before
session["history"].append({"role": "user", "content": marker})              # counted as a real turn
# tui_gateway/server.py — _append_model_switch_marker, for comparison
entry = {"role": "user", "content": marker, "display_kind": "model_switch"} # correctly excluded
```

After a personality change the gateway's address space contains a phantom turn no client can see, so every later rewind / edit / regenerate resolves **one slot too early**.

**I checked whether any other producer has the same hole, and none does.** The synthetic-turn path (`auto_continue`, `async_delegation_complete`) stamps the kind on the **live in-memory message**, not just the persisted row — `agent/turn_context.py`:

```python
# "Stamp that on the live message […] The model still receives role/content
#  unchanged; the api_messages build strips both fields from every outgoing copy."
if persist_user_display_kind:
    user_msg["display_kind"] = persist_user_display_kind
messages.append(user_msg)
```

The personality pivot was the one producer writing straight into `session["history"]` and bypassing that contract. The two direct `session["history"].append` injection sites in the gateway are now both tagged.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Client Rewind Request<br/>ordinal = 2] --> B{Gateway Address Space<br/>role=user AND NOT display_kind}

    subgraph BEFORE[Before - Untagged Pivot]
        C[Slot 0: first turn] --> D[PHANTOM SLOT<br/>personality pivot]
        D --> E[Slot 1: second turn]
        E --> F[Slot 2: third turn]
        G[Resolved Slot 2 = second turn] --> H[Cut Lands Too Early]
        H --> I[Unasked Turns Dropped]
    end

    subgraph AFTER[After - Tagged Pivot]
        J[Slot 0: first turn] --> K[EXCLUDED<br/>display_kind personality_switch]
        K --> L[Slot 1: second turn]
        L --> M[Slot 2: third turn]
        N[Resolved Slot 2 = third turn] --> O[Cut Lands On Target]
        O --> P[Only Intended Turns Dropped]
    end

    B --> BEFORE
    B --> AFTER

    style D fill:#8b0000,stroke:#ff0038,color:#ffccd5
    style I fill:#8b0000,stroke:#ff0038,color:#ffccd5
    style K fill:#1a3a1a,stroke:#4ade80,color:#d1fae5
    style P fill:#1a3a1a,stroke:#4ade80,color:#d1fae5
```
## Infographic : 
<img width="1024" height="1024" alt="infographic" src="https://github.com/user-attachments/assets/bea93379-6406-4cf1-a66c-60b40c16a485" />

## 2. Recoverability

Guarding the *aim* of a rewind still leaves every other way of aiming it wrong terminal. All three incidents ended at the same write, and all three were unrecoverable for the same reason: `replace_messages()` DELETEs the rows, which also evicts them from the FTS index — no `active=0` archive, nothing to restore from.

The codebase already draws this distinction and already ships the safe half of it:

- `archive_and_compact` is documented as *"the durability-preserving alternative to `replace_messages`"* (`active=0, compacted=1` — summarized away, still discoverable in search).
- `rewind_to_message` — the **`/undo`** path — soft-deletes to `active=0, compacted=0` and keeps the rows *"on disk for audit / forensic inspection"*.

The desktop rewind is the same user-facing operation as `/undo`, and it was the one taking the destructive branch. `replace_messages(..., archive_dropped=True)` flips the DELETE to a content-preserving `UPDATE messages SET active = 0`, reusing the existing transaction and the existing `compacted=0` marking, so the dropped turns stay readable via `get_messages(..., include_inactive=True)` and stay out of session search.

The live transcript is byte-identical either way — only the durability of the dropped turns changes. The parameter defaults to `False`, so the fork handler, the ACP adapter and `gateway/session.py` are untouched; a test pins that.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph LR
    A[Rewind Write] --> B{replace_messages}
    B -->|"before: DELETE"| C[Rows Removed]
    C --> D[FTS Entry Dropped]
    D --> E[Permanent Loss]
    B -->|"after: archive_dropped"| F["UPDATE active = 0"]
    F --> G[Rows Kept On Disk]
    G --> H[Readable via include_inactive]
    H --> I[Mis-aimed Cut Is Reversible]

    style E fill:#4a0d2e,stroke:#ff007f,color:#ffffff
    style I fill:#0d3a4a,stroke:#00f0ff,color:#ffffff
```

## Why the shipped guards let the original report through

| Incident | Guard | Why it does not fire |
|---|---|---|
| #70516 → #70895 | `confirm_empty_truncate` | Only covers ordinal 0; a mid-session cut leaves a non-empty transcript. |
| #80763 → #80802 | `confirm_truncate` required | Proves *intent*, not *agreement about the target*. The desktop legitimately sets it — this **was** a rewind, it just landed on the wrong turn. |
| #82514 (open) | out-of-range ordinals → 4018 | The ordinal was in range. It was in range **and wrong**. |

Both existing guards are correct and are unchanged. They are consent gates; commit 1 is the addressing bug underneath them and commit 2 is the blast radius when any of them is wrong.

## Test plan

- `python -m pytest tests/hermes_state/test_replace_messages_archive_siblings.py -q` — **8 passed** (5 existing #80216 tests + 3 new: dropped turns recoverable, rewind marking not compaction marking, default stays destructive).
- `python -m pytest tests/test_tui_gateway_server.py -k "truncat or personality_marker" -q` — **10 passed**.
- `python -m pytest tests/test_tui_gateway_server.py -q` — **514 passed, 15 failed**. All 15 are `save_cfg` / `config.set` / `persist_model_switch` YAML-persistence tests that **fail identically on an unmodified tree** (verified by stashing and re-running): pre-existing local Windows noise.
  - One real-threading test (`…requeues_all_unstarted_notifications_with_real_threading`) failed once under a combined run and passed on re-run and in isolation — load-sensitive, not related to these changes.
- Commit 1 was confirmed to fail without its fix: `AssertionError: the pivot shifted the ordinal: the cut landed at 3 instead of 5` — the `second` exchange is deleted although the user asked to rewind to `third`.
- Test doubles for `replace_messages` in the gateway suite were widened to the real signature — a double that does not accept what production passes silently converts this write into a `5008`.
- `apps/desktop/src/lib/chat-messages.test.ts` extends the existing `projects durable timeline kinds without inspecting text` contract case with `personality_switch`. **Not executed locally** — this checkout's desktop `node_modules` cannot resolve `@testing-library/react`, `@assistant-ui/react` or `@tanstack/react-query`, so `vitest` and `npm run typecheck` fail at import resolution across the whole app (605 pre-existing errors, none on the edited lines). CI is the real signal for that file.

## Deliberately out of scope

The cross-surface split-brain reported in the fourth occurrence (Telegram app and Desktop driving one DM). No marker fix reaches a second writer. Any general "attest the address space" mechanism also has to compose with #82514's compression-prefix mapping — auto-compression legitimately rewrites `session["history"]` to a suffix, so a naive client/gateway turn-count check would refuse every rewind after a compaction. That belongs in one design, not bolted onto this.

Commit 2 does reduce that case from permanent loss to a recoverable one.

## Relation to #82766

#82766 targets the same issue from a different layer — stable-id addressing, which is the direction the issue itself asks for. There is no overlap with this PR: no new wire field, no new error code, no change to either consent gate. The two compose (correct address space + recoverable write here, stable addressing there), and I have offered there to rebase, split, or drop whatever its author prefers so reviewers are not handed duplicate work.

One note left on that PR for the author to confirm: every writer of `session["history"]` stores **provider-format** messages — `list(agent_messages)`, `result["messages"]`, or `get_messages_as_conversation()`, whose docstring reads *"Load messages in the OpenAI conversation format (role + content dicts)"* — none of which carry a client message id, while the id its desktop side sends is the renderer's **ephemeral** one (`` `${timestamp}-${index}-${displayRole}` ``, documented as ephemeral in `SessionMessage`). I may be misreading that flow; it is raised there as a question, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
