### PR TITLE
fix(agent): retry title generation with json_object on HTTP 400

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -315,6 +315,24 @@ def _extract_title_text(content: str) -> str:
     return raw.strip("\"'").strip()
 
 
+def _response_format_rejected(exc: Exception) -> bool:
+    """Return whether *exc* is an HTTP 400 rejecting the request shape.
+
+    Some OpenAI-compatible backends (vLLM translating ``json_schema`` into a
+    ``guided_grammar`` it can't compile, DeepSeek/Kimi rejecting the type
+    outright) 400 on strict structured output but accept the looser
+    ``json_object`` mode. A 400 for an unrelated reason (bad auth, invalid
+    model) will just 400 again on retry and fall through to the outer
+    handler, so this check only needs to be cheap, not exhaustive.
+    """
+    status = getattr(exc, "status_code", None) or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    if status == 400:
+        return True
+    return "error code: 400" in str(exc).lower()
+
+
 def _clean_title(text: str) -> Optional[str]:
     """Normalize a model-produced title, or None when nothing usable remains."""
     title = " ".join((text or "").split())
@@ -391,18 +409,33 @@ def generate_title(
         {"role": "user", "content": user_snippet},
     ]
 
+    call_kwargs = dict(
+        task="title_generation",
+        messages=messages,
+        # A title is a handful of tokens. The old 500-token ceiling let a
+        # chatty model burn seconds generating prose we then threw away.
+        max_tokens=64,
+        temperature=0.3,
+        timeout=timeout,
+        main_runtime=main_runtime,
+    )
     try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
+        try:
+            response = call_llm(
+                **call_kwargs,
+                extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            )
+        except Exception as schema_exc:
+            if not _response_format_rejected(schema_exc):
+                raise
+            logger.info(
+                "Title provider rejected json_schema response_format (HTTP "
+                "400); retrying with json_object"
+            )
+            response = call_llm(
+                **call_kwargs,
+                extra_body={"response_format": {"type": "json_object"}},
+            )
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))
     except Exception as e:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -92,6 +92,69 @@ class TestGenerateTitle:
 
 
 
+    def test_retries_with_json_object_on_http_400_status_code(self):
+        """A provider that 400s on strict json_schema (status_code attr set,
+        as the openai SDK does) gets one retry with the looser json_object
+        mode instead of losing the title outright."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                exc = RuntimeError("bad request")
+                exc.status_code = 400
+                raise exc
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix login button"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("fix the login button") == "Fix login button"
+
+        assert len(calls) == 2
+        assert calls[0]["extra_body"]["response_format"]["type"] == "json_schema"
+        assert calls[1]["extra_body"] == {"response_format": {"type": "json_object"}}
+
+    def test_retries_on_vllm_guided_grammar_rejection(self):
+        """vLLM backends that translate json_schema into an uncompilable
+        guided_grammar reject with a plain HTTP 400 whose message never
+        mentions "response_format" — only the status must gate the retry."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Error code: 400 - {'error': {'message': \"guided_grammar "
+                    "has compile_grammar_error: No module named 'xgrammar'\", "
+                    "'type': 'invalid_request_error', 'code': '400'}}"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Debug xgrammar error"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("why does xgrammar fail") == "Debug xgrammar error"
+
+        assert len(calls) == 2
+
+    def test_does_not_retry_on_unrelated_error(self):
+        """A non-400 failure (e.g. payment/rate-limit) must not retry — it
+        would just burn a second call for a request shape that was never
+        the problem."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError("openrouter 402: credits exhausted")
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question") is None
+
+        assert len(calls) == 1
+
     def test_invokes_failure_callback_on_exception(self):
         """failure_callback must fire so the user sees a warning (issue #15775)."""
         captured = []


### PR DESCRIPTION
## What does this PR do?

`generate_title()` hardcodes a strict `response_format: json_schema` on every
title-generation call, with no fallback. Providers that reject `json_schema`
get a 400 that lands in the generic `except` bucket as non-retryable — the
session keeps its truncated derived title forever, with no user-visible
error.

This adds a single retry: if the `json_schema` attempt fails with an HTTP
400, retry once with `response_format: json_object`, which these providers
accept and which the existing loose-JSON extraction (`_extract_title_text`)
already tolerates. Detection is via `status_code` (set by the openai SDK)
with a text fallback for the `"Error code: 400 - ..."` message shape, so it
also catches rejections that never mention `response_format` by name — e.g.
vLLM translating `json_schema` into an uncompilable `guided_grammar` and
400ing with a `compile_grammar_error: No module named 'xgrammar'` message.

## Related Issue

Fixes #82816

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/title_generator.py`: added `_response_format_rejected()`; `generate_title()` now retries the title call with `json_object` when the `json_schema` attempt 400s, instead of giving up.
- `tests/agent/test_title_generator.py`: added tests for the SDK-`status_code`-400 case, the vLLM `guided_grammar`/`xgrammar` message shape (no `status_code` attribute, no mention of `response_format`), and a regression guard that an unrelated failure (e.g. a 402) does not retry.

## How to Test

1. Configure `auxiliary.title_generation` to point at an OpenAI-compatible endpoint that rejects `response_format: json_schema` (any vLLM gateway without `xgrammar`, or DeepSeek/Kimi).
2. Before the fix: every session's title stays the truncated first-message text; `agent.log` logs `Title generation failed: Error code: 400 - ...` on every new session.
3. After the fix: the title call retries with `json_object` and the session gets an LLM-generated title.

Test output (in a local venv with the project's pinned core deps + pytest):

```
$ python -m pytest tests/agent/test_title_generator.py -q
....................................                                     [100%]
36 passed in 1.24s
```

Confirmed the two new tests fail without the fix (`git checkout HEAD~1 -- agent/title_generator.py` — the commit before this one — then rerun):

```
FAILED tests/agent/test_title_generator.py::TestGenerateTitle::test_retries_with_json_object_on_http_400_status_code - AssertionError: assert None == 'Fix login button'
FAILED tests/agent/test_title_generator.py::TestGenerateTitle::test_retries_on_vllm_guided_grammar_rejection - AssertionError: assert None == 'Debug xgrammar error'
2 failed, 1 passed, 33 deselected in 0.39s
```

Also ran the neighboring suite to check for regressions:

```
$ python -m pytest tests/agent/test_auxiliary_client.py -q
180 passed in 7.41s
```

`ruff check agent/title_generator.py tests/agent/test_title_generator.py` — all checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — #82372, #82751, #82073, and #82307 all touch the same `response_format` fallback problem, but each is scoped to a specific provider (DeepSeek/Kimi hardcoded list, or Anthropic's `extra_body` passthrough) or gates the retry on the error message containing the literal string `"response_format"`. None of those cover this issue's vLLM `guided_grammar`/`xgrammar` failure, whose error text never mentions `response_format`. This PR's `status_code`-based detection is provider-agnostic and covers that case.
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested via a scratch venv (pinned core deps + pytest 9.1.1) on Linux; no platform-specific code touched

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or architecture changed

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, Anthropic) under human supervision: the agent read the issue and the four related open PRs, identified the gap (none of them catch the vLLM `guided_grammar`/`xgrammar` 400, since its message never says `response_format`), wrote the minimal fix and tests, and verified the tests fail on the pre-fix code and pass after.
