### PR TITLE
fix: retry title generation without response_format on HTTP 400

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -248,6 +248,27 @@ def derive_title(user_message: str) -> Optional[str]:
     return line or None
 
 
+def _is_response_format_rejection(exc: BaseException) -> bool:
+    """True when the provider rejected the response_format field itself.
+
+    DeepSeek and a few other OpenAI-compatible endpoints return HTTP 400 with
+    a message like "This response_format type is unavailable now" when handed
+    a ``json_schema`` response_format they don't support. We must NOT retry
+    (or fail) on unrelated errors — only when the request itself was refused
+    because of the structured-output field, which is safe to drop.
+    """
+    if not exc:
+        return False
+    msg = str(exc)
+    if "response_format" not in msg:
+        return False
+    status = getattr(exc, "status_code", None)
+    if status is not None:
+        return status == 400
+    # Non-SDK exceptions (e.g. httpx) may only carry the message.
+    return "400" in msg
+
+
 def _extract_title_text(content: str) -> str:
     """Pull the title out of a model response.
 
@@ -366,17 +387,40 @@ def generate_title(
     ]
 
     try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
+        try:
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                # A title is a handful of tokens. The old 500-token ceiling let a
+                # chatty model burn seconds generating prose we then threw away.
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+                extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            )
+        except Exception as e:
+            # Some providers (e.g. DeepSeek) reject the json_schema
+            # response_format outright with HTTP 400 ("This response_format
+            # type is unavailable now"). Retry once WITHOUT the schema; the
+            # prompt still asks for JSON-only output and _extract_title_text
+            # falls back through a loose JSON scan, so titling survives on
+            # providers that can't honor structured output.
+            if _is_response_format_rejection(e):
+                logger.warning(
+                    "Title generation: provider rejected response_format (%s); "
+                    "retrying without it", e,
+                )
+                response = call_llm(
+                    task="title_generation",
+                    messages=messages,
+                    max_tokens=64,
+                    temperature=0.3,
+                    timeout=timeout,
+                    main_runtime=main_runtime,
+                )
+            else:
+                raise
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))
     except Exception as e:


### PR DESCRIPTION
## Summary

Auto-title generation fails on providers that reject the `json_schema` response_format. DeepSeek returns HTTP 400 ("This response_format type is unavailable now") for any request carrying a `json_schema` response_format, so every title-generation attempt on DeepSeek-backed setups logs `Auxiliary title generation failed` and sessions stay untitled.

## Change

In `agent/title_generator.py`:

- Added `_is_response_format_rejection()` — returns True only for HTTP 400 errors whose message mentions `response_format` (the exact DeepSeek failure mode), so unrelated errors are never retried.
- `generate_title()` now retries **once without the response_format** when that specific rejection is detected.

The retry is safe because:
- The title prompt already instructs the model to reply with JSON only (`Reply with JSON only: {"title": "..."}`).
- `_extract_title_text()` already falls back through a loose JSON scan and prose parsing for providers that don't honor structured output — a code path that existed before this change but was unreachable when the request itself was rejected.

## Test Plan

- `tests/agent/test_title_generator.py`: 18 passed
- `tests/hermes_cli/test_aux_config.py`: 3 passed
- Live verification against DeepSeek: first attempt rejected with HTTP 400 `response_format` error → fallback retry succeeded, produced title `配置飞书网关连接 Hermes`.
- Unit-checked `_is_response_format_rejection`: (400 + "response_format" msg) → True; (500 + unrelated msg) → False.

## Notes

No behavior change for providers that support `json_schema` — the first attempt still uses the schema and only falls back on the specific 400 rejection.
