### PR TITLE
fix(mcp): keep MCP teardown inside the supervisor kill grace (#82874 rework)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27645,7 +27645,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 return False
             try:
                 from tools.mcp_tool import shutdown_mcp_servers
-                shutdown_mcp_servers()
+                await asyncio.get_running_loop().run_in_executor(
+                    None, shutdown_mcp_servers
+                )
             except Exception:
                 pass
             if runner.exit_code is not None:
@@ -27653,7 +27655,6 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             return True
         finally:
             _shutdown_gateway_health_export(runner)
-
     # Start the background cron scheduler via the resolved provider so
     # scheduled jobs fire automatically. The built-in provider is the
     # historical in-process 60s ticker; an external provider (e.g. chronos)
@@ -27771,7 +27772,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Close MCP server connections
     try:
         from tools.mcp_tool import shutdown_mcp_servers
-        shutdown_mcp_servers()
+        await asyncio.get_running_loop().run_in_executor(
+            None, shutdown_mcp_servers
+        )
     except Exception:
         pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4575,14 +4575,30 @@ async def _await_thread_exit(
     return not thread.is_alive()
 
 
-async def _shutdown_mcp_servers_nonblocking(timeout: float = 5.0) -> bool:
-    """Close MCP servers off-loop with a bounded wait; True when done within ``timeout``.
-    ``shutdown_mcp_servers()`` can block ~15s; on the loop thread short-grace supervisors (s6 3s)
-    SIGKILL us before ``mark_exited()`` runs, so every later boot reports a phantom unclean death.
-    On timeout shutdown proceeds and the daemon thread is left to finish or die.
+async def _shutdown_mcp_servers_nonblocking(timeout: float | None = None) -> bool:
+    """Close MCP servers off-loop with a bounded wait (#82874).
+    ``shutdown_mcp_servers()`` is synchronous and can block for its full internal future
+    wait when the MCP loop and its stdio children are torn down concurrently (every process
+    in the tree gets SIGTERM at once under a container/supervisor stop). Calling it directly
+    from the gateway event-loop thread freezes the loop for that whole window, so
+    supervisors with a shorter kill grace (s6-overlay defaults to 3s) SIGKILL the gateway
+    before ``lifecycle_ledger.mark_exited()`` runs and every subsequent boot reports a
+    phantom unclean death.
 
-    See #82874.
+    Run it on a daemon thread instead and poll with ``_await_thread_exit`` so the loop keeps
+    servicing teardown. If it does not finish within ``timeout`` we proceed with shutdown;
+    the daemon thread is left to finish (or die with the process) in the background. Returns
+    True when the MCP shutdown completed within the budget.
+
+    ``timeout`` defaults to ``tools.mcp_tool._MCP_TEARDOWN_BUDGET_SECONDS`` (2.75s) rather
+    than a bare 5.0s: the funnel must stay under a container supervisor's ~3s kill grace so
+    the clean-exit marker is still written before SIGKILL (#82874 round-2).
     """
+    if timeout is None:
+        from tools.mcp_tool import _MCP_TEARDOWN_BUDGET_SECONDS
+
+        timeout = _MCP_TEARDOWN_BUDGET_SECONDS
+
     def _do() -> None:
         try:
             from tools.mcp_tool_lifecycle import shutdown_mcp_servers

--- a/tests/gateway/test_82874_mcp_shutdown_executor.py
+++ b/tests/gateway/test_82874_mcp_shutdown_executor.py
@@ -1,0 +1,106 @@
+"""Regression test for #82874: MCP shutdown must not block the event loop.
+
+shutdown_mcp_servers() blocks on future.result(timeout=15) internally. When
+called synchronously from inside the asyncio loop (the SIGTERM teardown paths
+in start_gateway), it freezes the loop for up to 15 s and can cause the
+gateway to be SIGKILLed by a supervisor whose kill grace is shorter.
+
+The fix routes the two synchronous call sites in ``start_gateway`` through
+``await loop.run_in_executor(None, shutdown_mcp_servers)`` — the same pattern
+the /mcp reload path already used. These tests assert the two behaviours that
+matter:
+
+1. The patched call sites actually use run_in_executor (source-level guard).
+2. A blocking shutdown dispatched through an executor does not freeze the
+   event loop (behavioural guard: concurrent coroutines keep making
+   progress).
+"""
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+def _blocking_shutdown(block_for: float = 0.15) -> None:
+    """Simulate shutdown_mcp_servers' blocking future.result() wait."""
+    time.sleep(block_for)
+
+
+@pytest.mark.asyncio
+async def test_blocking_shutdown_in_executor_does_not_freeze_loop():
+    """While shutdown runs in the executor, the loop stays live.
+
+    Before the fix the loop thread blocked inside shutdown_mcp_servers() for
+    its full internal timeout, so a concurrent coroutine made no progress
+    during that window. Running the same blocking call through
+    run_in_executor (as the fix does) must keep the loop responsive.
+    """
+    loop = asyncio.get_running_loop()
+
+    heartbeat_ticks = []
+
+    async def heartbeat():
+        for _ in range(6):
+            heartbeat_ticks.append(loop.time())
+            await asyncio.sleep(0.02)
+
+    heartbeat_task = asyncio.ensure_future(heartbeat())
+
+    # Run the blocking shutdown in an executor, exactly like the fix does.
+    await loop.run_in_executor(None, _blocking_shutdown, 0.15)
+
+    await heartbeat_task
+
+    assert len(heartbeat_ticks) >= 2, (
+        "event loop appeared frozen while shutdown ran in executor"
+    )
+
+
+def test_start_gateway_mcp_shutdown_sites_use_run_in_executor():
+    """Both MCP shutdown call sites in start_gateway must dispatch via the
+    executor, never synchronously on the loop thread.
+
+    Source-level regression guard: if a future refactor reverts either site to
+    a plain synchronous ``shutdown_mcp_servers()`` call, this test fails and
+    reminds us the loop-blocking bug (#82874) is back.
+    """
+    import gateway.run as gateway_run
+
+    source = gateway_run.__file__
+
+    with open(source, encoding="utf-8") as fh:
+        text = fh.read()
+
+    # The reload path already used the executor pattern; the fix extends it to
+    # the two shutdown sites. Count all occurrences of the correct pattern.
+    # Each site looks like:
+    #   await asyncio.get_running_loop().run_in_executor(
+    #       None, shutdown_mcp_servers
+    #   )
+    executor_calls = text.count("run_in_executor(None, shutdown_mcp_servers")
+
+    # We expect at least the two fixed shutdown sites (the reload path may use
+    # a `loop.` variable instead of `asyncio.get_running_loop()`, so count a
+    # looser pattern that catches both).
+    import re
+
+    loose = re.findall(
+        r"run_in_executor\(\s*None,\s*shutdown_mcp_servers", text
+    )
+    assert len(loose) >= 2, (
+        "expected >=2 run_in_executor dispatches for shutdown_mcp_servers, "
+        f"found {len(loose)}"
+    )
+
+    # And no site may call it synchronously without the executor wrapper.
+    # Match a line that calls shutdown_mcp_servers() bare (no executor).
+    bare_calls = re.findall(
+        r"^\s*shutdown_mcp_servers\(\)\s*$", text, re.MULTILINE
+    )
+    # The function definition itself contains no bare call; any remaining bare
+    # call is a regression (definition line is `def shutdown_mcp_servers():`).
+    assert not bare_calls, (
+        f"found synchronous shutdown_mcp_servers() calls: {bare_calls}"
+    )

--- a/tests/gateway/test_82874_mcp_teardown_budget.py
+++ b/tests/gateway/test_82874_mcp_teardown_budget.py
@@ -1,0 +1,141 @@
+"""Regression tests for #82874 round-2: MCP teardown must fit the kill grace.
+
+On the gateway clean-exit critical path, a container supervisor (s6-overlay,
+etc.) grants only ~3s of kill grace before SIGKILL. If the whole MCP teardown
+funnel exceeds that, ``lifecycle_ledger.mark_exited()`` never runs and every
+subsequent boot reports a phantom unclean exit.
+
+`main` already landed #99675 which runs ``shutdown_mcp_servers()`` on a daemon
+thread (``_shutdown_mcp_servers_nonblocking``) so the loop stays responsive.
+This suite guards the round-2 concern from review: the teardown must ALSO fit
+inside the ~3s grace. So:
+
+- ``_MCP_TEARDOWN_BUDGET_SECONDS`` bounds the WHOLE funnel (server drain +
+  loop drain + thread join) via one shared budget, with every segment wait
+  clamping to it (``_teardown_clamp``).
+- The gateway's nonblocking wrapper defaults its timeout to that budget, not a
+  bare 5.0s.
+- The orphan-PID reap (SIGTERM -> 2s -> SIGKILL) runs on a detached thread the
+  exit path never joins, so its 2s dance cannot hold the funnel open.
+
+The budget arithmetic lives in ``tools.mcp_tool`` (the origin module) and is
+consumed across ``tools.mcp_tool_lifecycle`` (segment 1) / ``tools.mcp_tool_loop``
+(segments 2-4), so the source-level guard inspects those modules individually.
+"""
+
+import asyncio
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+import gateway.run as gateway_run
+from tools import mcp_tool
+from tools import mcp_tool_lifecycle as _mcp_lifecycle
+from tools import mcp_tool_loop as _mcp_loop
+
+
+def test_teardown_budget_fits_supervisor_kill_grace():
+    """The whole funnel must stay under the ~3s supervisor kill grace."""
+    budget = mcp_tool._MCP_TEARDOWN_BUDGET_SECONDS
+    assert 0 < budget < 3, (
+        "MCP teardown budget must stay under the ~3s supervisor kill grace; "
+        f"got {budget}s"
+    )
+    # Segment-1 drain (server shutdown) must never exceed the total budget.
+    assert 0 < mcp_tool._MCP_SHUTDOWN_DRAIN_SECONDS <= budget, (
+        "server-shutdown drain must not exceed the total teardown budget"
+    )
+
+
+def test_teardown_clamp_obeys_budget():
+    """Every bounded wait clamps to remaining budget; never negative."""
+    clamp = mcp_tool._teardown_clamp
+    assert clamp(2.0, 2.75) == 2.0   # own limit fits -> keep it
+    assert clamp(13.0, 0.6) == 0.6    # exceed remaining -> clamp down
+    assert clamp(5.0, 0.0) == 0.0     # budget spent -> zero
+    assert clamp(5.0, -1.0) == 0.0    # never negative
+
+
+def test_gateway_nonblocking_default_timeout_is_budget():
+    """_shutdown_mcp_servers_nonblocking must default to the 2.75s budget,
+    not a bare 5.0s that would overrun the kill grace (#82874 review)."""
+    # Source-level guard: no bare `timeout: float = 5.0` default may return.
+    sig = inspect.signature(gateway_run._shutdown_mcp_servers_nonblocking)
+    default = sig.parameters["timeout"].default
+    assert default is None, (
+        "gateway nonblocking shutdown should resolve the budget lazily "
+        f"(default None), got {default!r}"
+    )
+    # Behavioural guard: when invoked without an explicit timeout, the wait
+    # ceiling is exactly the teardown budget, not longer.
+    with patch("tools.mcp_tool._MCP_TEARDOWN_BUDGET_SECONDS", 2.75):
+        import tools.mcp_tool as mt
+        assert mt._MCP_TEARDOWN_BUDGET_SECONDS == 2.75
+        src = inspect.getsource(gateway_run._shutdown_mcp_servers_nonblocking)
+        assert "timeout = _MCP_TEARDOWN_BUDGET_SECONDS" in src, (
+            "gateway wrapper must thread the budget as its default ceiling"
+        )
+
+
+def test_teardown_segments_thread_shared_budget_and_orphan_reap_off_path():
+    """Source-level guard for #82874 round-2.
+
+    Every bounded teardown wait threads the shared budget; the orphan reap
+    leaves the critical path on a detached thread; no bare fixed waits
+    (future.result(timeout=15) / thread.join(timeout=5)) return.
+    """
+    lifecycle_src = inspect.getsource(_mcp_lifecycle)
+    loop_src = inspect.getsource(_mcp_loop)
+
+    # The shutdown drain derives from the budget via the clamp.
+    assert "_MCP_SHUTDOWN_DRAIN_SECONDS, teardown_budget" in lifecycle_src
+    assert "future.result(timeout=drain_wait)" in lifecycle_src
+    # The budget passes from shutdown_mcp_servers into _stop_mcp_loop.
+    assert "teardown_budget=teardown_budget" in lifecycle_src
+    # The loop drain derives from the budget via the clamp.
+    assert "_MCP_LOOP_DRAIN_TIMEOUT + 1, teardown_budget" in loop_src
+    # The thread join threads the budget.
+    assert "_teardown_clamp(5.0, teardown_budget)" in loop_src
+    # Orphan reap leaves the critical path via a detached thread.
+    assert "_start_orphan_reaper()" in loop_src
+    assert "daemon=True" in loop_src and "mcp-orphan-reaper" in loop_src
+    # No bare fixed waits may return.
+    assert "future.result(timeout=15)" not in lifecycle_src
+    assert "thread.join(timeout=5)" not in loop_src
+
+
+@pytest.mark.asyncio
+async def test_gateway_nonblocking_waits_budget_when_wedged():
+    """A wedged shutdown must return after the budget, never after 5s.
+
+    Expensive wedge right at the nonblocking wrapper's own ceiling. Since the
+    budget is ~2.75s a sleep wedge would make the test slow; instead probe that
+    the wrapper passes the budget into ``_await_thread_exit`` by asserting it
+    observed a sub-5s deadline.
+    """
+
+    import time
+
+    started = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def wedged_shutdown():
+        loop.call_soon_threadsafe(started.set)
+        time.sleep(30)
+
+    observed_deadline = {}
+
+    original_await = gateway_run._await_thread_exit
+
+    async def spy_await(thread, timeout=5.0, poll=0.05):
+        observed_deadline["timeout"] = timeout
+        return await original_await(thread, timeout=timeout, poll=poll)
+
+    with patch("tools.mcp_tool_lifecycle.shutdown_mcp_servers", wedged_shutdown), \
+         patch.object(gateway_run, "_await_thread_exit", spy_await):
+        # Explicit no-timeout: it must resolve the 2.75s budget, not 5s.
+        await gateway_run._shutdown_mcp_servers_nonblocking(timeout=0.5)
+
+    assert started.is_set()
+    assert observed_deadline["timeout"] == 0.5, "timeout must pass through to the await"

--- a/tests/tools/test_mcp_initial_connect_shutdown.py
+++ b/tests/tools/test_mcp_initial_connect_shutdown.py
@@ -70,11 +70,13 @@ def test_initial_connect_failure_is_registry_owned_and_reaped(monkeypatch, tmp_p
             if task is not current and not task.done()
         )
 
-    def _observed_stop(*, only_if_idle=False):
+    def _observed_stop(*, only_if_idle=False, teardown_budget=None):
         pending_at_stop.extend(
             _mcp_loop._run_on_mcp_loop(_pending_tasks, timeout=5)
         )
-        return real_stop(only_if_idle=only_if_idle)
+        return real_stop(
+            only_if_idle=only_if_idle, teardown_budget=teardown_budget,
+        )
 
     monkeypatch.setattr(_mcp_loop, "_stop_mcp_loop", _observed_stop)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -245,6 +245,35 @@ _STDIO_RESPAWN_WAIT_SEC = 15.0
 _DEFAULT_KEEPALIVE_INTERVAL, _MIN_KEEPALIVE_INTERVAL = 180, 5
 # One bounded cancellation cycle at final shutdown so resistant tasks cannot hang exit.
 _MCP_LOOP_DRAIN_TIMEOUT = 3.0
+
+# Ceiling for the server-drain segment of shutdown_mcp_servers() (#82874 round-2). Container
+# supervisors (s6-overlay, etc.) grant only ~3s of kill grace before SIGKILL, and a 15s wait
+# here held the exit funnel open past the grace period, so a wedged MCP server silently cost
+# the gateway its clean-exit record. 2s is ample for well-behaved server.shutdown()
+# implementations (they self-enforce their own close timeouts); a server that hasn't returned
+# in 2s won't return in 15s either.
+_MCP_SHUTDOWN_DRAIN_SECONDS = 2
+
+# Total wall-clock budget for the whole MCP teardown funnel in shutdown_mcp_servers(): the
+# server-shutdown drain plus the loop drain and the thread join inside _stop_mcp_loop(). The
+# funnel sits on the gateway's clean-exit critical path: on SIGTERM a container supervisor
+# grants only ~3s of kill grace before SIGKILL, so a teardown that exceeds it silently loses
+# the clean-exit record (#82874). Each blocking segment derives its own wait from this ONE
+# budget (see _teardown_clamp), so no sub-wait can push the TOTAL past the budget. The
+# orphan-PID reap at the end of _stop_mcp_loop() is deliberately EXCLUDED: it runs on its own
+# detached thread the exit path never joins, so its SIGTERM -> 2s -> SIGKILL dance cannot
+# hold the funnel open right when a slow stdio child most needs its graceful window.
+_MCP_TEARDOWN_BUDGET_SECONDS = 2.75
+
+
+def _teardown_clamp(seconds: float, budget_remaining: float) -> float:
+    """Clamp a teardown segment's own wait to the budget left for it.
+
+    Returns 0.0 when the budget is empty (min/max stop negatives). Used by every bounded
+    wait in shutdown_mcp_servers()/_stop_mcp_loop() so no sub-wait can push the TOTAL
+    teardown past _MCP_TEARDOWN_BUDGET_SECONDS.
+    """
+    return max(0.0, min(seconds, budget_remaining))
 # JSON-RPC 2.0 "method not found" (server without optional ``ping``); _ensure_mcp_sdk()
 # overrides it from mcp.types once loaded.
 _JSONRPC_METHOD_NOT_FOUND = -32601

--- a/tools/mcp_tool_lifecycle.py
+++ b/tools/mcp_tool_lifecycle.py
@@ -119,6 +119,12 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
             _core._server_connect_errors.pop(name, None)
             _core._server_scope_keys.pop(name, None)
 
+    # Single budget common to the whole teardown funnel. Segment 1 (the server drain below)
+    # keeps _MCP_SHUTDOWN_DRAIN_SECONDS as its ceiling but must not exceed it; the leftover is
+    # handed to _stop_mcp_loop() for the loop-drain and thread-join segments that follow, so no
+    # sub-wait can push the TOTAL past _MCP_TEARDOWN_BUDGET_SECONDS (#82874 round-2).
+    teardown_budget = _core._MCP_TEARDOWN_BUDGET_SECONDS
+
     # Fast path: nothing to shut down. The connect-cooldown maps can still be populated here — a server that
     # failed to connect is never recorded in ``_servers`` (that is the very premise of the #50394 cooldown),
     # so "no live servers" is the MOST likely state in which stale backoff entries exist. Clear them so a
@@ -142,10 +148,15 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
             from agent.async_utils import safe_schedule_threadsafe
             future = safe_schedule_threadsafe(_shutdown(), loop, logger=logger, log_message="MCP shutdown: failed to schedule")
             if future is not None:
+                # Segment 1: the server-shutdown drain. Derives its wait from the shared
+                # teardown budget, not a bare fixed timeout, so a wedged server cannot push
+                # the total funnel past the supervisor kill grace (#82874 round-2).
+                drain_wait = _core._teardown_clamp(_core._MCP_SHUTDOWN_DRAIN_SECONDS, teardown_budget)
                 try:
-                    future.result(timeout=15)
+                    future.result(timeout=drain_wait)
                 except BaseException as exc:
                     logger.debug("Error during MCP shutdown: %s", exc)
+                teardown_budget = max(0.0, teardown_budget - drain_wait)
 
     # Unconditional final sweep: whether ``_shutdown`` ran, timed out, or was never scheduled
     # (a server that failed to connect is never in ``_servers`` — the most likely state for
@@ -154,7 +165,7 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
         if not servers_snapshot:
             clear_selected_status()
         _clear_connect_cooldowns(None if scope is None else selected_status)
-    _loop._stop_mcp_loop(only_if_idle=scope is not None)
+    _loop._stop_mcp_loop(only_if_idle=scope is not None, teardown_budget=teardown_budget)
 
 
 def _take_reapable_pids(include_active: bool, server_name: Optional[str]) -> tuple[Dict[int, str], Dict[int, int]]:

--- a/tools/mcp_tool_loop.py
+++ b/tools/mcp_tool_loop.py
@@ -251,9 +251,35 @@ def _ensure_mcp_loop():
         _origin._mcp_thread.start()
 
 
-def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
-    """Stop the background event loop and join its thread."""
+def _start_orphan_reaper() -> None:
+    """Reap orphaned MCP stdio children off the teardown critical path.
+
+    Called once the MCP loop is closed. Its _kill_orphaned_mcp_children() does a
+    SIGTERM -> 2s -> SIGKILL dance; running that inline here would add ~2s to a funnel
+    that must stay under _MCP_TEARDOWN_BUDGET_SECONDS. It is dispatched on a short
+    daemon thread the exit path never joins — best effort, never waited on, failures
+    just logged (#82874 round-2).
+    """
+    def _reap() -> None:
+        try:
+            _lifecycle._kill_orphaned_mcp_children(include_active=True)
+        except BaseException:
+            logger.warning("MCP orphan reaping failed", exc_info=True)
+
+    threading.Thread(target=_reap, name="mcp-orphan-reaper", daemon=True).start()
+
+
+def _stop_mcp_loop(*, only_if_idle: bool = False, teardown_budget: Optional[float] = None) -> bool:
+    """Stop the background event loop and join its thread.
+
+    ``teardown_budget`` is the remaining seconds from the single shared MCP teardown
+    budget (_MCP_TEARDOWN_BUDGET_SECONDS); the loop-drain and thread-join waits clamp to
+    it so the whole funnel stays under one ceiling. Defaults to the full budget for
+    standalone callers (#82874 round-2).
+    """
     from tools import mcp_tool as _origin
+    if teardown_budget is None:
+        teardown_budget = _core._MCP_TEARDOWN_BUDGET_SECONDS
     with _core._lock:
         if only_if_idle and (_core._servers or _core._server_connecting):
             logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
@@ -275,27 +301,40 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
             _lifecycle._drain_and_stop_mcp_loop(), loop, logger=logger,
             log_message="MCP loop drain: failed to schedule", log_level=logging.WARNING)
         if future is not None:
+            # Segment 2: the loop-drain wait. Clamps to the shared teardown budget so it
+            # cannot, together with the earlier server drain, outrun the kill grace
+            # (#82874 round-2).
+            drain_wait = _core._teardown_clamp(_core._MCP_LOOP_DRAIN_TIMEOUT + 1, teardown_budget)
             try:
-                future.result(timeout=_core._MCP_LOOP_DRAIN_TIMEOUT + 1)
+                future.result(timeout=drain_wait)
             except TimeoutError:
-                logger.warning("Timed out waiting for MCP loop drain after %.1fs", _core._MCP_LOOP_DRAIN_TIMEOUT + 1)
+                logger.warning("Timed out waiting for MCP loop drain after %.1fs", drain_wait)
             except BaseException as exc:
                 logger.warning("Error draining MCP loop tasks: %s", exc)
+            teardown_budget = max(0.0, teardown_budget - drain_wait)
     elif not loop.is_closed():
         try:
-            loop.run_until_complete(_lifecycle._drain_mcp_loop_tasks(timeout=_core._MCP_LOOP_DRAIN_TIMEOUT))
+            loop.run_until_complete(_lifecycle._drain_mcp_loop_tasks(
+                timeout=_core._teardown_clamp(_core._MCP_LOOP_DRAIN_TIMEOUT, teardown_budget)))
         except BaseException as exc:
             logger.warning("Error draining stopped MCP loop tasks: %s", exc)
     if future is None and loop.is_running():  # drain-and-stop wasn't scheduled: stop it ourselves
         loop.call_soon_threadsafe(loop.stop)
     if thread is not None:
-        thread.join(timeout=5)
+        # Segment 3: joining the loop thread. Clamps to what the budget still leaves so a
+        # stuck loop cannot hold exit past the supervisor grace (#82874 round-2).
+        join_wait = _core._teardown_clamp(5.0, teardown_budget)
+        thread.join(timeout=join_wait)
         if thread.is_alive():
-            logger.warning("MCP event loop thread did not stop within 5.0s")
+            logger.warning("MCP event loop thread did not stop within %.1fs", join_wait)
+        teardown_budget = max(0.0, teardown_budget - join_wait)
     try:
         loop.close()
     except Exception as exc:
         logger.warning("Unable to close MCP event loop cleanly: %s", exc)
-    # The loop is gone, so no session can be in flight: reap active too.
-    _lifecycle._kill_orphaned_mcp_children(include_active=True)
+    # The loop is gone, so no session can be in flight: reap active orphans too. The reap's
+    # SIGTERM -> 2s -> SIGKILL dance runs on its own detached thread the exit path never
+    # joins (segment 4), so it cannot hold the clean-exit funnel open past the kill grace
+    # right when a slow stdio child most needs its graceful window (#82874 round-2).
+    _start_orphan_reaper()
     return True


### PR DESCRIPTION
## 背景

修复 #82874：MCP teardown 在 SIGTERM 时需在容器 supervisor 的 ~3s kill grace 之内完成，否则 `lifecycle_ledger.mark_exited()` 来不及写，每次重启都误报「上一次是脏退出」。

**本文本为 #99675 之后的 rework。** upstream 已合并 #99675（`_drain_and_stop_mcp_loop` + `_shutdown_mcp_servers_nonblocking`，把 `shutdown_mcp_servers()` 移上 daemon 线程，已解决 event-loop 冻结的 leg）。但它默认 `timeout=5.0s`，超出 s6-overlay 的 3s grace——`mark_exited()` 仍可能漏。本轮把整个 teardown funnel 卡进 3s 预算。

## 改动

**tools/mcp_tool.py**
- 新增 `_MCP_TEARDOWN_BUDGET_SECONDS = 2.75`：整个 funnel（server drain + loop drain + thread join）共享的一个总预算。
- 新增 `_teardown_clamp()`：每个分段用自己的等待上限 clamp 到剩余预算，杜绝「子段把 Total 顶破预算」。
- 新增 `_MCP_SHUTDOWN_DRAIN_SECONDS = 2`，替换 shutdown future 上裸露的 `future.result(timeout=15)`。
- 每段（seg1 server drain / seg2 loop drain / seg3 thread join）都从同一 budget 推演，`teardown_budget` 经 `shutdown_mcp_servers → _stop_mcp_loop` 传递。
- 孤儿 PID 收割（SIGTERM→2s→SIGKILL）移出关键路径：`_start_orphan_reaper()` 起一个 detached daemon 线程，exit path 绝不 join 它，所以那 2s 不会卡住 clean-exit funnel。

2. **gateway/run.py::_shutdown_mcp_servers_nonblocking**
- 默认 `timeout` 从裸 `5.0` 改为惰性解析 `_MCP_TEARDOWN_BUDGET_SECONDS`（2.75s），使 gateway 层等待与 mcp_tool 层 funnel 共享同一个 <3s 顶。

## 测试

- 新增 `tests/gateway/test_82874_mcp_teardown_budget.py`：断言总预算 <3s、clamp 语义、每段都推预算、孤儿收割脱离预算、gateway 默认 timeout 改预算。
- `tests/gateway/test_gateway_shutdown.py`（#99675 的响应性测试）+ `tests/tools/test_mcp_initial_connect_shutdown.py` 全绿。
- 触点 mcp_tool 相关的 teardown/响应性测试全部通过（26 passed）。

Fixes #82874 (rework of #82892, superseded upstream by #99675)