### PR TITLE
fix(state): stop rebuilding the whole FTS index on every open when the trigram tokenizer is missing

### DIFF
--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -11,7 +11,7 @@ module-level constants live in hermes_state_common.
 import logging
 import json
 import sqlite3
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 
 from hermes_constants import get_hermes_home
 from hermes_state_common import (
@@ -37,6 +37,19 @@ logger = logging.getLogger("hermes_state")
 # Cache for schema_read_probe_statements() — parsing SCHEMA_SQL spins up an
 # in-memory SQLite database, so derive the statements once per process.
 _READ_PROBE_STATEMENTS: Optional[tuple] = None
+
+# _FTS_TRIGGERS is the full canonical set, but its two halves have different
+# availability: the trigram triggers are declared ONLY by FTS_TRIGRAM_SQL /
+# LEGACY_FTS_TRIGRAM_SQL, whose CREATE VIRTUAL TABLE needs the trigram
+# tokenizer (SQLite >= 3.34). On a build without it, _ensure_fts_schema
+# soft-fails that DDL, so those three triggers can never exist and any check
+# for "all six are present" is permanently unsatisfiable. Split the set so a
+# trigger's absence is only ever measured against the DDL that can create it.
+# The two subsets are exhaustive and disjoint by construction (base is the
+# complement of trigram); test_fts_trigger_subsets_match_the_ddl pins them
+# against the DDL those triggers actually come from.
+_FTS_TRIGRAM_TRIGGERS = tuple(n for n in _FTS_TRIGGERS if "_trigram_" in n)
+_FTS_BASE_TRIGGERS = tuple(n for n in _FTS_TRIGGERS if n not in _FTS_TRIGRAM_TRIGGERS)
 
 
 def schema_read_probe_statements() -> tuple:
@@ -126,12 +139,25 @@ class SessionSchemaMixin:
                 pass
 
     @staticmethod
-    def _fts_trigger_count(cursor: sqlite3.Cursor) -> int:
-        placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+    def _fts_trigger_count(
+        cursor: sqlite3.Cursor,
+        names: Sequence[str] = _FTS_TRIGGERS,
+    ) -> int:
+        """Count how many of *names* currently exist as triggers.
+
+        Defaults to the full canonical set so existing callers are unchanged;
+        callers that need to know whether one HALF of the set is intact pass
+        _FTS_BASE_TRIGGERS or _FTS_TRIGRAM_TRIGGERS.
+        """
+        if not names:
+            # "name IN ()" is a syntax error in SQLite, and nothing can be
+            # missing from an empty set anyway.
+            return 0
+        placeholders = ",".join("?" for _ in names)
         row = cursor.execute(
             f"SELECT COUNT(*) FROM sqlite_master "
             f"WHERE type = 'trigger' AND name IN ({placeholders})",
-            _FTS_TRIGGERS,
+            tuple(names),
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
@@ -1223,8 +1249,17 @@ class SessionSchemaMixin:
                     self._trigram_available = False
                     self._fts_cjk_available = False
             elif legacy_fts:
-                triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+                # Measure BEFORE the DDL below runs, so these describe the
+                # pre-repair state. Whether the trigram half is even
+                # creatable is only known AFTER _ensure_fts_schema, which is
+                # why the two halves are combined at the `if`, not here.
+                base_triggers_missing = (
+                    self._fts_trigger_count(cursor, _FTS_BASE_TRIGGERS)
+                    < len(_FTS_BASE_TRIGGERS)
+                )
+                trigram_triggers_missing = (
+                    self._fts_trigger_count(cursor, _FTS_TRIGRAM_TRIGGERS)
+                    < len(_FTS_TRIGRAM_TRIGGERS)
                 )
                 self._fts_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts", LEGACY_FTS_SQL
@@ -1234,13 +1269,21 @@ class SessionSchemaMixin:
                         cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
                     )
                     self._trigram_available = trigram_enabled
-                    if triggers_need_repair:
+                    if base_triggers_missing or (
+                        trigram_enabled and trigram_triggers_missing
+                    ):
                         self._rebuild_legacy_fts_indexes(
                             cursor, include_trigram=trigram_enabled
                         )
             else:
-                triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+                # Same split as the legacy branch above, same reason.
+                base_triggers_missing = (
+                    self._fts_trigger_count(cursor, _FTS_BASE_TRIGGERS)
+                    < len(_FTS_BASE_TRIGGERS)
+                )
+                trigram_triggers_missing = (
+                    self._fts_trigger_count(cursor, _FTS_TRIGRAM_TRIGGERS)
+                    < len(_FTS_TRIGRAM_TRIGGERS)
                 )
                 self._fts_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts", FTS_SQL
@@ -1254,7 +1297,9 @@ class SessionSchemaMixin:
                         cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                     )
                     self._trigram_available = trigram_enabled
-                    if triggers_need_repair:
+                    if base_triggers_missing or (
+                        trigram_enabled and trigram_triggers_missing
+                    ):
                         self._rebuild_fts_indexes(
                             cursor,
                             include_trigram=trigram_enabled,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1857,6 +1857,316 @@ class TestReconcileColumnsErrorHandling:
         assert "last_read_at" in cols
 
 
+class TestFtsRebuildLoopWithoutTrigram:
+    """A trigram-less SQLite build must not re-index the store on every open.
+
+    The three ``messages_fts_trigram_*`` triggers are declared only by the
+    trigram DDL, whose ``CREATE VIRTUAL TABLE ... tokenize='trigram'`` needs a
+    tokenizer SQLite only gained in 3.34 — Ubuntu 20.04 (3.31), RHEL/CentOS 8
+    (3.26) and Amazon Linux 2 all ship older. ``_ensure_fts_schema``
+    soft-fails that DDL there by design, so those three triggers can never
+    exist, and startup's "are all six canonical triggers present?" check was
+    therefore permanently unsatisfiable: the full FTS repair ran on every
+    single ``SessionDB`` open, holding the write lock, and never converged.
+
+    The v23 repair also clears the deferred-rebuild resume markers, so an
+    interrupted ``hermes sessions optimize-storage`` silently lost its place
+    every time the store was reopened.
+    """
+
+    @staticmethod
+    def _trace(monkeypatch, statements, *, trigram):
+        """Record every statement SessionDB executes during an open.
+
+        ``trigram=False`` additionally routes connections through the
+        module's existing ``_NoTrigramConnection``, which raises
+        ``no such tokenizer: trigram`` for the trigram DDL exactly as an
+        older SQLite does.
+        """
+        real_connect = sqlite3.connect
+
+        def connect(*args, **kwargs):
+            if not trigram:
+                kwargs["factory"] = _NoTrigramConnection
+            conn = real_connect(*args, **kwargs)
+            conn.set_trace_callback(statements.append)
+            return conn
+
+        monkeypatch.setattr("hermes_state.sqlite3.connect", connect)
+
+    @staticmethod
+    def _rebuilds(statements):
+        """External-content 'rebuild' commands seen in *statements*."""
+        return [sql for sql in statements if "VALUES('rebuild')" in "".join(sql.split())]
+
+    @staticmethod
+    def _legacy_wipes(statements):
+        """Legacy inline repair wipes the index before reinserting every row."""
+        return [
+            sql for sql in statements
+            if "".join(sql.split()).upper().startswith("DELETEFROMMESSAGES_FTS")
+        ]
+
+    @staticmethod
+    def _seed(db_path):
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            for i in range(5):
+                db.append_message("s1", role="user", content=f"payload {i} zebra")
+        finally:
+            db.close()
+
+    @staticmethod
+    def _build_legacy_inline_db(db_path):
+        """A v22 store as it exists on a host that never had the tokenizer.
+
+        Only the three base inline triggers were ever creatable there, so —
+        unlike the migration fixtures elsewhere in this file — this build
+        deliberately has no trigram table and no trigram triggers.
+        """
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.executescript(SCHEMA_SQL)
+            conn.executescript("""
+                DROP TABLE IF EXISTS messages_fts;
+                DROP TABLE IF EXISTS messages_fts_trigram;
+                DROP VIEW IF EXISTS messages_fts_trigram_src;
+
+                CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+
+                CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+                    INSERT INTO messages_fts(rowid, content) VALUES (
+                        new.id,
+                        COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '')
+                        || ' ' || COALESCE(new.tool_calls, '')
+                    );
+                END;
+
+                CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+                    DELETE FROM messages_fts WHERE rowid = old.id;
+                END;
+
+                CREATE TRIGGER messages_fts_update
+                AFTER UPDATE OF content, tool_name, tool_calls ON messages BEGIN
+                    DELETE FROM messages_fts WHERE rowid = old.id;
+                    INSERT INTO messages_fts(rowid, content) VALUES (
+                        new.id,
+                        COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '')
+                        || ' ' || COALESCE(new.tool_calls, '')
+                    );
+                END;
+            """)
+            conn.execute("DELETE FROM schema_version")
+            conn.execute("INSERT INTO schema_version (version) VALUES (22)")
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at) VALUES ('s1', 'cli', ?)",
+                (time.time(),),
+            )
+            for i in range(5):
+                conn.execute(
+                    "INSERT INTO messages (session_id, timestamp, role, content) "
+                    "VALUES ('s1', ?, 'user', ?)",
+                    (time.time(), f"legacy payload {i} zebra"),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_fts_trigger_subsets_match_the_ddl(self):
+        """The split must track the DDL each trigger actually comes from.
+
+        The gate is only correct while every trigger classified as "trigram"
+        is one the trigram DDL creates, and every other one is created by DDL
+        that always works. Renaming a trigger without updating its DDL would
+        otherwise silently reintroduce an unsatisfiable check.
+        """
+        from hermes_state_common import (
+            FTS_SQL,
+            FTS_TRIGRAM_SQL,
+            LEGACY_FTS_SQL,
+            LEGACY_FTS_TRIGRAM_SQL,
+            _FTS_TRIGGERS,
+        )
+        from hermes_state_schema import _FTS_BASE_TRIGGERS, _FTS_TRIGRAM_TRIGGERS
+
+        # Exhaustive and disjoint: nothing may fall out of the classification.
+        assert set(_FTS_BASE_TRIGGERS) | set(_FTS_TRIGRAM_TRIGGERS) == set(_FTS_TRIGGERS)
+        assert not set(_FTS_BASE_TRIGGERS) & set(_FTS_TRIGRAM_TRIGGERS)
+
+        for name in _FTS_TRIGRAM_TRIGGERS:
+            assert name in FTS_TRIGRAM_SQL and name in LEGACY_FTS_TRIGRAM_SQL, (
+                f"{name} is classified as trigram-only but the trigram DDL "
+                f"does not create it"
+            )
+        for name in _FTS_BASE_TRIGGERS:
+            assert name in FTS_SQL and name in LEGACY_FTS_SQL, (
+                f"{name} is classified as always-creatable but the base DDL "
+                f"does not create it"
+            )
+            assert name not in FTS_TRIGRAM_SQL
+
+    def test_missing_trigram_tokenizer_does_not_rebuild_fts_on_every_open(
+        self, tmp_path, monkeypatch
+    ):
+        """v23 branch: the repair must converge instead of firing forever."""
+        db_path = tmp_path / "state.db"
+        statements = []
+        self._trace(monkeypatch, statements, trigram=False)
+
+        self._seed(db_path)
+
+        # Second and third opens of an already-initialised store. The trigram
+        # triggers are still absent and always will be, but nothing is
+        # actually broken, so there is nothing to repair.
+        for _ in range(2):
+            statements.clear()
+            db = SessionDB(db_path=db_path)
+            try:
+                assert db._trigram_available is False
+                assert self._rebuilds(statements) == []
+                # The narrowed gate must not have cost us a working index.
+                assert len(db.search_messages("zebra")) == 5
+            finally:
+                db.close()
+
+    def test_legacy_inline_fts_without_trigram_does_not_rebuild_on_every_open(
+        self, tmp_path, monkeypatch
+    ):
+        """Legacy (pre-v23) branch: same gate, same permanent repair loop.
+
+        This path is the more expensive of the two — inline tables have no
+        external-content 'rebuild' source, so the repair deletes the index and
+        reinserts a concatenation of every row in ``messages``.
+        """
+        db_path = tmp_path / "legacy.db"
+        self._build_legacy_inline_db(db_path)
+
+        statements = []
+        self._trace(monkeypatch, statements, trigram=False)
+
+        for _ in range(2):
+            statements.clear()
+            db = SessionDB(db_path=db_path)
+            try:
+                assert db._db_has_legacy_inline_fts(db._conn.cursor()) is True
+                assert db._trigram_available is False
+                assert self._legacy_wipes(statements) == []
+                assert len(db.search_messages("zebra")) == 5
+            finally:
+                db.close()
+
+    def test_pending_fts_rebuild_markers_survive_a_trigramless_open(
+        self, tmp_path, monkeypatch
+    ):
+        """An interrupted optimize-storage must keep its resume point.
+
+        ``_rebuild_fts_indexes`` clears both markers because a full rebuild
+        genuinely does cover every row. Running it unconditionally on a
+        trigram-less host therefore threw away the progress of a chunked,
+        throttled backfill on the very next open.
+        """
+        db_path = tmp_path / "state.db"
+        statements = []
+        self._trace(monkeypatch, statements, trigram=False)
+
+        self._seed(db_path)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            for key, value in (
+                ("fts_rebuild_high_water", "30"),
+                ("fts_rebuild_progress", "10"),
+            ):
+                db._conn.execute(
+                    "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    (key, value),
+                )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db.get_meta("fts_rebuild_high_water") == "30"
+            assert db.get_meta("fts_rebuild_progress") == "10"
+        finally:
+            db.close()
+
+    def test_missing_base_trigger_still_repairs_once(self, tmp_path, monkeypatch):
+        """Control: narrowing the gate must not disable genuine repair.
+
+        A base trigger really can go missing (an earlier no-FTS5 runtime drops
+        them to keep writes alive), and rows written meanwhile are absent from
+        the index. That still has to be repaired — once, and then converge.
+        """
+        db_path = tmp_path / "state.db"
+        statements = []
+        self._trace(monkeypatch, statements, trigram=False)
+
+        self._seed(db_path)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            db._conn.execute("DROP TRIGGER messages_fts_insert")
+            db._conn.commit()
+        finally:
+            db.close()
+
+        statements.clear()
+        db = SessionDB(db_path=db_path)
+        try:
+            assert len(self._rebuilds(statements)) == 1
+            assert db._conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type = 'trigger' AND name = 'messages_fts_insert'"
+            ).fetchone()[0] == 1
+        finally:
+            db.close()
+
+        # …and having repaired it, the next open is quiet again.
+        statements.clear()
+        db = SessionDB(db_path=db_path)
+        try:
+            assert self._rebuilds(statements) == []
+        finally:
+            db.close()
+
+    def test_missing_trigram_trigger_still_repairs_where_the_tokenizer_exists(
+        self, tmp_path, monkeypatch
+    ):
+        """Control: on a capable host a missing trigram trigger is real damage.
+
+        Only the permanently-unsatisfiable case changes. Where the trigram DDL
+        can run, a gap in those triggers means the index missed rows and must
+        still be rebuilt.
+        """
+        db_path = tmp_path / "state.db"
+        statements = []
+        self._trace(monkeypatch, statements, trigram=True)
+
+        self._seed(db_path)
+
+        db = SessionDB(db_path=db_path)
+        trigram_available = db._trigram_available
+        try:
+            if not trigram_available:
+                pytest.skip("this SQLite build has no trigram tokenizer")
+            db._conn.execute("DROP TRIGGER messages_fts_trigram_insert")
+            db._conn.commit()
+        finally:
+            db.close()
+
+        statements.clear()
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db._trigram_available is True
+            assert len(self._rebuilds(statements)) > 0
+        finally:
+            db.close()
+
+
 class TestTitleUniqueness:
     """Tests for unique title enforcement and title-based lookups."""
 


### PR DESCRIPTION
## What does this PR do?

`SessionDB._init_schema` decided whether the FTS triggers needed repair with this test, in two identical places:

```python
triggers_need_repair = (
    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
)
```

`_FTS_TRIGGERS` is six names, and three of them are the `messages_fts_trigram_*` triggers. Those three are declared **only** inside `FTS_TRIGRAM_SQL` and `LEGACY_FTS_TRIGRAM_SQL`, whose `CREATE VIRTUAL TABLE ... tokenize='trigram'` needs a tokenizer SQLite only gained in **3.34**. On an older build `_ensure_fts_schema` soft-fails that DDL through `_is_trigram_unavailable_error` and returns `False` — deliberately, so search degrades instead of breaking. The consequence is that those three triggers can never come into existence on such a host.

So the count is pinned at `3`, `3 < 6` is permanently `True`, and the repair path runs on **every** `SessionDB` open, forever, holding the SQLite write lock. It never converges. Every `hermes` command, gateway start, dashboard request and cron tick re-indexes the whole message corpus, and the cost is linear in it.

This is ordinary LTS territory rather than an exotic build — Ubuntu 20.04 ships SQLite 3.31, RHEL/CentOS 8 and Alibaba Cloud Linux ship 3.26, Amazon Linux 2 is older still. Hermes has no minimum-SQLite gate precisely because it is meant to degrade gracefully there, so those hosts run fine and pay the tax silently.

There is a second effect. `_rebuild_fts_indexes` ends with:

```python
cursor.execute(
    "DELETE FROM state_meta WHERE key IN "
    "('fts_rebuild_high_water', 'fts_rebuild_progress')"
)
```

which is correct after a genuine full rebuild, but running that rebuild unconditionally means an interrupted `hermes sessions optimize-storage` **silently loses its resume point on the very next open**. A chunked, throttled, progress-reported backfill is replaced by an unbounded foreground rebuild inside startup, every time.

### The fix

Keep `_FTS_TRIGGERS` as the single source of truth and *derive* two subsets from it, then measure each half only against the DDL that can actually create it:

```python
_FTS_TRIGRAM_TRIGGERS = tuple(n for n in _FTS_TRIGGERS if "_trigram_" in n)
_FTS_BASE_TRIGGERS = tuple(n for n in _FTS_TRIGGERS if n not in _FTS_TRIGRAM_TRIGGERS)
```

`_fts_trigger_count` gains an optional `names` sequence defaulting to the full set, so no existing caller changes, and both branches now gate on:

```python
if base_triggers_missing or (trigram_enabled and trigram_triggers_missing):
```

Ordering is preserved and load-bearing: both counts are still taken **before** the DDL runs, so they describe the pre-repair state, while `trigram_enabled` is only known **after** `_ensure_fts_schema`. That is why the two halves are combined at the `if` rather than at the assignment.

Behaviour is unchanged wherever the tokenizer exists — a genuinely missing trigram trigger on a capable host still triggers the rebuild, and a genuinely missing *base* trigger still triggers it everywhere. Only the permanently unsatisfiable comparison changes.

### Sibling sweep

`grep -rn "_fts_trigger_count\|triggers_need_repair"` over production code returns four sites, and all four are in this PR:

| Site | Covered |
|---|---|
| `hermes_state_schema.py` legacy inline-FTS gate in `_init_schema` | fixed |
| `hermes_state_schema.py` v23 external-content gate in `_init_schema` | fixed |
| `_fts_trigger_count` body | parameterized |
| `_FTS_TRIGGERS` definition in `hermes_state_common.py` | unchanged — the subsets are derived from it, not a replacement |

Deliberately **excluded**, because they do not share the root cause:

- `_drop_fts_triggers` iterates `_FTS_TRIGGERS` emitting `DROP TRIGGER IF EXISTS`. Dropping a trigger that was never created is a no-op; there is no count-vs-`len` comparison to get wrong.
- `_FTS_CJK_TRIGGERS` (`hermes_state_search.py`, `hermes_state.py`) has the same *shape* but a different mechanism: no count-vs-`len` comparison exists, and `_ensure_fts_cjk_schema` gates on `_fts_cjk_loaded` directly, so it cannot get stuck permanently true.

## Related Issue

No filed issue — self-found defect, so there is nothing to auto-close here.

The population is independently documented by open #35931, which names the SQLite 3.26 hosts, and the tree has already accepted the general principle twice: merged #48688 ("survive SQLite builds without trigram tokenizer") and merged #77629 ("skip trigram sweep in `_fts_rebuild_finish` when unavailable"). This is the same idea applied to startup — when trigram is unavailable, stop doing useless work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state_schema.py` — derive `_FTS_BASE_TRIGGERS` / `_FTS_TRIGRAM_TRIGGERS` from `_FTS_TRIGGERS` at module scope, with a comment explaining why the halves differ in availability.
- `hermes_state_schema.py` — `_fts_trigger_count(cursor, names=_FTS_TRIGGERS)` takes the set to count. The default preserves every existing caller. An empty `names` short-circuits to `0` rather than emitting `name IN ()`, which is a SQLite syntax error.
- `hermes_state_schema.py` — both `_init_schema` FTS branches (legacy inline and v23 external-content) compute `base_triggers_missing` / `trigram_triggers_missing` and gate the rebuild on `base_triggers_missing or (trigram_enabled and trigram_triggers_missing)`.
- `tests/test_hermes_state.py` — new `TestFtsRebuildLoopWithoutTrigram`, six tests, reusing the file's existing `_NoTrigramConnection` / `_NoTrigramCursor` rather than adding a fixture.

## How to Test

The tests observe the *actual SQL* SessionDB issues during an open, via `set_trace_callback` on the connection, so they cannot pass if the production change is reverted.

1. Check out this branch and run the new class:

   ```
   pytest tests/test_hermes_state.py -k TestFtsRebuildLoopWithoutTrigram -v
   ```

2. Revert only the production hunk (`git stash push hermes_state_schema.py`) and re-run. Measured on this branch:

   | Test | Before | After |
   |---|---|---|
   | `test_missing_trigram_tokenizer_does_not_rebuild_fts_on_every_open` | `INSERT INTO messages_fts(messages_fts) VALUES('rebuild')` on **every** open | zero after the first |
   | `test_legacy_inline_fts_without_trigram_does_not_rebuild_on_every_open` | `DELETE FROM messages_fts` + full reinsert on **every** open | zero |
   | `test_pending_fts_rebuild_markers_survive_a_trigramless_open` | markers `'30'` / `'10'` → `None` / `None` | both survive |
   | `test_missing_base_trigger_still_repairs_once` | repairs, then keeps repairing forever | repairs exactly once, then converges |
   | `test_fts_trigger_subsets_match_the_ddl` | symbols do not exist | passes |
   | `test_missing_trigram_trigger_still_repairs_where_the_tokenizer_exists` | passes | passes (control — preserved behaviour) |

   Five of the six go red without the production change; the sixth is the control that must stay green in both directions.

3. Or reproduce by hand on a host whose SQLite predates 3.34 (`python3 -c "import sqlite3; print(sqlite3.sqlite_version)"`): open a populated `state.db` twice with `hermes sessions list` and watch the second open re-index the corpus.

The two control tests are the point of the design: `test_missing_base_trigger_still_repairs_once` proves a real degradation is still repaired on a trigram-less host, and `test_missing_trigram_trigger_still_repairs_where_the_tokenizer_exists` proves a capable host is completely unaffected. `test_fts_trigger_subsets_match_the_ddl` pins the derived subsets against the DDL each trigger actually comes from, so renaming a trigger without moving it between DDL blocks fails loudly instead of quietly reintroducing an unsatisfiable check.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the state/FTS surface rather than the whole tree, and it is green: `tests/test_hermes_state.py` (226), `tests/state/` + `tests/hermes_state/` (129), and `tests/test_fts_cjk_bigram.py`, `tests/test_fts_update_of_narrowing.py`, `tests/test_search_slow_query_log.py`, `tests/test_schema_read_probe.py`, `tests/test_hermes_state_readonly_preflight.py`, `tests/test_hermes_state_wal_fallback.py`, `tests/test_state_db_malformed_repair.py`, `tests/test_state_db_stats.py`, `tests/test_zeroed_state_db.py`, `tests/test_hermes_state_compression_busy_retry.py`, `tests/test_hermes_state_compression_locks.py` (98) — 453 passed, 0 failed. Leaving this unticked rather than claim a full-tree run I did not complete; CI covers the rest.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15, SQLite 3.50.4. The trigram-less runtime is simulated with the test file's existing `_NoTrigramConnection`, which raises the exact `no such tokenizer: trigram` that an older SQLite does — I have not run this on a real SQLite < 3.34 host.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — docstrings and inline comments on the touched code; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — the change is pure SQLite-capability logic with no platform-specific paths; only macOS was exercised locally
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

**#69085** (@eiritsu, *"drop orphan FTS triggers on startup"*) edits the **same two expressions** for a different concern — it ORs a `had_orphans` flag in so that non-canonical duplicate triggers force a rebuild. It does not address this bug: with orphans absent, `had_orphans` is `False` and the comparison stays `3 < 6`, so the permanent loop remains.

The two compose mechanically rather than conflicting — the merged form is:

```python
if had_orphans or base_triggers_missing or (
    trigram_enabled and trigram_triggers_missing
):
```

I have deliberately **not** absorbed `_drop_orphan_fts_triggers` here, because it is a separate concern with its own scanning helper and its own tests, and folding it in would make this diff two ideas instead of one. Worth noting for whoever reviews them together: #69085's production hunks target `hermes_state.py:3108-3181`, but `_init_schema` no longer lives there since the `21c7ae85630` mixin split moved it to `hermes_state_schema.py`, so it will need a rebase before it can apply either way.

**#82568** (@thanosapollo) also touches `hermes_state_schema.py`, but inside `_reconcile_columns` (hunks at `@@ -394` and `@@ -415`) with its tests in a new file. No overlap with this change.
