### PR TITLE
feat(gateway): single-character scope aliases for plain-text approval replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -463,16 +463,21 @@ def _format_exec_approval_fallback(
         heading = "⚠️ **Smart DENY — owner override for one operation:**"
 
     choices = [f"Reply `{command_prefix}approve` to execute this one operation"]
+    shortcuts = ["`1`/`y`"]
     if not smart_denied and allow_session:
         choices.append(
             f"`{command_prefix}approve session` to approve this pattern for the session"
         )
+        shortcuts.append("`2`/`s`")
         if allow_permanent:
             choices.append(f"`{command_prefix}approve always` to approve permanently")
+            shortcuts.append("`3`/`a`")
     choices.append(f"`{command_prefix}deny` to cancel")
+    shortcuts.append("`0`/`n`")
     return (
         f"{heading}\n```\n{cmd_preview}\n```\nReason: {description}\n\n"
-        + ", ".join(choices[:-1]) + f", or {choices[-1]}."
+        + ", ".join(choices[:-1]) + f", or {choices[-1]}.\n"
+        + "Shortcuts: " + " · ".join(shortcuts) + "."
     )
 
 
@@ -6160,18 +6165,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from tools.approval import has_blocking_approval
             if has_blocking_approval(session_key):
                 _raw_text = (event.text or "").strip().lower()
-                _approve_words = {"approve", "yes", "ok", "okay", "confirm", "y", "👍"}
-                _deny_words = {"deny", "no", "reject", "cancel", "n", "👎"}
+                _approve_words = {"approve", "yes", "ok", "okay", "confirm", "y", "👍", "1"}
+                _deny_words = {"deny", "no", "reject", "cancel", "n", "👎", "0"}
                 _approval_handler = None
                 _normalized_args = ""
                 if _raw_text in _approve_words:
                     _approval_handler = self._handle_approve_command
                 elif _raw_text in _deny_words:
                     _approval_handler = self._handle_deny_command
-                elif _raw_text in {"always", "approve always", "always approve"}:
+                elif _raw_text in {"always", "approve always", "always approve", "3", "a"}:
                     _approval_handler = self._handle_approve_command
                     _normalized_args = "always"
-                elif _raw_text in {"session", "approve session", "session approve"}:
+                elif _raw_text in {"session", "approve session", "session approve", "2", "s"}:
                     _approval_handler = self._handle_approve_command
                     _normalized_args = "session"
                 if _approval_handler is not None:

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -186,3 +186,38 @@ class TestApprovalTextFallbackContract:
         )
         assert "`/approve session`" in text
         assert "`/approve always`" in text
+
+    def test_full_prompt_advertises_all_shortcuts(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "rm -rf /tmp/test", "dangerous deletion", "/",
+        )
+        assert "Shortcuts:" in text
+        assert "`1`/`y`" in text
+        assert "`2`/`s`" in text
+        assert "`3`/`a`" in text
+        assert "`0`/`n`" in text
+
+    def test_smart_deny_shortcuts_omit_session_and_always(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "rm -rf /", "dangerous deletion", "/",
+            allow_permanent=False, smart_denied=True,
+        )
+        assert "Shortcuts:" in text
+        assert "`1`/`y`" in text
+        assert "`0`/`n`" in text
+        assert "`2`/`s`" not in text
+        assert "`3`/`a`" not in text
+
+    def test_no_permanent_shortcut_when_permanent_disallowed(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "rm -rf /", "dangerous deletion", "/",
+            allow_session=True, allow_permanent=False,
+        )
+        assert "`2`/`s`" in text
+        assert "`3`/`a`" not in text

--- a/tests/gateway/test_plaintext_approval_routing.py
+++ b/tests/gateway/test_plaintext_approval_routing.py
@@ -194,3 +194,36 @@ def test_unrelated_text_with_pending_approval_falls_through():
     # Approval still pending — not resolved by unrelated text.
     assert not entry.event.is_set()
     _clear_approval_state()
+
+
+@pytest.mark.parametrize(
+    ("reply", "expected_result"),
+    [
+        ("1", "once"),
+        ("2", "session"),
+        ("3", "always"),
+        ("0", "deny"),
+        ("s", "session"),
+        ("a", "always"),
+    ],
+)
+def test_numeric_short_approval_scopes(reply, expected_result):
+    """Numeric/short aliases (1/2/3/0, s/a) map to the right approval scope.
+
+    Messaging users (WeCom/WeChat, SMS) approve from a phone where typing
+    "/approve always" is slow; a single character must express the full
+    scope matrix."""
+    _clear_approval_state()
+    runner, adapter = _make_runner()
+    session_key, entry = _register_blocking_approval(runner)
+
+    handled = asyncio.run(
+        runner._handle_active_session_busy_message(_make_event(reply), session_key)
+    )
+
+    assert handled is True
+    assert entry.event.is_set()
+    assert entry.result == expected_result
+    adapter._send_with_retry.assert_awaited()
+    _clear_approval_state()
+


### PR DESCRIPTION
# feat(gateway): single-character scope aliases for plain-text approval replies

## Summary

Messaging users (WeCom/WeChat, SMS, Signal) approve dangerous commands by
typing a reply. Today that reply must be a full slash form
(`/approve session`, `/approve always`) or one of the bare words from
#46866 (`yes`, `ok`, `always`, `session`, ...). On a phone, typing
`/approve always` before the 60–120s approval window fails closed is
unreliable, so users either miss the window (auto-deny) or type `/approve`
once when they actually wanted session/always semantics.

This PR extends the plain-text approval routing lane with
single-character aliases covering the full scope matrix, and advertises
them in the approval prompt so the feature is discoverable:

| Reply | Scope |
|---|---|
| `1` / `y` | approve once |
| `2` / `s` | approve for session |
| `3` / `a` | approve always |
| `0` / `n` | deny |

All existing words are preserved; this is strictly additive.

## Changes

1. `gateway/run.py` — extend `_approve_words` / `_deny_words` and the
   `always` / `session` groups in the plain-text approval router
   (`_handle_active_session_busy_message`, the #46866 lane) with the
   numeric/short aliases above.
2. `gateway/run.py` — `_format_exec_approval_fallback` now appends a
   `Shortcuts:` line to the text approval prompt so users know the
   aliases exist. The line mirrors the conditionally-advertised choices:
   `smart_denied` omits session/always, `allow_permanent` gates the
   always alias.

## Design rationale

- **Why single characters?** The approval prompt is rendered on small
  phone screens (WeCom, SMS). One tap beats three words when the clock
  is running.
- **Why this mapping?** `1/2/3/0` is the most common "ranked options"
  convention users already know from interactive menus; `y/s/a/n` are
  the first letters of the scopes for users who prefer letters. Both are
  checked as exact set membership, so `12` or `1f` do not match.
- **False-positive safety.** Aliases only resolve when
  `has_blocking_approval(session_key)` is true — a bare `1` in ordinary
  conversation with no pending approval falls through to normal busy
  handling and never triggers a command. This is the same disambiguator
  #46866 relies on for bare `yes`.
- **No scope regression.** Deny stays distinct from approve: `0`/`n`
  route to `_handle_deny_command`, everything else routes to
  `_handle_approve_command` with the normalized `session`/`always` args.

## Tests

- `tests/gateway/test_plaintext_approval_routing.py` — new
  `test_numeric_short_approval_scopes` parametrized over
  `(1, once), (2, session), (3, always), (0, deny), (s, session),
  (a, always)`; asserts the waiting approval resolves with the correct
  scope result.
- `tests/gateway/test_approval_prompt_redaction.py` — three new
  `TestApprovalTextFallbackContract` cases asserting the Shortcuts line
  renders fully, shrinks under `smart_denied`, and honors
  `allow_permanent`.
- Existing suites untouched and passing: 37 passed
  (`test_plaintext_approval_routing.py`,
  `test_approve_deny_commands.py`,
  `test_approval_prompt_redaction.py`).

## Risks / limitations

- Reply words remain hard-coded (same as the existing #46866 word set);
  no new config surface added in this PR. If localization is wanted,
  the word sets could move into i18n later.
- `0`/`n` deny cannot carry a free-text deny reason the way
  `/deny <reason>` can; users who want to explain still use the slash
  form.

## Checklist

- [x] Smallest footprint: 2 files, no new deps, no architecture change
- [x] Edge capability: gateway routing lane, not core agent / model tools
- [x] Cache-safe: no system-prompt or context mutation
- [x] Behavior-contract tests, not snapshots
- [x] Extends #46866, does not duplicate
