### PR TITLE
fix(secrets): validate external CLI discovery and invocation (#77466)

### DIFF
--- a/agent/secret_sources/_binary_security.py
+++ b/agent/secret_sources/_binary_security.py
@@ -1,0 +1,308 @@
+"""Small, side-effect-free checks for external secret-source binaries.
+
+The secret-source modules invoke third-party CLIs with live credentials.  Keep
+path canonicalisation and the PATH trust policy in one place so a new source
+does not accidentally reintroduce relative-path or writable-directory lookup.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+_PROBE_ENV_KEYS = (
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "SystemRoot",
+    "WINDIR",
+    # Windows native launchers and the official CLIs consult these when
+    # locating the system shell, executable suffixes, and user/machine
+    # configuration roots.  They are non-secret and safe for a version-only
+    # probe; provider credentials are deliberately not included here.
+    "SystemDrive",
+    "PATHEXT",
+    "COMSPEC",
+    "ProgramData",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "XDG_CONFIG_HOME",
+    "XDG_RUNTIME_DIR",
+)
+
+# ``.bat`` and ``.cmd`` files are interpreted by ``cmd.exe`` rather than
+# being native executable images.  They are not safe for credential-bearing
+# subprocesses, even when they are executable according to Windows APIs.
+_WINDOWS_EXECUTABLE_SUFFIXES = frozenset({".com", ".exe"})
+
+# Version probes may need to launch a helper from PATH (for example, Linux's
+# ``ldd`` is commonly a shell script).  Never hand a probe the caller's PATH:
+# it can contain a writable directory even when the already-resolved binary is
+# trusted.  These are candidates only; _trusted_probe_path filters them using
+# the same root-owned, non-writable directory policy as PATH discovery.
+_POSIX_PROBE_PATH = (
+    "/usr/local/sbin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/usr/bin",
+    "/sbin",
+    "/bin",
+)
+
+
+def _get_effective_uid() -> Optional[int]:
+    """Return the POSIX effective UID when the platform exposes it."""
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:
+        return None
+    try:
+        return geteuid()
+    except AttributeError:
+        return None
+
+
+def resolve_executable(
+    path: Path | str,
+    *,
+    check_parent_dirs: bool = False,
+    reject_current_owner: bool = False,
+    check_explicit_parent_dirs: bool = False,
+) -> Optional[Path]:
+    """Return a canonical executable path, or ``None`` when it is unsafe.
+
+    Callers that resolve a user-specified ``binary_path`` set
+    ``check_explicit_parent_dirs``.  On POSIX that mode permits a private
+    chain owned by root or the current user, while rejecting another
+    unprivileged owner and group/world-writable parents.  PATH results set
+    ``check_parent_dirs`` and ``reject_current_owner``: on POSIX they require
+    a root-owned leaf and root-owned, non-group/world-writable parent chain.
+    Profile-local installations such as ``~/.local/bin/op`` therefore remain
+    available through an explicit absolute ``binary_path`` without weakening
+    the stricter PATH policy.
+    """
+    if check_parent_dirs and check_explicit_parent_dirs:
+        return None
+    try:
+        candidate = Path(path).expanduser()
+    except (TypeError, ValueError, RuntimeError):
+        return None
+    if not candidate.is_absolute():
+        return None
+
+    try:
+        resolved = candidate.resolve(strict=True)
+        info = resolved.stat()
+    except (OSError, RuntimeError):
+        return None
+    if not stat.S_ISREG(info.st_mode):
+        return None
+
+    if os.name == "nt":
+        # ``os.access(..., X_OK)`` is effectively an existence check on
+        # Windows.  Restrict executable candidates to native executable
+        # suffixes so a credential-bearing child cannot be redirected to an
+        # arbitrary data file or a cmd.exe-interpreted script.
+        if (
+            not os.access(resolved, os.X_OK)
+            or resolved.suffix.lower() not in _WINDOWS_EXECUTABLE_SUFFIXES
+        ):
+            return None
+    elif not info.st_mode & (
+        stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    ):
+        return None
+
+    effective_uid: Optional[int] = None
+    if os.name != "nt":
+        effective_uid = _get_effective_uid()
+        # Root-owned system binaries are a valid trust anchor when Hermes
+        # itself runs as root.  A non-root process must still reject a PATH
+        # binary owned by that process, since it can be planted or replaced
+        # by the current user.
+        if (
+            reject_current_owner
+            and effective_uid is not None
+            and effective_uid != 0
+            and info.st_uid == effective_uid
+        ):
+            return None
+
+        # A group/world-writable executable can be replaced by another user
+        # before the credential-bearing child is started.  This applies to
+        # both explicit absolute paths and PATH results; explicit paths are
+        # intentionally allowed to remain user-owned otherwise.
+        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return None
+
+    if check_parent_dirs and os.name == "nt":
+        # Windows does not expose a portable owner/mode API equivalent to the
+        # POSIX checks below.  PATH discovery is therefore limited to the
+        # machine-managed installation roots; profile-local installs remain
+        # supported through an explicit absolute ``binary_path``.
+        trusted_roots = []
+        for env_name in (
+            "ProgramFiles",
+            "ProgramFiles(x86)",
+            "ProgramW6432",
+            "SystemRoot",
+        ):
+            value = os.environ.get(env_name)
+            if value:
+                try:
+                    trusted_roots.append(Path(value).resolve())
+                except (OSError, RuntimeError):
+                    pass
+        if not any(
+            resolved == root or root in resolved.parents
+            for root in trusted_roots
+        ):
+            return None
+    elif check_parent_dirs and os.name != "nt":
+        # PATH is a shared trust boundary.  A non-root owner can replace a
+        # leaf even when its current mode is safe, and a writable directory
+        # owned by another user can be made writable/replaced by that owner.
+        # Keep PATH candidates to a root-owned chain; users with profile-local
+        # installs can opt in with an explicit absolute path above.
+        if info.st_uid != 0:
+            return None
+        # A safe executable can still be replaced through a writable parent
+        # directory.  Check every canonical directory up to the filesystem
+        # root.
+        for parent in (resolved.parent, *resolved.parent.parents):
+            try:
+                parent_info = parent.stat()
+            except OSError:
+                return None
+            if not stat.S_ISDIR(parent_info.st_mode):
+                return None
+            if parent_info.st_uid != 0:
+                return None
+            if parent_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+                return None
+    elif check_explicit_parent_dirs and os.name == "nt":
+        # Windows has no portable stdlib equivalent of POSIX ownership/mode
+        # checks.  Keep explicit paths inside the normal per-user or
+        # machine-managed roots; administrators can still use an absolute
+        # path in Program Files, while profile-local installs remain valid.
+        trusted_roots = []
+        try:
+            trusted_roots.append(Path.home().resolve())
+        except (OSError, RuntimeError):
+            pass
+        for env_name in (
+            "USERPROFILE",
+            "LOCALAPPDATA",
+            "ProgramFiles",
+            "ProgramFiles(x86)",
+            "ProgramW6432",
+            "SystemRoot",
+        ):
+            value = os.environ.get(env_name)
+            if value:
+                try:
+                    trusted_roots.append(Path(value).resolve())
+                except (OSError, RuntimeError):
+                    pass
+        if not any(
+            resolved == root or root in resolved.parents
+            for root in trusted_roots
+        ):
+            return None
+    elif check_explicit_parent_dirs and os.name != "nt":
+        # An explicit profile path is allowed to be owned by the invoking
+        # user, but every canonical parent must still be private.  Checking
+        # the resolved chain prevents a symlinked ancestor from bypassing the
+        # policy before the credential-bearing child starts.
+        effective_uid = _get_effective_uid()
+        if effective_uid is None:
+            return None
+        trusted_owners = {0, effective_uid}
+        if info.st_uid not in trusted_owners:
+            return None
+        for parent in (resolved.parent, *resolved.parent.parents):
+            try:
+                parent_info = parent.stat()
+            except OSError:
+                return None
+            if not stat.S_ISDIR(parent_info.st_mode):
+                return None
+            if parent_info.st_uid not in trusted_owners:
+                return None
+            if parent_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+                return None
+
+    return resolved
+
+
+def _trusted_probe_path(path: Path) -> str:
+    """Return a credential-free PATH containing only trusted directories."""
+    candidates = [path.parent, *(Path(item) for item in _POSIX_PROBE_PATH)]
+    trusted = []
+    seen = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+        if os.name != "nt" and not _is_root_owned_private_chain(resolved):
+            continue
+        value = str(resolved)
+        if value not in seen:
+            trusted.append(value)
+            seen.add(value)
+    return os.pathsep.join(trusted)
+
+
+def _is_root_owned_private_chain(path: Path) -> bool:
+    """Whether a canonical directory and every ancestor are trusted on POSIX."""
+    for directory in (path, *path.parents):
+        try:
+            info = directory.stat()
+        except OSError:
+            return False
+        if not stat.S_ISDIR(info.st_mode):
+            return False
+        if info.st_uid != 0 or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return False
+    return True
+
+
+def probe_environment(path: Path) -> dict[str, str]:
+    """Build the minimal environment used by a version-only probe."""
+    env = {}
+    for key in _PROBE_ENV_KEYS:
+        if key == "PATH":
+            env[key] = _trusted_probe_path(path)
+        elif (value := os.environ.get(key)) is not None:
+            env[key] = value
+    return env
+
+
+def probe_version(path: Path, pattern: str, *, timeout: float = 5) -> bool:
+    """Run a version-only probe without passing provider credentials."""
+    env = probe_environment(path)
+    try:
+        proc = subprocess.run(
+            [str(path), "--version"],
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    output = f"{proc.stdout or ''}\n{proc.stderr or ''}"
+    return re.search(pattern, output) is not None

--- a/agent/secret_sources/_binary_security.py
+++ b/agent/secret_sources/_binary_security.py
@@ -1,0 +1,300 @@
+"""Small, side-effect-free checks for external secret-source binaries.
+
+The secret-source modules invoke third-party CLIs with live credentials.  Keep
+path canonicalisation and the PATH trust policy in one place so a new source
+does not accidentally reintroduce relative-path or writable-directory lookup.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+_PROBE_ENV_KEYS = (
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "SystemRoot",
+    "WINDIR",
+    # Windows native launchers and the official CLIs consult these when
+    # locating the system shell, executable suffixes, and user/machine
+    # configuration roots.  They are non-secret and safe for a version-only
+    # probe; provider credentials are deliberately not included here.
+    "SystemDrive",
+    "PATHEXT",
+    "COMSPEC",
+    "ProgramData",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "XDG_CONFIG_HOME",
+    "XDG_RUNTIME_DIR",
+)
+
+# ``.bat`` and ``.cmd`` files are interpreted by ``cmd.exe`` rather than
+# being native executable images.  They are not safe for credential-bearing
+# subprocesses, even when they are executable according to Windows APIs.
+_WINDOWS_EXECUTABLE_SUFFIXES = frozenset({".com", ".exe"})
+
+# Version probes may need to launch a helper from PATH (for example, Linux's
+# ``ldd`` is commonly a shell script).  Never hand a probe the caller's PATH:
+# it can contain a writable directory even when the already-resolved binary is
+# trusted.  These are candidates only; _trusted_probe_path filters them using
+# the same root-owned, non-writable directory policy as PATH discovery.
+_POSIX_PROBE_PATH = (
+    "/usr/local/sbin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/usr/bin",
+    "/sbin",
+    "/bin",
+)
+
+
+def resolve_executable(
+    path: Path | str,
+    *,
+    check_parent_dirs: bool = False,
+    reject_current_owner: bool = False,
+    check_explicit_parent_dirs: bool = False,
+) -> Optional[Path]:
+    """Return a canonical executable path, or ``None`` when it is unsafe.
+
+    Callers that resolve a user-specified ``binary_path`` set
+    ``check_explicit_parent_dirs``.  On POSIX that mode permits a private
+    chain owned by root or the current user, while rejecting another
+    unprivileged owner and group/world-writable parents.  PATH results set
+    ``check_parent_dirs`` and ``reject_current_owner``: on POSIX they require
+    a root-owned leaf and root-owned, non-group/world-writable parent chain.
+    Profile-local installations such as ``~/.local/bin/op`` therefore remain
+    available through an explicit absolute ``binary_path`` without weakening
+    the stricter PATH policy.
+    """
+    if check_parent_dirs and check_explicit_parent_dirs:
+        return None
+    try:
+        candidate = Path(path).expanduser()
+    except (TypeError, ValueError, RuntimeError):
+        return None
+    if not candidate.is_absolute():
+        return None
+
+    try:
+        resolved = candidate.resolve(strict=True)
+        info = resolved.stat()
+    except (OSError, RuntimeError):
+        return None
+    if not stat.S_ISREG(info.st_mode):
+        return None
+
+    if os.name == "nt":
+        # ``os.access(..., X_OK)`` is effectively an existence check on
+        # Windows.  Restrict executable candidates to native executable
+        # suffixes so a credential-bearing child cannot be redirected to an
+        # arbitrary data file or a cmd.exe-interpreted script.
+        if (
+            not os.access(resolved, os.X_OK)
+            or resolved.suffix.lower() not in _WINDOWS_EXECUTABLE_SUFFIXES
+        ):
+            return None
+    elif not info.st_mode & (
+        stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    ):
+        return None
+
+    effective_uid: Optional[int] = None
+    if os.name != "nt":
+        try:
+            effective_uid = os.geteuid()
+            # Root-owned system binaries are a valid trust anchor when Hermes
+            # itself runs as root.  A non-root process must still reject a
+            # PATH binary owned by that process, since it can be planted or
+            # replaced by the current user.
+            if (
+                reject_current_owner
+                and effective_uid != 0
+                and info.st_uid == effective_uid
+            ):
+                return None
+        except AttributeError:  # pragma: no cover - Windows has no geteuid
+            pass
+
+        # A group/world-writable executable can be replaced by another user
+        # before the credential-bearing child is started.  This applies to
+        # both explicit absolute paths and PATH results; explicit paths are
+        # intentionally allowed to remain user-owned otherwise.
+        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return None
+
+    if check_parent_dirs and os.name == "nt":
+        # Windows does not expose a portable owner/mode API equivalent to the
+        # POSIX checks below.  PATH discovery is therefore limited to the
+        # machine-managed installation roots; profile-local installs remain
+        # supported through an explicit absolute ``binary_path``.
+        trusted_roots = []
+        for env_name in (
+            "ProgramFiles",
+            "ProgramFiles(x86)",
+            "ProgramW6432",
+            "SystemRoot",
+        ):
+            value = os.environ.get(env_name)
+            if value:
+                try:
+                    trusted_roots.append(Path(value).resolve())
+                except (OSError, RuntimeError):
+                    pass
+        if not any(
+            resolved == root or root in resolved.parents
+            for root in trusted_roots
+        ):
+            return None
+    elif check_parent_dirs and os.name != "nt":
+        # PATH is a shared trust boundary.  A non-root owner can replace a
+        # leaf even when its current mode is safe, and a writable directory
+        # owned by another user can be made writable/replaced by that owner.
+        # Keep PATH candidates to a root-owned chain; users with profile-local
+        # installs can opt in with an explicit absolute path above.
+        if info.st_uid != 0:
+            return None
+        # A safe executable can still be replaced through a writable parent
+        # directory.  Check every canonical directory up to the filesystem
+        # root.
+        for parent in (resolved.parent, *resolved.parent.parents):
+            try:
+                parent_info = parent.stat()
+            except OSError:
+                return None
+            if not stat.S_ISDIR(parent_info.st_mode):
+                return None
+            if parent_info.st_uid != 0:
+                return None
+            if parent_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+                return None
+    elif check_explicit_parent_dirs and os.name == "nt":
+        # Windows has no portable stdlib equivalent of POSIX ownership/mode
+        # checks.  Keep explicit paths inside the normal per-user or
+        # machine-managed roots; administrators can still use an absolute
+        # path in Program Files, while profile-local installs remain valid.
+        trusted_roots = []
+        try:
+            trusted_roots.append(Path.home().resolve())
+        except (OSError, RuntimeError):
+            pass
+        for env_name in (
+            "USERPROFILE",
+            "LOCALAPPDATA",
+            "ProgramFiles",
+            "ProgramFiles(x86)",
+            "ProgramW6432",
+            "SystemRoot",
+        ):
+            value = os.environ.get(env_name)
+            if value:
+                try:
+                    trusted_roots.append(Path(value).resolve())
+                except (OSError, RuntimeError):
+                    pass
+        if not any(
+            resolved == root or root in resolved.parents
+            for root in trusted_roots
+        ):
+            return None
+    elif check_explicit_parent_dirs and os.name != "nt":
+        # An explicit profile path is allowed to be owned by the invoking
+        # user, but every canonical parent must still be private.  Checking
+        # the resolved chain prevents a symlinked ancestor from bypassing the
+        # policy before the credential-bearing child starts.
+        try:
+            effective_uid = os.geteuid()
+        except AttributeError:  # pragma: no cover - Windows has no geteuid
+            return None
+        trusted_owners = {0, effective_uid}
+        if info.st_uid not in trusted_owners:
+            return None
+        for parent in (resolved.parent, *resolved.parent.parents):
+            try:
+                parent_info = parent.stat()
+            except OSError:
+                return None
+            if not stat.S_ISDIR(parent_info.st_mode):
+                return None
+            if parent_info.st_uid not in trusted_owners:
+                return None
+            if parent_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+                return None
+
+    return resolved
+
+
+def _trusted_probe_path(path: Path) -> str:
+    """Return a credential-free PATH containing only trusted directories."""
+    candidates = [path.parent, *(Path(item) for item in _POSIX_PROBE_PATH)]
+    trusted = []
+    seen = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+        if os.name != "nt" and not _is_root_owned_private_chain(resolved):
+            continue
+        value = str(resolved)
+        if value not in seen:
+            trusted.append(value)
+            seen.add(value)
+    return os.pathsep.join(trusted)
+
+
+def _is_root_owned_private_chain(path: Path) -> bool:
+    """Whether a canonical directory and every ancestor are trusted on POSIX."""
+    for directory in (path, *path.parents):
+        try:
+            info = directory.stat()
+        except OSError:
+            return False
+        if not stat.S_ISDIR(info.st_mode):
+            return False
+        if info.st_uid != 0 or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return False
+    return True
+
+
+def probe_environment(path: Path) -> dict[str, str]:
+    """Build the minimal environment used by a version-only probe."""
+    env = {}
+    for key in _PROBE_ENV_KEYS:
+        if key == "PATH":
+            env[key] = _trusted_probe_path(path)
+        elif (value := os.environ.get(key)) is not None:
+            env[key] = value
+    return env
+
+
+def probe_version(path: Path, pattern: str, *, timeout: float = 5) -> bool:
+    """Run a version-only probe without passing provider credentials."""
+    env = probe_environment(path)
+    try:
+        proc = subprocess.run(
+            [str(path), "--version"],
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    output = f"{proc.stdout or ''}\n{proc.stderr or ''}"
+    return re.search(pattern, output) is not None

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -57,6 +57,11 @@ from agent.secret_sources._cache import (
     FetchResult,
     is_valid_env_name as _is_valid_env_name,
 )
+from agent.secret_sources._binary_security import (
+    probe_environment as _probe_environment,
+    probe_version as _probe_binary_version,
+    resolve_executable as _resolve_executable,
+)
 from agent.secret_sources.base import ErrorKind, SecretSource
 from agent.secret_sources.base import get_source_environment
 
@@ -80,6 +85,16 @@ _BWS_CHECKSUM_NAME = f"bws-sha256-checksums-{_BWS_VERSION}.txt"
 # How long to wait for bws subprocesses and HTTP downloads, in seconds.
 _BWS_DOWNLOAD_TIMEOUT = 60
 _BWS_RUN_TIMEOUT = 30
+
+# A PATH-provided bws is accepted only from a root-owned POSIX trust chain and
+# identifies the version Hermes expects.  Managed copies use a checksum
+# sidecar instead (see ``_verify_managed_bws``).
+_BWS_VERSION_PATTERN = rf"(?<![0-9.]){re.escape(_BWS_VERSION)}(?![0-9.])"
+_LDD_MUSL_PATTERN = r"(?i:musl)"
+_BWS_CHECKSUM_SUFFIX = ".sha256"
+_BWS_BIN_MODE = stat.S_IRWXU
+_BWS_BIN_DIR_MODE = stat.S_IRWXU
+_BWS_CHECKSUM_MODE = stat.S_IRUSR | stat.S_IWUSR
 
 # In-process cache so repeated load_hermes_dotenv() calls (CLI startup,
 # gateway hot-reload, test suites) don't re-fetch from BSM.
@@ -142,6 +157,122 @@ def _hermes_bin_dir() -> Path:
     return get_hermes_home() / "bin"
 
 
+def _managed_bws_checksum_path(path: Path) -> Path:
+    return path.with_name(f".{path.name}{_BWS_CHECKSUM_SUFFIX}")
+
+
+def _verify_managed_bws(path: Path) -> bool:
+    """Verify the canonical managed binary and its install-time digest.
+
+    This intentionally recomputes the digest for every call.  The discovery
+    and use-time gates must observe the actual bytes; caching by stat metadata
+    could accept a same-size, same-mtime replacement and weaken that gate.
+    """
+    if path.is_symlink():
+        return False
+    try:
+        resolved = _resolve_executable(path)
+        canonical_path = path.parent.resolve(strict=True) / path.name
+        if resolved is None or resolved != canonical_path:
+            return False
+        if os.name != "nt":
+            trusted_owners = {0, os.geteuid()}
+            binary_info = path.stat()
+            directory_info = path.parent.stat()
+            # The sidecar digest is only meaningful when an untrusted user
+            # cannot replace either the binary or its containing directory.
+            # Exact private modes alone are insufficient when Hermes runs as
+            # root against another user's HERMES_HOME: that user still owns
+            # and can rewrite both files.  Windows has no portable POSIX
+            # owner/mode equivalent; its canonical-path, native-executable,
+            # and checksum gates above remain the platform policy there.
+            if (
+                binary_info.st_uid not in trusted_owners
+                or directory_info.st_uid not in trusted_owners
+            ):
+                return False
+            if stat.S_IMODE(binary_info.st_mode) != _BWS_BIN_MODE:
+                return False
+            if stat.S_IMODE(directory_info.st_mode) != _BWS_BIN_DIR_MODE:
+                return False
+        checksum_path = _managed_bws_checksum_path(path)
+        if checksum_path.is_symlink():
+            return False
+        if (
+            os.name != "nt"
+            and stat.S_IMODE(checksum_path.stat().st_mode) != _BWS_CHECKSUM_MODE
+        ):
+            return False
+        expected = checksum_path.read_text(
+            encoding="ascii"
+        ).strip()
+        if not re.fullmatch(r"[0-9a-fA-F]{64}", expected):
+            return False
+        return _sha256_file(path).lower() == expected.lower()
+    except (OSError, UnicodeError):
+        return False
+
+
+def _write_managed_bws_checksum(path: Path) -> None:
+    """Atomically persist the verified digest beside a managed binary."""
+    checksum_path = _managed_bws_checksum_path(path)
+    fd, staged = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=_BWS_CHECKSUM_SUFFIX
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="ascii") as stream:
+            stream.write(f"{_sha256_file(path)}\n")
+        os.chmod(staged, _BWS_CHECKSUM_MODE)
+        os.replace(staged, checksum_path)
+    except Exception:
+        try:
+            os.unlink(staged)
+        except OSError:
+            pass
+        raise
+
+
+def _is_managed_bws(path: Path) -> bool:
+    """Whether ``path`` is the exact profile-managed bws location."""
+    try:
+        managed = _hermes_bin_dir() / _platform_binary_name()
+        # ``find_bws`` canonicalizes PATH results before returning them, while
+        # HERMES_HOME may itself contain a symlinked ancestor.  Compare the
+        # canonical locations so the use-time checksum gate cannot be skipped
+        # merely because the same managed file has two spellings.  A leaf
+        # symlink is intentionally not rejected here; _verify_managed_bws()
+        # performs the explicit leaf-symlink rejection after classification.
+        return path.resolve(strict=False) == managed.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+
+
+def verify_bws_for_use(path: Path) -> Optional[Path]:
+    """Return a BWS path that is safe for one immediate subprocess use.
+
+    Managed profile copies are checked against their install-time digest.
+    Other paths are treated as PATH candidates and must pass the same
+    canonical root-owned, non-writable, pinned-version policy as discovery.
+    Returning the canonical PATH result prevents callers from falling back to
+    an unvalidated spelling after this gate succeeds.
+    """
+    try:
+        candidate = Path(path)
+        if _is_managed_bws(candidate):
+            return candidate if _verify_managed_bws(candidate) else None
+
+        resolved = _resolve_executable(
+            candidate, check_parent_dirs=True, reject_current_owner=True
+        )
+        if resolved is None or not _probe_binary_version(
+            resolved, _BWS_VERSION_PATTERN
+        ):
+            return None
+        return resolved
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
 def find_bws(*, install_if_missing: bool = False) -> Optional[Path]:
     """Return a path to a usable ``bws`` binary, or None.
 
@@ -153,12 +284,24 @@ def find_bws(*, install_if_missing: bool = False) -> Optional[Path]:
     :func:`install_bws` to download and verify the pinned version.
     """
     managed = _hermes_bin_dir() / _platform_binary_name()
-    if managed.exists() and os.access(managed, os.X_OK):
+    if _verify_managed_bws(managed):
         return managed
+    if managed.exists() or managed.is_symlink():
+        logger.warning("managed bws binary failed integrity verification")
 
     system = shutil.which("bws")
     if system:
-        return Path(system)
+        resolved = _resolve_executable(
+            system, check_parent_dirs=True, reject_current_owner=True
+        )
+        if resolved is not None and _probe_binary_version(
+            resolved, _BWS_VERSION_PATTERN
+        ):
+            return resolved
+        logger.warning(
+            "refusing untrusted bws PATH binary (expected version %s)",
+            _BWS_VERSION,
+        )
 
     if install_if_missing:
         try:
@@ -197,18 +340,19 @@ def _platform_asset_name() -> str:
         # ldd --version writes to stderr on glibc, stdout on musl.  We
         # don't need bullet-proof detection — getting it wrong falls
         # back to a clear error from the binary loader, which we catch.
-        try:
-            res = subprocess.run(
-                ["ldd", "--version"],
-                capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
-                timeout=2,
-                stdin=subprocess.DEVNULL,
+        # ldd is itself an executable lookup boundary: on many Linux
+        # distributions it is a shell script that can run further helpers.
+        # Resolve it through the root-owned PATH policy, then probe it with the
+        # credential-free environment built by _binary_security.probe_version.
+        ldd = shutil.which("ldd")
+        if ldd:
+            trusted_ldd = _resolve_executable(
+                ldd, check_parent_dirs=True, reject_current_owner=True
             )
-            if "musl" in (res.stdout + res.stderr).lower():
+            if trusted_ldd is not None and _probe_binary_version(
+                trusted_ldd, _LDD_MUSL_PATTERN, timeout=2
+            ):
                 libc = "musl"
-        except (OSError, subprocess.TimeoutExpired):
-            pass
         return f"bws-{arch}-unknown-linux-{libc}-{_BWS_VERSION}.zip"
 
     raise RuntimeError(
@@ -226,10 +370,13 @@ def install_bws(*, force: bool = False) -> Path:
     """
     bin_dir = _hermes_bin_dir()
     bin_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(bin_dir, _BWS_BIN_DIR_MODE)
     target = bin_dir / _platform_binary_name()
 
     if target.exists() and not force:
-        return target
+        if _verify_managed_bws(target):
+            return target
+        logger.warning("managed bws binary is stale or tampered; reinstalling")
 
     asset_name = _platform_asset_name()
     asset_url = f"{_BWS_RELEASE_BASE}/{asset_name}"
@@ -253,6 +400,10 @@ def install_bws(*, force: bool = False) -> Path:
             )
 
         with zipfile.ZipFile(zip_path) as zf:
+            if any(_zip_info_is_symlink(info) for info in zf.infolist()):
+                raise RuntimeError(
+                    "Refusing bws archive containing symbolic-link members"
+                )
             member = _pick_zip_member(zf, _platform_binary_name())
             # Zip-slip guard: a malicious archive can carry member names like
             # ``../../etc/cron.d/x`` or absolute paths.  ``ZipFile.extract``
@@ -267,11 +418,10 @@ def install_bws(*, force: bool = False) -> Path:
         shutil.copy2(extracted, staged)
         os.chmod(
             staged,
-            stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
-            | stat.S_IRGRP | stat.S_IXGRP
-            | stat.S_IROTH | stat.S_IXOTH,
+            _BWS_BIN_MODE,
         )
         os.replace(staged, target)
+        _write_managed_bws_checksum(target)
 
     logger.info("Installed bws %s at %s", _BWS_VERSION, target)
     return target
@@ -338,6 +488,15 @@ def _safe_extract_member(
     ``dest_dir`` (a "zip-slip").  We resolve the would-be target and
     confirm it stays within ``dest_dir`` before extracting.
     """
+    try:
+        info = zf.getinfo(member)
+    except KeyError as exc:
+        raise RuntimeError(f"Archive member {member!r} is missing") from exc
+    if _zip_info_is_symlink(info):
+        raise RuntimeError(
+            f"Refusing to extract symbolic-link archive member {member!r}"
+        )
+
     dest_root = os.path.realpath(dest_dir)
     target = os.path.realpath(os.path.join(dest_root, member))
     # ``commonpath`` raises ValueError for e.g. different drives on
@@ -353,6 +512,12 @@ def _safe_extract_member(
         )
     zf.extract(member, dest_root)
     return Path(target)
+
+
+def _zip_info_is_symlink(info: zipfile.ZipInfo) -> bool:
+    """Return whether a ZIP member advertises a Unix symbolic-link type."""
+    mode = (info.external_attr >> 16) & 0o170000
+    return stat.S_ISLNK(mode)
 
 
 # ---------------------------------------------------------------------------
@@ -667,7 +832,10 @@ def _summarize_bws_stderr(raw: str) -> str:
 def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
 ) -> Tuple[Dict[str, str], List[str]]:
-    cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
+    verified = verify_bws_for_use(bws)
+    if verified is None:
+        raise RuntimeError("bws binary failed use-time verification")
+    cmd = [str(verified), "secret", "list", project_id, "--output", "json"]
     # bws child intentionally receives the access token.  Under a profile-local
     # fetch it must not inherit sibling credentials from process-global env.
     source_env = get_source_environment()

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -19,6 +19,7 @@ import os
 import platform
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 import time
@@ -31,6 +32,12 @@ from typing import Dict, List, Optional, Tuple
 from agent.secret_sources._cache import (
     CachedFetch as _CachedFetch, SecretCache, atomic_write_json, entry_from_payload,
     fingerprint as _token_fingerprint, resolve_cache_home,
+)
+from agent.secret_sources._binary_security import (
+    _get_effective_uid,
+    probe_environment as _probe_environment,
+    probe_version as _probe_binary_version,
+    resolve_executable as _resolve_executable,
 )
 from agent.secret_sources.base import (
     ErrorKind, FetchResult, SecretSource, classify_cli_error, coerce_float,
@@ -46,6 +53,16 @@ _BWS_RELEASE_BASE = f"https://github.com/bitwarden/sdk-sm/releases/download/bws-
 _BWS_CHECKSUM_NAME = f"bws-sha256-checksums-{_BWS_VERSION}.txt"
 _BWS_DOWNLOAD_TIMEOUT = 60
 _BWS_RUN_TIMEOUT = 30
+
+# A PATH-provided bws is accepted only from a root-owned POSIX trust chain and
+# identifies the version Hermes expects.  Managed copies use a checksum
+# sidecar instead (see ``_verify_managed_bws``).
+_BWS_VERSION_PATTERN = rf"(?<![0-9.]){re.escape(_BWS_VERSION)}(?![0-9.])"
+_LDD_MUSL_PATTERN = r"(?i:musl)"
+_BWS_CHECKSUM_SUFFIX = ".sha256"
+_BWS_BIN_MODE = stat.S_IRWXU
+_BWS_BIN_DIR_MODE = stat.S_IRWXU
+_BWS_CHECKSUM_MODE = stat.S_IRUSR | stat.S_IWUSR
 
 # <hermes_home>/cache/bws_cache.json holds only secret VALUES (never the access
 # token); kept out of .env so users editing .env don't commit BSM-sourced secrets.
@@ -97,19 +114,164 @@ def _hermes_bin_dir() -> Path:
     return get_hermes_home() / "bin"
 
 
+def _managed_bws_checksum_path(path: Path) -> Path:
+    return path.with_name(f".{path.name}{_BWS_CHECKSUM_SUFFIX}")
+
+
+def _verify_managed_bws(path: Path) -> bool:
+    """Verify the canonical managed binary and its install-time digest.
+
+    This intentionally recomputes the digest for every call.  The discovery
+    and use-time gates must observe the actual bytes; caching by stat metadata
+    could accept a same-size, same-mtime replacement and weaken that gate.
+    """
+    if path.is_symlink():
+        return False
+    try:
+        resolved = _resolve_executable(path, check_explicit_parent_dirs=os.name != "nt")
+        canonical_path = path.parent.resolve(strict=True) / path.name
+        if resolved is None or resolved != canonical_path:
+            return False
+        if os.name != "nt":
+            effective_uid = _get_effective_uid()
+            if effective_uid is None:
+                return False
+            trusted_owners = {0, effective_uid}
+            binary_info = path.stat()
+            directory_info = path.parent.stat()
+            # The sidecar digest is only meaningful when an untrusted user
+            # cannot replace either the binary or its containing directory.
+            # Exact private modes alone are insufficient when Hermes runs as
+            # root against another user's HERMES_HOME: that user still owns
+            # and can rewrite both files.  Windows has no portable POSIX
+            # owner/mode equivalent; its canonical-path, native-executable,
+            # and checksum gates above remain the platform policy there.
+            if (
+                binary_info.st_uid not in trusted_owners
+                or directory_info.st_uid not in trusted_owners
+            ):
+                return False
+            if stat.S_IMODE(binary_info.st_mode) != _BWS_BIN_MODE:
+                return False
+            if stat.S_IMODE(directory_info.st_mode) != _BWS_BIN_DIR_MODE:
+                return False
+        checksum_path = _managed_bws_checksum_path(path)
+        if checksum_path.is_symlink():
+            return False
+        if (
+            os.name != "nt"
+            and stat.S_IMODE(checksum_path.stat().st_mode) != _BWS_CHECKSUM_MODE
+        ):
+            return False
+        expected = checksum_path.read_text(
+            encoding="ascii"
+        ).strip()
+        if not re.fullmatch(r"[0-9a-fA-F]{64}", expected):
+            return False
+        return _sha256_file(path).lower() == expected.lower()
+    except (OSError, UnicodeError):
+        return False
+
+
+def _write_managed_bws_checksum(path: Path) -> None:
+    """Atomically persist the verified digest beside a managed binary."""
+    checksum_path = _managed_bws_checksum_path(path)
+    fd, staged = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=_BWS_CHECKSUM_SUFFIX
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="ascii") as stream:
+            stream.write(f"{_sha256_file(path)}\n")
+        os.chmod(staged, _BWS_CHECKSUM_MODE)
+        os.replace(staged, checksum_path)
+    except Exception:
+        try:
+            os.unlink(staged)
+        except OSError:
+            pass
+        raise
+
+
+def _is_managed_bws(path: Path) -> bool:
+    """Whether ``path`` is the exact profile-managed bws location."""
+    try:
+        managed = _hermes_bin_dir() / _platform_binary_name()
+        # ``find_bws`` canonicalizes PATH results before returning them, while
+        # HERMES_HOME may itself contain a symlinked ancestor.  Compare the
+        # canonical locations so the use-time checksum gate cannot be skipped
+        # merely because the same managed file has two spellings.  A leaf
+        # symlink is intentionally not rejected here; _verify_managed_bws()
+        # performs the explicit leaf-symlink rejection after classification.
+        return path.resolve(strict=False) == managed.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+
+
+def verify_bws_for_use(path: Path) -> Optional[Path]:
+    """Return a BWS path that is safe for one immediate subprocess use.
+
+    Managed profile copies are checked against their install-time digest.
+    Other paths are treated as PATH candidates and must pass the same
+    canonical root-owned, non-writable, pinned-version policy as discovery.
+    Returning the canonical PATH result prevents callers from falling back to
+    an unvalidated spelling after this gate succeeds.
+    """
+    try:
+        candidate = Path(path)
+        if _is_managed_bws(candidate):
+            if candidate.is_symlink():
+                return None
+            canonical = candidate.resolve(strict=True)
+            return canonical if _verify_managed_bws(canonical) else None
+
+        resolved = _resolve_executable(
+            candidate, check_parent_dirs=True, reject_current_owner=True
+        )
+        if resolved is None or not _probe_binary_version(
+            resolved, _BWS_VERSION_PATTERN
+        ):
+            return None
+        return resolved
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
 def find_bws(*, install_if_missing: bool = False) -> Optional[Path]:
-    """Managed ``<hermes_home>/bin/bws`` first, then PATH, then optional auto-install."""
+    """Return a path to a usable ``bws`` binary, or None.
+
+    Resolution order:
+      1. ``<hermes_home>/bin/bws``  (our managed copy — preferred)
+      2. ``shutil.which("bws")``    (system PATH)
+
+    When ``install_if_missing`` is True and neither resolves, this calls
+    :func:`install_bws` to download and verify the pinned version.
+    """
     managed = _hermes_bin_dir() / _platform_binary_name()
-    if managed.exists() and os.access(managed, os.X_OK):
+    if _verify_managed_bws(managed):
         return managed
+    if managed.exists() or managed.is_symlink():
+        logger.warning("managed bws binary failed integrity verification")
+
     system = shutil.which("bws")
     if system:
-        return Path(system)
+        resolved = _resolve_executable(
+            system, check_parent_dirs=True, reject_current_owner=True
+        )
+        if resolved is not None and _probe_binary_version(
+            resolved, _BWS_VERSION_PATTERN
+        ):
+            return resolved
+        logger.warning(
+            "refusing untrusted bws PATH binary (expected version %s)",
+            _BWS_VERSION,
+        )
+
     if install_if_missing:
         try:
             return install_bws()
         except Exception as exc:  # noqa: BLE001 — never block startup
             logger.warning("bws auto-install failed: %s", exc)
+            return None
     return None
 
 
@@ -130,13 +292,15 @@ def _platform_asset_name() -> str:
     if system == "Linux":
         # glibc default; musl only if ldd says so (a wrong guess surfaces as a loader error).
         libc = "gnu"
-        try:
-            res = subprocess.run(["ldd", "--version"], capture_output=True, text=True, encoding='utf-8',
-                                 errors='replace', timeout=2, stdin=subprocess.DEVNULL)
-            if "musl" in (res.stdout + res.stderr).lower():
+        ldd = shutil.which("ldd")
+        if ldd:
+            trusted_ldd = _resolve_executable(
+                ldd, check_parent_dirs=True, reject_current_owner=True
+            )
+            if trusted_ldd is not None and _probe_binary_version(
+                trusted_ldd, _LDD_MUSL_PATTERN, timeout=2
+            ):
                 libc = "musl"
-        except (OSError, subprocess.TimeoutExpired):
-            pass
         return f"bws-{arch}-unknown-linux-{libc}-{_BWS_VERSION}.zip"
 
     raise RuntimeError(f"Unsupported platform for bws auto-install: {system} {machine}")
@@ -147,9 +311,12 @@ def install_bws(*, force: bool = False) -> Path:
     (the auto-install path catches; the setup wizard shows the error)."""
     bin_dir = _hermes_bin_dir()
     bin_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(bin_dir, _BWS_BIN_DIR_MODE)
     target = bin_dir / _platform_binary_name()
     if target.exists() and not force:
-        return target
+        if _verify_managed_bws(target):
+            return target
+        logger.warning("managed bws binary is stale or tampered; reinstalling")
 
     asset_name = _platform_asset_name()
     with tempfile.TemporaryDirectory(prefix="hermes-bws-") as tmpdir:
@@ -167,6 +334,8 @@ def install_bws(*, force: bool = False) -> Path:
             raise RuntimeError(f"Checksum mismatch for {asset_name}: expected {expected}, got {actual}")
 
         with zipfile.ZipFile(zip_path) as zf:
+            if any(_zip_info_is_symlink(info) for info in zf.infolist()):
+                raise RuntimeError("Refusing bws archive containing symbolic-link members")
             member = _pick_zip_member(zf, _platform_binary_name())
             extracted = _safe_extract_member(zf, member, tmp)
 
@@ -174,8 +343,9 @@ def install_bws(*, force: bool = False) -> Path:
         fd, staged = tempfile.mkstemp(dir=str(bin_dir), prefix=".bws_")
         os.close(fd)
         shutil.copy2(extracted, staged)
-        os.chmod(staged, 0o755)
+        os.chmod(staged, _BWS_BIN_MODE)
         os.replace(staged, target)
+        _write_managed_bws_checksum(target)
 
     logger.info("Installed bws %s at %s", _BWS_VERSION, target)
     return target
@@ -219,6 +389,15 @@ def _pick_zip_member(zf: zipfile.ZipFile, binary_name: str) -> str:
 def _safe_extract_member(zf: zipfile.ZipFile, member: str, dest_dir: Path) -> Path:
     """Extract one member, refusing zip-slip: ``ZipFile.extract`` never verifies the
     joined path stays inside ``dest_dir``, so containment is checked here first."""
+    try:
+        info = zf.getinfo(member)
+    except KeyError as exc:
+        raise RuntimeError(f"Archive member {member!r} is missing") from exc
+    if _zip_info_is_symlink(info):
+        raise RuntimeError(
+            f"Refusing to extract symbolic-link archive member {member!r}"
+        )
+
     dest_root = os.path.realpath(dest_dir)
     target = os.path.realpath(os.path.join(dest_root, member))
     try:  # commonpath raises for e.g. different Windows drives — treat as escape
@@ -230,6 +409,12 @@ def _safe_extract_member(zf: zipfile.ZipFile, member: str, dest_dir: Path) -> Pa
                            f"it escapes the extraction directory")
     zf.extract(member, dest_root)
     return Path(target)
+
+
+def _zip_info_is_symlink(info: zipfile.ZipInfo) -> bool:
+    """Return whether a ZIP member advertises a Unix symbolic-link type."""
+    mode = (info.external_attr >> 16) & 0o170000
+    return stat.S_ISLNK(mode)
 
 
 # --- Encrypted last-good cache (opt-in) -------------------------------------
@@ -398,7 +583,10 @@ def _summarize_bws_stderr(raw: str) -> str:
 
 
 def _run_bws_list(bws: Path, access_token: str, project_id: str, server_url: str = "") -> Tuple[Dict[str, str], List[str]]:
-    cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
+    verified = verify_bws_for_use(bws)
+    if verified is None:
+        raise RuntimeError("bws binary failed use-time verification")
+    cmd = [str(verified), "secret", "list", project_id, "--output", "json"]
     # The bws child intentionally receives the access token; a profile-local
     # fetch must not inherit sibling credentials (source_child_env).
     env = source_child_env()

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -54,6 +54,10 @@ from agent.secret_sources._cache import (
     FetchResult,
     is_valid_env_name,
 )
+from agent.secret_sources._binary_security import (
+    probe_version as _probe_binary_version,
+    resolve_executable as _resolve_executable,
+)
 from agent.secret_sources.base import ErrorKind, SecretSource
 from agent.secret_sources.base import get_source_environment
 
@@ -72,6 +76,13 @@ _OP_RUN_TIMEOUT = 30
 # the value to the child as OP_SERVICE_ACCOUNT_TOKEN, which is what `op` itself
 # looks for.
 _DEFAULT_TOKEN_ENV = "OP_SERVICE_ACCOUNT_TOKEN"
+
+# 1Password does not publish a single version pinned by Hermes, so PATH
+# binaries must at least identify a conventional semantic version.  The
+# shared POSIX PATH policy requires a root-owned trust chain; users who
+# intentionally install ``op`` in a profile-local directory can set an
+# absolute ``binary_path`` instead.
+_OP_VERSION_PATTERN = r"(?<![0-9])\d+\.\d+\.\d+(?![0-9])"
 
 # ANSI stripping for `op` diagnostics we surface uses the shared
 # tools.ansi_strip.strip_ansi (full ECMA-48: CSI, OSC, DCS/SOS/PM/APC,
@@ -211,18 +222,31 @@ def _refs_fingerprint(references: Dict[str, str]) -> str:
 def find_op(binary_path: str = "") -> Optional[Path]:
     """Resolve a usable ``op`` binary, or None.
 
-    When ``binary_path`` is set it is used verbatim and PATH is NOT consulted
-    — pinning an absolute path is a way to avoid trusting whatever ``op`` shows
-    up first on ``PATH``.  A pinned-but-missing path returns None (the caller
-    surfaces a clear error) rather than silently falling back.
+    When ``binary_path`` is set it is canonicalised, checked for a private
+    canonical parent chain, and PATH is NOT consulted — pinning an absolute
+    path is a way to avoid trusting whatever ``op`` shows up first on ``PATH``.
+    A pinned-but-missing or untrusted path returns None (the caller surfaces a
+    clear error) rather than silently falling back.
     """
     if binary_path:
-        pinned = Path(binary_path)
-        if pinned.exists() and os.access(pinned, os.X_OK):
-            return pinned
-        return None
+        # Explicit configuration is still canonicalised so a relative path or
+        # a later symlink swap cannot redirect the child to an arbitrary CWD
+        # entry.  The resolved target is what callers execute.
+        return _resolve_executable(
+            binary_path, check_explicit_parent_dirs=True
+        )
     found = shutil.which("op")
-    return Path(found) if found else None
+    if not found:
+        return None
+    resolved = _resolve_executable(
+        found, check_parent_dirs=True, reject_current_owner=True
+    )
+    if resolved is None or not _probe_binary_version(
+        resolved, _OP_VERSION_PATTERN
+    ):
+        logger.warning("refusing untrusted op PATH binary")
+        return None
+    return resolved
 
 
 # ---------------------------------------------------------------------------

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -20,6 +20,10 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from agent.secret_sources._cache import CachedFetch, SecretCache, fingerprint as _fingerprint
+from agent.secret_sources._binary_security import (
+    probe_version as _probe_binary_version,
+    resolve_executable as _resolve_executable,
+)
 from agent.secret_sources.base import (
     ErrorKind, FetchResult, SecretSource, classify_cli_error, coerce_float,
     get_source_environment, is_valid_env_name, run_cli,
@@ -111,13 +115,37 @@ def _refs_fingerprint(references: Dict[str, str]) -> str:
     return _fingerprint("\n".join(f"{name}={references[name]}" for name in sorted(references)))
 
 
+_OP_VERSION_PATTERN = r"(?<![0-9])\d+\.\d+\.\d+(?![0-9])"
+
+
 def find_op(binary_path: str = "") -> Optional[Path]:
-    """Resolve a usable ``op`` binary, or None. A pinned ``binary_path`` is used
-    verbatim — pinned-but-missing returns None rather than falling back to PATH."""
-    found = binary_path or shutil.which("op")
-    if not found or (binary_path and not os.access(binary_path, os.X_OK)):
+    """Resolve a usable ``op`` binary, or None.
+
+    When ``binary_path`` is set it is canonicalised, checked for a private
+    canonical parent chain, and PATH is NOT consulted — pinning an absolute
+    path is a way to avoid trusting whatever ``op`` shows up first on ``PATH``.
+    A pinned-but-missing or untrusted path returns None (the caller surfaces a
+    clear error) rather than silently falling back.
+    """
+    if binary_path:
+        # Explicit configuration is still canonicalised so a relative path or
+        # a later symlink swap cannot redirect the child to an arbitrary CWD
+        # entry.  The resolved target is what callers execute.
+        return _resolve_executable(
+            binary_path, check_explicit_parent_dirs=True
+        )
+    found = shutil.which("op")
+    if not found:
         return None
-    return Path(found)
+    resolved = _resolve_executable(
+        found, check_parent_dirs=True, reject_current_owner=True
+    )
+    if resolved is None or not _probe_binary_version(
+        resolved, _OP_VERSION_PATTERN
+    ):
+        logger.warning("refusing untrusted op PATH binary")
+        return None
+    return resolved
 
 
 def _scrub(text: str) -> str:
@@ -137,10 +165,22 @@ def _op_child_env(token_value: str) -> Dict[str, str]:
     return env
 
 
-def _run_op_read(op: Path, reference: str, *, account: str = "", token_value: str = "") -> str:
+def verify_op_for_use(path: Path, *, explicit_binary: bool = False) -> Optional[Path]:
+    """Canonical path for an immediate use, preserving the discovery trust mode."""
+    return _resolve_executable(
+        path, check_explicit_parent_dirs=explicit_binary,
+        check_parent_dirs=not explicit_binary, reject_current_owner=not explicit_binary,
+    )
+
+
+def _run_op_read(op: Path, reference: str, *, account: str = "", token_value: str = "",
+                 explicit_binary: bool = False) -> str:
     """Resolve one ``op://`` reference; raises ``RuntimeError`` on any failure, including
     an exit-0 empty value (applying it would clobber a good credential with ``""``)."""
-    cmd: List[str] = [str(op), "read"]
+    verified = verify_op_for_use(op, explicit_binary=explicit_binary)
+    if verified is None:
+        raise RuntimeError("op binary failed use-time verification")
+    cmd: List[str] = [str(verified), "read"]
     if account:
         cmd += ["--account", account]
     cmd += ["--", reference]  # `--` so a reference can never parse as an op flag
@@ -170,7 +210,9 @@ def fetch_onepassword_secrets(
 
     Raises ``RuntimeError`` only when no ``op`` binary is available; per-ref
     failures become warnings. Only a complete, error-free pull is cached, so a
-    transient auth failure isn't frozen in for the whole TTL window.
+    transient auth failure isn't frozen in for the whole TTL window. ``binary``
+    is an explicit caller-selected path; normal source callers pass ``binary_path``
+    so automatic PATH discovery keeps its stricter ownership checks at use time.
     """
     valid, warnings = _validate_references(references)
     if not valid:
@@ -195,7 +237,10 @@ def fetch_onepassword_secrets(
     read_errors = 0
     for name in sorted(valid):
         try:
-            secrets[name] = _run_op_read(op, valid[name], account=account, token_value=token_value)
+            secrets[name] = _run_op_read(
+                op, valid[name], account=account, token_value=token_value,
+                explicit_binary=bool(binary_path or binary is not None),
+            )
         except RuntimeError as exc:
             warnings.append(str(exc))
             read_errors += 1
@@ -248,7 +293,7 @@ def apply_onepassword_secrets(
     try:
         secrets, fetch_warnings = fetch_onepassword_secrets(
             references=refs_to_fetch, account=account, token_env=service_account_token_env,
-            binary=binary, cache_ttl_seconds=cache_ttl_seconds, home_path=home_path)
+            binary_path=binary_path, cache_ttl_seconds=cache_ttl_seconds, home_path=home_path)
     except RuntimeError as exc:
         result.error = str(exc)
         return result
@@ -318,7 +363,7 @@ class OnePasswordSource(SecretSource):
         try:
             secrets, fetch_warnings = fetch_onepassword_secrets(
                 references=valid, account=str(cfg.get("account") or ""), token_env=self.token_env(cfg),
-                binary=binary, cache_ttl_seconds=coerce_float(cfg.get("cache_ttl_seconds", 300), 300.0),
+                binary_path=binary_path, cache_ttl_seconds=coerce_float(cfg.get("cache_ttl_seconds", 300), 300.0),
                 home_path=home_path)
         except RuntimeError as exc:
             return result.fail(str(exc), _classify_op_error(str(exc)))

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -20,7 +20,6 @@ from agent.secret_sources import onepassword as op_src
 from hermes_cli._secrets_common import (
     arg,
     cfg_str,
-    cli_version,
     disable_secret_source,
     flag,
     print_status_panel,
@@ -37,8 +36,6 @@ from hermes_cli.config import get_env_path, load_config, save_config, save_env_v
 _DEFAULT_TOKEN_ENV = "OP_SERVICE_ACCOUNT_TOKEN"
 _DOCS_URL = "https://developer.1password.com/docs/cli/get-started/"
 
-# Old name kept bound: tests call ``onepassword_secrets_cli._op_version`` directly.
-_op_version = cli_version
 
 
 def _op_cfg() -> dict:
@@ -110,7 +107,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
         )
         console.print(f"  Install the 1Password CLI: {_DOCS_URL}")
         return 1
-    console.print(f"  [green]✓[/green] {binary}  ({_op_version(binary)})")
+    console.print(f"  [green]✓[/green] {binary}  ({_op_version(binary, explicit_binary=bool(binary_path))})")
     if binary_path:
         op_cfg["binary_path"] = binary_path
 
@@ -131,7 +128,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     elif os.environ.get(token_env):
         console.print(f"  [green]✓[/green] using service-account token from {token_env}")
     else:
-        who = _op_whoami(binary, op_cfg.get("account", ""))
+        who = _op_whoami(binary, op_cfg.get("account", ""), explicit_binary=bool(binary_path))
         if who:
             console.print(f"  [green]✓[/green] using existing op session ({who})")
         else:
@@ -179,7 +176,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         ("Token in env", yn(token_set)),
         ("Override existing", yn(bool(op_cfg.get("override_existing", True)))),
         ("Cache TTL (s)", str(op_cfg.get("cache_ttl_seconds", 300))),
-        ("op binary", f"{binary} ({_op_version(binary)})" if binary else "[yellow]not found[/yellow]"),
+        ("op binary", f"{binary} ({_op_version(binary, explicit_binary=bool(binary_path))})" if binary else "[yellow]not found[/yellow]"),
         ("References", str(len(references))),
     ))
 
@@ -191,7 +188,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         console.print("\n  Run [cyan]hermes secrets onepassword setup[/cyan] to enable.")
         return 0
     if binary and not token_set:
-        who = _op_whoami(binary, account)
+        who = _op_whoami(binary, account, explicit_binary=bool(binary_path))
         if who:
             console.print(f"\n  [green]Active op session:[/green] {who}")
         else:
@@ -263,7 +260,7 @@ def cmd_token(args: argparse.Namespace) -> int:
             )
             return False
         console.print("Verifying with `op whoami`…")
-        who = _op_whoami(binary, account, token_value=token)
+        who = _op_whoami(binary, account, token_value=token, explicit_binary=bool(binary_path))
         if who is None:
             console.print("[red]✗ New token was rejected by op — nothing was changed.[/red]")
             return False
@@ -374,10 +371,34 @@ def cmd_disable(args: argparse.Namespace) -> int:
     )
 
 
-def _op_whoami(binary: Path, account: str, *, token_value: str = "") -> Optional[str]:
+def _op_version(binary: Path, *, explicit_binary: bool = True) -> str:
+    from agent.secret_sources._binary_security import probe_environment
+
+    verified = op_src.verify_op_for_use(binary, explicit_binary=explicit_binary)
+    if verified is None:
+        return "version unknown"
+    try:
+        res = subprocess.run(
+            [str(verified), "--version"], env=probe_environment(verified),
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=5, stdin=subprocess.DEVNULL,
+        )
+        lines = (res.stdout or res.stderr or "").strip().splitlines()
+        if res.returncode == 0 and lines:
+            return lines[0]
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return "version unknown"
+
+
+def _op_whoami(binary: Path, account: str, *, token_value: str = "",
+               explicit_binary: bool = True) -> Optional[str]:
     """Short identity string if op is authenticated, else None. ``token_value`` probes a candidate
     token via the child's ``OP_SERVICE_ACCOUNT_TOKEN`` without touching the caller's environment."""
-    cmd = [str(binary), "whoami"]
+    verified = op_src.verify_op_for_use(binary, explicit_binary=explicit_binary)
+    if verified is None:
+        return None
+    cmd = [str(verified), "whoami"]
     if account:
         cmd += ["--account", account]
     env = secret_cli_env()

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -558,12 +558,17 @@ def _yn(b: bool) -> str:
 
 
 def _bws_version(binary: Path) -> str:
+    verified = bw.verify_bws_for_use(binary)
+    if verified is None:
+        return "version unknown"
     try:
         res = subprocess.run(
-            [str(binary), "--version"],
+            [str(verified), "--version"],
+            env=bw._probe_environment(verified),
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
             timeout=5,
+            stdin=subprocess.DEVNULL,
         )
         if res.returncode == 0:
             return (res.stdout or res.stderr).strip().splitlines()[0]
@@ -608,6 +613,10 @@ def _list_projects(
     binary: Path, token: str, console: Console, *, server_url: str = ""
 ) -> Optional[List[dict]]:
     """Call ``bws project list`` and return the parsed list, or None on failure."""
+    verified = bw.verify_bws_for_use(binary)
+    if verified is None:
+        console.print("  [red]Refusing unverified bws binary.[/red]")
+        return None
     # Secret-manager CLI child: intentionally receives tokens — no scrub,
     # no HOME rewrite (bws stores state under the real user home).
     from tools.environments.local import build_subprocess_env
@@ -618,7 +627,7 @@ def _list_projects(
         env["BWS_SERVER_URL"] = server_url
     try:
         res = subprocess.run(
-            [str(binary), "project", "list", "--output", "json"],
+            [str(verified), "project", "list", "--output", "json"],
             env=env,
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -24,15 +24,13 @@ from rich.table import Table
 _BWS_VERSION = "2.0.0"
 
 from hermes_cli._secrets_common import (
-    arg, cfg_str, cli_version, disable_secret_source, flag, print_status_panel, print_table,
+    arg, cfg_str, disable_secret_source, flag, print_status_panel, print_table,
     prompt_index, register_subcommands, require_enabled, rotate_token, secret_cli_env, section_cfg,
     yn,
 )
 from hermes_cli.config import get_env_path, load_config, save_config, save_env_value
 from hermes_cli.secret_prompt import masked_secret_prompt
 
-# Old names kept bound: tests monkeypatch ``secrets_cli._bws_version``.
-_bws_version = cli_version
 _yn = yn
 
 _DEFAULT_TOKEN_ENV = "BWS_ACCESS_TOKEN"
@@ -50,6 +48,28 @@ def _load_bw():
     """Import ``agent.secret_sources.bitwarden`` on first use (crypto payload)."""
     from agent.secret_sources import bitwarden as _bw
     return _bw
+
+
+def _bws_version(binary: Path) -> str:
+    bw = _load_bw()
+    verified = bw.verify_bws_for_use(binary)
+    if verified is None:
+        return "version unknown"
+    try:
+        res = subprocess.run(
+            [str(verified), "--version"],
+            env=bw._probe_environment(verified),
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+        )
+        if res.returncode == 0:
+            return (res.stdout or res.stderr).strip().splitlines()[0]
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return "version unknown"
+
 
 
 def __getattr__(name: str):
@@ -447,13 +467,18 @@ def _list_projects(
     binary: Path, token: str, console: Console, *, server_url: str = ""
 ) -> Optional[List[dict]]:
     """Call ``bws project list`` and return the parsed list, or None on failure."""
+    bw = _load_bw()
+    verified = bw.verify_bws_for_use(binary)
+    if verified is None:
+        console.print("  [red]Refusing unverified bws binary.[/red]")
+        return None
     env = secret_cli_env()
     env["BWS_ACCESS_TOKEN"] = token
     if server_url:
         env["BWS_SERVER_URL"] = server_url
     try:
         res = subprocess.run(
-            [str(binary), "project", "list", "--output", "json"],
+            [str(verified), "project", "list", "--output", "json"],
             env=env, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=15)
     except (OSError, subprocess.TimeoutExpired) as exc:
         console.print(f"  [red]Couldn't list projects: {exc}[/red]")

--- a/tests/hermes_cli/test_bitwarden_binary_boundary.py
+++ b/tests/hermes_cli/test_bitwarden_binary_boundary.py
@@ -1,0 +1,197 @@
+"""Regression coverage for the Bitwarden CLI use-time trust boundary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from rich.console import Console
+
+from agent.secret_sources import bitwarden as bw
+from hermes_cli import secrets_cli
+
+
+@pytest.fixture(autouse=True)
+def _clear_hermes_home_cache():
+    import hermes_constants
+
+    if hasattr(hermes_constants, "_HERMES_HOME_CACHE"):
+        hermes_constants._HERMES_HOME_CACHE = None  # type: ignore[attr-defined]
+    yield
+    if hasattr(hermes_constants, "_HERMES_HOME_CACHE"):
+        hermes_constants._HERMES_HOME_CACHE = None  # type: ignore[attr-defined]
+
+
+def _managed_bws(tmp_path: Path, monkeypatch, *, tampered: bool) -> Path:
+    home = tmp_path / "hermes"
+    bin_dir = home / "bin"
+    bin_dir.mkdir(parents=True)
+    bin_dir.chmod(0o700)
+    binary = bin_dir / "bws"
+    payload = b"#!/bin/sh\nprintf 'bws 2.0.0\\n'\n"
+    binary.write_bytes(payload)
+    binary.chmod(0o700)
+    checksum = bin_dir / ".bws.sha256"
+    checksum.write_text(hashlib.sha256(payload).hexdigest() + "\n")
+    checksum.chmod(0o600)
+    if tampered:
+        binary.write_bytes(b"#!/bin/sh\nprintf 'tampered\\n'\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_constants
+
+    if hasattr(hermes_constants, "_HERMES_HOME_CACHE"):
+        monkeypatch.setattr(
+            hermes_constants, "_HERMES_HOME_CACHE", None, raising=False
+        )
+    return binary
+
+
+def test_version_refuses_tampered_managed_binary_before_spawn(tmp_path, monkeypatch):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "synthetic-token")
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    assert secrets_cli._bws_version(binary) == "version unknown"
+    run.assert_not_called()
+
+
+def test_projects_refuse_tampered_managed_binary_before_token_child(
+    tmp_path, monkeypatch
+):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+    output = io.StringIO()
+
+    projects = secrets_cli._list_projects(
+        binary, "synthetic-token", Console(file=output), server_url=""
+    )
+
+    assert projects is None
+    assert "Refusing unverified bws binary" in output.getvalue()
+    run.assert_not_called()
+
+
+def test_version_uses_credential_free_environment_for_valid_managed_binary(
+    tmp_path, monkeypatch
+):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=False)
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "synthetic-token")
+    monkeypatch.setenv("LD_PRELOAD", "must-not-pass")
+    result = mock.Mock(returncode=0, stdout="bws 2.0.0\n", stderr="")
+    run = mock.Mock(return_value=result)
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    assert secrets_cli._bws_version(binary) == "bws 2.0.0"
+
+    args, kwargs = run.call_args
+    assert args[0] == [str(binary), "--version"]
+    assert kwargs["stdin"] is secrets_cli.subprocess.DEVNULL
+    assert kwargs["env"].get("BWS_ACCESS_TOKEN") is None
+    assert kwargs["env"].get("LD_PRELOAD") is None
+
+
+def test_projects_accept_valid_managed_binary_and_pass_only_project_token(
+    tmp_path, monkeypatch
+):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=False)
+    result = mock.Mock(
+        returncode=0,
+        stdout='[{"id": "project-1", "name": "Project"}]',
+        stderr="",
+    )
+    run = mock.Mock(return_value=result)
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    projects = secrets_cli._list_projects(
+        binary, "synthetic-token", Console(), server_url="https://vault.example"
+    )
+
+    assert projects == [{"id": "project-1", "name": "Project"}]
+    args, kwargs = run.call_args
+    assert args[0] == [str(binary), "project", "list", "--output", "json"]
+    assert kwargs["env"]["BWS_ACCESS_TOKEN"] == "synthetic-token"
+    assert kwargs["env"]["BWS_SERVER_URL"] == "https://vault.example"
+
+
+def test_projects_accept_valid_path_candidate_through_policy_mocks(monkeypatch):
+    binary = Path("/trusted/bin/bws")
+    monkeypatch.setattr(bw, "_is_managed_bws", lambda _path: False)
+    monkeypatch.setattr(bw, "_resolve_executable", lambda path, **_kw: Path(path))
+    monkeypatch.setattr(bw, "_probe_binary_version", lambda *_args, **_kwargs: True)
+    result = mock.Mock(returncode=0, stdout="[]", stderr="")
+    run = mock.Mock(return_value=result)
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    assert secrets_cli._list_projects(binary, "synthetic-token", Console()) == []
+    args, kwargs = run.call_args
+    assert args[0] == [str(binary), "project", "list", "--output", "json"]
+    assert kwargs["env"]["BWS_ACCESS_TOKEN"] == "synthetic-token"
+
+
+def test_status_does_not_spawn_for_tampered_managed_binary(tmp_path, monkeypatch):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: {
+        "secrets": {"bitwarden": {
+            "enabled": True,
+            "access_token_env": "BWS_ACCESS_TOKEN",
+            "project_id": "project-1",
+        }},
+    })
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "synthetic-token")
+    monkeypatch.setattr(secrets_cli.bw, "find_bws", lambda **_kw: binary)
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    assert secrets_cli.cmd_status(argparse.Namespace()) == 0
+    run.assert_not_called()
+
+
+def test_token_rotation_does_not_spawn_or_store_for_tampered_managed_binary(
+    tmp_path, monkeypatch
+):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: {
+        "secrets": {"bitwarden": {
+            "enabled": True,
+            "access_token_env": "BWS_ACCESS_TOKEN",
+            "project_id": "project-1",
+        }},
+    })
+    monkeypatch.setattr(secrets_cli.bw, "find_bws", lambda **_kw: binary)
+    saved = mock.Mock()
+    monkeypatch.setattr(secrets_cli, "save_env_value", saved)
+    monkeypatch.setattr(secrets_cli.bw, "clear_caches", lambda: None)
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    args = argparse.Namespace(access_token="0.synthetic-token", no_verify=False)
+    assert secrets_cli.cmd_token(args) == 1
+    run.assert_not_called()
+    saved.assert_not_called()
+
+
+def test_setup_does_not_spawn_for_tampered_managed_binary(tmp_path, monkeypatch):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    monkeypatch.setattr(secrets_cli.bw, "find_bws", lambda **_kw: binary)
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: {})
+    monkeypatch.setattr(secrets_cli, "save_config", lambda _cfg: None)
+    monkeypatch.setattr(secrets_cli, "save_env_value", lambda *_args: None)
+    monkeypatch.setattr(secrets_cli, "get_env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    args = argparse.Namespace(
+        access_token="0.synthetic-token",
+        server_url="https://vault.example",
+        project_id="project-1",
+    )
+    assert secrets_cli.cmd_setup(args) == 1
+    run.assert_not_called()

--- a/tests/hermes_cli/test_bitwarden_binary_boundary.py
+++ b/tests/hermes_cli/test_bitwarden_binary_boundary.py
@@ -1,0 +1,219 @@
+"""Regression coverage for the Bitwarden CLI use-time trust boundary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import os
+import stat
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from rich.console import Console
+
+from agent.secret_sources import bitwarden as bw
+from hermes_cli import secrets_cli
+
+
+@pytest.fixture(autouse=True)
+def _clear_hermes_home_cache():
+    import hermes_constants
+
+    if hasattr(hermes_constants, "_HERMES_HOME_CACHE"):
+        hermes_constants._HERMES_HOME_CACHE = None  # type: ignore[attr-defined]
+    yield
+    if hasattr(hermes_constants, "_HERMES_HOME_CACHE"):
+        hermes_constants._HERMES_HOME_CACHE = None  # type: ignore[attr-defined]
+
+
+
+def _private_test_ancestors(monkeypatch, path):
+    """Model trusted install ancestors without trusting pytest's shared /tmp."""
+    if os.name == "nt":
+        return
+    original_stat = Path.stat
+    ancestors = {parent.resolve() for parent in path.parents}
+
+    def private_stat(candidate, *args, **kwargs):
+        result = original_stat(candidate, *args, **kwargs)
+        if candidate in ancestors:
+            fields = list(result)
+            fields[4] = 0
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+            return os.stat_result(fields)
+        return result
+
+    monkeypatch.setattr(Path, "stat", private_stat)
+
+def _managed_bws(tmp_path: Path, monkeypatch, *, tampered: bool) -> Path:
+    home = tmp_path / "hermes"
+    bin_dir = home / "bin"
+    bin_dir.mkdir(parents=True)
+    bin_dir.chmod(0o700)
+    binary = bin_dir / bw._platform_binary_name()
+    _private_test_ancestors(monkeypatch, binary)
+    payload = b"#!/bin/sh\nprintf 'bws 2.0.0\\n'\n"
+    binary.write_bytes(payload)
+    binary.chmod(0o700)
+    checksum = bw._managed_bws_checksum_path(binary)
+    checksum.write_text(hashlib.sha256(payload).hexdigest() + "\n")
+    checksum.chmod(0o600)
+    if tampered:
+        binary.write_bytes(b"#!/bin/sh\nprintf 'tampered\\n'\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import hermes_constants
+
+    if hasattr(hermes_constants, "_HERMES_HOME_CACHE"):
+        monkeypatch.setattr(
+            hermes_constants, "_HERMES_HOME_CACHE", None, raising=False
+        )
+    return binary
+
+
+def test_version_refuses_tampered_managed_binary_before_spawn(tmp_path, monkeypatch):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "synthetic-token")
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    assert secrets_cli._bws_version(binary) == "version unknown"
+    run.assert_not_called()
+
+
+def test_projects_refuse_tampered_managed_binary_before_token_child(
+    tmp_path, monkeypatch
+):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+    output = io.StringIO()
+
+    projects = secrets_cli._list_projects(
+        binary, "synthetic-token", Console(file=output), server_url=""
+    )
+
+    assert projects is None
+    assert "Refusing unverified bws binary" in output.getvalue()
+    run.assert_not_called()
+
+
+def test_version_uses_credential_free_environment_for_valid_managed_binary(
+    tmp_path, monkeypatch
+):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=False)
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "synthetic-token")
+    monkeypatch.setenv("LD_PRELOAD", "must-not-pass")
+    result = mock.Mock(returncode=0, stdout="bws 2.0.0\n", stderr="")
+    run = mock.Mock(return_value=result)
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    assert secrets_cli._bws_version(binary) == "bws 2.0.0"
+
+    args, kwargs = run.call_args
+    assert args[0] == [str(binary), "--version"]
+    assert kwargs["stdin"] is secrets_cli.subprocess.DEVNULL
+    assert kwargs["env"].get("BWS_ACCESS_TOKEN") is None
+    assert kwargs["env"].get("LD_PRELOAD") is None
+
+
+def test_projects_accept_valid_managed_binary_and_pass_only_project_token(
+    tmp_path, monkeypatch
+):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=False)
+    result = mock.Mock(
+        returncode=0,
+        stdout='[{"id": "project-1", "name": "Project"}]',
+        stderr="",
+    )
+    run = mock.Mock(return_value=result)
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    projects = secrets_cli._list_projects(
+        binary, "synthetic-token", Console(), server_url="https://vault.example"
+    )
+
+    assert projects == [{"id": "project-1", "name": "Project"}]
+    args, kwargs = run.call_args
+    assert args[0] == [str(binary), "project", "list", "--output", "json"]
+    assert kwargs["env"]["BWS_ACCESS_TOKEN"] == "synthetic-token"
+    assert kwargs["env"]["BWS_SERVER_URL"] == "https://vault.example"
+
+
+def test_projects_accept_valid_path_candidate_through_policy_mocks(monkeypatch):
+    binary = Path("/trusted/bin/bws")
+    monkeypatch.setattr(bw, "_is_managed_bws", lambda _path: False)
+    monkeypatch.setattr(bw, "_resolve_executable", lambda path, **_kw: Path(path))
+    monkeypatch.setattr(bw, "_probe_binary_version", lambda *_args, **_kwargs: True)
+    result = mock.Mock(returncode=0, stdout="[]", stderr="")
+    run = mock.Mock(return_value=result)
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    assert secrets_cli._list_projects(binary, "synthetic-token", Console()) == []
+    args, kwargs = run.call_args
+    assert args[0] == [str(binary), "project", "list", "--output", "json"]
+    assert kwargs["env"]["BWS_ACCESS_TOKEN"] == "synthetic-token"
+
+
+def test_status_does_not_spawn_for_tampered_managed_binary(tmp_path, monkeypatch):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: {
+        "secrets": {"bitwarden": {
+            "enabled": True,
+            "access_token_env": "BWS_ACCESS_TOKEN",
+            "project_id": "project-1",
+        }},
+    })
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "synthetic-token")
+    monkeypatch.setattr(secrets_cli.bw, "find_bws", lambda **_kw: binary)
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    assert secrets_cli.cmd_status(argparse.Namespace()) == 0
+    run.assert_not_called()
+
+
+def test_token_rotation_does_not_spawn_or_store_for_tampered_managed_binary(
+    tmp_path, monkeypatch
+):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: {
+        "secrets": {"bitwarden": {
+            "enabled": True,
+            "access_token_env": "BWS_ACCESS_TOKEN",
+            "project_id": "project-1",
+        }},
+    })
+    monkeypatch.setattr(secrets_cli.bw, "find_bws", lambda **_kw: binary)
+    saved = mock.Mock()
+    monkeypatch.setattr(secrets_cli, "save_env_value", saved)
+    monkeypatch.setattr(secrets_cli.bw, "clear_caches", lambda: None)
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    args = argparse.Namespace(access_token="0.synthetic-token", no_verify=False)
+    assert secrets_cli.cmd_token(args) == 1
+    run.assert_not_called()
+    saved.assert_not_called()
+
+
+def test_setup_does_not_spawn_for_tampered_managed_binary(tmp_path, monkeypatch):
+    binary = _managed_bws(tmp_path, monkeypatch, tampered=True)
+    monkeypatch.setattr(secrets_cli.bw, "find_bws", lambda **_kw: binary)
+    monkeypatch.setattr(secrets_cli, "load_config", lambda: {})
+    monkeypatch.setattr(secrets_cli, "save_config", lambda _cfg: None)
+    monkeypatch.setattr(secrets_cli, "save_env_value", lambda *_args: None)
+    monkeypatch.setattr(secrets_cli, "get_env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    run = mock.Mock()
+    monkeypatch.setattr(secrets_cli.subprocess, "run", run)
+
+    args = argparse.Namespace(
+        access_token="0.synthetic-token",
+        server_url="https://vault.example",
+        project_id="project-1",
+    )
+    assert secrets_cli.cmd_setup(args) == 1
+    run.assert_not_called()

--- a/tests/hermes_cli/test_onepassword_binary_boundary.py
+++ b/tests/hermes_cli/test_onepassword_binary_boundary.py
@@ -1,0 +1,70 @@
+"""The CLI must revalidate op before version and authenticated probes."""
+from __future__ import annotations
+
+import os
+import stat
+from unittest import mock
+
+import pytest
+
+from agent.secret_sources import _binary_security as security
+from hermes_cli import onepassword_secrets_cli as cli
+
+
+@pytest.fixture
+def explicit_op(tmp_path, monkeypatch):
+    path = tmp_path / "op.exe"
+    path.write_text("inert executable")
+    path.chmod(0o755)
+    if os.name == "nt":
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    else:
+        original_stat = security.Path.stat
+
+        def private_stat(path, *args, **kwargs):
+            result = original_stat(path, *args, **kwargs)
+            fields = list(result)
+            fields[4] = os.geteuid()
+            if stat.S_ISDIR(result.st_mode):
+                fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+            return os.stat_result(fields)
+
+        monkeypatch.setattr(security.Path, "stat", private_stat)
+    return path
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode boundary")
+@pytest.mark.parametrize("operation", ["version", "whoami"])
+def test_cli_rejects_changed_binary_before_spawn(explicit_op, monkeypatch, operation):
+    explicit_op.chmod(0o777)
+    run = mock.Mock(return_value=mock.Mock(returncode=0, stdout="2.0.0\n", stderr=""))
+    monkeypatch.setattr(cli.subprocess, "run", run)
+    if operation == "version":
+        assert cli._op_version(explicit_op) == "version unknown"
+    else:
+        assert cli._op_whoami(explicit_op, "", token_value="inert-token") is None
+    run.assert_not_called()
+
+
+def test_cli_version_probe_keeps_credentials_out_of_environment(explicit_op, monkeypatch):
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "inert-token")
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "inert-other-token")
+    run = mock.Mock(return_value=mock.Mock(returncode=0, stdout="2.0.0\n", stderr=""))
+    monkeypatch.setattr(cli.subprocess, "run", run)
+
+    assert cli._op_version(explicit_op) == "2.0.0"
+    args, kwargs = run.call_args
+    assert args[0] == [str(explicit_op.resolve()), "--version"]
+    assert "OP_SERVICE_ACCOUNT_TOKEN" not in kwargs["env"]
+    assert "BWS_ACCESS_TOKEN" not in kwargs["env"]
+    assert kwargs["stdin"] is cli.subprocess.DEVNULL
+
+
+def test_cli_authenticated_probe_keeps_intended_token(explicit_op, monkeypatch):
+    run = mock.Mock(return_value=mock.Mock(returncode=0, stdout="identity\n", stderr=""))
+    monkeypatch.setattr(cli.subprocess, "run", run)
+
+    assert cli._op_whoami(explicit_op, "account", token_value="inert-token") == "identity"
+    args, kwargs = run.call_args
+    assert args[0] == [str(explicit_op.resolve()), "whoami", "--account", "account"]
+    assert kwargs["env"]["OP_SERVICE_ACCOUNT_TOKEN"] == "inert-token"

--- a/tests/test_binary_security.py
+++ b/tests/test_binary_security.py
@@ -1,0 +1,287 @@
+"""Focused tests for credential-bearing CLI discovery and probing."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from agent.secret_sources import _binary_security as security
+
+
+def _patch_file_owner(
+    monkeypatch, candidate: Path, owner: int, *, safe_parents: bool = False
+) -> None:
+    original_stat = security.Path.stat
+    resolved_candidate = candidate.resolve()
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        if self == resolved_candidate:
+            fields = list(result)
+            fields[4] = owner  # st_uid
+            return os.stat_result(fields)
+        if safe_parents and stat.S_ISDIR(result.st_mode):
+            fields = list(result)
+            fields[4] = 0  # root-owned system directories
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+            return os.stat_result(fields)
+        return result
+
+    monkeypatch.setattr(security.Path, "stat", fake_stat)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_root_can_use_root_owned_path_binary(monkeypatch, tmp_path):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o755)
+    _patch_file_owner(monkeypatch, candidate, 0, safe_parents=True)
+    monkeypatch.setattr(security.os, "geteuid", lambda: 0)
+
+    assert security.resolve_executable(
+        candidate,
+        check_parent_dirs=True,
+        reject_current_owner=True,
+    ) == candidate.resolve()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_non_root_current_owner_remains_rejected(monkeypatch, tmp_path):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o755)
+    fake_uid = 424242
+    _patch_file_owner(monkeypatch, candidate, fake_uid)
+    monkeypatch.setattr(security.os, "geteuid", lambda: fake_uid)
+
+    assert security.resolve_executable(
+        candidate, reject_current_owner=True
+    ) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_root_rejects_root_owned_binary_in_writable_path(monkeypatch, tmp_path):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o755)
+    _patch_file_owner(monkeypatch, candidate, 0)
+    monkeypatch.setattr(security.os, "geteuid", lambda: 0)
+
+    assert security.resolve_executable(
+        candidate,
+        check_parent_dirs=True,
+        reject_current_owner=True,
+    ) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_explicit_group_world_writable_leaf_is_rejected(tmp_path):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o777)
+
+    assert security.resolve_executable(candidate) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_explicit_user_owned_non_group_world_writable_leaf_is_allowed(tmp_path):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o755)
+
+    assert security.resolve_executable(candidate) == candidate.resolve()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_explicit_mode_allows_private_current_user_chain(monkeypatch, tmp_path):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o755)
+    _patch_file_owner(monkeypatch, candidate, os.geteuid(), safe_parents=True)
+
+    assert security.resolve_executable(
+        candidate, check_explicit_parent_dirs=True
+    ) == candidate.resolve()
+
+
+@pytest.mark.parametrize("suffix", [".bat", ".cmd"])
+def test_windows_rejects_cmd_interpreted_scripts(monkeypatch, tmp_path, suffix):
+    candidate = tmp_path / f"op{suffix}"
+    candidate.write_text("echo unsafe\n")
+    candidate.chmod(0o755)
+    fake_os = mock.Mock(name="windows_os")
+    fake_os.name = "nt"
+    fake_os.X_OK = os.X_OK
+    fake_os.access = os.access
+    monkeypatch.setattr(security, "os", fake_os)
+
+    assert security.resolve_executable(candidate) is None
+
+
+@pytest.mark.parametrize("suffix", [".com", ".exe"])
+def test_windows_accepts_native_executables(monkeypatch, tmp_path, suffix):
+    candidate = tmp_path / f"op{suffix}"
+    candidate.write_text("native placeholder\n")
+    candidate.chmod(0o755)
+    fake_os = mock.Mock(name="windows_os")
+    fake_os.name = "nt"
+    fake_os.X_OK = os.X_OK
+    fake_os.access = os.access
+    monkeypatch.setattr(security, "os", fake_os)
+
+    assert security.resolve_executable(candidate) == candidate.resolve()
+
+
+def test_windows_explicit_path_is_limited_to_profile_or_machine_root(
+    monkeypatch, tmp_path
+):
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    candidate = profile / "op.exe"
+    candidate.write_text("native placeholder\n")
+    candidate.chmod(0o755)
+    fake_os = mock.Mock(name="windows_os")
+    fake_os.name = "nt"
+    fake_os.X_OK = os.X_OK
+    fake_os.access = os.access
+    fake_os.environ = {"USERPROFILE": str(profile)}
+    monkeypatch.setattr(security, "os", fake_os)
+    monkeypatch.setattr(security.Path, "home", lambda: profile)
+
+    assert security.resolve_executable(
+        candidate, check_explicit_parent_dirs=True
+    ) == candidate.resolve()
+
+    outside = tmp_path / "outside" / "op.exe"
+    outside.parent.mkdir()
+    outside.write_text("native placeholder\n")
+    outside.chmod(0o755)
+    assert (
+        security.resolve_executable(
+            outside, check_explicit_parent_dirs=True
+        )
+        is None
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_path_rejects_unprivileged_leaf_even_for_root(monkeypatch, tmp_path):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o755)
+    _patch_file_owner(monkeypatch, candidate, 424242, safe_parents=True)
+    monkeypatch.setattr(security.os, "geteuid", lambda: 0)
+
+    assert security.resolve_executable(
+        candidate,
+        check_parent_dirs=True,
+        reject_current_owner=True,
+    ) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_path_rejects_parent_owned_by_other_user(monkeypatch, tmp_path):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o755)
+    resolved_candidate = candidate.resolve()
+    unsafe_parent = resolved_candidate.parent
+    original_stat = security.Path.stat
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        fields = list(result)
+        if stat.S_ISDIR(result.st_mode):
+            fields[4] = 0
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+            if self == unsafe_parent:
+                fields[4] = 424242
+            return os.stat_result(fields)
+        if self == resolved_candidate:
+            fields[4] = 0
+        return os.stat_result(fields)
+
+    effective_uid = 424243
+    monkeypatch.setattr(security.Path, "stat", fake_stat)
+    monkeypatch.setattr(security.os, "geteuid", lambda: effective_uid)
+
+    assert security.resolve_executable(
+        candidate,
+        check_parent_dirs=True,
+        reject_current_owner=True,
+    ) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+@pytest.mark.parametrize("unsafe_mode", [stat.S_IWGRP, stat.S_IWOTH])
+def test_path_rejects_group_or_world_writable_parent(
+    monkeypatch, tmp_path, unsafe_mode
+):
+    candidate = tmp_path / "op"
+    candidate.write_text("#!/bin/sh\n")
+    candidate.chmod(0o755)
+    resolved_candidate = candidate.resolve()
+    unsafe_parent = resolved_candidate.parent
+    original_stat = security.Path.stat
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        fields = list(result)
+        if stat.S_ISDIR(result.st_mode):
+            fields[4] = 0
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+            if self == unsafe_parent:
+                fields[0] |= unsafe_mode
+            return os.stat_result(fields)
+        if self == resolved_candidate:
+            fields[4] = 0
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(security.Path, "stat", fake_stat)
+    monkeypatch.setattr(security.os, "geteuid", lambda: 424243)
+
+    assert security.resolve_executable(
+        candidate,
+        check_parent_dirs=True,
+        reject_current_owner=True,
+    ) is None
+
+
+def test_probe_version_keeps_cli_runtime_keys_without_credentials(monkeypatch):
+    required = (
+        "SystemDrive",
+        "PATHEXT",
+        "COMSPEC",
+        "ProgramData",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "XDG_CONFIG_HOME",
+        "XDG_RUNTIME_DIR",
+    )
+    for key in required:
+        monkeypatch.setenv(key, f"probe-{key}")
+    monkeypatch.setenv(
+        "PATH", f"/tmp/untrusted-probe-path{os.pathsep}{os.environ.get('PATH', '')}"
+    )
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "must-not-pass")
+    monkeypatch.setenv("OP_SESSION_example", "must-not-pass")
+    monkeypatch.setenv("LD_PRELOAD", "must-not-pass")
+
+    captured = {}
+
+    def fake_run(_argv, **kwargs):
+        captured.update(kwargs["env"])
+        return mock.Mock(returncode=0, stdout="op 2.0.0", stderr="")
+
+    monkeypatch.setattr(security.subprocess, "run", fake_run)
+
+    assert security.probe_version(Path("/unused/op.exe"), r"2\.0\.0")
+    assert all(captured[key] == f"probe-{key}" for key in required)
+    assert "/tmp/untrusted-probe-path" not in captured["PATH"]
+    assert "OP_SERVICE_ACCOUNT_TOKEN" not in captured
+    assert "OP_SESSION_example" not in captured
+    assert "LD_PRELOAD" not in captured

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -12,6 +12,7 @@ import hashlib
 import io
 import json
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -51,6 +52,18 @@ def hermes_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture
+def trusted_test_bws(monkeypatch):
+    """Bypass binary discovery for subprocess-shape tests using fake files.
+
+    These tests exercise fetch/cache behavior with mocked subprocesses, so the
+    security boundary itself is covered separately by the binary-boundary
+    tests.  Returning the supplied path models a successful use-time gate
+    without making a test fixture look like a real installed BWS binary.
+    """
+    monkeypatch.setattr(bw, "verify_bws_for_use", lambda path: Path(path))
+
+
 # ---------------------------------------------------------------------------
 # _platform_asset_name
 # ---------------------------------------------------------------------------
@@ -79,11 +92,65 @@ def test_platform_asset_name(system, machine, libc_text, expected):
     with mock.patch.object(bw.platform, "system", return_value=system), \
          mock.patch.object(bw.platform, "machine", return_value=machine), \
          mock.patch.object(
-             bw.subprocess,
-             "run",
-             return_value=mock.Mock(stdout=libc_text, stderr=libc_text),
+             bw, "_resolve_executable", side_effect=lambda path, **kwargs: Path(path)
+         ), \
+         mock.patch.object(
+             bw, "_probe_binary_version", return_value="musl" in libc_text
          ):
         assert bw._platform_asset_name() == expected
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Linux ldd policy")
+def test_platform_asset_name_rejects_untrusted_ldd(tmp_path, monkeypatch):
+    marker = tmp_path / "ldd-ran"
+    untrusted_dir = tmp_path / "untrusted"
+    untrusted_dir.mkdir()
+    untrusted_dir.chmod(0o777)
+    fake_ldd = untrusted_dir / "ldd"
+    fake_ldd.write_text(
+        "#!/bin/sh\n"
+        "printf '%s' \"${BWS_ACCESS_TOKEN-}\" > \"$LDD_MARKER\"\n"
+        "printf 'musl libc\\n'\n"
+    )
+    fake_ldd.chmod(0o755)
+    monkeypatch.setenv("PATH", str(untrusted_dir))
+    monkeypatch.setenv("LDD_MARKER", str(marker))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "must-not-reach-ldd")
+    monkeypatch.setattr(bw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(bw.platform, "machine", lambda: "x86_64")
+
+    # The temporary PATH entry is not a trusted root-owned chain, so ldd is
+    # rejected before subprocess creation and the marker is never written.
+    assert bw._platform_asset_name() == (
+        f"bws-x86_64-unknown-linux-gnu-{bw._BWS_VERSION}.zip"
+    )
+    assert not marker.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Linux ldd policy")
+def test_platform_asset_name_uses_trusted_ldd_probe(monkeypatch):
+    trusted_ldd = shutil.which("ldd")
+    if not trusted_ldd:
+        pytest.skip("ldd is unavailable")
+    calls = {}
+
+    def fake_probe(path, pattern, **kwargs):
+        calls.update(path=path, pattern=pattern, kwargs=kwargs)
+        return True
+
+    monkeypatch.setattr(bw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(bw.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        bw, "_resolve_executable", lambda path, **kwargs: Path(path).resolve()
+    )
+    monkeypatch.setattr(bw, "_probe_binary_version", fake_probe)
+
+    assert bw._platform_asset_name() == (
+        f"bws-x86_64-unknown-linux-musl-{bw._BWS_VERSION}.zip"
+    )
+    assert calls["path"] == Path(trusted_ldd).resolve()
+    assert calls["pattern"] == bw._LDD_MUSL_PATTERN
+    assert calls["kwargs"] == {"timeout": 2}
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +202,34 @@ def test_safe_extract_member_rejects_traversal(tmp_path, evil_name):
 
 
 
+def test_safe_extract_member_rejects_symlink_member(tmp_path):
+    info = zipfile.ZipInfo("bws")
+    info.create_system = 3  # Unix
+    info.external_attr = (stat.S_IFLNK | 0o777) << 16
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(info, "../escape")
+    buf.seek(0)
+
+    dest = tmp_path / "extract"
+    dest.mkdir()
+    with zipfile.ZipFile(buf) as zf:
+        with pytest.raises(RuntimeError, match="symbolic-link"):
+            bw._safe_extract_member(zf, "bws", dest)
+
+
+def test_find_bws_rejects_user_owned_path_binary(tmp_path, monkeypatch):
+    fake = tmp_path / "bws"
+    fake.write_bytes(b"not the Bitwarden CLI")
+    fake.chmod(0o755)
+    home = tmp_path / "home"
+    (home / "bin").mkdir(parents=True)
+    monkeypatch.setattr(bw, "_hermes_bin_dir", lambda: home / "bin")
+    monkeypatch.setattr(bw.shutil, "which", lambda _name: str(fake))
+
+    assert bw.find_bws() is None
+
+
 def test_install_bws_happy_path(hermes_home, monkeypatch):
     fake_binary = b"#!/bin/sh\necho 'bws fake 2.0.0'\n"
     zip_bytes = _make_fake_zip(fake_binary)
@@ -157,8 +252,150 @@ def test_install_bws_happy_path(hermes_home, monkeypatch):
     path = bw.install_bws()
     assert path.exists()
     assert path.read_bytes() == fake_binary
-    # Executable bit set
-    assert path.stat().st_mode & stat.S_IXUSR
+    assert stat.S_IMODE(path.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+    assert bw._managed_bws_checksum_path(path).read_text().strip() == hashlib.sha256(
+        fake_binary
+    ).hexdigest()
+    assert bw.find_bws() == path
+
+
+def test_managed_bws_tamper_is_rejected(hermes_home, monkeypatch):
+    fake_binary = b"#!/bin/sh\necho 'bws fake 2.0.0'\n"
+    zip_bytes = _make_fake_zip(fake_binary)
+    asset_name = bw._platform_asset_name()
+    checksum_text = f"{hashlib.sha256(zip_bytes).hexdigest()}  {asset_name}\n"
+
+    def fake_download(url, dest):
+        if url.endswith(".zip"):
+            Path(dest).write_bytes(zip_bytes)
+        else:
+            Path(dest).write_text(checksum_text)
+
+    monkeypatch.setattr(bw, "_http_download", fake_download)
+    monkeypatch.setattr(bw.shutil, "which", lambda _name: None)
+    path = bw.install_bws()
+    path.write_bytes(b"tampered")
+
+    assert not bw._verify_managed_bws(path)
+    assert bw.find_bws() is None
+
+
+def _make_managed_bws_fixture(tmp_path, name="managed"):
+    bin_dir = tmp_path / name / "bin"
+    bin_dir.mkdir(parents=True)
+    bin_dir.chmod(0o700)
+    path = bin_dir / "bws"
+    payload = b"managed bws"
+    path.write_bytes(payload)
+    path.chmod(0o700)
+    checksum = bin_dir / ".bws.sha256"
+    checksum.write_text(hashlib.sha256(payload).hexdigest() + "\n")
+    checksum.chmod(0o600)
+    return path
+
+
+def _patch_managed_bws_owners(monkeypatch, path, *, binary_owner, directory_owner):
+    original_stat = bw.Path.stat
+    resolved_path = path.resolve()
+    resolved_parent = path.parent.resolve()
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        if self == resolved_path:
+            fields = list(result)
+            fields[4] = binary_owner
+            return os.stat_result(fields)
+        if self == resolved_parent:
+            fields = list(result)
+            fields[4] = directory_owner
+            return os.stat_result(fields)
+        return result
+
+    monkeypatch.setattr(bw.Path, "stat", fake_stat)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+@pytest.mark.parametrize("owner_kind", ["root", "current"])
+def test_managed_bws_accepts_root_and_current_user_owners(
+    monkeypatch, tmp_path, owner_kind
+):
+    path = _make_managed_bws_fixture(tmp_path, owner_kind)
+    current_uid = os.geteuid()
+    owner = 0 if owner_kind == "root" else current_uid
+    _patch_managed_bws_owners(
+        monkeypatch,
+        path,
+        binary_owner=owner,
+        directory_owner=owner,
+    )
+    monkeypatch.setattr(bw.os, "geteuid", lambda: current_uid)
+
+    assert bw._verify_managed_bws(path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_managed_bws_rejects_foreign_binary_owner(monkeypatch, tmp_path):
+    path = _make_managed_bws_fixture(tmp_path, "foreign-binary")
+    current_uid = os.geteuid()
+    _patch_managed_bws_owners(
+        monkeypatch,
+        path,
+        binary_owner=424242,
+        directory_owner=current_uid,
+    )
+    monkeypatch.setattr(bw.os, "geteuid", lambda: current_uid)
+
+    assert not bw._verify_managed_bws(path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_managed_bws_rejects_foreign_directory_owner(monkeypatch, tmp_path):
+    path = _make_managed_bws_fixture(tmp_path, "foreign-directory")
+    current_uid = os.geteuid()
+    _patch_managed_bws_owners(
+        monkeypatch,
+        path,
+        binary_owner=current_uid,
+        directory_owner=424242,
+    )
+    monkeypatch.setattr(bw.os, "geteuid", lambda: current_uid)
+
+    assert not bw._verify_managed_bws(path)
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="symlink creation and permission semantics are POSIX-specific",
+)
+def test_managed_bws_canonicalizes_symlinked_ancestors(tmp_path, monkeypatch):
+    real_home = tmp_path / "real-home"
+    real_bin = real_home / "bin"
+    real_bin.mkdir(parents=True)
+    real_bin.chmod(0o700)
+    path = real_bin / "bws"
+    payload = b"managed bws"
+    path.write_bytes(payload)
+    path.chmod(0o700)
+    checksum = real_bin / ".bws.sha256"
+    checksum.write_text(hashlib.sha256(payload).hexdigest() + "\n")
+    checksum.chmod(0o600)
+
+    aliased_home = tmp_path / "aliased-home"
+    aliased_home.symlink_to(real_home, target_is_directory=True)
+    aliased_path = aliased_home / "bin" / "bws"
+    monkeypatch.setattr(bw, "_hermes_bin_dir", lambda: aliased_home / "bin")
+
+    # The managed file remains valid when HERMES_HOME has a symlinked
+    # ancestor, and a canonical PATH result is still classified as managed.
+    assert bw._verify_managed_bws(aliased_path)
+    assert bw._is_managed_bws(path.resolve())
+
+    # Canonicalizing the parent must not turn a leaf symlink into an accepted
+    # managed binary.
+    leaf = real_bin / "bws-link"
+    leaf.symlink_to(path)
+    assert not bw._verify_managed_bws(leaf)
 
 
 
@@ -186,7 +423,7 @@ def _fake_bws_payload(items):
 
 
 
-def test_fetch_server_url_sets_env(monkeypatch, tmp_path):
+def test_fetch_server_url_sets_env(monkeypatch, tmp_path, trusted_test_bws):
     """server_url must be plumbed into the subprocess as BWS_SERVER_URL."""
     fake_binary = tmp_path / "bws"
     fake_binary.write_text("")
@@ -208,6 +445,56 @@ def test_fetch_server_url_sets_env(monkeypatch, tmp_path):
         server_url="https://vault.bitwarden.eu",
     )
     assert captured_env.get("BWS_SERVER_URL") == "https://vault.bitwarden.eu"
+
+
+def test_run_bws_list_rejects_unverified_binary_before_token_child(
+    monkeypatch, tmp_path
+):
+    """Every credential-bearing fetch must pass the use-time binary gate."""
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("#!/bin/sh\n")
+    run = mock.Mock()
+    monkeypatch.setattr(bw, "verify_bws_for_use", lambda _path: None)
+    monkeypatch.setattr(bw.subprocess, "run", run)
+
+    with pytest.raises(RuntimeError, match="use-time verification"):
+        bw._run_bws_list(fake_binary, "synthetic-token", "project-1")
+    run.assert_not_called()
+
+
+def test_run_bws_list_executes_canonical_verified_path(
+    monkeypatch, tmp_path
+):
+    """The child must use the exact canonical path returned by verification."""
+    requested = tmp_path / "path-spelling" / "bws"
+    canonical = tmp_path / "trusted" / "bws"
+    requested.parent.mkdir()
+    canonical.parent.mkdir()
+    requested.write_text("placeholder")
+    canonical.write_text("placeholder")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return mock.Mock(
+            returncode=0,
+            stdout=_fake_bws_payload([{"key": "K", "value": "v"}]),
+            stderr="",
+        )
+
+    monkeypatch.setattr(bw, "verify_bws_for_use", lambda _path: canonical)
+    monkeypatch.setattr(bw.subprocess, "run", fake_run)
+
+    secrets, warnings = bw._run_bws_list(
+        requested, "synthetic-token", "project-1"
+    )
+
+    assert secrets == {"K": "v"}
+    assert warnings == []
+    assert captured["cmd"][0] == str(canonical)
+    assert captured["cmd"][0] != str(requested)
+    assert captured["env"]["BWS_ACCESS_TOKEN"] == "synthetic-token"
 
 
 
@@ -296,7 +583,9 @@ def test_env_loader_calls_bsm_when_enabled(tmp_path, monkeypatch):
 
 
 
-def test_disk_cache_key_mismatch_triggers_refetch(monkeypatch, tmp_path):
+def test_disk_cache_key_mismatch_triggers_refetch(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """Disk cache entry written by a different token/project is ignored."""
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -334,7 +623,9 @@ def test_disk_cache_key_mismatch_triggers_refetch(monkeypatch, tmp_path):
 
 
 
-def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
+def test_encrypted_cache_writes_without_plaintext(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """Encrypted cache stores last-good secrets without raw values on disk."""
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -384,7 +675,9 @@ def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
 
 
 
-def test_encrypted_cache_falls_back_on_network_error(monkeypatch, tmp_path):
+def test_encrypted_cache_falls_back_on_network_error(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """A fresh-enough encrypted cache is used when BWS is unreachable."""
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -457,7 +750,9 @@ def _seed_stale_disk_cache(home, *, secrets, age_seconds, project_id="proj-1",
     }))
 
 
-def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
+def test_stale_disk_cache_returned_when_bws_fails(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """When bws fails and the disk cache is stale, return the stale secrets
     with a warning rather than raising."""
     home = tmp_path / ".hermes"
@@ -494,7 +789,9 @@ def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
 
 
 
-def test_stale_fallback_skipped_on_auth_failure(monkeypatch, tmp_path):
+def test_stale_fallback_skipped_on_auth_failure(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """An AUTH_FAILED bws error must raise, not serve stale secrets — a bad
     access token indicates a real credential problem the caller needs to
     see, not a transient outage worth papering over."""
@@ -517,7 +814,3 @@ def test_stale_fallback_skipped_on_auth_failure(monkeypatch, tmp_path):
             access_token="0.t", project_id="proj-1", binary=fake_binary,
             cache_ttl_seconds=300, home_path=home,
         )
-
-
-
-

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -12,6 +12,7 @@ import hashlib
 import io
 import json
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -38,17 +39,49 @@ def _reset_caches():
     bw._reset_cache_for_tests()
 
 
+
+def _private_test_ancestors(monkeypatch, path):
+    """Model trusted install ancestors without trusting pytest's shared /tmp."""
+    if os.name == "nt":
+        return
+    original_stat = Path.stat
+    ancestors = {parent.resolve() for parent in path.parents}
+
+    def private_stat(candidate, *args, **kwargs):
+        result = original_stat(candidate, *args, **kwargs)
+        if candidate in ancestors:
+            fields = list(result)
+            fields[4] = 0
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+            return os.stat_result(fields)
+        return result
+
+    monkeypatch.setattr(Path, "stat", private_stat)
+
 @pytest.fixture
 def hermes_home(tmp_path, monkeypatch):
     """Point Hermes at an isolated home directory."""
     home = tmp_path / ".hermes"
     home.mkdir()
+    _private_test_ancestors(monkeypatch, home / "bin" / bw._platform_binary_name())
     monkeypatch.setenv("HERMES_HOME", str(home))
     # Some modules cache get_hermes_home; clear if needed.
     import hermes_constants
     if hasattr(hermes_constants, "_HERMES_HOME_CACHE"):
         hermes_constants._HERMES_HOME_CACHE = None  # type: ignore[attr-defined]
     return home
+
+
+@pytest.fixture
+def trusted_test_bws(monkeypatch):
+    """Bypass binary discovery for subprocess-shape tests using fake files.
+
+    These tests exercise fetch/cache behavior with mocked subprocesses, so the
+    security boundary itself is covered separately by the binary-boundary
+    tests.  Returning the supplied path models a successful use-time gate
+    without making a test fixture look like a real installed BWS binary.
+    """
+    monkeypatch.setattr(bw, "verify_bws_for_use", lambda path: Path(path))
 
 
 # ---------------------------------------------------------------------------
@@ -79,11 +112,65 @@ def test_platform_asset_name(system, machine, libc_text, expected):
     with mock.patch.object(bw.platform, "system", return_value=system), \
          mock.patch.object(bw.platform, "machine", return_value=machine), \
          mock.patch.object(
-             bw.subprocess,
-             "run",
-             return_value=mock.Mock(stdout=libc_text, stderr=libc_text),
+             bw, "_resolve_executable", side_effect=lambda path, **kwargs: Path(path)
+         ), \
+         mock.patch.object(
+             bw, "_probe_binary_version", return_value="musl" in libc_text
          ):
         assert bw._platform_asset_name() == expected
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Linux ldd policy")
+def test_platform_asset_name_rejects_untrusted_ldd(tmp_path, monkeypatch):
+    marker = tmp_path / "ldd-ran"
+    untrusted_dir = tmp_path / "untrusted"
+    untrusted_dir.mkdir()
+    untrusted_dir.chmod(0o777)
+    fake_ldd = untrusted_dir / "ldd"
+    fake_ldd.write_text(
+        "#!/bin/sh\n"
+        "printf '%s' \"${BWS_ACCESS_TOKEN-}\" > \"$LDD_MARKER\"\n"
+        "printf 'musl libc\\n'\n"
+    )
+    fake_ldd.chmod(0o755)
+    monkeypatch.setenv("PATH", str(untrusted_dir))
+    monkeypatch.setenv("LDD_MARKER", str(marker))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "must-not-reach-ldd")
+    monkeypatch.setattr(bw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(bw.platform, "machine", lambda: "x86_64")
+
+    # The temporary PATH entry is not a trusted root-owned chain, so ldd is
+    # rejected before subprocess creation and the marker is never written.
+    assert bw._platform_asset_name() == (
+        f"bws-x86_64-unknown-linux-gnu-{bw._BWS_VERSION}.zip"
+    )
+    assert not marker.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Linux ldd policy")
+def test_platform_asset_name_uses_trusted_ldd_probe(monkeypatch):
+    trusted_ldd = shutil.which("ldd")
+    if not trusted_ldd:
+        pytest.skip("ldd is unavailable")
+    calls = {}
+
+    def fake_probe(path, pattern, **kwargs):
+        calls.update(path=path, pattern=pattern, kwargs=kwargs)
+        return True
+
+    monkeypatch.setattr(bw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(bw.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        bw, "_resolve_executable", lambda path, **kwargs: Path(path).resolve()
+    )
+    monkeypatch.setattr(bw, "_probe_binary_version", fake_probe)
+
+    assert bw._platform_asset_name() == (
+        f"bws-x86_64-unknown-linux-musl-{bw._BWS_VERSION}.zip"
+    )
+    assert calls["path"] == Path(trusted_ldd).resolve()
+    assert calls["pattern"] == bw._LDD_MUSL_PATTERN
+    assert calls["kwargs"] == {"timeout": 2}
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +181,7 @@ def test_platform_asset_name(system, machine, libc_text, expected):
 def _make_fake_zip(binary_bytes: bytes) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("bws", binary_bytes)
+        zf.writestr(bw._platform_binary_name(), binary_bytes)
     return buf.getvalue()
 
 
@@ -135,6 +222,34 @@ def test_safe_extract_member_rejects_traversal(tmp_path, evil_name):
 
 
 
+def test_safe_extract_member_rejects_symlink_member(tmp_path):
+    info = zipfile.ZipInfo("bws")
+    info.create_system = 3  # Unix
+    info.external_attr = (stat.S_IFLNK | 0o777) << 16
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(info, "../escape")
+    buf.seek(0)
+
+    dest = tmp_path / "extract"
+    dest.mkdir()
+    with zipfile.ZipFile(buf) as zf:
+        with pytest.raises(RuntimeError, match="symbolic-link"):
+            bw._safe_extract_member(zf, "bws", dest)
+
+
+def test_find_bws_rejects_user_owned_path_binary(tmp_path, monkeypatch):
+    fake = tmp_path / "bws"
+    fake.write_bytes(b"not the Bitwarden CLI")
+    fake.chmod(0o755)
+    home = tmp_path / "home"
+    (home / "bin").mkdir(parents=True)
+    monkeypatch.setattr(bw, "_hermes_bin_dir", lambda: home / "bin")
+    monkeypatch.setattr(bw.shutil, "which", lambda _name: str(fake))
+
+    assert bw.find_bws() is None
+
+
 def test_install_bws_happy_path(hermes_home, monkeypatch):
     fake_binary = b"#!/bin/sh\necho 'bws fake 2.0.0'\n"
     zip_bytes = _make_fake_zip(fake_binary)
@@ -157,8 +272,155 @@ def test_install_bws_happy_path(hermes_home, monkeypatch):
     path = bw.install_bws()
     assert path.exists()
     assert path.read_bytes() == fake_binary
-    # Executable bit set
-    assert path.stat().st_mode & stat.S_IXUSR
+    if os.name != "nt":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o700
+        assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+    assert bw._managed_bws_checksum_path(path).read_text().strip() == hashlib.sha256(
+        fake_binary
+    ).hexdigest()
+    assert bw.find_bws() == path
+
+
+def test_managed_bws_tamper_is_rejected(hermes_home, monkeypatch):
+    fake_binary = b"#!/bin/sh\necho 'bws fake 2.0.0'\n"
+    zip_bytes = _make_fake_zip(fake_binary)
+    asset_name = bw._platform_asset_name()
+    checksum_text = f"{hashlib.sha256(zip_bytes).hexdigest()}  {asset_name}\n"
+
+    def fake_download(url, dest):
+        if url.endswith(".zip"):
+            Path(dest).write_bytes(zip_bytes)
+        else:
+            Path(dest).write_text(checksum_text)
+
+    monkeypatch.setattr(bw, "_http_download", fake_download)
+    monkeypatch.setattr(bw.shutil, "which", lambda _name: None)
+    path = bw.install_bws()
+    path.write_bytes(b"tampered")
+
+    assert not bw._verify_managed_bws(path)
+    assert bw.find_bws() is None
+
+
+def _make_managed_bws_fixture(tmp_path, name="managed", *, monkeypatch=None):
+    bin_dir = tmp_path / name / "bin"
+    bin_dir.mkdir(parents=True)
+    bin_dir.chmod(0o700)
+    path = bin_dir / bw._platform_binary_name()
+    if monkeypatch is not None:
+        _private_test_ancestors(monkeypatch, path)
+    payload = b"managed bws"
+    path.write_bytes(payload)
+    path.chmod(0o700)
+    checksum = bw._managed_bws_checksum_path(path)
+    checksum.write_text(hashlib.sha256(payload).hexdigest() + "\n")
+    checksum.chmod(0o600)
+    return path
+
+
+def _patch_managed_bws_owners(monkeypatch, path, *, binary_owner, directory_owner):
+    original_stat = bw.Path.stat
+    resolved_path = path.resolve()
+    resolved_parent = path.parent.resolve()
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        if self == resolved_path:
+            fields = list(result)
+            fields[4] = binary_owner
+            return os.stat_result(fields)
+        if self == resolved_parent:
+            fields = list(result)
+            fields[4] = directory_owner
+            return os.stat_result(fields)
+        return result
+
+    monkeypatch.setattr(bw.Path, "stat", fake_stat)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+@pytest.mark.parametrize("owner_kind", ["root", "current"])
+def test_managed_bws_accepts_root_and_current_user_owners(
+    monkeypatch, tmp_path, owner_kind
+):
+    path = _make_managed_bws_fixture(tmp_path, owner_kind, monkeypatch=monkeypatch)
+    current_uid = os.geteuid()
+    owner = 0 if owner_kind == "root" else current_uid
+    _patch_managed_bws_owners(
+        monkeypatch,
+        path,
+        binary_owner=owner,
+        directory_owner=owner,
+    )
+    monkeypatch.setattr(bw.os, "geteuid", lambda: current_uid)
+
+    assert bw._verify_managed_bws(path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_managed_bws_rejects_foreign_binary_owner(monkeypatch, tmp_path):
+    path = _make_managed_bws_fixture(tmp_path, "foreign-binary", monkeypatch=monkeypatch)
+    current_uid = os.geteuid()
+    _patch_managed_bws_owners(
+        monkeypatch,
+        path,
+        binary_owner=424242,
+        directory_owner=current_uid,
+    )
+    monkeypatch.setattr(bw.os, "geteuid", lambda: current_uid)
+
+    assert not bw._verify_managed_bws(path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="ownership policy is POSIX-specific")
+def test_managed_bws_rejects_foreign_directory_owner(monkeypatch, tmp_path):
+    path = _make_managed_bws_fixture(tmp_path, "foreign-directory", monkeypatch=monkeypatch)
+    current_uid = os.geteuid()
+    _patch_managed_bws_owners(
+        monkeypatch,
+        path,
+        binary_owner=current_uid,
+        directory_owner=424242,
+    )
+    monkeypatch.setattr(bw.os, "geteuid", lambda: current_uid)
+
+    assert not bw._verify_managed_bws(path)
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="symlink creation and permission semantics are POSIX-specific",
+)
+def test_managed_bws_canonicalizes_symlinked_ancestors(tmp_path, monkeypatch):
+    real_home = tmp_path / "real-home"
+    real_bin = real_home / "bin"
+    real_bin.mkdir(parents=True)
+    real_bin.chmod(0o700)
+    path = real_bin / "bws"
+    payload = b"managed bws"
+    path.write_bytes(payload)
+    path.chmod(0o700)
+    checksum = real_bin / ".bws.sha256"
+    checksum.write_text(hashlib.sha256(payload).hexdigest() + "\n")
+    checksum.chmod(0o600)
+
+    _private_test_ancestors(monkeypatch, path)
+    aliased_home = tmp_path / "aliased-home"
+    aliased_home.symlink_to(real_home, target_is_directory=True)
+    aliased_path = aliased_home / "bin" / "bws"
+    monkeypatch.setattr(bw, "_hermes_bin_dir", lambda: aliased_home / "bin")
+
+    # The managed file remains valid when HERMES_HOME has a symlinked
+    # ancestor, and a canonical PATH result is still classified as managed.
+    assert bw._verify_managed_bws(aliased_path)
+    assert bw._is_managed_bws(path.resolve())
+    assert bw.verify_bws_for_use(aliased_path) == path.resolve()
+
+    # Canonicalizing the parent must not turn a leaf symlink into an accepted
+    # managed binary.
+    leaf = real_bin / "bws-link"
+    leaf.symlink_to(path)
+    assert not bw._verify_managed_bws(leaf)
 
 
 
@@ -186,7 +448,7 @@ def _fake_bws_payload(items):
 
 
 
-def test_fetch_server_url_sets_env(monkeypatch, tmp_path):
+def test_fetch_server_url_sets_env(monkeypatch, tmp_path, trusted_test_bws):
     """server_url must be plumbed into the subprocess as BWS_SERVER_URL."""
     fake_binary = tmp_path / "bws"
     fake_binary.write_text("")
@@ -208,6 +470,56 @@ def test_fetch_server_url_sets_env(monkeypatch, tmp_path):
         server_url="https://vault.bitwarden.eu",
     )
     assert captured_env.get("BWS_SERVER_URL") == "https://vault.bitwarden.eu"
+
+
+def test_run_bws_list_rejects_unverified_binary_before_token_child(
+    monkeypatch, tmp_path
+):
+    """Every credential-bearing fetch must pass the use-time binary gate."""
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("#!/bin/sh\n")
+    run = mock.Mock()
+    monkeypatch.setattr(bw, "verify_bws_for_use", lambda _path: None)
+    monkeypatch.setattr(bw.subprocess, "run", run)
+
+    with pytest.raises(RuntimeError, match="use-time verification"):
+        bw._run_bws_list(fake_binary, "synthetic-token", "project-1")
+    run.assert_not_called()
+
+
+def test_run_bws_list_executes_canonical_verified_path(
+    monkeypatch, tmp_path
+):
+    """The child must use the exact canonical path returned by verification."""
+    requested = tmp_path / "path-spelling" / "bws"
+    canonical = tmp_path / "trusted" / "bws"
+    requested.parent.mkdir()
+    canonical.parent.mkdir()
+    requested.write_text("placeholder")
+    canonical.write_text("placeholder")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return mock.Mock(
+            returncode=0,
+            stdout=_fake_bws_payload([{"key": "K", "value": "v"}]),
+            stderr="",
+        )
+
+    monkeypatch.setattr(bw, "verify_bws_for_use", lambda _path: canonical)
+    monkeypatch.setattr(bw.subprocess, "run", fake_run)
+
+    secrets, warnings = bw._run_bws_list(
+        requested, "synthetic-token", "project-1"
+    )
+
+    assert secrets == {"K": "v"}
+    assert warnings == []
+    assert captured["cmd"][0] == str(canonical)
+    assert captured["cmd"][0] != str(requested)
+    assert captured["env"]["BWS_ACCESS_TOKEN"] == "synthetic-token"
 
 
 
@@ -296,7 +608,9 @@ def test_env_loader_calls_bsm_when_enabled(tmp_path, monkeypatch):
 
 
 
-def test_disk_cache_key_mismatch_triggers_refetch(monkeypatch, tmp_path):
+def test_disk_cache_key_mismatch_triggers_refetch(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """Disk cache entry written by a different token/project is ignored."""
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -334,7 +648,9 @@ def test_disk_cache_key_mismatch_triggers_refetch(monkeypatch, tmp_path):
 
 
 
-def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
+def test_encrypted_cache_writes_without_plaintext(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """Encrypted cache stores last-good secrets without raw values on disk."""
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -384,7 +700,9 @@ def test_encrypted_cache_writes_without_plaintext(monkeypatch, tmp_path):
 
 
 
-def test_encrypted_cache_falls_back_on_network_error(monkeypatch, tmp_path):
+def test_encrypted_cache_falls_back_on_network_error(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """A fresh-enough encrypted cache is used when BWS is unreachable."""
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -457,7 +775,9 @@ def _seed_stale_disk_cache(home, *, secrets, age_seconds, project_id="proj-1",
     }))
 
 
-def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
+def test_stale_disk_cache_returned_when_bws_fails(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """When bws fails and the disk cache is stale, return the stale secrets
     with a warning rather than raising."""
     home = tmp_path / ".hermes"
@@ -494,7 +814,9 @@ def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
 
 
 
-def test_stale_fallback_skipped_on_auth_failure(monkeypatch, tmp_path):
+def test_stale_fallback_skipped_on_auth_failure(
+    monkeypatch, tmp_path, trusted_test_bws
+):
     """An AUTH_FAILED bws error must raise, not serve stale secrets — a bad
     access token indicates a real credential problem the caller needs to
     see, not a transient outage worth papering over."""
@@ -519,5 +841,27 @@ def test_stale_fallback_skipped_on_auth_failure(monkeypatch, tmp_path):
         )
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ancestor ownership boundary")
+@pytest.mark.parametrize("unsafe", ["owner", "writable"])
+def test_managed_bws_rejects_replaceable_profile_ancestor(tmp_path, monkeypatch, unsafe):
+    path = _make_managed_bws_fixture(tmp_path)
+    foreign_ancestor = path.parent.parent
+    original_stat = bw.Path.stat
+    monkeypatch.setattr(bw, "_get_effective_uid", lambda: 0)
+    monkeypatch.setattr("agent.secret_sources._binary_security._get_effective_uid", lambda: 0)
 
+    def controlled_stat(candidate, *args, **kwargs):
+        result = original_stat(candidate, *args, **kwargs)
+        fields = list(result)
+        fields[4] = 0
+        if stat.S_ISDIR(result.st_mode):
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+        if candidate == foreign_ancestor:
+            if unsafe == "owner":
+                fields[4] = 424242
+            else:
+                fields[0] |= stat.S_IWOTH
+        return os.stat_result(fields)
 
+    monkeypatch.setattr(bw.Path, "stat", controlled_stat)
+    assert not bw._verify_managed_bws(path)

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import subprocess
 import sys
 import time
@@ -24,6 +25,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from agent.secret_sources import onepassword as op  # noqa: E402
+from agent.secret_sources import _binary_security as binary_security  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -52,6 +54,24 @@ def _ok(value: str):
 
 def _err(code: int, stderr: str):
     return mock.Mock(returncode=code, stdout="", stderr=stderr)
+
+
+def _patch_private_explicit_chain(monkeypatch):
+    """Give a temp fixture the metadata of a private user-owned chain."""
+    original_stat = binary_security.Path.stat
+    current_uid = os.geteuid()
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        fields = list(result)
+        if stat.S_ISDIR(result.st_mode):
+            fields[4] = current_uid
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+        elif stat.S_ISREG(result.st_mode):
+            fields[4] = current_uid
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(binary_security.Path, "stat", fake_stat)
 
 
 # ---------------------------------------------------------------------------
@@ -206,13 +226,15 @@ def test_connect_credential_change_invalidates_cache(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX parent ownership policy")
 def test_find_op_pinned_path_not_on_path(tmp_path, monkeypatch):
     pinned = tmp_path / "op"
     pinned.write_text("")
     pinned.chmod(0o755)
+    _patch_private_explicit_chain(monkeypatch)
     # PATH lookup must NOT be consulted when a binary_path is pinned.
     monkeypatch.setattr(op.shutil, "which", lambda name: "/usr/bin/op")
-    assert op.find_op(str(pinned)) == pinned
+    assert op.find_op(str(pinned)) == pinned.resolve()
 
 
 
@@ -220,6 +242,105 @@ def test_find_op_pinned_path_not_on_path(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # apply_onepassword_secrets
 # ---------------------------------------------------------------------------
+
+
+def test_find_op_requires_absolute_binary_path(tmp_path):
+    pinned = tmp_path / "op"
+    pinned.write_text("")
+    pinned.chmod(0o755)
+    assert op.find_op("op") is None
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="symlink creation and permission semantics are POSIX-specific",
+)
+def test_find_op_resolves_pinned_symlink(tmp_path, monkeypatch):
+    target = tmp_path / "op-real"
+    target.write_text("")
+    target.chmod(0o755)
+    link = tmp_path / "op"
+    link.symlink_to(target)
+    _patch_private_explicit_chain(monkeypatch)
+
+    assert op.find_op(str(link)) == target.resolve()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX parent ownership policy")
+def test_find_op_rejects_explicit_path_with_writable_parent(tmp_path):
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    shared.chmod(0o777)
+    fake = shared / "op"
+    fake.write_text("")
+    fake.chmod(0o755)
+
+    assert op.find_op(str(fake)) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX parent ownership policy")
+def test_find_op_rejects_explicit_path_with_other_owner_parent(
+    tmp_path, monkeypatch
+):
+    shared = tmp_path / "other-owner"
+    shared.mkdir()
+    shared.chmod(0o700)
+    fake = shared / "op"
+    fake.write_text("")
+    fake.chmod(0o755)
+    resolved_shared = shared.resolve()
+    _patch_private_explicit_chain(monkeypatch)
+    original_stat = binary_security.Path.stat
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        fields = list(result)
+        if self == resolved_shared:
+            fields[4] = os.geteuid() + 1
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(binary_security.Path, "stat", fake_stat)
+
+    assert op.find_op(str(fake)) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX parent ownership policy")
+def test_apply_rejects_untrusted_explicit_binary_before_op_read(
+    monkeypatch, tmp_path
+):
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    shared.chmod(0o777)
+    fake = shared / "op"
+    fake.write_text("")
+    fake.chmod(0o755)
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "must-not-reach-op")
+    calls = []
+    monkeypatch.setattr(
+        op,
+        "_run_op_read",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = op.apply_onepassword_secrets(
+        enabled=True,
+        env={"K": "op://V/I/F"},
+        binary_path=str(fake),
+        cache_ttl_seconds=0,
+    )
+
+    assert not result.ok
+    assert "not an executable op binary" in result.error
+    assert calls == []
+
+
+def test_find_op_rejects_user_owned_path_binary(tmp_path, monkeypatch):
+    fake = tmp_path / "op"
+    fake.write_text("")
+    fake.chmod(0o755)
+    monkeypatch.setattr(op.shutil, "which", lambda _name: str(fake))
+
+    assert op.find_op() is None
 
 
 def test_apply_disabled_returns_empty():
@@ -295,7 +416,3 @@ def test_apply_never_overrides_token_var(monkeypatch, tmp_path):
     assert "OP_SERVICE_ACCOUNT_TOKEN" in result.skipped
     assert os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "original"
     assert calls["n"] == 0
-
-
-
-

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import subprocess
 import sys
 import time
@@ -24,6 +25,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from agent.secret_sources import onepassword as op  # noqa: E402
+from agent.secret_sources import _binary_security as binary_security  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +56,35 @@ def _err(code: int, stderr: str):
     return mock.Mock(returncode=code, stdout="", stderr=stderr)
 
 
+def _patch_private_explicit_chain(monkeypatch):
+    """Give a temp fixture the metadata of a private user-owned chain."""
+    original_stat = binary_security.Path.stat
+    current_uid = os.geteuid()
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        fields = list(result)
+        if stat.S_ISDIR(result.st_mode):
+            fields[4] = current_uid
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+        elif stat.S_ISREG(result.st_mode):
+            fields[4] = current_uid
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(binary_security.Path, "stat", fake_stat)
+
+
+def _trusted_explicit_binary(tmp_path, monkeypatch):
+    fake = tmp_path / "op.exe"
+    fake.write_text("inert executable")
+    fake.chmod(0o755)
+    if os.name == "nt":
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    else:
+        _patch_private_explicit_chain(monkeypatch)
+    return fake
+
+
 # ---------------------------------------------------------------------------
 # Reference validation
 # ---------------------------------------------------------------------------
@@ -81,8 +112,7 @@ def test_validate_references_filters_bad_names_and_refs():
 
 
 def test_fetch_happy_path(monkeypatch, tmp_path):
-    fake_op = tmp_path / "op"
-    fake_op.write_text("")
+    fake_op = _trusted_explicit_binary(tmp_path, monkeypatch)
     values = {
         "op://Private/OpenAI/api key": "sk-abc\n",
         "op://Private/Anthropic/credential": "sk-ant-xyz",
@@ -113,8 +143,7 @@ def test_fetch_happy_path(monkeypatch, tmp_path):
 
 
 def test_fetch_read_failure_becomes_warning(monkeypatch, tmp_path):
-    fake_op = tmp_path / "op"
-    fake_op.write_text("")
+    fake_op = _trusted_explicit_binary(tmp_path, monkeypatch)
     monkeypatch.setattr(
         op.subprocess, "run", lambda *a, **k: _err(1, "\x1b[31m[ERROR] not signed in\x1b[0m")
     )
@@ -144,8 +173,7 @@ def test_fetch_read_failure_becomes_warning(monkeypatch, tmp_path):
 
 
 def test_inprocess_cache_hit(monkeypatch, tmp_path):
-    fake_op = tmp_path / "op"
-    fake_op.write_text("")
+    fake_op = _trusted_explicit_binary(tmp_path, monkeypatch)
     calls = {"n": 0}
 
     def fake_run(*a, **k):
@@ -170,8 +198,7 @@ def test_inprocess_cache_hit(monkeypatch, tmp_path):
 
 def test_connect_credential_change_invalidates_cache(monkeypatch, tmp_path):
     """A different 1Password Connect identity must not reuse a cached value."""
-    fake_op = tmp_path / "op"
-    fake_op.write_text("")
+    fake_op = _trusted_explicit_binary(tmp_path, monkeypatch)
     calls = {"n": 0}
 
     def fake_run(*a, **k):
@@ -206,13 +233,15 @@ def test_connect_credential_change_invalidates_cache(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX parent ownership policy")
 def test_find_op_pinned_path_not_on_path(tmp_path, monkeypatch):
     pinned = tmp_path / "op"
     pinned.write_text("")
     pinned.chmod(0o755)
+    _patch_private_explicit_chain(monkeypatch)
     # PATH lookup must NOT be consulted when a binary_path is pinned.
     monkeypatch.setattr(op.shutil, "which", lambda name: "/usr/bin/op")
-    assert op.find_op(str(pinned)) == pinned
+    assert op.find_op(str(pinned)) == pinned.resolve()
 
 
 
@@ -220,6 +249,105 @@ def test_find_op_pinned_path_not_on_path(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # apply_onepassword_secrets
 # ---------------------------------------------------------------------------
+
+
+def test_find_op_requires_absolute_binary_path(tmp_path):
+    pinned = tmp_path / "op"
+    pinned.write_text("")
+    pinned.chmod(0o755)
+    assert op.find_op("op") is None
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="symlink creation and permission semantics are POSIX-specific",
+)
+def test_find_op_resolves_pinned_symlink(tmp_path, monkeypatch):
+    target = tmp_path / "op-real"
+    target.write_text("")
+    target.chmod(0o755)
+    link = tmp_path / "op"
+    link.symlink_to(target)
+    _patch_private_explicit_chain(monkeypatch)
+
+    assert op.find_op(str(link)) == target.resolve()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX parent ownership policy")
+def test_find_op_rejects_explicit_path_with_writable_parent(tmp_path):
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    shared.chmod(0o777)
+    fake = shared / "op"
+    fake.write_text("")
+    fake.chmod(0o755)
+
+    assert op.find_op(str(fake)) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX parent ownership policy")
+def test_find_op_rejects_explicit_path_with_other_owner_parent(
+    tmp_path, monkeypatch
+):
+    shared = tmp_path / "other-owner"
+    shared.mkdir()
+    shared.chmod(0o700)
+    fake = shared / "op"
+    fake.write_text("")
+    fake.chmod(0o755)
+    resolved_shared = shared.resolve()
+    _patch_private_explicit_chain(monkeypatch)
+    original_stat = binary_security.Path.stat
+
+    def fake_stat(self, *args, **kwargs):
+        result = original_stat(self, *args, **kwargs)
+        fields = list(result)
+        if self == resolved_shared:
+            fields[4] = os.geteuid() + 1
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(binary_security.Path, "stat", fake_stat)
+
+    assert op.find_op(str(fake)) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX parent ownership policy")
+def test_apply_rejects_untrusted_explicit_binary_before_op_read(
+    monkeypatch, tmp_path
+):
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    shared.chmod(0o777)
+    fake = shared / "op"
+    fake.write_text("")
+    fake.chmod(0o755)
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "must-not-reach-op")
+    calls = []
+    monkeypatch.setattr(
+        op,
+        "_run_op_read",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = op.apply_onepassword_secrets(
+        enabled=True,
+        env={"K": "op://V/I/F"},
+        binary_path=str(fake),
+        cache_ttl_seconds=0,
+    )
+
+    assert not result.ok
+    assert "not an executable op binary" in result.error
+    assert calls == []
+
+
+def test_find_op_rejects_user_owned_path_binary(tmp_path, monkeypatch):
+    fake = tmp_path / "op"
+    fake.write_text("")
+    fake.chmod(0o755)
+    monkeypatch.setattr(op.shutil, "which", lambda _name: str(fake))
+
+    assert op.find_op() is None
 
 
 def test_apply_disabled_returns_empty():
@@ -238,14 +366,14 @@ def test_apply_missing_binary_sets_error(monkeypatch):
 
 
 def test_apply_sets_env(monkeypatch, tmp_path):
-    fake_op = tmp_path / "op"
-    fake_op.write_text("")
+    fake_op = _trusted_explicit_binary(tmp_path, monkeypatch)
     monkeypatch.setattr(op, "find_op", lambda binary_path="": fake_op)
     monkeypatch.setattr(op.subprocess, "run", lambda *a, **k: _ok("resolved-val"))
     monkeypatch.delenv("MY_OP_KEY", raising=False)
 
     result = op.apply_onepassword_secrets(
         enabled=True, env={"MY_OP_KEY": "op://V/I/F"}, cache_ttl_seconds=0,
+        binary_path=str(fake_op),
     )
     assert result.ok
     assert result.applied == ["MY_OP_KEY"]
@@ -297,5 +425,90 @@ def test_apply_never_overrides_token_var(monkeypatch, tmp_path):
     assert calls["n"] == 0
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX trust-chain regression")
+def test_changed_explicit_binary_is_rejected_before_credentials(monkeypatch, tmp_path):
+    fake = tmp_path / "op"
+    fake.write_text("inert executable")
+    fake.chmod(0o755)
+    _patch_private_explicit_chain(monkeypatch)
+    captured = op.find_op(str(fake))
+    assert captured == fake.resolve()
+    fake.chmod(0o777)
+    calls = []
+    monkeypatch.setattr(op.subprocess, "run", lambda *a, **kw: calls.append(kw) or _ok("secret"))
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "inert-service-account-token")
+
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references={"VALUE": "op://V/I/F"}, binary=captured, use_cache=False,
+    )
+
+    assert secrets == {}
+    assert warnings and "verification" in warnings[0]
+    assert calls == []
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX trust-chain regression")
+def test_each_reference_revalidates_explicit_binary(monkeypatch, tmp_path):
+    fake = tmp_path / "op"
+    fake.write_text("inert executable")
+    fake.chmod(0o755)
+    _patch_private_explicit_chain(monkeypatch)
+    calls = []
+
+    def first_read(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        fake.chmod(0o777)
+        return _ok("first-value")
+
+    monkeypatch.setattr(op.subprocess, "run", first_read)
+    secrets, warnings = op.fetch_onepassword_secrets(
+        references={"A": "op://V/I/A", "B": "op://V/I/B"},
+        binary_path=str(fake), use_cache=False,
+    )
+
+    assert secrets == {"A": "first-value"}
+    assert len(warnings) == 1 and "verification" in warnings[0]
+    assert len(calls) == 1
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX PATH ownership regression")
+@pytest.mark.parametrize("entrypoint", ["apply", "source"])
+def test_source_path_policy_remains_strict_between_reads(monkeypatch, tmp_path, entrypoint):
+    fake = tmp_path / "op"
+    fake.write_text("inert executable")
+    fake.chmod(0o755)
+    original_stat = binary_security.Path.stat
+    owner = [0]
+
+    def trusted_stat(path, *args, **kwargs):
+        result = original_stat(path, *args, **kwargs)
+        fields = list(result)
+        fields[4] = owner[0] if path == fake else 0
+        if stat.S_ISDIR(result.st_mode):
+            fields[0] &= ~(stat.S_IWGRP | stat.S_IWOTH)
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(binary_security.Path, "stat", trusted_stat)
+    monkeypatch.setattr(op.shutil, "which", lambda _name: str(fake))
+    monkeypatch.setattr(op, "_probe_binary_version", lambda *a, **kw: True)
+    calls = []
+
+    def first_read(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        owner[0] = os.geteuid() or 424242
+        return _ok("first-value")
+
+    monkeypatch.setattr(op.subprocess, "run", first_read)
+    cfg = {"enabled": True, "env": {"A": "op://V/I/A", "B": "op://V/I/B"}, "cache_ttl_seconds": 0}
+    for name in cfg["env"]:
+        monkeypatch.delenv(name, raising=False)
+    try:
+        if entrypoint == "apply":
+            result = op.apply_onepassword_secrets(**cfg)
+        else:
+            result = op.OnePasswordSource().fetch(cfg, tmp_path)
+        assert result.secrets == {"A": "first-value"}
+        assert len(result.warnings) == 1 and "verification" in result.warnings[0]
+        assert len(calls) == 1
+    finally:
+        os.environ.pop("A", None)

--- a/tests/tools/test_subprocess_utf8_encoding.py
+++ b/tests/tools/test_subprocess_utf8_encoding.py
@@ -37,13 +37,17 @@ def _assert_utf8_kwargs(mock_run):
     )
 
 
-def test_op_whoami_passes_utf8_encoding(tmp_path):
+def test_op_whoami_passes_utf8_encoding(tmp_path, monkeypatch):
     """_op_whoami must pass encoding='utf-8', errors='replace' so op CLI
     output containing non-ASCII account names doesn't crash on cp936."""
     from hermes_cli import onepassword_secrets_cli as op_cli
 
     fake_binary = tmp_path / "op"
     fake_binary.write_bytes(b"")
+    # Binary policy has dedicated tests; exercise the authenticated/version
+    # subprocess boundary here with an already verified path.
+    monkeypatch.setattr(op_cli.op_src, "verify_op_for_use",
+                        lambda path, **kwargs: Path(path))
     with patch.object(op_cli.subprocess, "run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0, stdout="user@example.com", stderr=""
@@ -52,7 +56,7 @@ def test_op_whoami_passes_utf8_encoding(tmp_path):
     _assert_utf8_kwargs(mock_run)
 
 
-def test_op_version_passes_utf8_encoding(tmp_path):
+def test_op_version_passes_utf8_encoding(tmp_path, monkeypatch):
     """_op_version must pass encoding='utf-8', errors='replace' so op CLI
     output containing non-ASCII bytes doesn't crash on cp936. Pairs with
     _op_whoami — both run in the same setup/status CLI flow."""
@@ -60,6 +64,10 @@ def test_op_version_passes_utf8_encoding(tmp_path):
 
     fake_binary = tmp_path / "op"
     fake_binary.write_bytes(b"")
+    # Binary policy has dedicated tests; exercise the authenticated/version
+    # subprocess boundary here with an already verified path.
+    monkeypatch.setattr(op_cli.op_src, "verify_op_for_use",
+                        lambda path, **kwargs: Path(path))
     with patch.object(op_cli.subprocess, "run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0, stdout="2.24.0", stderr=""


### PR DESCRIPTION
An op executable found on PATH or selected with binary_path can receive
1Password credentials. Previously discovery accepted relative or replaceable
paths, and a file that became writable after discovery still received tokens.

Canonicalize executable paths and validate their type, ownership, modes and
parent chain. Automatic POSIX PATH discovery requires root ownership; explicit
absolute paths permit a private root/current-user chain. Windows accepts native
executables under the existing machine/profile roots. Version probes receive a
minimal environment and a trusted helper PATH.

Revalidate the path before every op read and CLI authentication probe.
CLI version probes also receive the minimal environment. Preserve direct binary= as explicit
caller selection; source and apply entrypoints retain the distinction between
configured paths and automatic PATH discovery throughout the fetch.

Related #77466

Bitwarden adds install-time checksum sidecars, recomputed digests before use, and full private root/current-user ancestor checks on POSIX. It rejects symlink archive members and requires the pinned BWS version for automatic PATH candidates. CLI status, project listing and secret fetches execute the canonical path that passed validation; the backend import stays lazy for Windows updates.

The two-commit pseudo-stack keeps each prefix usable:

1. Shared executable policy plus all OnePassword fetch and CLI invocation gates.
2. Bitwarden installation integrity, discovery and CLI/secret-fetch gates using that policy.

The first prefix has 416 changed production lines because shared path validation and all OnePassword callers form one invocation contract. Splitting off the helper would leave it unused; splitting off the use gates would leave some paths using a weaker decision. Later repairs are folded into their owning prefix.

Validation: the original head passed 71 selected tests. Five current-main OnePassword discovery failures, two use-time failures, three CLI probe failures, a managed-path mismatch and two managed-ancestor failures reproduced before their fixes. Bitwarden's original regression suite reproduced untrusted ldd execution and tampered CLI invocation. The original first-prefix matrix passed 113 tests. After hosted CI exposed two neighboring UTF-8 fixtures, their verified-path setup was corrected within the owning OnePassword prefix; both real subprocess encoding assertions remain. The repaired first prefix passes 61 focused tests, and the complete branch passes 166 across 15 files, including the Windows-updater lazy-import contract. Ruff and the repository compatibility-pointer check pass.

This preserves explicit binary configuration and managed-profile symlinks. Filesystem checks do not make execution atomic against a concurrent trusted owner or administrator. A credential-free probe environment does not sandbox filesystem access by an explicitly trusted executable. Windows retains canonical-path/native-executable/checksum checks rather than claiming POSIX ownership enforcement.

Not checked: live vault services, native Windows/macOS execution, or CodeRabbit (self-authored P3 maintenance).

Prepared with GPT-6 Astra, ultra reasoning, in Codex Desktop. The account owner loosely reviews my actions and receives usual notifications from GitHub.
