### PR TITLE
fix(memory): preserve history for provider recovery

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1559,6 +1559,13 @@ def init_agent(
     
     # Track conversation messages for session logging
     agent._session_messages: List[Dict[str, Any]] = []
+    # Provider-only transcript continuity for callers that invoke
+    # run_conversation() repeatedly without passing conversation_history
+    # (notably chat() and direct API embeddings). This is deliberately
+    # separate from _session_messages: it must never alter model context or
+    # prompt-cache prefixes.
+    agent._external_memory_messages: List[Dict[str, Any]] = []
+    agent._external_memory_session_id = agent.session_id or ""
     # Responses encrypted reasoning replay state.  Some OpenAI-compatible
     # routes accept GPT-5 Responses requests but later reject replayed
     # encrypted reasoning blobs (HTTP 400 ``invalid_encrypted_content``).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1566,6 +1566,11 @@ def init_agent(
     # prompt-cache prefixes.
     agent._external_memory_messages: List[Dict[str, Any]] = []
     agent._external_memory_session_id = agent.session_id or ""
+    # Per-turn signal: the live message list is a complete provider transcript,
+    # independent of the session-DB flush baseline. Legacy compression rotation
+    # intentionally clears that baseline even though its compacted messages are
+    # authoritative.
+    agent._external_memory_transcript_authoritative = False
     # Responses encrypted reasoning replay state.  Some OpenAI-compatible
     # routes accept GPT-5 Responses requests but later reject replayed
     # encrypted reasoning blobs (HTTP 400 ``invalid_encrypted_content``).

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -623,7 +623,7 @@ def run_codex_app_server_turn(
     messages: List[Dict[str, Any]],
     effective_task_id: str,
     should_review_memory: bool = False,
-    messages_are_accumulated: bool = False,
+    messages_are_authoritative: bool = False,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
     app-server` subprocess and projects its events back into Hermes'
@@ -839,7 +839,7 @@ def run_codex_app_server_turn(
                 final_response=turn.final_text,
                 interrupted=False,
                 messages=messages,
-                messages_are_accumulated=messages_are_accumulated,
+                messages_are_authoritative=messages_are_authoritative,
             )
         except Exception:
             logger.debug("external memory sync raised", exc_info=True)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -623,6 +623,7 @@ def run_codex_app_server_turn(
     messages: List[Dict[str, Any]],
     effective_task_id: str,
     should_review_memory: bool = False,
+    messages_are_accumulated: bool = False,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
     app-server` subprocess and projects its events back into Hermes'
@@ -838,6 +839,7 @@ def run_codex_app_server_turn(
                 final_response=turn.final_text,
                 interrupted=False,
                 messages=messages,
+                messages_are_accumulated=messages_are_accumulated,
             )
         except Exception:
             logger.debug("external memory sync raised", exc_info=True)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1894,11 +1894,14 @@ def conversation_history_after_compression(
     if bool(getattr(agent, "_last_compression_attempt_recorded", False)):
         attempt_in_place = getattr(agent, "_last_compression_attempt_in_place", None)
         if attempt_in_place is True:
+            agent._external_memory_transcript_authoritative = True
             return list(messages)
         if attempt_in_place is False:
+            agent._external_memory_transcript_authoritative = True
             return None
         return previous_history
     if bool(getattr(agent, "_last_compaction_in_place", False)):
+        agent._external_memory_transcript_authoritative = True
         return list(messages)
     return None
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1629,7 +1629,9 @@ def run_conversation(
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
-            messages_are_accumulated=conversation_history is not None,
+            messages_are_authoritative=bool(
+                getattr(agent, "_external_memory_transcript_authoritative", False)
+            ),
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1629,6 +1629,7 @@ def run_conversation(
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
+            messages_are_accumulated=conversation_history is not None,
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -463,6 +463,12 @@ def build_turn_context(
     recovered_history = recover_rotated_compression_session(agent)
     if recovered_history is not None:
         conversation_history = recovered_history
+    # This is intentionally distinct from the persistence flush baseline.
+    # A later compression boundary may make ``messages`` authoritative while
+    # legacy rotation still resets ``conversation_history`` to None.
+    agent._external_memory_transcript_authoritative = (
+        conversation_history is not None
+    )
 
     # NOTE: the DB session row is created later, AFTER the system prompt is
     # restored/built (see _ensure_db_session() below the system-prompt block).

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -743,7 +743,9 @@ def finalize_turn(
         final_response=final_response,
         interrupted=interrupted,
         messages=messages,
-        messages_are_accumulated=conversation_history is not None,
+        messages_are_authoritative=bool(
+            getattr(agent, "_external_memory_transcript_authoritative", False)
+        ),
     )
 
     # Background memory/skill review — runs AFTER the response is delivered

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -743,6 +743,7 @@ def finalize_turn(
         final_response=final_response,
         interrupted=interrupted,
         messages=messages,
+        messages_are_accumulated=conversation_history is not None,
     )
 
     # Background memory/skill review — runs AFTER the response is delivered

--- a/run_agent.py
+++ b/run_agent.py
@@ -4177,6 +4177,7 @@ class AIAgent:
         final_response: Any,
         interrupted: bool,
         messages: list | None = None,
+        messages_are_accumulated: bool = False,
     ) -> None:
         """Mirror a completed turn into external memory providers.
 
@@ -4189,6 +4190,11 @@ class AIAgent:
         Uses ``original_user_message`` rather than ``user_message``
         because the latter may carry injected skill content that bloats
         or breaks provider queries.
+
+        ``messages_are_accumulated`` distinguishes a caller-supplied/recovered
+        transcript from a history-less current exchange. The latter is merged
+        into provider-only session history so a backend recovering on the next
+        turn can inspect the exchange it missed.
 
         Interrupted turns are skipped entirely (#15218).  A partial
         assistant output, an aborted tool chain, or a mid-stream reset
@@ -4216,9 +4222,13 @@ class AIAgent:
         if not (user_text and response_text):
             return
         try:
+            sync_messages = self._external_memory_transcript(
+                messages,
+                accumulated=messages_are_accumulated,
+            )
             sync_kwargs = {"session_id": self.session_id or ""}
-            if messages is not None:
-                sync_kwargs["messages"] = messages
+            if sync_messages is not None:
+                sync_kwargs["messages"] = sync_messages
             self._memory_manager.sync_all(
                 user_text,
                 response_text,
@@ -4235,6 +4245,54 @@ class AIAgent:
                 )
         except Exception:
             pass
+
+    def _external_memory_transcript(
+        self,
+        messages: list | None,
+        *,
+        accumulated: bool,
+    ) -> list | None:
+        """Snapshot completed turns for provider reconciliation only.
+
+        Most Hermes surfaces pass their accumulated conversation history into
+        ``run_conversation``. ``chat()`` and direct embedders may omit it,
+        though, so each finalizer receives a list containing only the current
+        exchange. If a provider was unreachable for turn N, sending only turn
+        N+1 after recovery makes N permanently invisible.
+
+        Preserve a separate per-session provider transcript in that
+        history-less mode. Caller-supplied or recovered conversation history
+        is authoritative and replaces the snapshot (which also handles
+        compression). A current-exchange-only list appends to the prior
+        snapshot. Nothing here is fed back into model context.
+        """
+        if messages is None:
+            return None
+
+        current = [dict(message) for message in messages if isinstance(message, dict)]
+        session_id = self.session_id or ""
+        previous_session_id = getattr(
+            self,
+            "_external_memory_session_id",
+            session_id,
+        )
+        previous = getattr(self, "_external_memory_messages", [])
+        if previous_session_id != session_id:
+            previous = []
+
+        if previous and not accumulated:
+            # A stateless turn may repeat the stable system prompt. Providers
+            # need source turns, not a second mid-session system message.
+            current_turn = [
+                message for message in current if message.get("role") != "system"
+            ]
+            transcript = [*previous, *current_turn]
+        else:
+            transcript = current
+
+        self._external_memory_messages = transcript
+        self._external_memory_session_id = session_id
+        return [dict(message) for message in transcript]
 
     def release_clients(self) -> None:
         """Release LLM client resources WITHOUT tearing down session tool state.
@@ -8075,10 +8133,21 @@ class AIAgent:
         messages: List[Dict[str, Any]],
         effective_task_id: str,
         should_review_memory: bool = False,
+        messages_are_accumulated: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
+        return run_codex_app_server_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=should_review_memory,
+            messages_are_accumulated=messages_are_accumulated,
+        )
+
 
 def main(
     query: str = None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -4177,7 +4177,7 @@ class AIAgent:
         final_response: Any,
         interrupted: bool,
         messages: list | None = None,
-        messages_are_accumulated: bool = False,
+        messages_are_authoritative: bool = False,
     ) -> None:
         """Mirror a completed turn into external memory providers.
 
@@ -4191,10 +4191,10 @@ class AIAgent:
         because the latter may carry injected skill content that bloats
         or breaks provider queries.
 
-        ``messages_are_accumulated`` distinguishes a caller-supplied/recovered
-        transcript from a history-less current exchange. The latter is merged
-        into provider-only session history so a backend recovering on the next
-        turn can inspect the exchange it missed.
+        ``messages_are_authoritative`` distinguishes a caller-supplied,
+        recovered, or compacted transcript from a history-less current
+        exchange. The latter is merged into provider-only session history so a
+        backend recovering on the next turn can inspect the exchange it missed.
 
         Interrupted turns are skipped entirely (#15218).  A partial
         assistant output, an aborted tool chain, or a mid-stream reset
@@ -4224,7 +4224,7 @@ class AIAgent:
         try:
             sync_messages = self._external_memory_transcript(
                 messages,
-                accumulated=messages_are_accumulated,
+                authoritative=messages_are_authoritative,
             )
             sync_kwargs = {"session_id": self.session_id or ""}
             if sync_messages is not None:
@@ -4250,7 +4250,7 @@ class AIAgent:
         self,
         messages: list | None,
         *,
-        accumulated: bool,
+        authoritative: bool,
     ) -> list | None:
         """Snapshot completed turns for provider reconciliation only.
 
@@ -4280,7 +4280,7 @@ class AIAgent:
         if previous_session_id != session_id:
             previous = []
 
-        if previous and not accumulated:
+        if previous and not authoritative:
             # A stateless turn may repeat the stable system prompt. Providers
             # need source turns, not a second mid-session system message.
             current_turn = [
@@ -8133,7 +8133,7 @@ class AIAgent:
         messages: List[Dict[str, Any]],
         effective_task_id: str,
         should_review_memory: bool = False,
-        messages_are_accumulated: bool = False,
+        messages_are_authoritative: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
@@ -8145,7 +8145,7 @@ class AIAgent:
             messages=messages,
             effective_task_id=effective_task_id,
             should_review_memory=should_review_memory,
-            messages_are_accumulated=messages_are_accumulated,
+            messages_are_authoritative=messages_are_authoritative,
         )
 
 

--- a/tests/agent/test_rotation_flush_persisted_boundary_68196.py
+++ b/tests/agent/test_rotation_flush_persisted_boundary_68196.py
@@ -116,3 +116,60 @@ def test_rotation_flush_does_not_duplicate_persisted_prefix(tmp_path: Path) -> N
     )
     assert contents.count("persisted answer") == 1
     assert contents == ["persisted question", "persisted answer", "new turn"]
+
+
+def test_rotation_memory_sync_uses_compacted_transcript_once(tmp_path: Path) -> None:
+    """Legacy rotation's ``None`` DB baseline must not make provider memory
+    append the compacted transcript to its pre-compression snapshot."""
+    from agent.conversation_compression import (
+        conversation_history_after_compression,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "MEMORY_SYNC_PARENT"
+    db.create_session(parent_sid, source="desktop")
+
+    messages = [
+        {"role": "user", "content": "obsolete question"},
+        {"role": "assistant", "content": "obsolete answer"},
+        {"role": "user", "content": "new turn"},
+    ]
+    agent = _build_agent_with_db(db, parent_sid)
+    agent._persist_user_message_idx = len(messages) - 1
+
+    compacted, _ = agent._compress_context(
+        messages,
+        "sys",
+        approx_tokens=120_000,
+    )
+    history = conversation_history_after_compression(agent, compacted, messages)
+
+    # Rotation still needs a cleared persistence baseline for its fresh child,
+    # but provider reconciliation has a separate, authoritative transcript.
+    assert history is None
+    assert agent._external_memory_transcript_authoritative is True
+
+    manager = MagicMock()
+    agent._memory_manager = manager
+    # Model the provider snapshot following the memory manager's child-session
+    # switch. If the compacted list were treated like a stateless exchange, the
+    # obsolete parent messages would be prepended here.
+    agent._external_memory_messages = [dict(message) for message in messages]
+    agent._external_memory_session_id = agent.session_id
+
+    agent._sync_external_memory_for_turn(
+        original_user_message="new turn",
+        final_response="new answer",
+        interrupted=False,
+        messages=compacted,
+        messages_are_authoritative=(
+            agent._external_memory_transcript_authoritative
+        ),
+    )
+
+    synced = manager.sync_all.call_args.kwargs["messages"]
+    assert [message["content"] for message in synced] == [
+        "[CONTEXT COMPACTION] summary",
+        "tail",
+    ]
+    assert all("obsolete" not in message["content"] for message in synced)

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -211,6 +211,49 @@ class TestRunConversationCodexPath:
         agent._memory_manager.sync_all.assert_called_once()
         assert agent._memory_manager.sync_all.call_args.kwargs["messages"] == result["messages"]
 
+    def test_recovered_provider_receives_turn_missed_during_outage(self, fake_session):
+        agent = _make_codex_agent()
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.build_system_prompt.return_value = ""
+        agent._memory_manager.prefetch_all.return_value = ""
+        agent._memory_manager.sync_all.side_effect = [
+            ConnectionError("simulated provider outage"),
+            None,
+        ]
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("the reserve gemstone is jade")
+            agent.run_conversation("are you back")
+
+        delivered = agent._memory_manager.sync_all.call_args_list[-1].kwargs["messages"]
+        assert any(
+            message.get("role") == "user"
+            and message.get("content") == "the reserve gemstone is jade"
+            for message in delivered
+        ), "the recovered provider never receives the turn missed during its outage"
+
+    def test_explicit_history_remains_authoritative_for_memory_sync(self, fake_session):
+        agent = _make_codex_agent()
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.build_system_prompt.return_value = ""
+        agent._memory_manager.prefetch_all.return_value = ""
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            first = agent.run_conversation("first turn")
+            agent.run_conversation(
+                "second turn",
+                conversation_history=first["messages"],
+            )
+
+        delivered = agent._memory_manager.sync_all.call_args_list[-1].kwargs["messages"]
+        first_users = [
+            message
+            for message in delivered
+            if message.get("role") == "user"
+            and message.get("content") == "first turn"
+        ]
+        assert len(first_users) == 1
+
     def test_nudge_counters_tick(self, fake_session):
         """The skill nudge counter must accumulate tool_iterations across
         turns. The memory nudge counter is gated on memory being configured

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -111,7 +111,7 @@ class TestSyncExternalMemoryForTurn:
             final_response="new answer",
             interrupted=False,
             messages=authoritative,
-            messages_are_accumulated=True,
+            messages_are_authoritative=True,
         )
 
         delivered = agent._memory_manager.sync_all.call_args.kwargs["messages"]

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -13,9 +13,10 @@ that replaces the inline block and returns early when ``interrupted``
 is True (regardless of whether ``final_response`` and
 ``original_user_message`` happen to be populated).
 
-These tests exercise the helper directly on a bare ``AIAgent`` built
-via ``__new__`` so the full ``run_conversation`` machinery isn't needed
-— the method is pure logic and three state arguments.
+These tests exercise the helper directly on a bare ``AIAgent`` built via
+``__new__`` so interruption safety, provider-only transcript continuity,
+authoritative-history replacement, and session isolation are independently
+observable.
 """
 from unittest.mock import MagicMock
 
@@ -57,6 +58,91 @@ class TestSyncExternalMemoryForTurn:
 
     # --- Normal completed turn still syncs ------------------------------
 
+    def test_historyless_completed_turns_accumulate_for_provider_reconciliation(self):
+        agent = _bare_agent()
+        first = [
+            {"role": "user", "content": "first user"},
+            {"role": "assistant", "content": "first answer"},
+        ]
+        second = [
+            {"role": "user", "content": "second user"},
+            {"role": "assistant", "content": "second answer"},
+        ]
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="first user",
+            final_response="first answer",
+            interrupted=False,
+            messages=first,
+        )
+        agent._sync_external_memory_for_turn(
+            original_user_message="second user",
+            final_response="second answer",
+            interrupted=False,
+            messages=second,
+        )
+
+        delivered = agent._memory_manager.sync_all.call_args.kwargs["messages"]
+        assert [message["content"] for message in delivered] == [
+            "first user",
+            "first answer",
+            "second user",
+            "second answer",
+        ]
+
+    def test_accumulated_history_replaces_the_provider_snapshot(self):
+        agent = _bare_agent()
+        agent._sync_external_memory_for_turn(
+            original_user_message="old user",
+            final_response="old answer",
+            interrupted=False,
+            messages=[
+                {"role": "user", "content": "old user"},
+                {"role": "assistant", "content": "old answer"},
+            ],
+        )
+        authoritative = [
+            {"role": "user", "content": "compressed summary"},
+            {"role": "assistant", "content": "new answer"},
+        ]
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="compressed summary",
+            final_response="new answer",
+            interrupted=False,
+            messages=authoritative,
+            messages_are_accumulated=True,
+        )
+
+        delivered = agent._memory_manager.sync_all.call_args.kwargs["messages"]
+        assert delivered == authoritative
+
+    def test_provider_snapshot_resets_when_the_session_changes(self):
+        agent = _bare_agent()
+        agent._sync_external_memory_for_turn(
+            original_user_message="old user",
+            final_response="old answer",
+            interrupted=False,
+            messages=[
+                {"role": "user", "content": "old user"},
+                {"role": "assistant", "content": "old answer"},
+            ],
+        )
+        agent.session_id = "test_session_002"
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="new user",
+            final_response="new answer",
+            interrupted=False,
+            messages=[
+                {"role": "user", "content": "new user"},
+                {"role": "assistant", "content": "new answer"},
+            ],
+        )
+
+        delivered = agent._memory_manager.sync_all.call_args.kwargs["messages"]
+        assert all(message["content"] != "old user" for message in delivered)
+
 
 
 
@@ -75,4 +161,3 @@ class TestSyncExternalMemoryForTurn:
 
 
     # --- The specific matrix the reporter asked about ------------------
-

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4709,6 +4709,73 @@ class TestRetryExhaustion:
         assert "bad messages" in result["error"]
 
 
+class TestExternalMemoryHistoryRecovery:
+    def test_recovered_memory_manager_receives_turn_missed_during_outage(self, agent):
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.build_system_prompt.return_value = ""
+        agent._memory_manager.prefetch_all.return_value = ""
+        agent._memory_manager.sync_all.side_effect = [
+            ConnectionError("simulated provider outage"),
+            None,
+        ]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("the reserve gemstone is jade")
+            agent.run_conversation("are you back")
+
+        delivered = agent._memory_manager.sync_all.call_args_list[-1].kwargs["messages"]
+        assert any(
+            message.get("role") == "user"
+            and message.get("content") == "the reserve gemstone is jade"
+            for message in delivered
+        ), "the recovered provider never receives the turn missed during its outage"
+
+    def test_explicit_history_remains_authoritative_for_memory_sync(self, agent):
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.build_system_prompt.return_value = ""
+        agent._memory_manager.prefetch_all.return_value = ""
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            first = agent.run_conversation("first turn")
+            agent.run_conversation(
+                "second turn",
+                conversation_history=first["messages"],
+            )
+
+        delivered = agent._memory_manager.sync_all.call_args_list[-1].kwargs["messages"]
+        first_users = [
+            message
+            for message in delivered
+            if message.get("role") == "user"
+            and message.get("content") == "first turn"
+        ]
+        assert len(first_users) == 1
+
+
 # ---------------------------------------------------------------------------
 # Conversation history mutation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

An external memory provider that is unavailable for one completed turn cannot recover that turn when a caller invokes `run_conversation()` again without `conversation_history`. The next successful sync receives only the new exchange, so the missed turn is permanently invisible to provider reconciliation.

This affects both the standard chat-completions finalizer and the Codex app-server finalizer.

## Fix

- Introduces `_external_memory_messages` — a separate provider-only transcript that accumulates history-less turns across calls, independent of model context
- `_external_memory_transcript_authoritative` flag separates the transcript-authority signal from the persistence baseline, correctly handling legacy compression rotation where `conversation_history` is deliberately `None` but the compacted transcript is authoritative
- Threads `messages_are_authoritative` through both standard and Codex sync paths
- Session isolation: provider snapshot resets when `session_id` changes

## Tests

- `test_recovered_memory_manager_receives_turn_missed_during_outage` — proves the missed turn reaches the recovered provider
- `test_rotation_memory_sync_uses_compacted_transcript_once` — regression for the compression boundary @teknium1 flagged
- `test_accumulated_history_replaces_the_provider_snapshot` — authoritative transcript replaces, doesn't append
- `test_provider_snapshot_resets_when_the_session_changes` — session isolation
- `test_explicit_history_remains_authoritative_for_memory_sync` — no duplication when caller supplies history
- Codex-path equivalents for outage recovery and authoritative history

## Rebased on current main (replaces #74991)

Previous PR was 976 commits behind with merge blocked. Clean cherry-pick onto current `main` — zero conflicts.