### PR TITLE
fix: make Discord task forums launch live sessions

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -471,6 +471,45 @@ class DeliveryRouter:
 
         if not target.chat_id:
             raise ValueError(f"No chat ID for {target.platform.value} delivery")
+
+        # Protect Discord task parents before transport selection matters.
+        # This keeps relay fallback from bypassing the native adapter's guard.
+        if target.platform == Platform.DISCORD:
+            discord_config = self.config.platforms.get(Platform.DISCORD)
+            extra = getattr(discord_config, "extra", None)
+            raw = (
+                extra.get("agent_task_forum_channels")
+                if isinstance(extra, dict)
+                else None
+            )
+            if isinstance(raw, list):
+                protected_ids = {
+                    str(value).strip() for value in raw if str(value).strip()
+                }
+            else:
+                protected_ids = {
+                    value.strip() for value in str(raw or "").split(",")
+                    if value.strip()
+                }
+            metadata_thread_id = (metadata or {}).get("thread_id")
+            metadata_message_thread_id = (metadata or {}).get("message_thread_id")
+            if (
+                metadata_thread_id
+                and metadata_message_thread_id
+                and str(metadata_thread_id) != str(metadata_message_thread_id)
+            ):
+                raise ValueError("Conflicting Discord delivery thread metadata")
+            effective_id = str(
+                metadata_thread_id
+                or metadata_message_thread_id
+                or target.thread_id
+                or target.chat_id
+            )
+            if effective_id in protected_ids:
+                raise ValueError(
+                    "Direct delivery to this Discord task channel is blocked; "
+                    "start a live agent task thread instead."
+                )
         
         # Guard: handle oversized cron output.
         #
@@ -640,7 +679,5 @@ class DeliveryRouter:
             if _send_result_failed(result):
                 raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
         return result
-
-
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -43,6 +43,12 @@ def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None)
 
 
 def _cron_api(**kwargs):
+    # CLI invocations are one-shot processes. Mark them stateless so a manual
+    # run executes synchronously instead of dispatching work to a daemon that
+    # dies as soon as this command returns.
+    from gateway.session_context import declare_stateless_channel
+    declare_stateless_channel()
+
     from tools.cronjob_tools import cronjob as cronjob_tool
 
     return json.loads(cronjob_tool(**kwargs))

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3099,7 +3099,37 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not channel:
                     return SendResult(success=False, error=f"Channel {chat_id} not found")
 
-            # Forum channels reject channel.send() — create a thread post instead.
+            # Configured task parents must never receive inert bot-authored
+            # messages.  A task parent may be either a ForumChannel or a
+            # normal TextChannel, so enforce this before the forum-only path.
+            effective_channel_id = str(thread_id or chat_id)
+            is_task_parent = (
+                effective_channel_id in self._get_agent_task_forum_channels()
+            )
+            if is_task_parent:
+                start_agent_task = bool(metadata and metadata.get("start_agent_task"))
+                if thread_id is not None or not start_agent_task:
+                    return SendResult(
+                        success=False,
+                        error=(
+                            "Direct bot delivery to this Discord task channel is blocked. "
+                            "Start a live agent task thread instead."
+                        ),
+                    )
+                if self._is_forum_parent(channel):
+                    result = await self._start_agent_task_in_forum(channel, content)
+                else:
+                    result = await self._start_agent_task_in_text_channel(channel, content)
+                await asyncio.to_thread(
+                    self._record_discord_response,
+                    reply_to=reply_to,
+                    result=result,
+                    content=content,
+                    final=final_delivery,
+                )
+                return result
+
+            # Non-task forum channels use ordinary forum-post delivery.
             if self._is_forum_parent(channel):
                 result = await self._send_to_forum(channel, content)
                 await asyncio.to_thread(
@@ -3190,7 +3220,196 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _start_agent_task_in_forum(
+        self,
+        forum_channel: Any,
+        task_text: str,
+    ) -> SendResult:
+        """Create a clearly bot-authored forum post and dispatch a live session."""
+        visible_text = f"🤖 **Hermes started this task**\n\n{task_text}"
+        result = await self._send_to_forum(
+            forum_channel,
+            visible_text,
+            thread_name=_derive_forum_thread_name(task_text),
+        )
+        return await self._dispatch_agent_task_thread(
+            forum_channel,
+            task_text,
+            result,
+        )
+
+    async def _start_agent_task_in_text_channel(
+        self,
+        parent_channel: Any,
+        task_text: str,
+    ) -> SendResult:
+        """Create a standalone public thread without posting in its parent."""
+        thread_name = _derive_forum_thread_name(task_text)
+        thread_channel = None
+        try:
+            thread_channel = await parent_channel.create_thread(
+                name=thread_name,
+                type=discord.ChannelType.public_thread,
+                auto_archive_duration=1440,
+                reason="Hermes live agent task",
+            )
+            starter = await thread_channel.send(
+                content=f"🤖 **Hermes started this task**\n\n{task_text}"
+            )
+        except Exception as exc:
+            logger.error(
+                "[%s] Failed to create live task thread under %s: %s",
+                self.name,
+                getattr(parent_channel, "id", "?"),
+                exc,
+                exc_info=True,
+            )
+            delete_thread = getattr(thread_channel, "delete", None)
+            if callable(delete_thread):
+                try:
+                    await delete_thread(
+                        reason="Hermes task starter failed; removing empty thread"
+                    )
+                except Exception as cleanup_exc:
+                    logger.error(
+                        "[%s] Failed to remove empty task thread %s: %s",
+                        self.name,
+                        getattr(thread_channel, "id", "?"),
+                        cleanup_exc,
+                        exc_info=True,
+                    )
+            return SendResult(
+                success=False,
+                error=f"Live task thread creation failed: {exc}",
+            )
+
+        result = SendResult(
+            success=True,
+            message_id=str(getattr(starter, "id", "") or "") or None,
+            raw_response={
+                "message_ids": [str(getattr(starter, "id", "") or "")],
+                "thread_id": str(getattr(thread_channel, "id", "") or ""),
+            },
+        )
+        return await self._dispatch_agent_task_thread(
+            parent_channel,
+            task_text,
+            result,
+            thread_channel=thread_channel,
+        )
+
+    async def _dispatch_agent_task_thread(
+        self,
+        parent_channel: Any,
+        task_text: str,
+        result: SendResult,
+        *,
+        thread_channel: Any = None,
+    ) -> SendResult:
+        """Bind a newly-created Discord task thread to a live Hermes session."""
+        if not result.success:
+            return result
+
+        raw = result.raw_response if isinstance(result.raw_response, dict) else {}
+        thread_id = str(raw.get("thread_id") or "")
+        if not thread_id:
+            return SendResult(
+                success=False,
+                message_id=result.message_id,
+                error="Task thread was created without a thread id; live session not started.",
+                raw_response=raw,
+            )
+
+        if thread_channel is None:
+            thread_channel = self._client.get_channel(int(thread_id)) if self._client else None
+            if thread_channel is None and self._client:
+                try:
+                    thread_channel = await self._client.fetch_channel(int(thread_id))
+                except Exception:
+                    thread_channel = None
+
+        self._threads.mark(thread_id)
+        guild = (
+            getattr(thread_channel, "guild", None)
+            or getattr(parent_channel, "guild", None)
+        )
+        chat_name = (
+            self._format_thread_chat_name(thread_channel)
+            if thread_channel is not None
+            else f"{getattr(parent_channel, 'name', 'tasks')} / {_derive_forum_thread_name(task_text)}"
+        )
+        source = self.build_source(
+            chat_id=thread_id,
+            chat_name=chat_name,
+            chat_type="thread",
+            user_id="system:hermes-task",
+            user_name="Hermes task launcher",
+            thread_id=thread_id,
+            chat_topic=self._get_effective_topic(
+                thread_channel or parent_channel,
+                is_thread=thread_channel is not None,
+            ),
+            is_bot=True,
+            guild_id=str(getattr(guild, "id", "") or "") or None,
+            parent_chat_id=str(getattr(parent_channel, "id", "") or "") or None,
+            message_id=result.message_id,
+            role_authorized=True,
+        )
+        parent_id = str(getattr(parent_channel, "id", "") or "")
+        event = MessageEvent(
+            text=(
+                "[Hermes-started task; not authored by the user]\n\n"
+                f"{task_text}"
+            ),
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=None,
+            auto_skill=self._resolve_channel_skills(thread_id, parent_id or None),
+            channel_prompt=self._resolve_channel_prompt(thread_id, parent_id or None),
+        )
+        try:
+            await self.handle_message(event)
+        except Exception as exc:
+            logger.error(
+                "[%s] Created task thread %s but failed to dispatch its session: %s",
+                self.name,
+                thread_id,
+                exc,
+                exc_info=True,
+            )
+            cleanup_error = None
+            delete_thread = getattr(thread_channel, "delete", None)
+            if callable(delete_thread):
+                try:
+                    await delete_thread(
+                        reason="Hermes live task dispatch failed; removing inert task thread"
+                    )
+                except Exception as cleanup_exc:
+                    cleanup_error = str(cleanup_exc)
+                    logger.error(
+                        "[%s] Failed to remove inert task thread %s: %s",
+                        self.name,
+                        thread_id,
+                        cleanup_exc,
+                        exc_info=True,
+                    )
+            if cleanup_error:
+                raw = {**raw, "cleanup_error": cleanup_error}
+            return SendResult(
+                success=False,
+                message_id=result.message_id,
+                error=f"Task thread created but live session dispatch failed: {exc}",
+                raw_response=raw,
+            )
+        return result
+
+    async def _send_to_forum(
+        self,
+        forum_channel: Any,
+        content: str,
+        *,
+        thread_name: Optional[str] = None,
+    ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
@@ -3205,7 +3424,7 @@ class DiscordAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-        thread_name = _derive_forum_thread_name(content)
+        thread_name = thread_name or _derive_forum_thread_name(content)
 
         starter_content = chunks[0] if chunks else thread_name
 
@@ -3352,6 +3571,11 @@ class DiscordAdapter(BasePlatformAdapter):
         re-split, looping forever (the Telegram #48648 lesson).  The complete
         text is delivered when ``finalize=True`` via ``_edit_overflow_split``.
         """
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Editing messages in this Discord task channel is blocked.",
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
         try:
@@ -3573,6 +3797,11 @@ class DiscordAdapter(BasePlatformAdapter):
         message with zero attachments — a silent drop for video/document
         MEDIA tags (#66797).
         """
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Direct media delivery to this Discord task channel is blocked.",
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -3646,6 +3875,13 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return
         if not images:
+            return
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            logger.warning(
+                "[%s] Blocked direct multi-image delivery to task channel %s",
+                self.name,
+                chat_id,
+            )
             return
 
         try:
@@ -3785,6 +4021,11 @@ class DiscordAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send audio as a Discord file attachment."""
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Direct media delivery to this Discord task channel is blocked.",
+            )
         try:
             import io
 
@@ -4999,6 +5240,11 @@ class DiscordAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively as a Discord file attachment."""
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Direct media delivery to this Discord task channel is blocked.",
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -5081,6 +5327,11 @@ class DiscordAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an animated GIF natively as a Discord file attachment."""
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Direct media delivery to this Discord task channel is blocked.",
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -5192,6 +5443,13 @@ class DiscordAdapter(BasePlatformAdapter):
         default), and continues — it does NOT die on a single rate-limit
         hit.  Only CancelledError (from stop_typing) stops the loop.
         """
+        chat_id = str(
+            (metadata or {}).get("thread_id")
+            or (metadata or {}).get("message_thread_id")
+            or chat_id
+        )
+        if chat_id in self._get_agent_task_forum_channels():
+            return
         if not self._client:
             return
         # Don't start a duplicate loop
@@ -6264,6 +6522,12 @@ class DiscordAdapter(BasePlatformAdapter):
         """This adapter's DISCORD_NO_THREAD_CHANNELS list (per-profile)."""
         return self._gate_csv_set(self._gate_raw("no_thread_channels", "DISCORD_NO_THREAD_CHANNELS"))
 
+    def _get_agent_task_forum_channels(self) -> set:
+        """Forums where bot-authored posts must launch a real agent session."""
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        raw = extra.get("agent_task_forum_channels") if isinstance(extra, dict) else None
+        return self._gate_csv_set(raw)
+
     def _get_allowed_users(self) -> set:
         """This adapter's DISCORD_ALLOWED_USERS entries (per-profile, cleaned)."""
         raw = self._gate_raw("allow_from", "DISCORD_ALLOWED_USERS")
@@ -6772,6 +7036,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 "thread_name": getattr(thread, "name", None) or name,
             }
         except Exception as direct_error:
+            if str(getattr(parent_channel, "id", "")) in self._get_agent_task_forum_channels():
+                return {
+                    "success": False,
+                    "error": (
+                        "Thread creation failed and the protected task channel "
+                        "does not allow a seed-message fallback."
+                    ),
+                }
             try:
                 seed_content = starter_message or f"\U0001f9f5 Thread created by Hermes: **{name}**"
                 seed_msg = await parent_channel.send(seed_content)
@@ -6843,6 +7115,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 return thread
             except Exception as direct_error:
                 last_direct_error = direct_error
+                if str(getattr(message.channel, "id", "")) in self._get_agent_task_forum_channels():
+                    logger.warning(
+                        "[%s] Auto-thread: refusing seed-message fallback in protected task channel %s",
+                        self.name,
+                        getattr(message.channel, "id", "?"),
+                    )
+                    break
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
@@ -6994,6 +7273,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name, direct_error,
             )
 
+        # A seed-message fallback would itself be a bot post in the protected
+        # task parent. Fail closed; callers can surface the thread-creation
+        # failure without violating the parent-channel contract.
+        if str(parent_chat_id) in self._get_agent_task_forum_channels():
+            logger.warning(
+                "[%s] Handoff thread: refusing seed-message fallback in task channel %s",
+                self.name,
+                parent_chat_id,
+            )
+            return None
+
         # Fallback: post a seed message and create the thread from it.
         try:
             send = getattr(parent, "send", None)
@@ -7072,6 +7362,9 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -7165,6 +7458,9 @@ class DiscordAdapter(BasePlatformAdapter):
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
 
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
+
             channel = self._client.get_channel(int(target_id))
             if not channel:
                 channel = await self._client.fetch_channel(int(target_id))
@@ -7231,6 +7527,9 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -7337,6 +7636,8 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
             channel = self._client.get_channel(int(target_id))
             if not channel:
                 channel = await self._client.fetch_channel(int(target_id))
@@ -7388,6 +7689,9 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -7449,6 +7753,9 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -9568,6 +9875,21 @@ async def _standalone_send(
     ``force_document`` is accepted for signature parity but unused — Discord
     treats every uploaded file as a generic attachment.
     """
+    extra = getattr(pconfig, "extra", None)
+    protected_raw = (
+        extra.get("agent_task_forum_channels")
+        if isinstance(extra, dict)
+        else None
+    )
+    protected_ids = DiscordAdapter._gate_csv_set(protected_raw)
+    if str(thread_id or chat_id) in protected_ids:
+        return {
+            "error": (
+                "Direct standalone delivery to this Discord task channel is blocked. "
+                "Use the running gateway to start a live agent task thread."
+            )
+        }
+
     try:
         import aiohttp
     except ImportError:

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -146,6 +146,58 @@ class RecordingAdapter:
 
 
 @pytest.mark.asyncio
+async def test_discord_task_parent_guard_uses_metadata_target_precedence(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                extra={"agent_task_forum_channels": ["protected-parent"]},
+            ),
+        },
+    )
+    router = DeliveryRouter(config, adapters={Platform.DISCORD: adapter})
+    target = DeliveryTarget(
+        platform=Platform.DISCORD,
+        chat_id="ordinary-chat",
+        thread_id="benign-target-thread",
+    )
+
+    with pytest.raises(ValueError, match="task channel"):
+        await router._deliver_to_platform(
+            target,
+            "blocked",
+            metadata={"thread_id": "protected-parent"},
+        )
+
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_discord_task_parent_guard_rejects_conflicting_metadata(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True)},
+    )
+    router = DeliveryRouter(config, adapters={Platform.DISCORD: adapter})
+
+    with pytest.raises(ValueError, match="Conflicting Discord delivery"):
+        await router._deliver_to_platform(
+            DeliveryTarget(platform=Platform.DISCORD, chat_id="ordinary-chat"),
+            "blocked",
+            metadata={"thread_id": "one", "message_thread_id": "two"},
+        )
+
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
 async def test_native_adapter_wins_when_relay_also_fronts_platform(tmp_path, monkeypatch):
     monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
     native = RecordingAdapter()

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -21,6 +21,7 @@ def _ensure_discord_mock():
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ChannelType = SimpleNamespace(public_thread="public_thread")
     discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
     discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
     discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
@@ -44,7 +45,7 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter, _standalone_send  # noqa: E402
 
 
 @pytest.mark.asyncio
@@ -172,6 +173,241 @@ class TestIsForumParent:
             _discord_mod.ForumChannel = forum_cls
         ch = forum_cls()
         assert adapter._is_forum_parent(ch) is True
+
+
+@pytest.mark.asyncio
+async def test_task_forum_rejects_static_bot_delivery():
+    """Configured task forums must never receive inert bot-authored posts."""
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock()
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("999", "do the task")
+
+    assert result.success is False
+    assert "task channel" in (result.error or "").lower()
+    forum_channel.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_text_channel_rejects_static_bot_delivery():
+    """Configured task parents are protected even when they are text channels."""
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    text_channel = SimpleNamespace(
+        id=999,
+        send=AsyncMock(),
+        create_thread=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: text_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("999", "do the task")
+
+    assert result.success is False
+    assert "task channel" in (result.error or "").lower()
+    text_channel.send.assert_not_awaited()
+    text_channel.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_parent_cannot_be_smuggled_as_thread_id():
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    task_parent = SimpleNamespace(id=999, send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: task_parent,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send(
+        "123",
+        "smuggled delivery",
+        metadata={"thread_id": "999"},
+    )
+
+    assert result.success is False
+    task_parent.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_parent_rejects_direct_media_and_standalone_delivery(tmp_path):
+    pconfig = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    )
+    adapter = DiscordAdapter(pconfig)
+    media_result = await adapter._send_file_attachment(
+        "999",
+        str(tmp_path / "unused.png"),
+    )
+    standalone_result = await _standalone_send(pconfig, "999", "blocked")
+
+    assert media_result.success is False
+    assert "task channel" in (media_result.error or "").lower()
+    assert "error" in standalone_result
+    assert "task channel" in standalone_result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_task_forum_explicit_agent_task_starts_live_thread():
+    """An explicit agent task creates a labeled post and dispatches a session."""
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    starter = SimpleNamespace(id=800)
+    thread_channel = SimpleNamespace(
+        id=777,
+        name="do the task",
+        parent=None,
+        guild=SimpleNamespace(id=55, name="My House"),
+        send=AsyncMock(),
+    )
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.name = "tasks"
+    forum_channel.topic = "Give the agent work."
+    forum_channel.guild = SimpleNamespace(id=55, name="My House")
+    thread_channel.parent = forum_channel
+    forum_channel.create_thread = AsyncMock(return_value=SimpleNamespace(
+        id=777,
+        thread=thread_channel,
+        message=starter,
+    ))
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    adapter.handle_message = AsyncMock()
+
+    result = await adapter.send(
+        "999",
+        "do the task",
+        metadata={"start_agent_task": True},
+    )
+
+    assert result.success is True
+    call = forum_channel.create_thread.await_args
+    assert call.kwargs["content"].startswith("🤖 **Hermes started this task**")
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "777"
+    assert event.source.thread_id == "777"
+    assert event.source.parent_chat_id == "999"
+    assert event.source.user_id == "system:hermes-task"
+    assert event.source.is_bot is True
+    assert event.source.role_authorized is True
+    assert event.text.startswith("[Hermes-started task; not authored by the user]")
+
+
+@pytest.mark.asyncio
+async def test_task_text_channel_explicit_agent_task_starts_live_thread():
+    """A text task parent creates a standalone live thread without a parent post."""
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    starter = SimpleNamespace(id=800)
+    parent = SimpleNamespace(
+        id=999,
+        name="tasks",
+        topic="Give the agent work.",
+        guild=SimpleNamespace(id=55, name="My House"),
+        send=AsyncMock(),
+    )
+    thread_channel = SimpleNamespace(
+        id=777,
+        name="do the task",
+        parent=parent,
+        guild=parent.guild,
+        send=AsyncMock(return_value=starter),
+    )
+    parent.create_thread = AsyncMock(return_value=thread_channel)
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        get_channel=lambda channel_id: parent if channel_id == 999 else thread_channel,
+        fetch_channel=AsyncMock(),
+    )
+    adapter.handle_message = AsyncMock()
+
+    result = await adapter.send(
+        "999",
+        "do the task",
+        metadata={"start_agent_task": True},
+    )
+
+    assert result.success is True
+    parent.send.assert_not_awaited()
+    parent.create_thread.assert_awaited_once()
+    assert (
+        parent.create_thread.await_args.kwargs["type"]
+        == sys.modules["discord"].ChannelType.public_thread
+    )
+    assert thread_channel.send.await_args.kwargs["content"].startswith(
+        "🤖 **Hermes started this task**"
+    )
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "777"
+    assert event.source.parent_chat_id == "999"
+    assert event.source.user_id == "system:hermes-task"
+    assert event.source.role_authorized is True
+
+
+@pytest.mark.asyncio
+async def test_task_text_channel_starter_failure_removes_empty_thread():
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    parent = SimpleNamespace(
+        id=999,
+        name="tasks",
+        guild=SimpleNamespace(id=55, name="My House"),
+    )
+    thread_channel = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=RuntimeError("starter failed")),
+        delete=AsyncMock(),
+    )
+    parent.create_thread = AsyncMock(return_value=thread_channel)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _channel_id: parent,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send(
+        "999",
+        "do the task",
+        metadata={"start_agent_task": True},
+    )
+
+    assert result.success is False
+    assert "starter failed" in (result.error or "")
+    thread_channel.delete.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -416,5 +652,3 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-
-

--- a/tests/tools/test_send_message_task_forum.py
+++ b/tests/tools/test_send_message_task_forum.py
@@ -1,0 +1,63 @@
+"""Behavior tests for Discord task-forum routing in send_message."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from tools.send_message_tool import _send_to_platform
+
+
+@pytest.mark.asyncio
+async def test_static_delivery_to_task_forum_is_blocked():
+    """Cron/lifecycle callers cannot create inert task-forum posts."""
+    pconfig = SimpleNamespace(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["tasks-parent"]},
+    )
+
+    result = await _send_to_platform(
+        Platform.DISCORD,
+        pconfig,
+        "tasks-parent",
+        "inert task",
+    )
+
+    assert "error" in result
+    assert "task forum" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_explicit_agent_task_uses_live_adapter(monkeypatch):
+    """Agent-initiated work is routed to the live session-start path."""
+    recorded = {}
+
+    class Adapter:
+        async def send(self, *, chat_id, content, metadata=None):
+            recorded.update(chat_id=chat_id, content=content, metadata=metadata)
+            return SimpleNamespace(
+                success=True,
+                message_id="starter",
+                raw_response={"thread_id": "task-thread"},
+            )
+
+    runner = SimpleNamespace(adapters={Platform.DISCORD: Adapter()})
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+    pconfig = SimpleNamespace(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["tasks-parent"]},
+    )
+
+    result = await _send_to_platform(
+        Platform.DISCORD,
+        pconfig,
+        "tasks-parent",
+        "real task",
+        start_agent_task=True,
+    )
+
+    assert result["success"] is True
+    assert result["thread_id"] == "task-thread"
+    assert recorded["metadata"] == {"start_agent_task": True}

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -487,6 +487,11 @@ def _handle_send(args):
 
     try:
         from model_tools import _run_async
+        start_agent_task = (
+            platform_name == "discord"
+            and thread_id is None
+            and _is_discord_agent_task_forum(pconfig, chat_id)
+        )
         result = _run_async(
             _send_to_platform(
                 platform,
@@ -496,13 +501,19 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                start_agent_task=start_agent_task,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
 
         # Mirror the sent message into the target's gateway session
-        if isinstance(result, dict) and result.get("success") and mirror_text:
+        if (
+            isinstance(result, dict)
+            and result.get("success")
+            and mirror_text
+            and not start_agent_task
+        ):
             try:
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env
@@ -685,6 +696,19 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
+def _is_discord_agent_task_forum(pconfig, chat_id) -> bool:
+    """Return whether ``chat_id`` is configured as an agent-only task forum."""
+    extra = getattr(pconfig, "extra", None)
+    raw = extra.get("agent_task_forum_channels") if isinstance(extra, dict) else None
+    if isinstance(raw, (list, tuple, set)):
+        configured = {str(value).strip() for value in raw if str(value).strip()}
+    else:
+        configured = {
+            value.strip() for value in str(raw or "").split(",") if value.strip()
+        }
+    return str(chat_id) in configured
+
+
 async def _send_via_adapter(
     platform,
     pconfig,
@@ -694,6 +718,7 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    start_agent_task=False,
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -726,6 +751,8 @@ async def _send_via_adapter(
                     metadata["thread_id"] = thread_id
                 if platform_name == "ntfy" and chat_id:
                     metadata["publish_topic"] = chat_id
+                if start_agent_task:
+                    metadata["start_agent_task"] = True
                 if not metadata:
                     metadata = None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
@@ -734,8 +761,19 @@ async def _send_via_adapter(
             except Exception as e:
                 return {"error": f"Plugin platform send failed: {e}"}
             if result.success:
-                return {"success": True, "message_id": result.message_id}
+                response = {"success": True, "message_id": result.message_id}
+                if isinstance(getattr(result, "raw_response", None), dict):
+                    response.update(result.raw_response)
+                return response
             return {"error": f"Adapter send failed: {result.error}"}
+
+    if start_agent_task:
+        return {
+            "error": (
+                "Starting a live Discord task requires the running gateway; "
+                "static task-forum delivery is blocked."
+            )
+        }
 
     entry = None
     try:
@@ -780,7 +818,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    start_agent_task=False,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -870,6 +917,31 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # historically went straight to the HTTP path; we preserve that by
     # explicitly invoking the registry hook here so behavior is unchanged.
     if platform == Platform.DISCORD:
+        is_task_forum = thread_id is None and _is_discord_agent_task_forum(
+            pconfig, chat_id
+        )
+        if is_task_forum and not start_agent_task:
+            return {
+                "error": (
+                    "Direct bot delivery to this Discord task forum is blocked. "
+                    "Use a live agent task thread instead."
+                )
+            }
+        if start_agent_task:
+            if media_files:
+                return {
+                    "error": (
+                        "Live Discord task-thread starts currently require a text-only "
+                        "prompt; attach files after the thread starts."
+                    )
+                }
+            return await _send_via_adapter(
+                platform,
+                pconfig,
+                chat_id,
+                message,
+                start_agent_task=True,
+            )
         from gateway.platform_registry import platform_registry
         entry = platform_registry.get("discord")
         if entry is None or entry.standalone_sender_fn is None:


### PR DESCRIPTION
## Summary
- block inert bot delivery to configured Discord task parents across native, relay, standalone, media, edit, and fallback paths
- allow explicit task starts only through the live gateway, creating public threads and dispatching a system-attributed live session
- clean up empty threads when starter delivery or session dispatch fails
- make one-shot cron CLI calls stateless/synchronous
- reject conflicting thread metadata and apply the same target precedence as delivery

## Validation
- 53 focused/adjacent tests passed on current origin/main
- Python compileall passed
- git diff --check passed
- independent high-reasoning review found no Critical or Important issues after three findings were fixed

## Risk
Scoped to configured agent_task_forum_channels; ordinary Discord channels retain existing behavior. No configuration or schema migration.