### PR TITLE
feat(desktop): add up/down session steppers for the flat sessions list

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -172,6 +172,7 @@ import {
 import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
+import { SessionStepNav } from './session-step-nav'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
@@ -708,6 +709,12 @@ export function ChatSidebar({
   // into the list here, so a drag ranks a row among its own day's chats
   // instead of flattening the whole sidebar into an undated manual mode.
   const agentSessions = unpinnedAgentSessions
+
+  // The ^/v steppers walk the chronological recents axis (the flat Sessions
+  // view). Pinned lives in its own section and the tree/browse views have no
+  // single honest up/down order, so the buttons render only in the flat view.
+  const showStepNav = !trimmedQuery && !showArchived && !showAllProfiles && !agentsGrouped
+  const stepSessionIds = useMemo(() => agentSessions.map(session => session.id), [agentSessions])
 
   // Recents are local-only: messaging-platform sessions are fetched as their
   // own slice ($messagingSessions) and rendered in self-managed per-platform
@@ -1567,13 +1574,24 @@ export function ChatSidebar({
 
         {showSessionSections && (
           <div className="shrink-0 px-2 pb-1 pt-1">
-            <SearchField
-              aria-label={s.searchAria}
-              inputRef={searchInputRef}
-              onChange={setSearchQuery}
-              placeholder={s.searchPlaceholder}
-              value={searchQuery}
-            />
+            <div className="flex items-center gap-0.5">
+              <div className="min-w-0 flex-1">
+                <SearchField
+                  aria-label={s.searchAria}
+                  inputRef={searchInputRef}
+                  onChange={setSearchQuery}
+                  placeholder={s.searchPlaceholder}
+                  value={searchQuery}
+                />
+              </div>
+              {showStepNav && (
+                <SessionStepNav
+                  activeId={activeSidebarSessionId}
+                  ids={stepSessionIds}
+                  onStep={onResumeSession}
+                />
+              )}
+            </div>
           </div>
         )}
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -160,6 +160,7 @@ import {
 import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId } from './session-index'
+import { SessionStepNav } from './session-step-nav'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
@@ -648,6 +649,12 @@ export function ChatSidebar({
   // into the list here, so a drag ranks a row among its own day's chats
   // instead of flattening the whole sidebar into an undated manual mode.
   const agentSessions = unpinnedAgentSessions
+
+  // The ^/v steppers walk the chronological recents axis (the flat Sessions
+  // view). Pinned lives in its own section and the tree/browse views have no
+  // single honest up/down order, so the buttons render only in the flat view.
+  const showStepNav = !trimmedQuery && !showArchived && !showAllProfiles && !agentsGrouped
+  const stepSessionIds = useMemo(() => agentSessions.map(session => session.id), [agentSessions])
 
   // Recents are local-only: messaging-platform sessions are fetched as their
   // own slice ($messagingSessions) and rendered in self-managed per-platform
@@ -1483,13 +1490,24 @@ export function ChatSidebar({
 
         {showSessionSections && (
           <div className="shrink-0 px-2 pb-1 pt-1">
-            <SearchField
-              aria-label={s.searchAria}
-              inputRef={searchInputRef}
-              onChange={setSearchQuery}
-              placeholder={s.searchPlaceholder}
-              value={searchQuery}
-            />
+            <div className="flex items-center gap-0.5">
+              <div className="min-w-0 flex-1">
+                <SearchField
+                  aria-label={s.searchAria}
+                  inputRef={searchInputRef}
+                  onChange={setSearchQuery}
+                  placeholder={s.searchPlaceholder}
+                  value={searchQuery}
+                />
+              </div>
+              {showStepNav && (
+                <SessionStepNav
+                  activeId={activeSidebarSessionId}
+                  ids={stepSessionIds}
+                  onStep={onResumeSession}
+                />
+              )}
+            </div>
           </div>
         )}
 

--- a/apps/desktop/src/app/chat/sidebar/session-step-nav.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-step-nav.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SessionStepNav } from './session-step-nav'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        stepDown: 'Next session',
+        stepUp: 'Previous session'
+      }
+    }
+  })
+}))
+
+const IDS = ['session-a', 'session-b', 'session-c']
+
+describe('SessionStepNav', () => {
+  it('steps to the previous session from a middle row', () => {
+    const onStep = vi.fn()
+    render(<SessionStepNav activeId="session-b" ids={IDS} onStep={onStep} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous session' }))
+
+    expect(onStep).toHaveBeenCalledWith('session-a')
+  })
+
+  it('steps to the next session from a middle row', () => {
+    const onStep = vi.fn()
+    render(<SessionStepNav activeId="session-b" ids={IDS} onStep={onStep} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next session' }))
+
+    expect(onStep).toHaveBeenCalledWith('session-c')
+  })
+
+  it('disables the up button at the top of the list', () => {
+    const onStep = vi.fn()
+    render(<SessionStepNav activeId="session-a" ids={IDS} onStep={onStep} />)
+
+    expect(screen.getByRole('button', { name: 'Previous session' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Next session' }).hasAttribute('disabled')).toBe(false)
+  })
+
+  it('disables the down button at the bottom of the list', () => {
+    const onStep = vi.fn()
+    render(<SessionStepNav activeId="session-c" ids={IDS} onStep={onStep} />)
+
+    expect(screen.getByRole('button', { name: 'Previous session' }).hasAttribute('disabled')).toBe(false)
+    expect(screen.getByRole('button', { name: 'Next session' }).hasAttribute('disabled')).toBe(true)
+  })
+
+  it('disables both buttons when no session is active', () => {
+    const onStep = vi.fn()
+    render(<SessionStepNav activeId={null} ids={IDS} onStep={onStep} />)
+
+    expect(screen.getByRole('button', { name: 'Previous session' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Next session' }).hasAttribute('disabled')).toBe(true)
+  })
+
+  it('disables both buttons when the active session is not in the list', () => {
+    const onStep = vi.fn()
+    render(<SessionStepNav activeId="session-elsewhere" ids={IDS} onStep={onStep} />)
+
+    expect(screen.getByRole('button', { name: 'Previous session' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Next session' }).hasAttribute('disabled')).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-step-nav.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-step-nav.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+
+interface SessionStepNavProps {
+  /** The currently active session, if the app is on a chat view. */
+  activeId: null | string
+  /** Ordered ids of the sessions the buttons step through (chronological). */
+  ids: string[]
+  /** Resume the stepped-to session (same as clicking its row). */
+  onStep: (id: string) => void
+}
+
+/**
+ * Up/down steppers for the flat sessions list. Move the active session one
+ * row in either direction and resume it — a visible complement to the
+ * Ctrl+Tab / Ctrl+PageUp-PageDown session switching keybinds (#53017), for
+ * users who navigate the sidebar by mouse.
+ *
+ * Deliberately scoped to the flat Sessions view: in the Projects tree and the
+ * Profiles browse view, "up/down" has no single honest axis, so the buttons
+ * only render there if a caller passes ids for them.
+ */
+export function SessionStepNav({ activeId, ids, onStep }: SessionStepNavProps) {
+  const { t } = useI18n()
+  const s = t.sidebar
+  const index = activeId ? ids.indexOf(activeId) : -1
+  const hasPrev = index > 0
+  const hasNext = index >= 0 && index < ids.length - 1
+
+  return (
+    <div className="flex shrink-0 items-center gap-0.5">
+      <Tip label={s.stepUp}>
+        <Button
+          aria-label={s.stepUp}
+          className="text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:opacity-35"
+          disabled={!hasPrev}
+          onClick={() => onStep(ids[index - 1])}
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="chevron-up" size="0.75rem" />
+        </Button>
+      </Tip>
+      <Tip label={s.stepDown}>
+        <Button
+          aria-label={s.stepDown}
+          className="text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground disabled:opacity-35"
+          disabled={!hasNext}
+          onClick={() => onStep(ids[index + 1])}
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="chevron-down" size="0.75rem" />
+        </Button>
+      </Tip>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -106,6 +106,30 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   // measurements from the previous mode before off-screen rows re-enter.
   useEffect(() => virtualizer.measure(), [density, virtualizer])
 
+  // When the active session changes from outside the list (the ^/v steppers,
+  // keyboard session switching), bring its row on screen. Local clicks land on
+  // an already-visible row, so this only ever moves the viewport for remote
+  // changes — never fights the user's scroll. The previous-id comparison is a
+  // render-time ref mirror (the codebase's sanctioned pattern); writing it
+  // inside the effect is banned by the ref-mirror lint rule.
+  const lastActiveIdRef = useRef<null | string>(null)
+  const activeIdChanged = activeSessionId !== lastActiveIdRef.current
+  lastActiveIdRef.current = activeSessionId
+
+  useEffect(() => {
+    if (!activeIdChanged || !activeSessionId) {
+      return
+    }
+
+    const index = listRows.findIndex(
+      row => row.kind === 'session' && row.entry.session.id === activeSessionId
+    )
+
+    if (index >= 0) {
+      virtualizer.scrollToIndex(index, { align: 'auto' })
+    }
+  }, [activeIdChanged, activeSessionId, listRows, virtualizer])
+
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()
 

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -2,7 +2,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type * as React from 'react'
-import { type FC, useCallback, useRef } from 'react'
+import { type FC, useCallback, useEffect, useRef } from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -77,6 +77,30 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     initialRect: { height: 600, width: 240 },
     overscan: OVERSCAN_ROWS
   })
+
+  // When the active session changes from outside the list (the ^/v steppers,
+  // keyboard session switching), bring its row on screen. Local clicks land on
+  // an already-visible row, so this only ever moves the viewport for remote
+  // changes — never fights the user's scroll. The previous-id comparison is a
+  // render-time ref mirror (the codebase's sanctioned pattern); writing it
+  // inside the effect is banned by the ref-mirror lint rule.
+  const lastActiveIdRef = useRef<null | string>(null)
+  const activeIdChanged = activeSessionId !== lastActiveIdRef.current
+  lastActiveIdRef.current = activeSessionId
+
+  useEffect(() => {
+    if (!activeIdChanged || !activeSessionId) {
+      return
+    }
+
+    const index = listRows.findIndex(
+      row => row.kind === 'session' && row.entry.session.id === activeSessionId
+    )
+
+    if (index >= 0) {
+      virtualizer.scrollToIndex(index, { align: 'auto' })
+    }
+  }, [activeIdChanged, activeSessionId, listRows, virtualizer])
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1613,6 +1613,9 @@ export const ar = defineLocale({
     results: 'النتائج',
     pinned: 'المثبتة',
     sessions: 'الجلسات',
+
+    stepUp: 'الجلسة السابقة',
+    stepDown: 'الجلسة التالية',
     cronJobs: 'المهام المجدولة',
     groupAriaGrouped: 'الجلسات مجمعة حسب مساحة العمل',
     groupAriaUngrouped: 'الجلسات غير مجمعة',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1548,6 +1548,9 @@ export const ar = defineLocale({
     results: 'النتائج',
     pinned: 'المثبتة',
     sessions: 'الجلسات',
+
+    stepUp: 'الجلسة السابقة',
+    stepDown: 'الجلسة التالية',
     cronJobs: 'المهام المجدولة',
     groupAriaGrouped: 'الجلسات مجمعة حسب مساحة العمل',
     groupAriaUngrouped: 'الجلسات غير مجمعة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2060,6 +2060,9 @@ export const en: Translations = {
     results: 'Results',
     pinned: 'Pinned',
     sessions: 'Sessions',
+
+    stepUp: 'Previous session',
+    stepDown: 'Next session',
     cronJobs: 'Cron jobs',
     groupAriaGrouped: 'Show sessions as a single list',
     groupAriaUngrouped: 'Group sessions by workspace',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1859,6 +1859,9 @@ export const en: Translations = {
     results: 'Results',
     pinned: 'Pinned',
     sessions: 'Sessions',
+
+    stepUp: 'Previous session',
+    stepDown: 'Next session',
     cronJobs: 'Cron jobs',
     groupAriaGrouped: 'Show sessions as a single list',
     groupAriaUngrouped: 'Group sessions by workspace',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1773,6 +1773,9 @@ export const ja = defineLocale({
     results: '結果',
     pinned: 'ピン留め',
     sessions: 'セッション',
+
+    stepUp: '前のセッション',
+    stepDown: '次のセッション',
     cronJobs: 'Cronジョブ',
     groupAriaGrouped: 'セッションを単一リストとして表示',
     groupAriaUngrouped: 'ワークスペースごとにセッションをグループ化',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1684,6 +1684,9 @@ export const ja = defineLocale({
     results: '結果',
     pinned: 'ピン留め',
     sessions: 'セッション',
+
+    stepUp: '前のセッション',
+    stepDown: '次のセッション',
     cronJobs: 'Cronジョブ',
     groupAriaGrouped: 'セッションを単一リストとして表示',
     groupAriaUngrouped: 'ワークスペースごとにセッションをグループ化',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1739,6 +1739,9 @@ export interface Translations {
     results: string
     pinned: string
     sessions: string
+
+    stepUp: string
+    stepDown: string
     cronJobs: string
     groupAriaGrouped: string
     groupAriaUngrouped: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1553,6 +1553,9 @@ export interface Translations {
     results: string
     pinned: string
     sessions: string
+
+    stepUp: string
+    stepDown: string
     cronJobs: string
     groupAriaGrouped: string
     groupAriaUngrouped: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1715,6 +1715,9 @@ export const zhHant = defineLocale({
     results: '結果',
     pinned: '已釘選',
     sessions: '工作階段',
+
+    stepUp: '上一個工作階段',
+    stepDown: '下一個工作階段',
     cronJobs: '排程任務',
     groupAriaGrouped: '以單一清單顯示工作階段',
     groupAriaUngrouped: '依工作區分組工作階段',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1629,6 +1629,9 @@ export const zhHant = defineLocale({
     results: '結果',
     pinned: '已釘選',
     sessions: '工作階段',
+
+    stepUp: '上一個工作階段',
+    stepDown: '下一個工作階段',
     cronJobs: '排程任務',
     groupAriaGrouped: '以單一清單顯示工作階段',
     groupAriaUngrouped: '依工作區分組工作階段',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2247,6 +2247,9 @@ export const zh: Translations = {
     results: '结果',
     pinned: '已置顶',
     sessions: '会话',
+
+    stepUp: '上一个会话',
+    stepDown: '下一个会话',
     cronJobs: '定时任务',
     groupAriaGrouped: '以单一列表显示会话',
     groupAriaUngrouped: '按工作区分组会话',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2051,6 +2051,9 @@ export const zh: Translations = {
     results: '结果',
     pinned: '已置顶',
     sessions: '会话',
+
+    stepUp: '上一个会话',
+    stepDown: '下一个会话',
     cronJobs: '定时任务',
     groupAriaGrouped: '以单一列表显示会话',
     groupAriaUngrouped: '按工作区分组会话',


### PR DESCRIPTION
## Summary

Add up/down controls for the flat Desktop Sessions list.

The controls step through unpinned chronological recents, resume the selected session, disable at the list ends, and remain out of Projects, Profiles, search, and archived views where no single ordering is defined. External selection changes scroll the virtualized list to the active row.

The change also adds localized labels and component coverage.

Verification:
- Focused stepper and virtual-list tests: 8 passed
- Typecheck passed
- Lint: 0 errors (existing warnings remain)
- `git diff --check` passed
