### PR TITLE
fix(agent): use factual placeholder for captionless image uploads

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -48,6 +48,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+# Factual placeholder when a user attaches an image with no caption. Must not
+# read as user-authored intent (issue #82847).
+CAPTIONLESS_IMAGE_PLACEHOLDER = "[User attached an image without a caption.]"
+
 
 _VALID_MODES = frozenset({"auto", "native", "text"})
 
@@ -798,7 +802,7 @@ def build_native_content_parts(
     # If at least one image attached, build a single text part that combines
     # the user's caption (or a neutral default) with one hint per image.
     if attached_paths or attached_urls:
-        base_text = text or "What do you see in this image?"
+        base_text = text or CAPTIONLESS_IMAGE_PLACEHOLDER
         hint_lines: List[str] = []
         hint_lines.extend(f"[Image attached at: {p}]" for p in attached_paths)
         hint_lines.extend(f"[Image attached: {u}]" for u in attached_urls)
@@ -815,6 +819,7 @@ def build_native_content_parts(
 
 
 __all__ = [
+    "CAPTIONLESS_IMAGE_PLACEHOLDER",
     "decide_image_input_mode",
     "build_native_content_parts",
     "extract_image_refs",

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -194,7 +194,8 @@ def _coerce_turn_input_text(user_input: Any) -> str:
             elif item_type in {"image", "image_url", "input_image"}:
                 parts.append("[image attached]")
         text = "\n\n".join(p for p in parts if p).strip()
-        return text or "What do you see in this image?"
+        from agent.image_routing import CAPTIONLESS_IMAGE_PLACEHOLDER
+        return text or CAPTIONLESS_IMAGE_PLACEHOLDER
     return "" if user_input is None else str(user_input)
 
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -50,6 +50,9 @@ import {
   withSessionNotFoundResume
 } from './utils'
 
+/** Factual placeholder for captionless image uploads (issue #82847). */
+const CAPTIONLESS_IMAGE_PLACEHOLDER = '[User attached an image without a caption.]'
+
 interface SubmitPromptDeps {
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
@@ -147,7 +150,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         return (
           [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
-          (present.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
+          (present.some(a => a.kind === 'image') ? CAPTIONLESS_IMAGE_PLACEHOLDER : '')
         )
       }
 

--- a/cli.py
+++ b/cli.py
@@ -7699,7 +7699,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if enriched_parts:
             prefix = "\n\n".join(enriched_parts)
             return f"{prefix}\n\n{user_text}" if user_text else prefix
-        return user_text or "What do you see in this image?"
+        from agent.image_routing import CAPTIONLESS_IMAGE_PLACEHOLDER
+        return user_text or CAPTIONLESS_IMAGE_PLACEHOLDER
 
     def _show_tool_availability_warnings(self):
         """Show warnings about disabled tools due to missing API keys."""

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 
 from agent.image_routing import (
+    CAPTIONLESS_IMAGE_PLACEHOLDER,
     _coerce_capability_bool,
     _coerce_mode,
     _explicit_aux_vision_override,
@@ -188,6 +189,15 @@ def _png_bytes() -> bytes:
 
 
 class TestBuildNativeContentParts:
+    def test_captionless_image_uses_factual_placeholder(self, tmp_path: Path):
+        img = tmp_path / "scan.png"
+        img.write_bytes(_png_bytes())
+        parts, skipped = build_native_content_parts("", [str(img)])
+        assert skipped == []
+        text_part = next(p for p in parts if p.get("type") == "text")
+        assert text_part["text"].startswith(CAPTIONLESS_IMAGE_PLACEHOLDER)
+        assert "What do you see in this image?" not in text_part["text"]
+
     def test_text_then_image(self, tmp_path: Path):
         img = tmp_path / "cat.png"
         img.write_bytes(_png_bytes())

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -141,6 +141,11 @@ class TestApprovalChoiceMapping:
 
 
 class TestTurnInputCoercion:
+    def test_empty_multimodal_list_uses_factual_placeholder(self):
+        from agent.image_routing import CAPTIONLESS_IMAGE_PLACEHOLDER
+
+        assert _coerce_turn_input_text([]) == CAPTIONLESS_IMAGE_PLACEHOLDER
+
     def test_list_content_keeps_text_and_marks_images(self):
         text = _coerce_turn_input_text([
             {"type": "text", "text": "caption"},

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6839,7 +6839,8 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     prefix = "\n\n".join(parts)
     if prefix:
         return f"{prefix}\n\n{text}" if text else prefix
-    return text or "What do you see in this image?"
+    from agent.image_routing import CAPTIONLESS_IMAGE_PLACEHOLDER
+    return text or CAPTIONLESS_IMAGE_PLACEHOLDER
 
 
 def _build_persist_message_with_image_refs(user_text: str, image_paths: list[str]) -> str:

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -2,7 +2,7 @@ import { execFile } from 'child_process'
 
 import { forceRedraw, onTerminalBackground, onTerminalForeground } from '@hermes/ink'
 
-import { STARTUP_IMAGE, STARTUP_QUERY } from '../config/env.js'
+import { CAPTIONLESS_IMAGE_PLACEHOLDER, STARTUP_IMAGE, STARTUP_QUERY } from '../config/env.js'
 import { STREAM_BATCH_MS } from '../config/timing.js'
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
 import type {
@@ -599,7 +599,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         }
       }
 
-      submitRef.current(STARTUP_QUERY || 'What do you see in this image?')
+      submitRef.current(STARTUP_QUERY || CAPTIONLESS_IMAGE_PLACEHOLDER)
     }, 0)
   }
 

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -29,6 +29,10 @@ export const STARTUP_RESUME_ID = (process.env.HERMES_TUI_RESUME ?? '').trim()
 export const STARTUP_QUERY = (process.env.HERMES_TUI_QUERY ?? '').trim()
 export const STARTUP_IMAGE = (process.env.HERMES_TUI_IMAGE ?? '').trim()
 
+/** Factual placeholder for captionless image uploads (issue #82847). */
+export const CAPTIONLESS_IMAGE_PLACEHOLDER =
+  '[User attached an image without a caption.]'
+
 // Mouse tracking mode resolution at startup. Per-mode selection (off|wheel|
 // buttons|all) lives in display.mouse_tracking in config.yaml — these env
 // vars only set the boot-time default before that config is applied.


### PR DESCRIPTION
## What does this PR do?

When a user attaches an image without a caption, Hermes previously inserted the fabricated instruction `What do you see in this image?` into the user message. That text reads as user-authored intent and can misroute skills, memory, and session history.

This PR introduces a shared factual placeholder (`[User attached an image without a caption.]`) and uses it across the native-image path and sibling transport surfaces (CLI text-mode enrichment, TUI gateway, desktop composer, TUI startup prompt, and Codex app-server coercion fallback).

## Related Issue

Fixes #82847

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/image_routing.py` — add `CAPTIONLESS_IMAGE_PLACEHOLDER` and use it in `build_native_content_parts`
- `cli.py` — use the shared placeholder in `_preprocess_images_with_vision` when no user text remains
- `tui_gateway/server.py` — use the shared placeholder in `_enrich_with_attached_images`
- `agent/transports/codex_app_server_session.py` — use the shared placeholder in `_coerce_turn_input_text` empty-text fallback
- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` — use factual placeholder for image-only desktop submits
- `ui-tui/src/config/env.ts` and `ui-tui/src/app/createGatewayEventHandler.ts` — export and use the same placeholder for startup image-only prompts
- `tests/agent/test_image_routing.py` — regression test for captionless native image parts
- `tests/agent/transports/test_codex_app_server_session.py` — regression test for empty multimodal list fallback

## How to Test

1. Call `build_native_content_parts("", ["/path/to/image.png"])` and confirm the text part begins with `[User attached an image without a caption.]` (not `What do you see in this image?`).
2. Run `scripts/run_tests.sh tests/agent/test_image_routing.py tests/agent/transports/test_codex_app_server_session.py -q`.
3. Attach an image with no caption via CLI/TUI/desktop and inspect the persisted user message in session history.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — behavior change is in message text composition; covered by unit tests.