### PR TITLE
fix(desktop): allow HTML5 video fullscreen through permission handlers

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5853,6 +5853,13 @@ function installContextMenu(window) {
 // usage strings), so the user keeps a real allow/deny and can revoke it in
 // System Settings afterwards.
 function isMediaCapturePermission(permission, details) {
+  // HTML5 video/audio fullscreen asks the request handler for 'fullscreen'
+  // and the check handler for 'automatic-fullscreen'. Both must be allowed
+  // or the native fullscreen button on <video controls> does nothing.
+  if (permission === 'fullscreen' || permission === 'automatic-fullscreen') {
+    return true
+  }
+
   if (permission === 'audioCapture' || permission === 'videoCapture') {
     return true
   }
@@ -5885,6 +5892,7 @@ function installMediaPermissions() {
   session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
     return (
       permission === 'media' ||
+      permission === 'automatic-fullscreen' ||
       permission === ('audioCapture' as any) /* todo: is this needed? */ ||
       permission === ('videoCapture' as any)
     )


### PR DESCRIPTION
## Problem

The desktop app installs custom permission handlers (`installMediaPermissions` in `electron/main.ts`) that only allow `media` / `audioCapture` / `videoCapture`:

- `setPermissionRequestHandler` routes through `isMediaCapturePermission`, which returns `false` for `fullscreen`
- `setPermissionCheckHandler` returns `false` for everything except the three media permissions

Electron consults these handlers for the HTML5 Fullscreen API permissions (`fullscreen` for the request handler, `automatic-fullscreen` for the check handler — verified empirically with a logging repro). The result: **the native fullscreen button on any inline `<video controls>` in chat silently does nothing** (`requestFullscreen()` rejects with `TypeError: Permissions check failed`).

## Fix

Allow `fullscreen` and `automatic-fullscreen` in both handlers:

- `isMediaCapturePermission()` now returns `true` for `fullscreen` / `automatic-fullscreen`
- `setPermissionCheckHandler` now also allows `automatic-fullscreen`

## Verification

- Minimal Electron repro using Hermes' exact handler logic: `requestFullscreen()` failed with `TypeError: Permissions check failed` before the fix, succeeds after (both handlers present, `sandbox: true`, same webPreferences)
- User-verified in the packaged desktop app: inline video fullscreen now works

## Notes

- Scope is intentionally narrow: only the two fullscreen permissions are added; media capture behavior is unchanged
- The `fullscreen` permission is also what Chromium's native video controls use — the fix is limited to allowing a user-initiated fullscreen request, no new capabilities