### PR TITLE
fix(background_review): honor the skill-creation kill switch in the memory-only review fork

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -950,6 +950,14 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            # Honor the user's skill-creation kill switch
+            # (skills.creation_nudge_interval: 0) at the fork level too. The
+            # memory-review trigger fires independently of the skill-review
+            # trigger, so it previously still carried skill_manage in its
+            # whitelist and could create skills the user explicitly disabled
+            # (#82708).
+            if getattr(agent, "_skill_nudge_interval", 1) <= 0:
+                review_whitelist.discard("skill_manage")
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -135,7 +135,45 @@ def test_background_review_installs_thread_local_whitelist():
     assert "execute_code" not in whitelist
 
 
+def test_memory_only_review_honors_skill_creation_kill_switch():
+    """``skills.creation_nudge_interval: 0`` must deny skill_manage in the
+    memory-review fork too (#82708).
 
+    That setting only gated the skill-review *trigger* in turn_finalizer.py;
+    the memory-review trigger fires independently and previously still
+    carried skill_manage in its runtime whitelist, letting the memory-only
+    fork create skills the user explicitly disabled.
+    """
+    import run_agent
+    from hermes_cli import plugins as _plugins
 
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    agent._skill_nudge_interval = 0  # user's skill-creation kill switch
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "whitelist" in captured, "set_thread_tool_whitelist was not called"
+    whitelist = captured["whitelist"]
+    assert "skill_manage" not in whitelist, (
+        "skill_manage must be denied when the skill-creation kill switch is "
+        "on, even for a memory-only review fork"
+    )
+    assert "memory" in whitelist, "memory review itself must be unaffected"
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #82708 — `skills.creation_nudge_interval: 0` is documented as the
switch that stops the background review from creating skills, but it only
disabled the **skill-review** trigger in `agent/turn_finalizer.py`. The
**memory-review** trigger (`memory.nudge_interval`) fires independently, and
the review fork's runtime tool whitelist always included the `skills`
toolset (and therefore `skill_manage`) regardless of which trigger actually
fired. A user who set the kill switch could still get a brand-new skill
created by a memory-only review pass.

## Root cause

`agent/background_review.py::_run_review_in_thread` builds the fork's
dispatch whitelist from `review_toolsets = ["skills"]` unconditionally (plus
`memory` when the memory feature is enabled) — it never looked at whether
skill creation was actually meant to be in scope for this pass, or at the
user's `_skill_nudge_interval` kill switch on the parent agent.

## Fix

At the whitelist-build site, when the parent agent's `_skill_nudge_interval`
is `<= 0` (the user's kill switch is on), drop `skill_manage` from the
computed whitelist before installing it via `set_thread_tool_whitelist`. The
tool is then denied at dispatch time for *every* review fork — memory-only,
skill-only, or combined — closing the bypass at the one place runtime safety
is actually enforced, without touching the by-design cross-availability of
memory/skill tools when the switch is off.

## Test plan

Added `test_memory_only_review_honors_skill_creation_kill_switch` to
`tests/run_agent/test_background_review_toolset_restriction.py`, alongside
the existing whitelist-restriction tests. It spawns a memory-only review
(`review_memory=True, review_skills=False`) with `agent._skill_nudge_interval
= 0` and asserts `skill_manage` is absent from the installed whitelist while
`memory` is still present.

Verified the test fails without the fix (`git checkout HEAD~1 --
agent/background_review.py`, rerun):

```
AssertionError: skill_manage must be denied when the skill-creation kill switch is on, even for a memory-only review fork
assert 'skill_manage' not in {'memory', 'skill_manage', 'skill_view', 'skills_list'}
```

And passes with the fix restored:

```
tests/run_agent/test_background_review_toolset_restriction.py::test_background_review_matches_parent_toolset_config PASSED
tests/run_agent/test_background_review_toolset_restriction.py::test_background_review_installs_thread_local_whitelist PASSED
tests/run_agent/test_background_review_toolset_restriction.py::test_memory_only_review_honors_skill_creation_kill_switch PASSED
```

Full related suite via the canonical runner (`scripts/run_tests.sh`), all
green, no regressions:

```
=== Summary: 8 files, 45 tests passed, 0 failed (100% complete) in 6.7s (8 workers) ===
```

Also ran `ruff check` and `scripts/check-windows-footguns.py` on both
changed files — clean.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code / Claude agent),
under human supervision reviewing the diff, running the test suite, and
verifying the fix against a real repro of the reported behavior.
