### PR TITLE
fix(desktop): catch zoom drift with no observable trigger

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5610,6 +5610,7 @@ function installPreviewShortcut(window) {
 import {
   applyZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  installZoomDriftReassert,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
   ZOOM_STEP,
@@ -8785,6 +8786,9 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     // recovery and any in-place reload/navigation (#46429).
     installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
     win.webContents.on('did-finish-load', () => restorePersistedZoomLevel(win))
+    // Catches resets with no window/screen event at all, e.g. another
+    // Electron app's launch/quit silently re-normalizing our zoom (#82713).
+    installZoomDriftReassert(win, () => readZoomState(), () => restorePersistedZoomLevel(win))
   }
 
   installContextMenu(win)

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -12,8 +12,10 @@ import {
   applyZoomLevel,
   clampZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  installZoomDriftReassert,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
+  ZOOM_DRIFT_POLL_INTERVAL_MS,
   ZOOM_RESIZE_REASSERT_DELAY_MS,
   ZOOM_STEP,
   ZOOM_STORAGE_KEY,
@@ -160,6 +162,115 @@ test('installZoomReassertOnWindowEvents skips destroyed windows', () => {
   destroyed = true
   handlers.get('show')()
   assert.equal(calls, 0)
+})
+
+test('installZoomDriftReassert reasserts when the live zoom level drifts from the persisted one', () => {
+  vi.useFakeTimers()
+
+  try {
+    const handlers = new Map()
+    let zoomLevel = 0.5
+
+    const win = {
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        getZoomLevel: () => zoomLevel
+      },
+      on(event, listener) {
+        handlers.set(event, listener)
+      }
+    }
+
+    let calls = 0
+    installZoomDriftReassert(
+      win,
+      () => 0.5,
+      () => {
+        calls += 1
+      }
+    )
+
+    vi.advanceTimersByTime(ZOOM_DRIFT_POLL_INTERVAL_MS)
+    assert.equal(calls, 0, 'in-sync zoom must not trigger a reassert')
+
+    // Simulates the invisible reset (#82713): the runtime zoom moved but no
+    // window/screen event fired, so nothing else would ever notice.
+    zoomLevel = 0
+    vi.advanceTimersByTime(ZOOM_DRIFT_POLL_INTERVAL_MS)
+    assert.equal(calls, 1)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('installZoomDriftReassert skips when there is no persisted level yet or the window is destroyed', () => {
+  vi.useFakeTimers()
+
+  try {
+    let destroyed = false
+
+    const win = {
+      isDestroyed: () => destroyed,
+      webContents: {
+        isDestroyed: () => false,
+        getZoomLevel: () => 0
+      },
+      on() {}
+    }
+
+    let calls = 0
+    installZoomDriftReassert(
+      win,
+      () => null,
+      () => {
+        calls += 1
+      }
+    )
+
+    vi.advanceTimersByTime(ZOOM_DRIFT_POLL_INTERVAL_MS)
+    assert.equal(calls, 0)
+
+    destroyed = true
+    vi.advanceTimersByTime(ZOOM_DRIFT_POLL_INTERVAL_MS)
+    assert.equal(calls, 0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('installZoomDriftReassert clears its timer on window close', () => {
+  vi.useFakeTimers()
+
+  try {
+    const handlers = new Map()
+
+    const win = {
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        getZoomLevel: () => 9
+      },
+      on(event, listener) {
+        handlers.set(event, listener)
+      }
+    }
+
+    let calls = 0
+    installZoomDriftReassert(
+      win,
+      () => 0,
+      () => {
+        calls += 1
+      }
+    )
+
+    handlers.get('closed')()
+    vi.advanceTimersByTime(ZOOM_DRIFT_POLL_INTERVAL_MS * 3)
+    assert.equal(calls, 0)
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 // Zoom-wiring contract: chat windows keep global UI zoom while fixed-size

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -97,6 +97,43 @@ export function installZoomReassertOnWindowEvents(win, reassert, platform = proc
   }
 }
 
+// Some zoom resets never touch a BrowserWindow or screen event at all — e.g.
+// macOS silently re-normalizing every Electron app's rendering layer when a
+// second Electron app (observed with Antigravity) launches or quits produces
+// no window bounds change and no display-metrics-changed, so neither
+// installZoomReassertOnWindowEvents nor a screen listener ever fires (#82713).
+// A low-frequency drift check is the only thing that catches resets with zero
+// observable trigger: compare the live zoom level against the persisted one
+// and reassert on mismatch.
+export const ZOOM_DRIFT_POLL_INTERVAL_MS = 4000
+const ZOOM_DRIFT_EPSILON = 0.01
+
+export function installZoomDriftReassert(win, getPersistedLevel, reassert) {
+  if (!win?.on) {
+    return undefined
+  }
+
+  const timer = setInterval(() => {
+    if (win.isDestroyed?.() || win.webContents?.isDestroyed?.()) {
+      return
+    }
+
+    const persisted = getPersistedLevel()
+
+    if (persisted == null) {
+      return
+    }
+
+    if (Math.abs(win.webContents.getZoomLevel() - clampZoomLevel(persisted)) > ZOOM_DRIFT_EPSILON) {
+      reassert()
+    }
+  }, ZOOM_DRIFT_POLL_INTERVAL_MS)
+
+  win.on('closed', () => clearInterval(timer))
+
+  return timer
+}
+
 /**
  * Zoom-wiring decision per window kind. Chat windows (main + session + the HUD)
  * keep global UI zoom; the pet overlay and the Quick Entry composer opt out


### PR DESCRIPTION
## What does this PR do?

Adds a low-frequency fallback that catches Electron zoom resets which fire **no observable event at all** — the specific gap described in #82713. `installZoomReassertOnWindowEvents` (window `show`/`restore`/`resized`/`moved`) and a `screen`-level `display-metrics-changed` listener both require *something* to fire; the reporter's own 250ms `CGWindowListCopyWindowInfo` + `CGDisplayCopyDisplayMode` poller recorded no window-bounds change and no display-mode change while the drift happened (triggered by launching/quitting Antigravity, another Electron app, on macOS). The re-normalization happens below the layer either mechanism can see, so neither ever runs and the runtime zoom silently diverges from the persisted 90% while every persisted layer (JSON state file, Chromium `Preferences`, the Settings UI) still reports 90%.

`installZoomDriftReassert` polls `webContents.getZoomLevel()` every 4s against the persisted level and calls the existing `restorePersistedZoomLevel` reassert path on mismatch — the same funnel every other zoom path already uses, so the Settings UI stays in sync via the existing `hermes:zoom:changed` event. This closes the whole class of undetectable resets, not just the Antigravity trigger, per the issue's own suggested fix #2.

## Related Issue

Fixes #82713

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/zoom.ts`: add `installZoomDriftReassert(win, getPersistedLevel, reassert)` + `ZOOM_DRIFT_POLL_INTERVAL_MS` (4000ms). Guards on destroyed window/webContents, no-ops when there's no persisted value yet, clears its timer on `win`'s `closed` event.
- `apps/desktop/electron/main.ts`: wire it into `wireCommonWindowHandlers` alongside the existing window-event reassert, passing `readZoomState()` as the persisted-level source and `restorePersistedZoomLevel(win)` as the reassert action (the same pair already used by `installZoomReassertOnWindowEvents`).
- `apps/desktop/electron/zoom.test.ts`: 3 new tests — reasserts on drift, no-op when in sync / no persisted value / destroyed, and timer cleanup on `closed`.

## How to Test

1. `npm ci` at the repo root (workspace deps install there).
2. `cd apps/desktop && npx vitest run electron/zoom.test.ts` — 20/20 pass.
3. Confirm the new tests actually catch the regression: `git checkout HEAD~1 -- apps/desktop/electron/zoom.ts` (reverts only the fix, keeps the new test file) → the 3 new tests fail with `TypeError: installZoomDriftReassert is not a function`. `git checkout HEAD -- apps/desktop/electron/zoom.ts` restores the fix → all 20 pass again.
4. `npx eslint electron/zoom.ts electron/zoom.test.ts electron/main.ts` — clean.
5. `npx tsc -p tsconfig.electron.json --noEmit` — clean.
6. `npx vitest run --project electron` — 1004 passed, 2 skipped (pre-existing skips, unrelated).

### Test output (step 2, with the fix in place)

```
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

### Test output (step 3, fix reverted)

```
 FAIL  apps/desktop/electron/zoom.test.ts > installZoomDriftReassert reasserts when the live zoom level drifts from the persisted one
TypeError: installZoomDriftReassert is not a function
 FAIL  apps/desktop/electron/zoom.test.ts > installZoomDriftReassert skips when there is no persisted level yet or the window is destroyed
TypeError: installZoomDriftReassert is not a function
 FAIL  apps/desktop/electron/zoom.test.ts > installZoomDriftReassert clears its timer on window close
TypeError: installZoomDriftReassert is not a function

 Test Files  1 failed (1)
      Tests  3 failed | 17 passed (20)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the related open PRs (#75305, #75495, #76214, #50873, #67745, #76908) all add reassert triggers to specific window/screen *events*; none polls for drift with no event at all, which is the exact gap this issue reports.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (unit tests only — this path is cross-platform Electron code with no OS-specific branching, so it isn't gated to macOS)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool-schema changes

## Disclosure

This PR was written with AI assistance (Claude).

## Screenshots / Logs

N/A — behavioral fix in main-process zoom handling, no visual change.
