### PR TITLE
feat(telegram): deliver reaction-only replies as reactions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -807,7 +807,12 @@ PLATFORM_HINTS = {
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
         "bubbles, and videos (.mp4) play inline. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as native photos."
+        "URLs in markdown format ![alt](url) and they will be sent as native photos. "
+        "For tiny social acknowledgments where a text bubble would waste chat real "
+        "estate, prefer a native reaction: respond with exactly one tasteful emoji "
+        "(or `REACTION: <emoji>`) and no other text. Pick the emoji from the room's "
+        "energy/context — e.g. 🫡, 😭, 💀, 🤝, 🔥, 👀 — rather than defaulting to 👍 "
+        "unless thumbs-up is genuinely the best fit."
     ),
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -21,6 +21,7 @@ import time
 import uuid
 import weakref
 from abc import ABC, abstractmethod
+from typing import Optional
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
@@ -74,6 +75,39 @@ _HISTORY_MEDIA_LOOKUP_MAX_WORKERS = 2
 _HISTORY_MEDIA_LOOKUP_ADMISSION = threading.BoundedSemaphore(
     _HISTORY_MEDIA_LOOKUP_MAX_WORKERS
 )
+
+_REACTION_RESPONSE_MARKER_RE = re.compile(
+    r"^\s*(?:\[\s*)?REACTION\s*:\s*(?P<emoji>\S+?)\s*(?:\])?\s*$",
+    re.IGNORECASE,
+)
+_REACTION_ONLY_RESPONSES = frozenset({
+    "👍", "👎", "❤️", "🔥", "🥰", "👏", "😁", "🤔", "🤯", "😱",
+    "🤬", "😢", "🎉", "🤩", "🤮", "💩", "🙏", "👌", "🕊", "🤡",
+    "🥱", "🥴", "😍", "🐳", "❤️‍🔥", "🌚", "🌭", "💯", "🤣", "⚡",
+    "🍌", "🏆", "💔", "🤨", "😐", "🍓", "🍾", "💋", "🖕", "😈",
+    "😴", "😭", "🤓", "👻", "👨‍💻", "👀", "🎃", "🙈", "😇", "😨",
+    "🤝", "✍", "🤗", "🫡", "🎅", "🎄", "☃", "💅", "🤪", "🗿",
+    "🆒", "💘", "🙉", "🦄", "😘", "💊", "🙊", "😎", "👾", "🤷‍♂",
+    "🤷", "🤷‍♀", "😡",
+})
+
+
+def _extract_reaction_only_response(text: str) -> Optional[str]:
+    """Return a Telegram-compatible reaction emoji for reaction-only replies.
+
+    The gateway uses this as a delivery affordance, not a content filter: a
+    normal sentence containing an emoji remains a text bubble, while an exact
+    emoji reply (or explicit ``REACTION: <emoji>`` marker) can become a native
+    platform reaction when the adapter supports it.
+    """
+    stripped = str(text or "").strip()
+    if not stripped:
+        return None
+    marker = _REACTION_RESPONSE_MARKER_RE.match(stripped)
+    if marker:
+        candidate = marker.group("emoji").strip()
+        return candidate if candidate in _REACTION_ONLY_RESPONSES else None
+    return stripped if stripped in _REACTION_ONLY_RESPONSES else None
 
 
 def _platform_name(platform) -> str:
@@ -3952,6 +3986,15 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    async def react_to_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+    ) -> SendResult:
+        """React to an existing inbound message. Optional platform capability."""
+        return SendResult(success=False, error="Not supported", retryable=False)
+
     async def delete_message(
         self,
         chat_id: str,
@@ -6427,6 +6470,52 @@ class BasePlatformAdapter(ABC):
                             os.remove(_cleanup_path)
                         except OSError:
                             pass
+
+                # Convert reaction-only final replies into native platform
+                # reactions when supported. This lets a model answer a quick
+                # social ack with "🫡" / "REACTION: 🫡" without consuming a
+                # separate chat bubble. Fall back to the text send on failure
+                # so content is never silently lost.
+                _reaction_only = _extract_reaction_only_response(text_content)
+                if (
+                    _reaction_only
+                    and not is_ephemeral_response
+                    and not _tts_caption_delivered
+                    and not (images or local_files or media_files)
+                    and getattr(event, "message_id", None)
+                ):
+                    delivery_adapter = self._final_delivery_adapter(event.source)
+                    try:
+                        reaction_result = await delivery_adapter.react_to_message(
+                            chat_id=event.source.chat_id,
+                            message_id=str(event.message_id),
+                            emoji=_reaction_only,
+                        )
+                    except Exception as reaction_err:
+                        logger.debug(
+                            "[%s] reaction-only delivery failed: %s",
+                            delivery_adapter.name,
+                            reaction_err,
+                            exc_info=True,
+                        )
+                        reaction_result = SendResult(
+                            success=False,
+                            error=str(reaction_err),
+                            retryable=False,
+                        )
+                    _record_delivery(reaction_result)
+                    if getattr(reaction_result, "success", False):
+                        try:
+                            event.metadata["final_response_reaction"] = _reaction_only
+                        except Exception:
+                            pass
+                        logger.info(
+                            "[%s] Reacted to %s with %s instead of sending a text bubble",
+                            delivery_adapter.name,
+                            event.message_id,
+                            _reaction_only,
+                        )
+                        text_content = ""
 
                 # Send the text portion. A reconnect may have replaced this
                 # adapter while its in-flight handler was still producing a

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9963,6 +9963,21 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[%s] clear reactions failed: %s", self.name, _redact_telegram_error_text(e))
             return False
 
+    async def react_to_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+    ) -> SendResult:
+        """React to an existing Telegram message with a single emoji."""
+        if await self._set_reaction(chat_id, message_id, emoji):
+            return SendResult(success=True, message_id=message_id)
+        return SendResult(
+            success=False,
+            error="set_message_reaction failed",
+            retryable=False,
+        )
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():
@@ -9990,6 +10005,8 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if not (chat_id and message_id):
+            return
+        if getattr(event, "metadata", {}).get("final_response_reaction"):
             return
         if outcome == ProcessingOutcome.CANCELLED:
             await self._clear_reactions(chat_id, message_id)

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -339,3 +339,12 @@ class TestSkillsInVolatileBand:
         full = _build(build_system_prompt)
         assert full.index(_CONTEXT) < full.index(_SKILLS)
         assert full.index(_SKILLS) < full.index("Conversation started:")
+
+def test_telegram_prompt_advertises_tasteful_reaction_only_replies():
+    parts = _prompt_parts(_make_agent(platform="telegram"))
+    prompt = "\n\n".join(parts.values())
+
+    assert "native reaction" in prompt
+    assert "exactly one tasteful emoji" in prompt
+    assert "rather than defaulting to 👍" in prompt
+

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -153,4 +153,53 @@ def test_config_bridges_telegram_reactions(monkeypatch, tmp_path):
     import os
     assert os.getenv("TELEGRAM_REACTIONS") == "true"
 
+# ── reaction-only final responses ────────────────────────────────────
+
+
+def test_extract_reaction_only_response_accepts_exact_emoji():
+    """A one-emoji assistant reply can be delivered as a native reaction."""
+    from gateway.platforms.base import _extract_reaction_only_response
+
+    assert _extract_reaction_only_response("🫡") == "🫡"
+    assert _extract_reaction_only_response("  REACTION: 👍  ") == "👍"
+    assert _extract_reaction_only_response("[REACTION: 🔥]") == "🔥"
+
+
+def test_extract_reaction_only_response_rejects_sentences():
+    """Emoji inside real text must remain a normal text bubble."""
+    from gateway.platforms.base import _extract_reaction_only_response
+
+    assert _extract_reaction_only_response("😭 fair") is None
+    assert _extract_reaction_only_response("ok 🫡") is None
+    assert _extract_reaction_only_response("REACTION: not-an-emoji") is None
+
+
+@pytest.mark.asyncio
+async def test_react_to_message_sets_reaction_without_text_bubble(monkeypatch):
+    """TelegramAdapter exposes a public reaction delivery primitive."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+
+    result = await adapter.react_to_message("123", "456", "🫡")
+
+    assert result.success is True
+    assert result.message_id == "456"
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="🫡",
+    )
+
+
+@pytest.mark.asyncio
+async def test_processing_complete_preserves_final_response_reaction(monkeypatch):
+    """The lifecycle 👍 should not overwrite a deliberate reaction-only reply."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    event = _make_event()
+    event.metadata["final_response_reaction"] = "🫡"
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    adapter._bot.set_message_reaction.assert_not_awaited()
 


### PR DESCRIPTION
## Summary
- add a platform reaction delivery primitive
- let Telegram turn exact emoji / `REACTION: <emoji>` final replies into native reactions
- avoid overwriting deliberate reaction-only replies with lifecycle completion reactions

## Test Plan
- `uv run --python 3.11 --with pytest --with pytest-asyncio pytest tests/gateway/test_telegram_reactions.py tests/gateway/test_telegram_send_path_health.py -q`