### PR TITLE
fix(deps): enforce multipart and Weixin crypto floors (#47997)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -44,12 +44,10 @@ except ImportError:  # pragma: no cover - dependency gate
     AIOHTTP_AVAILABLE = False
 
 try:
-    from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
     CRYPTO_AVAILABLE = True
 except ImportError:  # pragma: no cover - dependency gate
-    default_backend = None  # type: ignore[assignment]
     Cipher = None  # type: ignore[assignment]
     algorithms = None  # type: ignore[assignment]
     modes = None  # type: ignore[assignment]
@@ -207,13 +205,13 @@ def _pkcs7_pad(data: bytes, block_size: int = 16) -> bytes:
 
 
 def _aes128_ecb_encrypt(plaintext: bytes, key: bytes) -> bytes:
-    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    cipher = Cipher(algorithms.AES(key), modes.ECB())
     encryptor = cipher.encryptor()
     return encryptor.update(_pkcs7_pad(plaintext)) + encryptor.finalize()
 
 
 def _aes128_ecb_decrypt(ciphertext: bytes, key: bytes) -> bytes:
-    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    cipher = Cipher(algorithms.AES(key), modes.ECB())
     decryptor = cipher.decryptor()
     padded = decryptor.update(ciphertext) + decryptor.finalize()
     if not padded:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dependencies = [
   # FastAPI's UploadFile/Form depend on python-multipart; it is NOT pulled in
   # by fastapi itself, so the dashboard's multipart upload endpoint would 500
   # without an explicit dependency here (and in the `web` extra below).
-  "python-multipart>=0.0.9,<1",
+  "python-multipart>=0.0.32,<1",  # GHSA-5rvq-cxj2-64vf and related multipart parser fixes
   "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
   # Desktop SSH's Windows remote runtime (hermes_cli/windows_ssh_runtime.py)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -168,6 +168,42 @@ class TestWeixinStatePersistence:
         assert json.loads(account_path.read_text(encoding="utf-8")) == original
 
 
+class TestWeixinAesCryptographyCompatibility:
+    def test_aes_round_trip_does_not_require_removed_default_backend(self, monkeypatch):
+        cipher_kwargs = []
+
+        class _FakeContext:
+            def update(self, data):
+                return data
+
+            def finalize(self):
+                return b""
+
+        class _FakeCipher:
+            def __init__(self, *args, **kwargs):
+                cipher_kwargs.append(kwargs)
+
+            def encryptor(self):
+                return _FakeContext()
+
+            def decryptor(self):
+                return _FakeContext()
+
+        def _removed_default_backend():
+            raise AssertionError("default_backend() must not be called")
+
+        monkeypatch.setattr(weixin, "Cipher", _FakeCipher)
+        monkeypatch.setattr(weixin, "algorithms", type("_Algorithms", (), {"AES": staticmethod(lambda key: key)}))
+        monkeypatch.setattr(weixin, "modes", type("_Modes", (), {"ECB": staticmethod(lambda: object())}))
+        monkeypatch.setattr(weixin, "default_backend", _removed_default_backend, raising=False)
+
+        key = b"0123456789abcdef"
+        ciphertext = weixin._aes128_ecb_encrypt(b"weixin-media", key)
+
+        assert weixin._aes128_ecb_decrypt(ciphertext, key) == b"weixin-media"
+        assert cipher_kwargs == [{}, {}]
+
+
 class TestWeixinQrLogin:
     @pytest.mark.asyncio
     async def test_qr_login_timeout_uses_monotonic_clock(self, tmp_path):
@@ -827,4 +863,3 @@ class TestWeixinVoiceGatewayHandoff:
             "VOICE event body leaked Tencent's STT text — runner would trust "
             "the wrong transcript instead of re-transcribing (#27300)."
         )
-

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -3,6 +3,7 @@ import re
 import tomllib
 from pathlib import Path
 
+from packaging.version import Version
 import pytest
 
 
@@ -63,7 +64,8 @@ def test_faster_whisper_is_not_a_base_dependency():
 # transitive dep (fastapi in [web]; sse-starlette/mcp in [mcp]/[computer-use]/
 # [dev]) so we pin it directly in every extra that exposes a server surface and
 # enforce the floor in both pyproject and the committed lockfile.
-_STARLETTE_CVE_FLOOR = (1, 0, 1)
+_STARLETTE_CVE_FLOOR = Version("1.0.1")
+_PYTHON_MULTIPART_CVE_FLOOR = Version("0.0.32")
 _UPDATE_DOWNGRADE_GUARD_FLOORS = {
     # `hermes update` reinstalls exact pins from pyproject/lazy_deps. These
     # reviewed CVE pins must not slide back to stale versions that downgrade
@@ -74,16 +76,36 @@ _UPDATE_DOWNGRADE_GUARD_FLOORS = {
 }
 
 
-def _version_tuple(spec: str) -> tuple[int, ...]:
-    # "1.0.1" -> (1, 0, 1); tolerant of pre/post suffixes by truncating.
-    head = spec.split("+", 1)[0]
-    parts = []
-    for chunk in head.split("."):
-        digits = "".join(ch for ch in chunk if ch.isdigit())
-        if not digits:
-            break
-        parts.append(int(digits))
-    return tuple(parts)
+def _starlette_at_cve_floor(version: str) -> bool:
+    return Version(version) >= _STARLETTE_CVE_FLOOR
+
+
+def _python_multipart_at_cve_floor(version: str) -> bool:
+    return Version(version) >= _PYTHON_MULTIPART_CVE_FLOOR
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    (
+        ("0.0.31.post999", False),
+        ("0.0.32rc1", False),
+        ("0.0.32", True),
+    ),
+)
+def test_python_multipart_floor_uses_pep440_ordering(version, expected):
+    assert _python_multipart_at_cve_floor(version) is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    (
+        ("1.0.0", False),
+        ("1.0.1rc1", False),
+        ("1.0.1", True),
+    ),
+)
+def test_starlette_floor_uses_pep440_ordering(version, expected):
+    assert _starlette_at_cve_floor(version) is expected
 
 
 def test_starlette_pinned_above_cve_2026_48710_floor_in_pyproject():
@@ -114,9 +136,9 @@ def test_starlette_pinned_above_cve_2026_48710_floor_in_pyproject():
         )
 
     for extra, ver in found.items():
-        assert _version_tuple(ver) >= _STARLETTE_CVE_FLOOR, (
+        assert _starlette_at_cve_floor(ver), (
             f"[{extra}] pins starlette=={ver}, below the CVE-2026-48710 fix "
-            f"floor {'.'.join(map(str, _STARLETTE_CVE_FLOOR))}"
+            f"floor {_STARLETTE_CVE_FLOOR}"
         )
 
 
@@ -142,11 +164,57 @@ def test_locked_starlette_is_not_vulnerable_to_cve_2026_48710():
 
     assert versions, "starlette not found in uv.lock"
     for ver in versions:
-        assert _version_tuple(ver) >= _STARLETTE_CVE_FLOOR, (
+        assert _starlette_at_cve_floor(ver), (
             f"uv.lock resolves starlette=={ver}, below the CVE-2026-48710 fix "
-            f"floor {'.'.join(map(str, _STARLETTE_CVE_FLOOR))} — regenerate the "
+            f"floor {_STARLETTE_CVE_FLOOR} — regenerate the "
             f"lockfile after bumping the pin"
         )
+
+
+def test_python_multipart_core_dependency_has_cve_fixed_floor():
+    """The core upload path must not resolve a vulnerable multipart parser.
+
+    ``python-multipart`` is a direct core dependency for FastAPI upload/form
+    handling.  The exact ``[web]`` pin and lockfile do not protect users who
+    install the default core package, so the core requirement must carry the
+    same patched floor.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    specs = [
+        spec
+        for spec in data["project"]["dependencies"]
+        if _distribution_name(spec) == "python-multipart"
+    ]
+    assert len(specs) == 1, f"expected one core python-multipart requirement, got {specs}"
+
+    spec = specs[0]
+    match = re.search(r">=\s*([^,\s;]+)", spec)
+    assert match, f"core python-multipart requirement must declare a lower bound: {spec}"
+    version = match.group(1)
+    assert _python_multipart_at_cve_floor(version), (
+        f"core python-multipart floor {match.group(1)} is below the patched "
+        f"floor {_PYTHON_MULTIPART_CVE_FLOOR}"
+    )
+    assert re.search(r"<\s*1(?:\b|$)", spec), (
+        f"core python-multipart requirement must retain its major-version ceiling: {spec}"
+    )
+    locked_versions = _locked_versions("python-multipart")
+    assert locked_versions, "python-multipart is missing from uv.lock"
+    assert all(_python_multipart_at_cve_floor(version) for version in locked_versions), (
+        f"uv.lock resolves python-multipart below the patched floor: {sorted(locked_versions)}"
+    )
+
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    root_package = next(package for package in lock["package"] if package["name"] == "hermes-agent")
+    locked_core_specs = [
+        requirement["specifier"]
+        for requirement in root_package["metadata"]["requires-dist"]
+        if requirement["name"] == "python-multipart" and "marker" not in requirement
+    ]
+    expected_specifier = re.sub(r"^[^=<>!~]+", "", spec).strip()
+    assert locked_core_specs == [expected_specifier], (
+        "uv.lock root metadata must mirror the core python-multipart requirement"
+    )
 
 
 
@@ -339,4 +407,26 @@ def test_security_pins_present_in_mirrored_lazy_features():
         "a lazy feature is missing a security pin it must mirror from the "
         "pyproject extras — the lazy install path would not enforce the "
         "CVE-patched floor:\n  " + "\n  ".join(problems)
+    )
+
+
+def test_dashboard_lazy_install_pins_python_multipart_at_cve_floor():
+    """The dashboard lazy path must keep the patched multipart parser pin."""
+    dashboard_specs = _lazy_deps_by_feature().get("tool.dashboard")
+    assert dashboard_specs is not None, "tool.dashboard is missing from LAZY_DEPS"
+
+    multipart_specs = [
+        spec for spec in dashboard_specs if _distribution_name(spec) == "python-multipart"
+    ]
+    assert len(multipart_specs) == 1, (
+        "tool.dashboard must carry one exact python-multipart pin, "
+        f"got {multipart_specs}"
+    )
+
+    spec = multipart_specs[0]
+    assert "==" in spec, f"tool.dashboard must exact-pin python-multipart, got {spec!r}"
+    version = spec.split("==", 1)[1].split(";", 1)[0].strip()
+    assert _python_multipart_at_cve_floor(version), (
+        f"tool.dashboard pins python-multipart=={version}, below the patched "
+        f"floor {_PYTHON_MULTIPART_CVE_FLOOR}"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1898,7 +1898,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
-    { name = "python-multipart", specifier = ">=0.0.9,<1" },
+    { name = "python-multipart", specifier = ">=0.0.32,<1" },
     { name = "python-multipart", marker = "extra == 'web'", specifier = "==0.0.32" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = "==22.6" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.6" },


### PR DESCRIPTION
Superseded by three focused contributions after their published heads were verified:

- https://github.com/sycamoregroupltd/hermes-agent/pull/74 extends [#73225](https://github.com/NousResearch/hermes-agent/pull/73225) with the core 0.0.32 floor and core/lock metadata checks.
- https://github.com/ilonagaja509-glitch/hermes-agent/pull/1 completes the import-path cleanup requested on [#35483](https://github.com/NousResearch/hermes-agent/pull/35483), preserving that contributor's backend-free AES calls and real round-trip tests.
- [#82740](https://github.com/NousResearch/hermes-agent/pull/82740) retains the independent PEP 440, exact-pin anti-downgrade, and dashboard lazy-pin regression guards.

The useful code and test invariants from this combined PR are preserved in those changes. The Weixin change is deprecated API cleanup; released cryptography 49/50 retains default_backend.

Refs #47997
Related #72362

Prepared and reviewed under controller GPT-6 Astra, ultra reasoning, using the Codex harness. The account owner loosely reviews these actions and receives the usual GitHub notifications.
