### PR TITLE
fix(desktop): clear per-profile project state on gateway switch

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -697,8 +697,13 @@ export function ChatSidebar({
     // Flat view: warm the tree in the background anyway. Fetching it only on
     // the switch meant the first switch of every run paid for the whole round
     // trip behind a skeleton, and the menu's Project filter had nothing to
-    // list until you'd visited the grouped view at least once.
-    const warm = window.setTimeout(() => void refreshProjectTree(), PROJECT_TREE_WARM_MS)
+    // list until you'd visited the grouped view at least once. The list is
+    // warmed alongside: after a profile switch (wipe → empty) the sidebar
+    // would otherwise show no projects until the user enters the grouped view.
+    const warm = window.setTimeout(() => {
+      void refreshProjects()
+      void refreshProjectTree()
+    }, PROJECT_TREE_WARM_MS)
 
     return () => window.clearTimeout(warm)
   }, [worktreeGroupingActive, showAllProfiles, profileScope, gatewayReady])

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -2,6 +2,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $sessionsLimit, resetSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import {
+  $activeProjectId,
+  $projects,
+  $projectScope,
+  $projectsRpcAvailable,
+  $projectTree,
+  $removedSessionIds,
+  $reposScanning,
+  ALL_PROJECTS,
+  enterProject
+} from '@/store/projects'
+import {
   $cronSessions,
   $freshDraftReady,
   $messagingSessions,
@@ -34,6 +45,13 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setSessionsLoading(false)
     setFreshDraftReady(false)
     $sessionsLimit.set(SIDEBAR_SESSIONS_PAGE_SIZE * 3)
+    $projects.set([{ id: 'p_old', label: 'old', repos: [], isNoProject: false } as never])
+    $projectTree.set([{ id: 'p_old', label: 'old', repos: [], sessionCount: 0 } as never])
+    $activeProjectId.set('p_old')
+    enterProject('p_old')
+    $projectsRpcAvailable.set(true)
+    $reposScanning.set(true)
+    $removedSessionIds.set(new Set(['s1']))
   })
 
   afterEach(() => {
@@ -57,5 +75,17 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     expect($sessionsLoading.get()).toBe(true)
     expect($sessionsLimit.get()).toBe(SIDEBAR_SESSIONS_PAGE_SIZE)
     expect($freshDraftReady.get()).toBe(true)
+  })
+
+  it('clears per-profile project state so the next gateway repaints its own', () => {
+    wipeSessionListsForGatewaySwitch()
+
+    expect($projects.get()).toEqual([])
+    expect($projectTree.get()).toEqual([])
+    expect($activeProjectId.get()).toBeNull()
+    expect($projectScope.get()).toBe(ALL_PROJECTS)
+    expect($projectsRpcAvailable.get()).toBeNull()
+    expect($reposScanning.get()).toBe(false)
+    expect($removedSessionIds.get().size).toBe(0)
   })
 })

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -6,6 +6,7 @@ import { invalidateProfileScopedQueries } from '@/lib/query-client'
 import { clearArtifactRegistry } from '@/store/artifacts'
 import { resetSessionsLimit } from '@/store/layout'
 import { resetLiveSync } from '@/store/live-sync'
+import { resetProjectsForGatewaySwitch } from '@/store/projects'
 import {
   $unreadFinishedSessionIds,
   setActiveSessionId,
@@ -74,6 +75,12 @@ export function wipeSessionListsForGatewaySwitch(): void {
   // Artifacts are keyed by sessions on the previous backend, so both the
   // registry and any rail tab pointing into it go with them.
   clearArtifactRegistry()
+
+  // Projects are per-profile (each gateway has its own projects.db): the tree,
+  // list, active pointer, drill-in scope, and tombstones must not carry across
+  // a switch, or the sidebar paints the previous profile's projects (or a
+  // stale drill-in id that doesn't exist in the new catalog).
+  resetProjectsForGatewaySwitch()
 
   // Narrowed: account/marketplace/onboarding caches are global, not gateway-
   // scoped, so a mode swap must not refetch them.

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -168,6 +168,26 @@ export function exitProjectScope(): void {
   $projectScope.set(ALL_PROJECTS)
 }
 
+// Clear every project-sidebar atom on a gateway/profile switch. The backend
+// tree, list, active pointer, drill-in scope, tombstones, and the RPC
+// capability verdict are all per-profile — the next gateway has its own
+// projects.db and has never seen them. Without this wipe the sidebar keeps
+// painting the previous profile's project tree (and a stale drill-in id that
+// doesn't exist in the new catalog), which is exactly the "Projects view
+// doesn't work on other profiles" symptom. Mirrors the session/cron/messaging
+// wipes in wipeSessionListsForGatewaySwitch.
+export function resetProjectsForGatewaySwitch(): void {
+  $projects.set([])
+  $activeProjectId.set(null)
+  $projectTree.set([])
+  $projectTreeLoading.set(false)
+  $projectsRpcAvailable.set(null)
+  $removedSessionIds.set(new Set())
+  $sessionMutationsInFlight.set(new Set())
+  $reposScanning.set(false)
+  $projectScope.set(ALL_PROJECTS)
+}
+
 // A project's working root: its primary folder, else the first repo that has
 // one. Empty for the path-less Home bucket. (The sidebar's `projectTreeCwd` is
 // the same rule over the same tree — this is the store-side copy so the store


### PR DESCRIPTION
## Summary

Reset Desktop project state when switching gateway or profile context.

The gateway-switch wipe now clears the project list and tree, active project and scope, capability and scan state, tombstones, and in-flight mutations. The store warms the project list and tree after reconnecting, while preserving the existing profile-list and transcript-tail resets.

This prevents the next profile from displaying another profile's cached project tree or selection.

Verification:
- Focused gateway/project store tests: 42 passed
- Typecheck passed
- Lint: 0 errors (existing warnings remain)
- `git diff --check` passed
