### PR TITLE
fix: stamp timestamp at message append, not at persist

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -35,6 +35,7 @@ from agent.turn_context import substitute_api_content
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
 from agent.message_content import flatten_message_text
+from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -1689,12 +1690,12 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # a DB-side pad can't survive ``_rows_to_conversation``'s whitespace strip
     # anyway.  Repair belongs at the send boundary, once.
 
-    msg = {
+    msg = stamp_message_timestamp({
         "role": "assistant",
         "content": _san_content,
         "reasoning": reasoning_text,
         "finish_reason": finish_reason,
-    }
+    })
 
     raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
     if raw_reasoning_content is None and hasattr(assistant_message, "model_extra"):
@@ -2343,7 +2344,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
 
     summary_request = MAX_ITERATIONS_SUMMARY_REQUEST
-    messages.append({"role": "user", "content": summary_request})
+    append_message(messages, {"role": "user", "content": summary_request})
 
     try:
         # Build API messages, stripping internal-only fields
@@ -2566,7 +2567,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
             if final_response:
                 summary_call_outcome = "success"
-                messages.append({"role": "assistant", "content": final_response})
+                append_message(
+                    messages,
+                    {"role": "assistant", "content": final_response},
+                )
             else:
                 final_response = "I reached the iteration limit and couldn't generate a summary."
         else:
@@ -2628,7 +2632,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
                 if final_response:
                     summary_call_outcome = "success"
-                    messages.append({"role": "assistant", "content": final_response})
+                    append_message(
+                        messages,
+                        {"role": "assistant", "content": final_response},
+                    )
                 else:
                     final_response = "I reached the iteration limit and couldn't generate a summary."
             else:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -765,7 +765,10 @@ def run_codex_app_server_turn(
     # standard {role, content, tool_calls, tool_call_id} entries, which
     # is exactly what curator.py / sessions DB expect.
     if turn.projected_messages:
-        messages.extend(turn.projected_messages)
+        from agent.message_metadata import append_message
+
+        for projected_message in turn.projected_messages:
+            append_message(messages, projected_message)
 
         # Persist the newly-projected assistant/tool messages ourselves.
         # This path is an early return that bypasses conversation_loop, whose

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2074,10 +2074,15 @@ def _ensure_compressed_has_user_turn(original_messages: list, compressed: list) 
                 _fresh_compaction_message_copy(message),
             )
             return
-    compressed.append({
-        "role": "user",
-        "content": COMPRESSION_CONTINUATION_USER_CONTENT,
-    })
+    from agent.message_metadata import append_message
+
+    append_message(
+        compressed,
+        {
+            "role": "user",
+            "content": COMPRESSION_CONTINUATION_USER_CONTENT,
+        },
+    )
 
 
 _PENDING_CONTEXT_ENGINE_NOTIFICATION = (

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -38,6 +38,7 @@ from agent.conversation_compression import (
 from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
+from agent.message_metadata import append_message
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
     build_turn_context,
@@ -131,7 +132,7 @@ def _restore_user_after_reference_handoff(
         and messages[-1].get("content") == content
     ):
         return False
-    messages.append({"role": "user", "content": content})
+    append_message(messages, {"role": "user", "content": content})
     return True
 
 
@@ -257,8 +258,9 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
     if messages and messages[-1].get("role") == "assistant":
         # Transcript shows the user's own words; the provider replays the
         # scaffolded form so it still sees the interrupted context.
-        messages.append(
-            {"role": "user", "content": text, "api_content": correction}
+        append_message(
+            messages,
+            {"role": "user", "content": text, "api_content": correction},
         )
     else:
         # Placeholder preserves role alternation only. Scaffold bytes must
@@ -271,9 +273,10 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
         }
         if not visible:
             placeholder["display_kind"] = "hidden"
-        messages.append(placeholder)
-        messages.append(
-            {"role": "user", "content": text, "api_content": correction}
+        append_message(messages, placeholder)
+        append_message(
+            messages,
+            {"role": "user", "content": text, "api_content": correction},
         )
 
     agent._current_streamed_assistant_text = ""
@@ -2175,7 +2178,7 @@ def run_conversation(
             final_response = _runtime_context_error
             failed = True
             _turn_exit_reason = "ollama_runtime_context_too_small"
-            messages.append({"role": "assistant", "content": final_response})
+            append_message(messages, {"role": "assistant", "content": final_response})
             agent._emit_status("❌ Ollama runtime context is too small for Hermes tool use")
             api_call_count -= 1
             agent._api_call_count = api_call_count
@@ -3367,7 +3370,7 @@ def run_conversation(
                                 interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
                                 # Marked so the ceiling exit can drop the fragment trail.
                                 interim_msg["_length_continuation_fragment"] = True
-                                messages.append(interim_msg)
+                                append_message(messages, interim_msg)
                                 if assistant_message.content:
                                     truncated_response_parts.append(assistant_message.content)
 
@@ -3407,7 +3410,7 @@ def run_conversation(
                                     "content": _continue_content,
                                     "_length_continuation_nudge": True,
                                 }
-                                messages.append(continue_msg)
+                                append_message(messages, continue_msg)
                                 agent._session_messages = messages
                                 _retry.restart_with_length_continuation = True
                                 break
@@ -3438,7 +3441,7 @@ def run_conversation(
                                 )
                             ]
                             if partial_response:
-                                messages.append({
+                                append_message(messages, {
                                     "role": "assistant",
                                     "content": partial_response,
                                     "finish_reason": "length",
@@ -3842,7 +3845,7 @@ def run_conversation(
                     getattr(agent, "_current_streamed_assistant_text", "") or ""
                 ).strip()
                 if _partial:
-                    messages.append({"role": "assistant", "content": _partial})
+                    append_message(messages, {"role": "assistant", "content": _partial})
                     final_response = _partial
                 else:
                     final_response = f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}{api_elapsed:.1f}s elapsed)."
@@ -6275,7 +6278,7 @@ def run_conversation(
                                 else:
                                     last_msg[_key] = interim_msg[_key]
                     else:
-                        messages.append(interim_msg)
+                        append_message(messages, interim_msg)
                         agent._emit_interim_assistant_message(interim_msg)
 
                 if agent._codex_incomplete_retries < 3:
@@ -6313,7 +6316,7 @@ def run_conversation(
                             and _last_msg.get("role") == "assistant"
                         )
                         if not _already_nudged and _last_is_assistant:
-                            messages.append({
+                            append_message(messages, {
                                 "role": "user",
                                 "content": _CODEX_INCOMPLETE_NUDGE,
                             })
@@ -6433,7 +6436,7 @@ def run_conversation(
                         }
 
                     assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                    messages.append(assistant_msg)
+                    append_message(messages, assistant_msg)
                     for tc in assistant_message.tool_calls:
                         _tc_name = tc.function.name
                         if _tc_name not in agent.valid_tool_names:
@@ -6444,7 +6447,7 @@ def run_conversation(
                             )
                         else:
                             content = "Skipped: another tool call in this turn used an invalid name. Please retry this tool call."
-                        messages.append({
+                        append_message(messages, {
                             "role": "tool",
                             "name": tc.function.name,
                             "tool_call_id": tc.id,
@@ -6534,7 +6537,7 @@ def run_conversation(
                         
                         # Append the assistant message with its (broken) tool_calls
                         recovery_assistant = agent._build_assistant_message(assistant_message, finish_reason)
-                        messages.append(recovery_assistant)
+                        append_message(messages, recovery_assistant)
                         
                         # Respond with tool error results for each tool call
                         invalid_names = {name for name, _ in invalid_json_args}
@@ -6548,7 +6551,7 @@ def run_conversation(
                                 )
                             else:
                                 tool_result = "Skipped: other tool call in this response had invalid JSON."
-                            messages.append({
+                            append_message(messages, {
                                 "role": "tool",
                                 "name": tc.function.name,
                                 "tool_call_id": tc.id,
@@ -6687,7 +6690,7 @@ def run_conversation(
                     and previous_msg.get("finish_reason") == "incomplete"
                     and previous_interim_visible == current_interim_visible
                 )
-                messages.append(assistant_msg)
+                append_message(messages, assistant_msg)
 
                 # Mixed batch: error-result the invalid calls and strip them
                 # from the execution set. The assistant message above keeps
@@ -6696,7 +6699,7 @@ def run_conversation(
                 # provider-side tool_call/result pairing stays intact.
                 if _invalid_batch_calls:
                     for tc in _invalid_batch_calls:
-                        messages.append({
+                        append_message(messages, {
                             "role": "tool",
                             "name": tc.function.name,
                             "tool_call_id": tc.id,
@@ -6781,7 +6784,7 @@ def run_conversation(
                     agent._emit_status(
                         f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
                     )
-                    messages.append({"role": "assistant", "content": final_response})
+                    append_message(messages, {"role": "assistant", "content": final_response})
                     # Emit the halt message to the client so it's not
                     # indistinguishable from a crash.  The stream display
                     # was flushed (callback(None)) before tool execution,
@@ -7108,8 +7111,8 @@ def run_conversation(
                         _nudge_msg = agent._build_assistant_message(assistant_message, finish_reason)
                         _nudge_msg["content"] = "(empty)"
                         _nudge_msg["_empty_recovery_synthetic"] = True
-                        messages.append(_nudge_msg)
-                        messages.append({
+                        append_message(messages, _nudge_msg)
+                        append_message(messages, {
                             "role": "user",
                             "content": _EMPTY_TOOL_RESPONSE_NUDGE,
                             "_empty_recovery_synthetic": True,
@@ -7146,7 +7149,7 @@ def run_conversation(
                             assistant_message, "incomplete"
                         )
                         interim_msg["_thinking_prefill"] = True
-                        messages.append(interim_msg)
+                        append_message(messages, interim_msg)
                         agent._session_messages = messages
                         continue
 
@@ -7260,7 +7263,7 @@ def run_conversation(
                     # were a meaningful model response, which can keep long
                     # tool-heavy sessions stuck in empty-response loops.
                     assistant_msg["_empty_terminal_sentinel"] = True
-                    messages.append(assistant_msg)
+                    append_message(messages, assistant_msg)
 
                     if reasoning_text:
                         reasoning_preview = reasoning_text[:500] + "..." if len(reasoning_text) > 500 else reasoning_text
@@ -7339,14 +7342,14 @@ def run_conversation(
                 ):
                     codex_ack_continuations += 1
                     interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
-                    messages.append(interim_msg)
+                    append_message(messages, interim_msg)
                     agent._emit_interim_assistant_message(interim_msg)
 
                     continue_msg = {
                         "role": "user",
                         "content": _CODEX_ACK_CONTINUATION_NUDGE,
                     }
-                    messages.append(continue_msg)
+                    append_message(messages, continue_msg)
                     agent._session_messages = messages
                     # An acknowledgment is explicitly non-final. Do not let its
                     # text suppress iteration-limit summarization if this
@@ -7409,8 +7412,8 @@ def run_conversation(
                     # buried mid-list in live memory but is skipped by the
                     # flush regardless of position.
                     final_msg["_dropped_toolcall_nudge"] = True
-                    messages.append(final_msg)
-                    messages.append({
+                    append_message(messages, final_msg)
+                    append_message(messages, {
                         "role": "user",
                         "content": _DROPPED_TOOLCALL_NUDGE_CONTENT,
                         "_dropped_toolcall_nudge": True,
@@ -7470,12 +7473,12 @@ def run_conversation(
                     # Only the nudge is flagged synthetic so it gets stripped
                     # from the durable transcript (#65919 §7).
                     agent._emit_interim_assistant_message(final_msg)
-                    messages.append(final_msg)
+                    append_message(messages, final_msg)
                     try:
                         agent._flush_messages_to_session_db(messages, conversation_history)
                     except Exception:
                         logger.debug("verify-on-stop interim flush failed", exc_info=True)
-                    messages.append({
+                    append_message(messages, {
                         "role": "user",
                         "content": _verify_nudge,
                         "_verification_stop_synthetic": True,
@@ -7542,12 +7545,12 @@ def run_conversation(
                     # Only the nudge is flagged synthetic so it gets stripped
                     # from the durable transcript (#65919 §7).
                     agent._emit_interim_assistant_message(final_msg)
-                    messages.append(final_msg)
+                    append_message(messages, final_msg)
                     try:
                         agent._flush_messages_to_session_db(messages, conversation_history)
                     except Exception:
                         logger.debug("pre_verify interim flush failed", exc_info=True)
-                    messages.append({
+                    append_message(messages, {
                         "role": "user",
                         "content": _verify_nudge2,
                         "_pre_verify_synthetic": True,
@@ -7585,8 +7588,8 @@ def run_conversation(
                     )
                     final_msg["finish_reason"] = "kanban_terminal_required"
                     final_msg["_kanban_stop_synthetic"] = True
-                    messages.append(final_msg)
-                    messages.append({
+                    append_message(messages, final_msg)
+                    append_message(messages, {
                         "role": "user",
                         "content": _kanban_nudge,
                         "_kanban_stop_synthetic": True,
@@ -7612,7 +7615,7 @@ def run_conversation(
                     final_response = None
                     continue
 
-                messages.append(final_msg)
+                append_message(messages, final_msg)
                 # Make the completed answer durable before leaving the loop —
                 # a session torn down before finalize_turn's _persist_session
                 # otherwise loses a reply the user already saw (#81641). Same
@@ -7704,7 +7707,7 @@ def run_conversation(
                                 "tool_call_id": tc["id"],
                                 "content": f"Error executing tool: {error_msg}",
                             }
-                            messages.append(err_msg)
+                            append_message(messages, err_msg)
                 break
             
             # Non-tool errors don't need a synthetic message injected.
@@ -7728,7 +7731,7 @@ def run_conversation(
                     final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 # Append as assistant so the history stays valid for
                 # session resume (avoids consecutive user messages).
-                messages.append({"role": "assistant", "content": final_response})
+                append_message(messages, {"role": "assistant", "content": final_response})
                 break
     
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn

--- a/agent/message_metadata.py
+++ b/agent/message_metadata.py
@@ -1,0 +1,41 @@
+"""Internal metadata attached to durable conversation messages."""
+
+from __future__ import annotations
+
+from time import time as wall_time
+from typing import Any, MutableMapping, Optional, TypeVar
+
+
+# These fields describe Hermes' durable record, not provider-visible message
+# content. They must not influence context-pressure decisions.
+PERSISTENCE_ONLY_MESSAGE_FIELDS = frozenset({"timestamp"})
+
+_Message = TypeVar("_Message", bound=MutableMapping[str, Any])
+
+
+def stamp_message_timestamp(
+    message: _Message,
+    *,
+    timestamp: Optional[float] = None,
+) -> _Message:
+    """Attach a creation timestamp without replacing source-provided time.
+
+    Gateway adapters can supply the platform event time. All other callers use
+    the local wall clock at the point the message enters the live transcript.
+    Returning the same mapping keeps the helper convenient at append sites.
+    """
+    if message.get("timestamp") is None:
+        message["timestamp"] = wall_time() if timestamp is None else timestamp
+    return message
+
+
+def append_message(
+    messages: list[Any],
+    message: _Message,
+    *,
+    timestamp: Optional[float] = None,
+) -> _Message:
+    """Stamp and append one live transcript message."""
+    stamp_message_timestamp(message, timestamp=timestamp)
+    messages.append(message)
+    return message

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -318,7 +318,9 @@ def close_interrupted_tool_sequence(messages: list, final_response: Any = None) 
     if not isinstance(last, dict) or last.get("role") != "tool":
         return False
     text = final_response if isinstance(final_response, str) else ""
-    messages.append({
+    from agent.message_metadata import append_message
+
+    append_message(messages, {
         "role": "assistant",
         "content": text.strip() or "Operation interrupted.",
     })

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover — runtime import is lazy (see below)
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname
 
 from hermes_constants import OPENROUTER_MODELS_URL
+from agent.message_metadata import PERSISTENCE_ONLY_MESSAGE_FIELDS
 
 logger = logging.getLogger(__name__)
 
@@ -3212,7 +3213,7 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
     )
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
-        if k in ("_anthropic_content_blocks", "reasoning_details"):
+        if k in ("_anthropic_content_blocks", "reasoning_details") or k in PERSISTENCE_ONLY_MESSAGE_FIELDS:
             continue
         if k == "api_content":
             # Always popped before the request is built; only counted when it

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -32,6 +32,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from agent.message_metadata import stamp_message_timestamp
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
 )
@@ -557,13 +558,13 @@ def make_tool_result_message(
     callers should compare by value, not by ``is``.
     """
     wrapped = _maybe_wrap_untrusted(name, content)
-    message = {
+    message = stamp_message_timestamp({
         "role": "tool",
         "name": name,
         "tool_name": name,
         "content": wrapped,
         "tool_call_id": tool_call_id,
-    }
+    })
     try:
         risk_metadata = _tool_output_risk_metadata(name, content)
     except Exception as exc:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -42,6 +42,7 @@ from agent.context_engine import automatic_compaction_status_message
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.memory_provider import is_trivial_prompt
+from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
@@ -625,9 +626,15 @@ def build_turn_context(
         # the same dict and any close-path durable marker.
         user_msg["content"] = user_message
     else:
-        user_msg = {"role": "user", "content": user_message}
+        user_msg = stamp_message_timestamp(
+            {"role": "user", "content": user_message},
+            timestamp=persist_user_timestamp,
+        )
         if isinstance(pending_cli_message, dict):
             agent._pending_cli_user_message = None
+    # CLI input is stamped when staged. Gateway input may carry the platform
+    # event time. Preserve either value and cover any legacy unstamped handoff.
+    stamp_message_timestamp(user_msg, timestamp=persist_user_timestamp)
 
     # Hydrate todo store from conversation history.
     if conversation_history and not agent._todo_store.has_items():
@@ -659,7 +666,7 @@ def build_turn_context(
         if persist_user_display_metadata:
             user_msg["display_metadata"] = persist_user_display_metadata
 
-    messages.append(user_msg)
+    append_message(messages, user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -26,6 +26,7 @@ import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.message_content import flatten_message_text
+from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import _sanitize_surrogates
 
 
@@ -315,7 +316,10 @@ def finalize_turn(
             if _tail_role != "assistant":
                 # Tail is not an assistant row — append the final response
                 # so the durable turn closes with the answer (#43849/#44100).
-                messages.append({"role": "assistant", "content": final_response})
+                append_message(
+                    messages,
+                    {"role": "assistant", "content": final_response},
+                )
             elif isinstance(_tail, dict) and _tail.get("content") != final_response and _is_pure_tool_call_tail(_tail):
                 # The tail IS an assistant row, but a *pure tool-call turn*:
                 # tool_calls with no text of its own. The role check alone
@@ -332,6 +336,10 @@ def finalize_turn(
                 # candidate collapse — the provisional answer was persisted and
                 # reused as the terminal response, #65919 §7).
                 _tail["content"] = final_response
+                # The normal assistant builder already stamps this row. Cover
+                # legacy/exceptional pure-tool tails before they become a
+                # delivered final response.
+                stamp_message_timestamp(_tail)
                 # The row may have already been flushed to SQLite by the
                 # incremental tool-call persist (conversation_loop.py:4990),
                 # which stamps ``_DB_PERSISTED_MARKER`` so subsequent flushes

--- a/cli.py
+++ b/cli.py
@@ -14029,7 +14029,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             agent._persist_user_message_idx = None
             agent._persist_user_message_override = None
             agent._persist_user_message_timestamp = None
-            staged_user_message = {"role": "user", "content": message}
+            from agent.message_metadata import stamp_message_timestamp
+
+            staged_user_message = stamp_message_timestamp(
+                {"role": "user", "content": message}
+            )
             agent._pending_cli_user_message = staged_user_message
             self.conversation_history.append(staged_user_message)
 

--- a/tests/agent/test_close_interrupted_tool_sequence.py
+++ b/tests/agent/test_close_interrupted_tool_sequence.py
@@ -46,6 +46,7 @@ def test_closing_makes_next_user_message_alternation_safe():
     produce the ``tool → user`` shape strict providers choke on."""
     messages = _tool_tail()
     close_interrupted_tool_sequence(messages, None)
+    assert isinstance(messages[-1]["timestamp"], float)
     follow_on = messages + [{"role": "user", "content": "they do! increase the timing"}]
     _assert_no_tool_then_user(follow_on)
 
@@ -64,5 +65,4 @@ def test_user_tail_is_left_untouched():
     messages = [{"role": "user", "content": "hi"}]
     assert close_interrupted_tool_sequence(messages, None) is False
     assert len(messages) == 1
-
 

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -72,6 +72,7 @@ def test_codex_success_flushes_and_reports_persisted():
         effective_task_id="task-1",
     )
     assert result["completed"] is True
+    assert isinstance(result["messages"][-1]["timestamp"], float)
     # With the agent as sole persister, the gateway must SKIP its DB write.
     assert result["agent_persisted"] is True
 
@@ -152,6 +153,10 @@ def test_codex_turn_persists_each_message_exactly_once():
         # Exactly one user turn, exactly one assistant turn — no duplicates.
         assert contents.count("USER_TURN") == 1, contents
         assert contents.count("CODEX_ASSISTANT") == 1, contents
+        assistant_row = next(
+            row for row in rows if row["content"] == "CODEX_ASSISTANT"
+        )
+        assert isinstance(assistant_row["timestamp"], float)
         # session_search can now see the codex conversation.
         hits = {r["session_id"] for r in db.search_messages("CODEX_ASSISTANT")}
         assert sid in hits

--- a/tests/agent/test_empty_tool_name_loop_dampening.py
+++ b/tests/agent/test_empty_tool_name_loop_dampening.py
@@ -220,6 +220,12 @@ def test_mixed_batch_preserves_tool_call_result_pairing(agent_env):
     # and each must have exactly one matching tool result.
     assert set(tc_ids) == {"call_0", "call_1"}
     assert sorted(result_ids) == sorted(tc_ids)
+    assert all(
+        isinstance(message.get("timestamp"), float)
+        for message in msgs
+        if isinstance(message, dict)
+        and message.get("role") in {"user", "assistant", "tool"}
+    )
 
 
 
@@ -245,5 +251,4 @@ def test_invalid_tool_exhaustion_closes_tool_tail(agent_env):
     assert msgs, "expected persisted conversation messages"
     assert msgs[-1].get("role") == "assistant"
     assert "invalid tool call" in (msgs[-1].get("content") or "").lower()
-
 

--- a/tests/agent/test_message_metadata.py
+++ b/tests/agent/test_message_metadata.py
@@ -1,0 +1,23 @@
+from agent.message_metadata import append_message, stamp_message_timestamp
+
+
+def test_stamp_preserves_source_timestamp(monkeypatch):
+    monkeypatch.setattr("agent.message_metadata.wall_time", lambda: 999.0)
+    message = {"role": "user", "content": "hello", "timestamp": 123.0}
+
+    result = stamp_message_timestamp(message)
+
+    assert result is message
+    assert message["timestamp"] == 123.0
+
+
+def test_append_stamps_same_mapping_at_append_time(monkeypatch):
+    monkeypatch.setattr("agent.message_metadata.wall_time", lambda: 456.0)
+    messages = []
+    message = {"role": "tool", "content": "ok"}
+
+    result = append_message(messages, message)
+
+    assert result is message
+    assert messages == [message]
+    assert message["timestamp"] == 456.0

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -62,6 +62,24 @@ class TestEstimateMessagesTokensRough:
         assert result > 0
         assert result == (len(str(msg)) + 3) // 4
 
+    def test_persistence_timestamp_does_not_change_estimate(self):
+        """Durability metadata must not create artificial context pressure."""
+        msg = {
+            "role": "assistant",
+            "content": "done",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        }
+        stamped = {**msg, "timestamp": 1_781_976_577.123456}
+
+        assert estimate_messages_tokens_rough([stamped]) == (
+            estimate_messages_tokens_rough([msg])
+        )
+
     def test_message_with_list_content(self):
         """Vision messages with multimodal content arrays.
 

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -135,6 +135,12 @@ class TestUntrustedWrapping:
 
 class TestMakeToolResultMessage:
 
+    def test_message_is_timestamped_when_result_is_created(self, monkeypatch):
+        monkeypatch.setattr("agent.message_metadata.wall_time", lambda: 123.5)
+
+        msg = make_tool_result_message("terminal", "ok", "call_timestamp")
+
+        assert msg["timestamp"] == 123.5
 
     def test_high_risk_message_content_wrapped(self):
         msg = make_tool_result_message("web_extract", SAMPLE_LONG_TEXT, "call_2")

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -203,9 +203,19 @@ def test_returns_turn_context_with_user_message_appended():
     assert isinstance(ctx, TurnContext)
     assert ctx.user_message == "hello"
     # The user turn was appended and indexed.
-    assert ctx.messages[-1] == {"role": "user", "content": "hello"}
+    assert ctx.messages[-1]["role"] == "user"
+    assert ctx.messages[-1]["content"] == "hello"
+    assert isinstance(ctx.messages[-1]["timestamp"], float)
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
     assert ctx.active_system_prompt == "SYSTEM"
+
+
+def test_user_message_preserves_platform_event_timestamp():
+    agent = _FakeAgent()
+
+    ctx = _build(agent, persist_user_timestamp=123.5)
+
+    assert ctx.messages[-1]["timestamp"] == 123.5
 
 
 # ── Trivial-prompt prefetch gate (PR #25350 salvage) ─────────────────────────
@@ -267,7 +277,10 @@ def test_turn_start_replaces_stale_parent_history_with_compression_child():
     assert agent._current_turn_id.startswith("compression-child:")
     log_context.assert_called_once_with("compression-child")
     assert ctx.conversation_history == compacted_history
-    assert ctx.messages == compacted_history + [{"role": "user", "content": "hello"}]
+    assert ctx.messages[:-1] == compacted_history
+    assert ctx.messages[-1]["role"] == "user"
+    assert ctx.messages[-1]["content"] == "hello"
+    assert isinstance(ctx.messages[-1]["timestamp"], float)
     assert all(message.get("content") != "stale parent" for message in ctx.messages)
 
 
@@ -309,6 +322,7 @@ def test_pending_cli_message_uses_clean_override_for_api_local_note():
     assert ctx.messages[-1] is staged
     assert ctx.messages[-1]["content"] == "[MODEL NOTE]\n\nclean prompt"
     assert ctx.messages[-1]["_db_persisted"] is True
+    assert isinstance(ctx.messages[-1]["timestamp"], float)
     assert agent._pending_cli_user_message is None
 
 
@@ -405,4 +419,3 @@ def test_prologue_does_not_title_machine_driven_runs(platform):
     overwritten or never read.
     """
     assert not _title_turn(platform).called
-

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -123,9 +123,57 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
         _turn_exit_reason="fallback_prior_turn_content",
     )
 
-    assert result["messages"][-1] == {"role": "assistant", "content": "Done."}
+    assert result["messages"][-1]["role"] == "assistant"
+    assert result["messages"][-1]["content"] == "Done."
+    assert isinstance(result["messages"][-1]["timestamp"], float)
     assert agent.persisted_messages is not None
-    assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}
+    assert agent.persisted_messages[-1] == result["messages"][-1]
+
+
+def test_fallback_timestamp_survives_delayed_sqlite_persistence(
+    monkeypatch, tmp_path
+):
+    """The durable row records message creation, not the later DB flush."""
+    from hermes_state import SessionDB
+
+    created_at = 1_781_976_577.25
+    persisted_at = created_at + 600
+    monkeypatch.setattr("agent.message_metadata.wall_time", lambda: created_at)
+    monkeypatch.setattr("hermes_state.time.time", lambda: persisted_at)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("sess-test", source="cli")
+    agent = FakeAgent()
+
+    def persist_to_sqlite(messages, _conversation_history):
+        db.replace_messages(agent.session_id, messages)
+        agent.persisted_messages = db.get_messages_as_conversation(agent.session_id)
+
+    agent._persist_session = persist_to_sqlite
+    messages = [
+        {"role": "user", "content": "do it", "timestamp": created_at - 1},
+        {"role": "tool", "content": "ok", "tool_call_id": "call-1"},
+    ]
+
+    finalize_turn(
+        agent,
+        final_response="Done.",
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="do it",
+        original_user_message="do it",
+        _should_review_memory=False,
+        _turn_exit_reason="fallback_prior_turn_content",
+    )
+
+    assert agent.persisted_messages[-1]["timestamp"] == created_at
+    assert agent.persisted_messages[-1]["timestamp"] != persisted_at
 
 
 def test_final_response_fills_pure_tool_call_tail(monkeypatch):

--- a/tests/cli/test_cli_interrupt_ack_race.py
+++ b/tests/cli/test_cli_interrupt_ack_race.py
@@ -411,7 +411,9 @@ def test_chat_clears_previous_turn_persistence_override_before_staging():
     assert agent.staged_override is None
     assert agent._persist_user_message_idx is None
     assert agent._persist_user_message_timestamp is None
-    assert agent.staged_message == {"role": "user", "content": "new prompt"}
+    assert agent.staged_message["role"] == "user"
+    assert agent.staged_message["content"] == "new prompt"
+    assert isinstance(agent.staged_message["timestamp"], float)
 
 
 

--- a/tests/cli/test_focus_view.py
+++ b/tests/cli/test_focus_view.py
@@ -323,10 +323,13 @@ class TestModelFacingMessagesUnchanged:
 
     @pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
     def test_model_facing_messages_identical_with_focus_on_vs_off(self, dispatch_mode):
-        # Focus ON == the existing tool_progress "off" suppression path.
-        focus_on = _run_fake_turn(FOCUS_TOOL_PROGRESS_MODE, dispatch_mode)
-        # Focus OFF == the default noisy display mode.
-        focus_off = _run_fake_turn("all", dispatch_mode)
+        # Creation timestamps are durable metadata, so hold the clock steady
+        # while comparing otherwise identical turns.
+        with patch("agent.message_metadata.wall_time", return_value=1_700_000_000.0):
+            # Focus ON == the existing tool_progress "off" suppression path.
+            focus_on = _run_fake_turn(FOCUS_TOOL_PROGRESS_MODE, dispatch_mode)
+            # Focus OFF == the default noisy display mode.
+            focus_off = _run_fake_turn("all", dispatch_mode)
 
         assert focus_on == focus_off, (
             "focus view altered the model-facing messages — display-only "

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -135,10 +135,12 @@ def test_current_user_turn_is_persisted_before_provider_call(agent):
     assert observed[0][0] == "persist"
     assert observed[1][0] == "provider"
     persisted_messages = observed[0][1]
-    assert persisted_messages[-1] == {
-        "role": "user",
-        "content": "new message that must survive a crash",
-    }
+    assert persisted_messages[-1]["role"] == "user"
+    assert (
+        persisted_messages[-1]["content"]
+        == "new message that must survive a crash"
+    )
+    assert isinstance(persisted_messages[-1]["timestamp"], float)
 
 
 class TestHTTP413Compression:

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -608,6 +608,7 @@ class TestBuildAssistantMessageEmptyContentPad:
             "Builder must store textless turns as-is — wire repair is owned "
             "by repair_empty_non_final_messages at the send boundary."
         )
+        assert isinstance(msg["timestamp"], float)
 
 
     def test_tool_call_turn_content_left_empty(self):
@@ -622,6 +623,7 @@ class TestBuildAssistantMessageEmptyContentPad:
         )
         assert msg["content"] == ""
         assert msg["tool_calls"]
+        assert isinstance(msg["timestamp"], float)
 
     def test_non_empty_content_unchanged(self):
         from agent.chat_completion_helpers import build_assistant_message
@@ -630,6 +632,7 @@ class TestBuildAssistantMessageEmptyContentPad:
         agent = self._agent_for_builder()
         msg = build_assistant_message(agent, _mock_assistant_msg(content="hi"), "stop")
         assert msg["content"] == "hi"
+        assert isinstance(msg["timestamp"], float)
 
 
 class TestSendTimeEmptyAssistantPad:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3495,10 +3495,12 @@ class TestRunConversation:
         # Partial reply is surfaced and persisted as an assistant turn so the
         # next turn remembers what the model said.
         assert result["final_response"] == "Sure, here's how to do it: first"
-        assert result["messages"][-1] == {
-            "role": "assistant",
-            "content": "Sure, here's how to do it: first",
-        }
+        assert result["messages"][-1]["role"] == "assistant"
+        assert (
+            result["messages"][-1]["content"]
+            == "Sure, here's how to do it: first"
+        )
+        assert isinstance(result["messages"][-1]["timestamp"], float)
 
     def test_redirect_during_thinking_retries_same_turn_with_context(self, agent):
         """A corrective follow-up does not end the turn, and displayed reasoning


### PR DESCRIPTION
## Summary

`timestamp` every durable conversation message at creation time (append) instead of at persist time. This makes the session transcript useful to downstream observers such as Attest: persisted timestamps now describe when each message entered the conversation, including messages that are flushed much later.

## Changes

- New `agent/message_metadata.py` module with `stamp_message_timestamp()` and `append_message()` helpers
- `PERSISTENCE_ONLY_MESSAGE_FIELDS` frozenset excludes timestamps from context-pressure estimates
- `build_assistant_message()` stamps timestamps at message construction
- All `messages.append()` calls in core conversation paths converted to `append_message()` across conversation_loop, chat_completion_helpers, turn_context, turn_finalizer, codex_runtime, conversation_compression, message_sanitization, and CLI entry points
- Unit tests for the metadata module

## Rebased on current main (replaces #72086)

Previous PR had merge conflicts after upstream divergence. This is a clean rebase onto current `main` with all changes manually ported.