### PR TITLE
fix(desktop): use native drag region for HUD composer on drag, fixing Wayland

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2410,6 +2410,15 @@ button[data-slot='aui_msg-reactions'] svg {
   background: color-mix(in srgb, var(--dt-card) 92%, transparent);
 }
 
+/* HUD drag handle. press-and-hold the composer, and the compositor takes over
+   the window move. -webkit-app-region maps to the native interactive-move
+   protocol on every platform (xdg_toplevel.move on Wayland, _NET_WM_MOVERESIZE
+   on X11, NSWindow.move on macOS). Without it, the setPosition path silently
+   no-ops on Wayland — the compositor owns window placement. */
+[data-hud-grabbing] {
+  -webkit-app-region: drag;
+}
+
 /* Flipped, the sheet hangs from the bar instead of standing on it. */
 [data-hud-shell][data-hud-edge='top'] [data-hud-glass] {
   top: var(--hud-bar-height, var(--composer-fallback-height));


### PR DESCRIPTION
On Linux/Wayland, `BrowserWindow.setPosition()` is a no-op — the compositor owns window placement. The HUD drag gesture (long-press on the composer) currently calls `setPosition` on every pointermove, which silently does nothing under Wayland compositors including KWin.

## What this does

Adds `-webkit-app-region: drag` to the composer element when the drag handle is engaged (`data-hud-grabbing` is present). This maps to the compositor's native interactive-move protocol on every platform:

| Platform | Protocol |
|---|---|
| Wayland | `xdg_toplevel.move` |
| X11 | `_NET_WM_MOVERESIZE` |
| macOS | `NSWindow.move` |
| Windows | native drag |

The compositor handles the window movement directly, bypassing the broken `setPosition` path entirely. The existing pointer-capture delta tracking in `composer-drag.ts` becomes unreachable during drag (the OS takes pointer events for the drag region) and remains as a harmless fallback.

## Why this works on all platforms

The `[data-hud-grabbing]` selector is only active during the long-press drag gesture in HUD mode. `click-through.ts` already exempts the window from mouse-ignore when this attribute is present (line 32: `hudIgnoresMouse` returns `false`), so the window is solid during the drag — the compositor can safely take over.

## Changes

- `apps/desktop/src/styles.css`: 9 lines — one CSS rule + comment explaining the platform mapping

## Testing

Built and verified on Linux (Arch, KDE Plasma 6 / Wayland). The CSS rule is confirmed present in the packaged build. Untested on macOS and Windows — on those platforms, `setPosition` already works, but the native drag region should be a strictly better experience (compositor-synced movement, no frame-by-frame teleport).

Fixes: #82851