### PR TITLE
feat(cron): fire cron_job_failed lifecycle hook on job failure

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -124,6 +124,21 @@ emitted by each built-in hook site.
     child_status    – exit status string (e.g. "success", "error")
     tool_call_history – redacted tool name/input summary/byte counts/status list
     duration_ms     – wall-clock time of the child run in milliseconds
+
+``cron_job_failed`` (emitted from ``cron/scheduler.py`` when a scheduled
+job fails):::
+
+    job_id          – cron job id (e.g. "abc123def456")
+    job_name        – job name, or the job id when unnamed
+    profile         – Hermes profile the job belongs to ("" when default)
+    error           – human-readable failure text
+    last_run_at     – job's last_run_at value before this run, if any
+    job             – the full job dict (schedule, prompt, script, deliver,
+                      skills, etc.) — useful for reactive self-healing
+                      scripts that need to inspect or rewrite the job
+
+The payload is delivered to the hook script on stdin as JSON (see
+``_serialize_payload``); all fields above arrive under ``extra``.
 """
 
 from __future__ import annotations

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -151,6 +151,36 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     return f"⚠️ Cron '{job_name}' failed: {cleaned}"
 
 
+def _fire_cron_job_failed_hook(job: dict, error: str | None) -> None:
+    """Fire the ``cron_job_failed`` lifecycle hook on a failed cron run.
+
+    Gives reactive consumers (shell hooks, outbound webhooks, plugins) a
+    programmatic failure signal without polling ``jobs.json`` or wrapping
+    per-job delivery paths.  Best-effort: a hook that raises must never
+    crash the scheduler or mask the original job failure — this mirrors the
+    defensive pattern used by the ``on_session_end`` hook in
+    ``agent/turn_finalizer.py``.
+
+    Fired from the worker thread that ran the job, so blocking hook scripts
+    (``subprocess.run`` inside ``agent/shell_hooks.py``) do not freeze the
+    scheduler's event loop or the main gateway loop.
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+        _invoke_hook(
+            "cron_job_failed",
+            job_id=job.get("id", ""),
+            job_name=job.get("name") or job.get("id") or "",
+            profile=job.get("profile", ""),
+            error=error or "",
+            last_run_at=job.get("last_run_at") or "",
+            job=job,
+        )
+    except Exception as exc:
+        logger.warning("cron_job_failed hook failed: %s", exc)
+
+
 class CronPromptInjectionBlocked(Exception):
     """Raised by _build_job_prompt when the fully-assembled prompt trips the
     injection scanner. Caught in run_job so the operator sees a clean
@@ -4661,6 +4691,11 @@ def run_one_job(
                 )
             else:
                 deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            # Fire the cron_job_failed hook on failure — before delivery so a
+            # broken hook (or a blocking hook script) can never suppress or
+            # delay the failure message itself; hook failures are swallowed.
+            if not success:
+                _fire_cron_job_failed_hook(job, error)
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -344,6 +344,36 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     return message
 
 
+def _fire_cron_job_failed_hook(job: dict, error: str | None) -> None:
+    """Fire the ``cron_job_failed`` lifecycle hook on a failed cron run.
+
+    Gives reactive consumers (shell hooks, outbound webhooks, plugins) a
+    programmatic failure signal without polling ``jobs.json`` or wrapping
+    per-job delivery paths.  Best-effort: a hook that raises must never
+    crash the scheduler or mask the original job failure — this mirrors the
+    defensive pattern used by the ``on_session_end`` hook in
+    ``agent/turn_finalizer.py``.
+
+    Fired from the worker thread that ran the job, so blocking hook scripts
+    (``subprocess.run`` inside ``agent/shell_hooks.py``) do not freeze the
+    scheduler's event loop or the main gateway loop.
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+        _invoke_hook(
+            "cron_job_failed",
+            job_id=job.get("id", ""),
+            job_name=job.get("name") or job.get("id") or "",
+            profile=job.get("profile", ""),
+            error=error or "",
+            last_run_at=job.get("last_run_at") or "",
+            job=job,
+        )
+    except Exception as exc:
+        logger.warning("cron_job_failed hook failed: %s", exc)
+
+
 def _upsert_incident_for_failure(
     job: dict, error: str, *, output_file: Optional[Any] = None
 ) -> tuple[bool, Optional[str]]:
@@ -2741,6 +2771,11 @@ def _save_compose_deliver(
     ) = _compose_run_delivery(
         job, success=d.success, error=d.error, final_response=final_response,
         output_file=output_file)
+    # Fire the cron_job_failed hook on failure — before delivery so a broken
+    # hook (or a blocking hook script) can never suppress or delay the failure
+    # message itself; hook failures are swallowed.
+    if not d.success:
+        _fire_cron_job_failed_hook(job, d.error)
     # Whitespace-only == empty: skip delivery; the guard below marks it a soft failure.
     d.should_deliver = bool(deliver_content.strip()) and not _silent_alert
     # Not a substring check: bare "SILENT"/"NO_REPLY" or a report quoting "[SILENT]" must
@@ -2845,6 +2880,9 @@ def _deliver_crash_failure(
     job: dict, err_text: str, *, adapters, loop,
 ) -> tuple[Optional[str], str]:
     """Failure notice for a run that raised out of run_job. Returns (delivery_error, outcome)."""
+    # Fire the lifecycle hook first: a crash out of run_job is a job failure
+    # too, and the hook must see it even when the notice itself is ack-suppressed.
+    _fire_cron_job_failed_hook(job, err_text)
     normalized_deliver = _normalize_deliver_value(_delivery_lane_value(job, for_failure=True))
     # Same ack gate as the normal failure delivery: acked signatures stay silent here too.
     incident_acked, failure_incident_id = _upsert_incident_for_failure(job, err_text)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -216,6 +216,13 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Cron job lifecycle hooks. Fired by cron/scheduler.py from the worker
+    # thread that ran the job. Observers only: return values are ignored.
+    #
+    # cron_job_failed kwargs: job_id: str, job_name: str, profile: str,
+    #   error: str, last_run_at: str, job: dict (full job spec — schedule,
+    #   prompt, script, deliver, skills — for reactive self-healing).
+    "cron_job_failed",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -185,6 +185,13 @@ VALID_HOOKS: Set[str] = {
     # IGNORED in v1 — a plugin returning a directive-shaped dict gets a debug log so future block/rewrite
     # adopters are discoverable once the middleware variant ships against the #64231 taxonomy.
     "pre_command",
+    # Cron job lifecycle hooks. Fired by cron/scheduler.py from the worker
+    # thread that ran the job. Observers only: return values are ignored.
+    #
+    # cron_job_failed kwargs: job_id: str, job_name: str, profile: str,
+    #   error: str, last_run_at: str, job: dict (full job spec — schedule,
+    #   prompt, script, deliver, skills — for reactive self-healing).
+    "cron_job_failed",
 }
 
 # Hooks whose directive the shell-hook response parser has no channel for. VALID_HOOKS doubles as

--- a/tests/cron/test_cron_job_failed_hook.py
+++ b/tests/cron/test_cron_job_failed_hook.py
@@ -1,0 +1,117 @@
+"""Tests for the ``cron_job_failed`` lifecycle hook.
+
+The hook fires from ``cron/scheduler.py::run_one_job`` when a job fails
+(error surfaced, success=False), so reactive consumers (shell hooks,
+outbound webhooks, plugins) get a programmatic failure signal without
+polling ``jobs.json``.  It must:
+
+* fire exactly once per failed run, with the full job payload
+* NOT fire on success
+* never raise into the scheduler (a broken hook cannot crash the job loop)
+"""
+
+import cron.scheduler as s
+
+
+def _patch_pipeline(monkeypatch, *, success=True, error=None):
+    """Patch the job pipeline primitives (same shape as test_run_one_job)."""
+
+    def fake_run_job(job):
+        return (success, "out", "final response", error)
+
+    def fake_save(jid, out):
+        return f"/tmp/{jid}.txt"
+
+    def fake_deliver(job, content, adapters=None, loop=None):
+        return None
+
+    def fake_mark(jid, ok, err=None, delivery_error=None):
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", fake_save)
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", fake_mark)
+
+
+def test_failed_job_fires_cron_job_failed_hook(monkeypatch):
+    """A failing job fires the hook with the job spec and error text."""
+    _patch_pipeline(monkeypatch, success=False, error="boom")
+    captured = {}
+
+    def fake_hook(job, err):
+        captured["job"] = job
+        captured["err"] = err
+
+    monkeypatch.setattr(s, "_fire_cron_job_failed_hook", fake_hook)
+
+    job = {"id": "jfail", "name": "nightly", "profile": "work"}
+    s.run_one_job(job)
+
+    assert captured["job"] is job
+    assert captured["err"] == "boom"
+
+
+def test_successful_job_does_not_fire_hook(monkeypatch):
+    """A successful job must NOT fire the failure hook."""
+    _patch_pipeline(monkeypatch, success=True)
+    fired = []
+
+    def fake_hook(job, err):
+        fired.append((job, err))
+
+    monkeypatch.setattr(s, "_fire_cron_job_failed_hook", fake_hook)
+
+    ok = s.run_one_job({"id": "jok", "name": "ok-job"})
+
+    assert ok is True
+    assert fired == []
+
+
+def test_hook_exception_does_not_crash_scheduler(monkeypatch):
+    """A raising hook is swallowed: the job still completes without raising."""
+    _patch_pipeline(monkeypatch, success=False, error="boom")
+
+    def exploding_hook(job, err):
+        raise RuntimeError("hook script exploded")
+
+    monkeypatch.setattr(s, "_fire_cron_job_failed_hook", exploding_hook)
+
+    # run_one_job must not raise even though the hook raises.
+    s.run_one_job({"id": "jboom", "name": "boom-job"})
+
+
+def test_real_hook_function_uses_plugins_invoke_hook(monkeypatch):
+    """The real _fire_cron_job_failed_hook dispatches through
+    hermes_cli.plugins.invoke_hook and swallows its own failures."""
+    import hermes_cli.plugins as plugins
+
+    calls = []
+
+    def fake_plugins_invoke_hook(name, **kwargs):
+        calls.append((name, kwargs))
+
+    monkeypatch.setattr(plugins, "invoke_hook", fake_plugins_invoke_hook)
+
+    job = {"id": "jreal", "name": "real-job", "profile": "ops", "last_run_at": "2026-08-10T00:00:00Z"}
+    s._fire_cron_job_failed_hook(job, "kaput")
+
+    assert len(calls) == 1
+    name, kwargs = calls[0]
+    assert name == "cron_job_failed"
+    assert kwargs["job_id"] == "jreal"
+    assert kwargs["error"] == "kaput"
+    assert kwargs["job"] is job
+
+
+def test_real_hook_function_swallows_exception(monkeypatch):
+    """A failure inside plugins.invoke_hook must be logged, not raised."""
+    import hermes_cli.plugins as plugins
+
+    def raising_invoke_hook(name, **kwargs):
+        raise RuntimeError("plugin dispatch failed")
+
+    monkeypatch.setattr(plugins, "invoke_hook", raising_invoke_hook)
+
+    # Must not raise.
+    s._fire_cron_job_failed_hook({"id": "jx", "name": "x"}, "err")

--- a/tests/cron/test_cron_job_failed_hook.py
+++ b/tests/cron/test_cron_job_failed_hook.py
@@ -1,0 +1,203 @@
+"""Tests for the ``cron_job_failed`` lifecycle hook.
+
+The hook fires from the cron scheduler's failure path
+(``cron/scheduler.py::_save_compose_deliver``, reached via ``run_one_job``)
+when a job finishes with ``success=False``, so reactive consumers (shell
+hooks, outbound webhooks, plugins) get a programmatic failure signal without
+polling ``jobs.json`` or wrapping per-job delivery paths.  It must:
+
+* fire exactly once per failed run, with the full job payload
+* NOT fire on success
+* fire BEFORE the failure notice is delivered, so a broken/blocking hook can
+  never suppress or delay it
+* never raise into the scheduler (a broken hook cannot crash the job loop)
+"""
+
+import pytest
+
+import cron.scheduler as s
+
+
+@pytest.fixture
+def run_env(monkeypatch, tmp_path):
+    """Drive ``run_one_job`` with the real delivery path down to a fake sender.
+
+    Same shape as ``tests/cron/test_cron_failure_deliver.py``: bookkeeping
+    primitives are stubbed, but ``_deliver_result`` and the real
+    ``_fire_cron_job_failed_hook`` run unless a test patches them.  Returns an
+    ordered ``events`` list; a delivery appends ``("deliver", chat_id, text)``.
+    """
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "platforms:\n  slack:\n    enabled: true\n    token: xoxb-test\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    events = []
+
+    async def fake_sender(pconfig, chat_id, message, *, thread_id=None,
+                          media_files=None, force_document=False, caption=None):
+        events.append(("deliver", chat_id, message))
+        return {"success": True, "chat_id": chat_id, "message_id": "1.2"}
+
+    import gateway.platform_registry as reg
+    import hermes_cli.plugins as hp
+
+    entry = reg.platform_registry.get("slack")
+    if entry is None:
+        hp.discover_plugins()
+        entry = reg.platform_registry.get("slack")
+    if entry is None:
+        pytest.skip("slack platform entry not registered")
+    monkeypatch.setattr(entry, "standalone_sender_fn", fake_sender)
+    monkeypatch.setattr(hp, "discover_plugins", lambda *a, **k: None)
+
+    monkeypatch.setattr(s, "create_execution", lambda *_a, **_kw: {"id": "exec-t"})
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: {})
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **kw: True)
+    monkeypatch.setattr(s, "finish_execution", lambda *a, **kw: None)
+    # No durable incident store in play: never acked, no id.
+    monkeypatch.setattr(s, "_upsert_incident_for_failure", lambda *_a, **_kw: (False, None))
+    monkeypatch.setattr(s, "load_config", lambda: {})
+    return events
+
+
+def _failing_run_job(error="provider exploded"):
+    def _fake(job, **_kw):
+        return (False, "raw output", "", error)
+    return _fake
+
+
+def _succeeding_run_job(final="all good, here is the brief"):
+    def _fake(job, **_kw):
+        return (True, "raw output", final, None)
+    return _fake
+
+
+class TestFireSite:
+    def test_failed_job_fires_hook_once_with_job_and_error(self, run_env, monkeypatch):
+        monkeypatch.setattr(s, "run_job", _failing_run_job("boom"))
+        fired = []
+        monkeypatch.setattr(
+            s, "_fire_cron_job_failed_hook", lambda job, err: fired.append((job, err))
+        )
+
+        job = {"id": "jfail", "name": "nightly", "profile": "work", "deliver": "slack:D0MAIN"}
+        s.run_one_job(job)
+
+        assert len(fired) == 1
+        assert fired[0][0] is job
+        assert fired[0][1] == "boom"
+
+    def test_successful_job_does_not_fire_hook(self, run_env, monkeypatch):
+        monkeypatch.setattr(s, "run_job", _succeeding_run_job())
+        fired = []
+        monkeypatch.setattr(
+            s, "_fire_cron_job_failed_hook", lambda job, err: fired.append((job, err))
+        )
+
+        ok = s.run_one_job({"id": "jok", "name": "ok-job", "deliver": "slack:D0MAIN"})
+
+        assert ok is True
+        assert fired == []
+
+    def test_hook_fires_before_delivery(self, run_env, monkeypatch):
+        """A blocking hook must not be able to delay/suppress the failure notice."""
+        monkeypatch.setattr(s, "run_job", _failing_run_job("boom"))
+        monkeypatch.setattr(
+            s, "_fire_cron_job_failed_hook",
+            lambda job, err: run_env.append(("hook", job["id"])),
+        )
+
+        s.run_one_job({"id": "jorder", "name": "ordered", "deliver": "slack:D0MAIN"})
+
+        assert run_env, "expected the failure notice to be delivered"
+        assert run_env[0][0] == "hook"
+        assert any(e[0] == "deliver" for e in run_env)
+
+    def test_real_hook_swallows_plugin_exception_end_to_end(self, run_env, monkeypatch):
+        """A raising plugin dispatch is swallowed: run_one_job still completes."""
+        monkeypatch.setattr(s, "run_job", _failing_run_job("boom"))
+        import hermes_cli.plugins as plugins
+
+        def raising_invoke_hook(name, **kwargs):
+            raise RuntimeError("plugin dispatch failed")
+
+        monkeypatch.setattr(plugins, "invoke_hook", raising_invoke_hook)
+
+        # Must not raise even though the real hook dispatch raises internally.
+        s.run_one_job({"id": "jboom", "name": "boom-job", "deliver": "slack:D0MAIN"})
+
+    def test_escaped_exception_fires_hook(self, run_env, monkeypatch):
+        """A crash out of run_job is a failure too and must fire the hook."""
+        monkeypatch.setattr(
+            s, "run_job",
+            lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("cannot import name X")),
+        )
+        fired = []
+        monkeypatch.setattr(
+            s, "_fire_cron_job_failed_hook", lambda job, err: fired.append((job, err))
+        )
+
+        s.run_one_job({"id": "jcrashed", "name": "crasher", "deliver": "slack:D0MAIN"})
+
+        assert len(fired) == 1
+        assert fired[0][0]["id"] == "jcrashed"
+        assert "cannot import name X" in fired[0][1]
+
+
+class TestRealHookFunction:
+    def test_dispatches_through_plugins_invoke_hook(self, monkeypatch):
+        import hermes_cli.plugins as plugins
+
+        calls = []
+
+        def fake_invoke_hook(name, **kwargs):
+            calls.append((name, kwargs))
+
+        monkeypatch.setattr(plugins, "invoke_hook", fake_invoke_hook)
+
+        job = {
+            "id": "jreal", "name": "real-job", "profile": "ops",
+            "last_run_at": "2026-08-10T00:00:00Z",
+        }
+        s._fire_cron_job_failed_hook(job, "kaput")
+
+        assert len(calls) == 1
+        name, kwargs = calls[0]
+        assert name == "cron_job_failed"
+        assert kwargs["job_id"] == "jreal"
+        assert kwargs["job_name"] == "real-job"
+        assert kwargs["profile"] == "ops"
+        assert kwargs["error"] == "kaput"
+        assert kwargs["last_run_at"] == "2026-08-10T00:00:00Z"
+        assert kwargs["job"] is job
+
+    def test_job_name_falls_back_to_id_and_empty_defaults(self, monkeypatch):
+        import hermes_cli.plugins as plugins
+
+        calls = []
+        monkeypatch.setattr(
+            plugins, "invoke_hook", lambda name, **kwargs: calls.append(kwargs)
+        )
+
+        s._fire_cron_job_failed_hook({"id": "jonly"}, None)
+
+        assert calls[0]["job_name"] == "jonly"
+        assert calls[0]["error"] == ""
+        assert calls[0]["profile"] == ""
+        assert calls[0]["last_run_at"] == ""
+
+    def test_swallows_exception(self, monkeypatch):
+        import hermes_cli.plugins as plugins
+
+        def raising_invoke_hook(name, **kwargs):
+            raise RuntimeError("plugin dispatch failed")
+
+        monkeypatch.setattr(plugins, "invoke_hook", raising_invoke_hook)
+
+        # Must not raise.
+        s._fire_cron_job_failed_hook({"id": "jx", "name": "x"}, "err")

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -460,6 +460,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_session_finalize` | Observer | CLI/TUI/gateway teardown through `finalize_session`; gateway shutdown may finalize without a reset. Return ignored. | Surface-dependent `session_id`, `platform`, optionally `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
 | `on_session_reset` | Observer | CLI/TUI session boundary and gateway after the replacement session exists; return ignored. | CLI: `session_id`, `platform`, `reason`; TUI: `session_id`, `platform`; gateway: those plus `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
 | `on_skill_lifecycle` | Observer | After an authoritative skill-usage state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
+| `cron_job_failed` | Observer | From the cron worker thread when a scheduled job run fails — finishes with `success=False` or raises out of the run — before the failure notice is delivered; return ignored. | `job_id`, `job_name`, `profile`, `error`, `last_run_at`, `job` (full job spec) | `error` and `job` may contain prompt text, script paths, and other job content. |
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
 | `pre_gateway_dispatch` | Directive/control | Incoming non-internal message before auth/pairing/dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
@@ -1574,6 +1575,12 @@ Five additional observers (RFC #58548) extend the kanban family. All are observe
 - **`on_kanban_dispatch_tick`** — once per dispatcher tick, strictly after the dispatch lock is released, including idle and lock-contended ticks. Payload: `board`, `profile_name`, `dry_run`, `outcome`, `result`.
 
 ---
+
+### Cron job lifecycle observers
+
+#### `cron_job_failed`
+
+Fires once per failed cron run, from the worker thread that ran the job, immediately before the failure notice is delivered. Covers both failure shapes: a run that finishes with `success=False` (provider error, empty output, blocked config) and a run that raises out of `run_job`. Observer-only: return values are ignored, and a hook that raises is logged and swallowed so it can never mask or delay the original failure message. Payload: `job_id`, `job_name`, `profile`, `error`, `last_run_at`, and `job` (the full job spec — schedule, prompt, script, deliver, skills — for reactive self-healing scripts). It is registered in `VALID_HOOKS`, so it is available to Python plugins and `hooks:` shell hooks alike.
 
 ## Shell Hooks
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
@@ -394,6 +394,7 @@ def register(ctx):
 | `on_session_finalize` | 观察者 | CLI/TUI/gateway 通过 `finalize_session` teardown；gateway 关闭时可只 finalize 而不 reset。忽略返回值。 | 按 surface：`session_id`, `platform`，可选 `reason`, `old_session_id`, `new_session_id` | Session 和 routing 标识。 |
 | `on_session_reset` | 观察者 | CLI/TUI session boundary，或 gateway 创建替代 session 后；忽略返回值。 | CLI：`session_id`, `platform`, `reason`；TUI：`session_id`, `platform`；gateway：另有 `reason`, `old_session_id`, `new_session_id` | Session 和 routing 标识。 |
 | `on_skill_lifecycle` | 观察者 | 权威 skill 使用状态变更后；忽略返回值。 | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | 暴露本地 skill 名和 provenance。 |
+| `cron_job_failed` | 观察者 | 定时任务失败时触发——以 `success=False` 结束，或运行中抛出异常——在失败通知投递前，由运行该任务的 worker 线程发出；忽略返回值。 | `job_id`, `job_name`, `profile`, `error`, `last_run_at`, `job`（完整任务规格） | `error` 和 `job` 可能包含 prompt 文本、脚本路径及其他任务内容。 |
 | `subagent_start` | 观察者 | 子 agent 已构造、即将运行；忽略返回值。 | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal 可能含用户/项目内容。 |
 | `subagent_stop` | 观察者 | 子 agent 退出；忽略返回值。 | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary 和已脱敏 tool-history metadata 仍可能暴露项目结构。 |
 | `pre_gateway_dispatch` | 指令/控制 | 非 internal 入站消息在 auth/pairing/dispatch 前；第一个有效 `skip`、`rewrite` 或 `allow` 控制流程。 | `event`, `gateway`, `session_store` | 极高权限的进程内对象会暴露入站用户/routing 数据和 host handle。 |
@@ -1178,6 +1179,12 @@ Completion 和 cleanup 后触发，通常位于 worker 进程；`summary` 可能
 三个 kanban hook 均仅观察，并携带 `task_id`、`profile_name`、`board`、`assignee`、`run_id`；completed 增加 `summary`，blocked 增加 `reason`。
 
 ---
+
+### Cron 任务生命周期观察者
+
+#### `cron_job_failed`
+
+定时任务失败时触发一次，由运行该任务的 worker 线程在失败通知投递前发出。覆盖两种失败形态：以 `success=False` 结束（provider 报错、输出为空、配置被阻断）以及 `run_job` 抛出异常。仅观察：忽略返回值；hook 抛出的异常会被记录并吞掉，绝不会掩盖或延迟原始失败通知。Payload：`job_id`、`job_name`、`profile`、`error`、`last_run_at`，以及 `job`（完整任务规格——schedule、prompt、script、deliver、skills——供自愈脚本使用）。它已注册进 `VALID_HOOKS`，因此 Python 插件和 `hooks:` shell hook 均可使用。
 
 ## Shell Hooks
 


### PR DESCRIPTION
## Summary

Fixes #82353

Adds a new lifecycle hook event **`cron_job_failed`**, fired from `cron/scheduler.py` when a scheduled job fails. Reactive consumers (shell hooks, outbound webhooks, plugins) get a programmatic failure signal **immediately**, instead of polling `jobs.json` on a timer or wrapping per-job delivery paths.

## Why it matters

Auto-repair of cron jobs (config-format bugs, missing module wrappers, provider flakiness) is a common ops need. Today the only options are:
1. Poll `cron/jobs.json` on a timer (wasteful when healthy), or
2. Wrap every failing job's delivery path (fragile, per-job).

The scheduler already delivers a failure alert to the origin chat at `_summarize_cron_failure_for_delivery` — the failure is known at delivery time, it just wasn't exposed as a hookable event.

## What changed

| File | Change |
|---|---|
| `cron/scheduler.py` | New `_fire_cron_job_failed_hook(job, error)` — dispatches `cron_job_failed` via `plugins.invoke_hook`; called from `run_one_job` right after failure is determined, **before** delivery so a broken hook can never suppress the failure message. Best-effort: exceptions are caught and logged (mirrors the `on_session_end` defensive pattern). |
| `hermes_cli/plugins.py` | Registered `cron_job_failed` in `VALID_HOOKS` so `hooks:` config accepts it. |
| `agent/shell_hooks.py` | Documented the new event and its `extra` payload keys. |
| `tests/cron/test_cron_job_failed_hook.py` | 5 regression tests (see Test Plan). |

## Payload

Delivered on stdin as JSON (shell hooks) / as kwargs (plugins):

```json
{
  "hook_event_name": "cron_job_failed",
  "job_id": "abc123def456",
  "job_name": "Weekly summary digest",
  "profile": "work",
  "error": "Provider timeout ...",
  "last_run_at": "2026-08-10T00:00:00Z",
  "job": { "...full job spec... schedule, prompt, script, deliver, skills ..." }
}
```

`job` includes the full job spec so a self-healing script can inspect or rewrite the failing job.

## How to Verify

1. Configure a shell hook:
   ```yaml
   # cli-config.yaml
   hooks:
     cron_job_failed:
       - command: /path/to/on_fail.sh
   ```
2. Run a job that fails (e.g. a prompt that errors).
3. Observe the hook script receives the failure payload on stdin; the normal failure alert is still delivered to the origin chat.

## Test Plan

- [x] Added regression tests:
  - `test_failed_job_fires_cron_job_failed_hook` — failing job fires the hook with the job spec + error
  - `test_successful_job_does_not_fire_hook` — success never fires it
  - `test_hook_exception_does_not_crash_scheduler` — raising hook is swallowed, job completes
  - `test_real_hook_function_uses_plugins_invoke_hook` — real dispatch path hits `plugins.invoke_hook` with correct kwargs
  - `test_real_hook_function_swallows_exception` — dispatch failure logged, not raised
- [x] Existing tests pass: `tests/cron/test_run_one_job.py` + `tests/cron/test_scheduler.py` → 213 passed (1 pre-existing failure in `test_all_token_case_insensitive` unrelated to this change — reproduces on clean `main`, caused by a locally-registered `weixin` platform in the test environment)

## Risk Assessment

Low — a new observer-only hook event; no existing behavior changes. The hook fires only on failure, from the worker thread (never blocks the event loop), and its own exceptions are swallowed. Per AGENTS.md, this hook is non-speculative: it has a concrete consumer use case (reactive self-healing), which the issue documents.
