### PR TITLE
fix(cron): record no_agent run sessions for desktop run history

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3161,6 +3161,54 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
     return None
 
 
+def _record_no_agent_run_session(job: dict, doc: str) -> None:
+    """Record a script-only cron run as a lightweight session (desktop run history).
+
+    Agent runs create ``cron_{job_id}_{timestamp}`` sessions through run_agent;
+    no_agent runs short-circuit before any agent machinery, so they never
+    produce a session row and the desktop run-history list (SessionDB
+    ``list_cron_job_runs`` — an id-prefix scan over ``source='cron'``) shows
+    "no runs yet" even though executions.db recorded the run. Write a minimal
+    row here — session + one user-role message carrying the run doc — so the
+    run list, preview and open-run paths work identically for script jobs.
+
+    Deliberately tiny and fully fault-tolerant: this must never affect the
+    script's own result or delivery. Failures degrade to a debug log.
+    """
+    job_id = job.get("id") or ""
+    if not job_id:
+        return
+    try:
+        from hermes_state import SessionDB
+
+        session_db = SessionDB()
+    except Exception as e:
+        logger.debug("Job '%s': no_agent run session store unavailable: %s", job_id, e)
+        return
+    try:
+        session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+        session_db.create_session(session_id, "cron")
+        if doc:
+            session_db.append_message(
+                session_id, "user", doc, timestamp=time.time()
+            )
+        job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+        title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
+        _set_cron_session_title(
+            session_db,
+            session_id,
+            f"{title_base} · {_hermes_now().strftime('%b %d %H:%M')}",
+        )
+        session_db.end_session(session_id, "cron_complete")
+    except Exception as e:
+        logger.debug("Job '%s': failed to record no_agent run session: %s", job_id, e)
+    finally:
+        try:
+            session_db.close()
+        except Exception:
+            pass
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None,
     extra_prompt: Optional[str] = None,
@@ -3211,6 +3259,7 @@ def run_job(
         if not script_path:
             err = "no_agent=True but no script is set for this job"
             logger.error("Job '%s': %s", job_id, err)
+            _record_no_agent_run_session(job, err)
             return False, "", "", err
 
         # Apply workdir if configured — lets scripts use predictable relative
@@ -3254,6 +3303,7 @@ def run_job(
                 f"**Status:** script failed\n\n"
                 f"{output}\n"
             )
+            _record_no_agent_run_session(job, doc)
             return False, doc, alert, output
 
         # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
@@ -3269,6 +3319,7 @@ def run_job(
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
             )
+            _record_no_agent_run_session(job, silent_doc)
             return True, silent_doc, SILENT_MARKER, None
 
         if not output.strip():
@@ -3280,6 +3331,7 @@ def run_job(
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
             )
+            _record_no_agent_run_session(job, silent_doc)
             return True, silent_doc, SILENT_MARKER, None
 
         doc = (
@@ -3290,6 +3342,7 @@ def run_job(
             f"---\n\n"
             f"{output}\n"
         )
+        _record_no_agent_run_session(job, doc)
         return True, doc, output, None
 
     # ---------------------------------------------------------------

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -120,6 +120,48 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     assert "Blocked" in output or "outside" in output
 
 
+def test_run_job_no_agent_records_run_session(hermes_env):
+    """Script-only runs must leave a desktop-visible run session.
+
+    Regression for the desktop run-history list: agent runs create
+    ``cron_{job_id}_{timestamp}`` sessions (SessionDB.list_cron_job_runs),
+    but the no_agent short-circuit never wrote one — so script jobs always
+    showed "no runs yet" in the desktop cron sidebar even though
+    executions.db recorded every tick. The short-circuit now records a
+    lightweight session carrying the run doc.
+    """
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+    from hermes_state import SessionDB
+
+    script_path = hermes_env / "scripts" / "report.sh"
+    script_path.write_text("#!/bin/bash\necho 'sync ok'\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="report.sh", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert error is None
+
+    db = SessionDB()
+    try:
+        runs = db.list_cron_job_runs(job["id"], limit=5)
+        assert len(runs) == 1
+        assert runs[0]["id"].startswith(f"cron_{job['id']}_")
+        assert runs[0]["source"] == "cron"
+        # preview is the shaped (truncated) head of the stored run doc
+        assert (runs[0].get("preview") or "").startswith("# Cron Job:")
+        # the full run doc is persisted as the session's user message
+        rows = db._conn.execute(
+            "SELECT content FROM messages WHERE session_id = ?",
+            (runs[0]["id"],),
+        ).fetchall()
+        assert any("sync ok" in (row[0] or "") for row in rows)
+    finally:
+        db.close()
+
+
 def test_run_job_script_nul_path_fails_cleanly(hermes_env):
     """Sibling of the lifecycle-guard ingestion fix: a NUL-bearing script
     value can survive to fire time (the creation-time guard treats it as


### PR DESCRIPTION
## Bug Description

Desktop cron run-history shows "尚无运行 / no runs yet" for `no_agent` (script-only) jobs even though they fire successfully on schedule. The sidebar's run-history list under each cron job (backed by `GET /api/cron/jobs/{id}/runs` → `SessionDB.list_cron_job_runs`) queries sessions whose id carries the `cron_{job_id}_` prefix. Agent jobs create such a session per run via `run_agent`; script-only jobs take the no_agent short-circuit in `cron/scheduler.run_job`, which never touches the session store — so their history is invisible in the desktop UI (executions.db records every tick, but the panel never shows it).

## Root Cause

`cron/scheduler.py` no_agent short-circuit returns directly after running the script (success / silent / failure paths) without creating a session row. The desktop run-history endpoint only looks at `source='cron'` sessions with the job's id prefix, so script jobs always render an empty list.

## Fix

- New `_record_no_agent_run_session(job, doc)` in `cron/scheduler.py`: opens `SessionDB`, creates a minimal `cron_{job_id}_{timestamp}` session (`source='cron'`), appends one user-role message carrying the same run doc the agent path would produce (status + script output), titles it like agent runs (`<job name> · <time>`), and marks it complete.
- Called at all five return points of the no_agent short-circuit (missing script, script failure, `wakeAgent=false` silent, empty-stdout silent, success).
- Fully fault-tolerant: any failure (SessionDB unavailable, write error) degrades to a debug log and can never affect the script's own result or delivery. SessionDB import stays lazy inside the function so pure-script ticks still don't pay for agent machinery.

## How to Verify

1. Create a `no_agent=True` cron job with a script that echoes something.
2. Trigger it (`hermes cron run <job_id>` or wait for the tick).
3. In Hermes Desktop, expand the job in the 定时任务 (Scheduled Tasks) sidebar — the run now appears with timestamp and output preview, and clicking it opens the run doc.

## Test Plan

- [x] Added regression test `test_run_job_no_agent_records_run_session` (`tests/cron/test_cron_no_agent.py`) — asserts the run session is created, id-prefixed, `source='cron'`, and the full run doc is persisted as the session message.
- [x] Existing tests still pass: `tests/cron/test_cron_no_agent.py` (7), plus `test_scheduler_cron_session_isolation`, `test_run_one_job`, `test_cron_script`, `test_cron_profile_isolation` (29 total).
- [x] Manual verification: triggered the real `Obsidian 日记每日备份` script job on this machine — `state.db` gains `cron_d9c9107a18a5_*` session with title and message, and `list_cron_job_runs` returns it.

## Risk Assessment

Low — the change is additive: the no_agent branch's return values, script execution, and delivery are untouched; a new session row is written only after the script outcome is known, wrapped in try/except with debug-log fallback. Blast radius is limited to the desktop run-history display for script jobs.
