### PR TITLE
feat(photon): gate setup success on iMessage opt-in via first message

### DIFF
--- a/plugins/platforms/photon/auth.py
+++ b/plugins/platforms/photon/auth.py
@@ -912,7 +912,9 @@ def register_user_if_absent(
     same phone number already exists (the official CLI does no dedup, so we
     add it here to make ``setup`` safely re-runnable).
     """
-    existing = find_user_by_phone(project_id, project_secret, phone_number)
+    existing = find_routable_user(
+        list_users(project_id, project_secret), phone_number,
+    )
     if existing is not None:
         return existing, False
     user = create_user(
@@ -939,6 +941,79 @@ def user_assigned_line(user: Optional[Dict[str, Any]]) -> Optional[str]:
         return None
     val = user.get("assignedPhoneNumber")
     return str(val) if val else None
+
+
+def user_opted_in(user: Optional[Dict[str, Any]]) -> bool:
+    """True when the delivery plane will route messages for this user.
+
+    The row must carry ``meta.opt_in``, which the service sets once the human
+    has sent one message from ``phoneNumber`` to the row's
+    ``assignedPhoneNumber``. A row without it looks registered everywhere but
+    never sends or receives — outbound fails with "Target not allowed for
+    this project". Client-supplied meta is ignored on create, so the flag
+    cannot be produced through the API. (Ported from qwibitai/nanoclaw#3181.)
+    """
+    if not user:
+        return False
+    meta = user.get("meta")
+    return bool(isinstance(meta, dict) and meta.get("opt_in"))
+
+
+def find_routable_user(
+    users: List[Dict[str, Any]], phone_number: str,
+) -> Optional[Dict[str, Any]]:
+    """Return the row that decides routing for ``phone_number``.
+
+    When duplicates exist for the same number, an opted-in row wins over
+    whichever happens to list first — opt-in is scoped to one
+    user-number/assigned-line pair, so only that row routes.
+    """
+    target = _normalize_phone(phone_number)
+    match: Optional[Dict[str, Any]] = None
+    for user in users:
+        if _normalize_phone(user.get("phoneNumber") or "") != target:
+            continue
+        if user_opted_in(user):
+            return user
+        if match is None:
+            match = user
+    return match
+
+
+def wait_for_opted_in_user(
+    project_id: str,
+    project_secret: str,
+    phone_number: str,
+    *,
+    timeout_s: float = 300.0,
+    interval_s: float = 5.0,
+    on_waiting: Optional[Callable[[int], None]] = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> Optional[Dict[str, Any]]:
+    """Poll until ``phone_number``'s user row exists AND is opted in.
+
+    A row starts un-opted-in whatever created it; the flag lands only after
+    the human sends a message from their phone to the row's assigned line.
+    Transient list failures are counted as missed polls (the whole point of
+    the wait is to ride out the operator's manual step). Returns the opted-in
+    row, or ``None`` after ``timeout_s`` (attempt-count based so tests with an
+    instant ``sleep_fn`` stay deterministic).
+    """
+    max_attempts = max(1, int(timeout_s / interval_s))
+    for attempt in range(1, max_attempts + 1):
+        try:
+            user = find_routable_user(
+                list_users(project_id, project_secret), phone_number,
+            )
+            if user_opted_in(user):
+                return user
+        except Exception as exc:  # noqa: BLE001 — transient API failure = missed poll
+            logger.debug("photon: opt-in poll failed (attempt %d): %s", attempt, exc)
+        if on_waiting is not None:
+            on_waiting(attempt)
+        if attempt < max_attempts:
+            sleep_fn(interval_s)
+    return None
 
 
 def load_user_numbers() -> Tuple[Optional[str], Optional[str]]:

--- a/plugins/platforms/photon/cli.py
+++ b/plugins/platforms/photon/cli.py
@@ -289,6 +289,57 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         # no dedicated entry in /lines, so this per-user field is the source of
         # truth — and we already have it from the (reused) user object.
         agent_number = photon_auth.user_assigned_line(user)
+        # Opt-in gate (ported from qwibitai/nanoclaw#3181): the delivery
+        # plane only routes numbers whose user row carries meta.opt_in, and
+        # that flag is set server-side when the human sends ONE message from
+        # their phone to the row's assigned line. A row without it looks
+        # registered everywhere but never sends or receives — outbound fails
+        # with "Target not allowed for this project". Client-supplied meta is
+        # ignored on create, so the API cannot produce the flag; the wizard
+        # names the line to text and polls until the opt-in lands. An
+        # already-opted-in row (re-run) short-circuits to success.
+        if photon_auth.user_opted_in(user):
+            print("  ✓ number is opted in — routing is live")
+        else:
+            _line_hint = agent_number or "the line Photon assigns to your number"
+            print()
+            print(color("      One manual step: opt in by texting your agent", Colors.CYAN, Colors.BOLD))
+            print("      Your number only enters iMessage routing after it has")
+            print("      messaged the line Photon assigned to it:")
+            print(f"        1. Open Messages on {phone}.")
+            print(f"        2. Text {_line_hint} — one message of any content is enough.")
+            if not sys.stdin.isatty():
+                # Non-interactive (scripted setup, CI): don't block on a poll
+                # nobody can answer. `hermes photon status` verifies later.
+                print(
+                    "      Non-interactive run — skipping the opt-in wait. "
+                    "Verify later with `hermes photon status`.",
+                )
+            else:
+                print("      Setup waits here (up to 5 minutes) and continues once the opt-in lands.")
+                print("      (Ctrl-C to skip — re-running setup resumes where it left off.)")
+
+                def _on_waiting(attempt: int) -> None:
+                    if attempt % 6 == 0:
+                        print("      ... still waiting for your message to land")
+
+                try:
+                    opted = photon_auth.wait_for_opted_in_user(
+                        spectrum_id, secret, phone, on_waiting=_on_waiting,
+                    )
+                except KeyboardInterrupt:
+                    opted = None
+                    print()
+                if opted is not None:
+                    print("  ✓ opt-in landed — routing is live")
+                    # The assignment can materialize with the opt-in.
+                    agent_number = photon_auth.user_assigned_line(opted) or agent_number
+                else:
+                    print(
+                        f"      ⚠ {phone} is not opted in yet. Send one message from "
+                        f"{phone} to {_line_hint}, then re-run "
+                        "`hermes photon setup` — it resumes where it left off.",
+                    )
         # Allowlist the operator and make their DM the cron home channel —
         # otherwise the gateway denies their own inbound messages
         # ("Unauthorized user") and has no default space for cron delivery.
@@ -390,7 +441,36 @@ def _cmd_status(_args: argparse.Namespace) -> int:
     print(f"  node binary         : {node_bin or '✗ missing (install Node 18+)'}")
     print(f"  sidecar deps        : {'✓ installed' if sidecar_installed else '✗ run `hermes photon install-sidecar`'}")
     print(f"  telemetry           : {'on' if _telemetry_enabled() else 'off'} (`hermes photon telemetry on|off`)")
+    _print_routing_status()
     return 0
+
+
+def _print_routing_status() -> None:
+    """Live opt-in check: a registered number that never texted its assigned
+    line looks configured everywhere but never routes (Target not allowed).
+    Verify against the API instead of trusting local markers when possible.
+    (Ported from qwibitai/nanoclaw#3181.)"""
+    phone, assigned = photon_auth.load_user_numbers()
+    if not phone:
+        return
+    spectrum_id, project_secret = photon_auth.load_project_credentials()
+    if not spectrum_id or not project_secret:
+        return
+    try:
+        user = photon_auth.find_routable_user(
+            photon_auth.list_users(spectrum_id, project_secret), phone,
+        )
+    except Exception as e:
+        print(f"  routing             : ? could not verify ({e})")
+        return
+    if photon_auth.user_opted_in(user):
+        print("  routing             : ✓ opted in (verified live)")
+    else:
+        line = photon_auth.user_assigned_line(user) or assigned or "your assigned line"
+        print(
+            f"  routing             : ✗ not opted in — text {line} once from "
+            f"{phone}, then re-check"
+        )
 
 
 def _refresh_status_numbers() -> None:

--- a/tests/plugins/platforms/photon/test_auth.py
+++ b/tests/plugins/platforms/photon/test_auth.py
@@ -314,6 +314,119 @@ def test_user_assigned_line() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Opt-in routing (ported from qwibitai/nanoclaw#3181)
+
+def test_user_opted_in() -> None:
+    assert photon_auth.user_opted_in({"meta": {"opt_in": True}}) is True
+    # A row without the flag never routes, however it was created.
+    assert photon_auth.user_opted_in({"meta": {}}) is False
+    assert photon_auth.user_opted_in({"meta": None}) is False
+    assert photon_auth.user_opted_in({}) is False
+    assert photon_auth.user_opted_in(None) is False
+
+
+def test_find_routable_user_prefers_opted_in_duplicate() -> None:
+    users = [
+        {"id": "stale", "phoneNumber": "+15551234567", "meta": {}},
+        {"id": "live", "phoneNumber": "+1 (555) 123-4567", "meta": {"opt_in": True}},
+        {"id": "other", "phoneNumber": "+15559999999", "meta": {"opt_in": True}},
+    ]
+    row = photon_auth.find_routable_user(users, "+15551234567")
+    assert row is not None and row["id"] == "live"
+    # No opted-in duplicate → first matching row.
+    row = photon_auth.find_routable_user(users[:1], "+15551234567")
+    assert row is not None and row["id"] == "stale"
+    assert photon_auth.find_routable_user([], "+15551234567") is None
+
+
+def test_wait_for_opted_in_user_polls_until_flag_lands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"n": 0}
+
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        calls["n"] += 1
+        meta = {"opt_in": True} if calls["n"] >= 3 else {}
+        return _FakeResponse(json_body={"succeed": True, "data": {"users": [{
+            "id": "u1", "phoneNumber": "+15551234567",
+            "assignedPhoneNumber": "+16282679185", "meta": meta,
+        }]}})
+
+    monkeypatch.setattr(photon_auth.httpx, "get", fake_get)
+    waits: list = []
+    user = photon_auth.wait_for_opted_in_user(
+        "proj", "secret", "+15551234567",
+        timeout_s=50, interval_s=5,
+        on_waiting=waits.append, sleep_fn=lambda _s: None,
+    )
+    assert user is not None and photon_auth.user_opted_in(user)
+    assert calls["n"] == 3
+    assert waits == [1, 2]  # progress hook fired for the two missed polls
+
+
+def test_wait_for_opted_in_user_rides_out_transient_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"n": 0}
+
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient")
+        return _FakeResponse(json_body={"succeed": True, "data": {"users": [{
+            "id": "u1", "phoneNumber": "+15551234567", "meta": {"opt_in": True},
+        }]}})
+
+    monkeypatch.setattr(photon_auth.httpx, "get", fake_get)
+    user = photon_auth.wait_for_opted_in_user(
+        "proj", "secret", "+15551234567",
+        timeout_s=20, interval_s=5, sleep_fn=lambda _s: None,
+    )
+    assert user is not None
+
+
+def test_wait_for_opted_in_user_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(json_body={"succeed": True, "data": {"users": [{
+            "id": "u1", "phoneNumber": "+15551234567", "meta": {},
+        }]}})
+
+    monkeypatch.setattr(photon_auth.httpx, "get", fake_get)
+    user = photon_auth.wait_for_opted_in_user(
+        "proj", "secret", "+15551234567",
+        timeout_s=15, interval_s=5, sleep_fn=lambda _s: None,
+    )
+    assert user is None
+
+
+def test_register_user_if_absent_reuses_opted_in_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second create would hand out a fresh row and drop a landed opt-in —
+    the reuse path must pick the OPTED-IN duplicate, not list order."""
+    posted = {"n": 0}
+
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(json_body={"succeed": True, "data": {"users": [
+            {"id": "stale", "phoneNumber": "+15551234567", "meta": {}},
+            {"id": "live", "phoneNumber": "+15551234567", "meta": {"opt_in": True}},
+        ]}})
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        posted["n"] += 1
+        return _FakeResponse(json_body={"success": True, "user": {}})
+
+    monkeypatch.setattr(photon_auth.httpx, "get", fake_get)
+    monkeypatch.setattr(photon_auth.httpx, "post", fake_post)
+    user, created = photon_auth.register_user_if_absent(
+        "proj", "secret", phone_number="+15551234567",
+    )
+    assert created is False
+    assert user["id"] == "live"
+    assert posted["n"] == 0
+
+
+# ---------------------------------------------------------------------------
 # Lines (assigned number)
 
 def test_get_imessage_line_returns_existing(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
`hermes photon setup` no longer reports success for a number that cannot actually receive messages: the wizard now surfaces the real iMessage opt-in step (text the assigned line once) and waits for it to land.

Ported from qwibitai/nanoclaw#3181 ("opt in via first message to the assigned line"). Photon's Spectrum delivery plane only routes numbers whose user row carries `meta.opt_in`, and that flag is set server-side when the human sends one message from their phone to the row's `assignedPhoneNumber`. A registered row without it looks configured everywhere but outbound fails with `Target not allowed for this project` — a symptom we already document in the adapter but never prevented at setup time. Client-supplied meta is ignored on create, so the API cannot produce the flag.

## Changes
- `plugins/platforms/photon/auth.py`:
  - `user_opted_in()` — the routing predicate (`meta.opt_in`).
  - `find_routable_user()` — duplicate arbitration: an opted-in row wins over list order.
  - `wait_for_opted_in_user()` — poll until the flag lands; transient list failures count as missed polls; attempt-count timeout so tests with an instant `sleep_fn` stay deterministic.
  - `register_user_if_absent()` now reuses the ROUTABLE duplicate, so a re-run never drops an opt-in that already landed.
- `plugins/platforms/photon/cli.py`:
  - Setup step [4/5] prints the exact line to text, waits up to 5 minutes for the opt-in (Ctrl-C skips; non-TTY runs skip the wait and defer to `status`), and names the line in the not-opted-in warning.
  - `hermes photon status` gains a live `routing` row: `✓ opted in (verified live)` / `✗ not opted in — text <line> once from <phone>` — verified against the API instead of trusting local markers.

## Architectural notes vs the source PR
NanoClaw's wizard is a standalone TypeScript script; here the logic lives in the existing plugin `auth.py`/`cli.py` split (API helpers in auth, UX in cli), matching how the rest of Photon onboarding is structured. The non-interactive skip has no NanoClaw equivalent (their wizard is always interactive) — added so scripted setup and the gateway-setup wizard path can't hang on a poll nobody can answer.

## Validation
| | Result |
|---|---|
| `tests/plugins/platforms/photon/test_auth.py` | 25 passed (6 new) |
| `tests/plugins/platforms/photon/` full suite | 135 passed |

## Infographic

![Opt in by texting your agent](https://v3b.fal.media/files/b/0aa5b663/BrlqcQ-5mbOWFXlgCO7_t_4YLOeAy3.png)
