### PR TITLE
feat(install): independent Electron mirror checksum verification — supply-chain guard (3 mirrors, 1 anchor)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3226,6 +3226,107 @@ function Test-ElectronDist {
     return (Test-Path -LiteralPath $distExe)
 }
 
+# ---------------------------------------------------------------------------
+# Electron mirror supply-chain hardening (#47266 follow-up).
+#
+# When the GitHub download is blocked and we fall back to a third-party
+# mirror (npmmirror.com by default), @electron/get fetches the SHASUMS256.txt
+# checksum file from the SAME mirror - the supply of bytes and the proof of
+# their integrity come from the same party, so a compromised mirror could
+# ship a tampered binary and "verify" it with a matching checksum. This is
+# the same trust-boundary collapse the #81883 cua-driver review flagged for
+# install scripts: executable content must never be judged by its supplier.
+#
+# The helpers below break that link: the checksum file is fetched from the
+# OFFICIAL GitHub release (a ~10KB file that succeeds on blocked networks far
+# more often than the ~150MB binary), and the mirror-downloaded zip is then
+# verified against it independently. If the official checksum is unreachable
+# we degrade transparently (warn) instead of failing the install.
+# ---------------------------------------------------------------------------
+
+# Fetch the OFFICIAL SHASUMS256.txt for the Electron version pinned by
+# $ElectronDir\package.json. Returns a temp-file path on success, $null on
+# failure (callers degrade transparently).
+function Get-OfficialElectronChecksums {
+    param([string]$ElectronDir)
+    $pkg = Join-Path $ElectronDir 'package.json'
+    if (-not (Test-Path -LiteralPath $pkg)) { return $null }
+    try {
+        $ver = (Get-Content -Raw -LiteralPath $pkg | ConvertFrom-Json).version
+    } catch { return $null }
+    if (-not $ver) { return $null }
+    $url = "https://github.com/electron/electron/releases/download/v${ver}/SHASUMS256.txt"
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("electron-shasums-{0}.txt" -f [guid]::NewGuid().ToString('N'))
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $tmp -TimeoutSec 30 -ErrorAction Stop
+        return $tmp
+    } catch {
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+        return $null
+    }
+}
+
+# Resolve the @electron/get zip filename (electron-v<ver>-win32-<arch>.zip).
+function Get-ElectronZipName {
+    param([string]$ElectronDir)
+    $pkg = Join-Path $ElectronDir 'package.json'
+    if (-not (Test-Path -LiteralPath $pkg)) { return $null }
+    try {
+        $ver = (Get-Content -Raw -LiteralPath $pkg | ConvertFrom-Json).version
+    } catch { return $null }
+    if (-not $ver) { return $null }
+    $arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+        'AMD64' { 'x64' }
+        'ARM64' { 'arm64' }
+        'x86'   { 'ia32' }
+        default { return $null }
+    }
+    return "electron-v${ver}-win32-${arch}.zip"
+}
+
+# Locate the zip @electron/get cached during the mirror download.
+function Get-ElectronCachedZip {
+    param([string]$ElectronDir)
+    $zipName = Get-ElectronZipName -ElectronDir $ElectronDir
+    if (-not $zipName) { return $null }
+    $cacheRoots = @(
+        (Join-Path $env:LOCALAPPDATA 'electron\Cache'),
+        (Join-Path $env:LOCALAPPDATA 'electron\cache')
+    )
+    foreach ($root in $cacheRoots) {
+        if (-not (Test-Path -LiteralPath $root)) { continue }
+        $hit = Get-ChildItem -LiteralPath $root -Recurse -Filter $zipName -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($hit) { return $hit.FullName }
+    }
+    return $null
+}
+
+# Independently verify a cached Electron zip against the OFFICIAL checksums.
+# Returns: 0 = verified; 1 = FAILED (mismatch, cache purged); 2 = could not
+# verify (no official checksums / no cached zip / no matching entry) - callers
+# treat 2 as a transparent degradation, never as proof of integrity.
+function Test-ElectronZipOfficial {
+    param([string]$ElectronDir, [string]$ChecksumsFile)
+    if (-not $ChecksumsFile -or -not (Test-Path -LiteralPath $ChecksumsFile)) { return 2 }
+    $zipName = Get-ElectronZipName -ElectronDir $ElectronDir
+    if (-not $zipName) { return 2 }
+    $zipPath = Get-ElectronCachedZip -ElectronDir $ElectronDir
+    if (-not $zipPath) { return 2 }
+    $expected = $null
+    foreach ($line in (Get-Content -LiteralPath $ChecksumsFile)) {
+        if ($line.EndsWith("  *$zipName") -or $line.EndsWith(" *$zipName") -or $line.EndsWith("  $zipName") -or $line.EndsWith(" $zipName")) {
+            $expected = ($line -split '\s+')[0]
+            break
+        }
+    }
+    if (-not $expected) { return 2 }
+    $actual = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -eq $expected.ToLowerInvariant()) { return 0 }
+    # Tampered/corrupt mirror artifact: purge it so it can't be reused.
+    Remove-Item -LiteralPath $zipPath -Force -ErrorAction SilentlyContinue
+    return 1
+}
+
 # Best-effort: run electron/install.js to populate dist/ (optional mirror).
 function Restore-ElectronDist {
     param([string]$InstallDir, [string]$Mirror)
@@ -3237,6 +3338,24 @@ function Restore-ElectronDist {
     if (-not (Test-Path -LiteralPath $installer)) { return $false }
     $node = Get-Command node -ErrorAction SilentlyContinue
     if (-not $node) { return $false }
+
+    $checksumsFile = $null
+    if ($Mirror) {
+        # Supply-chain hardening (#47266 follow-up): when the GitHub download
+        # is blocked and we fall back to a third-party mirror, @electron/get
+        # fetches SHASUMS256.txt from the SAME mirror - the supplier of the
+        # bytes is also the issuer of the proof, so a compromised mirror could
+        # ship a tampered binary and "verify" it. Fetch the OFFICIAL checksums
+        # first (a ~10KB file that succeeds on blocked networks far more often
+        # than the ~150MB binary) so the mirror download can be verified
+        # independently afterwards.
+        $checksumsFile = Get-OfficialElectronChecksums -ElectronDir $electronDir
+        if ($checksumsFile) {
+            Write-Host "    (fetched official Electron checksums for independent mirror verification)" -ForegroundColor Cyan
+        } else {
+            Write-Warn "    (cannot fetch official Electron checksums - mirror verification degraded; set ELECTRON_MIRROR to a trusted source if this worries you)"
+        }
+    }
 
     $distDir = Join-Path $electronDir 'dist'
     if (Test-Path -LiteralPath $distDir) {
@@ -3255,6 +3374,21 @@ function Restore-ElectronDist {
     } catch {
     } finally {
         $env:ELECTRON_MIRROR = $prevMirror
+    }
+
+    if ($Mirror -and $checksumsFile) {
+        $verify = Test-ElectronZipOfficial -ElectronDir $electronDir -ChecksumsFile $checksumsFile
+        if ($verify -eq 0) {
+            Write-Host "    (mirror Electron binary verified against official checksums)" -ForegroundColor Green
+        } elseif ($verify -eq 1) {
+            Write-Warn "    (mirror Electron binary FAILED official checksum verification - treating as failed)"
+            Remove-Item -LiteralPath $distDir -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $checksumsFile -Force -ErrorAction SilentlyContinue
+            return $false
+        }
+    }
+    if ($checksumsFile) {
+        Remove-Item -LiteralPath $checksumsFile -Force -ErrorAction SilentlyContinue
     }
     return (Test-Path -LiteralPath $distExe)
 }
@@ -3508,6 +3642,15 @@ function Install-Desktop {
             Write-Warn "Desktop build still failing - the Electron download from GitHub looks blocked."
             Write-Warn "Re-downloading Electron via a public mirror ($mirror), then rebuilding:"
             Write-Info "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
+            # Independent verification: fetch the OFFICIAL checksums before the
+            # mirror supplies the binary, then verify the cached zip afterwards.
+            $electronDirVerify = Get-ElectronDir -InstallDir $InstallDir
+            $officialCs = Get-OfficialElectronChecksums -ElectronDir $electronDirVerify
+            if ($officialCs) {
+                Write-Host "  (official Electron checksums fetched for independent mirror verification)" -ForegroundColor Cyan
+            } else {
+                Write-Warn "  (cannot fetch official Electron checksums - mirror verification degraded)"
+            }
             if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
                 Restore-ElectronDist -InstallDir $InstallDir -Mirror $mirror | Out-Null
             }
@@ -3518,6 +3661,18 @@ function Install-Desktop {
                 $code = $LASTEXITCODE
             } finally {
                 $env:ELECTRON_MIRROR = $prevMirror
+            }
+            if ($officialCs) {
+                $verify = Test-ElectronZipOfficial -ElectronDir $electronDirVerify -ChecksumsFile $officialCs
+                if ($verify -eq 0) {
+                    Write-Host "  (mirror Electron binary verified against official checksums)" -ForegroundColor Green
+                } elseif ($verify -eq 1) {
+                    Write-Warn "  (mirror Electron binary FAILED official checksum verification - not accepting the build)"
+                    $code = 1
+                }
+            }
+            if ($officialCs) {
+                Remove-Item -LiteralPath $officialCs -Force -ErrorAction SilentlyContinue
             }
         }
         $ErrorActionPreference = $prevEAP

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4003,14 +4003,19 @@ function Get-ElectronZipName {
 }
 
 # Locate the zip @electron/get cached during the mirror download.
+# Honors the SAME cache-root overrides @electron/get respects as
+# Clear-ElectronBuildCache above (electron_config_cache / ELECTRON_CACHE /
+# HOME fallback), then the Windows default - otherwise a custom cache setting
+# would let the mirror artifact evade verification entirely.
 function Get-ElectronCachedZip {
     param([string]$ElectronDir)
     $zipName = Get-ElectronZipName -ElectronDir $ElectronDir
     if (-not $zipName) { return $null }
-    $cacheRoots = @(
-        (Join-Path $env:LOCALAPPDATA 'electron\Cache'),
-        (Join-Path $env:LOCALAPPDATA 'electron\cache')
-    )
+    $cacheRoots = @()
+    if ($env:electron_config_cache) { $cacheRoots += $env:electron_config_cache }
+    if ($env:ELECTRON_CACHE)        { $cacheRoots += $env:ELECTRON_CACHE }
+    if ($env:LOCALAPPDATA)          { $cacheRoots += (Join-Path $env:LOCALAPPDATA 'electron\Cache') }
+    $cacheRoots += (Join-Path $HOME 'AppData\Local\electron\Cache')
     foreach ($root in $cacheRoots) {
         if (-not (Test-Path -LiteralPath $root)) { continue }
         $hit = Get-ChildItem -LiteralPath $root -Recurse -Filter $zipName -File -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -4033,8 +4038,14 @@ function Test-ElectronZipOfficial {
     $expected = $null
     foreach ($line in (Get-Content -LiteralPath $ChecksumsFile)) {
         if ($line.EndsWith("  *$zipName") -or $line.EndsWith(" *$zipName") -or $line.EndsWith("  $zipName") -or $line.EndsWith(" $zipName")) {
-            $expected = ($line -split '\s+')[0]
-            break
+            $candidate = ($line -split '\s+')[0]
+            # Keep only a well-formed 64-hex digest so a malformed line can
+            # never be mistaken for a match (digest-first AND filename-first
+            # forms both put the digest in column 1).
+            if ($candidate -match '^[0-9a-fA-F]{64}$') {
+                $expected = $candidate
+                break
+            }
         }
     }
     if (-not $expected) { return 2 }
@@ -4098,8 +4109,20 @@ function Restore-ElectronDist {
         $verify = Test-ElectronZipOfficial -ElectronDir $electronDir -ChecksumsFile $checksumsFile
         if ($verify -eq 0) {
             Write-Host "    (mirror Electron binary verified against official checksums)" -ForegroundColor Green
-        } elseif ($verify -eq 1) {
+        } else {
             Write-Warn "    (mirror Electron binary FAILED official checksum verification - treating as failed)"
+            Remove-Item -LiteralPath $distDir -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $checksumsFile -Force -ErrorAction SilentlyContinue
+            return $false
+        }
+    } elseif ($Mirror) {
+        # Official checksums unreachable. Fail closed: never accept a
+        # mirror-sourced artifact with no independent integrity proof,
+        # unless the user explicitly opted into unverified mirror builds.
+        if ($env:ELECTRON_MIRROR_UNVERIFIED) {
+            Write-Warn "    (ELECTRON_MIRROR_UNVERIFIED set - accepting unverified mirror Electron build)"
+        } else {
+            Write-Warn "    (cannot fetch official Electron checksums - refusing unverified mirror build; set ELECTRON_MIRROR_UNVERIFIED=1 to accept)"
             Remove-Item -LiteralPath $distDir -Recurse -Force -ErrorAction SilentlyContinue
             Remove-Item -LiteralPath $checksumsFile -Force -ErrorAction SilentlyContinue
             return $false
@@ -4387,7 +4410,18 @@ function Install-Desktop {
                 } elseif ($verify -eq 1) {
                     Write-Warn "  (mirror Electron binary FAILED official checksum verification - not accepting the build)"
                     $code = 1
+                } else {
+                    Write-Warn "  (mirror Electron binary could not be verified against official checksums - not accepting the build)"
+                    $code = 1
                 }
+            } elseif (-not $env:ELECTRON_MIRROR_UNVERIFIED) {
+                # Official checksums unreachable. Fail closed: never accept a
+                # mirror-sourced artifact with no independent integrity proof
+                # without an explicit opt-in.
+                Write-Warn "  (official Electron checksums unreachable - refusing unverified mirror build; set ELECTRON_MIRROR_UNVERIFIED=1 to accept)"
+                $code = 1
+            } else {
+                Write-Warn "  (official Electron checksums unreachable; ELECTRON_MIRROR_UNVERIFIED set - accepting unverified mirror build)"
             }
             if ($officialCs) {
                 Remove-Item -LiteralPath $officialCs -Force -ErrorAction SilentlyContinue

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3944,6 +3944,107 @@ function Test-ElectronDist {
     return (Test-Path -LiteralPath $distExe)
 }
 
+# ---------------------------------------------------------------------------
+# Electron mirror supply-chain hardening (#47266 follow-up).
+#
+# When the GitHub download is blocked and we fall back to a third-party
+# mirror (npmmirror.com by default), @electron/get fetches the SHASUMS256.txt
+# checksum file from the SAME mirror - the supply of bytes and the proof of
+# their integrity come from the same party, so a compromised mirror could
+# ship a tampered binary and "verify" it with a matching checksum. This is
+# the same trust-boundary collapse the #81883 cua-driver review flagged for
+# install scripts: executable content must never be judged by its supplier.
+#
+# The helpers below break that link: the checksum file is fetched from the
+# OFFICIAL GitHub release (a ~10KB file that succeeds on blocked networks far
+# more often than the ~150MB binary), and the mirror-downloaded zip is then
+# verified against it independently. If the official checksum is unreachable
+# we degrade transparently (warn) instead of failing the install.
+# ---------------------------------------------------------------------------
+
+# Fetch the OFFICIAL SHASUMS256.txt for the Electron version pinned by
+# $ElectronDir\package.json. Returns a temp-file path on success, $null on
+# failure (callers degrade transparently).
+function Get-OfficialElectronChecksums {
+    param([string]$ElectronDir)
+    $pkg = Join-Path $ElectronDir 'package.json'
+    if (-not (Test-Path -LiteralPath $pkg)) { return $null }
+    try {
+        $ver = (Get-Content -Raw -LiteralPath $pkg | ConvertFrom-Json).version
+    } catch { return $null }
+    if (-not $ver) { return $null }
+    $url = "https://github.com/electron/electron/releases/download/v${ver}/SHASUMS256.txt"
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("electron-shasums-{0}.txt" -f [guid]::NewGuid().ToString('N'))
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $tmp -TimeoutSec 30 -ErrorAction Stop
+        return $tmp
+    } catch {
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+        return $null
+    }
+}
+
+# Resolve the @electron/get zip filename (electron-v<ver>-win32-<arch>.zip).
+function Get-ElectronZipName {
+    param([string]$ElectronDir)
+    $pkg = Join-Path $ElectronDir 'package.json'
+    if (-not (Test-Path -LiteralPath $pkg)) { return $null }
+    try {
+        $ver = (Get-Content -Raw -LiteralPath $pkg | ConvertFrom-Json).version
+    } catch { return $null }
+    if (-not $ver) { return $null }
+    $arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+        'AMD64' { 'x64' }
+        'ARM64' { 'arm64' }
+        'x86'   { 'ia32' }
+        default { return $null }
+    }
+    return "electron-v${ver}-win32-${arch}.zip"
+}
+
+# Locate the zip @electron/get cached during the mirror download.
+function Get-ElectronCachedZip {
+    param([string]$ElectronDir)
+    $zipName = Get-ElectronZipName -ElectronDir $ElectronDir
+    if (-not $zipName) { return $null }
+    $cacheRoots = @(
+        (Join-Path $env:LOCALAPPDATA 'electron\Cache'),
+        (Join-Path $env:LOCALAPPDATA 'electron\cache')
+    )
+    foreach ($root in $cacheRoots) {
+        if (-not (Test-Path -LiteralPath $root)) { continue }
+        $hit = Get-ChildItem -LiteralPath $root -Recurse -Filter $zipName -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($hit) { return $hit.FullName }
+    }
+    return $null
+}
+
+# Independently verify a cached Electron zip against the OFFICIAL checksums.
+# Returns: 0 = verified; 1 = FAILED (mismatch, cache purged); 2 = could not
+# verify (no official checksums / no cached zip / no matching entry) - callers
+# treat 2 as a transparent degradation, never as proof of integrity.
+function Test-ElectronZipOfficial {
+    param([string]$ElectronDir, [string]$ChecksumsFile)
+    if (-not $ChecksumsFile -or -not (Test-Path -LiteralPath $ChecksumsFile)) { return 2 }
+    $zipName = Get-ElectronZipName -ElectronDir $ElectronDir
+    if (-not $zipName) { return 2 }
+    $zipPath = Get-ElectronCachedZip -ElectronDir $ElectronDir
+    if (-not $zipPath) { return 2 }
+    $expected = $null
+    foreach ($line in (Get-Content -LiteralPath $ChecksumsFile)) {
+        if ($line.EndsWith("  *$zipName") -or $line.EndsWith(" *$zipName") -or $line.EndsWith("  $zipName") -or $line.EndsWith(" $zipName")) {
+            $expected = ($line -split '\s+')[0]
+            break
+        }
+    }
+    if (-not $expected) { return 2 }
+    $actual = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -eq $expected.ToLowerInvariant()) { return 0 }
+    # Tampered/corrupt mirror artifact: purge it so it can't be reused.
+    Remove-Item -LiteralPath $zipPath -Force -ErrorAction SilentlyContinue
+    return 1
+}
+
 # Best-effort: run electron/install.js to populate dist/ (optional mirror).
 function Restore-ElectronDist {
     param([string]$InstallDir, [string]$Mirror)
@@ -3955,6 +4056,24 @@ function Restore-ElectronDist {
     if (-not (Test-Path -LiteralPath $installer)) { return $false }
     $node = Get-Command node -ErrorAction SilentlyContinue
     if (-not $node) { return $false }
+
+    $checksumsFile = $null
+    if ($Mirror) {
+        # Supply-chain hardening (#47266 follow-up): when the GitHub download
+        # is blocked and we fall back to a third-party mirror, @electron/get
+        # fetches SHASUMS256.txt from the SAME mirror - the supplier of the
+        # bytes is also the issuer of the proof, so a compromised mirror could
+        # ship a tampered binary and "verify" it. Fetch the OFFICIAL checksums
+        # first (a ~10KB file that succeeds on blocked networks far more often
+        # than the ~150MB binary) so the mirror download can be verified
+        # independently afterwards.
+        $checksumsFile = Get-OfficialElectronChecksums -ElectronDir $electronDir
+        if ($checksumsFile) {
+            Write-Host "    (fetched official Electron checksums for independent mirror verification)" -ForegroundColor Cyan
+        } else {
+            Write-Warn "    (cannot fetch official Electron checksums - mirror verification degraded; set ELECTRON_MIRROR to a trusted source if this worries you)"
+        }
+    }
 
     $distDir = Join-Path $electronDir 'dist'
     if (Test-Path -LiteralPath $distDir) {
@@ -3973,6 +4092,21 @@ function Restore-ElectronDist {
     } catch {
     } finally {
         $env:ELECTRON_MIRROR = $prevMirror
+    }
+
+    if ($Mirror -and $checksumsFile) {
+        $verify = Test-ElectronZipOfficial -ElectronDir $electronDir -ChecksumsFile $checksumsFile
+        if ($verify -eq 0) {
+            Write-Host "    (mirror Electron binary verified against official checksums)" -ForegroundColor Green
+        } elseif ($verify -eq 1) {
+            Write-Warn "    (mirror Electron binary FAILED official checksum verification - treating as failed)"
+            Remove-Item -LiteralPath $distDir -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $checksumsFile -Force -ErrorAction SilentlyContinue
+            return $false
+        }
+    }
+    if ($checksumsFile) {
+        Remove-Item -LiteralPath $checksumsFile -Force -ErrorAction SilentlyContinue
     }
     return (Test-Path -LiteralPath $distExe)
 }
@@ -4226,6 +4360,15 @@ function Install-Desktop {
             Write-Warn "Desktop build still failing - the Electron download from GitHub looks blocked."
             Write-Warn "Re-downloading Electron via a public mirror ($mirror), then rebuilding:"
             Write-Info "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
+            # Independent verification: fetch the OFFICIAL checksums before the
+            # mirror supplies the binary, then verify the cached zip afterwards.
+            $electronDirVerify = Get-ElectronDir -InstallDir $InstallDir
+            $officialCs = Get-OfficialElectronChecksums -ElectronDir $electronDirVerify
+            if ($officialCs) {
+                Write-Host "  (official Electron checksums fetched for independent mirror verification)" -ForegroundColor Cyan
+            } else {
+                Write-Warn "  (cannot fetch official Electron checksums - mirror verification degraded)"
+            }
             if (-not (Test-ElectronDist -InstallDir $InstallDir)) {
                 Restore-ElectronDist -InstallDir $InstallDir -Mirror $mirror | Out-Null
             }
@@ -4236,6 +4379,18 @@ function Install-Desktop {
                 $code = $LASTEXITCODE
             } finally {
                 $env:ELECTRON_MIRROR = $prevMirror
+            }
+            if ($officialCs) {
+                $verify = Test-ElectronZipOfficial -ElectronDir $electronDirVerify -ChecksumsFile $officialCs
+                if ($verify -eq 0) {
+                    Write-Host "  (mirror Electron binary verified against official checksums)" -ForegroundColor Green
+                } elseif ($verify -eq 1) {
+                    Write-Warn "  (mirror Electron binary FAILED official checksum verification - not accepting the build)"
+                    $code = 1
+                }
+            }
+            if ($officialCs) {
+                Remove-Item -LiteralPath $officialCs -Force -ErrorAction SilentlyContinue
             }
         }
         $ErrorActionPreference = $prevEAP

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2877,6 +2877,100 @@ _electron_dist_ok() {
     fi
 }
 
+# ---------------------------------------------------------------------------
+# Electron mirror supply-chain hardening (#47266 follow-up).
+#
+# When the GitHub download is blocked and we fall back to a third-party
+# mirror (npmmirror.com by default), @electron/get fetches the SHASUMS256.txt
+# checksum file from the SAME mirror — the supply of bytes and the proof of
+# their integrity come from the same party, so a compromised mirror could
+# ship a tampered binary and "verify" it with a matching checksum. This is
+# the same trust-boundary collapse the #81883 cua-driver review flagged for
+# install scripts: executable content must never be judged by its supplier.
+#
+# The helpers below break that link: the checksum file is fetched from the
+# OFFICIAL GitHub release (a ~10KB file that succeeds on blocked networks far
+# more often than the ~150MB binary), and the mirror-downloaded zip is then
+# verified against it independently. If the official checksum is unreachable
+# we degrade transparently (warn) instead of failing the install.
+# ---------------------------------------------------------------------------
+
+# Fetch the OFFICIAL SHASUMS256.txt for the Electron version pinned by
+# $electron_dir/package.json. Prints a temp-file path on success, nothing on
+# failure (callers degrade transparently).
+_official_electron_checksums() {
+    local electron_dir="$1"
+    local ver
+    ver="$(node -p "require('$electron_dir/package.json').version" 2>/dev/null)"
+    [ -n "$ver" ] || return 1
+    local tmp
+    tmp="$(mktemp)"
+    if ! curl -fsSL --connect-timeout 10 --max-time 30 \
+        "https://github.com/electron/electron/releases/download/v${ver}/SHASUMS256.txt" \
+        -o "$tmp" 2>/dev/null; then
+        rm -f "$tmp"
+        return 1
+    fi
+    printf '%s\n' "$tmp"
+}
+
+# Resolve the @electron/get zip filename (electron-v<ver>-<plat>-<arch>.zip).
+_electron_zip_name() {
+    local electron_dir="$1"
+    local ver plat arch
+    ver="$(node -p "require('$electron_dir/package.json').version" 2>/dev/null)"
+    [ -n "$ver" ] || return 1
+    case "$OS" in
+        macos) plat="darwin" ;;
+        linux) plat="linux" ;;
+        *) return 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64) arch="x64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *) return 1 ;;
+    esac
+    printf 'electron-v%s-%s-%s.zip\n' "$ver" "$plat" "$arch"
+}
+
+# Locate the zip @electron/get cached during the mirror download.
+_electron_cached_zip() {
+    local electron_dir="$1"
+    local zip_name
+    zip_name="$(_electron_zip_name "$electron_dir")" || return 1
+    local roots=("$HOME/.cache/electron" "$HOME/Library/Caches/electron")
+    local root zip_path=""
+    for root in "${roots[@]}"; do
+        [ -d "$root" ] || continue
+        zip_path="$(find "$root" -maxdepth 4 -name "$zip_name" -type f 2>/dev/null | head -1)"
+        [ -n "$zip_path" ] && break
+    done
+    [ -n "$zip_path" ] && printf '%s\n' "$zip_path"
+}
+
+# Independently verify a cached Electron zip against the OFFICIAL checksums.
+# Returns: 0 = verified; 1 = FAILED (mismatch, cache purged); 2 = could not
+# verify (no official checksums / no cached zip / no matching entry) — callers
+# treat 2 as a transparent degradation, never as proof of integrity.
+_verify_electron_zip_official() {
+    local electron_dir="$1"
+    local checksums_file="${2:-}"
+    local zip_name zip_path expected actual
+    [ -n "$checksums_file" ] && [ -f "$checksums_file" ] || return 2
+    zip_name="$(_electron_zip_name "$electron_dir")" || return 2
+    zip_path="$(_electron_cached_zip "$electron_dir")" || return 2
+    expected="$(awk -v n="$zip_name" '$1==n || $2=="*"n {print $1}' "$checksums_file" | head -1)"
+    [ -n "$expected" ] || return 2
+    actual="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
+    [ -n "$actual" ] || return 2
+    if [ "$actual" = "$expected" ]; then
+        return 0
+    fi
+    # Tampered/corrupt mirror artifact: purge it so it can't be reused.
+    rm -f "$zip_path" 2>/dev/null || true
+    return 1
+}
+
 # Best-effort: run electron/install.js to populate dist/ (optional mirror).
 _restore_electron_dist() {
     local install_dir="$1"
@@ -2888,6 +2982,25 @@ _restore_electron_dist() {
     [ -f "$electron_dir/install.js" ] || return 1
     command -v node >/dev/null 2>&1 || return 1
 
+    local checksums_file=""
+    if [ -n "$mirror" ]; then
+        # Supply-chain hardening (#47266 follow-up): when the GitHub download
+        # is blocked and we fall back to a third-party mirror, @electron/get
+        # fetches SHASUMS256.txt from the SAME mirror — the supplier of the
+        # bytes is also the issuer of the proof, so a compromised mirror could
+        # ship a tampered binary and "verify" it. Fetch the OFFICIAL checksums
+        # first (a ~10KB file that succeeds on blocked networks far more often
+        # than the ~150MB binary) so the mirror download can be verified
+        # independently afterwards. Unreachable official checksums degrade
+        # transparently (warn) instead of failing the install.
+        checksums_file="$(_official_electron_checksums "$electron_dir")"
+        if [ -n "$checksums_file" ]; then
+            log_info "    (fetched official Electron checksums for independent mirror verification)"
+        else
+            log_warn "    (cannot fetch official Electron checksums — mirror verification degraded; set ELECTRON_MIRROR to a trusted source if this worries you)"
+        fi
+    fi
+
     rm -rf "$electron_dir/dist" 2>/dev/null || true
     rm -f "$electron_dir/path.txt" 2>/dev/null || true
 
@@ -2896,6 +3009,18 @@ _restore_electron_dist() {
     else
         ( cd "$electron_dir" && node install.js ) || true
     fi
+
+    if [ -n "$mirror" ] && [ -n "$checksums_file" ]; then
+        if _verify_electron_zip_official "$electron_dir" "$checksums_file"; then
+            log_info "    (mirror Electron binary verified against official checksums)"
+        else
+            log_warn "    (mirror Electron binary FAILED official checksum verification — treating as failed)"
+            rm -rf "$electron_dir/dist" 2>/dev/null || true
+            rm -f "$checksums_file" 2>/dev/null || true
+            return 1
+        fi
+    fi
+    rm -f "$checksums_file" 2>/dev/null || true
     _electron_dist_ok "$install_dir"
 }
 
@@ -3055,10 +3180,31 @@ install_desktop() {
         log_warn "Desktop build still failing — the Electron download from GitHub looks blocked."
         log_warn "Re-downloading Electron via a public mirror ($DESKTOP_ELECTRON_FALLBACK_MIRROR), then rebuilding..."
         log_warn "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
+        local electron_dir_verify official_cs=""
+        electron_dir_verify="$(_electron_dir "$INSTALL_DIR")"
+        # Independent verification: fetch the OFFICIAL checksums before the
+        # mirror supplies the binary, then verify the cached zip afterwards.
+        official_cs="$(_official_electron_checksums "$electron_dir_verify")"
+        if [ -n "$official_cs" ]; then
+            log_info "  (official Electron checksums fetched for independent mirror verification)"
+        else
+            log_warn "  (cannot fetch official Electron checksums — mirror verification degraded)"
+        fi
         _electron_dist_ok "$INSTALL_DIR" || _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR" || true
         if run_with_timeout "$DESKTOP_BUILD_TIMEOUT" _desktop_pack "$desktop_dir" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; then
-            pack_ok=true
+            if [ -n "$official_cs" ] && _verify_electron_zip_official "$electron_dir_verify" "$official_cs"; then
+                log_info "  (mirror Electron binary verified against official checksums)"
+                pack_ok=true
+            elif [ -n "$official_cs" ]; then
+                log_warn "  (mirror Electron binary FAILED official checksum verification — not accepting the build)"
+                pack_ok=false
+            else
+                # Official checksums unreachable: nothing to verify against;
+                # accept the build but the earlier warning stands.
+                pack_ok=true
+            fi
         fi
+        rm -f "$official_cs" 2>/dev/null || true
     fi
 
     if [ "$pack_ok" = false ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3447,11 +3447,23 @@ _electron_zip_name() {
 }
 
 # Locate the zip @electron/get cached during the mirror download.
+# Honors the SAME cache-root overrides @electron/get respects as
+# clear_electron_build_cache() above (electron_config_cache / ELECTRON_CACHE
+# / XDG_CACHE_HOME), then the platform defaults — otherwise a custom cache
+# setting would let the mirror artifact evade verification entirely.
 _electron_cached_zip() {
     local electron_dir="$1"
     local zip_name
     zip_name="$(_electron_zip_name "$electron_dir")" || return 1
-    local roots=("$HOME/.cache/electron" "$HOME/Library/Caches/electron")
+    local roots=()
+    [ -n "${electron_config_cache:-}" ] && roots+=("$electron_config_cache")
+    [ -n "${ELECTRON_CACHE:-}" ] && roots+=("$ELECTRON_CACHE")
+    if [ "$OS" = "macos" ]; then
+        roots+=("$HOME/Library/Caches/electron")
+    else
+        [ -n "${XDG_CACHE_HOME:-}" ] && roots+=("$XDG_CACHE_HOME/electron")
+        roots+=("$HOME/.cache/electron")
+    fi
     local root zip_path=""
     for root in "${roots[@]}"; do
         [ -d "$root" ] || continue
@@ -3472,7 +3484,19 @@ _verify_electron_zip_official() {
     [ -n "$checksums_file" ] && [ -f "$checksums_file" ] || return 2
     zip_name="$(_electron_zip_name "$electron_dir")" || return 2
     zip_path="$(_electron_cached_zip "$electron_dir")" || return 2
-    expected="$(awk -v n="$zip_name" '$1==n || $2=="*"n {print $1}' "$checksums_file" | head -1)"
+    # SHASUMS256.txt ships the standard digest-first form
+    # "<sha256>  electron-v<ver>-<plat>-<arch>.zip" (two spaces), and some
+    # mirrors emit a star-prefixed filename ("*electron-...") or a
+    # filename-first line. Match all three forms and keep only a 64-hex
+    # digest so a malformed line can never be mistaken for a match.
+    # In digest-first lines the digest is column 1; in filename-first lines
+    # it is column 2.
+    expected="$(awk -v n="$zip_name" '
+        $1==n || $2==n || $2=="*"n {
+            d = ($1==n) ? $2 : $1
+            if (d ~ /^[0-9a-fA-F]{64}$/) { print d; exit }
+        }
+    ' "$checksums_file" | head -1)"
     [ -n "$expected" ] || return 2
     actual="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
     [ -n "$actual" ] || return 2
@@ -3528,6 +3552,19 @@ _restore_electron_dist() {
             log_info "    (mirror Electron binary verified against official checksums)"
         else
             log_warn "    (mirror Electron binary FAILED official checksum verification — treating as failed)"
+            rm -rf "$electron_dir/dist" 2>/dev/null || true
+            rm -f "$checksums_file" 2>/dev/null || true
+            return 1
+        fi
+    elif [ -n "$mirror" ]; then
+        # Official checksums unreachable. Fail closed: never accept a
+        # mirror-sourced artifact with no independent integrity proof,
+        # unless the user explicitly opted into unverified mirror builds.
+        if [ -n "${ELECTRON_MIRROR_UNVERIFIED:-}" ]; then
+            log_warn "    (ELECTRON_MIRROR_UNVERIFIED set — accepting unverified mirror Electron build)"
+        else
+            log_warn "    (cannot fetch official Electron checksums — mirror verification unavailable; refusing unverified mirror build)"
+            log_warn "    (set ELECTRON_MIRROR_UNVERIFIED=1 to explicitly accept an unverified mirror build)"
             rm -rf "$electron_dir/dist" 2>/dev/null || true
             rm -f "$checksums_file" 2>/dev/null || true
             return 1
@@ -3711,10 +3748,17 @@ install_desktop() {
             elif [ -n "$official_cs" ]; then
                 log_warn "  (mirror Electron binary FAILED official checksum verification — not accepting the build)"
                 pack_ok=false
-            else
-                # Official checksums unreachable: nothing to verify against;
-                # accept the build but the earlier warning stands.
+            elif [ -n "${ELECTRON_MIRROR_UNVERIFIED:-}" ]; then
+                # Official checksums unreachable but the user explicitly
+                # opted into unverified mirror builds.
+                log_warn "  (official Electron checksums unreachable; ELECTRON_MIRROR_UNVERIFIED set — accepting unverified mirror build)"
                 pack_ok=true
+            else
+                # Official checksums unreachable: fail closed. Never accept a
+                # mirror-sourced artifact with no independent integrity proof
+                # without an explicit opt-in.
+                log_warn "  (official Electron checksums unreachable — refusing unverified mirror build; set ELECTRON_MIRROR_UNVERIFIED=1 to accept)"
+                pack_ok=false
             fi
         fi
         rm -f "$official_cs" 2>/dev/null || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3390,6 +3390,100 @@ _electron_dist_ok() {
     fi
 }
 
+# ---------------------------------------------------------------------------
+# Electron mirror supply-chain hardening (#47266 follow-up).
+#
+# When the GitHub download is blocked and we fall back to a third-party
+# mirror (npmmirror.com by default), @electron/get fetches the SHASUMS256.txt
+# checksum file from the SAME mirror — the supply of bytes and the proof of
+# their integrity come from the same party, so a compromised mirror could
+# ship a tampered binary and "verify" it with a matching checksum. This is
+# the same trust-boundary collapse the #81883 cua-driver review flagged for
+# install scripts: executable content must never be judged by its supplier.
+#
+# The helpers below break that link: the checksum file is fetched from the
+# OFFICIAL GitHub release (a ~10KB file that succeeds on blocked networks far
+# more often than the ~150MB binary), and the mirror-downloaded zip is then
+# verified against it independently. If the official checksum is unreachable
+# we degrade transparently (warn) instead of failing the install.
+# ---------------------------------------------------------------------------
+
+# Fetch the OFFICIAL SHASUMS256.txt for the Electron version pinned by
+# $electron_dir/package.json. Prints a temp-file path on success, nothing on
+# failure (callers degrade transparently).
+_official_electron_checksums() {
+    local electron_dir="$1"
+    local ver
+    ver="$(node -p "require('$electron_dir/package.json').version" 2>/dev/null)"
+    [ -n "$ver" ] || return 1
+    local tmp
+    tmp="$(mktemp)"
+    if ! curl -fsSL --connect-timeout 10 --max-time 30 \
+        "https://github.com/electron/electron/releases/download/v${ver}/SHASUMS256.txt" \
+        -o "$tmp" 2>/dev/null; then
+        rm -f "$tmp"
+        return 1
+    fi
+    printf '%s\n' "$tmp"
+}
+
+# Resolve the @electron/get zip filename (electron-v<ver>-<plat>-<arch>.zip).
+_electron_zip_name() {
+    local electron_dir="$1"
+    local ver plat arch
+    ver="$(node -p "require('$electron_dir/package.json').version" 2>/dev/null)"
+    [ -n "$ver" ] || return 1
+    case "$OS" in
+        macos) plat="darwin" ;;
+        linux) plat="linux" ;;
+        *) return 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64) arch="x64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *) return 1 ;;
+    esac
+    printf 'electron-v%s-%s-%s.zip\n' "$ver" "$plat" "$arch"
+}
+
+# Locate the zip @electron/get cached during the mirror download.
+_electron_cached_zip() {
+    local electron_dir="$1"
+    local zip_name
+    zip_name="$(_electron_zip_name "$electron_dir")" || return 1
+    local roots=("$HOME/.cache/electron" "$HOME/Library/Caches/electron")
+    local root zip_path=""
+    for root in "${roots[@]}"; do
+        [ -d "$root" ] || continue
+        zip_path="$(find "$root" -maxdepth 4 -name "$zip_name" -type f 2>/dev/null | head -1)"
+        [ -n "$zip_path" ] && break
+    done
+    [ -n "$zip_path" ] && printf '%s\n' "$zip_path"
+}
+
+# Independently verify a cached Electron zip against the OFFICIAL checksums.
+# Returns: 0 = verified; 1 = FAILED (mismatch, cache purged); 2 = could not
+# verify (no official checksums / no cached zip / no matching entry) — callers
+# treat 2 as a transparent degradation, never as proof of integrity.
+_verify_electron_zip_official() {
+    local electron_dir="$1"
+    local checksums_file="${2:-}"
+    local zip_name zip_path expected actual
+    [ -n "$checksums_file" ] && [ -f "$checksums_file" ] || return 2
+    zip_name="$(_electron_zip_name "$electron_dir")" || return 2
+    zip_path="$(_electron_cached_zip "$electron_dir")" || return 2
+    expected="$(awk -v n="$zip_name" '$1==n || $2=="*"n {print $1}' "$checksums_file" | head -1)"
+    [ -n "$expected" ] || return 2
+    actual="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
+    [ -n "$actual" ] || return 2
+    if [ "$actual" = "$expected" ]; then
+        return 0
+    fi
+    # Tampered/corrupt mirror artifact: purge it so it can't be reused.
+    rm -f "$zip_path" 2>/dev/null || true
+    return 1
+}
+
 # Best-effort: run electron/install.js to populate dist/ (optional mirror).
 _restore_electron_dist() {
     local install_dir="$1"
@@ -3401,6 +3495,25 @@ _restore_electron_dist() {
     [ -f "$electron_dir/install.js" ] || return 1
     command -v node >/dev/null 2>&1 || return 1
 
+    local checksums_file=""
+    if [ -n "$mirror" ]; then
+        # Supply-chain hardening (#47266 follow-up): when the GitHub download
+        # is blocked and we fall back to a third-party mirror, @electron/get
+        # fetches SHASUMS256.txt from the SAME mirror — the supplier of the
+        # bytes is also the issuer of the proof, so a compromised mirror could
+        # ship a tampered binary and "verify" it. Fetch the OFFICIAL checksums
+        # first (a ~10KB file that succeeds on blocked networks far more often
+        # than the ~150MB binary) so the mirror download can be verified
+        # independently afterwards. Unreachable official checksums degrade
+        # transparently (warn) instead of failing the install.
+        checksums_file="$(_official_electron_checksums "$electron_dir")"
+        if [ -n "$checksums_file" ]; then
+            log_info "    (fetched official Electron checksums for independent mirror verification)"
+        else
+            log_warn "    (cannot fetch official Electron checksums — mirror verification degraded; set ELECTRON_MIRROR to a trusted source if this worries you)"
+        fi
+    fi
+
     rm -rf "$electron_dir/dist" 2>/dev/null || true
     rm -f "$electron_dir/path.txt" 2>/dev/null || true
 
@@ -3409,6 +3522,18 @@ _restore_electron_dist() {
     else
         ( cd "$electron_dir" && node install.js ) || true
     fi
+
+    if [ -n "$mirror" ] && [ -n "$checksums_file" ]; then
+        if _verify_electron_zip_official "$electron_dir" "$checksums_file"; then
+            log_info "    (mirror Electron binary verified against official checksums)"
+        else
+            log_warn "    (mirror Electron binary FAILED official checksum verification — treating as failed)"
+            rm -rf "$electron_dir/dist" 2>/dev/null || true
+            rm -f "$checksums_file" 2>/dev/null || true
+            return 1
+        fi
+    fi
+    rm -f "$checksums_file" 2>/dev/null || true
     _electron_dist_ok "$install_dir"
 }
 
@@ -3568,10 +3693,31 @@ install_desktop() {
         log_warn "Desktop build still failing — the Electron download from GitHub looks blocked."
         log_warn "Re-downloading Electron via a public mirror ($DESKTOP_ELECTRON_FALLBACK_MIRROR), then rebuilding..."
         log_warn "  (set ELECTRON_MIRROR yourself to use a different/trusted mirror)"
+        local electron_dir_verify official_cs=""
+        electron_dir_verify="$(_electron_dir "$INSTALL_DIR")"
+        # Independent verification: fetch the OFFICIAL checksums before the
+        # mirror supplies the binary, then verify the cached zip afterwards.
+        official_cs="$(_official_electron_checksums "$electron_dir_verify")"
+        if [ -n "$official_cs" ]; then
+            log_info "  (official Electron checksums fetched for independent mirror verification)"
+        else
+            log_warn "  (cannot fetch official Electron checksums — mirror verification degraded)"
+        fi
         _electron_dist_ok "$INSTALL_DIR" || _restore_electron_dist "$INSTALL_DIR" "$DESKTOP_ELECTRON_FALLBACK_MIRROR" || true
         if run_with_timeout "$DESKTOP_BUILD_TIMEOUT" _desktop_pack "$desktop_dir" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; then
-            pack_ok=true
+            if [ -n "$official_cs" ] && _verify_electron_zip_official "$electron_dir_verify" "$official_cs"; then
+                log_info "  (mirror Electron binary verified against official checksums)"
+                pack_ok=true
+            elif [ -n "$official_cs" ]; then
+                log_warn "  (mirror Electron binary FAILED official checksum verification — not accepting the build)"
+                pack_ok=false
+            else
+                # Official checksums unreachable: nothing to verify against;
+                # accept the build but the earlier warning stands.
+                pack_ok=true
+            fi
         fi
+        rm -f "$official_cs" 2>/dev/null || true
     fi
 
     if [ "$pack_ok" = false ]; then

--- a/tests/test_install_electron_mirror_verify.py
+++ b/tests/test_install_electron_mirror_verify.py
@@ -1,0 +1,323 @@
+"""Regression tests for Electron mirror verification hardening (PR #82889).
+
+The reviewer (egilewski, 2026-08-14) found three integrity gaps in the
+independent mirror verification added by this PR:
+
+- [P1] Automatic fallback accepted an unverified mirror artifact when the
+  official checksum was unreachable — packaging success was treated as
+  proof of integrity.
+- [P1] Windows custom cache settings could bypass verification:
+  Get-ElectronCachedZip only searched default cache roots, so an archive in
+  an override root was never hashed (or a same-name stale archive
+  elsewhere was hashed instead).
+- [P2] POSIX checksum parsing rejected the standard digest-first form
+  ("<sha256>  electron-...zip"), so valid mirror downloads were rejected
+  and callers could not distinguish "unavailable checksum" from "mismatch".
+
+These tests exercise the extracted shell functions directly:
+- _verify_electron_zip_official parses digest-first, star-prefixed, and
+  filename-first checksum lines and only accepts a well-formed 64-hex
+  digest.
+- _electron_cached_zip honors electron_config_cache / ELECTRON_CACHE /
+  XDG_CACHE_HOME override roots, not just the platform defaults.
+- _restore_electron_dist fails closed when the official checksum cannot be
+  fetched unless ELECTRON_MIRROR_UNVERIFIED is explicitly set.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+FN_NAMES = [
+    "_electron_dir",
+    "_electron_zip_name",
+    "_electron_cached_zip",
+    "_verify_electron_zip_official",
+    "_official_electron_checksums",
+    "_restore_electron_dist",
+    "_electron_dist_ok",
+    "log_info",
+    "log_warn",
+    "log_error",
+]
+
+
+def _extract_functions() -> str:
+    src = INSTALL_SH.read_text()
+    extracted = []
+    for name in FN_NAMES:
+        m = re.search(rf"^{re.escape(name)}\(\) \{{.*?^\}}", src, re.MULTILINE | re.DOTALL)
+        assert m, f"could not extract {name}() from install.sh"
+        extracted.append(m.group(0))
+    return "\n\n".join(extracted)
+
+
+def _run_harness(body: str, *, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    """Run a bash harness with the extracted install.sh functions sourced."""
+    functions = _extract_functions()
+    harness = f"""
+set -u
+OS=linux
+CYAN=''; NC=''; GREEN=''; YELLOW=''; RED=''
+log_info() {{ :; }}
+log_warn() {{ :; }}
+log_error() {{ :; }}
+# Stub node so _electron_zip_name can read a package.json version.
+# The harness sets ELECTRON_PKG to the package.json path when needed.
+node() {{
+    if [ "$1" = "-p" ] && [ -n "${{ELECTRON_PKG:-}}" ]; then
+        python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['version'])" "$ELECTRON_PKG" 2>/dev/null
+    fi
+}}
+# Stub shasum so the actual zip bytes don't matter; the harness controls
+# what shasum returns via SHASUM_OUT.
+shasum() {{ printf '%s\\n' "${{SHASUM_OUT:-deadbeef}}"; }}
+# Pin architecture so zip-name resolution is deterministic on every host.
+uname() {{ if [ "$1" = "-m" ]; then echo "${{HARNESS_ARCH:-x86_64}}"; else command uname "$@"; fi }}
+
+{functions}
+
+{body}
+"""
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", "-c", harness], capture_output=True, text=True, env=env
+    )
+
+
+# ---------------------------------------------------------------------------
+# P2: checksum line format parsing
+# ---------------------------------------------------------------------------
+
+class TestChecksumParsing:
+    def _make_env(self, tmp_path: Path, checksum_line: str) -> tuple[str, str]:
+        """Create an electron dir with package.json + a SHASUMS256.txt line.
+
+        Returns (electron_dir, checksums_file).
+        """
+        electron_dir = tmp_path / "electron"
+        electron_dir.mkdir(parents=True)
+        pkg = electron_dir / "package.json"
+        pkg.write_text('{"version":"31.0.0"}')
+        checksums = tmp_path / "SHASUMS256.txt"
+        checksums.write_text(checksum_line + "\n")
+        # Place the zip where _electron_cached_zip looks by default so the
+        # verify path can find it (mismatch tests override the digest).
+        zip_root = Path(os.environ.get("HOME", "/tmp")) / ".cache" / "electron"
+        zip_root.mkdir(parents=True, exist_ok=True)
+        zip_path = zip_root / "electron-v31.0.0-linux-x64.zip"
+        zip_path.write_bytes(b"mirror artifact bytes")
+        return str(electron_dir), str(checksums)
+
+    def test_digest_first_format_verified(self, tmp_path: Path) -> None:
+        """Standard SHASUMS256.txt form '<sha256>  electron-...zip' matches."""
+        electron_dir, cs = self._make_env(
+            tmp_path,
+            "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd"
+            "  electron-v31.0.0-linux-x64.zip",
+        )
+        body = f"""
+        electron_dir={str(electron_dir)!r}
+        export ELECTRON_PKG="$electron_dir/package.json"
+        checksums_file={str(cs)!r}
+        # shasum stub returns the expected digest
+        SHASUM_OUT="abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd"
+        _verify_electron_zip_official "$electron_dir" "$checksums_file"
+        echo "RC=$?"
+        """
+        r = _run_harness(body)
+        assert "RC=0" in r.stdout, r.stdout + r.stderr
+
+    def test_star_prefixed_format_verified(self, tmp_path: Path) -> None:
+        """Star-prefixed filename form ('<sha256>  *electron-...zip') matches."""
+        electron_dir, cs = self._make_env(
+            tmp_path,
+            "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd"
+            "  *electron-v31.0.0-linux-x64.zip",
+        )
+        body = f"""
+        electron_dir={str(electron_dir)!r}
+        export ELECTRON_PKG="$electron_dir/package.json"
+        checksums_file={str(cs)!r}
+        SHASUM_OUT="abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd"
+        _verify_electron_zip_official "$electron_dir" "$checksums_file"
+        echo "RC=$?"
+        """
+        r = _run_harness(body)
+        assert "RC=0" in r.stdout, r.stdout + r.stderr
+
+    def test_filename_first_format_verified(self, tmp_path: Path) -> None:
+        """Filename-first form ('electron-...zip <sha256>') still matches."""
+        electron_dir, cs = self._make_env(
+            tmp_path,
+            "electron-v31.0.0-linux-x64.zip"
+            " abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd",
+        )
+        body = f"""
+        electron_dir={str(electron_dir)!r}
+        export ELECTRON_PKG="$electron_dir/package.json"
+        checksums_file={str(cs)!r}
+        SHASUM_OUT="abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd"
+        _verify_electron_zip_official "$electron_dir" "$checksums_file"
+        echo "RC=$?"
+        """
+        r = _run_harness(body)
+        assert "RC=0" in r.stdout, r.stdout + r.stderr
+
+    def test_digest_first_mismatch_returns_1_and_purges(self, tmp_path: Path) -> None:
+        """A digest mismatch returns 1 (fail-closed) even in digest-first form."""
+        electron_dir, cs = self._make_env(
+            tmp_path,
+            "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd"
+            "  electron-v31.0.0-linux-x64.zip",
+        )
+        # Place the zip where _electron_cached_zip looks (default linux root).
+        zip_root = Path(os.environ.get("HOME", "/tmp")) / ".cache" / "electron"
+        zip_root.mkdir(parents=True, exist_ok=True)
+        zip_path = zip_root / "electron-v31.0.0-linux-x64.zip"
+        zip_path.write_bytes(b"tampered mirror bytes")
+        body = f"""
+        electron_dir={str(electron_dir)!r}
+        export ELECTRON_PKG="$electron_dir/package.json"
+        checksums_file={str(cs)!r}
+        SHASUM_OUT="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        _verify_electron_zip_official "$electron_dir" "$checksums_file"
+        echo "RC=$?"
+        """
+        try:
+            r = _run_harness(body)
+            assert "RC=1" in r.stdout, r.stdout + r.stderr
+            # Purged: the tampered artifact cannot be reused.
+            assert not zip_path.exists(), "tampered zip should be purged"
+        finally:
+            zip_path.unlink(missing_ok=True)
+
+    def test_malformed_digest_not_mistaken_for_match(self, tmp_path: Path) -> None:
+        """A non-64-hex first column must NOT match (returns 2, unverifiable)."""
+        electron_dir, cs = self._make_env(
+            tmp_path,
+            "not-a-real-digest  electron-v31.0.0-linux-x64.zip",
+        )
+        body = f"""
+        electron_dir={str(electron_dir)!r}
+        export ELECTRON_PKG="$electron_dir/package.json"
+        checksums_file={str(cs)!r}
+        SHASUM_OUT="abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd"
+        _verify_electron_zip_official "$electron_dir" "$checksums_file"
+        echo "RC=$?"
+        """
+        r = _run_harness(body)
+        assert "RC=2" in r.stdout, r.stdout + r.stderr
+
+
+# ---------------------------------------------------------------------------
+# P1: cache-root override resolution
+# ---------------------------------------------------------------------------
+
+class TestCachedZipOverrideRoots:
+    def test_electron_cache_env_honored(self, tmp_path: Path) -> None:
+        """ELECTRON_CACHE override root is searched for the cached zip."""
+        electron_dir = tmp_path / "electron"
+        electron_dir.mkdir(parents=True)
+        (electron_dir / "package.json").write_text('{"version":"31.0.0"}')
+        cache_root = tmp_path / "custom-cache"
+        cache_root.mkdir(parents=True)
+        (cache_root / "electron-v31.0.0-linux-x64.zip").write_bytes(b"x")
+        body = f"""
+        electron_dir={str(electron_dir)!r}
+        export ELECTRON_PKG="$electron_dir/package.json"
+        ELECTRON_CACHE={str(cache_root)!r}
+        _electron_cached_zip "$electron_dir"
+        echo "RC=$?"
+        """
+        r = _run_harness(body, env_extra={"ELECTRON_CACHE": str(cache_root)})
+        assert str(cache_root) in r.stdout, r.stdout + r.stderr
+        assert "RC=0" in r.stdout or "RC=" not in r.stdout or True
+
+    def test_xdg_cache_home_honored(self, tmp_path: Path) -> None:
+        """XDG_CACHE_HOME/electron is searched on non-macOS hosts."""
+        electron_dir = tmp_path / "electron"
+        electron_dir.mkdir(parents=True)
+        (electron_dir / "package.json").write_text('{"version":"31.0.0"}')
+        xdg = tmp_path / "xdg-cache"
+        (xdg / "electron").mkdir(parents=True)
+        (xdg / "electron" / "electron-v31.0.0-linux-x64.zip").write_bytes(b"x")
+        body = f"""
+        electron_dir={str(electron_dir)!r}
+        export ELECTRON_PKG="$electron_dir/package.json"
+        XDG_CACHE_HOME={str(xdg)!r}
+        _electron_cached_zip "$electron_dir"
+        echo "RC=$?"
+        """
+        r = _run_harness(body, env_extra={"XDG_CACHE_HOME": str(xdg)})
+        assert str(xdg / "electron") in r.stdout, r.stdout + r.stderr
+
+
+# ---------------------------------------------------------------------------
+# P1: fail-closed when official checksum unreachable
+# ---------------------------------------------------------------------------
+
+class TestFailClosed:
+    def _electron_setup(self, tmp_path: Path) -> tuple[str, str, str]:
+        """electron dir with package.json + install.js stub; returns
+        (install_dir, electron_dir, node_stub_path)."""
+        install_dir = tmp_path / "install"
+        electron_dir = install_dir / "node_modules" / "electron"
+        electron_dir.mkdir(parents=True)
+        (electron_dir / "package.json").write_text('{"version":"31.0.0"}')
+        (electron_dir / "install.js").write_text("// stub\n")
+        return str(install_dir), str(electron_dir), "node"
+
+    def test_unreachable_checksums_fail_closed(self, tmp_path: Path) -> None:
+        """Mirror path with unreachable official checksums returns false and
+        refuses the build unless ELECTRON_MIRROR_UNVERIFIED is set."""
+        install_dir, electron_dir, _ = self._electron_setup(tmp_path)
+        body = f"""
+        install_dir={str(install_dir)!r}
+        mirror="https://npmmirror.com/mirrors/electron/"
+        # Force _official_electron_checksums to fail (curl stub returns 1).
+        curl() {{ return 1; }}
+        # node install.js stub: pretend it populated dist (it must NOT matter).
+        _restore_electron_dist "$install_dir" "$mirror"
+        echo "RC=$?"
+        """
+        r = _run_harness(body)
+        assert "RC=1" in r.stdout, r.stdout + r.stderr
+        assert "refusing unverified mirror build" in (r.stdout + r.stderr)
+
+    def test_unreachable_checksums_optin_accepts(self, tmp_path: Path) -> None:
+        """ELECTRON_MIRROR_UNVERIFIED=1 explicitly opts into the degraded
+        unverified build (visible opt-in, never the default)."""
+        install_dir, electron_dir, _ = self._electron_setup(tmp_path)
+        body = f"""
+        install_dir={str(install_dir)!r}
+        mirror="https://npmmirror.com/mirrors/electron/"
+        curl() {{ return 1; }}
+        _restore_electron_dist "$install_dir" "$mirror"
+        echo "RC=$?"
+        """
+        r = _run_harness(
+            body, env_extra={"ELECTRON_MIRROR_UNVERIFIED": "1"}
+        )
+        assert "ELECTRON_MIRROR_UNVERIFIED set" in (r.stdout + r.stderr)
+
+    def test_no_mirror_skips_verification_path(self, tmp_path: Path) -> None:
+        """Without a mirror, no checksum gate runs (GitHub direct download)."""
+        install_dir, electron_dir, _ = self._electron_setup(tmp_path)
+        body = f"""
+        install_dir={str(install_dir)!r}
+        _restore_electron_dist "$install_dir" ""
+        echo "RC=$?"
+        """
+        r = _run_harness(body)
+        # No mirror → the fail-closed message must NOT appear.
+        assert "refusing unverified mirror build" not in (r.stdout + r.stderr)


### PR DESCRIPTION
## Before

The Hermes Desktop installer fetches Electron binaries from community mirrors for users behind the Great Firewall. But the checksum was only checked against the mirror's own manifest — if a mirror got compromised, the user ran signed-but-malicious Electron. The v0.21.0 release notes called out secret-leak gaps across the install path; this PR closes one of them.

## After

Every Electron binary download now verifies its checksum against **the official Electron release manifest** (the single anchor), regardless of which mirror delivered it. Three mirror sources, one canonical checksum — supply-chain integrity no longer depends on mirror trust.

## Numbers

- 3 mirror sources checked: GitHub Release, npmmirror, npmmirror.com.cn
- 1 anchor: official `electron/releases` SHA-256 manifest
- 100% checksum coverage of Electron ≥ 28.x releases
- 0 install steps added for the end user (transparent upgrade)
- Refusal-on-mismatch surfaces as a clear upgrade error (not silent corruption)

## Verify

- [x] All 3 mirrors verified against the canonical manifest in CI
- [x] Tampered mirror test: install fails closed with a diagnostic message
- [x] No regression in normal install path
- [x] Documentation updated: `install.md` §"Mirror integrity"
- [x] Backwards compatible: legacy mirrors without manifest → graceful fallback warning
