### PR TITLE
fix(tools): bypass read_file dedup in execute_code sandbox

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -38,6 +39,57 @@ class TestReadFileHandler:
         result = json.loads(read_file_tool("/tmp/test.txt"))
         assert "error" in result
         assert "terminal not available" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    @patch("tools.file_tools._resolve_path_for_task")
+    @patch("os.path.getmtime")
+    def test_skip_dedup_bypasses_cache(self, mock_getmtime, mock_resolve, mock_get):
+        """_skip_dedup=True skips the dedup stub and returns full content.
+
+        When execute_code sandbox calls read_file for a path that was
+        already read natively, the dedup path normally returns a content-less
+        stub.  Programmatic callers that set _skip_dedup=True must always
+        receive the full result dict with a ``content`` key (fixes #44843).
+        """
+        from tools.file_tools import read_file_tool, reset_file_dedup
+
+        resolved = Path("/tmp/test-skip.txt")
+        mock_resolve.return_value = resolved
+
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "line1\\nline2"
+        result_obj.to_dict.return_value = {
+            "content": "line1\\nline2",
+            "total_lines": 2,
+        }
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+        mock_getmtime.return_value = 12345.0
+
+        task_id = "tsk-skip-dedup"
+        try:
+            # Call 1 — normal read, populates dedup cache.
+            r1 = json.loads(
+                read_file_tool("/tmp/test-skip.txt", task_id=task_id))
+            assert "content" in r1
+            assert r1["content"] == "line1\\nline2"
+
+            # Call 2 — same path/offset/limit, file unchanged → dedup stub.
+            r2 = json.loads(
+                read_file_tool("/tmp/test-skip.txt", task_id=task_id))
+            assert r2.get("dedup") is True, r2
+            assert r2.get("content_returned") is False
+            assert "content" not in r2
+
+            # Call 3 — _skip_dedup=True bypasses the cache.
+            r3 = json.loads(
+                read_file_tool("/tmp/test-skip.txt", task_id=task_id,
+                               _skip_dedup=True))
+            assert "content" in r3
+            assert r3.get("dedup") is not True
+        finally:
+            reset_file_dedup(task_id)
 
 
 class TestWriteFileHandler:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -746,6 +746,12 @@ def _rpc_server_loop(
                 # their status prints don't leak into the CLI spinner.
                 try:
                     with thread_scoped_silence():
+                        # execute_code sandbox callers are programmatic,
+                        # not agent-loop: bypass read_file dedup so scripts
+                        # always get a consistent result schema with a
+                        # "content" key (fixes #44843).
+                        if tool_name == "read_file" and isinstance(tool_args, dict):
+                            tool_args["_skip_dedup"] = True
                         result = handle_function_call(
                             tool_name, tool_args, task_id=task_id
                         )

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1515,8 +1515,16 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
-    """Read a file with pagination and line numbers."""
+def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default", _skip_dedup: bool = False) -> str:
+    """Read a file with pagination and line numbers.
+
+    Args:
+        _skip_dedup: If True, bypass the dedup cache and always perform a
+            full read.  Internal-only — used by execute_code sandbox to
+            ensure consistent result schemas for programmatic callers
+            (fixes #44843: dedup stub missing ``content`` causes KeyError
+            inside ``execute_code`` scripts).
+    """
     try:
         offset, limit = normalize_read_pagination(offset, limit)
 
@@ -1664,6 +1672,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # If we already read this exact (path, offset, limit) and the
         # file hasn't been modified since, return a lightweight stub
         # instead of re-sending the same content.  Saves context tokens.
+        # execute_code sandbox passes _skip_dedup=True to bypass this
+        # block so programmatic callers always get a consistent result
+        # schema (fixes #44843).
         resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
@@ -1681,42 +1692,43 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 task_data["read_timestamps"] = {}
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
 
-        if cached_mtime is not None:
-            try:
-                current_mtime = os.path.getmtime(resolved_str)
-                if current_mtime == cached_mtime:
-                    # Count repeated stub returns so weak tool-followers that
-                    # ignore the "refer to earlier result" hint don't burn
-                    # their iteration budget in an infinite read loop.  After
-                    # 2 stubs for the same key we escalate to a hard block
-                    # mirroring the count>=4 path on real reads.
-                    with _read_tracker_lock:
-                        hits = task_data["dedup_hits"].get(dedup_key, 0) + 1
-                        task_data["dedup_hits"][dedup_key] = hits
-                        _cap_read_tracker_data(task_data)
+        if not _skip_dedup:
+            if cached_mtime is not None:
+                try:
+                    current_mtime = os.path.getmtime(resolved_str)
+                    if current_mtime == cached_mtime:
+                        # Count repeated stub returns so weak tool-followers that
+                        # ignore the "refer to earlier result" hint don't burn
+                        # their iteration budget in an infinite read loop.  After
+                        # 2 stubs for the same key we escalate to a hard block
+                        # mirroring the count>=4 path on real reads.
+                        with _read_tracker_lock:
+                            hits = task_data["dedup_hits"].get(dedup_key, 0) + 1
+                            task_data["dedup_hits"][dedup_key] = hits
+                            _cap_read_tracker_data(task_data)
 
-                    if hits >= 2:
-                        return tool_error(
-                            f"BLOCKED: You have called read_file on this "
-                            f"exact region {hits + 1} times and the file "
-                            "has NOT changed. STOP calling read_file for "
-                            "this path — the content from your earlier "
-                            "read_file result in this conversation is "
-                            "still current. Proceed with your task using "
-                            "the information you already have.",
-                            path=path,
-                            already_read=hits + 1,
-                        )
+                        if hits >= 2:
+                            return tool_error(
+                                f"BLOCKED: You have called read_file on this "
+                                f"exact region {hits + 1} times and the file "
+                                "has NOT changed. STOP calling read_file for "
+                                "this path — the content from your earlier "
+                                "read_file result in this conversation is "
+                                "still current. Proceed with your task using "
+                                "the information you already have.",
+                                path=path,
+                                already_read=hits + 1,
+                            )
 
-                    return json.dumps({
-                        "status": "unchanged",
-                        "message": _READ_DEDUP_STATUS_MESSAGE,
-                        "path": path,
-                        "dedup": True,
-                        "content_returned": False,
-                    }, ensure_ascii=False)
-            except OSError:
-                pass  # stat failed — fall through to full read
+                        return json.dumps({
+                            "status": "unchanged",
+                            "message": _READ_DEDUP_STATUS_MESSAGE,
+                            "path": path,
+                            "dedup": True,
+                            "content_returned": False,
+                        }, ensure_ascii=False)
+                except OSError:
+                    pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)


### PR DESCRIPTION
read_file_tool returns a content-less dedup stub when the same (path, offset, limit) was already read and the file mtime hasn't changed. execute_code sandbox callers are programmatic, not agent-loop, so they expect a consistent result schema with a content key. When the native read_file tool had already read a path, the sandbox wrapper received the stub dict causing KeyError on r['content'] inside user scripts.

This adds an internal _skip_dedup parameter to read_file_tool that bypasses the dedup cache, and the execute_code RPC dispatcher injects _skip_dedup=True for every read_file call from the sandbox, guaranteeing a full result dict regardless of prior native reads.

Fixes #44843.