### PR TITLE
fix(memory): inject Hindsight memory on the first turn of a session

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -56,6 +56,12 @@ _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _MIN_CLIENT_VERSION = "0.6.1"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
+# Upper bound for the synchronous recall fallback in prefetch() (first turn
+# of a session). The memory manager runs prefetch in a thread with an 8 s
+# budget (agent/memory_manager.py _EXTERNAL_PREFETCH_TIMEOUT_S); staying
+# under it keeps the first turn fast and avoids marking the provider as
+# "stuck". Normal embedded recalls are ~1-2 s on this class of workload.
+_SYNC_RECALL_FALLBACK_TIMEOUT = 6.0  # seconds
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
 # `update_mode='append'` semantics on retain (vectorize-io/hindsight#932).
 # Without it, reusing a stable session-scoped document_id silently
@@ -1074,9 +1080,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = Hindsight(**kwargs)
         return self._client
 
-    def _run_sync(self, coro):
+    def _run_sync(self, coro, timeout: float | None = None):
         """Schedule *coro* on the shared loop using the configured timeout."""
-        return _run_sync(coro, timeout=self._timeout)
+        return _run_sync(coro, timeout=timeout if timeout is not None else self._timeout)
 
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
@@ -1160,11 +1166,11 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception as exc:
             logger.debug("Hindsight atexit shutdown failed: %s", exc)
 
-    def _run_hindsight_operation(self, operation):
+    def _run_hindsight_operation(self, operation, timeout: float | None = None):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), timeout=timeout)
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
@@ -1175,7 +1181,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), timeout=timeout)
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1469,6 +1475,51 @@ class HindsightMemoryProvider(MemoryProvider):
             f"hindsight_retain to store facts."
         )
 
+    def _build_recall_kwargs(self, query: str) -> dict:
+        """Build the recall API kwargs shared by the async and sync prefetch paths."""
+        if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
+            query = query[:self._recall_max_input_chars]
+        recall_kwargs: dict = {
+            "bank_id": self._bank_id, "query": query,
+            "budget": self._budget, "max_tokens": self._recall_max_tokens,
+        }
+        if self._recall_tags:
+            recall_kwargs["tags"] = self._recall_tags
+            recall_kwargs["tags_match"] = self._recall_tags_match
+        if self._recall_types:
+            recall_kwargs["types"] = self._recall_types
+        return recall_kwargs
+
+    @staticmethod
+    def _format_recall_results(resp) -> str:
+        """Render recall results into the bullet list injected into context."""
+        results = getattr(resp, "results", None)
+        if not results:
+            return ""
+        return "\n".join(f"- {r.text}" for r in results if r.text)
+
+    def _sync_recall(self, query: str) -> str:
+        """Blocking recall with the current query; returns context text.
+
+        Fallback used when no background prefetch result is queued — first
+        turn of a session, or the queued recall raced/failed. Runs inline in
+        the memory manager's prefetch thread (8 s budget), bounded by
+        _SYNC_RECALL_FALLBACK_TIMEOUT so a slow bank never stalls the first
+        turn — on timeout it degrades to the previous cold-start behavior
+        (no injected memory).
+        """
+        recall_kwargs = self._build_recall_kwargs(query)
+        logger.debug("Prefetch: synchronous recall fallback (bank=%s, query_len=%d, budget=%s)",
+                     self._bank_id, len(recall_kwargs["query"]), self._budget)
+        resp = self._run_hindsight_operation(
+            lambda client: client.arecall(**recall_kwargs),
+            timeout=_SYNC_RECALL_FALLBACK_TIMEOUT,
+        )
+        text = self._format_recall_results(resp)
+        logger.debug("Prefetch: synchronous recall returned %d results",
+                     len(resp.results) if getattr(resp, "results", None) else 0)
+        return text
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
@@ -1476,6 +1527,16 @@ class HindsightMemoryProvider(MemoryProvider):
         with self._prefetch_lock:
             result = self._prefetch_result
             self._prefetch_result = ""
+        if not result and self._auto_recall and self._memory_mode != "tools" and not self._shutting_down.is_set():
+            # No queued result from a previous turn (first message of a session,
+            # or the background recall raced/failed). Do a synchronous recall
+            # with the CURRENT query so the first turn still gets memory.
+            logger.debug("Prefetch: no queued result; synchronous recall fallback")
+            try:
+                result = self._sync_recall(query)
+            except Exception as e:
+                logger.debug("Hindsight synchronous recall fallback failed: %s", e, exc_info=True)
+                result = ""
         if not result:
             logger.debug("Prefetch: no results available")
             return ""
@@ -1508,21 +1569,11 @@ class HindsightMemoryProvider(MemoryProvider):
                     resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
                     text = resp.text or ""
                 else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
+                    recall_kwargs = self._build_recall_kwargs(query)
                     logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
                                  self._bank_id, len(query), self._budget)
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
-                    logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = self._format_recall_results(resp)
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -21,6 +21,7 @@ from plugins.memory.hindsight import (
     RECALL_SCHEMA,
     REFLECT_SCHEMA,
     RETAIN_SCHEMA,
+    _SYNC_RECALL_FALLBACK_TIMEOUT,
     _load_config,
     _load_simple_env,
     _build_embedded_profile_env,
@@ -791,7 +792,10 @@ class TestToolHandlers:
 
 
 class TestPrefetch:
-    def test_prefetch_returns_empty_when_no_result(self, provider):
+    def test_prefetch_returns_empty_when_recall_has_no_results(self, provider):
+        # On a cold start the sync fallback runs; an empty recall still
+        # yields no context (graceful degradation, same as the old path).
+        provider._client.arecall = AsyncMock(return_value=SimpleNamespace(results=[]))
         assert provider.prefetch("test") == ""
 
     def test_prefetch_default_preamble(self, provider):
@@ -855,6 +859,98 @@ class TestPrefetch:
         assert call_kwargs["tags"] == ["t1"]
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
+
+
+class TestPrefetchSyncFallback:
+    """prefetch() must not leave the first turn of a session memory-less.
+
+    The async design queues a recall at the end of turn N and injects it at
+    the start of turn N+1, so the very first message of a session has no
+    queued result. prefetch() falls back to a synchronous recall with the
+    CURRENT query so the first turn still gets injected memory.
+    """
+
+    def test_prefetch_falls_back_to_sync_recall(self, provider):
+        result = provider.prefetch("oil change")
+        assert "- Memory 1" in result
+        assert "- Memory 2" in result
+        provider._client.arecall.assert_called_once()
+        assert provider._client.arecall.call_args.kwargs["query"] == "oil change"
+
+    def test_prefetch_uses_queued_result_without_sync_recall(self, provider):
+        provider._prefetch_result = "- queued memory"
+        result = provider.prefetch("irrelevant")
+        assert "- queued memory" in result
+        provider._client.arecall.assert_not_called()
+
+    def test_prefetch_skips_fallback_in_tools_mode(self, provider_with_config):
+        p = provider_with_config(memory_mode="tools")
+        assert p.prefetch("oil change") == ""
+        p._client.arecall.assert_not_called()
+
+    def test_prefetch_skips_fallback_when_auto_recall_off(self, provider_with_config):
+        p = provider_with_config(auto_recall=False)
+        assert p.prefetch("oil change") == ""
+        p._client.arecall.assert_not_called()
+
+    def test_sync_fallback_uses_bounded_timeout(self, provider, monkeypatch):
+        captured = {}
+
+        def _fake_operation(operation, timeout=None):
+            captured["timeout"] = timeout
+            return SimpleNamespace(results=[SimpleNamespace(text="m")])
+
+        monkeypatch.setattr(provider, "_run_hindsight_operation", _fake_operation)
+        result = provider.prefetch("query")
+        # Contract: the fallback passes the module's bounded timeout (kept
+        # under the memory manager's 8s prefetch budget), whatever its value.
+        assert captured["timeout"] == _SYNC_RECALL_FALLBACK_TIMEOUT
+        assert captured["timeout"] < 8.0
+        assert "- m" in result
+
+    def test_sync_fallback_truncates_long_query(self, provider_with_config):
+        p = provider_with_config(recall_max_input_chars=10)
+        p.prefetch("x" * 100)
+        assert len(p._client.arecall.call_args.kwargs["query"]) <= 10
+
+    def test_sync_fallback_degrades_gracefully_on_failure(self, provider, monkeypatch):
+        def _boom(operation, timeout=None):
+            raise RuntimeError("daemon down")
+
+        monkeypatch.setattr(provider, "_run_hindsight_operation", _boom)
+        assert provider.prefetch("query") == ""
+
+
+class TestRecallHelpers:
+    def test_build_recall_kwargs_includes_params(self, provider_with_config):
+        p = provider_with_config(
+            recall_tags=["t1"],
+            recall_tags_match="all",
+            recall_max_tokens=1024,
+            recall_types=["world"],
+        )
+        kwargs = p._build_recall_kwargs("query here")
+        assert kwargs["bank_id"] == "test-bank"
+        assert kwargs["budget"] == "mid"
+        assert kwargs["max_tokens"] == 1024
+        assert kwargs["tags"] == ["t1"]
+        assert kwargs["tags_match"] == "all"
+        assert kwargs["types"] == ["world"]
+        assert kwargs["query"] == "query here"
+
+    def test_format_recall_results_skips_empty_text(self, provider):
+        resp = SimpleNamespace(
+            results=[
+                SimpleNamespace(text="a"),
+                SimpleNamespace(text=""),
+                SimpleNamespace(text="b"),
+            ]
+        )
+        assert provider._format_recall_results(resp) == "- a\n- b"
+
+    def test_format_recall_results_empty(self, provider):
+        assert provider._format_recall_results(SimpleNamespace(results=[])) == ""
+        assert provider._format_recall_results(SimpleNamespace()) == ""
 
 
 # ---------------------------------------------------------------------------
@@ -1248,8 +1344,11 @@ class TestSessionSwitchBufferFlush:
         provider._prefetch_result = "old-session recall: User likes Rust"
         provider.on_session_switch("new-sid")
         assert provider._prefetch_result == ""
-        # And subsequent prefetch() should now report empty, not the leftover.
-        assert provider.prefetch("anything") == ""
+        # The queued leftover is gone; a subsequent prefetch returns fresh
+        # memory for the current query (sync fallback), never the stale text.
+        result = provider.prefetch("anything")
+        assert "old-session recall" not in result
+        assert "Memory 1" in result
 
     def test_in_flight_prefetch_thread_drained_on_switch(self, provider, monkeypatch):
         """on_session_switch must wait for an in-flight prefetch from the


### PR DESCRIPTION
## Problem

`prefetch()` only reads recall results queued by the **previous** turn's `queue_prefetch()` (queue at end of turn N, inject at start of turn N+1). That async design means the **very first message of a session never gets injected memory** — there is no previous turn to queue from. The same happens after a queued recall that raced, failed, or returned nothing.

With `memory_mode=context` and `auto_recall=true`, the first question in a fresh session comes back with zero memory context, forcing the agent to fall back to searching session history instead of using injected memory.

## Fix

When `prefetch()` finds no queued result, it falls back to a **synchronous recall with the current query** (the query the turn is actually about), bounded by a 6 s timeout so a slow bank degrades to the previous cold-start behavior instead of stalling the turn. The memory manager runs prefetch in a thread with an 8 s budget (`agent/memory_manager.py` `_EXTERNAL_PREFETCH_TIMEOUT_S`), so the fallback fits within it.

The fallback is skipped when it would not apply: `memory_mode=tools`, `auto_recall=false`, or during shutdown.

Also extracts the recall-kwargs building and result formatting shared by the async and sync prefetch paths (`_build_recall_kwargs`, `_format_recall_results`) — no behavior change to the async path.

## Tests

- `TestPrefetchSyncFallback` — cold start runs the sync recall with the current query; queued results are used without a sync call; fallback skipped in tools mode / auto_recall off; the 6 s timeout is passed; long queries are truncated; failures degrade to empty context.
- `TestRecallHelpers` — kwargs assembly and result formatting.
- Updated `test_prefetch_returns_empty_when_no_result` (now `..._when_recall_has_no_results`) and `test_prefetch_result_cleared_on_switch` to match the new contract (stale queued text never leaks; fresh sync recall is returned instead).

`python -m pytest tests/plugins/memory/test_hindsight_provider.py` → **131 passed, 1 failed**. The 1 failure (`TestPostSetup::test_local_embedded_setup_materializes_profile_env`) is a pre-existing string-snapshot assertion on the materialized env file, unrelated to this change — it reproduces on `main` without this patch.