### PR TITLE
fix(gateway): preserve approval card content when resolving on Telegram and Feishu

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2121,6 +2121,10 @@ class FeishuAdapter(BasePlatformAdapter):
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    # Original request body — preserved on the resolved card
+                    # so shared chats keep an audit trail of WHAT was
+                    # approved (parity with Slack/Discord/Teams).
+                    "body": self._format_exec_approval(command, description, smart_denied),
                 }
             return result
         except Exception as exc:
@@ -2196,22 +2200,31 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
-    def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
-        """Build raw card JSON for a resolved approval action."""
+    def _build_resolved_approval_card(*, choice: str, user_name: str, body: str = "") -> Dict[str, Any]:
+        """Build raw card JSON for a resolved approval action.
+
+        ``body`` is the original request markdown (command + reason). It is
+        kept on the resolved card so the chat retains WHAT was approved —
+        the decision alone loses the audit trail.
+        """
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
+        elements: List[Dict[str, Any]] = []
+        if body:
+            elements.append({"tag": "markdown", "content": body})
+        elements.append(
+            {
+                "tag": "markdown",
+                "content": f"{icon} **{label}** by {user_name}",
+            }
+        )
         return {
             "config": {"wide_screen_mode": True},
             "header": {
                 "title": {"content": f"{icon} {label}", "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "elements": elements,
         }
 
     @staticmethod
@@ -2830,7 +2843,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            card.data = self._build_resolved_approval_card(
+                choice=choice,
+                user_name=user_name,
+                body=str(state.get("body", "") or ""),
+            )
             response.card = card
         return response
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6524,11 +6524,22 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await query.answer(text=label)
 
-                # Edit message to show decision, remove buttons
+                # Edit message to show decision, remove buttons. Preserve the
+                # original approval body (command + reason) so shared chats
+                # keep an audit trail of WHAT was approved — replacing the
+                # whole card with just the decision loses the request context
+                # (parity with Discord/Slack/Teams, which keep the body and
+                # only append the outcome). Plain-text edit, mirroring the
+                # gmail-triage callback: query.message.text is the rendered
+                # plain text of the HTML prompt, so re-sending it with a parse
+                # mode would corrupt it.
+                original_text = str(getattr(query.message, "text", None) or "") if query.message else ""
+                appended = (
+                    f"{original_text}\n\n— {edit_text}" if original_text else edit_text
+                )
                 try:
                     await query.edit_message_text(
-                        text=self.format_message(edit_text),
-                        parse_mode=ParseMode.MARKDOWN_V2,
+                        text=appended,
                         reply_markup=None,
                     )
                 except Exception:
@@ -6576,10 +6587,16 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await query.answer(text=label)
 
+                # Preserve the original prompt body and append the decision —
+                # same audit-trail contract as the exec-approval edit above.
+                _sc_original = str(getattr(query.message, "text", None) or "") if query.message else ""
+                _sc_edit = (
+                    f"{_sc_original}\n\n— {label} by {user_display}"
+                    if _sc_original else f"{label} by {user_display}"
+                )
                 try:
                     await query.edit_message_text(
-                        text=self.format_message(f"{label} by {user_display}"),
-                        parse_mode=ParseMode.MARKDOWN_V2,
+                        text=_sc_edit,
                         reply_markup=None,
                     )
                 except Exception:

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -152,6 +152,8 @@ class TestFeishuExecApproval:
         assert state["session_key"] == "my-session-key"
         assert state["message_id"] == "msg_002"
         assert state["chat_id"] == "oc_12345"
+        # Original request body is stored so the resolved card can keep it.
+        assert "echo test" in state["body"]
 
 
 # ===========================================================================
@@ -314,6 +316,7 @@ class TestCardActionCallbackResponse:
             "session_key": "sess-1",
             "message_id": "msg-1",
             "chat_id": "oc_12345",
+            "body": "```\nrm -rf /important\n```\n**Reason:** dangerous deletion",
         }
         data = _make_card_action_data(
             {"hermes_action": "approve_once", "approval_id": 1},
@@ -330,7 +333,10 @@ class TestCardActionCallbackResponse:
         card = response.card.data
         assert card["header"]["template"] == "green"
         assert "Approved once" in card["header"]["title"]["content"]
-        assert "Bob" in card["elements"][0]["content"]
+        # Resolved card keeps the original request body (audit trail),
+        # followed by the decision + actor.
+        assert "rm -rf /important" in card["elements"][0]["content"]
+        assert "Bob" in card["elements"][-1]["content"]
 
 
     def test_ignores_expired_cached_name(self, _patch_callback_card_types):

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -241,7 +241,15 @@ class TestTelegramApprovalCallback:
 
 
     @pytest.mark.asyncio
-    async def test_approval_callback_escapes_dynamic_user_name(self):
+    async def test_approval_callback_preserves_original_body(self):
+        """Resolving an approval must keep the original request text.
+
+        The edit appends the decision under the original command + reason
+        (audit trail in shared chats) instead of replacing the whole
+        message with just the outcome. Plain-text edit — the rendered
+        message text must not be re-parsed as MarkdownV2.
+        Ported from qwibitai/nanoclaw#3143.
+        """
         adapter = _make_adapter()
         adapter._approval_state[3] = "agent:main:telegram:group:12345:99"
 
@@ -249,6 +257,11 @@ class TestTelegramApprovalCallback:
         query.data = "ea:once:3"
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.text = (
+            "⚠️ Command Approval Required\n"
+            "rm -rf /tmp/scratch\n"
+            "Reason: cleanup"
+        )
         query.from_user = MagicMock()
         query.from_user.first_name = "Alice_Bob"
         query.answer = AsyncMock()
@@ -264,9 +277,44 @@ class TestTelegramApprovalCallback:
                 await adapter._handle_callback_query(update, context)
 
         edit_kwargs = query.edit_message_text.call_args[1]
-        assert "MARKDOWN_V2" in repr(edit_kwargs["parse_mode"])
-        assert "Alice\\_Bob" in edit_kwargs["text"]
-        assert "Approved once" in edit_kwargs["text"]
+        # Original request body survives the resolution edit.
+        assert "rm -rf /tmp/scratch" in edit_kwargs["text"]
+        assert "Reason: cleanup" in edit_kwargs["text"]
+        # Decision + actor appended after the body.
+        assert "Approved once by Alice_Bob" in edit_kwargs["text"]
+        assert edit_kwargs["text"].index("rm -rf") < edit_kwargs["text"].index("Approved once")
+        # Plain-text edit: no parse mode, buttons removed.
+        assert "parse_mode" not in edit_kwargs
+        assert edit_kwargs["reply_markup"] is None
+
+    @pytest.mark.asyncio
+    async def test_expired_approval_edit_keeps_original_body(self):
+        """A stale tap (count == 0) also keeps the request text visible."""
+        adapter = _make_adapter()
+        adapter._approval_state[4] = "agent:main:telegram:group:12345:99"
+
+        query = AsyncMock()
+        query.data = "ea:once:4"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.text = "⚠️ Command Approval Required\nsudo reboot"
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Alice"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=0):
+                await adapter._handle_callback_query(update, context)
+
+        edit_kwargs = query.edit_message_text.call_args[1]
+        assert "sudo reboot" in edit_kwargs["text"]
+        assert "Approval expired" in edit_kwargs["text"]
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Resolving an exec-approval or slash-confirm prompt on Telegram and Feishu now keeps the original request (command + reason) visible and appends the decision + actor, instead of replacing the whole message with just the outcome. Shared chats keep an audit trail of WHAT was approved.

Ported from qwibitai/nanoclaw#3143 ("Preserve resolved approval card content"), adapted to the hermes-agent gateway adapters. Discord, Slack, and Teams already preserved the request body on resolution; Telegram and Feishu were the two adapters that discarded it.

## Changes
- `plugins/platforms/telegram/adapter.py`:
  - Exec-approval callback (`ea:`) edit now appends `— <decision> by <user>` to the original message text (plain-text edit, mirroring the existing gmail-triage callback pattern — the rendered message text must not be re-parsed as MarkdownV2) instead of overwriting the body with a decision-only MarkdownV2 line.
  - Slash-confirm callback (`sc:`) gets the same append-decision contract (sibling-site widening).
- `plugins/platforms/feishu/adapter.py`: stash the request markdown in `_approval_state` at send time; `_build_resolved_approval_card()` renders it ahead of the decision line on the resolved card.
- Tests: replaced the Telegram test pinning the old replace-body behavior with body-preservation tests (approved + expired paths); extended Feishu state + resolved-card tests.

## Architectural notes vs the source PR
NanoClaw persists the card body in a DB column (migration 021) because its approvals survive host restarts. Hermes gateway approvals are in-memory per-process (`_approval_state`), so the body rides in the same in-memory state — no schema change needed. The Telegram path reads the body straight from `query.message.text`, so nothing extra is stored there.

## Validation
| | Before | After |
|---|---|---|
| Telegram/Feishu resolved prompt | decision line only, request text gone | request text + appended decision/actor |
| Targeted tests | — | `test_telegram_approval_buttons.py`, `test_feishu_approval_buttons.py`, `test_telegram_slash_confirm.py`, `test_telegram_thread_fallback.py`, `test_telegram_format.py` — 87 passed |

## Infographic

![Approval cards keep their content](https://v3b.fal.media/files/b/0aa5b5bf/XKjOzn2_9W8vnjneEow1E_Ed4eGGYz.png)
