### PR TITLE
fix(desktop): clear unread for the whole conversation family, don't re-light read sessions

### DIFF
--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -14,7 +14,7 @@
  *   - `window` (⇧⌘-click) — pop into its own window; falls back to `tab` when
  *     the bridge has no session-window support.
  */
-import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
+import { $activeSessionId, $selectedStoredSessionId, markSessionRead } from '@/store/session'
 import {
   focusedSessionNeedsRoute,
   focusOpenSession,
@@ -77,6 +77,12 @@ export function openSession(
   if (!storedSessionId) {
     return
   }
+
+  // Any explicit open/focus means the user has seen the finished-turn marker.
+  // Must run BEFORE the focus short-circuits below: clicking a session that is
+  // already on screen (open tile, or the main session) would otherwise return
+  // at focusOpenSession and never clear its unread dot.
+  markSessionRead(storedSessionId)
 
   let resolved: OpenSessionIntent = intent
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -35,6 +35,7 @@ import type { SessionInfo } from '@/types/hermes'
 import { $activeGatewayProfile, normalizeProfileKey } from './profile'
 import {
   $activeSessionId,
+  $lastReadAtBySessionId,
   $selectedStoredSessionId,
   $sessions,
   $unreadFinishedSessionIds,
@@ -183,10 +184,18 @@ function handleTransition(previous: ClientSessionState | null, next: ClientSessi
     markSettled(storedId)
 
     if (storedId !== $selectedStoredSessionId.get()) {
-      const cur = $unreadFinishedSessionIds.get()
+      // Re-light only genuinely new completions: if the user already viewed
+      // this session (or its family) at or after this settle moment, a
+      // re-assert of the same completion must not re-arm the dot. `-1` for
+      // "never read" (not `0`) so fake-timer tests pinned to t=0 still light.
+      const lastReadAt = $lastReadAtBySessionId.get()[storedId] ?? -1
 
-      if (!cur.includes(storedId)) {
-        $unreadFinishedSessionIds.set([...cur, storedId])
+      if (Date.now() > lastReadAt) {
+        const cur = $unreadFinishedSessionIds.get()
+
+        if (!cur.includes(storedId)) {
+          $unreadFinishedSessionIds.set([...cur, storedId])
+        }
       }
     }
   }

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -531,6 +531,93 @@ describe('unread finished sessions', () => {
     setSelectedStoredSessionId('s1')
     expect($unreadFinishedSessionIds.get()).toEqual([])
   })
+
+  it('clears the whole conversation family when any row is opened', () => {
+    $sessions.set([
+      session({ id: 'parent', _lineage_root_id: null }),
+      session({ id: 'child', _lineage_root_id: 'parent' }),
+      session({ id: 'root', _lineage_root_id: null })
+    ])
+    $selectedStoredSessionId.set('other')
+
+    // Parent and child both finish in the background.
+    for (const storedId of ['parent', 'child']) {
+      const working = makeState({ busy: true, storedSessionId: storedId })
+      publishSessionState(`rt-${storedId}`, working)
+      publishSessionState(`rt-${storedId}`, { ...working, busy: false })
+    }
+
+    expect($unreadFinishedSessionIds.get().sort()).toEqual(['child', 'parent'])
+
+    // Opening the CHILD clears the PARENT's dot too (same family).
+    setSelectedStoredSessionId('child')
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+
+    $sessions.set([])
+  })
+
+  it('does NOT re-light a completion that settled before the user read it', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    $selectedStoredSessionId.set('other')
+
+    const working = makeState({ busy: true, storedSessionId: 's1' })
+    publishSessionState('rt1', working)
+
+    // User reads the session at t=2s, then the same completion re-asserts at
+    // t=3s — the re-assert is the same settled state, so it must not re-light.
+    vi.setSystemTime(2_000_000)
+    setSelectedStoredSessionId('s1')
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+
+    vi.setSystemTime(3_000_000)
+    publishSessionState('rt1', { ...working, busy: false })
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+
+    vi.useRealTimers()
+  })
+
+  it('re-lights when a NEW turn settles after the read baseline', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    $selectedStoredSessionId.set('other')
+
+    const working = makeState({ busy: true, storedSessionId: 's1' })
+    publishSessionState('rt1', working)
+
+    // User reads s1 at t=2s, then moves on to another session.
+    vi.setSystemTime(2_000_000)
+    setSelectedStoredSessionId('s1')
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+    setSelectedStoredSessionId('other')
+
+    // A NEW turn starts (busy again) and finishes at t=4s — genuinely new
+    // completion after the read baseline, so it re-lights.
+    vi.setSystemTime(3_000_000)
+    publishSessionState('rt1', { ...working, busy: true })
+
+    vi.setSystemTime(4_000_000)
+    publishSessionState('rt1', { ...working, busy: false })
+    expect($unreadFinishedSessionIds.get()).toEqual(['s1'])
+
+    vi.useRealTimers()
+  })
+
+  it('openSession marks read before any focus short-circuit', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    $selectedStoredSessionId.set('s1')
+    $unreadFinishedSessionIds.set(['s1'])
+
+    // A no-op navigate — openSession with 'in-place' against the already
+    // selected session hits focusOpenSession and returns without loading.
+    const { openSession } = await import('@/app/open-session')
+    openSession('s1', () => {}, 'in-place')
+
+    expect($unreadFinishedSessionIds.get()).toEqual([])
+
+    vi.useRealTimers()
+  })
 })
 
 describe('remembered session id (per profile)', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -653,14 +653,46 @@ export const markAllSessionsRead = () => {
   }
 }
 
+// Last time the user actually viewed a session. A finished turn should only
+// re-arm the unread marker if it settles AFTER this baseline; otherwise an
+// already-viewed completion keeps re-lighting the row.
+export const $lastReadAtBySessionId = atom<Record<string, number>>({})
+
 export const setSelectedStoredSessionId = (next: Updater<string | null>) => {
   updateAtom($selectedStoredSessionId, next)
   // Opening a session clears its unread state — the user is now looking at it.
+  // Clear the whole conversation family (branch children + compression lineage
+  // root), not just the exact row: the sidebar lights the dot for every alias
+  // of a lineage, so reading any row must clear all of them.
   const id = $selectedStoredSessionId.get()
 
-  if (id && $unreadFinishedSessionIds.get().includes(id)) {
-    $unreadFinishedSessionIds.set($unreadFinishedSessionIds.get().filter(x => x !== id))
+  if (id) {
+    markSessionRead(id)
   }
+}
+
+/** Record that the user has seen a session (and its conversation family) at
+ *  this moment. Clears the unread set for the family and stores a last-read
+ *  baseline so a later completion that settles BEFORE this view is not
+ *  re-lit. Must be callable before any focus short-circuit (openSession top)
+ *  so re-clicking an already-visible session still clears its dot. */
+export const markSessionRead = (storedSessionId: string | null | undefined) => {
+  if (!storedSessionId) {
+    return
+  }
+
+  const sessions = $sessions.get()
+  const familyIds = new Set<string>(lineageAliases(storedSessionId, sessions))
+
+  const lastReadAt = Date.now()
+  const nextReadMap = { ...$lastReadAtBySessionId.get() }
+
+  for (const id of familyIds) {
+    nextReadMap[id] = lastReadAt
+  }
+
+  $lastReadAtBySessionId.set(nextReadMap)
+  $unreadFinishedSessionIds.set($unreadFinishedSessionIds.get().filter(id => !familyIds.has(id)))
 }
 
 export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($messages, next)


### PR DESCRIPTION
## Problem

The Desktop sidebar lights a green "finished-unread" dot on any session whose background turn completed while it was not the current selection. Reading the session is supposed to clear it, but three gaps remained:

1. **Branched / compressed conversations never fully cleared.** The dot is lit for every alias of a conversation lineage (`lineageAliases`: branch children + compression root), but reading a session cleared only the exact row id — sibling rows of the same conversation stayed lit no matter how many times they were opened.
2. **Already-viewed completions re-lit the dot.** Any settled completion re-armed unread even when the user had read the session since it finished — there was no "last read" baseline.
3. **Re-clicking an already-visible session did nothing.** `openSession()` short-circuits on a focus hit when the session is already on screen, so the unread dot stayed lit no matter how many times the user clicked in.

## Fix

- `setSelectedStoredSessionId` now clears unread for the **whole conversation family** via the existing `lineageAliases` helper, not just the selected id — reading any row in a branched/compressed conversation clears all of them.
- New `` baseline: `handleTransition` only **re-arms** unread when a completion settles strictly *after* the user's last read of that session. An already-viewed completion never re-lights the row.
- `openSession()` marks read at the very top, **before** any focus short-circuit, so re-clicking an on-screen session clears its dot.

The fix builds on the existing unread mechanism (`` + `markAllSessionsRead`) — no API surface removed, display-side lineage handling in `session-dot-state.ts` untouched.

## Test

4635 desktop tests pass (490 files), including new cases for family-clear, read-baseline re-light suppression, new-turn re-light, and the openSession focus short-circuit. Full `tsc --noEmit` typecheck clean.