### PR TITLE
fix(gateway): log warning on unrecognized busy_input_mode fallback (#82878)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8485,6 +8485,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "queue"
         if mode == "steer":
             return "steer"
+        if mode:
+            logger.warning(
+                "busy_input_mode=%r is not a recognized value (expected "
+                "interrupt|queue|steer); falling back to 'interrupt'",
+                mode,
+            )
         return "interrupt"
 
     @staticmethod


### PR DESCRIPTION
## Summary

`gateway/run.py`'s `_load_busy_input_mode()` silently coerces any unrecognized `display.busy_input_mode` config value to `"interrupt"` with no log record. A misconfigured value (e.g. `wait` from an older config schema or a plain typo) runs as `interrupt` indefinitely with zero signal that the configured behavior differs from what's actually running.

## Fix

Add a `logger.warning()` on the fallback path so a bad value is visible in logs. Behavior unchanged (still falls back to `interrupt`), just makes the fallback observable.

```
busy_input_mode='wait' is not a recognized value (expected interrupt|queue|steer); falling back to 'interrupt'
```

## Changes

- `gateway/run.py`: Add `if mode:` guard + `logger.warning()` before `return "interrupt"` in `_load_busy_input_mode()`

## Test Plan

- [x] `gateway/run.py` passes syntax check
- [ ] Setting `busy_input_mode: wait` in config produces warning log on gateway start
- [ ] Valid values (`interrupt`, `queue`, `steer`) produce no warning

Fixes #82878