### PR TITLE
fix(model-switch): enforce free-only default policy for OpenCode Zen model switches

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -236,7 +236,8 @@ describe('useModelControls', () => {
     expect(requestGateway).toHaveBeenCalledWith('config.set', {
       session_id: 'session-1',
       key: 'model',
-      value: 'claude-sonnet-4.6 --provider anthropic --session'
+      value: 'claude-sonnet-4.6 --provider anthropic --session',
+      picker_selected: true
     })
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
@@ -333,7 +334,8 @@ describe('useModelControls', () => {
     expect(requestGateway).toHaveBeenCalledWith('config.set', {
       session_id: 'session-1',
       key: 'model',
-      value: 'BeastMode --provider moa --session'
+      value: 'BeastMode --provider moa --session',
+      picker_selected: true
     })
   })
 
@@ -547,7 +549,8 @@ describe('useModelControls', () => {
     expect(requestGateway).toHaveBeenCalledWith('config.set', {
       session_id: 'tile-runtime',
       key: 'model',
-      value: 'tile-model --provider anthropic --session'
+      value: 'tile-model --provider anthropic --session',
+      picker_selected: true
     })
     // Primary footer untouched — the busy primary must not absorb a tile pick.
     expect($currentModel.get()).toBe('primary/model')

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -210,7 +210,12 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         const result = await requestGateway<{ deferred?: boolean }>('config.set', {
           session_id: liveSessionId,
           key: 'model',
-          value: `${selection.model} --provider ${selection.provider} --session`
+          value: `${selection.model} --provider ${selection.provider} --session`,
+          // Disambiguates this from a hand-typed `--provider` override: the
+          // picker sets explicit_provider to identify the clicked catalog row,
+          // not because the user deliberately named a provider. The gateway's
+          // OpenCode Zen free-only gate relies on this to still apply.
+          picker_selected: true
         })
 
         // A pick made DURING a turn is queued by the gateway and applied at the

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -58,7 +58,14 @@ model:
   #
   # Can also be overridden for a single invocation with the --provider flag.
   provider: "auto"
-  
+
+  # OpenCode Zen mixes free and paid models in one catalog. An ordinary
+  # /model switch onto a Zen model that models.dev reports as paid (or has
+  # no pricing data for) is rejected by default; only an explicit
+  # `/model <model> --provider opencode-zen` bypasses the check. Set true
+  # to allow ordinary switches onto paid Zen models too.
+  # allow_paid_opencode_zen: false
+
   # API configuration (falls back to OPENROUTER_API_KEY env var)
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"

--- a/cli.py
+++ b/cli.py
@@ -9444,6 +9444,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     explicit_provider=provider_data.get("slug"),
                     user_providers=state.get("user_provs"),
                     custom_providers=state.get("custom_provs"),
+                    picker_selected=True,
                 )
                 # Capture before close — picker state is cleared on close.
                 _picker_custom_provs = state.get("custom_provs")

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1831,6 +1831,7 @@ class GatewaySlashCommandsMixin:
                             explicit_provider=provider_slug,
                             user_providers=user_provs,
                             custom_providers=custom_provs,
+                            picker_selected=True,
                         )
                         if not result.success:
                             return t("gateway.model.error_prefix", error=result.error_message)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -296,8 +296,9 @@ def _check_hermes_model_warning(model_name: str) -> str:
 # The picker intentionally exposes Zen's full free+paid catalog (see
 # _UNCAPPED_PICKER_PROVIDERS above), but switching onto a paid or
 # unknown-cost model without the user asking for it by name is a silent
-# billing surprise. Ordinary /model switches (no --provider flag) are
-# gated to verified-zero-cost models unless the user opts in via
+# billing surprise. /model switches (no hand-typed --provider flag, and
+# picker selections — see picker_selected in switch_model) are gated to
+# verified-zero-cost models unless the user opts in via
 # ``model.allow_paid_opencode_zen: true``.
 
 def _model_info_is_verified_free(info: Optional[ModelInfo]) -> bool:
@@ -324,9 +325,10 @@ def _opencode_zen_paid_model_blocked(new_model: str, model_info: Optional[ModelI
     """Return an error message if the free-only Zen policy blocks *new_model*.
 
     Returns "" when the switch is allowed. Callers must only invoke this
-    when the target provider is "opencode-zen" and the switch was not an
-    explicit ``--provider opencode-zen`` request (that flag is itself the
-    override).
+    when the target provider is "opencode-zen" and the switch was not a
+    hand-typed ``--provider opencode-zen`` request (that flag is itself the
+    override; a picker selection reusing the same parameter is not — see
+    picker_selected in switch_model).
     """
     if _model_info_is_verified_free(model_info):
         return ""
@@ -1350,6 +1352,7 @@ def switch_model(
     explicit_provider: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
+    picker_selected: bool = False,
 ) -> ModelSwitchResult:
     """Core model-switching pipeline shared between CLI and gateway.
 
@@ -1381,9 +1384,14 @@ def switch_model(
         current_base_url: The currently active base URL.
         current_api_key: The currently active API key.
         is_global: Whether to persist the switch.
-        explicit_provider: From --provider flag (empty = no explicit provider).
+        explicit_provider: From --provider flag (empty = no explicit provider),
+            or the picker's own row slug when picker_selected is True.
         user_providers: The ``providers:`` dict from config.yaml (for user endpoints).
         custom_providers: The ``custom_providers:`` list from config.yaml.
+        picker_selected: True when explicit_provider came from an interactive
+            model picker selecting a catalog row, not from the user typing
+            --provider. Callers set this so provider-scoped policy gates
+            (e.g. the OpenCode Zen free-only default) still apply.
 
     Returns:
         ModelSwitchResult with all information the caller needs.
@@ -1973,10 +1981,21 @@ def switch_model(
     model_info = get_model_info(target_provider, new_model)
 
     # --- OpenCode Zen free-only default policy (#82764) ---
-    # An explicit --provider opencode-zen selection is itself the override;
-    # only gate ordinary switches (bare model name, aggregator resolution,
-    # alias fallback) that land on opencode-zen.
-    if target_provider == "opencode-zen" and not explicit_provider:
+    # A user typing --provider opencode-zen on the command line is itself
+    # the override. But the interactive pickers (cli.py, gateway/
+    # slash_commands.py) also pass explicit_provider — set to the picker's
+    # own row slug — on every model selection, paid or free, since
+    # _UNCAPPED_PICKER_PROVIDERS deliberately shows Zen's full catalog.
+    # picker_selected distinguishes that case so a paid model chosen from
+    # the picker is still gated instead of riding through on
+    # explicit_provider alone.
+    #
+    # target_provider is "opencode-zen" when it comes straight from
+    # current_provider (PATH B, no --provider), but resolve_provider_full()
+    # normalizes an explicit "opencode-zen" to models.dev's canonical id
+    # "opencode" (PATH A, which both the CLI flag and the pickers go
+    # through) — check both so the gate still recognizes the provider.
+    if target_provider in ("opencode-zen", "opencode") and (not explicit_provider or picker_selected):
         block_msg = _opencode_zen_paid_model_blocked(new_model, model_info)
         if block_msg:
             return ModelSwitchResult(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -290,6 +290,62 @@ def _check_hermes_model_warning(model_name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# OpenCode Zen free-only default policy (#82764)
+# ---------------------------------------------------------------------------
+#
+# The picker intentionally exposes Zen's full free+paid catalog (see
+# _UNCAPPED_PICKER_PROVIDERS above), but switching onto a paid or
+# unknown-cost model without the user asking for it by name is a silent
+# billing surprise. Ordinary /model switches (no --provider flag) are
+# gated to verified-zero-cost models unless the user opts in via
+# ``model.allow_paid_opencode_zen: true``.
+
+def _model_info_is_verified_free(info: Optional[ModelInfo]) -> bool:
+    """True only if *info* reports verified-zero cost for every category.
+
+    Fails closed: ``None`` (model missing from models.dev, unknown pricing)
+    is treated as not free.
+    """
+    if info is None:
+        return False
+    if info.cost_input > 0 or info.cost_output > 0:
+        return False
+    if (info.cost_cache_read or 0) > 0 or (info.cost_cache_write or 0) > 0:
+        return False
+    return True
+
+
+def opencode_zen_model_is_free(model: str) -> bool:
+    """True only if models.dev reports verified-zero cost for *model*."""
+    return _model_info_is_verified_free(get_model_info("opencode-zen", model))
+
+
+def _opencode_zen_paid_model_blocked(new_model: str, model_info: Optional[ModelInfo]) -> str:
+    """Return an error message if the free-only Zen policy blocks *new_model*.
+
+    Returns "" when the switch is allowed. Callers must only invoke this
+    when the target provider is "opencode-zen" and the switch was not an
+    explicit ``--provider opencode-zen`` request (that flag is itself the
+    override).
+    """
+    if _model_info_is_verified_free(model_info):
+        return ""
+
+    from hermes_cli.config import load_config
+
+    model_cfg = load_config().get("model")
+    if isinstance(model_cfg, dict) and model_cfg.get("allow_paid_opencode_zen"):
+        return ""
+
+    return (
+        f"{new_model!r} is a paid or unknown-cost OpenCode Zen model. "
+        "OpenCode Zen defaults to free models only. Run "
+        f"'/model {new_model} --provider opencode-zen' to override, or set "
+        "model.allow_paid_opencode_zen: true in config.yaml."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Model aliases -- short names -> (vendor, family) with NO version numbers.
 # Resolved dynamically against the live models.dev catalog.
 # ---------------------------------------------------------------------------
@@ -1915,6 +1971,22 @@ def switch_model(
 
     # --- Get full model info from models.dev ---
     model_info = get_model_info(target_provider, new_model)
+
+    # --- OpenCode Zen free-only default policy (#82764) ---
+    # An explicit --provider opencode-zen selection is itself the override;
+    # only gate ordinary switches (bare model name, aggregator resolution,
+    # alias fallback) that land on opencode-zen.
+    if target_provider == "opencode-zen" and not explicit_provider:
+        block_msg = _opencode_zen_paid_model_blocked(new_model, model_info)
+        if block_msg:
+            return ModelSwitchResult(
+                success=False,
+                new_model=new_model,
+                target_provider=target_provider,
+                provider_label=provider_label,
+                is_global=is_global,
+                error_message=block_msg,
+            )
 
     # --- Collect warnings ---
     warnings: list[str] = []

--- a/tests/hermes_cli/test_model_switch_opencode_anthropic.py
+++ b/tests/hermes_cli/test_model_switch_opencode_anthropic.py
@@ -105,6 +105,7 @@ class TestOpenCodeZenV1Strip:
             current_model="claude-sonnet-4-6",
             current_base_url="https://opencode.ai/zen",
             runtime_base_url="https://opencode.ai/zen/v1",
+            explicit_provider="opencode-zen",
         )
 
         assert result.success

--- a/tests/hermes_cli/test_opencode_zen_free_only_policy.py
+++ b/tests/hermes_cli/test_opencode_zen_free_only_policy.py
@@ -1,10 +1,13 @@
 """OpenCode Zen free-only default policy (#82764).
 
 Zen's model picker intentionally exposes its full free+paid catalog, but the
-model-switch pipeline must not let an ordinary (non-explicit-provider)
-``/model`` switch land on a paid or unknown-cost Zen model without the user
-asking for it by name (``--provider opencode-zen``) or opting in via
-``model.allow_paid_opencode_zen: true``.
+model-switch pipeline must not let a ``/model`` switch land on a paid or
+unknown-cost Zen model without the user asking for it by name
+(hand-typed ``--provider opencode-zen``) or opting in via
+``model.allow_paid_opencode_zen: true``. Picker selections pass
+explicit_provider too (it's the row's own slug), so ``picker_selected=True``
+marks that case and keeps the gate active even though explicit_provider is
+set.
 """
 
 from unittest.mock import patch
@@ -35,7 +38,14 @@ def _paid_model_info(model_id: str) -> ModelInfo:
     )
 
 
-def _run_zen_switch(raw_input: str, *, model_info, explicit_provider: str = "", allow_paid=None):
+def _run_zen_switch(
+    raw_input: str,
+    *,
+    model_info,
+    explicit_provider: str = "",
+    allow_paid=None,
+    picker_selected: bool = False,
+):
     cfg = {"model": {"allow_paid_opencode_zen": allow_paid}} if allow_paid is not None else {}
     with (
         patch("hermes_cli.model_switch.resolve_alias", return_value=None),
@@ -61,6 +71,7 @@ def _run_zen_switch(raw_input: str, *, model_info, explicit_provider: str = "", 
             current_base_url="https://opencode.ai/zen/v1",
             current_api_key="sk-zen-fake",
             explicit_provider=explicit_provider,
+            picker_selected=picker_selected,
         )
 
 
@@ -86,7 +97,9 @@ class TestOpenCodeZenFreeOnlyPolicy:
         assert result.success, f"switch_model failed: {result.error_message}"
         assert result.new_model == "deepseek-v4-flash-free"
 
-    def test_explicit_provider_flag_overrides_paid_block(self):
+    def test_explicit_provider_cli_flag_overrides_paid_block(self):
+        """A hand-typed ``--provider opencode-zen`` is the override; no
+        picker involved (picker_selected defaults to False)."""
         result = _run_zen_switch(
             "gpt-5.6-luna",
             model_info=_paid_model_info("gpt-5.6-luna"),
@@ -98,6 +111,42 @@ class TestOpenCodeZenFreeOnlyPolicy:
     def test_config_override_allows_paid_model(self):
         result = _run_zen_switch(
             "gpt-5.6-luna", model_info=_paid_model_info("gpt-5.6-luna"), allow_paid=True
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"
+
+    def test_picker_selection_of_paid_model_is_blocked(self):
+        """Both interactive pickers (cli.py, gateway/slash_commands.py) pass
+        explicit_provider=<row's own slug> on every selection, paid or free,
+        since Zen's picker intentionally shows its full catalog. That must
+        not be treated as an override the way a hand-typed --provider is."""
+        result = _run_zen_switch(
+            "gpt-5.6-luna",
+            model_info=_paid_model_info("gpt-5.6-luna"),
+            explicit_provider="opencode-zen",
+            picker_selected=True,
+        )
+
+        assert not result.success
+        assert "gpt-5.6-luna" in result.error_message
+
+    def test_picker_selection_of_free_model_is_allowed(self):
+        result = _run_zen_switch(
+            "deepseek-v4-flash-free",
+            model_info=_free_model_info("deepseek-v4-flash-free"),
+            explicit_provider="opencode-zen",
+            picker_selected=True,
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"
+
+    def test_picker_selection_of_paid_model_allowed_via_config(self):
+        result = _run_zen_switch(
+            "gpt-5.6-luna",
+            model_info=_paid_model_info("gpt-5.6-luna"),
+            explicit_provider="opencode-zen",
+            picker_selected=True,
+            allow_paid=True,
         )
 
         assert result.success, f"switch_model failed: {result.error_message}"

--- a/tests/hermes_cli/test_opencode_zen_free_only_policy.py
+++ b/tests/hermes_cli/test_opencode_zen_free_only_policy.py
@@ -1,0 +1,103 @@
+"""OpenCode Zen free-only default policy (#82764).
+
+Zen's model picker intentionally exposes its full free+paid catalog, but the
+model-switch pipeline must not let an ordinary (non-explicit-provider)
+``/model`` switch land on a paid or unknown-cost Zen model without the user
+asking for it by name (``--provider opencode-zen``) or opting in via
+``model.allow_paid_opencode_zen: true``.
+"""
+
+from unittest.mock import patch
+
+from agent.models_dev import ModelInfo
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def _free_model_info(model_id: str) -> ModelInfo:
+    return ModelInfo(
+        id=model_id, name=model_id, family=model_id, provider_id="opencode-zen",
+        cost_input=0.0, cost_output=0.0,
+    )
+
+
+def _paid_model_info(model_id: str) -> ModelInfo:
+    return ModelInfo(
+        id=model_id, name=model_id, family=model_id, provider_id="opencode-zen",
+        cost_input=0.20, cost_output=1.20,
+    )
+
+
+def _run_zen_switch(raw_input: str, *, model_info, explicit_provider: str = "", allow_paid=None):
+    cfg = {"model": {"allow_paid_opencode_zen": allow_paid}} if allow_paid is not None else {}
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "sk-zen-fake",
+                "base_url": "https://opencode.ai/zen/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=model_info),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+        patch("hermes_cli.config.load_config", return_value=cfg),
+    ):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider="opencode-zen",
+            current_model="deepseek-v4-flash-free",
+            current_base_url="https://opencode.ai/zen/v1",
+            current_api_key="sk-zen-fake",
+            explicit_provider=explicit_provider,
+        )
+
+
+class TestOpenCodeZenFreeOnlyPolicy:
+    def test_paid_model_blocked_without_explicit_provider(self):
+        result = _run_zen_switch("gpt-5.6-luna", model_info=_paid_model_info("gpt-5.6-luna"))
+
+        assert not result.success
+        assert "gpt-5.6-luna" in result.error_message
+        assert "opencode-zen" in result.error_message
+
+    def test_unknown_cost_model_blocked_fails_closed(self):
+        result = _run_zen_switch("some-new-model", model_info=None)
+
+        assert not result.success
+        assert "some-new-model" in result.error_message
+
+    def test_verified_free_model_allowed(self):
+        result = _run_zen_switch(
+            "deepseek-v4-flash-free", model_info=_free_model_info("deepseek-v4-flash-free")
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"
+        assert result.new_model == "deepseek-v4-flash-free"
+
+    def test_explicit_provider_flag_overrides_paid_block(self):
+        result = _run_zen_switch(
+            "gpt-5.6-luna",
+            model_info=_paid_model_info("gpt-5.6-luna"),
+            explicit_provider="opencode-zen",
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"
+
+    def test_config_override_allows_paid_model(self):
+        result = _run_zen_switch(
+            "gpt-5.6-luna", model_info=_paid_model_info("gpt-5.6-luna"), allow_paid=True
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"

--- a/tests/tui_gateway/test_opencode_zen_picker_gate.py
+++ b/tests/tui_gateway/test_opencode_zen_picker_gate.py
@@ -1,0 +1,89 @@
+"""OpenCode Zen free-only gate must also apply to the desktop/TUI picker.
+
+The desktop app's model picker (apps/desktop/src/app/session/hooks/
+use-model-controls.ts) and the ink TUI's picker both select a model by
+sending `config.set key=model value="<model> --provider <slug> --session"`
+over the gateway RPC. That lands in `_apply_model_switch`, which forwards to
+`hermes_cli.model_switch.switch_model` — the same gate already covers the
+`cli.py` and `gateway/slash_commands.py` pickers via `picker_selected=True`,
+but this third entry point never threaded that flag through, so a paid Zen
+model picked from the desktop/TUI catalog switched successfully instead of
+being blocked (issue #82764).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import tui_gateway.server as server
+from agent.models_dev import ModelInfo
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+_PAID_MODEL = ModelInfo(
+    id="gpt-5.6-luna", name="gpt-5.6-luna", family="gpt-5.6-luna",
+    provider_id="opencode-zen", cost_input=0.20, cost_output=1.20,
+)
+_FREE_MODEL = ModelInfo(
+    id="big-pickle", name="big-pickle", family="big-pickle",
+    provider_id="opencode-zen", cost_input=0.0, cost_output=0.0,
+)
+
+
+def _config_set(params: dict) -> dict:
+    return server._methods["config.set"]("rid-1", params)
+
+
+def _picker_pick(model_id: str, model_info, picker_selected: bool) -> dict:
+    session = {
+        "session_key": "k1",
+        "agent": None,
+        "model_override": None,
+    }
+    params = {
+        "key": "model",
+        "session_id": "s1",
+        "value": f"{model_id} --provider opencode-zen --session",
+    }
+    if picker_selected:
+        params["picker_selected"] = True
+    with (
+        patch.dict(server._sessions, {"s1": session}, clear=False),
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "sk-zen-fake",
+                "base_url": "https://opencode.ai/zen/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=model_info),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch.object(server, "_write_config_key"),
+        patch.object(server, "_emit"),
+    ):
+        return _config_set(params)
+
+
+class TestOpenCodeZenPickerGate:
+    def test_picker_selection_of_paid_model_is_blocked(self):
+        resp = _picker_pick("gpt-5.6-luna", _PAID_MODEL, picker_selected=True)
+
+        assert "error" in resp, f"expected the paid Zen model to be blocked, got {resp}"
+        assert "gpt-5.6-luna" in resp["error"]["message"]
+
+    def test_picker_selection_of_free_model_is_allowed(self):
+        resp = _picker_pick("big-pickle", _FREE_MODEL, picker_selected=True)
+
+        assert "result" in resp, f"expected the free Zen model to switch, got {resp}"
+        assert resp["result"]["value"] == "big-pickle"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4483,6 +4483,7 @@ def _apply_model_switch(
     pin_session_override: bool = True,
     parsed_flags: Any | None = None,
     persist_override: bool | None = None,
+    picker_selected: bool = False,
 ) -> dict:
     from hermes_cli.model_switch import (
         parse_model_switch_args,
@@ -4574,6 +4575,7 @@ def _apply_model_switch(
         explicit_provider=explicit_provider,
         user_providers=user_provs,
         custom_providers=custom_provs,
+        picker_selected=picker_selected,
     )
     if not result.success:
         raise ValueError(result.error_message or "model switch failed")
@@ -4755,6 +4757,7 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
             session,
             pending["raw"],
             confirm_expensive_model=bool(pending.get("confirm_expensive_model")),
+            picker_selected=bool(pending.get("picker_selected")),
         )
         # A queued pick is a deliberate user action; honour the expensive-model
         # confirm by NOT applying it silently — surface the warning and drop the
@@ -10705,6 +10708,7 @@ def _(rid, params: dict) -> dict:
         try:
             if not value:
                 return _err(rid, 4002, "model value required")
+            picker_selected = bool(params.get("picker_selected", False))
             if session:
                 from hermes_cli.model_switch import parse_model_switch_args
 
@@ -10729,6 +10733,7 @@ def _(rid, params: dict) -> dict:
                         "confirm_expensive_model": bool(
                             params.get("confirm_expensive_model", False)
                         ),
+                        "picker_selected": picker_selected,
                         # The resolved model/provider the next turn will run on.
                         # _session_info reports these while the switch is pending
                         # so the end-of-turn settle keeps showing the user's pick
@@ -10768,6 +10773,7 @@ def _(rid, params: dict) -> dict:
                         params.get("confirm_expensive_model", False)
                     ),
                     parsed_flags=parsed_flags,
+                    picker_selected=picker_selected,
                 )
             else:
                 result = _apply_model_switch(
@@ -10777,6 +10783,7 @@ def _(rid, params: dict) -> dict:
                     confirm_expensive_model=bool(
                         params.get("confirm_expensive_model", False)
                     ),
+                    picker_selected=picker_selected,
                 )
             return _ok(
                 rid,


### PR DESCRIPTION
## What does this PR do?

OpenCode Zen's catalog mixes free and paid models. `hermes_cli.model_switch.switch_model` — the shared pipeline behind every CLI/gateway/TUI `/model` command — accepted any Zen model with no cost check at all, so an ordinary `/model gpt-5.6-luna` (no `--provider` flag) while already on `opencode-zen` would silently switch onto a paid model and start billing the user. That included the interactive model pickers (`cli.py`'s native picker, `gateway/slash_commands.py`'s scoped picker): both deliberately list Zen's full free+paid catalog (`_UNCAPPED_PICKER_PROVIDERS`) for discovery, and both call `switch_model` with `explicit_provider` set to the picker's own row slug on every selection — which is exactly the reproduction in issue #82764 (configure opencode-zen, pick a paid model from the catalog).

This adds a free-only default policy scoped to `opencode-zen`:

- A model is allowed only when models.dev reports verified-zero cost for input, output, and cache tokens.
- A model missing from models.dev entirely (unknown pricing) fails closed — treated as not free.
- A hand-typed `/model <model> --provider opencode-zen` selection is itself the override (the user named the provider on purpose).
- `model.allow_paid_opencode_zen: true` in `config.yaml` opts out of the gate entirely.
- **Picker selections do not bypass the gate.** `switch_model` gains a `picker_selected` parameter; both picker call sites now pass `picker_selected=True` so a paid model chosen from either picker is still blocked even though the picker also sets `explicit_provider` (to disambiguate which catalog row was clicked, not to signal a deliberate CLI-flag override).

The picker's full-catalog listing (`_UNCAPPED_PICKER_PROVIDERS`) is still untouched — showing the catalog for discovery is fine; the fix is entirely in what happens when a paid row from that catalog is actually selected.

### A second latent issue found while fixing the above

`resolve_provider_full("opencode-zen")` normalizes the provider to models.dev's canonical id `"opencode"` (not `"opencode-zen"`) whenever an explicit provider is resolved (the `--provider` flag path, which both the CLI-flag route and both pickers go through). The gate's provider check was written as `target_provider == "opencode-zen"`, so even with `picker_selected` wired up, the check would never fire for any explicit-provider call — including picker selections. Fixed by checking `target_provider in ("opencode-zen", "opencode")` (verified `"opencode"` uniquely refers to Zen in the built-in provider registry; `opencode-go` never normalizes to it).

## Related Issue

Fixes #82764

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`:
  - `_model_info_is_verified_free`, `opencode_zen_model_is_free`, `_opencode_zen_paid_model_blocked` helpers (unchanged from the original fix).
  - `switch_model()` gains a `picker_selected: bool = False` parameter.
  - The gate condition is now `target_provider in ("opencode-zen", "opencode") and (not explicit_provider or picker_selected)`, closing both the picker bypass and the provider-id normalization gap described above.
- `cli.py`: the native model picker's `switch_model` call (`_handle_model_picker_selection`) now passes `picker_selected=True`.
- `gateway/slash_commands.py`: the scoped picker's `switch_model` call (`_on_model_selected_scoped`) now passes `picker_selected=True`.
- `cli-config.yaml.example`: documents the `model.allow_paid_opencode_zen` key (unchanged from the original fix).
- `tests/hermes_cli/test_opencode_zen_free_only_policy.py`: existing tests kept (paid-blocked, unknown-cost-blocked, verified-free-allowed, config override); renamed the CLI-flag-override test to `test_explicit_provider_cli_flag_overrides_paid_block` for clarity; added three new tests covering the picker path — paid model blocked, free model allowed, and paid model allowed via `allow_paid_opencode_zen` — all with `picker_selected=True`.
- `tests/hermes_cli/test_model_switch_opencode_anthropic.py`: unchanged from the original fix (`explicit_provider="opencode-zen"`, no picker involved, so the CLI-flag override still applies).

## How to Test

1. `python -m pytest tests/hermes_cli/test_opencode_zen_free_only_policy.py -v`
2. Reproduce the picker bypass without this remediation: revert just the gate condition in `hermes_cli/model_switch.py` back to `target_provider == "opencode-zen" and not explicit_provider` (keeping the `picker_selected` parameter itself) and rerun — `test_picker_selection_of_paid_model_is_blocked` fails with `success=True` for a paid model, reproducing the reviewer's finding exactly. Reverting the whole parameter (`git checkout HEAD~1 -- hermes_cli/model_switch.py`, HEAD~1 = the pre-remediation commit) fails all 8 tests in the file with `TypeError: unexpected keyword argument 'picker_selected'` since the test file now always passes it.

### Actual output

Isolated repro of the reviewer's finding (gate condition reverted to the pre-remediation form, `picker_selected` parameter kept):
```
tests/hermes_cli/test_opencode_zen_free_only_policy.py::TestOpenCodeZenFreeOnlyPolicy::test_picker_selection_of_paid_model_is_blocked FAILED
  AssertionError: assert not True
   +  where True = ModelSwitchResult(success=True, ... target_provider='opencode', ...).success
1 failed, 7 passed
```

With the fix:
```
tests/hermes_cli/test_opencode_zen_free_only_policy.py ........ [100%]
8 passed in 0.95s
```

Broader related suites, no regressions (98 passed):
```
tests/hermes_cli/test_opencode_zen_free_only_policy.py
tests/hermes_cli/test_model_switch_opencode_anthropic.py
tests/hermes_cli/test_model_switch_custom_providers.py
tests/hermes_cli/test_opencode_go_flat_namespace.py
tests/hermes_cli/test_opencode_go_validation_fallback.py
tests/hermes_cli/test_opencode_zen_model_limit.py
tests/hermes_cli/test_model_switch_persist_default.py
tests/hermes_cli/test_model_validation.py
=> 98 passed, 0 failed
```

Gateway/TUI picker-adjacent suites, no regressions (33 passed):
```
tests/gateway/test_model_command_custom_providers.py
tests/gateway/test_25107_stale_base_url_api_mode.py
tests/gateway/test_model_command_context_offload.py
tests/gateway/test_model_picker_persist.py
tests/gateway/test_10710_auto_reset_evicts_cached_agent.py
tests/gateway/test_model_switch_persistence.py
tests/gateway/test_model_command_async_offload.py
tests/gateway/test_model_command_flat_string_config.py
tests/gateway/test_model_command_expensive_confirm.py
tests/tui_gateway/test_image_routing_stale_model.py
tests/tui_gateway/test_model_switch_marker_role.py
tests/tui_gateway/test_make_agent_provider.py
=> 33 passed, 0 failed
```
`ruff check hermes_cli/model_switch.py tests/hermes_cli/test_opencode_zen_free_only_policy.py cli.py gateway/slash_commands.py`: all checks passed.

## Scope note

The issue's proposed fix also lists "automatic runtime provider resolution" (`hermes_cli/runtime_provider.py` / `hermes_cli/auth.py`) as an enforcement point. I deliberately left that path alone. With this update, every route that can land a model on `opencode-zen` as `model.default` — the CLI-flag `--provider opencode-zen`, an ordinary implicit `/model` switch, *and* both interactive pickers — goes through `switch_model`'s gate, and only a hand-typed `--provider` flag or `allow_paid_opencode_zen: true` bypasses it. A paid model can still reach `runtime_provider.py` only via a hand-edited `config.yaml` or an explicit opt-in, which is the user asking for it by name, not an accidental billing surprise. Gating the resolver itself would need much deeper changes to a large, heavily-branched, sensitive shared path for a narrower marginal benefit, so I kept this PR to the concrete, directly-reproducible bug: the `/model` switch pipeline, now covering the picker path a previous revision of this fix missed.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(model-switch):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` (relevant subset — see above) and all tests pass
- [x] I've added tests for my changes
- [x] Tested on Ubuntu 24.04 (CI runner)

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` for the new `model.allow_paid_opencode_zen` key
- [ ] N/A — no other docs/schema changes

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, via an autonomous coding agent), reviewed and tested before submission.
