### PR TITLE
fix(skills-guard): exclude __PLACEHOLDER__ tokens from hardcoded_secret regex

### DIFF
--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -469,7 +469,7 @@ THREAT_PATTERNS = [
      "references other agent configuration files"),
 
     # ── Hardcoded secrets (credentials embedded in the skill itself) ──
-    (r'(?:api[_-]?key|token|secret|password)\s*[=:]\s*["\'][A-Za-z0-9+/=_-]{20,}',
+    (r'(?:api[_-]?key|token|secret|password)\s*[=:]\s*["\'](?!__[A-Za-z0-9+/=_-]+__)[A-Za-z0-9+/=_-]{20,}',
      "hardcoded_secret", "critical", "credential_exposure",
      "possible hardcoded API key, token, or secret"),
     (r'-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----',


### PR DESCRIPTION
## Summary

The `hardcoded_secret` rule in `tools/skills_guard.py` matches template placeholder tokens of the form `__SOME_NAME__` as real credentials, blocking skill install even with `--force`.

The character class `[A-Za-z0-9+/=_-]{20,}` matches double-underscore placeholders (27+ chars, all in the class). Any skill that documents a placeholder assignment gets flagged as `CRITICAL credential_exposure`.

## Fix

Added a negative lookahead `(?!__[A-Za-z0-9+/=_-]+__)` before the character class to skip values wrapped in `__...__`.

Real keys (e.g. `sk-...`, `ghp_...`, arbitrary 20+ char values) still match; only `__...__` placeholders are excluded.

## Changes

- `tools/skills_guard.py:472` — added negative lookahead to `hardcoded_secret` regex

## Test Plan

- [x] Syntax check passes (`ast.parse`)
- [x] Regex test: `__PLACEHOLDER__` values not matched, real keys still matched
- [x] `tests/tools/test_skills_guard.py` — 31/31 passed
- [x] `tests/tools/test_memory_tool.py::test_exfiltration_and_secrets_blocked` — passed
- [x] `tests/skills/test_openclaw_migration.py::test_skill_installs_cleanly_under_skills_guard` — passed

Fixes #82798