### PR TITLE
fix(tui): redact approval commands without importing gateway.run

### DIFF
--- a/tests/gateway/test_tui_approval_redaction.py
+++ b/tests/gateway/test_tui_approval_redaction.py
@@ -3,10 +3,15 @@
 Follow-up to #50767, which redacted the chat-platform and SSE/API approval
 transports. The TUI JSON-RPC transport is the third egress: three
 `register_gateway_notify` callbacks in `tui_gateway/server.py` emit the raw
-`approval_data` (with an unredacted `command`) to the TUI client. They now
-route through the module-level `_emit_approval_request` helper, which redacts
-`payload["command"]` via the shared `gateway.run._redact_approval_command` seam
+`approval_data` (with an unredacted `command`) to the TUI client. They route
+through the module-level `_emit_approval_request` helper, which redacts
+`payload["command"]` via `agent.redact.redact_sensitive_text(force=True)`
 before emitting.
+
+Importing `gateway.run` from this path is deliberately avoided: a long-lived
+dashboard/TUI process can already have a stale `agent.turn_context` in
+`sys.modules`, and `gateway.run`'s import chain then raises ImportError.
+Approval notify treats that as hard-block ("Failed to send approval request").
 """
 
 import inspect
@@ -20,18 +25,31 @@ class TestTuiApprovalEmitRedaction:
 
         emitted = {}
         monkeypatch.setattr(
-            tui_server, "_emit",
+            tui_server,
+            "_emit",
             lambda event, sid, payload=None: emitted.update(
                 {"event": event, "sid": sid, "payload": payload}
             ),
         )
-        raw = "curl -H 'Authorization: token ghp_01...6789' https://api.github.com"
-        tui_server._emit_approval_request("sess-1", {"command": raw, "description": "x"})
+        raw = (
+            "curl -H 'Authorization: Bearer "
+            "ghp_0123456789abcdefghijklmnopqrstuvwx' https://api.github.com"
+        )
+        tui_server._emit_approval_request(
+            "sess-1", {"command": raw, "description": "x"}
+        )
 
         assert emitted["event"] == "approval.request"
-        # credential removed, non-command field + command structure preserved
-        assert "ghp_01...6789" not in emitted["payload"]["command"]
+        cmd = emitted["payload"]["command"]
+        assert "ghp_0123456789abcdefghijklmnopqrstuvwx" not in cmd
         assert emitted["payload"]["description"] == "x"
-        assert "github.com" in emitted["payload"]["command"]
+        assert "github.com" in cmd
 
+    def test_emit_approval_request_source_avoids_gateway_run_import(self):
+        """TUI emit path must not import gateway.run (stale-process ImportError)."""
+        from tui_gateway import server as tui_server
 
+        source = inspect.getsource(tui_server._emit_approval_request)
+        assert "from gateway.run import" not in source
+        assert "agent.redact" in source
+        assert "redact_sensitive_text" in source

--- a/tests/gateway/test_tui_approval_redaction.py
+++ b/tests/gateway/test_tui_approval_redaction.py
@@ -3,10 +3,15 @@
 Follow-up to #50767, which redacted the chat-platform and SSE/API approval
 transports. The TUI JSON-RPC transport is the third egress: three
 `register_gateway_notify` callbacks in `tui_gateway/server.py` emit the raw
-`approval_data` (with an unredacted `command`) to the TUI client. They now
-route through the module-level `_emit_approval_request` helper, which redacts
-`payload["command"]` via the shared `gateway.run._redact_approval_command` seam
+`approval_data` (with an unredacted `command`) to the TUI client. They route
+through `_emit_approval_request` → `_approval_request_payload`, which redacts
+`payload["command"]` via `agent.redact.redact_sensitive_text(force=True)`
 before emitting.
+
+Importing `gateway.run` from this path is deliberately avoided: a long-lived
+dashboard/TUI process can already have a stale `agent.turn_context` in
+`sys.modules`, and `gateway.run`'s import chain then raises ImportError.
+Approval notify treats that as hard-block ("Failed to send approval request").
 """
 
 import inspect
@@ -20,19 +25,25 @@ class TestTuiApprovalEmitRedaction:
 
         emitted = {}
         monkeypatch.setattr(
-            tui_server, "_emit",
+            tui_server,
+            "_emit",
             lambda event, sid, payload=None: emitted.update(
                 {"event": event, "sid": sid, "payload": payload}
             ),
         )
-        raw = "curl -H 'Authorization: token ghp_01...6789' https://api.github.com"
-        tui_server._emit_approval_request("sess-1", {"command": raw, "description": "x"})
+        raw = (
+            "curl -H 'Authorization: token "
+            "ghp_01...uvwx' https://api.github.com"
+        )
+        tui_server._emit_approval_request(
+            "sess-1", {"command": raw, "description": "x"}
+        )
 
         assert emitted["event"] == "approval.request"
-        # credential removed, non-command field + command structure preserved
-        assert "ghp_01...6789" not in emitted["payload"]["command"]
+        cmd = emitted["payload"]["command"]
+        assert "ghp_01...uvwx" not in cmd
         assert emitted["payload"]["description"] == "x"
-        assert "github.com" in emitted["payload"]["command"]
+        assert "github.com" in cmd
 
     @pytest.mark.parametrize(
         ("allow_session", "allow_permanent", "expected"),
@@ -65,3 +76,11 @@ class TestTuiApprovalEmitRedaction:
 
         assert emitted["payload"]["choices"] == expected
 
+    def test_approval_payload_source_avoids_gateway_run_import(self):
+        """TUI payload builder must not import gateway.run (stale-process ImportError)."""
+        from tui_gateway import server as tui_server
+
+        source = inspect.getsource(tui_server._approval_request_payload)
+        assert "from gateway.run import" not in source
+        assert "agent.redact" in source
+        assert "redact_sensitive_text" in source

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2787,9 +2787,19 @@ def _approval_request_payload(data: dict | None) -> dict:
             choices.append("deny")
             payload["choices"] = choices
     if "command" in payload:
-        from gateway.run import _redact_approval_command
+        # Call agent.redact directly. Do NOT import gateway.run here.
+        # gateway.run pulls agent.turn_context (and a large gateway graph) at
+        # import time. In a long-lived dashboard/TUI process that already has
+        # an older agent.turn_context in sys.modules, that import can raise
+        # ImportError (e.g. missing compression_made_progress). tools.approval
+        # treats notify failure as hard-block: "Failed to send approval
+        # request. Do NOT retry." Same semantics as
+        # gateway.run._redact_approval_command (redact_sensitive_text force=True).
+        from agent.redact import redact_sensitive_text
 
-        payload["command"] = _redact_approval_command(payload.get("command"))
+        payload["command"] = redact_sensitive_text(
+            str(payload.get("command") or ""), force=True
+        )
     return payload
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1839,9 +1839,19 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
         elif "allow_permanent" in payload:
             payload["choices"] = ["once", "session", "always", "deny"]
     if "command" in payload:
-        from gateway.run import _redact_approval_command
+        # Call agent.redact directly. Do NOT import gateway.run here.
+        # gateway.run pulls agent.turn_context (and a large gateway graph) at
+        # import time. In a long-lived dashboard/TUI process that already has
+        # an older agent.turn_context in sys.modules, that import can raise
+        # ImportError (e.g. missing compression_made_progress). tools.approval
+        # treats notify failure as hard-block: "Failed to send approval
+        # request. Do NOT retry." Same semantics as
+        # gateway.run._redact_approval_command (redact_sensitive_text force=True).
+        from agent.redact import redact_sensitive_text
 
-        payload["command"] = _redact_approval_command(payload.get("command"))
+        payload["command"] = redact_sensitive_text(
+            str(payload.get("command") or ""), force=True
+        )
     _emit("approval.request", sid, payload)
 
 


### PR DESCRIPTION
## Summary

TUI approval requests can hard-block with:

`BLOCKED: Failed to send approval request to user. Do NOT retry.`

`_emit_approval_request` in `tui_gateway/server.py` imported `_redact_approval_command` from `gateway.run`. That import pulls `agent.turn_context` (and a large gateway graph). In a long-lived dashboard/TUI process that already has an older `agent.turn_context` in `sys.modules`, the import raises `ImportError` (observed: missing `compression_made_progress`). `tools.approval` treats notify failure as a hard block, so a dangerous-command approval never reaches the human.

## Fix

Call `agent.redact.redact_sensitive_text(..., force=True)` directly.

`gateway.run._redact_approval_command` is already that one-liner, so redaction semantics are unchanged and the heavy import goes away.

## Tests

- `tests/gateway/test_tui_approval_redaction.py`
  - redaction still applied on the TUI emit path
  - source guard: `_emit_approval_request` must not `from gateway.run import ...`
- Local: `2 passed`

## Notes

- Complementary to open refactor #77707 (extracts helpers from `gateway.run` but does not change the TUI import site).
- Lived on Ubuntu with a multi-day dashboard process: after patch + dashboard restart, approval notify ImportError stopped appearing in `errors.log`.

## Test plan

- [x] Focused pytest above
- [ ] Dashboard/TUI restart after pull; trigger a dangerous-command approval and confirm the prompt appears instead of hard-block
