### PR TITLE
feat(cron): add reactive job chaining via trigger_on_complete

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -476,6 +476,12 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     # "paused" while the fleet is still live. See effective_job_state().
     normalized["state"] = effective_job_state(normalized)
 
+    # Reactive-chaining defaults so legacy records (written before the feature
+    # landed) expose the same shape as new ones instead of a KeyError/.get()
+    # gap for UI/API/tool/scheduler consumers.
+    normalized.setdefault("trigger_on_complete", False)
+    normalized.setdefault("trigger_status", "ok")
+
     return normalized
 
 
@@ -1586,6 +1592,8 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    trigger_on_complete: bool = False,
+    trigger_status: str = "ok",
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1643,6 +1651,16 @@ def create_job(
         monitor_url: Optional http(s) URL used as the monitor source instead
                 of a script — fetched with a bounded GET each tick. Same
                 hash-suppression semantics as ``monitor_script``.
+    trigger_on_complete: When True, this job is fired immediately on the
+                completion of any job listed in ``context_from`` (in addition
+                to its own schedule). The upstream output already flows in via
+                ``context_from``; this flag adds the reactive kick so a chain
+                runs without waiting for the next tick. Requires
+                ``context_from`` to be set; cycles are rejected at create time.
+    trigger_status: Which parent outcomes fire this child when
+                ``trigger_on_complete=True``: ``"ok"`` (default, only
+                successful parents), ``"error"`` (only failed parents — useful
+                for alert fan-out), or ``"any"`` (fire regardless).
 
     Returns:
         The created job dict
@@ -1701,6 +1719,19 @@ def create_job(
     else:
         context_from = None
 
+    # Normalize reactive-chaining fields and validate their invariants.
+    # trigger_on_complete requires context_from (something to react to);
+    # cycles across the context_from+trigger graph are rejected so a chain
+    # can't loop back to its own root and fire forever.
+    normalized_toc, normalized_tstatus = _normalize_trigger_fields(
+        trigger_on_complete, trigger_status
+    )
+    if normalized_toc and not context_from:
+        raise ValueError(
+            "trigger_on_complete=True requires context_from to be set "
+            "(there must be at least one upstream job to react to)."
+        )
+
     prompt_text = _coerce_job_text(prompt)
 
     # Reject cron jobs that schedule gateway-lifecycle commands. Prevents
@@ -1756,6 +1787,8 @@ def create_job(
         # "last_changed_at": ...}. None until the first monitor tick.
         "monitor_state": None,
         "context_from": context_from,
+        "trigger_on_complete": normalized_toc,
+        "trigger_status": normalized_tstatus,
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {
@@ -1785,6 +1818,16 @@ def create_job(
         job["attach_to_session"] = normalized_attach
 
     with _jobs_lock():
+        # Validate against the same locked snapshot we append to. Otherwise a
+        # concurrent update could close a reactive cycle after validation but
+        # before this job is persisted.
+        if normalized_toc and context_from:
+            cycle = _detect_trigger_cycle(job_id, context_from, normalized_toc)
+            if cycle:
+                raise ValueError(
+                    "Refusing to create cron job: trigger_on_complete would form a "
+                    f"cycle: {' -> '.join(cycle)}"
+                )
         jobs = load_jobs()
         jobs.append(job)
         save_jobs(jobs)
@@ -1855,6 +1898,132 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
     return jobs
 
 
+# ---------------------------------------------------------------------------
+# Reactive chaining: trigger_on_complete
+# ---------------------------------------------------------------------------
+# A job with ``trigger_on_complete=True`` is fired automatically when any job
+# listed in its ``context_from`` completes — instead of (or in addition to)
+# waiting for its own schedule. The upstream's output already flows in through
+# ``context_from``; this flag just adds the reactive kick so the chain runs
+# immediately on the parent's completion rather than on the next tick.
+#
+# ``trigger_status`` gates which parent outcomes fire the child:
+#   "ok"    — only successful parents (default)
+#   "error" — only failed parents (alert/fan-out on failure)
+#   "any"   — fire regardless of outcome
+#
+# Cycles are rejected at create/update time: A.context_from=[B] with both
+# trigger_on_complete would have A fire B fire A forever. DFS over the
+# context_from+trigger graph catches that before it persists.
+
+_VALID_TRIGGER_STATUSES = frozenset({"ok", "error", "any"})
+
+
+def _normalize_trigger_fields(
+    trigger_on_complete: Any, trigger_status: Any
+) -> Tuple[bool, str]:
+    """Coerce the two reactive-chaining fields to their canonical forms.
+
+    Returns ``(trigger_on_complete, trigger_status)``. ``trigger_status`` is
+    only meaningful when ``trigger_on_complete`` is True, but we keep its
+    value normalized either way so stored records are always valid.
+    """
+    if not isinstance(trigger_on_complete, bool):
+        raise ValueError(
+            "trigger_on_complete must be a boolean "
+            f"(got {trigger_on_complete!r})"
+        )
+    toc = trigger_on_complete
+    ts = _coerce_job_text(trigger_status).strip().lower() or "ok"
+    if ts not in _VALID_TRIGGER_STATUSES:
+        raise ValueError(
+            f"trigger_status must be one of {sorted(_VALID_TRIGGER_STATUSES)} "
+            f"(got {trigger_status!r})"
+        )
+    return toc, ts
+
+
+def _reactive_parents(job: Dict[str, Any]) -> List[str]:
+    """Job IDs this job reacts to (its ``context_from`` when trigger_on_complete)."""
+    if not job.get("trigger_on_complete"):
+        return []
+    cf = job.get("context_from") or []
+    if isinstance(cf, str):
+        cf = [cf]
+    return [str(j).strip() for j in cf if str(j).strip()]
+
+
+def _detect_trigger_cycle(
+    job_id: str, context_from: List[str], trigger_on_complete: bool
+) -> Optional[List[str]]:
+    """Return a cycle path if setting these fields would create one, else None.
+
+    The prospective job fires when any of its ``context_from`` parents
+    completes, which adds edges ``parent -> job_id`` to the reactive graph
+    (an edge P -> C means "P's completion fires C"). Those new edges close a
+    loop iff there is already a path ``job_id -> ... -> parent`` through the
+    *persisted* graph: job_id's completion would then (transitively) fire the
+    parent, which fires job_id again — forever.
+
+    So we DFS from ``job_id`` along existing reactive edges only (edges among
+    already-persisted jobs; the prospective ``parent -> job_id`` edges are NOT
+    added to the map — including them would make every legitimate chain look
+    like a 2-node cycle) and treat reaching any prospective parent as a cycle.
+    A ``context_from`` containing ``job_id`` itself is the trivial self-loop
+    and is caught by the same walk (the start node is a prospective parent).
+    """
+    if not trigger_on_complete or not context_from:
+        return None
+
+    prospective_parents = {str(p).strip() for p in context_from if str(p).strip()}
+    if not prospective_parents:
+        return None
+
+    # Existing reactive edges among persisted jobs: parent_id -> [children that
+    # react to it]. job_id's own record is included normally — its context_from
+    # only contributes edges pointing INTO it, which this outward DFS ignores.
+    edges: Dict[str, List[str]] = {}
+    for j in load_jobs():
+        for parent in _reactive_parents(j):
+            edges.setdefault(parent, []).append(j["id"])
+
+    # DFS from job_id; reaching a prospective parent means the new
+    # parent->job_id edge closes a loop: job_id ~> ... ~> parent -> job_id.
+    visited: Set[str] = set()
+    stack: List[Tuple[str, List[str]]] = [(job_id, [job_id])]
+    while stack:
+        node, path = stack.pop()
+        if node in prospective_parents:
+            return path + [job_id]
+        if node in visited:
+            continue
+        visited.add(node)
+        for child in edges.get(node, []):
+            stack.append((child, path + [child]))
+    return None
+
+
+def get_dependent_jobs(parent_id: str) -> List[Dict[str, Any]]:
+    """Jobs that reactively chain off ``parent_id``'s completion.
+
+    Returns enabled jobs with ``trigger_on_complete=True`` whose
+    ``context_from`` contains ``parent_id``. Used by the scheduler after a
+    job finishes to kick its reactive children.
+    """
+    out: List[Dict[str, Any]] = []
+    for job in load_jobs():
+        if not job.get("trigger_on_complete"):
+            continue
+        if not is_job_runnable(job):
+            continue
+        cf = job.get("context_from") or []
+        if isinstance(cf, str):
+            cf = [cf]
+        if parent_id in [str(j).strip() for j in cf if str(j).strip()]:
+            out.append(_normalize_job_record(job))
+    return out
+
+
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Update a job by ID, refreshing derived schedule fields when needed."""
     # Block mutation of immutable fields. ``id`` in particular is a filesystem
@@ -1888,6 +2057,75 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     _mv = updates[_mon_field]
                     _mv = str(_mv).strip() if isinstance(_mv, str) else None
                     updates[_mon_field] = _mv or None
+
+            # Normalize context_from the same way create_job does: accept a
+            # single ID string or a list of IDs, store as a list (or None when
+            # empty/cleared). Without this, the stored shape depends on which
+            # caller updated the job, and _reactive_parents()/get_dependent_jobs()
+            # have to special-case both shapes on every read.
+            if "context_from" in updates:
+                _cf = updates["context_from"]
+                if isinstance(_cf, str):
+                    _cf = [_cf.strip()] if _cf.strip() else None
+                elif isinstance(_cf, list):
+                    _cf = [str(j).strip() for j in _cf if str(j).strip()] or None
+                else:
+                    _cf = None
+                updates["context_from"] = _cf
+
+            # Normalize reactive-chaining fields when present in the update.
+            # Merges against the existing record so e.g. setting
+            # trigger_on_complete=True on a job that already has context_from
+            # works, and clearing context_from while leaving trigger_on_complete
+            # is rejected (no upstream to react to). Cycle detection runs on the
+            # merged context_from + trigger_on_complete so an update can't
+            # introduce a loop either — including a context_from-only change on
+            # an already-reactive job (context_from is half of every reactive
+            # edge, so touching it without touching trigger fields can still
+            # close a cycle).
+            if (
+                "trigger_on_complete" in updates
+                or "trigger_status" in updates
+                or "context_from" in updates
+            ):
+                _toc = updates.get(
+                    "trigger_on_complete", job.get("trigger_on_complete", False)
+                )
+                _tstatus = updates.get(
+                    "trigger_status", job.get("trigger_status", "ok")
+                )
+                _norm_toc, _norm_tstatus = _normalize_trigger_fields(_toc, _tstatus)
+                updates["trigger_on_complete"] = _norm_toc
+                updates["trigger_status"] = _norm_tstatus
+
+                # Recompute merged context_from for invariant checks below.
+                _merged_cf = job.get("context_from")
+                if "context_from" in updates:
+                    _cf_upd = updates["context_from"]
+                    if isinstance(_cf_upd, str):
+                        _merged_cf = [_cf_upd] if _cf_upd.strip() else []
+                    elif isinstance(_cf_upd, list):
+                        _merged_cf = [str(j).strip() for j in _cf_upd if str(j).strip()]
+                    else:
+                        _merged_cf = []
+                if isinstance(_merged_cf, str):
+                    _merged_cf = (
+                        [_merged_cf.strip()] if _merged_cf.strip() else []
+                    )
+                _merged_cf = _merged_cf or []
+
+                if _norm_toc and not _merged_cf:
+                    raise ValueError(
+                        "trigger_on_complete=True requires context_from to be set "
+                        "(there must be at least one upstream job to react to)."
+                    )
+                if _norm_toc and _merged_cf:
+                    cycle = _detect_trigger_cycle(job_id, _merged_cf, _norm_toc)
+                    if cycle:
+                        raise ValueError(
+                            "Refusing to update cron job: trigger_on_complete "
+                            f"would form a cycle: {' -> '.join(cycle)}"
+                        )
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
@@ -2037,6 +2275,32 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "next_run_at": _hermes_now().isoformat(),
         },
     )
+
+
+def trigger_job_if_runnable(job_id: str) -> Optional[Dict[str, Any]]:
+    """Atomically schedule an enabled, unpaused job without resurrecting it.
+
+    Reactive fan-out first discovers children and then fires them. A user may
+    pause/remove a child between those two operations; the regular
+    :func:`trigger_job` intentionally re-enables jobs for manual ``run`` calls,
+    which would undo that concurrent operator action. This variant performs the
+    runnable check and ``next_run_at`` update under the same jobs lock and never
+    changes ``enabled`` or pause markers.
+    """
+    with _jobs_lock():
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job.get("id") != job_id:
+                continue
+            if not is_job_runnable(job):
+                return None
+            updated = dict(job)
+            updated["state"] = "scheduled"
+            updated["next_run_at"] = _hermes_now().isoformat()
+            jobs[i] = updated
+            save_jobs(jobs)
+            return _normalize_job_record(updated)
+    return None
 
 
 def remove_job(job_id: str) -> bool:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -290,7 +290,16 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    advance_next_runs,
+    claim_dispatch,
+    get_dependent_jobs,
+    get_due_jobs,
+    heartbeat_run_claim,
+    mark_job_run,
+    save_job_output,
+    trigger_job_if_runnable,
+)
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -4516,6 +4525,68 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def _fire_dependent_jobs(parent_id: str, parent_success: bool) -> None:
+    """Kick reactive children of a just-completed job.
+
+    After ``run_one_job`` records a job's terminal status, any enabled job
+    with ``trigger_on_complete=True`` whose ``context_from`` names this parent
+    is scheduled to run on the next tick via ``trigger_job``. The child's
+    ``trigger_status`` gate decides whether a successful/failed/any parent
+    outcome fires it.
+
+    Best-effort and isolated: a failure to fire one child never prevents the
+    parent's own completion from being recorded (this runs after
+    ``mark_job_run``) and never prevents siblings from firing. Each child's
+    current ``trigger_status`` is read fresh from disk so an update between
+    the parent starting and finishing is honoured.
+    """
+    try:
+        dependents = get_dependent_jobs(parent_id)
+    except Exception:
+        logger.debug("Failed to load dependents for %s", parent_id, exc_info=True)
+        return
+    notified = False
+    for child in dependents:
+        gate = (child.get("trigger_status") or "ok").strip().lower()
+        if gate not in {"ok", "error", "any"}:
+            logger.warning(
+                "Reactive chain: child %s has invalid trigger_status %r; skipping",
+                child.get("id"), gate,
+            )
+            continue
+        if gate == "ok" and not parent_success:
+            continue
+        if gate == "error" and parent_success:
+            continue
+        # "any" fires unconditionally.
+        child_id = child.get("id")
+        if not child_id:
+            continue
+        try:
+            updated = trigger_job_if_runnable(child_id)
+            if updated is None:
+                # The child may have been removed after get_dependent_jobs()
+                # loaded it. Do not notify providers for a no-op mutation.
+                continue
+            notified = True
+            logger.info(
+                "Reactive chain: parent %s (%s) fired child %s",
+                parent_id, "ok" if parent_success else "error", child_id,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to trigger reactive child %s for parent %s",
+                child_id, parent_id, exc_info=True,
+            )
+
+    if notified:
+        # trigger_job() mutates the built-in jobs store. External scheduler
+        # providers (for example Chronos) also need a provisioning refresh;
+        # without this callback the child is due in jobs.json but may never be
+        # scheduled by the active provider. Notify once per fan-out batch.
+        _notify_provider_jobs_changed()
+
+
 def run_one_job(
     job: dict, *, adapters=None, loop=None, verbose: bool = False,
     extra_prompt: Optional[str] = None,
@@ -4725,6 +4796,22 @@ def run_one_job(
             error=error,
             delivery_outcome=delivery_outcome,
         )
+        # Reactive chaining (#15831): now that the parent's terminal status
+        # and output are durably recorded, kick any children waiting on this
+        # job's completion. Runs after finish_execution so a child fire never
+        # races the parent's own bookkeeping; best-effort, never raises into
+        # the caller after the parent outcome has already been recorded.
+        # Blocked-config alerts are already deduplicated with a silent marker.
+        # Preserve the same once-only behavior for reactive error fan-out: the
+        # first blocked run may fire an alert child, later silent retries must
+        # not create an alert storm.
+        if not blocked_config_silent:
+            try:
+                _fire_dependent_jobs(job["id"], success)
+            except Exception:
+                logger.debug(
+                    "Reactive chain fan-out failed for parent %s", job["id"], exc_info=True
+                )
         return True
 
     except BaseException as e:  # noqa: BLE001 — deliberate: see below
@@ -4757,6 +4844,16 @@ def run_one_job(
             )
         if not isinstance(e, Exception):
             raise
+        # Reactive chaining (#15831): a hard failure still fires children gated
+        # on trigger_status="error"/"any" (alert fan-out on upstream failure).
+        # Runs after finish_execution like the success path; best-effort, never
+        # raises into the caller (the parent's failure is already recorded).
+        try:
+            _fire_dependent_jobs(job["id"], False)
+        except Exception:
+            logger.debug(
+                "Reactive chain fan-out failed for parent %s", job["id"], exc_info=True
+            )
         return False
 
 

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -384,6 +384,8 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    trigger_on_complete: bool = False
+    trigger_status: str = "ok"
 
 
 class CronJobUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11740,6 +11740,8 @@ def _normalize_dashboard_cron_updates(
         normalized["context_from"] = _cron_string_list(normalized["context_from"])
     if "enabled_toolsets" in normalized:
         normalized["enabled_toolsets"] = _cron_string_list(normalized["enabled_toolsets"])
+    if "trigger_status" in normalized and normalized["trigger_status"] is not None:
+        normalized["trigger_status"] = str(normalized["trigger_status"]).strip().lower() or "ok"
     return normalized
 
 
@@ -12007,6 +12009,8 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            trigger_on_complete=bool(body.trigger_on_complete),
+            trigger_status=body.trigger_status or "ok",
         )
     except HTTPException:
         raise

--- a/tests/cron/test_cron_trigger_on_complete.py
+++ b/tests/cron/test_cron_trigger_on_complete.py
@@ -1,0 +1,599 @@
+"""Tests for cron job reactive chaining via trigger_on_complete (issue #15831).
+
+A job with ``trigger_on_complete=True`` is fired when any job in its
+``context_from`` completes, gated by ``trigger_status`` (ok/error/any).
+Cycles across the context_from+trigger graph are rejected at create/update.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    """Isolated cron environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+
+    return hermes_home
+
+
+# ---------------------------------------------------------------------------
+# Field storage / normalization
+# ---------------------------------------------------------------------------
+
+class TestTriggerFieldsStorage:
+    def test_defaults_off(self, cron_env):
+        from cron.jobs import create_job, get_job
+
+        job = create_job(prompt="Hello", schedule="every 1h")
+        assert job["trigger_on_complete"] is False
+        assert job["trigger_status"] == "ok"
+        loaded = get_job(job["id"])
+        assert loaded["trigger_on_complete"] is False
+        assert loaded["trigger_status"] == "ok"
+
+    def test_create_with_trigger_on_complete(self, cron_env):
+        from cron.jobs import create_job, get_job
+
+        parent = create_job(prompt="Collect", schedule="every 1h")
+        child = create_job(
+            prompt="Process",
+            schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+        )
+        assert child["trigger_on_complete"] is True
+        assert child["trigger_status"] == "ok"
+        assert get_job(child["id"])["trigger_on_complete"] is True
+
+    def test_trigger_status_normalized_to_lowercase(self, cron_env):
+        from cron.jobs import create_job
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        child = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+            trigger_status="ANY",
+        )
+        assert child["trigger_status"] == "any"
+
+    def test_trigger_status_invalid_rejected(self, cron_env):
+        from cron.jobs import create_job
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        with pytest.raises(ValueError, match="trigger_status"):
+            create_job(
+                prompt="C", schedule="every 1h",
+                context_from=parent["id"],
+                trigger_on_complete=True,
+                trigger_status="bogus",
+            )
+
+    def test_trigger_on_complete_rejects_truthy_strings(self, cron_env):
+        """String 'false' must not silently become boolean True."""
+        from cron.jobs import create_job
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        truthy_string: Any = "false"
+        with pytest.raises(ValueError, match="must be a boolean"):
+            create_job(
+                prompt="C", schedule="every 1h",
+                context_from=parent["id"],
+                trigger_on_complete=truthy_string,
+            )
+
+    def test_trigger_on_complete_requires_context_from(self, cron_env):
+        from cron.jobs import create_job
+
+        with pytest.raises(ValueError, match="context_from"):
+            create_job(
+                prompt="C", schedule="every 1h",
+                trigger_on_complete=True,
+            )
+
+    def test_legacy_empty_context_from_cannot_enable_trigger(self, cron_env):
+        """A hand-edited legacy empty string is still treated as no parent."""
+        from cron.jobs import create_job, load_jobs, save_jobs, update_job
+
+        child = create_job(prompt="C", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["context_from"] = ""
+        save_jobs(jobs)
+
+        with pytest.raises(ValueError, match="context_from"):
+            update_job(child["id"], {"trigger_on_complete": True})
+
+
+# ---------------------------------------------------------------------------
+# Cycle detection
+# ---------------------------------------------------------------------------
+
+class TestCycleDetection:
+    def test_self_cycle_rejected(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        # Two-node cycle A->B->A. Build B reactive on A, then try to make A
+        # reactive on B — that closes the loop and must be rejected.
+        job_a = create_job(prompt="A", schedule="every 1h", trigger_on_complete=False)
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_a["id"],
+            trigger_on_complete=True,
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            update_job(job_a["id"], {
+                "context_from": job_b["id"],
+                "trigger_on_complete": True,
+            })
+
+    def test_no_cycle_when_only_one_side_reactive(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job_a = create_job(prompt="A", schedule="every 1h")
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_a["id"],
+            trigger_on_complete=True,
+        )
+        # job_a also reads from job_b but is NOT reactive — no cycle.
+        updated = update_job(job_a["id"], {"context_from": job_b["id"]})
+        assert updated["context_from"] == [job_b["id"]]
+        assert updated["trigger_on_complete"] is False
+
+    def test_update_clearing_trigger_allows_readding(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job_a = create_job(prompt="A", schedule="every 1h")
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_a["id"],
+            trigger_on_complete=True,
+        )
+        # Turn off, then the reverse direction becomes safe.
+        update_job(job_b["id"], {"trigger_on_complete": False})
+        updated = update_job(job_a["id"], {
+            "context_from": job_b["id"],
+            "trigger_on_complete": True,
+        })
+        assert updated["trigger_on_complete"] is True
+
+    def test_self_cycle_rejected_via_update(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job_a = create_job(prompt="A", schedule="every 1h")
+        # A reacting to its own completion is the trivial self-loop.
+        with pytest.raises(ValueError, match="cycle"):
+            update_job(job_a["id"], {
+                "context_from": job_a["id"],
+                "trigger_on_complete": True,
+            })
+
+    def test_three_node_chain_creation_succeeds(self, cron_env):
+        from cron.jobs import create_job
+
+        # A -> B -> C is a legitimate linear chain; no false cycle.
+        job_a = create_job(prompt="A", schedule="every 1h")
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_a["id"],
+            trigger_on_complete=True,
+        )
+        job_c = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=job_b["id"],
+            trigger_on_complete=True,
+        )
+        assert job_c["trigger_on_complete"] is True
+        assert job_c["context_from"] == [job_b["id"]]
+
+    def test_three_node_cycle_rejected(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        # A -> B -> C reactive chain; closing C -> A must be rejected.
+        job_a = create_job(prompt="A", schedule="every 1h")
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_a["id"],
+            trigger_on_complete=True,
+        )
+        job_c = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=job_b["id"],
+            trigger_on_complete=True,
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            update_job(job_a["id"], {
+                "context_from": job_c["id"],
+                "trigger_on_complete": True,
+            })
+
+    def test_transitive_chain_still_rejected(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        # A 4-node reactive chain; closing the gap at the far end (A reacts to
+        # D) must be rejected even though A is not D's direct parent — the
+        # existing path A->B->C->D plus the new D->A edge loops forever.
+        job_a = create_job(prompt="A", schedule="every 1h")
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_a["id"],
+            trigger_on_complete=True,
+        )
+        job_c = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=job_b["id"],
+            trigger_on_complete=True,
+        )
+        job_d = create_job(
+            prompt="D", schedule="every 1h",
+            context_from=job_c["id"],
+            trigger_on_complete=True,
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            update_job(job_a["id"], {
+                "context_from": job_d["id"],
+                "trigger_on_complete": True,
+            })
+
+    def test_context_from_only_update_cycle_rejected(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        # B already fires reactively off X, and B->C->A is a reactive path.
+        # Repointing B's context_from at A — WITHOUT touching trigger fields —
+        # closes A->B->C->A and must be rejected: context_from alone is half of
+        # every reactive edge and can introduce a cycle on its own.
+        job_x = create_job(prompt="X", schedule="every 1h")
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_x["id"],
+            trigger_on_complete=True,
+        )
+        job_c = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=job_b["id"],
+            trigger_on_complete=True,
+        )
+        job_a = create_job(
+            prompt="A", schedule="every 1h",
+            context_from=job_c["id"],
+            trigger_on_complete=True,
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            update_job(job_b["id"], {"context_from": job_a["id"]})
+
+    def test_non_reactive_job_breaks_cycle(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        # B consumes A's output but never fires off it (trigger off), while
+        # B fires C and C fires A. B's passive edge breaks the loop, so the
+        # A->C edge is safe...
+        job_a = create_job(prompt="A", schedule="every 1h")
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_a["id"],
+            trigger_on_complete=False,
+        )
+        job_c = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=job_b["id"],
+            trigger_on_complete=True,
+        )
+        updated = update_job(job_a["id"], {
+            "context_from": job_c["id"],
+            "trigger_on_complete": True,
+        })
+        assert updated["trigger_on_complete"] is True
+
+        # ...but flipping B reactive closes A->B->C->A and must be rejected.
+        with pytest.raises(ValueError, match="cycle"):
+            update_job(job_b["id"], {"trigger_on_complete": True})
+
+
+# ---------------------------------------------------------------------------
+# Dependency lookup + scheduler fan-out
+# ---------------------------------------------------------------------------
+
+class TestGetDependentJobs:
+    def test_finds_reactive_children(self, cron_env):
+        from cron.jobs import create_job, get_dependent_jobs
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        child = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+        )
+        unrelated = create_job(prompt="U", schedule="every 1h")
+        deps = get_dependent_jobs(parent["id"])
+        ids = [d["id"] for d in deps]
+        assert child["id"] in ids
+        assert unrelated["id"] not in ids
+
+    def test_excludes_non_reactive_context_from_jobs(self, cron_env):
+        from cron.jobs import create_job, get_dependent_jobs
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        # Passive consumer: context_from but no trigger_on_complete.
+        create_job(
+            prompt="C", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=False,
+        )
+        assert get_dependent_jobs(parent["id"]) == []
+
+    def test_excludes_disabled_children(self, cron_env):
+        from cron.jobs import create_job, get_dependent_jobs, pause_job
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        child = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+        )
+        pause_job(child["id"])
+        assert get_dependent_jobs(parent["id"]) == []
+
+    def test_atomic_trigger_does_not_resurrect_paused_child(self, cron_env):
+        """A pause racing reactive discovery wins over the automatic fire."""
+        from cron.jobs import (
+            create_job,
+            get_job,
+            pause_job,
+            trigger_job_if_runnable,
+        )
+
+        child = create_job(prompt="C", schedule="every 1h")
+        pause_job(child["id"])
+
+        assert trigger_job_if_runnable(child["id"]) is None
+        loaded = get_job(child["id"])
+        assert loaded is not None
+        assert loaded["enabled"] is False
+        assert loaded["state"] == "paused"
+
+
+class TestFireDependentJobs:
+    """The scheduler's _fire_dependent_jobs kicks children via trigger_job_if_runnable."""
+
+    def test_fires_child_on_parent_success(self, cron_env, monkeypatch):
+        from cron.jobs import create_job
+        from cron import scheduler as sched_mod
+
+        fired = []
+        monkeypatch.setattr(
+            sched_mod, "trigger_job_if_runnable",
+            lambda jid: fired.append(jid),
+        )
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        child = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+            trigger_status="ok",
+        )
+        sched_mod._fire_dependent_jobs(parent["id"], parent_success=True)
+        assert child["id"] in fired
+
+    def test_notifies_external_provider_once_per_fanout(self, cron_env, monkeypatch):
+        """Reactive mutations must be provisioned by non-built-in schedulers."""
+        from cron.jobs import create_job
+        from cron import scheduler as sched_mod
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        children = [
+            create_job(
+                prompt=f"C{i}", schedule="every 1h",
+                context_from=parent["id"],
+                trigger_on_complete=True,
+            )
+            for i in range(2)
+        ]
+        fired = []
+        notifications = []
+
+        def fake_trigger(job_id):
+            fired.append(job_id)
+            return {"id": job_id}
+
+        monkeypatch.setattr(sched_mod, "trigger_job_if_runnable", fake_trigger)
+        monkeypatch.setattr(
+            sched_mod, "_notify_provider_jobs_changed",
+            lambda: notifications.append("notified"),
+        )
+
+        sched_mod._fire_dependent_jobs(parent["id"], parent_success=True)
+
+        assert set(fired) == {child["id"] for child in children}
+        assert notifications == ["notified"]
+
+    def test_does_not_notify_provider_when_no_child_is_scheduled(
+        self, cron_env, monkeypatch
+    ):
+        """A status-gated no-op must not churn external scheduler state."""
+        from cron.jobs import create_job
+        from cron import scheduler as sched_mod
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        create_job(
+            prompt="C", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+            trigger_status="error",
+        )
+        notifications = []
+        monkeypatch.setattr(
+            sched_mod, "_notify_provider_jobs_changed",
+            lambda: notifications.append("notified"),
+        )
+
+        sched_mod._fire_dependent_jobs(parent["id"], parent_success=True)
+
+        assert notifications == []
+
+    def test_invalid_persisted_status_fails_closed(self, monkeypatch):
+        """Tampered/legacy invalid status must not behave like 'any'."""
+        from cron import scheduler as sched_mod
+
+        fired = []
+        monkeypatch.setattr(
+            sched_mod,
+            "get_dependent_jobs",
+            lambda _parent: [{"id": "child", "trigger_status": "bogus"}],
+        )
+        monkeypatch.setattr(sched_mod, "trigger_job_if_runnable", lambda jid: fired.append(jid))
+
+        sched_mod._fire_dependent_jobs("parent", parent_success=True)
+
+        assert fired == []
+
+    def test_skips_child_when_status_gate_mismatches(self, cron_env, monkeypatch):
+        from cron.jobs import create_job
+        from cron import scheduler as sched_mod
+
+        fired = []
+        monkeypatch.setattr(sched_mod, "trigger_job_if_runnable", lambda jid: fired.append(jid))
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        child_ok = create_job(
+            prompt="Cok", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+            trigger_status="ok",
+        )
+        child_err = create_job(
+            prompt="Cerr", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+            trigger_status="error",
+        )
+        child_any = create_job(
+            prompt="Cany", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+            trigger_status="any",
+        )
+
+        # Parent failed: only error+any children fire.
+        sched_mod._fire_dependent_jobs(parent["id"], parent_success=False)
+        assert child_err["id"] in fired
+        assert child_any["id"] in fired
+        assert child_ok["id"] not in fired
+
+    def test_failure_to_trigger_one_child_does_not_block_siblings(
+        self, cron_env, monkeypatch
+    ):
+        from cron.jobs import create_job
+        from cron import scheduler as sched_mod
+
+        calls = []
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        child1 = create_job(
+            prompt="C1", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+        )
+        child2 = create_job(
+            prompt="C2", schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+        )
+
+        def selective(jid):
+            calls.append(jid)
+            if jid == child1["id"]:
+                raise RuntimeError("boom")
+            return {"id": jid}
+
+        monkeypatch.setattr(sched_mod, "trigger_job_if_runnable", selective)
+        monkeypatch.setattr(sched_mod, "_notify_provider_jobs_changed", lambda: None)
+        sched_mod._fire_dependent_jobs(parent["id"], parent_success=True)
+
+        # child2 still gets scheduled even though child1 failed.
+        assert child1["id"] in calls
+        assert child2["id"] in calls
+
+
+# ---------------------------------------------------------------------------
+# Tool surface (cronjob action=create/update)
+# ---------------------------------------------------------------------------
+
+class TestCronjobToolTrigger:
+    def test_create_via_tool(self, cron_env):
+        from cron.jobs import create_job, get_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        result = json.loads(cronjob(
+            action="create",
+            prompt="C",
+            schedule="every 1h",
+            context_from=parent["id"],
+            trigger_on_complete=True,
+            trigger_status="any",
+        ))
+        assert result["success"] is True
+        loaded = get_job(result["job_id"])
+        assert loaded["trigger_on_complete"] is True
+        assert loaded["trigger_status"] == "any"
+
+    def test_update_via_tool(self, cron_env):
+        from cron.jobs import create_job, get_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        parent = create_job(prompt="P", schedule="every 1h")
+        child = create_job(
+            prompt="C", schedule="every 1h",
+            context_from=parent["id"],
+        )
+        assert child["trigger_on_complete"] is False
+
+        result = json.loads(cronjob(
+            action="update",
+            job_id=child["id"],
+            trigger_on_complete=True,
+            trigger_status="error",
+        ))
+        assert result["success"] is True
+        loaded = get_job(child["id"])
+        assert loaded["trigger_on_complete"] is True
+        assert loaded["trigger_status"] == "error"
+
+    def test_update_rejects_cycle_via_tool(self, cron_env):
+        from cron.jobs import create_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        job_a = create_job(prompt="A", schedule="every 1h")
+        job_b = create_job(
+            prompt="B", schedule="every 1h",
+            context_from=job_a["id"],
+            trigger_on_complete=True,
+        )
+        result = json.loads(cronjob(
+            action="update",
+            job_id=job_a["id"],
+            context_from=job_b["id"],
+            trigger_on_complete=True,
+        ))
+        assert result["success"] is False
+        assert "cycle" in result.get("error", "").lower()

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -66,6 +66,68 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j2", True)
 
 
+def test_run_one_job_failure_fires_error_dependents(monkeypatch):
+    """A job that raises still kicks reactive children with parent_success=False.
+
+    Regression for reactive chaining (#15831): the success path fires children
+    with ``parent_success=True``; a hard failure must fire them with
+    ``parent_success=False`` so ``trigger_status='error'`` / ``'any'`` alert
+    children actually run on upstream failure instead of silently never firing.
+    """
+    fired = []
+
+    def boom(job, *, defer_agent_teardown=None, **kw):
+        raise RuntimeError("simulated failure")
+
+    monkeypatch.setattr(s, "run_job", boom)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+    monkeypatch.setattr(
+        s, "_fire_dependent_jobs",
+        lambda jid, parent_success: fired.append((jid, parent_success)),
+    )
+
+    ok = s.run_one_job({"id": "j-fail", "name": "t"})
+
+    assert ok is False
+    assert fired == [("j-fail", False)]
+
+
+def test_run_one_job_success_fires_ok_dependents(monkeypatch):
+    """Successful jobs fire reactive children with parent_success=True."""
+    fired = []
+    calls = _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(
+        s, "_fire_dependent_jobs",
+        lambda jid, parent_success: fired.append((jid, parent_success)),
+    )
+
+    ok = s.run_one_job({"id": "j3", "name": "t"})
+
+    assert ok is True
+    assert fired == [("j3", True)]
+
+
+def test_blocked_config_silent_retry_does_not_refire_dependents(monkeypatch):
+    """The once-only blocked-config alert policy also gates reactive fan-out."""
+    fired = []
+    _patch_pipeline(
+        monkeypatch,
+        success=False,
+        error=f"{s.BLOCKED_CONFIG_SILENT_MARKER} still blocked",
+    )
+    monkeypatch.setattr(
+        s, "_fire_dependent_jobs",
+        lambda jid, parent_success: fired.append((jid, parent_success)),
+    )
+
+    ok = s.run_one_job({"id": "j-blocked", "name": "t"})
+
+    assert ok is True
+    assert fired == []
+
+
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
     """Regression: under profile isolation (multiplex active), run_one_job must
     execute run_job inside a profile secret scope so credential reads

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1052,6 +1052,8 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    trigger_on_complete: Optional[bool] = None,
+    trigger_status: Optional[str] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1140,6 +1142,8 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    trigger_on_complete=trigger_on_complete if trigger_on_complete is not None else False,
+                    trigger_status=trigger_status or "ok",
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1413,6 +1417,15 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if trigger_on_complete is not None or trigger_status is not None:
+                # Pass through raw values; update_job() normalizes both and
+                # runs cycle detection against the merged context_from. A
+                # trigger_on_complete=True with no context_from (on the job or
+                # in this same update) is rejected there.
+                if trigger_on_complete is not None:
+                    updates["trigger_on_complete"] = trigger_on_complete
+                if trigger_status is not None:
+                    updates["trigger_status"] = trigger_status
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -1539,6 +1552,30 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                     "On update, pass an empty array to clear."
                 ),
             },
+            "trigger_on_complete": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "When True, this job is fired immediately when any job listed in "
+                    "context_from completes — instead of (or in addition to) waiting for "
+                    "its own schedule. The upstream output already flows in via context_from; "
+                    "this flag adds the reactive kick so a pipeline runs without waiting for "
+                    "the next tick. Requires context_from to be set. Cycles are rejected "
+                    "(A→B→A). Combine with trigger_status to gate on success/failure/any. "
+                    "On update, set False to disable reactive chaining while keeping context_from."
+                ),
+            },
+            "trigger_status": {
+                "type": "string",
+                "enum": ["ok", "error", "any"],
+                "default": "ok",
+                "description": (
+                    "Which parent outcome fires this child when trigger_on_complete=True: "
+                    "'ok' (default, only successful parents), 'error' (only failed parents — "
+                    "useful for alert fan-out on upstream failure), or 'any' (fire regardless). "
+                    "Only meaningful when trigger_on_complete is True."
+                ),
+            },
             "enabled_toolsets": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -1611,6 +1648,8 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        trigger_on_complete=args.get("trigger_on_complete"),
+        trigger_status=args.get("trigger_status"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -584,6 +584,84 @@ Outputs are concatenated in the order listed.
 - Dependent tasks where step N's work depends on step N−1's output
 - Fan-out/fan-in patterns where one job aggregates results from several others
 
+### Reactive chaining: `trigger_on_complete`
+
+Plain `context_from` chains still wait for each job's own schedule — Job 2 runs
+at 07:30 whether or not Job 1 finished at 07:01. **Reactive chaining** flips
+that: a job with `trigger_on_complete=True` is marked due as soon as any job
+listed in its `context_from` completes and runs on the next scheduler tick,
+rather than waiting for its own scheduled time.
+
+```python
+# Job 1: Collect raw data (runs on its schedule)
+cronjob(
+    action="create",
+    prompt="Fetch the top 10 AI/ML stories from Hacker News and rank them.",
+    schedule="0 7 * * *",
+    name="AI News Collector",
+)
+
+# Job 2: Triage — becomes due when Job 1 finishes
+cronjob(
+    action="create",
+    prompt="Turn the ranked stories into 3 tweet drafts and deliver them.",
+    schedule="0 8 * * *",                # fallback schedule still applies
+    context_from="<job1_id>",
+    trigger_on_complete=True,            # also fires on Job 1 completion
+    name="AI News Brief",
+)
+```
+
+**How it works:**
+
+- When an upstream job finishes, every enabled job whose `context_from` names
+  it and that has `trigger_on_complete=True` is scheduled to run on the next
+  tick. The upstream's output still flows in via `context_from` as usual.
+- `trigger_on_complete` is *in addition to* the job's own schedule: the fallback
+  schedule guarantees the job still runs even if its upstream never completes
+  (e.g. a paused parent).
+- Fan-out works naturally: many children can react to one parent, and children
+  can react to several parents — a child fires when *any* listed parent
+  completes.
+- Reactive fires are coalesced for backpressure: several parents completing
+  before the next scheduler tick produce one child run, not one run per event.
+  If that child is already running, Hermes does not overlap a second copy; the
+  reactive fire is absorbed by the existing in-flight dedupe policy. At run
+  time, `context_from` still injects the latest completed output from every
+  listed parent.
+
+**Gating on success or failure with `trigger_status`:**
+
+`trigger_status` decides which parent outcome fires the child (default `"ok"`):
+
+| Value | Fires when a parent... |
+|-------|------------------------|
+| `"ok"` | completes successfully |
+| `"error"` | finishes with a recorded failure |
+| `"any"` | completes, regardless of outcome |
+
+```python
+# Alert fan-out: fire a notification job only when the collector FAILS
+cronjob(
+    action="create",
+    prompt="The AI News Collector failed. Investigate and report what went wrong.",
+    schedule="every 1h",
+    context_from="<job1_id>",
+    trigger_on_complete=True,
+    trigger_status="error",
+    name="Collector Failure Alert",
+)
+```
+
+**Cycle protection:** because reactive chains fire on completion, a loop
+(A fires B, B fires A) would run forever. Hermes rejects any create or update
+that would form a cycle — either directly (`context_from` naming the job
+itself) or transitively (a longer path that loops back). The rejection is
+enforced at create and update time against the merged `context_from` +
+`trigger_on_complete`, including updates that only change `context_from` on an
+already-reactive job. `trigger_on_complete=True` also requires at least one
+`context_from` entry — there must be something to react to.
+
 ## Provider recovery
 
 Cron jobs inherit your configured fallback providers and credential pool rotation. If the primary API key is rate-limited or the provider returns an error, the cron agent can:
@@ -825,6 +903,19 @@ cronjob(action="create", name="daily-digest",
 ```
 
 The referenced jobs' most recent completed outputs are injected above the prompt as context for this run. Each upstream entry must be a valid job ID or name (see `cronjob action="list"`). Note: chaining reads the *most recent completed* output — it does not wait for upstream jobs that are running in the same tick.
+
+To fire a child *immediately* when an upstream job completes (instead of waiting for its own schedule), set `trigger_on_complete=True` on the child and gate the outcome with `trigger_status` (`"ok"` default, `"error"`, or `"any"`):
+
+```text
+cronjob(action="create", name="digest-alert",
+        schedule="every day 7am",
+        context_from=["daily-digest"],
+        trigger_on_complete=True,
+        trigger_status="error",
+        prompt="The daily digest failed. Summarize what happened and what to check.")
+```
+
+Reactive edges are validated at create/update time: `trigger_on_complete=True` requires a non-empty `context_from`, and any create or update that would form a reactive cycle (A → B → A, transitively included) is rejected.
 
 ## Job storage
 


### PR DESCRIPTION
## What

Adds **reactive cron job chaining**: a job with `trigger_on_complete=True` is marked due when any job listed in its `context_from` completes, then runs on the next scheduler tick — instead of (or in addition to) waiting for its own schedule. This implements the feature requested in #15831 (job chaining / run Job B right after Job A completes).

`trigger_status` gates which parent outcome fires the child:
- `"ok"` (default) — fires only on successful parents
- `"error"` — fires only on failed parents (alert/fan-out on upstream failure)
- `"any"` — fires regardless of outcome

This enables pipelines, fan-out/fan-in, conditional execution and dependency ordering without manual schedule coordination.

## Why

Currently cron jobs run on independent schedules with no native "run B after A" mechanism — chained automations require fragile schedule alignment. This adds a deterministic, auditable reactive edge (matching the pattern used by Airflow DAGs, Prefect flows and GitHub Actions `workflow_run`), with cycle protection so a chain can never loop forever.

## What changed

- **`cron/jobs.py`** — persist/normalize `trigger_on_complete` + `trigger_status`; validate `trigger_on_complete=True` requires a non-empty `context_from`; reject cycles (direct and transitive) across the `context_from`+trigger graph at create and update time, against the locked snapshot.
- **`cron/scheduler.py`** — fire dependent jobs after a parent's terminal status is durably recorded, on both the success and hard-failure paths; respect the `trigger_status` gate; coalesce fan-out and notify external providers once per batch; keep the blocked-config once-only alert policy (a silent retry never re-fires alert children).
- **`tools/cronjob_tools.py`, `hermes_cli/web_models.py`, `hermes_cli/web_server.py`** — expose the two fields through the `cronjob` tool and the dashboard create/update API.
- **`website/docs/user-guide/features/cron.md`** — reactive chaining guide, `trigger_status` table, coalescing/backpressure and cycle-protection rules.
- **tests** — new `tests/cron/test_cron_trigger_on_complete.py` plus additions to `test_run_one_job.py`.

## How to test

```python
# Job 1: collect
cronjob(action="create", prompt="fetch data", schedule="0 7 * * *", name="collector")
# Job 2: triage — becomes due when Job 1 completes (runs on the next scheduler tick)
cronjob(action="create", prompt="summarize", schedule="0 8 * * *",
        context_from="<job1_id>", trigger_on_complete=True, name="brief")
# Alert fan-out on failure
cronjob(action="create", prompt="investigate failure", schedule="every 1h",
        context_from="<job1_id>", trigger_on_complete=True, trigger_status="error")
```

Cycle protection: creating `A.context_from=[B]` where both are reactive is rejected.

## Verification

- Targeted: `35 passed` (`tests/cron/test_cron_trigger_on_complete.py` + `test_run_one_job.py`)
- Cron suite: `547 passed` (`tests/cron/`)
- Dashboard/web: `9 passed` (`test_web_server_cron_profiles.py`, `test_cron_dashboard_off_loop.py`)
- Platform tested: macOS (aarch64). Cross-platform: no new POSIX-only syscalls; changes are pure Python logic + doc/tool surface.

Closes #15831
