### PR TITLE
fix(browser): skip CDP supervisor for agent-browser path (stop target churn)

### DIFF
--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -739,14 +739,32 @@ class CDPSupervisor:
             backoff = min(backoff * 2, 10.0)
 
     async def _attach_initial_page(self) -> None:
-        """Find a page target, attach flattened session, enable domains, install dialog bridge."""
-        resp = await self._cdp("Target.getTargets")
-        targets = resp.get("result", {}).get("targetInfos", [])
-        page_target = next((t for t in targets if t.get("type") == "page"), None)
-        if page_target is None:
+        """Create (or reuse) a page target, attach flattened session, enable domains, install dialog bridge."""
+        try:
+            # Prefer creating a fresh target WE own. Real CDP backends (Chrome,
+            # obscura, ...) list ALL live page targets globally — including
+            # pages owned by other connections. Those remote pages are
+            # volatile: the owning connection may drop them between
+            # getTargets and attachToTarget, so attaching to them races and
+            # fails with "Target not found" (e.g. after an obscura server
+            # restart). A target we create ourselves is stable for the life of
+            # our connection and matches Chrome's behavior for fresh
+            # browser-level clients.
             created = await self._cdp("Target.createTarget", {"url": "about:blank"})
             target_id = created["result"]["targetId"]
-        else:
+        except Exception as e:
+            # Some backends disallow Target.createTarget — fall back to the
+            # first existing page target.
+            logger.debug(
+                "CDP supervisor %s: createTarget unavailable (%s), reusing existing page target",
+                self.task_id,
+                _redact_cdp_error_text(e),
+            )
+            resp = await self._cdp("Target.getTargets")
+            targets = resp.get("result", {}).get("targetInfos", [])
+            page_target = next((t for t in targets if t.get("type") == "page"), None)
+            if page_target is None:
+                raise
             target_id = page_target["targetId"]
 
         attach = await self._cdp(

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -739,32 +739,14 @@ class CDPSupervisor:
             backoff = min(backoff * 2, 10.0)
 
     async def _attach_initial_page(self) -> None:
-        """Create (or reuse) a page target, attach flattened session, enable domains, install dialog bridge."""
-        try:
-            # Prefer creating a fresh target WE own. Real CDP backends (Chrome,
-            # obscura, ...) list ALL live page targets globally — including
-            # pages owned by other connections. Those remote pages are
-            # volatile: the owning connection may drop them between
-            # getTargets and attachToTarget, so attaching to them races and
-            # fails with "Target not found" (e.g. after an obscura server
-            # restart). A target we create ourselves is stable for the life of
-            # our connection and matches Chrome's behavior for fresh
-            # browser-level clients.
+        """Find a page target, attach flattened session, enable domains, install dialog bridge."""
+        resp = await self._cdp("Target.getTargets")
+        targets = resp.get("result", {}).get("targetInfos", [])
+        page_target = next((t for t in targets if t.get("type") == "page"), None)
+        if page_target is None:
             created = await self._cdp("Target.createTarget", {"url": "about:blank"})
             target_id = created["result"]["targetId"]
-        except Exception as e:
-            # Some backends disallow Target.createTarget — fall back to the
-            # first existing page target.
-            logger.debug(
-                "CDP supervisor %s: createTarget unavailable (%s), reusing existing page target",
-                self.task_id,
-                _redact_cdp_error_text(e),
-            )
-            resp = await self._cdp("Target.getTargets")
-            targets = resp.get("result", {}).get("targetInfos", [])
-            page_target = next((t for t in targets if t.get("type") == "page"), None)
-            if page_target is None:
-                raise
+        else:
             target_id = page_target["targetId"]
 
         attach = await self._cdp(

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2218,7 +2218,12 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
     # backend surfaces a CDP URL via override or session_info["cdp_url"]).
     # Idempotent; swallows errors. See _ensure_cdp_supervisor for details.
     # Skip for local sidecars — they have no CDP URL.
-    if not force_local:
+    # Skip for user-supplied CDP override sessions too: the supervisor owns
+    # competing about:blank targets on the agent-browser path, causing target
+    # churn (old page targets get reaped after navigation -> "Target not
+    # found"). Cloud providers (Browserbase) still get the supervisor.
+    is_cdp_override = bool(session_info.get("features", {}).get("cdp_override"))
+    if not force_local and not is_cdp_override:
         _ensure_cdp_supervisor(task_id)
 
     return session_info


### PR DESCRIPTION
Repurposed from the earlier revert. The revert alone (c215db4981) restored getTargets-first attach but did NOT fix the root cause of target churn on the local obscura CDP backend.

**Problem (reproduced live, Aug 2026):** with the supervisor active, every `browser_navigate` creates a fresh supervisor-owned about:blank target. The real page target gets reaped when the CDP session cycles → subsequent `Target.attachToTarget`/`Runtime.evaluate` fail with `Target not found`. This makes multi-step browser flows (login forms etc.) unreliable — each step needs a manual re-attach.

**Root cause:** the CDP supervisor (a dialog/frame-tree helper for snapshots) owns competing targets on the agent-browser path. agent-browser (the Rust CDP driver) attaches to listed targets and navigates the first one — often a supervisor-owned zombie — producing `No page for session` / target churn.

**Fix:** skip `_ensure_cdp_supervisor` for the agent-browser/CDP path. Verified live: with supervisor stopped + fresh obscura, `_run_browser_command` succeeds (`Example Domain`); with supervisor active it fails reproducibly.

**Why this PR:** the earlier revert was correct as far as it went but incomplete — this makes the supervisor not own targets on this path at all.