### PR TITLE
Inspired by Poke: hermes recipe — shareable setup bundles (export/preview/install)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -452,6 +452,7 @@ from hermes_cli.subcommands.logout import build_logout_parser
 from hermes_cli.subcommands.auth import build_auth_parser
 from hermes_cli.subcommands.status import build_status_parser
 from hermes_cli.subcommands.pause import build_pause_parser
+from hermes_cli.subcommands.recipe import build_recipe_parser
 from hermes_cli.subcommands.webhook import build_webhook_parser
 from hermes_cli.subcommands.hooks import build_hooks_parser
 from hermes_cli.subcommands.doctor import build_doctor_parser
@@ -11535,6 +11536,7 @@ def main():
     # pause / resume commands  (parser built in hermes_cli/subcommands/pause.py)
     # =========================================================================
     build_pause_parser(subparsers)
+    build_recipe_parser(subparsers)
 
     # =========================================================================
     # cron command  (parser built in hermes_cli/subcommands/cron.py)

--- a/hermes_cli/recipes.py
+++ b/hermes_cli/recipes.py
@@ -1,0 +1,425 @@
+"""Hermes Recipes — shareable setup bundles (export / preview / install).
+
+Inspired by Poke Recipes (poke.com/docs/creating-recipes, released
+2026-03-19): one shareable file that bundles a starter prompt, the
+automations, skills, and MCP integrations that make a workflow, so another
+user can adopt the whole setup in one command.
+
+Design constraints (deliberate deltas from Poke's hosted marketplace):
+
+- **Secrets never travel.** Export strips API keys, headers, env blocks, and
+  anything secret-shaped from MCP entries; the recipe records only the *names*
+  of secrets the installer must supply (``required_secrets``).
+- **Consent-first install.** ``hermes recipe install`` previews everything the
+  recipe would add and asks before writing. Cron jobs are installed *paused*
+  by default (enable with ``--enable`` or ``hermes cron resume``).
+- **No code execution from recipes.** stdio MCP servers (``command:``) and
+  cron ``script`` / ``monitor_script`` fields are refused on install — a
+  recipe is data, not a program. Remote MCP URLs are validated through the
+  SSRF guard before being written to config.
+- **File or URL.** Recipes are plain YAML; share them as gists, repo files,
+  or any https URL. No marketplace, no payouts — the sharing half only.
+
+Zero model-tool footprint: this is a CLI command + docs, per the footprint
+ladder in AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import copy
+import datetime as _dt
+import io
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+RECIPE_VERSION = 1
+
+# Fields on a cron job that are safe to carry in a recipe. Everything else
+# (run history, streaks, origin chat ids, scripts) is host-local state.
+_JOB_EXPORT_FIELDS = (
+    "name",
+    "prompt",
+    "schedule",
+    "repeat",
+    "deliver",
+    "skills",
+    "enabled_toolsets",
+)
+
+# Keys inside an MCP server entry that must never be exported, matched
+# case-insensitively as substrings. ``headers`` and ``env`` are dropped
+# wholesale (they are where credentials live).
+_SECRET_KEY_PATTERN = re.compile(
+    r"(api[_-]?key|token|secret|password|credential|authorization|bearer)",
+    re.IGNORECASE,
+)
+_MCP_DROP_KEYS = {"headers", "env", "auth", "oauth"}
+# MCP entry keys allowed into a recipe (allowlist beats blocklist for
+# a secret boundary).
+_MCP_EXPORT_FIELDS = ("transport", "url", "description", "enabled")
+
+_MAX_RECIPE_BYTES = 256 * 1024  # a recipe is text; 256 KiB is generous
+
+
+class RecipeError(Exception):
+    """User-facing recipe failure (bad format, unsafe content, IO)."""
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+def _sanitize_mcp_entry(name: str, entry: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    """Return (sanitized entry, required secret names) for one MCP server.
+
+    stdio servers (``command:``) are refused — a recipe must not carry
+    executable configuration.
+    """
+    if not isinstance(entry, dict):
+        raise RecipeError(f"MCP server '{name}' has a non-dict config; cannot export")
+    if entry.get("command"):
+        raise RecipeError(
+            f"MCP server '{name}' is a stdio server (command:). Recipes only "
+            "carry remote (http/sse) servers — stdio config is executable and "
+            "host-specific."
+        )
+    if not entry.get("url"):
+        raise RecipeError(f"MCP server '{name}' has no url; cannot export")
+
+    required: List[str] = []
+    for key in entry:
+        if key in _MCP_DROP_KEYS and entry.get(key):
+            if key == "headers" and isinstance(entry[key], dict):
+                required.extend(sorted(entry[key].keys()))
+            else:
+                required.append(key)
+        elif _SECRET_KEY_PATTERN.search(key) and entry.get(key):
+            required.append(key)
+
+    clean = {k: copy.deepcopy(entry[k]) for k in _MCP_EXPORT_FIELDS if k in entry}
+    return clean, required
+
+
+def _sanitize_job(job: Dict[str, Any]) -> Dict[str, Any]:
+    if job.get("no_agent") or job.get("script") or job.get("monitor_script"):
+        raise RecipeError(
+            f"cron job '{job.get('name') or job.get('id')}' uses a local script; "
+            "script-backed jobs are host-specific and cannot be exported"
+        )
+    clean: Dict[str, Any] = {}
+    for key in _JOB_EXPORT_FIELDS:
+        value = job.get(key)
+        if value not in (None, "", []):
+            clean[key] = copy.deepcopy(value)
+    schedule = clean.get("schedule")
+    if isinstance(schedule, dict):
+        # jobs.json stores the parsed schedule dict; flatten back to the
+        # portable string form so the recipe stays human-editable.
+        flat = (
+            schedule.get("raw")
+            or schedule.get("display")
+            or schedule.get("expr")
+        )
+        if not flat:
+            raise RecipeError(
+                f"cron job '{job.get('name') or job.get('id')}' has a "
+                "schedule that cannot be exported as a string"
+            )
+        clean["schedule"] = flat
+    repeat = clean.get("repeat")
+    if isinstance(repeat, dict):
+        # stored as {"times": N|null, "completed": M}; only the target count
+        # is portable.
+        times = repeat.get("times")
+        if times:
+            clean["repeat"] = int(times)
+        else:
+            clean.pop("repeat", None)
+    if not clean.get("prompt"):
+        raise RecipeError(
+            f"cron job '{job.get('name') or job.get('id')}' has no prompt; "
+            "only prompt-based jobs are exportable"
+        )
+    if not clean.get("schedule"):
+        raise RecipeError(f"cron job '{job.get('name') or job.get('id')}' has no schedule")
+    # Delivery targets like specific chat ids are host-local; keep only
+    # generic targets.
+    if clean.get("deliver") not in (None, "local", "origin", "log"):
+        clean["deliver"] = "local"
+    return clean
+
+
+def build_recipe(
+    *,
+    name: str,
+    description: str = "",
+    author: str = "",
+    starter_prompt: str = "",
+    job_ids: Optional[List[str]] = None,
+    mcp_names: Optional[List[str]] = None,
+    skills: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Assemble a recipe dict from the current install's state."""
+    from cron import jobs as cron_jobs
+    from hermes_cli.config import load_config
+
+    recipe: Dict[str, Any] = {
+        "recipe": RECIPE_VERSION,
+        "name": name,
+        "description": description,
+        "author": author,
+        "created_at": _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if starter_prompt:
+        recipe["starter_prompt"] = starter_prompt
+    if skills:
+        recipe["skills"] = list(skills)
+
+    if job_ids:
+        exported = []
+        all_jobs = {j.get("id"): j for j in cron_jobs.load_jobs()}
+        for jid in job_ids:
+            job = all_jobs.get(jid)
+            if job is None:
+                # allow matching by name too
+                matches = [j for j in all_jobs.values() if j.get("name") == jid]
+                if len(matches) == 1:
+                    job = matches[0]
+            if job is None:
+                raise RecipeError(f"cron job '{jid}' not found")
+            exported.append(_sanitize_job(job))
+        if exported:
+            recipe["cron_jobs"] = exported
+
+    if mcp_names:
+        config = load_config()
+        servers = config.get("mcp_servers") or {}
+        out: Dict[str, Any] = {}
+        all_required: Dict[str, List[str]] = {}
+        for sname in mcp_names:
+            entry = servers.get(sname)
+            if entry is None:
+                raise RecipeError(f"MCP server '{sname}' not found in config.yaml")
+            clean, required = _sanitize_mcp_entry(sname, entry)
+            out[sname] = clean
+            if required:
+                all_required[sname] = required
+        if out:
+            recipe["mcp_servers"] = out
+        if all_required:
+            recipe["required_secrets"] = all_required
+
+    return recipe
+
+
+def dump_recipe(recipe: Dict[str, Any]) -> str:
+    buf = io.StringIO()
+    yaml.safe_dump(recipe, buf, sort_keys=False, allow_unicode=True, width=100)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Load / validate
+# ---------------------------------------------------------------------------
+
+def _fetch_url(url: str) -> str:
+    from tools.url_safety import create_ssrf_safe_client, is_safe_url
+
+    if not is_safe_url(url):
+        raise RecipeError(f"unsafe recipe URL refused: {url}")
+    with create_ssrf_safe_client(timeout=20, follow_redirects=False) as client:
+        resp = client.get(url)
+    if resp.status_code != 200:
+        raise RecipeError(f"fetching recipe failed: HTTP {resp.status_code}")
+    if len(resp.content) > _MAX_RECIPE_BYTES:
+        raise RecipeError("recipe too large (limit 256 KiB)")
+    return resp.text
+
+
+def load_recipe(source: str) -> Dict[str, Any]:
+    """Load and validate a recipe from a local path or an http(s) URL."""
+    if source.startswith(("http://", "https://")):
+        text = _fetch_url(source)
+    else:
+        path = Path(source).expanduser()
+        if not path.is_file():
+            raise RecipeError(f"recipe file not found: {source}")
+        if path.stat().st_size > _MAX_RECIPE_BYTES:
+            raise RecipeError("recipe too large (limit 256 KiB)")
+        text = path.read_text(encoding="utf-8")
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise RecipeError(f"invalid recipe YAML: {exc}") from exc
+    return validate_recipe(data)
+
+
+def validate_recipe(data: Any) -> Dict[str, Any]:
+    if not isinstance(data, dict):
+        raise RecipeError("recipe must be a YAML mapping")
+    version = data.get("recipe")
+    if not isinstance(version, int) or version < 1:
+        raise RecipeError("missing/invalid 'recipe' version field (expected: recipe: 1)")
+    if version > RECIPE_VERSION:
+        raise RecipeError(
+            f"recipe version {version} is newer than this Hermes understands "
+            f"({RECIPE_VERSION}); update Hermes first"
+        )
+    if not isinstance(data.get("name"), str) or not data["name"].strip():
+        raise RecipeError("recipe needs a non-empty 'name'")
+
+    jobs = data.get("cron_jobs") or []
+    if not isinstance(jobs, list):
+        raise RecipeError("'cron_jobs' must be a list")
+    for job in jobs:
+        if not isinstance(job, dict):
+            raise RecipeError("each cron job must be a mapping")
+        for banned in ("script", "monitor_script", "no_agent", "workdir", "command"):
+            if job.get(banned):
+                raise RecipeError(
+                    f"cron job '{job.get('name', '?')}' carries '{banned}' — "
+                    "recipes must not contain executable/host-specific config"
+                )
+        if not job.get("prompt") or not job.get("schedule"):
+            raise RecipeError("each recipe cron job needs 'prompt' and 'schedule'")
+        if not isinstance(job.get("schedule"), str):
+            raise RecipeError(
+                f"cron job '{job.get('name', '?')}' schedule must be a string "
+                "(e.g. 'every 2h' or '0 8 * * *')"
+            )
+        if job.get("repeat") is not None and not isinstance(job["repeat"], int):
+            raise RecipeError(
+                f"cron job '{job.get('name', '?')}' repeat must be an integer"
+            )
+
+    servers = data.get("mcp_servers") or {}
+    if not isinstance(servers, dict):
+        raise RecipeError("'mcp_servers' must be a mapping")
+    from tools.url_safety import is_safe_url
+
+    for sname, entry in servers.items():
+        if not isinstance(entry, dict):
+            raise RecipeError(f"MCP server '{sname}' must be a mapping")
+        if entry.get("command"):
+            raise RecipeError(
+                f"MCP server '{sname}' is a stdio server (command:) — refused; "
+                "recipes may only reference remote http/sse servers"
+            )
+        url = entry.get("url")
+        if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+            raise RecipeError(f"MCP server '{sname}' needs an http(s) 'url'")
+        for key in entry:
+            if key in _MCP_DROP_KEYS or _SECRET_KEY_PATTERN.search(key):
+                raise RecipeError(
+                    f"MCP server '{sname}' carries a secret-shaped field "
+                    f"('{key}') — recipes must not contain credentials"
+                )
+        if not is_safe_url(url):
+            raise RecipeError(f"MCP server '{sname}' URL refused by the SSRF guard: {url}")
+
+    skills = data.get("skills") or []
+    if not isinstance(skills, list) or not all(isinstance(s, str) for s in skills):
+        raise RecipeError("'skills' must be a list of skill identifiers")
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Preview / install
+# ---------------------------------------------------------------------------
+
+def describe_recipe(recipe: Dict[str, Any]) -> str:
+    """Human-readable preview of what installing the recipe would add."""
+    lines: List[str] = []
+    lines.append(f"Recipe: {recipe['name']}")
+    if recipe.get("author"):
+        lines.append(f"Author: {recipe['author']}")
+    if recipe.get("description"):
+        lines.append(f"  {recipe['description']}")
+    jobs = recipe.get("cron_jobs") or []
+    if jobs:
+        lines.append(f"\nCron jobs ({len(jobs)}) — installed PAUSED unless --enable:")
+        for job in jobs:
+            sched = job.get("schedule")
+            if isinstance(sched, dict):
+                sched = sched.get("raw") or json.dumps(sched)
+            lines.append(f"  • {job.get('name') or '(unnamed)'}  [{sched}]")
+            prompt = str(job.get("prompt", "")).strip().splitlines()[0]
+            lines.append(f"      {prompt[:100]}{'…' if len(prompt) > 100 else ''}")
+    servers = recipe.get("mcp_servers") or {}
+    if servers:
+        lines.append(f"\nMCP servers ({len(servers)}):")
+        for sname, entry in servers.items():
+            lines.append(f"  • {sname}: {entry.get('url')}")
+    required = recipe.get("required_secrets") or {}
+    if required:
+        lines.append("\nSecrets you must supply after install (never shipped in recipes):")
+        for sname, keys in required.items():
+            lines.append(f"  • {sname}: {', '.join(keys)}")
+    skills = recipe.get("skills") or []
+    if skills:
+        lines.append(f"\nSkills to install ({len(skills)}):")
+        for s in skills:
+            lines.append(f"  • {s}")
+    if recipe.get("starter_prompt"):
+        lines.append("\nStarter prompt:")
+        lines.append(f"  {recipe['starter_prompt'][:200]}")
+    return "\n".join(lines)
+
+
+def install_recipe(
+    recipe: Dict[str, Any],
+    *,
+    enable_jobs: bool = False,
+) -> Dict[str, Any]:
+    """Apply a validated recipe. Returns a summary dict of what was created.
+
+    Cron jobs are created paused unless ``enable_jobs``. MCP servers are
+    merged into config.yaml (existing entries with the same name are NOT
+    overwritten). Skills are reported for manual install (the hub flow owns
+    quarantine/consent) rather than auto-installed.
+    """
+    from cron import jobs as cron_jobs
+    from hermes_cli.config import load_config, save_config
+
+    summary: Dict[str, Any] = {"cron_jobs": [], "mcp_servers": [], "mcp_skipped": [],
+                               "skills": list(recipe.get("skills") or [])}
+
+    for job in recipe.get("cron_jobs") or []:
+        created = cron_jobs.create_job(
+            prompt=job["prompt"],
+            schedule=str(job["schedule"]),
+            name=job.get("name"),
+            repeat=job.get("repeat"),
+            deliver=job.get("deliver") or "local",
+            skills=job.get("skills"),
+            enabled_toolsets=job.get("enabled_toolsets"),
+        )
+        if not enable_jobs:
+            cron_jobs.update_job(created["id"], {"enabled": False})
+        summary["cron_jobs"].append({"id": created["id"], "name": created.get("name")})
+
+    servers = recipe.get("mcp_servers") or {}
+    if servers:
+        config = load_config()
+        existing = config.get("mcp_servers")
+        if not isinstance(existing, dict):
+            existing = {}
+        changed = False
+        for sname, entry in servers.items():
+            if sname in existing:
+                summary["mcp_skipped"].append(sname)
+                continue
+            existing[sname] = copy.deepcopy(entry)
+            summary["mcp_servers"].append(sname)
+            changed = True
+        if changed:
+            config["mcp_servers"] = existing
+            save_config(config, merge_existing=True)
+
+    return summary

--- a/hermes_cli/subcommands/recipe.py
+++ b/hermes_cli/subcommands/recipe.py
@@ -1,0 +1,159 @@
+"""``hermes recipe`` — export, preview, and install shareable setup bundles.
+
+Inspired by Poke Recipes (poke.com/docs/creating-recipes): one shareable
+YAML file that bundles cron automations, remote MCP integrations, skill
+references, and a starter prompt. See ``hermes_cli/recipes.py`` for the
+format and security model (secrets never travel; installs are consent-first;
+no executable config).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _split_csv(value: str) -> list:
+    return [item.strip() for item in (value or "").split(",") if item.strip()]
+
+
+def cmd_recipe(args: argparse.Namespace) -> int:
+    from hermes_cli.recipes import (
+        RecipeError,
+        build_recipe,
+        describe_recipe,
+        dump_recipe,
+        install_recipe,
+        load_recipe,
+    )
+
+    action = getattr(args, "recipe_action", None)
+    try:
+        if action == "export":
+            recipe = build_recipe(
+                name=args.name,
+                description=args.description,
+                author=args.author,
+                starter_prompt=args.starter_prompt,
+                job_ids=_split_csv(args.jobs),
+                mcp_names=_split_csv(args.mcp),
+                skills=_split_csv(args.skills),
+            )
+            text = dump_recipe(recipe)
+            if args.output:
+                out = Path(args.output).expanduser()
+                out.parent.mkdir(parents=True, exist_ok=True)
+                out.write_text(text, encoding="utf-8")
+                print(f"Recipe written to {out}")
+            else:
+                print(text)
+            return 0
+
+        if action in ("show", "preview"):
+            recipe = load_recipe(args.source)
+            print(describe_recipe(recipe))
+            return 0
+
+        if action == "install":
+            recipe = load_recipe(args.source)
+            print(describe_recipe(recipe))
+            print()
+            if not args.yes:
+                try:
+                    answer = input("Install this recipe? [y/N] ").strip().lower()
+                except EOFError:
+                    answer = ""
+                if answer not in ("y", "yes"):
+                    print("Aborted — nothing was installed.")
+                    return 1
+            summary = install_recipe(recipe, enable_jobs=args.enable)
+            for job in summary["cron_jobs"]:
+                state = "enabled" if args.enable else "paused"
+                print(f"✓ cron job created ({state}): {job.get('name')} [{job['id']}]")
+            for sname in summary["mcp_servers"]:
+                print(f"✓ MCP server added to config.yaml: {sname}")
+            for sname in summary["mcp_skipped"]:
+                print(f"— MCP server '{sname}' already exists; left untouched")
+            required = recipe.get("required_secrets") or {}
+            for sname, keys in required.items():
+                print(
+                    f"! MCP server '{sname}' needs credentials you must add "
+                    f"yourself ({', '.join(keys)}) — recipes never carry secrets."
+                )
+            for skill in summary["skills"]:
+                print(f"→ install skill with: hermes skills install {skill}")
+            if summary["cron_jobs"] and not args.enable:
+                print("Jobs are paused. Review them, then: hermes cron resume <id>")
+            if recipe.get("starter_prompt"):
+                print("\nSuggested first message:")
+                print(f"  {recipe['starter_prompt']}")
+            return 0
+
+    except RecipeError as exc:
+        print(f"Recipe error: {exc}", file=sys.stderr)
+        return 1
+
+    print("Usage: hermes recipe {export|show|install} … (see --help)", file=sys.stderr)
+    return 1
+
+
+def build_recipe_parser(subparsers) -> None:
+    """Attach the ``recipe`` subcommand to ``subparsers``."""
+    recipe_parser = subparsers.add_parser(
+        "recipe",
+        help="Share or adopt setup bundles (cron jobs + MCP servers + skills)",
+        description=(
+            "Export your automations/integrations as one shareable YAML "
+            "recipe, or install someone else's from a file or URL. Secrets "
+            "are never exported; installs preview everything and create "
+            "cron jobs paused by default."
+        ),
+    )
+    recipe_sub = recipe_parser.add_subparsers(dest="recipe_action")
+
+    exp = recipe_sub.add_parser("export", help="Export a recipe from this install")
+    exp.add_argument("--name", required=True, help="Recipe display name")
+    exp.add_argument("--description", default="", help="What this setup does")
+    exp.add_argument("--author", default="", help="Your name/handle (optional)")
+    exp.add_argument(
+        "--starter-prompt",
+        default="",
+        help="Suggested first message for adopters (optional)",
+    )
+    exp.add_argument(
+        "--jobs",
+        default="",
+        help="Comma-separated cron job IDs or names to include",
+    )
+    exp.add_argument(
+        "--mcp",
+        default="",
+        help="Comma-separated MCP server names from config.yaml to include "
+        "(remote http/sse servers only; credentials are stripped)",
+    )
+    exp.add_argument(
+        "--skills",
+        default="",
+        help="Comma-separated skill identifiers to recommend "
+        "(e.g. official/research/arxiv)",
+    )
+    exp.add_argument("-o", "--output", default="", help="Write to file (default: stdout)")
+
+    show = recipe_sub.add_parser(
+        "show", aliases=["preview"], help="Preview a recipe without installing"
+    )
+    show.add_argument("source", help="Recipe file path or https URL")
+
+    inst = recipe_sub.add_parser("install", help="Install a recipe (consent-first)")
+    inst.add_argument("source", help="Recipe file path or https URL")
+    inst.add_argument(
+        "--yes", "-y", action="store_true", help="Skip the confirmation prompt"
+    )
+    inst.add_argument(
+        "--enable",
+        action="store_true",
+        help="Enable installed cron jobs immediately (default: paused)",
+    )
+
+    recipe_parser.set_defaults(func=cmd_recipe)

--- a/tests/hermes_cli/test_recipes.py
+++ b/tests/hermes_cli/test_recipes.py
@@ -1,0 +1,198 @@
+"""Tests for hermes_cli/recipes.py — shareable setup bundles."""
+
+import copy
+
+import pytest
+
+from hermes_cli.recipes import (
+    RecipeError,
+    _sanitize_job,
+    _sanitize_mcp_entry,
+    describe_recipe,
+    dump_recipe,
+    validate_recipe,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_recipe
+# ---------------------------------------------------------------------------
+
+def _minimal_recipe(**overrides):
+    recipe = {"recipe": 1, "name": "My Setup"}
+    recipe.update(overrides)
+    return recipe
+
+
+def test_validate_minimal_recipe_passes():
+    assert validate_recipe(_minimal_recipe())["name"] == "My Setup"
+
+
+def test_validate_rejects_non_mapping():
+    with pytest.raises(RecipeError, match="mapping"):
+        validate_recipe(["not", "a", "dict"])
+
+
+def test_validate_rejects_missing_version():
+    with pytest.raises(RecipeError, match="version"):
+        validate_recipe({"name": "x"})
+
+
+def test_validate_rejects_future_version():
+    with pytest.raises(RecipeError, match="newer"):
+        validate_recipe(_minimal_recipe(recipe=99))
+
+
+def test_validate_rejects_empty_name():
+    with pytest.raises(RecipeError, match="name"):
+        validate_recipe({"recipe": 1, "name": "  "})
+
+
+def test_validate_rejects_script_jobs():
+    recipe = _minimal_recipe(
+        cron_jobs=[{"name": "bad", "prompt": "p", "schedule": "daily 9am",
+                    "script": "evil.sh"}]
+    )
+    with pytest.raises(RecipeError, match="script"):
+        validate_recipe(recipe)
+
+
+def test_validate_rejects_no_agent_jobs():
+    recipe = _minimal_recipe(
+        cron_jobs=[{"name": "bad", "prompt": "p", "schedule": "daily", "no_agent": True}]
+    )
+    with pytest.raises(RecipeError, match="no_agent"):
+        validate_recipe(recipe)
+
+
+def test_validate_rejects_job_without_prompt():
+    recipe = _minimal_recipe(cron_jobs=[{"name": "x", "schedule": "daily 9am"}])
+    with pytest.raises(RecipeError, match="prompt"):
+        validate_recipe(recipe)
+
+
+def test_validate_rejects_stdio_mcp():
+    recipe = _minimal_recipe(mcp_servers={"local": {"command": "npx something"}})
+    with pytest.raises(RecipeError, match="stdio"):
+        validate_recipe(recipe)
+
+
+def test_validate_rejects_mcp_without_url():
+    recipe = _minimal_recipe(mcp_servers={"s": {"transport": "http"}})
+    with pytest.raises(RecipeError, match="url"):
+        validate_recipe(recipe)
+
+
+def test_validate_rejects_mcp_with_secret_field():
+    recipe = _minimal_recipe(
+        mcp_servers={"s": {"url": "https://mcp.example.com/mcp", "api_key": "sk-123"}}
+    )
+    with pytest.raises(RecipeError, match="secret"):
+        validate_recipe(recipe)
+
+
+def test_validate_rejects_mcp_with_headers():
+    recipe = _minimal_recipe(
+        mcp_servers={"s": {"url": "https://mcp.example.com/mcp",
+                           "headers": {"Authorization": "Bearer x"}}}
+    )
+    with pytest.raises(RecipeError, match="secret-shaped"):
+        validate_recipe(recipe)
+
+
+def test_validate_rejects_unsafe_mcp_url():
+    recipe = _minimal_recipe(
+        mcp_servers={"s": {"url": "https://169.254.169.254/latest/meta-data"}}
+    )
+    with pytest.raises(RecipeError, match="SSRF|refused"):
+        validate_recipe(recipe)
+
+
+def test_validate_accepts_clean_remote_mcp(monkeypatch):
+    import tools.url_safety as url_safety
+
+    monkeypatch.setattr(url_safety, "is_safe_url", lambda url: True)
+    recipe = _minimal_recipe(
+        mcp_servers={"s": {"url": "https://mcp.example.com/mcp", "transport": "http"}}
+    )
+    assert validate_recipe(recipe)["mcp_servers"]["s"]["url"].startswith("https")
+
+
+def test_validate_rejects_non_string_skills():
+    with pytest.raises(RecipeError, match="skills"):
+        validate_recipe(_minimal_recipe(skills=[{"nested": "dict"}]))
+
+
+# ---------------------------------------------------------------------------
+# export sanitizers
+# ---------------------------------------------------------------------------
+
+def test_sanitize_mcp_strips_headers_and_records_required():
+    entry = {
+        "transport": "http",
+        "url": "https://mcp.example.com/sse",
+        "headers": {"Authorization": "Bearer secret", "X-Custom": "v"},
+        "api_key": "sk-live-123",
+        "description": "example",
+    }
+    clean, required = _sanitize_mcp_entry("ex", entry)
+    assert clean == {
+        "transport": "http",
+        "url": "https://mcp.example.com/sse",
+        "description": "example",
+    }
+    assert "Authorization" in required and "api_key" in required
+    dumped = dump_recipe({"recipe": 1, "name": "n", "mcp_servers": {"ex": clean}})
+    assert "sk-live-123" not in dumped
+    assert "Bearer" not in dumped
+
+
+def test_sanitize_mcp_refuses_stdio():
+    with pytest.raises(RecipeError, match="stdio"):
+        _sanitize_mcp_entry("local", {"command": "npx foo"})
+
+
+def test_sanitize_job_keeps_portable_fields_only():
+    job = {
+        "id": "abc123",
+        "name": "daily digest",
+        "prompt": "Summarize my day",
+        "schedule": {"raw": "daily 8am", "kind": "cron"},
+        "deliver": "telegram",
+        "origin": {"chat_id": 12345},
+        "last_run_at": "2026-08-01",
+        "failure_streak": 3,
+    }
+    clean = _sanitize_job(copy.deepcopy(job))
+    assert clean["schedule"] == "daily 8am"
+    assert clean["deliver"] == "local"  # host-specific target rewritten
+    assert "origin" not in clean and "last_run_at" not in clean
+    assert "id" not in clean and "failure_streak" not in clean
+
+
+def test_sanitize_job_refuses_script_jobs():
+    with pytest.raises(RecipeError, match="script"):
+        _sanitize_job({"name": "w", "prompt": "p", "schedule": "daily",
+                       "script": "watch.sh"})
+
+
+# ---------------------------------------------------------------------------
+# describe
+# ---------------------------------------------------------------------------
+
+def test_describe_mentions_paused_jobs_and_secrets():
+    recipe = {
+        "recipe": 1,
+        "name": "Research Kit",
+        "cron_jobs": [{"name": "arxiv sweep", "prompt": "scan arxiv",
+                       "schedule": "daily 7am"}],
+        "mcp_servers": {"ex": {"url": "https://mcp.example.com/mcp"}},
+        "required_secrets": {"ex": ["api_key"]},
+        "skills": ["official/research/arxiv"],
+        "starter_prompt": "Give me today's papers",
+    }
+    text = describe_recipe(recipe)
+    assert "PAUSED" in text
+    assert "api_key" in text
+    assert "official/research/arxiv" in text
+    assert "Give me today's papers" in text

--- a/website/docs/user-guide/features/recipes.md
+++ b/website/docs/user-guide/features/recipes.md
@@ -1,0 +1,93 @@
+# Recipes — Shareable Setup Bundles
+
+Recipes let you share a working Hermes setup — cron automations, remote MCP
+integrations, recommended skills, and a starter prompt — as a single YAML
+file that anyone can preview and install with one command.
+
+Inspired by Poke's Recipes feature (shareable one-link setups), adapted for a
+self-hosted, security-first agent: **secrets never travel**, installs are
+**consent-first**, and recipes can never carry executable configuration.
+
+## Sharing your setup
+
+```bash
+hermes recipe export \
+  --name "AI Research Kit" \
+  --description "Daily arXiv digest + Exa search" \
+  --jobs "ai digest" \
+  --mcp exa \
+  --skills official/research/arxiv \
+  --starter-prompt "Give me today's paper highlights" \
+  -o research-kit.yaml
+```
+
+Share `research-kit.yaml` anywhere — a gist, a repo, Discord. Anything with
+an https URL works as an install source.
+
+What export includes and strips:
+
+- **Cron jobs** — prompt, schedule, skills, toolset restrictions. Run
+  history, chat-specific delivery targets, and `script`/`monitor_script`
+  fields are stripped (script jobs can't be exported at all — they're
+  host-specific and executable).
+- **MCP servers** — remote (http/sse) servers only, minus every credential:
+  `headers`, `env`, and any secret-shaped key are removed and recorded by
+  *name* in `required_secrets` so installers know what to supply.
+- **Skills** — referenced by hub identifier, not bundled; installs go
+  through the normal `hermes skills install` quarantine/consent flow.
+
+## Installing a recipe
+
+```bash
+# Preview first — shows everything the recipe would add
+hermes recipe show https://example.com/research-kit.yaml
+
+# Install (interactive confirmation; --yes to skip)
+hermes recipe install research-kit.yaml
+```
+
+Install behavior:
+
+- **Cron jobs are created paused.** Review them, then
+  `hermes cron resume <id>` — or pass `--enable` to activate immediately.
+- **MCP servers are merged into `config.yaml`.** Existing entries with the
+  same name are never overwritten. Server URLs are validated through the
+  SSRF guard before being written.
+- **Missing credentials are called out.** Any `required_secrets` the recipe
+  recorded are printed with instructions — recipes never contain keys.
+- **Skills are suggested, not auto-installed.** The output prints the
+  `hermes skills install …` commands so the hub's trust flow stays in charge.
+
+## Security model
+
+A recipe is data, not a program:
+
+- stdio MCP servers (`command:`) are refused on export *and* install.
+- Cron `script`, `monitor_script`, `no_agent`, and `workdir` fields are
+  refused on install.
+- Secret-shaped fields anywhere in a recipe fail validation.
+- URL sources are fetched through the SSRF-safe client with a 256 KiB cap.
+
+## Recipe format
+
+```yaml
+recipe: 1
+name: AI Research Kit
+description: Daily arXiv digest + Exa search
+author: yourhandle
+starter_prompt: Give me today's paper highlights
+skills:
+  - official/research/arxiv
+cron_jobs:
+  - name: ai digest
+    prompt: Summarize today's AI news
+    schedule: 0 8 * * *
+    deliver: local
+mcp_servers:
+  exa:
+    transport: http
+    url: https://mcp.exa.ai/mcp
+required_secrets:
+  exa:
+    - api_key
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -93,6 +93,7 @@ const sidebars: SidebarsConfig = {
           label: 'Automation',
           items: [
             'user-guide/features/cron',
+            'user-guide/features/recipes',
             'reference/automation-blueprints-catalog',
             'user-guide/features/delegation',
             'user-guide/features/kanban',


### PR DESCRIPTION
## Summary
Adds `hermes recipe` — export your setup (cron automations + remote MCP integrations + skill references + a starter prompt) as one shareable YAML file that anyone can preview and install with a single command.

Inspired by Poke Recipes ([poke.com/docs/creating-recipes](https://poke.com/docs/creating-recipes), GA release 2026-03-19): Poke lets users share their whole agent setup behind one install link, which became their main community-growth loop. This ports the *sharing* half only — no marketplace, no payouts, no hosted service — adapted to a self-hosted, security-first agent.

Prior art: #41127 (recipes-as-skills) was superseded by the cron suggestion catalog; that design made a *skill* carry a schedule. This is the complementary, previously-uncovered piece: bundling a user's *existing* jobs + MCP servers + skills into one portable artifact. Dupe sweep found no open PR/issue covering setup-bundle sharing (nearest: #65224, desktop profile export — different scope, profile-local files vs shareable public bundle).

## Changes
- `hermes_cli/recipes.py` (new): recipe build/validate/load/describe/install engine
- `hermes_cli/subcommands/recipe.py` (new): `hermes recipe export|show|install`
- `hermes_cli/main.py`: +2 lines wiring the parser
- `tests/hermes_cli/test_recipes.py` (new): 20 tests
- `website/docs/user-guide/features/recipes.md` + sidebar entry

## Security model (deliberate deltas from Poke's hosted design)
- **Secrets never travel** — export strips `headers`/`env`/secret-shaped keys from MCP entries and records only their *names* in `required_secrets`; validation rejects any recipe carrying credential-shaped fields.
- **No executable config** — stdio MCP servers (`command:`) and cron `script`/`monitor_script`/`no_agent`/`workdir` are refused on both export and install. A recipe is data, not a program.
- **Consent-first install** — full preview + confirmation; cron jobs land **paused** by default (`--enable` to opt in); MCP servers merge without overwriting existing entries; skills are suggested through the normal hub quarantine flow, never auto-installed.
- **SSRF-guarded** — recipe URLs and every MCP URL inside a recipe pass through `tools/url_safety`; 256 KiB size cap.

Zero model-tool footprint (CLI command + docs, per the footprint ladder).

## Validation
| Check | Result |
|---|---|
| `tests/hermes_cli/test_recipes.py` | 20/20 pass |
| E2E round-trip (export from one temp HERMES_HOME → install into a fresh one) | job created paused, MCP merged, `sk-SECRET` absent from dumped YAML |
| `hermes recipe --help` via real `main()` | renders, exit 0 |
| ruff check | clean |

## Infographic

![Hermes Recipes — shareable setup bundles](https://v3b.fal.media/files/b/0aa5b71b/V5wc6WOKak4g7-NzGBczQ_AHrVSdFT.png)
