### PR TITLE
feat(session_search): bounded lexical query expansion for conversational recall

### DIFF
--- a/tests/tools/test_query_expansion.py
+++ b/tests/tools/test_query_expansion.py
@@ -1,0 +1,163 @@
+"""Tests for bounded lexical query expansion (port of openclaw/openclaw#121196).
+
+Covers the keyword extractor in tools/query_expansion.py and the
+supplemental OR probe wired into session_search's discovery shape.
+"""
+import json
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+from tools import query_expansion as qe
+from tools.session_search_tool import session_search
+
+
+# =========================================================================
+# Keyword extraction
+# =========================================================================
+
+class TestExtractKeywords:
+    def test_conversational_query_keeps_meaningful_terms(self):
+        kws = qe.extract_keywords("that thing we discussed about the API")
+        assert kws == ["API"]
+
+    def test_filler_only_query_yields_nothing(self):
+        assert qe.extract_keywords("that thing we talked about yesterday") == []
+
+    def test_identifiers_survive_edge_punct_stripping(self):
+        kws = qe.extract_keywords("what did we decide about chat-send and app.config?")
+        assert "chat-send" in kws
+        assert "app.config" in kws
+
+    def test_bounded_to_max_terms(self):
+        query = " ".join(f"keyword{i}" for i in range(20))
+        assert len(qe.extract_keywords(query)) == qe.MAX_EXPANSION_TERMS
+
+    def test_dedupes_case_insensitively(self):
+        assert qe.extract_keywords("Docker docker DOCKER networking") == [
+            "Docker", "networking",
+        ]
+
+    def test_cjk_tokens_exempt_from_length_floor(self):
+        kws = qe.extract_keywords("我们 讨论 的 那个 方案")
+        # Two-char CJK tokens are full words and must survive.
+        assert "讨论" in kws
+        assert "方案" in kws
+
+    def test_empty_query(self):
+        assert qe.extract_keywords("") == []
+        assert qe.extract_keywords(None) == []
+
+
+class TestOperatorDetection:
+    def test_quoted_phrase_detected(self):
+        assert qe.has_fts_operators('"docker networking"')
+
+    def test_boolean_operators_detected(self):
+        assert qe.has_fts_operators("alpha OR beta")
+        assert qe.has_fts_operators("python NOT java")
+        assert qe.has_fts_operators("a AND b")
+
+    def test_wildcard_detected(self):
+        assert qe.has_fts_operators("deploy*")
+
+    def test_lowercase_or_is_not_an_operator(self):
+        # FTS5 operators are uppercase-only; "this or that" is plain prose.
+        assert not qe.has_fts_operators("this or that")
+
+    def test_plain_query_not_detected(self):
+        assert not qe.has_fts_operators("auth refactor discussion")
+
+
+class TestNoopGuard:
+    def test_all_tokens_kept_is_noop(self):
+        query = "docker networking bridge"
+        kws = qe.extract_keywords(query)
+        assert qe.expansion_is_noop(query, kws)
+
+    def test_narrowed_query_is_not_noop(self):
+        query = "that thing about docker networking"
+        kws = qe.extract_keywords(query)
+        assert not qe.expansion_is_noop(query, kws)
+
+
+class TestBuildQuery:
+    def test_joins_with_or(self):
+        assert qe.build_expansion_query(["a", "b", "c"]) == "a OR b OR c"
+
+
+# =========================================================================
+# Discovery-shape integration
+# =========================================================================
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _seed(db):
+    now = int(time.time())
+    db.create_session("s_auth", source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now - 5000, "OAuth token refresh", "s_auth"),
+    )
+    db.append_message("s_auth", role="user", content="Fix the OAuth refresh flow")
+    db.append_message(
+        "s_auth", role="assistant",
+        content="API authentication uses short-lived OAuth tokens now.",
+    )
+    db.create_session("s_deploy", source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now - 3000, "Deploy pipeline", "s_deploy"),
+    )
+    db.append_message("s_deploy", role="user", content="Set up the deploy pipeline")
+    db.append_message(
+        "s_deploy", role="assistant",
+        content="Deployment strategy requires a maintenance window.",
+    )
+    db._conn.commit()
+
+
+class TestDiscoveryExpansion:
+    def test_conversational_query_finds_keyword_sessions(self, db):
+        _seed(db)
+        # Strict AND query matches nothing: "thing", "we", "discussed" never
+        # co-occur with API in one message. Expansion must recover the hit.
+        result = json.loads(
+            session_search(query="that thing we discussed about the API", db=db)
+        )
+        assert result["success"] is True
+        assert result["count"] >= 1
+        assert any(r["session_id"] == "s_auth" for r in result["results"])
+        assert result.get("expanded_terms") == ["API"]
+
+    def test_strict_hits_rank_above_expanded_hits(self, db):
+        _seed(db)
+        # "deploy pipeline" strictly matches s_deploy; expansion may pull in
+        # more, but the strict hit must stay first.
+        result = json.loads(session_search(query="deploy pipeline", db=db, limit=3))
+        assert result["results"][0]["session_id"] == "s_deploy"
+
+    def test_operator_queries_skip_expansion(self, db):
+        _seed(db)
+        result = json.loads(
+            session_search(query='"phrase that matches nothing at all"', db=db)
+        )
+        assert result["success"] is True
+        assert "expanded_terms" not in result
+
+    def test_no_expansion_marker_when_strict_pool_is_full(self, db):
+        _seed(db)
+        result = json.loads(session_search(query="OAuth", db=db, limit=1))
+        assert result["count"] == 1
+        assert "expanded_terms" not in result
+
+    def test_filler_only_query_still_returns_cleanly(self, db):
+        _seed(db)
+        result = json.loads(
+            session_search(query="that thing from yesterday", db=db)
+        )
+        assert result["success"] is True

--- a/tools/query_expansion.py
+++ b/tools/query_expansion.py
@@ -1,0 +1,148 @@
+"""Bounded lexical query expansion for conversational FTS5 searches.
+
+FTS5 works best with specific keywords, but users often phrase recall
+requests conversationally — "that thing we discussed about the API",
+"what did we decide yesterday about deployment". The default AND
+semantics of multi-word FTS5 queries make such prompts match almost
+nothing: every filler word ("that", "thing", "we") must appear in the
+same message as the meaningful terms.
+
+This module extracts the meaningful keywords from a conversational
+query so callers can run ONE bounded supplemental OR probe when the
+strict query comes back thin. It never replaces the strict query —
+strict hits always rank first; expansion only supplements recall.
+
+Ported from openclaw/openclaw#121196 ("supplement thin strict recall
+with bounded lexical expansion"), adapted to hermes's single-probe
+BM25 pipeline: instead of N per-term FTS probes merged client-side,
+we emit one `kw1 OR kw2 OR ...` query and let FTS5 rank it.
+
+Design constraints (mirroring the source PR):
+- Expansion is bounded: at most ``MAX_EXPANSION_TERMS`` keywords, so a
+  long prompt cannot fan out into unbounded sqlite work.
+- Queries that already use explicit FTS5 syntax (quoted phrases,
+  OR/NOT operators, prefix wildcards) are the user being precise —
+  never rewritten.
+- When extraction does not actually narrow the query (every token is
+  already a keyword) an OR probe could only dilute the strict AND
+  semantics, so expansion reports "no-op" via ``expansion_is_noop``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+# Cap on extracted keywords — mirrors the probe bound in the source PR.
+MAX_EXPANSION_TERMS = 6
+
+# Minimum keyword length (codepoints). Single characters are noise for
+# unicode61 tokenization; CJK terms are exempted below since a 2-char
+# CJK token is a full word.
+_MIN_KEYWORD_LEN = 2
+
+_CJK_RE = re.compile(
+    r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]"
+)
+
+# Explicit FTS5 query syntax: quoted phrase, boolean operators (upper
+# case, FTS5's requirement), or a prefix wildcard. Presence of any of
+# these means the user is writing a precise query — leave it alone.
+_FTS_OPERATOR_RE = re.compile(r'"|\*|\b(?:OR|NOT|AND)\b')
+
+# Filler vocabulary that carries no lexical search value. Grouped by
+# function; deliberately conservative — a false keep costs one extra OR
+# term, a false drop can hide the only meaningful term in the query.
+_STOP_WORDS = frozenset(
+    # articles / determiners
+    "a an the this that these those some any each every".split()
+    # pronouns
+    + "i me my mine we us our you your yours he him his she her it its "
+      "they them their there".split()
+    # auxiliaries / common verbs
+    + "is are was were be been being am have has had having do does did "
+      "done will would could should shall can may might must".split()
+    # prepositions / conjunctions
+    + "in on at to for of with by from about into through during before "
+      "after between under over and or but if then because so as while "
+      "when where".split()
+    # question / request words
+    + "what which who whom whose how why please help find show get tell "
+      "give look search remember recall".split()
+    # vague time references — useless for lexical match
+    + "yesterday today tomorrow earlier later recently ago just now once "
+      "last previous".split()
+    # vague nouns
+    + "thing things stuff something anything everything nothing one ones "
+      "way time".split()
+    # conversational glue
+    + "we're i'm it's that's did we you know like really actually kind "
+      "sort mentioned discussed talked said told chat conversation "
+      "session talking".split()
+)
+
+_TOKEN_RE = re.compile(r"[^\s]+")
+# Strip leading/trailing punctuation from a token but keep interior
+# hyphens/dots/underscores (identifiers like chat-send, app.config).
+_EDGE_PUNCT_RE = re.compile(r"^[^\w\u0080-\uffff]+|[^\w\u0080-\uffff]+$")
+
+
+def has_fts_operators(query: str) -> bool:
+    """Return True when *query* uses explicit FTS5 syntax.
+
+    Such queries express user intent precisely and must never be
+    rewritten or supplemented by lexical expansion.
+    """
+    return bool(_FTS_OPERATOR_RE.search(query or ""))
+
+
+def extract_keywords(query: str, max_terms: int = MAX_EXPANSION_TERMS) -> List[str]:
+    """Extract up to *max_terms* meaningful keywords from a query.
+
+    Tokenizes on whitespace, strips edge punctuation, drops stop words
+    and too-short tokens (CJK tokens are exempt from the length floor —
+    two CJK characters form a full word). Order of first appearance is
+    preserved; duplicates are removed case-insensitively.
+    """
+    if not query:
+        return []
+    keywords: List[str] = []
+    seen = set()
+    for match in _TOKEN_RE.finditer(query):
+        token = _EDGE_PUNCT_RE.sub("", match.group(0))
+        if not token:
+            continue
+        lowered = token.lower()
+        if lowered in _STOP_WORDS:
+            continue
+        if len(token) < _MIN_KEYWORD_LEN and not _CJK_RE.search(token):
+            continue
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        keywords.append(token)
+        if len(keywords) >= max_terms:
+            break
+    return keywords
+
+
+def expansion_is_noop(query: str, keywords: List[str]) -> bool:
+    """Return True when expansion did not narrow the query.
+
+    If every token of the original query survived extraction, the OR
+    probe covers the same terms as the strict AND query — it can only
+    weaken relevance, never add meaningful recall beyond what a broader
+    ranking would surface. Mirrors the strict-vs-keyword query equality
+    guard in the source PR.
+    """
+    original_tokens = set()
+    for match in _TOKEN_RE.finditer(query or ""):
+        token = _EDGE_PUNCT_RE.sub("", match.group(0))
+        if token:
+            original_tokens.add(token.lower())
+    return original_tokens == {k.lower() for k in keywords}
+
+
+def build_expansion_query(keywords: List[str]) -> str:
+    """Join keywords into a single FTS5 OR probe query."""
+    return " OR ".join(keywords)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -33,6 +33,8 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from tools import query_expansion as qe
+
 # Sources that are excluded from session browsing/searching by default.
 # Third-party integrations tag their sessions with HERMES_SESSION_SOURCE=tool;
 # delegate subagent runs are tagged "subagent"; kanban dispatcher workers are
@@ -717,6 +719,41 @@ def _discover(
         logging.error("FTS5 search failed: %s", e, exc_info=True)
         return tool_error(f"Search failed: {e}", success=False)
 
+    # Bounded lexical expansion for conversational queries (port of
+    # openclaw/openclaw#121196). Multi-word FTS5 queries default to AND
+    # semantics, so a conversational recall prompt like "that thing we
+    # discussed about the API" matches almost nothing — every filler word
+    # must co-occur with the meaningful terms. When the strict query's
+    # candidate pool is thin (< limit distinct lineages), run ONE
+    # supplemental OR probe over the extracted keywords and append its
+    # hits BELOW every strict hit. Strict results always rank first;
+    # explicit FTS5 syntax (quotes, OR/NOT, wildcards) disables expansion
+    # entirely — the user is being precise.
+    expanded_terms: List[str] = []
+    strict_lineages = {r.get("session_id") for r in raw_results}
+    if len(strict_lineages) < limit and not qe.has_fts_operators(query):
+        keywords = qe.extract_keywords(query)
+        if keywords and not qe.expansion_is_noop(query, keywords):
+            try:
+                supplemental = db.search_messages(
+                    query=qe.build_expansion_query(keywords),
+                    role_filter=role_list,
+                    exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                    limit=_DISCOVER_SCAN_LIMIT,
+                    offset=0,
+                    sort=sort,
+                    fields=_DISCOVER_SEARCH_FIELDS,
+                )
+            except Exception:
+                logging.debug("supplemental keyword probe failed", exc_info=True)
+                supplemental = []
+            if supplemental:
+                seen_ids = {r.get("id") for r in raw_results}
+                extras = [r for r in supplemental if r.get("id") not in seen_ids]
+                if extras:
+                    raw_results = list(raw_results) + extras
+                    expanded_terms = keywords
+
     # Demote automation (cron) rows below interactive ones before dedup, so a
     # high-volume cron corpus can't starve the user's own sessions out of the
     # top `limit` results (#19434). Stable — preserves BM25/recency order
@@ -841,6 +878,12 @@ def _discover(
         "count": len(results),
         "sessions_searched": len(seen_sessions),
     }
+    if expanded_terms:
+        _final_payload["expanded_terms"] = expanded_terms
+        _final_payload["expansion_note"] = (
+            "Strict query was thin; results were supplemented by a bounded "
+            "keyword OR probe over the terms above. Strict matches rank first."
+        )
     _annotate_rebuild_status(db, _final_payload)
     return json.dumps(_final_payload, ensure_ascii=False)
 


### PR DESCRIPTION
## Summary
`session_search` discovery now recovers matches for conversational recall queries ("that thing we discussed about the API") that strict FTS5 AND semantics previously returned zero results for — via one bounded keyword OR probe that only fires when the strict candidate pool is thin.

Port of openclaw/openclaw#121196 ("feat(memory): supplement thin strict recall with bounded lexical expansion"), adapted to hermes's session-search pipeline.

## Changes
- `tools/query_expansion.py` (new): stop-word-filtered keyword extractor (max 6 terms, dedup, edge-punctuation stripping that preserves identifiers like `chat-send` / `app.config`, CJK tokens exempt from the length floor), FTS5-operator detection, and a no-op guard.
- `tools/session_search_tool.py`: when the strict query yields fewer distinct sessions than the requested limit, run ONE supplemental `kw1 OR kw2 ...` probe and append its hits below every strict hit. Payload gains `expanded_terms` + `expansion_note` so the model knows which results came from the widened probe.
- `tests/tools/test_query_expansion.py` (new): 19 tests — extractor units + discovery-shape integration against a real SessionDB.

## Guarantees / invariants preserved
- Strict hits always rank above expanded hits (append-below, then the existing `_order_for_recall` cron-demotion pass runs over the combined pool).
- Explicit FTS5 syntax (quoted phrases, `OR`/`NOT`/`AND`, prefix wildcards) disables expansion entirely — precise queries are never rewritten.
- Expansion that doesn't narrow the query (every token already a keyword) is skipped: an OR probe over the same terms can only dilute AND relevance.
- Zero LLM calls, one extra bounded `search_messages` call worst-case; existing compaction/lineage visibility guards apply unchanged since expansion happens before dedup.

## Architectural adaptation vs the source
The source PR runs N per-term FTS probes and merges client-side with custom ranking. Hermes's `search_messages` already BM25-ranks a single query, so this port issues one `OR` probe bounded by the existing `_DISCOVER_SCAN_LIMIT` — same recall benefit, simpler and cheaper.

## Validation
| | Before | After |
|---|---|---|
| `"that thing we discussed about the API"` vs a DB where "API" appears only with other words | 0 results | finds the API session, `expanded_terms: ["API"]` |
| `"docker networking"` (all-keyword query) | strict AND | unchanged (no-op guard) |
| `'"exact phrase"'` / `alpha OR beta` | strict | unchanged (operator guard) |
| tests/tools (test_query_expansion.py + test_session_search.py) | — | 59/59 pass |

## Infographic

![Session search query expansion — arcade attract screen](https://v3b.fal.media/files/b/0aa5b592/yQbRkDhJzkMCsrU4NgKgg_KviN2jSl.png)
