### PR TITLE
fix(skills): serialize unquoted YAML dates in skill_view frontmatter

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -334,6 +334,19 @@ class TestSkillView:
         assert by_name["success"] is True
         assert "Step 1" in by_name["content"]
 
+    def test_view_serializes_unquoted_yaml_date_in_frontmatter(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "dated-skill",
+                frontmatter_extra="compatibility:\n  updated: 2026-03-05\n",
+            )
+            raw = skill_view("dated-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["compatibility"]["updated"] == "2026-03-05"
+
     def test_registered_view_tracks_use_with_task_and_session(self, tmp_path):
         from tools.skills_tool import _skill_view_with_bump
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1797,7 +1797,11 @@ def skill_view(
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
-        return json.dumps(result, ensure_ascii=False)
+        # `compatibility`/`metadata` are passed through from YAML frontmatter
+        # verbatim, so an unquoted date/datetime scalar (e.g. `updated:
+        # 2026-03-05`) can reach here as a non-JSON-serializable object.
+        # `default=str` renders it as its ISO-ish string instead of erroring.
+        return json.dumps(result, ensure_ascii=False, default=str)
 
     except Exception as e:
         return tool_error(str(e), success=False)


### PR DESCRIPTION
## What does this PR do?

`skill_view()` copies a skill's `compatibility` and `metadata` frontmatter
blocks straight into the JSON response it returns. If that YAML contains an
unquoted ISO date (e.g. `updated: 2026-03-05`), PyYAML resolves it to a
`datetime.date` object, and the final `json.dumps()` call raises
`TypeError: Object of type date is not JSON serializable`. The tool then
returns `{"error": "Object of type date is not JSON serializable", "success":
false}` instead of the skill content.

Fix: pass `default=str` to that `json.dumps()` call, so any date/datetime
value reachable through the response (top-level or nested in
`compatibility`/`metadata`) is rendered as its string form instead of
crashing. This mirrors the `default=str` convention already used elsewhere
in this codebase for the same class of problem (`tools/browser_tool.py`,
`tools/delegate_tool.py`, `tools/mcp_tool.py`, `tools/skills_hub.py`).

Note on reproduction: the issue's literal example puts `updated:` as a
top-level frontmatter key, which `skill_view()` doesn't currently surface in
its response, so that exact snippet doesn't reproduce the crash on current
`main`. The same underlying bug does reproduce with an unquoted date nested
under `compatibility` (or `metadata`), which real agentskills.io-style
skills use and which `skill_view()` does copy into the response — see the
"How to Test" repro below, which reproduces the exact error message from the
issue and is fixed by this change.

## Related Issue

Fixes #82812

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_tool.py`: add `default=str` to the final `json.dumps()` call
  in `skill_view()`.
- `tests/tools/test_skills_tool.py`: add
  `TestSkillView.test_view_serializes_unquoted_yaml_date_in_frontmatter`,
  which creates a skill with an unquoted date nested in `compatibility:` and
  asserts `skill_view()` succeeds and returns the date as a string.

## How to Test

1. Repro against unmodified code (fails with the exact error from the issue):
   ```python
   import tempfile, json
   from pathlib import Path
   from unittest.mock import patch
   import tools.skills_tool as st

   with tempfile.TemporaryDirectory() as td:
       tmp_path = Path(td)
       skill_dir = tmp_path / "dated-skill"
       skill_dir.mkdir(parents=True)
       (skill_dir / "SKILL.md").write_text(
           "---\nname: dated-skill\ndescription: Example\n"
           "compatibility:\n  updated: 2026-03-05\n---\n\n"
           "# dated-skill\n\nStep 1: Do the thing.\n"
       )
       with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
           print(st.skill_view("dated-skill"))
   # before fix: {"error": "Object of type date is not JSON serializable", "success": false}
   # after fix:  {"success": true, ..., "compatibility": {"updated": "2026-03-05"}}
   ```
2. `pytest tests/tools/test_skills_tool.py -q` → `42 passed`
3. Confirmed the new test fails on the pre-fix code (`git checkout HEAD~1 -- tools/skills_tool.py`, rerun, restore) and passes after the fix.
4. `ruff check tools/skills_tool.py tests/tools/test_skills_tool.py` → all checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/tools/test_skills_tool.py -q` and all tests pass
- [x] I've added a test for this change
- [x] Tested on Linux (the CI/dev environment for this change)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed.
