### PR TITLE
fix(desktop): stop empty REST transcript refresh from wiping a warm resume

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1610,6 +1610,77 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(renderedMessages).not.toContain('stale runtime answer')
   })
 
+  it('keeps the activated transcript when a persisted transcript refresh returns empty rows', async () => {
+    // Regression: after a wake/reconnect, session.activate can legitimately
+    // rebind a session with a non-empty transcript while the concurrent REST
+    // refresh (getLatestSessionMessages) races a just-respawned backend and
+    // resolves with zero rows. That empty page must not be trusted over the
+    // transcript activate already restored.
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'cached-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'still here after wake' }]
+      },
+      {
+        id: 'cached-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'still here after wake too' }]
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const activatedMessages = [
+      { content: 'still here after wake', role: 'user', timestamp: 1 },
+      { content: 'still here after wake too', role: 'assistant', timestamp: 2 }
+    ]
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: activatedMessages.length,
+          messages: activatedMessages,
+          running: false,
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, next) => (resumedState = next)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    const renderedMessages = JSON.stringify(resumedState?.messages)
+    expect(renderedMessages).toContain('still here after wake')
+    expect(renderedMessages).toContain('still here after wake too')
+  })
+
   it('keeps a warm runtime and optimistic turn on a transient activation timeout', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
       current: new Map([['stored-A', 'rt-A']])

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -804,7 +804,13 @@ export function useSessionActions({
                   !activatedStoredSessionId ||
                   persisted.session_id === activatedStoredSessionId
 
-                if (persisted && persistedMatchesActivatedSession) {
+                // An empty REST page is not proof the transcript is empty — it's
+                // also what a backend respawn returns while its state.db read
+                // races the activate response. Reconciling against it anyway
+                // wipes the just-restored activate/cache transcript (the same
+                // wipe the `activated.messages.length || ...` guard above
+                // already prevents for the activate payload itself).
+                if (persisted && persistedMatchesActivatedSession && (persisted.messages.length || !activatedMessages.length)) {
                   activatedMessages = reconcileAuthoritativeMessages(persisted.messages, activatedMessages)
                 }
               }


### PR DESCRIPTION
## What does this PR do?

Fixes a narrow but real slice of #82806 (macOS Desktop: previous prompts and the right-hand chat timeline disappear after sleep/reopen).

`resumeSession`'s warm-cache path calls `session.activate` and, while idle, kicks off a concurrent `getLatestSessionMessages` REST refresh because the runtime's compressed context projection isn't always the full conversation. That refresh was reconciled into the view **unconditionally**:

```ts
if (persisted && persistedMatchesActivatedSession) {
  activatedMessages = reconcileAuthoritativeMessages(persisted.messages, activatedMessages)
}
```

`reconcileAuthoritativeMessages([], activatedMessages)` treats an empty authoritative array as "the transcript is now empty" for any settled (non-pending/non-optimistic) message, so a REST response that resolves successfully but with zero rows wipes the transcript `session.activate` had just restored. This can happen when the REST call races a backend that just respawned (exactly the kind of transient state a wake/reconnect can produce) — the read succeeds, but returns nothing yet.

The `activated.messages` payload from `session.activate` itself is already guarded against this a few lines above (`activated.messages.length || activated.inflight || activated.queued ? reconcile(...) : cachedViewState.messages`). This PR applies the same guard to the REST refresh: an empty persisted page no longer overrides a non-empty cached transcript.

```ts
if (persisted && persistedMatchesActivatedSession && (persisted.messages.length || !activatedMessages.length)) {
  activatedMessages = reconcileAuthoritativeMessages(persisted.messages, activatedMessages)
}
```

This does not claim to fix every symptom described in #82806 (the issue's own root-cause writeup covers several call paths); it closes the one concrete, provable wipe path in the warm-resume/activate flow, consistent with `apps/desktop/AGENTS.md`'s "merge, don't clobber" rule for server-truth reconciliation.

## Related Issue

Refs #82806

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` — guard the idle persisted-transcript merge so an empty REST page can't wipe a non-empty warm/activated transcript.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx` — regression test: warm cache + `session.activate` returning a real transcript + `getLatestSessionMessages` resolving `{ messages: [] }` must keep the activated transcript, not wipe it.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/session/hooks/use-session-actions.test.tsx -t "keeps the activated transcript when a persisted transcript refresh returns empty rows"`
2. To see it fail pre-fix: `git checkout HEAD~1 -- src/app/session/hooks/use-session-actions/index.ts`, rerun the same test (fails: `expected '[]' to contain 'still here after wake'`), then `git checkout HEAD -- src/app/session/hooks/use-session-actions/index.ts` to restore the fix.

### Real output

New test, on the fix commit:
```
✓ src/app/session/hooks/use-session-actions.test.tsx (42 tests | 41 skipped)
  ✓ resumeSession warm-cache mapping integrity > keeps the activated transcript when a persisted transcript refresh returns empty rows

Test Files  1 passed (1)
     Tests  42 passed (42)
```

Same test, source reverted to HEAD~1 (fix removed, test kept):
```
FAIL  |ui| src/app/session/hooks/use-session-actions.test.tsx > resumeSession warm-cache mapping integrity > keeps the activated transcript when a persisted transcript refresh returns empty rows
AssertionError: expected '[]' to contain 'still here after wake'
Expected: "still here after wake"
Received: "[]"
```

Full desktop suite on the fix commit:
```
 Test Files  490 passed | 1 skipped (491)
      Tests  4632 passed | 2 skipped (4634)
```

`npx eslint src/app/session/hooks/use-session-actions/index.ts src/app/session/hooks/use-session-actions.test.tsx` — clean.
`npx tsc -p . --noEmit` — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added a regression test
- [x] Tested via the desktop vitest suite (no macOS hardware available in this environment to physically reproduce sleep/wake; the fix targets the concrete code path — an empty REST resolution racing a non-empty warm transcript — that the issue's root-cause analysis names)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## AI assistance disclosure

This PR was prepared by an AI coding agent (Claude, via an autonomous OSS-contribution harness) against a human-reviewed, human-triggered workflow. The agent read the issue, the referenced open PRs (to rule out duplication), traced the actual reconciliation code, wrote the regression test, and verified it fails without the fix and passes with it, per this repo's own TDD/verification conventions.
