### PR TITLE
fix(compression): preserve terminal stdout head in demoted summaries (#82814)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1388,7 +1388,22 @@ def _summarize_tool_result_unguarded(tool_name: str, tool_args: str, tool_conten
             cmd = cmd[:77] + "..."
         exit_match = re.search(r'"exit_code"\s*:\s*(-?\d+)', content)
         exit_code = exit_match.group(1) if exit_match else "?"
-        return f"[terminal] ran `{cmd}` -> exit {exit_code}, {line_count} lines output"
+        # Preserve a short head of real stdout so the model can still
+        # diagnose failures when the command exits 0 but prints errors
+        # (e.g. ``curl`` returning HTTP 422 with exit 0).  #82814
+        stdout_head = ""
+        try:
+            _parsed = json.loads(content) if content else {}
+            if isinstance(_parsed, dict):
+                _out = _parsed.get("output", "")
+                if isinstance(_out, str) and _out.strip():
+                    stdout_head = _out.strip()[:160]
+                    if len(_out.strip()) > 160:
+                        stdout_head += "..."
+        except Exception:
+            pass
+        _extra = f" | stdout: {stdout_head}" if stdout_head else ""
+        return f"[terminal] ran `{cmd}` -> exit {exit_code}, {line_count} lines output{_extra}"
 
     if tool_name == "read_file":
         path = args.get("path", "?")


### PR DESCRIPTION
## Problem

The context compressor's `_summarize_tool_result()` replaces large terminal outputs with:

```
[terminal] ran `curl -s https://httpbin.org/status/422` -> exit 0, 3 lines output
```

This discards the actual stdout content. Commands that exit 0 but print error messages (e.g., `curl` returning HTTP 422, `git` printing warnings) are silently masked as successes. The model loses the ability to diagnose or self-correct on old tool results.

## Fix

Append a 160-char head of the real stdout to the compressed summary:

```
[terminal] ran `curl -s https://httpbin.org/status/422` -> exit 0, 3 lines output | stdout: 422 Failed to parse request body
```

The head is extracted from the `output` field of the JSON content. If parsing fails or output is empty, no extra text is added (backward compatible).

## Testing

1. Run a terminal command that exits 0 but prints errors
2. Continue conversation until compressor demotes the result
3. Before fix: only exit code shown, no stdout
4. After fix: 160-char stdout head preserved in summary

Fixes #82814