### PR TITLE
fix(desktop): use native -webkit-app-region drag on HUD composer for Wayland

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -79,6 +79,14 @@ import { UrlDialog } from './url-dialog'
 import { chipTypedUrlOnSpace, linkifyUrls } from './url-refs'
 import { VoiceActivity, VoicePlaybackActivity } from './voice-activity'
 
+// Linux-only: the HUD bar becomes a native compositor drag region there
+// (composer root gets `-webkit-app-region: drag`, the input carves itself out
+// with no-drag) so the compositor moves the window — xdg_toplevel.move on
+// Wayland, _NET_WM_MOVERESIZE on X11 — instead of the JS setBounds path that
+// Wayland ignores. macOS/Windows keep the long-press gesture; see
+// click-through.ts for why the drag region is Linux-only.
+const IS_LINUX = typeof navigator !== 'undefined' && /linux/i.test(navigator.platform)
+
 export function ChatBar({
   busy,
   cwd,
@@ -953,7 +961,11 @@ export function ChatBar({
           'min-h-[1.625rem] min-h-(--composer-input-min-height) max-h-(--composer-input-max-height) cursor-text overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] bg-transparent pb-1 pr-1 pt-1 leading-normal text-foreground outline-none disabled:cursor-not-allowed',
           '**:data-ref-text:cursor-default',
           stacked && 'pl-3',
-          stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1'
+          stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1',
+          // Inside the Linux HUD drag region: a drag region swallows the page's
+          // mouse input whole, so the input must opt back out or it becomes
+          // unclickable. Buttons are covered by the global no-drag rule.
+          hudMode && IS_LINUX && '[-webkit-app-region:no-drag]'
         )}
         contentEditable={!inputDisabled}
         data-placeholder={placeholder}
@@ -1121,7 +1133,12 @@ export function ChatBar({
             className={cn(
               'group/composer relative w-full overflow-visible rounded-2xl',
               poppedOut && 'bg-transparent',
-              dragging && 'cursor-grabbing select-none touch-none'
+              dragging && 'cursor-grabbing select-none touch-none',
+              // Linux HUD: the whole bar is a native drag handle for the
+              // compositor (the input opts out below). setPosition/setBounds
+              // is a no-op under Wayland compositors, so this is the only way
+              // the HUD can be repositioned there.
+              hudMode && IS_LINUX && '[-webkit-app-region:drag]'
             )}
             data-drag-active={dragActive ? '' : undefined}
             data-hud-grabbing={hudGrabbing ? '' : undefined}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1137,8 +1137,11 @@ export function ChatBar({
               // Linux HUD: the whole bar is a native drag handle for the
               // compositor (the input opts out below). setPosition/setBounds
               // is a no-op under Wayland compositors, so this is the only way
-              // the HUD can be repositioned there.
-              hudMode && IS_LINUX && '[-webkit-app-region:drag]'
+              // the HUD can be repositioned there. The top padding (pt-4) is
+              // the region's own grab band — the input/buttons below opt out
+              // with no-drag, so without it there'd be no surface left to
+              // grab. `.hud-native-drag` carries the grip pill (styles.css).
+              hudMode && IS_LINUX && 'hud-native-drag pt-4 [-webkit-app-region:drag]'
             )}
             data-drag-active={dragActive ? '' : undefined}
             data-hud-grabbing={hudGrabbing ? '' : undefined}

--- a/apps/desktop/src/app/hud/click-through.ts
+++ b/apps/desktop/src/app/hud/click-through.ts
@@ -63,10 +63,15 @@ export function hudIgnoresMouse(
  * decision, a different courier.
  *
  * It follows that nothing in HUD mode may declare `-webkit-app-region: drag`
- * at all: a draggable region swallows the page's mouse events, so the moves
- * never arrive and the window is stranded on whatever it last decided —
- * usually transparent, which is also why pressing the handle fell through to
- * the app behind. Dragging is `useHudComposerDrag` instead.
+ * on macOS/Windows: a draggable region swallows the page's mouse events, so
+ * the moves never arrive and the window is stranded on whatever it last
+ * decided — usually transparent, which is also why pressing the handle fell
+ * through to the app behind. Dragging there is `useHudComposerDrag` instead.
+ *
+ * Linux is the exception: the solidity decision is fed from MAIN's cursor poll
+ * (`startHudCursorFeed`), which a drag region cannot starve — so the HUD
+ * composer root declares `-webkit-app-region: drag` (with the input carved
+ * out as no-drag) and the compositor moves the window natively.
  */
 export function useHudClickThrough(rootRef: RefObject<HTMLElement | null>): void {
   useEffect(() => {

--- a/apps/desktop/src/app/hud/composer-drag.ts
+++ b/apps/desktop/src/app/hud/composer-drag.ts
@@ -23,11 +23,14 @@ interface PressState {
 /**
  * HUD-only: press and hold the composer, then drag to move the window.
  *
- * The only way to move the HUD. An `-webkit-app-region: drag` handle is the
- * obvious alternative and cannot work here: the window manager takes a drag
- * region's mouse input whole, which starves `useHudClickThrough` of the moves
- * it decides solidity from, so the window is already transparent by the time
- * the press lands and it falls through to the app behind. See click-through.ts.
+ * The way to move the HUD on macOS/Windows. An `-webkit-app-region: drag`
+ * handle is the obvious alternative and cannot work THERE: the window manager
+ * takes a drag region's mouse input whole, which starves `useHudClickThrough`
+ * of the moves it decides solidity from, so the window is already transparent
+ * by the time the press lands and it falls through to the app behind. See
+ * click-through.ts. On Linux the composer bar itself is a native drag region
+ * instead (root drag + input no-drag), so this gesture is only the fallback
+ * for presses that land on the interactive surface.
  *
  * Deltas are read in SCREEN coordinates. Client coordinates are relative to the
  * window we are moving, so a window that keeps up with the cursor reports the

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2712,6 +2712,23 @@ button[data-slot='aui_msg-reactions'] svg {
    element + the global button rule); the rest of the bar is the handle.
    macOS/Windows keep dragging on `useHudComposerDrag` — press and hold the
    bar, then move. */
+
+/* Grip affordance for the Linux drag band: the composer's top padding (pt-4)
+   is the only surface the region owns once the input/buttons are carved out,
+   so make it look like a handle — a centered pill, like a mobile grip. */
+.hud-native-drag::before {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 40px;
+  height: 4px;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--ui-text-tertiary) 55%, transparent);
+  pointer-events: none;
+}
+
 [data-hud-shell] [data-slot='composer-dock'] {
   /* The one surface that is always there, so the one that always takes the
      mouse — everything else in the shell earns it by being on screen. */

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2698,15 +2698,20 @@ button[data-slot='aui_msg-reactions'] svg {
   --thread-viewport-height: 100%;
 }
 
-/* NOTHING in HUD mode declares `-webkit-app-region: drag`. The window manager
+/* `-webkit-app-region: drag` in HUD mode is LINUX ONLY. The window manager
    takes a draggable region's mouse input whole, so the page never sees the
-   cursor arrive there — and `useHudClickThrough`, which decides whether the
-   window is solid from exactly those moves, has already handed the window away
-   by the time you press. Every version of the app-region handle was therefore
-   both unusable (the press fell through to the app behind) and the reason the
-   HUD stayed solid over dead space once you left it. The two mechanisms cannot
-   share a window; click-through wins, and dragging is `useHudComposerDrag` —
-   press and hold the bar, then move. */
+   cursor arrive there — on macOS/Windows that starves `useHudClickThrough`,
+   which decides solidity from exactly those moves, so the press falls through
+   to the app behind (every app-region attempt there was therefore unusable,
+   and left the HUD solid over dead space once you left it). On Linux the
+   click-through decision is fed by MAIN's cursor poll (`startHudCursorFeed`),
+   not by page events, so a drag region cannot starve it: the bar stays solid,
+   the compositor takes the press, and the window moves natively
+   (xdg_toplevel.move on Wayland, _NET_WM_MOVERESIZE on X11). The composer's
+   interactive surface opts back out with `-webkit-app-region: no-drag` (input
+   element + the global button rule); the rest of the bar is the handle.
+   macOS/Windows keep dragging on `useHudComposerDrag` — press and hold the
+   bar, then move. */
 [data-hud-shell] [data-slot='composer-dock'] {
   /* The one surface that is always there, so the one that always takes the
      mouse — everything else in the shell earns it by being on screen. */


### PR DESCRIPTION
## Problem

On Linux/Wayland, `BrowserWindow.setPosition()` / `setBounds()` position changes are a no-op — the compositor owns window placement. The HUD drag gesture calls `setPosition` on every pointermove, which silently does nothing under KWin and other Wayland compositors. The HUD renders and accepts input but cannot be repositioned.

## Fix

Make the HUD composer bar a **native compositor drag region on Linux**:

- Composer root gets `-webkit-app-region: drag` (Tailwind arbitrary-property class, same pattern as the overlay titlebar / sidebar) when `hudMode` is active on Linux.
- The composer input opts back out with `-webkit-app-region: no-drag` — a drag region swallows the page's mouse input whole, so without this carve-out the HUD input would become unclickable on Linux.
- The compositor initiates the move itself: `xdg_toplevel.move` on Wayland, `_NET_WM_MOVERESIZE` on X11. No JS drag math.

**Why Linux-only:** the HUD's click-through logic decides window solidity from *page mouse moves* on macOS/Windows, and a drag region starves those — every earlier app-region attempt there was unusable (press fell through to the app behind). On Linux the solidity decision is fed by **main's cursor poll** (`startHudCursorFeed`), which a drag region cannot starve, so the bar stays solid and the native move works. The codebase comments that documented this constraint (styles.css, click-through.ts, composer-drag.ts) are updated to scope it to macOS/Windows.

The existing 140ms long-press gesture remains as the macOS/Windows path and as a fallback for presses that land on the interactive surface.

## Testing

- Reproduced the CI failure locally (`check:lint` → TS2322: `WebkitAppRegion` is not in React's `CSSProperties` — the original inline-style approach could not typecheck; the class-based approach fixes it).
- `tsc -p . / tsconfig.electron.json / tsconfig.e2e.json` — clean.
- `eslint src/ electron/` on changed files — clean.
- `vitest` hud + composer suites — 309 tests pass; electron platform project — 4699 tests pass.
- Tested on Arch Linux, KDE Plasma 6 / Wayland (KWin), Electron 40.10.2 / Hermes v0.20.0: the HUD drags after restart and the input remains clickable.

## Changes

- `apps/desktop/src/app/chat/composer/index.tsx`: +drag class on composer root, +no-drag class on the input, `IS_LINUX` platform const (codebase pattern)
- `apps/desktop/src/app/hud/click-through.ts`, `composer-drag.ts`, `src/styles.css`: landmine comments scoped to macOS/Windows, Linux exception documented

Fixes: #82851