### PR TITLE
feat(cron): give scheduled jobs their actual run time in the prompt

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2714,8 +2714,19 @@ def _build_job_prompt(
 
     # Always prepend cron execution guidance so the agent knows how
     # delivery works and can suppress delivery when appropriate.
+    #
+    # TIME: the system prompt only carries a date-granularity timestamp
+    # ("Conversation started: <day>") to keep it byte-stable for prompt
+    # caching, so a scheduled run has no idea WHAT TIME it fired — a
+    # "morning brief" job that runs at 07:00 can't distinguish that from a
+    # 19:00 retry, and time-sensitive reports get stamped with stale or
+    # invented times. Give every fire its actual wall-clock run time.
+    # Cron sessions are fresh per fire, so this per-run line does not
+    # break any cached prefix. (Ported from qwibitai/nanoclaw#3154.)
+    _run_time_line = _hermes_now().strftime("%A, %Y-%m-%d %H:%M %Z").strip()
     cron_hint = (
         "[IMPORTANT: You are running as a scheduled cron job. "
+        f"CURRENT RUN TIME: {_run_time_line}. "
         "DELIVERY: Your final response will be automatically delivered "
         "to the user — do NOT use send_message or try to deliver "
         "the output yourself. Just produce your report/output as your "

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1047,6 +1047,44 @@ class TestBuildJobPromptSilentHint:
         assert "Check for updates" in result
 
 
+class TestBuildJobPromptRunTime:
+    """The cron hint must carry the actual wall-clock run time.
+
+    The system prompt is date-granularity only (byte-stable for prompt
+    caching), so without this line a scheduled run can't tell 07:00
+    from a 19:00 retry. Ported from qwibitai/nanoclaw#3154.
+    """
+
+    def test_run_time_line_present_and_current(self):
+        import re
+        from datetime import datetime, timedelta
+        from hermes_time import now as _now
+
+        job = {"prompt": "Morning brief"}
+        before = _now()
+        result = _build_job_prompt(job)
+        after = _now()
+
+        m = re.search(r"CURRENT RUN TIME: \w+, (\d{4}-\d{2}-\d{2} \d{2}:\d{2})", result)
+        assert m, f"run-time line missing from cron hint: {result[:300]!r}"
+        stamped = datetime.strptime(m.group(1), "%Y-%m-%d %H:%M")
+        # Minute-granularity stamp must fall within the call window
+        # (± one minute for a boundary tick).
+        lo = before.replace(second=0, microsecond=0, tzinfo=None) - timedelta(minutes=1)
+        hi = after.replace(second=0, microsecond=0, tzinfo=None) + timedelta(minutes=1)
+        assert lo <= stamped <= hi
+
+    def test_run_time_present_with_skills_path_too(self):
+        """The hint (with run time) is prepended before skill loading, so
+        it must survive the has-skills assembly path as well."""
+        with patch(
+            "tools.skills_tool.skill_view",
+            return_value='{"success": false, "error": "not found"}',
+        ):
+            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "go"})
+        assert "CURRENT RUN TIME:" in result
+
+
 class TestParseWakeGate:
     """Unit tests for _parse_wake_gate — pure function, no side effects."""
 


### PR DESCRIPTION
## Summary
Cron jobs now know what time they fired: the cron-hint block prepended to every scheduled prompt carries `CURRENT RUN TIME: <weekday, date time tz>`.

Ported from qwibitai/nanoclaw#3154 ("give scheduled tasks current run time"). The hermes system prompt is intentionally date-granularity only ("Conversation started: <day>") to stay byte-stable for prompt caching — which means a scheduled fire couldn't distinguish a 07:00 morning-brief run from a 19:00 retry, and time-sensitive reports stamped stale or invented times unless the agent burned a tool call to check the clock.

## Changes
- `cron/scheduler.py` `_build_job_prompt()`: cron hint now includes the wall-clock run time (via `hermes_time.now()`, so the configured timezone applies).
- `tests/cron/test_scheduler.py`: run-time line present + falls within the call window; survives the skills-assembly path.

## Cache safety
Cron sessions are fresh per fire (`cron_<job>_<timestamp>` session, new agent), so a per-run line in the first user message cannot invalidate any cached prefix. NanoClaw's version threads a `process_after` column through its message DB; hermes needs none of that since the prompt is assembled at fire time.

## Validation
| | Result |
|---|---|
| `tests/cron/test_scheduler.py` | 70 passed |
| full `tests/cron/` suite | 517 passed |

## Infographic

![Cron jobs know what time it is](https://v3b.fal.media/files/b/0aa5b5cf/NDnn8R0P4NDsU6ako83oV_gJvnKGVU.png)
