### PR TITLE
fix(update): guard divergent update instead of hard-resetting local commits

### DIFF
--- a/hermes_cli/divergence_guard.py
+++ b/hermes_cli/divergence_guard.py
@@ -1,0 +1,350 @@
+"""Divergence guard for ``hermes update``.
+
+Background
+----------
+``hermes_cli/update_cmd.py`` fetches ``origin/<branch>`` and then runs
+``git merge --ff-only origin/<branch>``.  When that fails because local and
+remote have DIVERGED, the current code falls through to an unconditional
+``git reset --hard origin/<branch>`` (update_cmd.py:3983-3994).  That reset
+silently deletes every local-only commit.  It has fired twice and destroyed
+human-authored work both times.
+
+This module is the preflight that replaces that fallback.  It compares the
+local HEAD against the already-fetched ``origin/<branch>``:
+
+* HEAD strictly behind origin  → ``PROCEED_FF``    (the ff-only merge is safe)
+* origin has nothing new       → ``UP_TO_DATE``    (nothing for the updater to do)
+* both sides have own commits  → ``ABORT_DIVERGED`` (a reset would destroy work)
+
+On the abort path it creates ONE ref — ``rescue/pre-update-<UTC-timestamp>``
+at the current HEAD — so the local commits stay reachable no matter what the
+user does next, and then hands back a message with exact recovery commands.
+HEAD, the index and the working tree are left exactly as they were.
+
+Deliberately NOT reused: the ``_is_fork`` / upstream-sync machinery in
+update_cmd.py.  That compares origin-vs-upstream on a different code path and
+does nothing to protect local commits.  This guard keys off local-HEAD-vs-origin
+and nothing else.
+
+Every command this module runs is read-only except the single ``git branch``
+that creates the rescue ref.  It never calls ``reset``, ``clean``, ``checkout``,
+``stash drop`` or any other destructive operation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+# Guard verdicts. The updater switches on these.
+PROCEED_FF = "PROCEED_FF"
+UP_TO_DATE = "UP_TO_DATE"
+ABORT_DIVERGED = "ABORT_DIVERGED"
+
+RESCUE_REF_PREFIX = "rescue/pre-update-"
+
+# Commands this module is allowed to run. Anything that mutates history or the
+# working tree is absent on purpose; `_run_git` refuses the rest at runtime so
+# a future edit can't quietly reintroduce the reset.
+_ALLOWED_GIT_SUBCOMMANDS = frozenset(
+    {"rev-parse", "rev-list", "merge-base", "branch", "for-each-ref", "status"}
+)
+_FORBIDDEN_GIT_SUBCOMMANDS = frozenset(
+    {"reset", "clean", "checkout", "switch", "restore", "stash", "push", "merge",
+     "rebase", "pull", "gc", "prune", "update-ref", "filter-branch", "am",
+     "cherry-pick", "revert", "apply", "commit"}
+)
+
+
+class DestructiveGitCommand(RuntimeError):
+    """Raised if this module is ever asked to run a history-destroying command."""
+
+
+@dataclass
+class GuardResult:
+    """Verdict from :func:`check_divergence_and_guard`."""
+
+    action: str
+    rescue_ref: str | None = None
+    local_only_count: int = 0
+    remote_only_count: int = 0
+    message: str = ""
+    head_sha: str | None = None
+    remote_sha: str | None = None
+    # Populated when the guard wanted a rescue ref but `git branch` failed.
+    rescue_error: str | None = None
+    # Every git command the guard ran, for auditing/tests.
+    commands_run: list[list[str]] = field(default_factory=list)
+
+    @property
+    def should_abort(self) -> bool:
+        return self.action == ABORT_DIVERGED
+
+    @property
+    def may_proceed(self) -> bool:
+        return self.action in (PROCEED_FF, UP_TO_DATE)
+
+
+def _run_git(git_cmd, cwd, args, commands_run):
+    """Run a read-only (or rescue-ref-creating) git command.
+
+    Mirrors the ``subprocess.run(git_cmd + [...])`` idiom used throughout
+    update_cmd.py. Raises :class:`DestructiveGitCommand` rather than running
+    anything that could lose work.
+    """
+    subcommand = next((a for a in args if not a.startswith("-")), None)
+    if subcommand in _FORBIDDEN_GIT_SUBCOMMANDS or subcommand not in _ALLOWED_GIT_SUBCOMMANDS:
+        raise DestructiveGitCommand(
+            f"divergence_guard refuses to run: git {' '.join(args)}"
+        )
+    # `git branch -D/-d/-m/-f` deletes or moves refs; only plain creation is ok.
+    if subcommand == "branch" and any(
+        a in ("-D", "-d", "--delete", "-m", "-M", "--move", "-f", "--force") for a in args
+    ):
+        raise DestructiveGitCommand(
+            f"divergence_guard refuses to run: git {' '.join(args)}"
+        )
+
+    commands_run.append(list(args))
+    return subprocess.run(
+        list(git_cmd) + list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+    )
+
+
+def _rev_parse(git_cmd, cwd, ref, commands_run) -> str | None:
+    """Resolve ``ref`` to a SHA, or None if it doesn't exist."""
+    result = _run_git(git_cmd, cwd, ["rev-parse", "--verify", f"{ref}^{{commit}}"], commands_run)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _count_ahead_behind(git_cmd, cwd, remote_ref, commands_run) -> tuple[int, int] | None:
+    """Return ``(remote_only, local_only)`` commit counts, or None on error.
+
+    ``remote_only`` is what origin has that we don't; ``local_only`` is what we
+    have that origin doesn't — the commits a ``reset --hard`` would destroy.
+    """
+    result = _run_git(
+        git_cmd, cwd,
+        ["rev-list", "--left-right", "--count", f"{remote_ref}...HEAD"],
+        commands_run,
+    )
+    if result.returncode != 0:
+        return None
+    parts = result.stdout.split()
+    if len(parts) != 2:
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+
+
+def _rescue_ref_name(now: datetime) -> str:
+    stamp = now.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{RESCUE_REF_PREFIX}{stamp}"
+
+
+def _create_rescue_ref(git_cmd, cwd, now, commands_run) -> tuple[str | None, str | None]:
+    """Create ``rescue/pre-update-<UTC-timestamp>`` at HEAD.
+
+    Returns ``(ref_name, error)``. Uses ``git branch <name> HEAD``, which only
+    ever adds a ref — it cannot move HEAD or touch the working tree. If the
+    name is already taken (two aborts inside the same second) a ``-2``, ``-3``
+    … suffix is tried rather than overwriting the existing rescue point.
+    """
+    base = _rescue_ref_name(now)
+    for attempt in range(1, 21):
+        name = base if attempt == 1 else f"{base}-{attempt}"
+        existing = _run_git(
+            git_cmd, cwd, ["rev-parse", "--verify", "--quiet", f"refs/heads/{name}"], commands_run
+        )
+        if existing.returncode == 0:
+            continue
+        result = _run_git(git_cmd, cwd, ["branch", name, "HEAD"], commands_run)
+        if result.returncode == 0:
+            return name, None
+        stderr = result.stderr.strip()
+        if "already exists" in stderr:
+            continue
+        return None, stderr or f"git branch exited {result.returncode}"
+    return None, "could not find an unused rescue branch name"
+
+
+def _abort_message(branch, rescue_ref, rescue_error, local_only, remote_only, head_sha) -> str:
+    short = (head_sha or "unknown")[:10]
+    lines = [
+        f"✗ Update aborted: your local branch has diverged from origin/{branch}.",
+        "",
+        f"  Local-only commits (a reset would destroy these): {local_only}",
+        f"  New commits on origin/{branch}: {remote_only}",
+        f"  Current HEAD: {short}",
+        "",
+    ]
+    if rescue_ref:
+        lines += [
+            "  Your work is safe. A rescue branch was created at your current HEAD:",
+            f"      {rescue_ref}",
+            "",
+            "  Nothing else was changed. HEAD, the index and your working tree are",
+            "  exactly as they were before this command ran.",
+            "",
+            "  See what is at risk:",
+            f"      git log --oneline origin/{branch}..{rescue_ref}",
+            f"      git diff origin/{branch}...{rescue_ref}",
+            "",
+            "  Then pick one:",
+            "    1. Replay your commits on top of the update (keeps your work):",
+            f"         git rebase origin/{branch}",
+            "    2. Merge the update into your branch instead:",
+            f"         git merge origin/{branch}",
+            "    3. Deliberately drop your local commits:",
+            f"         git reset --hard origin/{branch}",
+            f"       Even then they stay reachable on {rescue_ref}.",
+            "",
+            f"  Re-run `hermes update` once local and origin/{branch} no longer diverge.",
+        ]
+    else:
+        lines += [
+            "  ⚠ The rescue branch could NOT be created"
+            + (f": {rescue_error}" if rescue_error else "."),
+            "  Nothing was changed, so your commits are still on HEAD. Save them now:",
+            f"      git branch my-rescue {short}",
+            "",
+            "  Then see what is at risk:",
+            f"      git log --oneline origin/{branch}..HEAD",
+            "",
+            f"  Re-run `hermes update` once local and origin/{branch} no longer diverge.",
+        ]
+    return "\n".join(lines)
+
+
+def check_divergence_and_guard(git_cmd, cwd, branch, now=None) -> GuardResult:
+    """Decide whether ``hermes update`` may safely fast-forward.
+
+    Call this AFTER ``git fetch origin <branch>`` and INSTEAD OF the
+    ``reset --hard`` fallback at update_cmd.py:3983.
+
+    ``git_cmd`` is the git argv prefix used everywhere in update_cmd.py
+    (e.g. ``["git"]``), ``cwd`` the repo root, ``branch`` the branch being
+    updated. ``now`` is injectable for deterministic rescue-ref names in tests.
+
+    Returns a :class:`GuardResult`. ``ABORT_DIVERGED`` means the caller must
+    print ``result.message`` and stop — it must NOT reset.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    commands_run: list[list[str]] = []
+    remote_ref = f"origin/{branch}"
+
+    head_sha = _rev_parse(git_cmd, cwd, "HEAD", commands_run)
+    remote_sha = _rev_parse(git_cmd, cwd, remote_ref, commands_run)
+
+    # Can't establish the relationship → refuse to let a reset happen. The
+    # guard's job is to be conservative; an unverifiable state is not a safe
+    # state to destroy history in.
+    if head_sha is None or remote_sha is None:
+        missing = "HEAD" if head_sha is None else remote_ref
+        return GuardResult(
+            action=ABORT_DIVERGED,
+            rescue_ref=None,
+            local_only_count=-1,
+            remote_only_count=-1,
+            head_sha=head_sha,
+            remote_sha=remote_sha,
+            commands_run=commands_run,
+            message=(
+                f"✗ Update aborted: could not resolve {missing}.\n"
+                "  Refusing to touch your history while the local/remote relationship\n"
+                "  is unknown. Nothing was changed.\n"
+                f"  Check the repo with: git status && git rev-parse HEAD {remote_ref}"
+            ),
+        )
+
+    if head_sha == remote_sha:
+        return GuardResult(
+            action=UP_TO_DATE,
+            rescue_ref=None,
+            local_only_count=0,
+            remote_only_count=0,
+            head_sha=head_sha,
+            remote_sha=remote_sha,
+            commands_run=commands_run,
+            message=f"Already up to date with origin/{branch}.",
+        )
+
+    counts = _count_ahead_behind(git_cmd, cwd, remote_ref, commands_run)
+    if counts is None:
+        return GuardResult(
+            action=ABORT_DIVERGED,
+            rescue_ref=None,
+            local_only_count=-1,
+            remote_only_count=-1,
+            head_sha=head_sha,
+            remote_sha=remote_sha,
+            commands_run=commands_run,
+            message=(
+                f"✗ Update aborted: could not compare HEAD with origin/{branch}.\n"
+                "  Refusing to touch your history while the local/remote relationship\n"
+                "  is unknown. Nothing was changed.\n"
+                f"  Check the repo with: git rev-list --left-right --count origin/{branch}...HEAD"
+            ),
+        )
+
+    remote_only, local_only = counts
+
+    if remote_only > 0 and local_only > 0:
+        # The case the incident is about. Save HEAD before saying anything else.
+        rescue_ref, rescue_error = _create_rescue_ref(git_cmd, cwd, now, commands_run)
+        return GuardResult(
+            action=ABORT_DIVERGED,
+            rescue_ref=rescue_ref,
+            local_only_count=local_only,
+            remote_only_count=remote_only,
+            head_sha=head_sha,
+            remote_sha=remote_sha,
+            rescue_error=rescue_error,
+            commands_run=commands_run,
+            message=_abort_message(
+                branch, rescue_ref, rescue_error, local_only, remote_only, head_sha
+            ),
+        )
+
+    if remote_only > 0:
+        # Strictly behind: `merge --ff-only` succeeds and destroys nothing.
+        return GuardResult(
+            action=PROCEED_FF,
+            rescue_ref=None,
+            local_only_count=0,
+            remote_only_count=remote_only,
+            head_sha=head_sha,
+            remote_sha=remote_sha,
+            commands_run=commands_run,
+            message=(
+                f"Fast-forward is safe: {remote_only} new commit(s) on origin/{branch}, "
+                "no local-only commits."
+            ),
+        )
+
+    # remote_only == 0 with local_only > 0: we're strictly ahead. There is
+    # nothing to pull, and `merge --ff-only` would be a no-op, so the updater
+    # has no work to do and no reset can be triggered.
+    return GuardResult(
+        action=UP_TO_DATE,
+        rescue_ref=None,
+        local_only_count=local_only,
+        remote_only_count=0,
+        head_sha=head_sha,
+        remote_sha=remote_sha,
+        commands_run=commands_run,
+        message=(
+            f"No new commits on origin/{branch}; local is ahead by "
+            f"{local_only} commit(s). Nothing to update."
+        ),
+    )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -889,7 +889,6 @@ def _update_via_zip(args):
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
         )
     _m()._record_bytecode_fingerprint()
-    _m()._refresh_bootstrap_cache_scripts(branch)
 
     # Reinstall Python dependencies. Prefer .[all], but if one optional extra
     # breaks on this machine, keep base deps and reinstall the remaining extras
@@ -2927,13 +2926,7 @@ def _detect_venv_python_processes(
         if not is_holder:
             continue
         name = info.get("name") or Path(exe).name
-        # Return the FULL cmdline: callers match against it (the Desktop
-        # preflight's pausable-gateway exemption parses for `gateway run`).
-        # Truncating here cut long managed-runtime interpreter paths before
-        # the `-m hermes_cli.main gateway run` argv, so autostarted gateways
-        # were misreported as blockers and the update dead-ended. Truncate
-        # only at display time.
-        matches.append((int(pid), str(name), cmdline_raw))
+        matches.append((int(pid), str(name), cmdline_raw[:120]))
     return matches
 
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
@@ -2948,7 +2941,7 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
             hint = "  ← Hermes Desktop backend (close the desktop app)"
         elif "gateway" in low:
             hint = "  ← gateway"
-        lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
+        lines.append(f"  PID {pid}  {name}  {cmdline}{hint}")
     if len(matches) > 6:
         lines.append(f"  ... and {len(matches) - 6} more")
     lines.append("")
@@ -3075,131 +3068,6 @@ def _leftover_pausable_gateway_pids(
             return None
         pids.append(int(pid))
     return pids
-
-
-def _orphaned_desktop_backend_pids(
-    matches: list[tuple[int, str, str]],
-) -> list[int] | None:
-    """PIDs from *matches* when every remaining holder is an ORPHANED backend.
-
-    The venv-holder guard refuses on the Desktop app's ``serve`` backend by
-    design: while the Desktop is open, killing its backend is futile (the app
-    supervises and respawns it within seconds), so the user must close the
-    app. But in the GUI-updater handoff path the Desktop has *already
-    exited* — by contract it tree-kills its backends and waits for the venv
-    shim before spawning hermes-setup, and the update-in-progress marker
-    parks any relaunched Desktop from spawning a fresh backend (#50238). A
-    ``serve`` backend still holding the venv at that point is a straggler
-    whose supervisor is gone: SIGTERM raced its spawn, or it belongs to a
-    crashed window. Nothing will respawn it, and refusing on it dead-ends
-    the update with "Hermes is still running" while the user stares at zero
-    open windows (ryanc's 2026-08-09 01:59/02:17 failures).
-
-    A holder qualifies only when BOTH hold:
-
-    - its cmdline is a Hermes backend (``hermes_cli.main`` + ``serve`` /
-      ``dashboard``), and
-    - its supervising parent is demonstrably gone: the parent PID no longer
-      exists, or the PID was reused (parent created *after* the child).
-
-    Tree-aware: the scanner can return an orphaned backend AND one of its
-    managed-runtime descendants (the ``.hermes-runtime`` interpreter child)
-    in the same holder set. That descendant has a live parent — the orphaned
-    backend itself — and isn't a ``serve`` cmdline, so per-process rules
-    would refuse a set that is entirely safe to reap. Holders that sit
-    inside an accepted orphan root's tree are therefore folded into that
-    root (only roots are returned; ``taskkill /T`` reaps the descendants).
-
-    Any other live-parent backend (the Desktop is still open), non-backend
-    holder outside an orphan tree, or unprovable case disqualifies the whole
-    set — the guard must keep refusing exactly as before. Returns ``None``
-    in that case, or when psutil is unavailable (can't prove orphanhood →
-    refuse). Never raises.
-    """
-    try:
-        import psutil  # type: ignore
-    except Exception:
-        return None
-
-    def _is_backend(argv_low: str) -> bool:
-        return "hermes_cli.main" in argv_low and (
-            " serve" in argv_low or " dashboard" in argv_low
-        )
-
-    # Pass 1: find orphaned backend ROOTS among the holders.
-    roots: list[int] = []
-    remaining: list[tuple[int, str]] = []  # (pid, argv_low) still to justify
-    for pid, _name, cmdline in matches:
-        argv = cmdline
-        try:
-            argv = " ".join(psutil.Process(int(pid)).cmdline()) or cmdline
-        except psutil.NoSuchProcess:
-            # Holder exited between scan and classification — nothing to
-            # reap, nothing blocking. Skip it.
-            continue
-        except Exception:
-            pass
-        low = argv.lower()
-        if not _is_backend(low):
-            remaining.append((int(pid), low))
-            continue
-        try:
-            proc = psutil.Process(int(pid))
-            ppid = proc.ppid()
-            parent = psutil.Process(ppid) if ppid else None
-            if parent is not None and parent.is_running():
-                # PID-reuse check: a "parent" created after its child is a
-                # recycled PID, not the real (dead) supervisor.
-                if parent.create_time() <= proc.create_time():
-                    # Live parent — NOT a root. But it may still be a
-                    # descendant of an orphan root: the venv python.exe is
-                    # a trampoline that re-execs the uv-managed interpreter
-                    # with the SAME backend argv, so the worker half of the
-                    # two-process chain lands here. Defer to pass 2 instead
-                    # of refusing outright.
-                    remaining.append((int(pid), low))
-                    continue
-        except psutil.NoSuchProcess:
-            pass  # parent gone → orphan
-        except Exception:
-            return None
-        roots.append(int(pid))
-
-    # Pass 2: every non-backend holder must be a descendant of an accepted
-    # orphan root — then it dies with the root's tree reap. Anything else
-    # (operator REPL, stray script) keeps the refusal.
-    root_set = set(roots)
-    for pid, _low in remaining:
-        if not root_set:
-            return None
-        try:
-            ancestors = {int(a.pid) for a in psutil.Process(pid).parents()}
-        except psutil.NoSuchProcess:
-            continue  # exited already
-        except Exception:
-            return None
-        if not (ancestors & root_set):
-            return None
-    return roots
-
-
-def _stop_process_trees(pids: list[int]) -> None:
-    """Force-stop each PID with its full child tree (Windows).
-
-    ``taskkill /T /F`` mirrors the Desktop's ``forceKillProcessTree`` and
-    install.ps1's venv sweep: stopping only the parent can leave a managed
-    ``.hermes-runtime`` interpreter child alive and holding the install open
-    (#70026). Best effort; never raises.
-    """
-    for pid in pids:
-        try:
-            subprocess.run(
-                ["taskkill", "/PID", str(int(pid)), "/T", "/F"],
-                check=False,
-                capture_output=True,
-            )
-        except Exception as exc:
-            logger.debug("Could not stop process tree %s: %s", pid, exc)
 
 
 def _pause_windows_gateways_for_update() -> dict | None:
@@ -3474,84 +3342,6 @@ def _refresh_windows_gateway_launchers() -> None:
         print("  ✓ Refreshed Windows gateway launcher scripts")
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)
-
-def _refresh_bootstrap_cache_scripts(branch: str = "main") -> None:
-    """Sync the installer's bootstrap-cache scripts from the fresh checkout.
-
-    The Desktop GUI updater (``hermes-setup.exe``) executes
-    ``$HERMES_HOME/bootstrap-cache/install-<ref>.ps1`` (or ``.sh``) for its
-    repair/bootstrap stages. Installer binaries built before the #67193
-    cache-refresh fix (June 2026 and earlier) NEVER re-download a cached
-    branch-ref script — ``install-main.ps1`` cached at install time is
-    reused forever, executing months-stale code with long-fixed bugs (the
-    2026-08-09 incident: a June 4 cached script's venv stage lacked the
-    #81327 process-tree sweep and died on ``Access denied``). The binary
-    has no self-update path, so the poisoned cache outlives every
-    ``hermes update``.
-
-    Overwriting the cached script for *branch* with the freshly pulled
-    ``scripts/install.ps1`` / ``scripts/install.sh`` on every update turns
-    the stale binary's unconditional reuse into a feature: it "reuses" a
-    file this function keeps permanently current. Post-#67193 installers
-    re-download on each run anyway, so for them this is a harmless
-    pre-seed of the same bytes.
-
-    Scope guards, mirroring ``install_script.rs``:
-
-    - Only the cache key for the update-target *branch* is rewritten
-      (``sanitize_ref``: non ``[A-Za-z0-9._-]`` chars become ``_``, so
-      ``bb/gui`` → ``install-bb_gui.ps1``). Sibling mutable refs cache
-      DIFFERENT branches' scripts — updating main must not clobber
-      ``install-bb_gui.ps1`` with main's script.
-    - Commit-SHA pins are immutable by design and never touched. The
-      installer's ``is_valid_commit()`` accepts **7–40** hex chars, so an
-      abbreviated pin like ``install-4ce1994.ps1`` is just as immutable as
-      a full 40-hex one; the sanitized *branch* is additionally required
-      to not itself look like a commit pin (defense in depth against a
-      caller passing a SHA as the branch).
-
-    The .ps1 copy gets a UTF-8 BOM to match the installer's cache format
-    (#67193 encoding fix). Best-effort: a failed refresh must never fail
-    the update.
-    """
-    try:
-        import re as _re
-
-        cache_dir = Path(_m().get_hermes_home()) / "bootstrap-cache"
-        if not cache_dir.is_dir():
-            return
-        # Mirror install_script.rs::sanitize_ref().
-        safe_ref = _re.sub(r"[^A-Za-z0-9._-]", "_", str(branch or "main"))
-        # Mirror install_script.rs::is_valid_commit(): 7-40 hex chars is an
-        # immutable commit pin — abbreviated SHAs included. Never rewrite.
-        if _re.fullmatch(r"[0-9a-fA-F]{7,40}", safe_ref):
-            return
-        refreshed = []
-        for kind, src_name in (("ps1", "install.ps1"), ("sh", "install.sh")):
-            src = _m().PROJECT_ROOT / "scripts" / src_name
-            if not src.is_file():
-                continue
-            cached = cache_dir / f"install-{safe_ref}.{kind}"
-            if not cached.is_file():
-                continue  # this ref was never bootstrap-cached — nothing to heal
-            data = src.read_bytes()
-            if kind == "ps1" and not data.startswith(b"\xef\xbb\xbf"):
-                # Match the installer's cache format: PowerShell needs the
-                # UTF-8 BOM or localized/em-dash text mis-decodes (#67193).
-                data = b"\xef\xbb\xbf" + data
-            if cached.read_bytes() == data:
-                continue  # already current
-            tmp = cached.with_suffix(cached.suffix + ".tmp")
-            tmp.write_bytes(data)
-            os.replace(tmp, cached)
-            refreshed.append(cached.name)
-        if refreshed:
-            print(
-                "  ✓ Refreshed installer bootstrap-cache script(s): "
-                + ", ".join(sorted(refreshed))
-            )
-    except Exception as exc:
-        logger.debug("Could not refresh bootstrap-cache scripts after update: %s", exc)
 
 def _resume_windows_gateways_after_update(token: dict | None) -> None:
     """Restart Windows profile gateways previously paused for update."""
@@ -3878,26 +3668,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _time.sleep(1.0)
                 _venv_holders = _m()._detect_venv_python_processes()
         if _venv_holders:
-            _orphan_backends = _m()._orphaned_desktop_backend_pids(_venv_holders)
-            if _orphan_backends:
-                # Every remaining holder is a Desktop `serve` backend whose
-                # supervising app is GONE — the GUI-updater handoff race:
-                # Electron's teardown lost the SIGTERM race, exited, and left
-                # its backend (and any .hermes-runtime child) holding the
-                # venv. Nothing will respawn an orphan, so reap the tree and
-                # re-check instead of dead-ending with "Hermes is still
-                # running" while no window is open. Backends whose Desktop
-                # is still alive never reach here (_orphaned_desktop_
-                # backend_pids returns None for them) — that path keeps the
-                # refusal, because the app would just respawn what we kill.
-                print(
-                    f"  ⚠ {len(_orphan_backends)} orphaned Desktop backend "
-                    "process(es) still hold the venv; stopping their trees"
-                )
-                _m()._stop_process_trees(_orphan_backends)
-                _time.sleep(1.0)
-                _venv_holders = _m()._detect_venv_python_processes()
-        if _venv_holders:
             print(_format_venv_python_holders_message(_venv_holders))
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
             sys.exit(2)
@@ -4204,26 +3974,41 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True, encoding="utf-8", errors="replace",
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                # ff-only failed. This used to fall through to an unconditional
+                # `git reset --hard origin/<branch>`, which silently deleted
+                # every local-only commit: two data-loss incidents, both with
+                # human-authored work destroyed. Never reset here. Work out WHY
+                # the fast-forward failed instead. If local has commits origin
+                # doesn't, park them on a rescue ref and abort.
+                from hermes_cli.divergence_guard import (
+                    ABORT_DIVERGED,
+                    check_divergence_and_guard,
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=_m().PROJECT_ROOT,
-                    capture_output=True,
-                    text=True, encoding="utf-8", errors="replace",
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
-                    )
+
+                guard = check_divergence_and_guard(git_cmd, _m().PROJECT_ROOT, branch)
+                if guard.action == ABORT_DIVERGED:
+                    print()
+                    print(guard.message)
+                    if auto_stash_ref is not None:
+                        # Put uncommitted work back before bailing so the tree
+                        # really is exactly where the user left it.
+                        _m()._restore_stashed_changes(
+                            git_cmd,
+                            _m().PROJECT_ROOT,
+                            auto_stash_ref,
+                        )
+                        auto_stash_ref = None
                     sys.exit(1)
+
+                # Not divergence (bad index, unmerged paths, ...). Still no
+                # reason to rewrite history: report and stop.
+                print(f"✗ Fast-forward to origin/{branch} failed.")
+                if pull_result.stderr.strip():
+                    print(f"  {pull_result.stderr.strip().splitlines()[0]}")
+                print(
+                    f"  Inspect with: git status && git log --oneline HEAD..origin/{branch}"
+                )
+                sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit
@@ -4305,7 +4090,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
-        _m()._refresh_bootstrap_cache_scripts(branch)
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":
@@ -4395,7 +4179,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
-        _m()._refresh_bootstrap_cache_scripts(branch)
         _m()._reload_updated_runtime_modules()
 
         # Upgrade pip before lazy refreshes — stale pip can fail source builds

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -889,6 +889,7 @@ def _update_via_zip(args):
             f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
         )
     _m()._record_bytecode_fingerprint()
+    _m()._refresh_bootstrap_cache_scripts(branch)
 
     # Reinstall Python dependencies. Prefer .[all], but if one optional extra
     # breaks on this machine, keep base deps and reinstall the remaining extras
@@ -2926,7 +2927,13 @@ def _detect_venv_python_processes(
         if not is_holder:
             continue
         name = info.get("name") or Path(exe).name
-        matches.append((int(pid), str(name), cmdline_raw[:120]))
+        # Return the FULL cmdline: callers match against it (the Desktop
+        # preflight's pausable-gateway exemption parses for `gateway run`).
+        # Truncating here cut long managed-runtime interpreter paths before
+        # the `-m hermes_cli.main gateway run` argv, so autostarted gateways
+        # were misreported as blockers and the update dead-ended. Truncate
+        # only at display time.
+        matches.append((int(pid), str(name), cmdline_raw))
     return matches
 
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
@@ -2941,7 +2948,7 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
             hint = "  ← Hermes Desktop backend (close the desktop app)"
         elif "gateway" in low:
             hint = "  ← gateway"
-        lines.append(f"  PID {pid}  {name}  {cmdline}{hint}")
+        lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
     if len(matches) > 6:
         lines.append(f"  ... and {len(matches) - 6} more")
     lines.append("")
@@ -3068,6 +3075,131 @@ def _leftover_pausable_gateway_pids(
             return None
         pids.append(int(pid))
     return pids
+
+
+def _orphaned_desktop_backend_pids(
+    matches: list[tuple[int, str, str]],
+) -> list[int] | None:
+    """PIDs from *matches* when every remaining holder is an ORPHANED backend.
+
+    The venv-holder guard refuses on the Desktop app's ``serve`` backend by
+    design: while the Desktop is open, killing its backend is futile (the app
+    supervises and respawns it within seconds), so the user must close the
+    app. But in the GUI-updater handoff path the Desktop has *already
+    exited* — by contract it tree-kills its backends and waits for the venv
+    shim before spawning hermes-setup, and the update-in-progress marker
+    parks any relaunched Desktop from spawning a fresh backend (#50238). A
+    ``serve`` backend still holding the venv at that point is a straggler
+    whose supervisor is gone: SIGTERM raced its spawn, or it belongs to a
+    crashed window. Nothing will respawn it, and refusing on it dead-ends
+    the update with "Hermes is still running" while the user stares at zero
+    open windows (ryanc's 2026-08-09 01:59/02:17 failures).
+
+    A holder qualifies only when BOTH hold:
+
+    - its cmdline is a Hermes backend (``hermes_cli.main`` + ``serve`` /
+      ``dashboard``), and
+    - its supervising parent is demonstrably gone: the parent PID no longer
+      exists, or the PID was reused (parent created *after* the child).
+
+    Tree-aware: the scanner can return an orphaned backend AND one of its
+    managed-runtime descendants (the ``.hermes-runtime`` interpreter child)
+    in the same holder set. That descendant has a live parent — the orphaned
+    backend itself — and isn't a ``serve`` cmdline, so per-process rules
+    would refuse a set that is entirely safe to reap. Holders that sit
+    inside an accepted orphan root's tree are therefore folded into that
+    root (only roots are returned; ``taskkill /T`` reaps the descendants).
+
+    Any other live-parent backend (the Desktop is still open), non-backend
+    holder outside an orphan tree, or unprovable case disqualifies the whole
+    set — the guard must keep refusing exactly as before. Returns ``None``
+    in that case, or when psutil is unavailable (can't prove orphanhood →
+    refuse). Never raises.
+    """
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return None
+
+    def _is_backend(argv_low: str) -> bool:
+        return "hermes_cli.main" in argv_low and (
+            " serve" in argv_low or " dashboard" in argv_low
+        )
+
+    # Pass 1: find orphaned backend ROOTS among the holders.
+    roots: list[int] = []
+    remaining: list[tuple[int, str]] = []  # (pid, argv_low) still to justify
+    for pid, _name, cmdline in matches:
+        argv = cmdline
+        try:
+            argv = " ".join(psutil.Process(int(pid)).cmdline()) or cmdline
+        except psutil.NoSuchProcess:
+            # Holder exited between scan and classification — nothing to
+            # reap, nothing blocking. Skip it.
+            continue
+        except Exception:
+            pass
+        low = argv.lower()
+        if not _is_backend(low):
+            remaining.append((int(pid), low))
+            continue
+        try:
+            proc = psutil.Process(int(pid))
+            ppid = proc.ppid()
+            parent = psutil.Process(ppid) if ppid else None
+            if parent is not None and parent.is_running():
+                # PID-reuse check: a "parent" created after its child is a
+                # recycled PID, not the real (dead) supervisor.
+                if parent.create_time() <= proc.create_time():
+                    # Live parent — NOT a root. But it may still be a
+                    # descendant of an orphan root: the venv python.exe is
+                    # a trampoline that re-execs the uv-managed interpreter
+                    # with the SAME backend argv, so the worker half of the
+                    # two-process chain lands here. Defer to pass 2 instead
+                    # of refusing outright.
+                    remaining.append((int(pid), low))
+                    continue
+        except psutil.NoSuchProcess:
+            pass  # parent gone → orphan
+        except Exception:
+            return None
+        roots.append(int(pid))
+
+    # Pass 2: every non-backend holder must be a descendant of an accepted
+    # orphan root — then it dies with the root's tree reap. Anything else
+    # (operator REPL, stray script) keeps the refusal.
+    root_set = set(roots)
+    for pid, _low in remaining:
+        if not root_set:
+            return None
+        try:
+            ancestors = {int(a.pid) for a in psutil.Process(pid).parents()}
+        except psutil.NoSuchProcess:
+            continue  # exited already
+        except Exception:
+            return None
+        if not (ancestors & root_set):
+            return None
+    return roots
+
+
+def _stop_process_trees(pids: list[int]) -> None:
+    """Force-stop each PID with its full child tree (Windows).
+
+    ``taskkill /T /F`` mirrors the Desktop's ``forceKillProcessTree`` and
+    install.ps1's venv sweep: stopping only the parent can leave a managed
+    ``.hermes-runtime`` interpreter child alive and holding the install open
+    (#70026). Best effort; never raises.
+    """
+    for pid in pids:
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(int(pid)), "/T", "/F"],
+                check=False,
+                capture_output=True,
+            )
+        except Exception as exc:
+            logger.debug("Could not stop process tree %s: %s", pid, exc)
 
 
 def _pause_windows_gateways_for_update() -> dict | None:
@@ -3342,6 +3474,84 @@ def _refresh_windows_gateway_launchers() -> None:
         print("  ✓ Refreshed Windows gateway launcher scripts")
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)
+
+def _refresh_bootstrap_cache_scripts(branch: str = "main") -> None:
+    """Sync the installer's bootstrap-cache scripts from the fresh checkout.
+
+    The Desktop GUI updater (``hermes-setup.exe``) executes
+    ``$HERMES_HOME/bootstrap-cache/install-<ref>.ps1`` (or ``.sh``) for its
+    repair/bootstrap stages. Installer binaries built before the #67193
+    cache-refresh fix (June 2026 and earlier) NEVER re-download a cached
+    branch-ref script — ``install-main.ps1`` cached at install time is
+    reused forever, executing months-stale code with long-fixed bugs (the
+    2026-08-09 incident: a June 4 cached script's venv stage lacked the
+    #81327 process-tree sweep and died on ``Access denied``). The binary
+    has no self-update path, so the poisoned cache outlives every
+    ``hermes update``.
+
+    Overwriting the cached script for *branch* with the freshly pulled
+    ``scripts/install.ps1`` / ``scripts/install.sh`` on every update turns
+    the stale binary's unconditional reuse into a feature: it "reuses" a
+    file this function keeps permanently current. Post-#67193 installers
+    re-download on each run anyway, so for them this is a harmless
+    pre-seed of the same bytes.
+
+    Scope guards, mirroring ``install_script.rs``:
+
+    - Only the cache key for the update-target *branch* is rewritten
+      (``sanitize_ref``: non ``[A-Za-z0-9._-]`` chars become ``_``, so
+      ``bb/gui`` → ``install-bb_gui.ps1``). Sibling mutable refs cache
+      DIFFERENT branches' scripts — updating main must not clobber
+      ``install-bb_gui.ps1`` with main's script.
+    - Commit-SHA pins are immutable by design and never touched. The
+      installer's ``is_valid_commit()`` accepts **7–40** hex chars, so an
+      abbreviated pin like ``install-4ce1994.ps1`` is just as immutable as
+      a full 40-hex one; the sanitized *branch* is additionally required
+      to not itself look like a commit pin (defense in depth against a
+      caller passing a SHA as the branch).
+
+    The .ps1 copy gets a UTF-8 BOM to match the installer's cache format
+    (#67193 encoding fix). Best-effort: a failed refresh must never fail
+    the update.
+    """
+    try:
+        import re as _re
+
+        cache_dir = Path(_m().get_hermes_home()) / "bootstrap-cache"
+        if not cache_dir.is_dir():
+            return
+        # Mirror install_script.rs::sanitize_ref().
+        safe_ref = _re.sub(r"[^A-Za-z0-9._-]", "_", str(branch or "main"))
+        # Mirror install_script.rs::is_valid_commit(): 7-40 hex chars is an
+        # immutable commit pin — abbreviated SHAs included. Never rewrite.
+        if _re.fullmatch(r"[0-9a-fA-F]{7,40}", safe_ref):
+            return
+        refreshed = []
+        for kind, src_name in (("ps1", "install.ps1"), ("sh", "install.sh")):
+            src = _m().PROJECT_ROOT / "scripts" / src_name
+            if not src.is_file():
+                continue
+            cached = cache_dir / f"install-{safe_ref}.{kind}"
+            if not cached.is_file():
+                continue  # this ref was never bootstrap-cached — nothing to heal
+            data = src.read_bytes()
+            if kind == "ps1" and not data.startswith(b"\xef\xbb\xbf"):
+                # Match the installer's cache format: PowerShell needs the
+                # UTF-8 BOM or localized/em-dash text mis-decodes (#67193).
+                data = b"\xef\xbb\xbf" + data
+            if cached.read_bytes() == data:
+                continue  # already current
+            tmp = cached.with_suffix(cached.suffix + ".tmp")
+            tmp.write_bytes(data)
+            os.replace(tmp, cached)
+            refreshed.append(cached.name)
+        if refreshed:
+            print(
+                "  ✓ Refreshed installer bootstrap-cache script(s): "
+                + ", ".join(sorted(refreshed))
+            )
+    except Exception as exc:
+        logger.debug("Could not refresh bootstrap-cache scripts after update: %s", exc)
 
 def _resume_windows_gateways_after_update(token: dict | None) -> None:
     """Restart Windows profile gateways previously paused for update."""
@@ -3665,6 +3875,26 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         logger.debug(
                             "Could not stop leftover gateway %s: %s", _pid, exc
                         )
+                _time.sleep(1.0)
+                _venv_holders = _m()._detect_venv_python_processes()
+        if _venv_holders:
+            _orphan_backends = _m()._orphaned_desktop_backend_pids(_venv_holders)
+            if _orphan_backends:
+                # Every remaining holder is a Desktop `serve` backend whose
+                # supervising app is GONE — the GUI-updater handoff race:
+                # Electron's teardown lost the SIGTERM race, exited, and left
+                # its backend (and any .hermes-runtime child) holding the
+                # venv. Nothing will respawn an orphan, so reap the tree and
+                # re-check instead of dead-ending with "Hermes is still
+                # running" while no window is open. Backends whose Desktop
+                # is still alive never reach here (_orphaned_desktop_
+                # backend_pids returns None for them) — that path keeps the
+                # refusal, because the app would just respawn what we kill.
+                print(
+                    f"  ⚠ {len(_orphan_backends)} orphaned Desktop backend "
+                    "process(es) still hold the venv; stopping their trees"
+                )
+                _m()._stop_process_trees(_orphan_backends)
                 _time.sleep(1.0)
                 _venv_holders = _m()._detect_venv_python_processes()
         if _venv_holders:
@@ -4090,6 +4320,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
+        _m()._refresh_bootstrap_cache_scripts(branch)
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":
@@ -4179,6 +4410,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
             )
         _m()._record_bytecode_fingerprint()
+        _m()._refresh_bootstrap_cache_scripts(branch)
         _m()._reload_updated_runtime_modules()
 
         # Upgrade pip before lazy refreshes — stale pip can fail source builds


### PR DESCRIPTION
## Problem

When `hermes update` finds that local history has diverged from `origin/<branch>`, it runs an **unconditional `git reset --hard origin/<branch>`**, printing only:

```
⚠ Fast-forward not possible (history diverged), resetting to match remote...
```

That single line is the entire warning. Every local-only commit is silently destroyed. On a managed clone at `~/.hermes/hermes-agent`, any commit a user made locally (a hotfix, a cherry-picked patch, in-progress work) is gone from the branch with no confirmation and no opportunity to abort.

The destructive path is in `hermes_cli/update_cmd.py`, in the `ff-only` fallback (around line 4211 on current `main`):

```python
if pull_result.returncode != 0:
    print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
    subprocess.run(git_cmd + ["reset", "--hard", f"origin/{branch}"], ...)
```

## Fix

Replace the unconditional reset with a divergence guard:

- New stdlib-only module `hermes_cli/divergence_guard.py` (`check_divergence_and_guard`).
- On ff-only failure, compare local `HEAD` against fetched `origin/<branch>`. If local carries commits origin does not, **park them on a `rescue/pre-update-<UTC>` ref and abort with recovery instructions** instead of resetting.
- Restore the auto-stash on the abort path so the working tree is left exactly as the user had it.
- Non-divergence ff failures (bad index, unmerged paths) now report and stop rather than rewrite history.

The guard never resets. It leaves HEAD, index, and working tree untouched and prints the three explicit choices (`rebase`, `merge`, or a deliberate `reset --hard`), so destroying local work becomes an informed decision the user makes, not a silent side effect of running an update.

## Reproduction on current main

```
# in a managed clone tracking origin/main
git commit --allow-empty -m "local-only work"
hermes update          # history now diverged
# BEFORE: prints "resetting to match remote", local commit destroyed
# AFTER:  aborts, parks commit on rescue/pre-update-<UTC>, tree unchanged
```

## Notes

- stdlib only, no new dependencies.
- Preserves the fast-forward happy path unchanged.
- Two commits: the guard itself, and its reintegration onto current upstream after the surrounding code moved.
