### PR TITLE
fix(desktop): stop sidebar session titles from shrinking on hover

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -268,4 +268,20 @@ describe('SidebarSessionRow', () => {
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
   })
+
+  // #82807: the age used to fade in `absolute`, spilling left over the title
+  // track instead of living in the actions column, while the title's own
+  // padding only grew `group-hover:*` — so hovering shrank the truncate point
+  // at the same moment the age painted over it. Both must hold at rest, not
+  // just conditionally on hover, so the row's shape (and the title's
+  // truncation point) never changes on hover.
+  it('reserves the age in the actions column at rest instead of overlaying it only on hover', () => {
+    const { container } = renderRow(makeSession({ title: 'A long session title that runs toward the row edge' }))
+
+    const body = container.querySelector<HTMLElement>('[data-slot="row-button"]')
+    const age = screen.getByText('5m')
+
+    expect(body?.className).not.toMatch(/group-hover:pr-/)
+    expect(age.className).not.toMatch(/absolute/)
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -131,10 +131,9 @@ function SidebarSessionRowImpl({
   const pinnedLabel = pinnedFacts.join(' · ')
   // Chips that ride in the BODY, beside the title. The kebab lifts out of the
   // actions slot, so it only ever covers what's in there — a body chip has no
-  // reason to step aside, and the hover-age (which does overlay the body) is
-  // dropped rather than made to fight them.
+  // reason to step aside, and the hover-age (which sits in the actions column)
+  // is dropped rather than made to fight them.
   const bodyChip = Boolean(pr) || pinnedProfile || (showProfile && hasProfileTag)
-  const pinnedMeta = Boolean(pinnedLabel) || bodyChip
   // A handed-off session's live source is local, but it originated on a
   // messaging platform — surface that origin as a small badge so e.g. a
   // Telegram thread continued here still reads as Telegram.
@@ -174,15 +173,16 @@ function SidebarSessionRowImpl({
           <div className="relative z-2 flex items-center justify-end" data-row-actions>
             {/* Pinned metadata stays put through a turn — it was switched on to
                 be read. Only the tail hands its slot to the kebab; anything
-                ahead of it stays legible while you hover. The hover-only age is
-                an overlay instead, so it needs the row to open up 48px of right
-                padding — which beside a body chip reads as a hole. A row that
-                already shows a chip skips it. */}
+                ahead of it stays legible while you hover. The hover-only age
+                sits in normal flow too (opacity fade only, never absolute) so
+                the actions column reserves its width at rest — hovering never
+                shrinks the title's truncate point or paints over its glyphs
+                (#82807). A row that already shows a chip skips it. */}
             {(pinnedLabel || (!liveTurn && !bodyChip)) && (
               <span
                 className={cn(
                   'pointer-events-none whitespace-nowrap text-right text-[0.625rem] leading-none text-(--ui-text-tertiary)',
-                  !pinnedLabel && 'absolute right-6 opacity-0 transition-opacity group-hover:opacity-100'
+                  !pinnedLabel && 'opacity-0 transition-opacity group-hover:opacity-100'
                 )}
               >
                 {pinnedLabel ? (
@@ -266,10 +266,12 @@ function SidebarSessionRowImpl({
       >
         {showsRunningArc(dotState) && <span aria-hidden="true" className="arc-border arc-row" />}
         <SidebarRowBody
-          // Pinned metadata already sits in the actions slot, so the title only
-          // needs a gap from it — and the same gap on hover, or the row would
-          // jump every time the kebab took over.
-          className={cn('z-0', pinnedMeta ? 'pr-2' : 'group-hover:pr-12', branchStem && 'pl-3.5')}
+          // The actions column (kebab + optional metadata/age) always sits in
+          // normal flow now, so the grid's auto track already reserves its
+          // width — the title only needs a fixed gap from it, the same at rest
+          // and on hover, or the truncate point would jump the moment you
+          // hover (#82807).
+          className={cn('z-0 pr-2', branchStem && 'pl-3.5')}
           // Middle-click = open in a new tab (browser muscle memory).
           {...middleClickHandlers(() => {
             triggerHaptic('selection')


### PR DESCRIPTION
## What does this PR do?

Fixes the left-sidebar session row so hovering never eats part of the title. On the default row (no pinned metadata, no PR/profile chip, no live turn), hovering:

1. Applied `group-hover:pr-12` to the title's tap target — the title's available width (and therefore its truncate point) only shrank on hover, so text visible at rest could vanish under hover.
2. Rendered the relative-age text (`12h`, `3d`, …) with `absolute right-6 opacity-0 group-hover:opacity-100` — since it was taken out of flow, the actions column's `auto` grid track never sized for it, so on hover it could render out past the narrow actions column and over the title.

Both problems have the same root cause: the age's width was only ever accounted for conditionally, on hover, instead of being reserved at rest like the "pinned metadata" branch already does correctly a few lines above.

## Related Issue

Fixes #82807

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/session-row.tsx`: the hover-only age span is no longer `absolute` — it sits in normal flow (opacity fade only), so the actions column's grid track reserves its width at rest. The title's tap target now uses a constant `pr-2` gap instead of a hover-only `group-hover:pr-12`, since the actions column already reserves the space it needs. Removed the now-unused `pinnedMeta` variable that only existed to pick between the two paddings.
- `apps/desktop/src/app/chat/sidebar/session-row.test.tsx`: added a test asserting the title's tap target has no `group-hover:pr-*` class and the age span has no `absolute` class — i.e. the row's geometry doesn't depend on `:hover` state.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/chat/sidebar/session-row.test.tsx`
2. Reverting just the source fix (`git checkout HEAD~1 -- apps/desktop/src/app/chat/sidebar/session-row.tsx`) makes the new test fail with:
   ```
   AssertionError: expected 'pl-2 pr-1 gap-1.5 flex h-full min-w-0…' not to match /group-hover:pr-/
   + Received:
   "pl-2 pr-1 gap-1.5 flex h-full min-w-0 items-center self-stretch py-0.5 bg-transparent text-left z-0 group-hover:pr-12"
   ```
3. Full suite: `cd apps/desktop && npx vitest run` → 490 files passed, 4632 tests passed (1 file / 2 tests skipped, pre-existing and unrelated).
4. `cd apps/desktop && npx eslint src/app/chat/sidebar/session-row.tsx src/app/chat/sidebar/session-row.test.tsx` → clean.
5. `cd apps/desktop && npx tsc -p . --noEmit` → clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the desktop test suite (`npx vitest run` in `apps/desktop`) and all tests pass
- [x] I've added tests for my changes
- [x] Tested on Linux (unit/DOM tests only; no macOS hardware available in this environment — the bug is pure CSS/layout logic, not platform-specific)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas touched

## AI assistance disclosure

This fix was prepared with AI assistance (Claude), including the diagnosis, patch, and test. It was verified locally: the added test fails on the pre-fix code and passes on the fix, the full desktop vitest suite passes, and lint/typecheck are clean.
