### PR TITLE
fix(telegram): bound fallback-pool connection budget by pool count

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -302,8 +302,10 @@ from plugins.platforms.telegram.telegram_ids import (
 )
 from plugins.platforms.telegram.telegram_network import (
     TelegramFallbackTransport,
+    cap_fallback_ips,
     discover_fallback_ips,
     parse_fallback_ip_env,
+    safe_fallback_pool_limits,
 )
 from utils import atomic_replace, env_float, env_int
 
@@ -3833,6 +3835,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     self.name,
                     ", ".join(fallback_ips),
                 )
+            fallback_ips = cap_fallback_ips(fallback_ips)
 
             proxy_targets = ["api.telegram.org", *fallback_ips]
             proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
@@ -3851,9 +3854,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 # directly into TelegramFallbackTransport so its inner
                 # AsyncHTTPTransport instances honour keepalive_expiry — do not
                 # route this through `_with_limits`, httpx would discard it.
+                # TelegramFallbackTransport forwards this same `limits` object
+                # to its primary pool AND every lazily-built fallback pool, so
+                # passing `_pool_limits` unmodified would let the configured
+                # per-pool budget multiply by the pool count instead of
+                # bounding it (#82678) — derate it first.
                 _transport_kwargs: dict = {}
                 if _pool_limits is not None:
-                    _transport_kwargs["limits"] = _pool_limits
+                    _transport_kwargs["limits"] = safe_fallback_pool_limits(
+                        _pool_limits, len(fallback_ips)
+                    )
                 request = HTTPXRequest(
                     **request_kwargs,
                     httpx_kwargs={

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -42,6 +42,11 @@ _DOH_PROVIDERS: list[dict] = [
 # endpoints in the 149.154.160.0/20 block (same seed used by OpenClaw).
 _SEED_FALLBACK_IPS: list[str] = ["149.154.166.110", "149.154.167.220"]
 
+# DoH discovery returns every unique A record with no upper bound, and each
+# fallback IP gets its own httpx connection pool. Cap the count so the number
+# of pools a gateway can materialize has a finite worst case (#82678).
+DEFAULT_MAX_FALLBACK_IPS = 3
+
 
 def _resolve_proxy_url(target_hosts=None) -> str | None:
     # Delegate to shared implementation (env vars + macOS system proxy detection)
@@ -191,6 +196,49 @@ def parse_fallback_ip_env(value: str | None) -> list[str]:
         return []
     parts = [part.strip() for part in value.split(",")]
     return _normalize_fallback_ips(parts)
+
+
+def cap_fallback_ips(
+    ips: list[str], max_ips: int = DEFAULT_MAX_FALLBACK_IPS
+) -> list[str]:
+    """Bound the fallback-IP list so pool fan-out has a finite worst case.
+
+    Both configured (``HERMES_TELEGRAM_FALLBACK_IPS``) and DoH-discovered lists
+    are otherwise unbounded, and every fallback IP gets its own connection
+    pool (#82678).
+    """
+    if len(ips) <= max_ips:
+        return ips
+    logger.warning(
+        "Telegram fallback IP count %d exceeds the safety cap of %d; using only the first %d",
+        len(ips), max_ips, max_ips,
+    )
+    return ips[:max_ips]
+
+
+def safe_fallback_pool_limits(
+    base_limits: httpx.Limits, fallback_ip_count: int, num_ptb_clients: int = 2
+) -> httpx.Limits:
+    """Derate a per-client connection limit for the fallback-IP transport.
+
+    ``TelegramFallbackTransport`` forwards whatever ``limits`` it is given to
+    its primary pool and to every lazily-built fallback pool unchanged (that
+    "caller wins" contract is itself load-bearing, see
+    ``test_caller_limits_win_over_pool_default``). Passing the same
+    ``base_limits`` used for a single pool means the *effective* connection
+    budget scales with ``num_ptb_clients * (1 + fallback_ip_count)`` instead
+    of staying at what the operator configured (#82678). Divide the budget
+    across every pool that will actually be constructed so the total stays
+    bounded.
+    """
+    num_pools = num_ptb_clients * (1 + fallback_ip_count)
+    max_connections = max(1, base_limits.max_connections // num_pools)
+    max_keepalive = max(1, min(base_limits.max_keepalive_connections, max_connections))
+    return httpx.Limits(
+        max_connections=max_connections,
+        max_keepalive_connections=max_keepalive,
+        keepalive_expiry=base_limits.keepalive_expiry,
+    )
 
 
 def _resolve_system_dns() -> set[str]:

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -94,6 +94,42 @@ class TestNormalizeFallbackIps:
         assert tnet._normalize_fallback_ips(raw) == ["149.154.167.220", "149.154.167.220"]
 
 
+class TestCapFallbackIps:
+    def test_under_cap_is_unchanged(self):
+        ips = ["149.154.167.220", "149.154.167.221"]
+        assert tnet.cap_fallback_ips(ips, max_ips=3) is ips
+
+    def test_over_cap_is_truncated_and_logged(self, caplog):
+        ips = ["1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"]
+        capped = tnet.cap_fallback_ips(ips, max_ips=3)
+        assert capped == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+        assert "exceeds the safety cap" in caplog.text
+
+
+class TestSafeFallbackPoolLimits:
+    def test_derates_by_total_pool_count(self):
+        """2 PTB clients * (1 primary + 2 fallback) = 6 pools; the configured
+        512-connection budget must be divided across all of them, not applied
+        to each independently (#82678)."""
+        base = httpx.Limits(max_connections=512, max_keepalive_connections=100, keepalive_expiry=20.0)
+        derated = tnet.safe_fallback_pool_limits(base, fallback_ip_count=2, num_ptb_clients=2)
+
+        assert derated.max_connections == 512 // 6
+        assert derated.max_connections * 6 <= 512
+        assert derated.keepalive_expiry == 20.0
+
+    def test_never_derates_below_one_connection(self):
+        base = httpx.Limits(max_connections=4, max_keepalive_connections=4)
+        derated = tnet.safe_fallback_pool_limits(base, fallback_ip_count=10, num_ptb_clients=2)
+        assert derated.max_connections >= 1
+        assert derated.max_keepalive_connections >= 1
+
+    def test_no_fallback_ips_still_accounts_for_both_ptb_clients(self):
+        base = httpx.Limits(max_connections=100, max_keepalive_connections=100)
+        derated = tnet.safe_fallback_pool_limits(base, fallback_ip_count=0, num_ptb_clients=2)
+        assert derated.max_connections == 50
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Request rewriting
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What does this PR do?

Bounds the Telegram fallback-IP connection-pool budget so it no longer scales
multiplicatively with the number of fallback IPs.

## Related Issue

Fixes #82678

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Root cause

`TelegramAdapter.connect()` builds two `HTTPXRequest` clients (general +
`get_updates`). On the fallback-IP path, each wraps a `TelegramFallbackTransport`
that owns one primary `AsyncHTTPTransport` plus one lazily-built transport per
fallback IP. The adapter passed the same `httpx.Limits(max_connections=connection_pool_size)`
(default 512, `HERMES_TELEGRAM_HTTP_POOL_SIZE`) straight into
`TelegramFallbackTransport`, which forwards that exact object to its primary
pool and to every fallback pool unchanged — that "caller limits win" behavior
is intentional and already covered by
`test_caller_limits_win_over_pool_default` / `test_forwards_limits_to_inner_transports`.

The result: the effective ceiling was `2 clients × (1 primary + N fallback) ×
512`, i.e. 1024 connections with zero fallback IPs and 2048 with one — far
beyond a typical 256 soft `RLIMIT_NOFILE`, before SQLite, logs, pipes, and
other sockets are counted. The fallback-IP list itself was also unbounded,
since DNS-over-HTTPS discovery returns every unique A record it sees.

#45507 lowers the same default from 512 to 64 but (as noted on the issue)
still doesn't bound the address count or the per-pool multiplication — with
one fallback IP it's still `2 × (1+1) × 64 = 256` before other descriptors are
counted, growing further with more addresses.

## Changes Made

- `plugins/platforms/telegram/telegram_network.py`: added `cap_fallback_ips()`
  (bounds the fallback-IP list to `DEFAULT_MAX_FALLBACK_IPS = 3`, logging when
  truncated) and `safe_fallback_pool_limits()` (derates a `httpx.Limits` by the
  total pool count — `num_ptb_clients * (1 + fallback_ip_count)` — so the
  *total* connection budget across every pool stays close to what was
  configured, rather than multiplying by pool count).
- `plugins/platforms/telegram/adapter.py`: apply `cap_fallback_ips()` to the
  resolved fallback-IP list in `connect()`, and pass the derated limits (via
  `safe_fallback_pool_limits()`) into `TelegramFallbackTransport` instead of
  the raw per-client limits object. `TelegramFallbackTransport` itself is
  unchanged — its "caller limits win" contract stays intact.
- `tests/gateway/test_telegram_network.py`: added `TestCapFallbackIps` and
  `TestSafeFallbackPoolLimits` covering the cap and the derating math
  (including the zero-fallback-IP and near-zero-budget edge cases).

## How to Test

1. `bash scripts/run_tests.sh tests/gateway/test_telegram_network.py` — new
   tests fail with `AttributeError: module ... has no attribute
   'cap_fallback_ips'` / `'safe_fallback_pool_limits'` against the pre-fix
   source (confirmed via `git stash` on just the two source files with the
   test file kept), and pass after the fix.
2. `bash scripts/run_tests.sh tests/gateway/test_telegram_network.py
   tests/gateway/test_telegram_fallback_pool_release_71593.py
   tests/gateway/test_telegram_closewait_limits_31599.py
   tests/gateway/test_telegram_connect.py
   tests/gateway/test_telegram_network_reconnect.py` — all pass:

   ```
   === Summary: 5 files, 45 tests passed, 0 failed (100% complete) in 6.6s (8 workers) ===
   ```
3. `bash scripts/run_tests.sh tests/gateway/` (611 files):

   ```
   === Summary: 611 files, 5113 tests passed, 2 failed (100% complete) in 151.6s (8 workers) ===
   ```

   The 2 failures are both in `tests/gateway/test_wecom_callback.py`
   (`test_build_event_extracts_text_message`,
   `test_poll_loop_dispatches_handle_message`), unrelated to this change —
   they fail with the same `AttributeError: 'NoneType' object has no
   attribute 'fromstring'` in `plugins/platforms/wecom/callback_adapter.py:400`
   on `HEAD~1` (before this commit) as well, confirmed by checking out the
   pre-fix source and rerunning that file in isolation.
4. `ruff check plugins/platforms/telegram/adapter.py
   plugins/platforms/telegram/telegram_network.py
   tests/gateway/test_telegram_network.py` — `All checks passed!`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (see
  Root cause section re: #45507; #39336 proposes raising the OS FD limit
  instead and is orthogonal)
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite; all tests related to this change pass (2
  pre-existing, unrelated `test_wecom_callback.py` failures reproduce
  identically on `HEAD~1`, see step 3 above)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not run against live Telegram infra; the
  new tests and existing pool/transport tests are unit-level with fake
  transports, no network

### Documentation & Housekeeping

- [ ] N/A — no config keys added, no docs/architecture changes

## Note on AI assistance

Drafted with AI assistance (an autonomous coding agent), with the diff,
tests, and RED→GREEN verification reviewed before pushing.
