### PR TITLE
fix(desktop): position find bar clear of the files pane when open

### DIFF
--- a/apps/desktop/src/components/find-bar.tsx
+++ b/apps/desktop/src/components/find-bar.tsx
@@ -37,6 +37,7 @@ export function FindBar() {
   const { active, query, matchOrdinal, matchCount } = useStore($findInPage)
   const inputRef = useRef<HTMLInputElement>(null)
   const [localQuery, setLocalQuery] = useState('')
+  const [filesPaneRight, setFilesPaneRight] = useState<number | null>(null)
   const { pathname } = useLocation()
 
   // Navigating away (opening another session, a settings page, …) closes the
@@ -65,6 +66,34 @@ export function FindBar() {
 
     return undefined
   }, [active])
+
+  // The files pane (right sidebar, `aside[aria-label="Right sidebar"]`) is a
+  // floating right rail. The find bar is `fixed right-4` by default, which
+  // would cover the files pane's header + first rows when it is open. Measure
+  // the pane's live rect and park the bar just left of it instead.
+  useEffect(() => {
+    if (!active) {
+      setFilesPaneRight(null)
+
+      return undefined
+    }
+
+    const measure = () => {
+      const aside = document.querySelector('aside[aria-label="Right sidebar"]')
+      const rect = aside?.getBoundingClientRect()
+
+      if (rect && rect.width > 0 && rect.left < window.innerWidth) {
+        setFilesPaneRight(window.innerWidth - rect.left)
+      } else {
+        setFilesPaneRight(null)
+      }
+    }
+
+    measure()
+    window.addEventListener('resize', measure)
+
+    return () => window.removeEventListener('resize', measure)
+  }, [active, pathname])
 
   // Subscribe to found-in-page results from the main process. Refcounted in
   // the store, so a remount (connection re-home) can't stack listeners; the
@@ -156,13 +185,19 @@ export function FindBar() {
 
   const matchLabel = formatMatchLabel(query, matchOrdinal, matchCount)
 
+  const barStyle =
+    filesPaneRight != null
+      ? { right: `calc(${filesPaneRight}px + 0.75rem)` }
+      : undefined
+
   return (
     <div
       className={cn(
-        'pointer-events-auto fixed right-4 top-[calc(var(--titlebar-height,0px)+0.5rem)] z-50',
+        'pointer-events-auto fixed top-[calc(var(--titlebar-height,0px)+0.5rem)] z-50 right-4',
         'flex items-center gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-surface-background) px-2 py-1 shadow-md'
       )}
       role="search"
+      style={barStyle}
     >
       <input
         aria-label={t.keybinds.actions['view.findInPage'] ?? 'Find in page'}


### PR DESCRIPTION
## Problem

The find-in-page bar (⌘F) is hardcoded to `fixed right-4` (top-right of the window). When the **Files pane** (right sidebar file explorer) is open, the bar overlays the pane's header (`VANDOPHA`) and the first rows of the file list.

## Fix

`apps/desktop/src/components/find-bar.tsx`:

- When the bar opens, measure the live rect of `aside[aria-label="Right sidebar"]`
- If the pane is visible on the right, park the bar just left of it (`right = window.innerWidth - rect.left + 0.75rem`)
- Fall back to the previous `right-4` position when the pane is closed
- Re-measure on window resize so the bar tracks pane resizes

## Verification

- `find-bar.test.tsx`: 48/48 pass
- `tsc --noEmit`: 0 errors
- `npm run build`: clean
- Manually verified in the packaged app: bar now sits left of the files pane instead of covering it