### PR TITLE
fix(desktop): stop legacy plugin rows from crashing Settings

### DIFF
--- a/apps/desktop/src/app/settings/plugins-settings.test.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { requestGateway } = vi.hoisted(() => ({ requestGateway: vi.fn() }))
+
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway })
+}))
+
+import { $pluginRecords } from '@/contrib/plugins-store'
+import {
+  $agentPluginBusy,
+  $agentPlugins,
+  $agentPluginsError,
+  $agentPluginsStatus,
+  type AgentPluginRow
+} from '@/store/agent-plugins'
+import { $connection, $gatewayState } from '@/store/session'
+
+import { PluginsSettings } from './plugins-settings'
+
+const legacyRow = {
+  name: 'Legacy plugin',
+  version: '0.20.0',
+  description: 'Returned by a pre-key backend',
+  source: 'user',
+  status: 'disabled'
+} satisfies AgentPluginRow
+
+beforeEach(() => {
+  requestGateway.mockReset()
+  $pluginRecords.set({})
+  $agentPlugins.set([legacyRow])
+  $agentPluginsStatus.set('ready')
+  $agentPluginsError.set(null)
+  $agentPluginBusy.set(null)
+  $gatewayState.set('idle')
+  $connection.set(null)
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('PluginsSettings', () => {
+  it('renders and searches plugin rows returned without a canonical key', () => {
+    render(<PluginsSettings />)
+
+    expect(screen.getByText('Legacy plugin')).toBeTruthy()
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'pre-key' } })
+
+    expect(screen.getByText('Legacy plugin')).toBeTruthy()
+  })
+
+  it('uses the legacy name address when toggling a row without a key', async () => {
+    requestGateway.mockResolvedValue({ ok: true, plugin: { ...legacyRow, status: 'enabled' } })
+
+    render(<PluginsSettings />)
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable Legacy plugin' }))
+
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('plugins.manage', {
+        action: 'toggle',
+        name: 'Legacy plugin',
+        enable: true
+      })
+    )
+  })
+
+  it('keeps using the canonical key when the backend provides one', async () => {
+    const keyedRow = { ...legacyRow, key: 'image_gen/legacy' }
+
+    $agentPlugins.set([keyedRow])
+    requestGateway.mockResolvedValue({ ok: true, plugin: { ...keyedRow, status: 'enabled' } })
+
+    render(<PluginsSettings />)
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable Legacy plugin' }))
+
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('plugins.manage', {
+        action: 'toggle',
+        key: 'image_gen/legacy',
+        enable: true
+      })
+    )
+  })
+})

--- a/apps/desktop/src/app/settings/plugins-settings.test.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.test.tsx
@@ -40,6 +40,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
 })
 
 describe('PluginsSettings', () => {
@@ -66,6 +67,27 @@ describe('PluginsSettings', () => {
         enable: true
       })
     )
+  })
+
+  it('keeps duplicate-named legacy rows distinct after a name-addressed toggle', async () => {
+    const sibling = {
+      ...legacyRow,
+      description: 'A second plugin category with the same legacy name'
+    }
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    $agentPlugins.set([legacyRow, sibling])
+    requestGateway.mockResolvedValue({ ok: true, plugin: { ...legacyRow, status: 'enabled' } })
+
+    render(<PluginsSettings />)
+    fireEvent.click(screen.getAllByRole('switch', { name: 'Enable Legacy plugin' })[0])
+
+    await waitFor(() =>
+      expect(screen.getAllByRole('switch', { name: 'Disable Legacy plugin' })).toHaveLength(2)
+    )
+
+    expect(screen.getByText(sibling.description)).toBeTruthy()
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('same key')
   })
 
   it('keeps using the canonical key when the backend provides one', async () => {

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -45,6 +45,9 @@ const isDesktopRelevant = (row: AgentPluginRow) => {
   return !key || !HIDDEN_KEY_PREFIXES.some(prefix => key.startsWith(prefix))
 }
 
+const agentPluginRowKey = (row: AgentPluginRow) =>
+  row.key ?? [row.name, row.source, row.version, row.description].join('\0')
+
 function reveal(file: string) {
   void window.hermesDesktop?.revealPath?.(file)?.catch(() => undefined)
 }
@@ -240,7 +243,7 @@ function AgentPluginsSection() {
       ) : (
         <div>
           {sorted.map(row => (
-            <AgentPluginRowView key={row.key || row.name} row={row} />
+            <AgentPluginRowView key={agentPluginRowKey(row)} row={row} />
           ))}
         </div>
       )}

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -39,7 +39,11 @@ const SOURCE_ORDER: Record<string, number> = { user: 0, git: 0, project: 1, entr
 // the user-facing control for any of them, so listing them here is noise.
 const HIDDEN_KEY_PREFIXES = ['dashboard_auth/', 'model-providers/', 'platforms/']
 
-const isDesktopRelevant = (row: AgentPluginRow) => !HIDDEN_KEY_PREFIXES.some(prefix => row.key.startsWith(prefix))
+const isDesktopRelevant = (row: AgentPluginRow) => {
+  const key = row.key
+
+  return !key || !HIDDEN_KEY_PREFIXES.some(prefix => key.startsWith(prefix))
+}
 
 function reveal(file: string) {
   void window.hermesDesktop?.revealPath?.(file)?.catch(() => undefined)
@@ -134,10 +138,10 @@ function AgentPluginRowView({ row }: { row: AgentPluginRow }) {
         <Switch
           aria-label={`${row.status === 'enabled' ? p.disable : p.enable} ${row.name}`}
           checked={row.status === 'enabled'}
-          disabled={busy === row.key}
+          disabled={busy === (row.key ?? row.name)}
           onCheckedChange={on => {
             triggerHaptic('selection')
-            void toggleAgentPlugin(requestGateway, row.key, on, p.agent.toggleFailed(row.name))
+            void toggleAgentPlugin(requestGateway, row, on, p.agent.toggleFailed(row.name))
           }}
         />
       }
@@ -180,7 +184,7 @@ function AgentPluginsSection() {
       row =>
         !needle ||
         row.name.toLowerCase().includes(needle) ||
-        row.key.toLowerCase().includes(needle) ||
+        (row.key ?? '').toLowerCase().includes(needle) ||
         row.description.toLowerCase().includes(needle)
     )
     .sort((a, b) => (SOURCE_ORDER[a.source] ?? 9) - (SOURCE_ORDER[b.source] ?? 9) || a.name.localeCompare(b.name))

--- a/apps/desktop/src/store/agent-plugins.ts
+++ b/apps/desktop/src/store/agent-plugins.ts
@@ -96,10 +96,14 @@ export async function toggleAgentPlugin(
     const refreshed = result.plugin
 
     if (refreshed) {
+      const currentRows = $agentPlugins.get()
+
       $agentPlugins.set(
-        $agentPlugins
-          .get()
-          .map(current => ((current.key ?? current.name) === address ? { ...current, ...refreshed } : current))
+        row.key
+          ? currentRows.map(current => (current.key === row.key ? { ...current, ...refreshed } : current))
+          : currentRows.map(current =>
+              current.name === row.name ? { ...current, status: refreshed.status } : current
+            )
       )
     } else {
       await loadAgentPlugins(request)

--- a/apps/desktop/src/store/agent-plugins.ts
+++ b/apps/desktop/src/store/agent-plugins.ts
@@ -17,8 +17,8 @@ import { notifyError } from '@/store/notifications'
 
 export interface AgentPluginRow {
   name: string
-  /** Canonical registry key (e.g. `image_gen/fal`) — names can collide. */
-  key: string
+  /** Canonical registry key (e.g. `image_gen/fal`) — absent on legacy backends. */
+  key?: string
   version: string
   description: string
   /** 'bundled' | 'user' | 'git' | 'project' | 'entrypoint' */
@@ -36,7 +36,7 @@ export type GatewayRequest = <T>(method: string, params?: Record<string, unknown
 export const $agentPlugins = atom<AgentPluginRow[]>([])
 export const $agentPluginsStatus = atom<AgentPluginsStatus>('idle')
 export const $agentPluginsError = atom<string | null>(null)
-/** Key of the row whose toggle RPC is in flight (disables its switch). */
+/** Best available address of the row whose toggle RPC is in flight. */
 export const $agentPluginBusy = atom<string | null>(null)
 
 let inflight: Promise<void> | null = null
@@ -70,20 +70,22 @@ export function loadAgentPlugins(request: GatewayRequest): Promise<void> {
 }
 
 /** Flip a backend plugin on/off and patch the row from the RPC's refreshed
- *  copy. Addressed by canonical key — bare names collide (image_gen/fal vs
- *  video_gen/fal). Returns whether the toggle stuck. */
+ *  copy. Current backends use canonical keys; legacy keyless rows fall back
+ *  to the name-addressed protocol they were returned by. */
 export async function toggleAgentPlugin(
   request: GatewayRequest,
-  key: string,
+  row: Pick<AgentPluginRow, 'key' | 'name'>,
   enable: boolean,
   failMessage: string
 ): Promise<boolean> {
-  $agentPluginBusy.set(key)
+  const address = row.key ?? row.name
+
+  $agentPluginBusy.set(address)
 
   try {
     const result = await request<{ ok?: boolean; plugin?: AgentPluginRow | null }>('plugins.manage', {
       action: 'toggle',
-      key,
+      ...(row.key ? { key: row.key } : { name: row.name }),
       enable
     })
 
@@ -94,7 +96,11 @@ export async function toggleAgentPlugin(
     const refreshed = result.plugin
 
     if (refreshed) {
-      $agentPlugins.set($agentPlugins.get().map(row => (row.key === key ? { ...row, ...refreshed } : row)))
+      $agentPlugins.set(
+        $agentPlugins
+          .get()
+          .map(current => ((current.key ?? current.name) === address ? { ...current, ...refreshed } : current))
+      )
     } else {
       await loadAgentPlugins(request)
     }


### PR DESCRIPTION
## What does this PR do?

Opening Settings > Plugins against an older backend can currently tear down the entire Settings view. This change treats a missing plugin registry key as an expected version-skew case, keeps the list renderable and searchable, and preserves toggling through the legacy name-addressed RPC without changing current key-addressed behavior.

### Symptom

A current Desktop connected to a Hermes 0.20.0 backend receives plugin rows without `key`. Opening Settings > Plugins then reaches the root error boundary with `Cannot read properties of undefined (reading 'startsWith')`.

### Impact

The failure was reproduced with 89 keyless rows from an actual 0.20.0 backend. A single legacy row prevents affected users from using the Plugins settings view at all.

### Bug Cause

**Trigger:** `apps/desktop/src/app/settings/plugins-settings.tsx:42` / `isDesktopRelevant`

**Causal chain:**
1. An older backend returns a valid plugin row without the canonical `key` field.
2. Desktop trusts the current gateway shape and calls `key.startsWith(...)` while filtering the list; search later makes the same assumption with `key.toLowerCase()`.
3. The exception escapes rendering and the root error boundary replaces the Settings view.

**Why it is wrong:** Desktop and the backend update independently, so the renderer must represent the older payload contract instead of assuming every connected backend already emits canonical keys.

**Working sibling / contrast:** Current backends provide canonical keys and continue to use key-based filtering, identity, and toggle requests. Legacy rows use the name-addressed toggle protocol supported by the backend version that returned them.

**Ruled out:** Current gateway serialization is not dropping keys. The current gateway emits canonical keys; the reproduced payload came from a real pre-key backend, confirming version skew at the Desktop boundary.

### Fix

Make `AgentPluginRow.key` optional, guard key-based filtering and search, derive a stable metadata identity for keyless rows, and address legacy toggle requests by name. Focused tests cover rendering, search, duplicate-named row identity, legacy toggling, and unchanged current-backend key toggling.

## Related Issue

Closes #82697

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/agent-plugins.ts` - model legacy keyless rows and preserve the correct toggle protocol.
- `apps/desktop/src/app/settings/plugins-settings.tsx` - make filtering, search, busy state, and render identity safe without a key.
- `apps/desktop/src/app/settings/plugins-settings.test.tsx` - add behavioral coverage for keyless and keyed backend rows.

## How to Test

1. Connect the current Desktop to a Hermes 0.20.0 backend whose `plugins.manage` response omits `key`.
2. Open Settings > Plugins, search the legacy rows, and toggle one plugin.
3. Confirm the view remains rendered, the name-addressed toggle succeeds, and no duplicate React key errors appear.
4. Run the focused automated checks:

```bash
cd apps/desktop
npx vitest run src/app/settings/plugins-settings.test.tsx
npm run typecheck
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop Vitest and TypeScript checks and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; this is a compatibility fix covered by code comments and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no configuration changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the renderer-only contract fix is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no tool schema changed
