### PR TITLE
fix(file_ops): stop classifying UTF-8 truncation artifacts as binary

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -51,6 +51,42 @@ class TestIsLikelyBinary:
         sample = "\x00" * 200 + "a" * 800 + "\x00" * 1000
         assert ops._is_likely_binary("file.xyz", content_sample=sample) is False
 
+    def test_ufffd_from_truncated_multibyte_not_binary(self, ops):
+        """U+FFFD caused by `head -c 1000` cutting a multi-byte UTF-8 char in
+        half must NOT classify the file as binary. The longer re-read shows
+        the replacement char only at the new boundary, so it's truncation
+        artifact, not corruption."""
+        sample = "中文内容" * 200 + "\ufffd"  # cut mid-character
+        with patch.object(ops, "_exec", return_value=MagicMock(
+            exit_code=0,
+            stdout="中文内容" * 300,  # longer sample: boundary moves, no mid U+FFFD
+        )) as mock_exec:
+            assert ops._is_likely_binary("file.md", content_sample=sample) is False
+        # The retry read of a longer sample must have happened
+        retry_cmd = mock_exec.call_args[0][0]
+        assert "head -c 4096" in retry_cmd
+
+    def test_ufffd_scattered_middle_is_binary(self, ops):
+        """U+FFFD scattered through the middle of the longer re-read means the
+        file is genuinely corrupt and must stay read-only/binary."""
+        sample = "中文" + "\ufffd" + "内容" * 200
+        with patch.object(ops, "_exec", return_value=MagicMock(
+            exit_code=0,
+            stdout="开头" + "\ufffd" + "中间" + "\ufffd" + "结尾" * 300,
+        )):
+            assert ops._is_likely_binary("file.md", content_sample=sample) is True
+
+    def test_ufffd_only_at_very_end_of_long_sample_not_binary(self, ops):
+        """Even the 4096-byte retry may itself cut a multi-byte char at its
+        tail; a lone U+FFFD within the last 4 chars is still a truncation
+        artifact, not corruption."""
+        sample = "中文" + "\ufffd" + "内容" * 200
+        with patch.object(ops, "_exec", return_value=MagicMock(
+            exit_code=0,
+            stdout="中文内容" * 1000 + "\ufffd",  # trailing partial char only
+        )):
+            assert ops._is_likely_binary("file.md", content_sample=sample) is False
+
 
 # =========================================================================
 # _check_lint edge cases

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -983,6 +983,24 @@ class ShellFileOperations(FileOperations):
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
             if "\ufffd" in content_sample[:1000]:
+                # BUT: a U+FFFD here may also be an artifact of `head -c 1000`
+                # cutting a multi-byte UTF-8 character in half, not genuine
+                # corruption. Re-read a longer sample to disambiguate: valid
+                # text truncated mid-character only shows the replacement char
+                # near the new (longer) cut boundary, whereas a truly corrupt
+                # file shows it scattered through the middle.
+                retry_cmd = f"head -c 4096 {self._escape_shell_arg(path)} 2>/dev/null"
+                retry_result = self._exec(retry_cmd)
+                if retry_result.exit_code == 0 and retry_result.stdout:
+                    retry_sample = _strip_terminal_fence_leaks(retry_result.stdout)
+                    # Only a trailing partial character may produce U+FFFD;
+                    # anything earlier in the sample means real corruption.
+                    boundary = max(0, len(retry_sample) - 4)
+                    corrupt = any(
+                        i < boundary for i, c in enumerate(retry_sample) if c == "\ufffd"
+                    )
+                    if not corrupt:
+                        return False
                 return True
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')


### PR DESCRIPTION
## Bug Description

`read_file` misclassifies perfectly valid UTF-8 text files as binary, making them unreadable through the file tools. Any file whose content includes multi-byte characters (CJK, emoji, accented Latin) can trigger this.

## Root Cause

`ShellFileOperations.read_file` samples the first 1000 bytes with `head -c 1000` and passes the sample to `_is_likely_binary`. That check treats **any** U+FFFD replacement character in the sample as evidence the file is binary. But when byte 1000 cuts a multi-byte UTF-8 character in half, decoding the truncated byte slice with `errors='replace'` *fabricates* a U+FFFD — the file on disk is perfectly fine. A 3-byte CJK character straddling the 1000-byte boundary is all it takes, so CJK/emoji-heavy files fail at roughly a 2/3 probability depending on content.

## Fix

On detecting U+FFFD in the 1000-byte sample, re-read a longer 4096-byte sample to disambiguate:

- **Truncation artifact**: the replacement char only appears at the new (longer) cut boundary → file is valid UTF-8 text → return `False` (not binary)
- **Genuine corruption**: replacement chars appear scattered through the middle of the sample → stay `True` (binary, read-only)

The boundary check tolerates a trailing partial character on the 4096-byte retry sample itself, since `head -c 4096` can also cut mid-character.

## How to Verify

1. Create a text file with CJK content sized so byte 1000 falls mid-character (e.g. `中文内容` repeated)
2. `read_file` on it previously returned `Binary file - cannot display as text`
3. With this fix it returns the content normally

## Test Plan

- [x] Added 3 regression tests: truncation artifact → not binary; mid-sample U+FFFD → binary; trailing artifact on retry sample → not binary
- [x] Existing tests still pass (69 passed)
- [x] Manual verification: previously-failing CJK files now read; genuinely corrupt files and NUL-heavy binaries still classify as binary

## Risk Assessment

Low — the change only adds a re-read path *after* U+FFFD is detected in the initial sample. Files that never produce U+FFFD (the common case) take the exact same code path as before. The only behavioral change is that truncation-induced U+FFFD no longer marks a file binary; real corruption still does.