### PR TITLE
feat: add Telegram finance records plugin

### DIFF
--- a/docs/finance-records.md
+++ b/docs/finance-records.md
@@ -1,0 +1,27 @@
+# Finance records Telegram plugin
+
+The bundled `finance_records` plugin safely records a narrow set of Japanese Telegram finance messages. It is conservative by default: only explicitly allowed Telegram chats are processed, the timezone defaults to `Asia/Tokyo`, currency is `JPY`, dry-run is on, and live Google Sheets writes are disabled/fail closed until workbook mappings are confirmed.
+
+For full operational details see [`plugins/finance_records/README.md`](../../plugins/finance_records/README.md).
+
+## Quick setup
+
+Configure only non-secret flags and IDs in your environment or service manager:
+
+```bash
+FINANCE_ALLOWED_TELEGRAM_CHAT_IDS="123456789"
+FINANCE_TIMEZONE="Asia/Tokyo"
+FINANCE_DRY_RUN="true"
+FINANCE_SHEETS_ENABLED="false"
+```
+
+Live mode additionally needs a private Google service-account JSON path in `GOOGLE_APPLICATION_CREDENTIALS`. Never commit, paste, or log that JSON file.
+
+## Rollback
+
+Disable processing by unsetting `FINANCE_ALLOWED_TELEGRAM_CHAT_IDS`, or force safe mode:
+
+```bash
+FINANCE_SHEETS_ENABLED="false"
+FINANCE_DRY_RUN="true"
+```

--- a/plugins/finance_records/README.md
+++ b/plugins/finance_records/README.md
@@ -1,0 +1,93 @@
+# finance_records plugin
+
+`finance_records` records a narrow, deterministic set of Japanese Telegram finance messages to a cashflow/repayment sheet workflow. It is safe by default: it only handles explicitly allowed Telegram chats, uses `Asia/Tokyo` and `JPY`, runs in dry-run mode by default, and refuses live Google Sheets writes unless live mode is explicitly enabled and service-account prerequisites are present.
+
+## What it recognizes
+
+Examples supported by the deterministic parser:
+
+- `今日シェアフルで6,000円稼いだ。今日入金済み` → received income
+- `今日シェアフルで6,000円稼いだ。8月15日入金予定` → scheduled income
+- `今日松屋で750円使った` → expense
+- `今日ぼんに70,000円返した` → cashflow repayment plus repayment history linkage
+- `さっきの6,000円は5,800円だった` → correction audit row referencing the original record
+- `さっきの記録を取り消して` → cancellation audit row referencing the original record
+- `今月あといくら足りない？` → current-month shortage query
+- `直近の記録を5件見せて` → latest five records query
+
+Ambiguous income such as `今日シェアフルで6,000円稼いだ` is not recorded. Hermes replies:
+
+`その6,000円は、もう使える状態で入金されていますか？　それとも後日入金ですか？`
+
+## Environment variables
+
+- `FINANCE_ALLOWED_TELEGRAM_CHAT_IDS`: comma-separated Telegram chat IDs. If unset, the plugin does not process messages.
+- `FINANCE_TIMEZONE`: defaults to `Asia/Tokyo`.
+- `FINANCE_DRY_RUN`: defaults to `true`. Keeps writes in the fake/dry-run adapter.
+- `FINANCE_SHEETS_ENABLED`: defaults to `false`. Must be `true` with `FINANCE_DRY_RUN=false` before live Sheets mode is even attempted.
+- `CASHFLOW_SPREADSHEET_ID`: defaults to `1QXrtN2MVNfvjIFYUlcpuI8yEPjrFDLCep07eMYOcc0Q`.
+- `REPAYMENT_SPREADSHEET_ID`: defaults to `1ufERJYzKAMZUoErVFXN02eEXdzd4FHivS17gCrFNoiI`.
+- `GOOGLE_APPLICATION_CREDENTIALS`: path to a Google service-account JSON file for live mode. Do not commit or print this file.
+
+## Google service account setup
+
+1. Create or choose a Google Cloud project.
+2. Enable the Google Sheets API.
+3. Create a service account with the minimum permissions needed for the target spreadsheets.
+4. Download the service-account JSON to a private local path outside the repository.
+5. Share both spreadsheets with the service account email.
+6. Set `GOOGLE_APPLICATION_CREDENTIALS` to the private JSON path.
+7. Keep `FINANCE_DRY_RUN=true` until you have verified parser behavior and workbook mappings.
+
+Live writes currently fail closed unless fixed SheetLayout mappings are confirmed in code. This prevents accidental writes to guessed tabs/ranges.
+
+## Dry-run to live switch
+
+Recommended dry-run configuration:
+
+```bash
+FINANCE_ALLOWED_TELEGRAM_CHAT_IDS="123456789"
+FINANCE_TIMEZONE="Asia/Tokyo"
+FINANCE_DRY_RUN="true"
+FINANCE_SHEETS_ENABLED="false"
+```
+
+Live-mode prerequisites:
+
+```bash
+FINANCE_ALLOWED_TELEGRAM_CHAT_IDS="123456789"
+FINANCE_TIMEZONE="Asia/Tokyo"
+FINANCE_DRY_RUN="false"
+FINANCE_SHEETS_ENABLED="true"
+GOOGLE_APPLICATION_CREDENTIALS="/private/path/to/service-account.json"
+```
+
+Do not store secrets in the repository. Do not paste service-account JSON into logs or chat.
+
+## Audit trail
+
+The cashflow spreadsheet uses the `Hermes入力履歴` audit tab with fixed headers:
+
+```text
+event_id, telegram_chat_id, telegram_message_id, received_at, type, occurred_date, payment_date, source, creditor, amount, status, raw_text, correction_of, processing_status, error, created_at
+```
+
+The idempotency key is `telegram_chat_id + telegram_message_id`. Duplicate Telegram deliveries are acknowledged but not double-counted.
+
+Corrections and cancellations append audit rows and reference the original `event_id`; existing audit rows are not silently deleted.
+
+## Rollback / disable
+
+Fast rollback options:
+
+- Remove the plugin from `plugins.enabled` if you explicitly enabled it in `config.yaml`.
+- Unset `FINANCE_ALLOWED_TELEGRAM_CHAT_IDS` so no chat is processed.
+- Set `FINANCE_SHEETS_ENABLED=false`.
+- Set `FINANCE_DRY_RUN=true`.
+
+The safest emergency switch is:
+
+```bash
+FINANCE_SHEETS_ENABLED="false"
+FINANCE_DRY_RUN="true"
+```

--- a/plugins/finance_records/__init__.py
+++ b/plugins/finance_records/__init__.py
@@ -1,0 +1,113 @@
+"""Bundled Telegram finance-recording plugin for Hermes Agent."""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+from .parser import parse_finance_message
+from .service import FinanceProcessor
+from .sheets import FinanceSheetAdapter, build_adapter_from_env
+
+_PROCESSOR: FinanceProcessor | None = None
+_TEST_ADAPTER: FinanceSheetAdapter | None = None
+
+
+def set_test_adapter(adapter: FinanceSheetAdapter | None) -> None:
+    """Inject an adapter for tests; pass None to restore env-based construction."""
+    global _TEST_ADAPTER, _PROCESSOR
+    _TEST_ADAPTER = adapter
+    _PROCESSOR = None
+
+
+def get_processor() -> FinanceProcessor:
+    global _PROCESSOR
+    if _PROCESSOR is None:
+        adapter = _TEST_ADAPTER if _TEST_ADAPTER is not None else build_adapter_from_env()
+        _PROCESSOR = FinanceProcessor(adapter, timezone=os.getenv("FINANCE_TIMEZONE", "Asia/Tokyo") or "Asia/Tokyo")
+    return _PROCESSOR
+
+
+def _allowed_chat_ids() -> set[str]:
+    raw = os.getenv("FINANCE_ALLOWED_TELEGRAM_CHAT_IDS", "")
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def _is_telegram_event(event: Any) -> bool:
+    source = getattr(event, "source", None)
+    platform = getattr(source, "platform", None)
+    value = getattr(platform, "value", platform)
+    return str(value).lower() == "telegram"
+
+
+def _chat_id(event: Any) -> str | None:
+    source = getattr(event, "source", None)
+    chat_id = getattr(source, "chat_id", None)
+    return str(chat_id) if chat_id is not None else None
+
+
+def _message_id(event: Any) -> str:
+    mid = getattr(event, "message_id", None)
+    if mid is None:
+        metadata = getattr(event, "metadata", {}) or {}
+        mid = metadata.get("message_id") or metadata.get("telegram_message_id")
+    return str(mid or "")
+
+
+def _send_reply(gateway: Any, event: Any, reply: str) -> None:
+    if not reply:
+        return
+    adapter = None
+    getter = getattr(gateway, "_adapter_for_source", None)
+    if callable(getter):
+        adapter = getter(getattr(event, "source", None))
+    if adapter is None:
+        source = getattr(event, "source", None)
+        platform = getattr(source, "platform", None)
+        adapter = getattr(gateway, "adapters", {}).get(platform)
+    send = getattr(adapter, "send", None) if adapter is not None else None
+    if not callable(send):
+        return
+    result = send(_chat_id(event), reply)
+    if asyncio.iscoroutine(result):
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(result)
+        except RuntimeError:
+            asyncio.run(result)
+
+
+def on_pre_gateway_dispatch(event: Any, gateway: Any = None, session_store: Any = None, **_: Any) -> dict[str, str] | None:
+    """Intercept allowed Telegram finance messages before normal agent dispatch."""
+    del session_store
+    if not _is_telegram_event(event):
+        return {"action": "allow"}
+    chat_id = _chat_id(event)
+    allowed = _allowed_chat_ids()
+    if not chat_id or not allowed or chat_id not in allowed:
+        return {"action": "allow"}
+    text = getattr(event, "text", "") or ""
+    # Parse first so unrelated messages continue to Hermes normally.
+    if parse_finance_message(text, now=getattr(event, "timestamp", None), timezone=os.getenv("FINANCE_TIMEZONE", "Asia/Tokyo") or "Asia/Tokyo") is None:
+        return {"action": "allow"}
+    try:
+        processor = get_processor()
+    except Exception as exc:
+        if gateway is not None:
+            _send_reply(gateway, event, f"財務記録の初期化に失敗しました。成功として扱いません。エラー: {exc}")
+        return {"action": "skip", "reason": "finance_records_init_failed"}
+    result = processor.process(
+        text=text,
+        telegram_chat_id=chat_id,
+        telegram_message_id=_message_id(event),
+        received_at=getattr(event, "timestamp", None),
+    )
+    if result.handled:
+        if gateway is not None and result.reply:
+            _send_reply(gateway, event, result.reply)
+        return {"action": "skip", "reason": "finance_records_handled"}
+    return {"action": "allow"}
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_gateway_dispatch", on_pre_gateway_dispatch)

--- a/plugins/finance_records/parser.py
+++ b/plugins/finance_records/parser.py
@@ -1,0 +1,140 @@
+"""Deterministic Japanese finance-message parser for the finance_records plugin."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, date
+from typing import Literal
+from zoneinfo import ZoneInfo
+
+RecordType = Literal["income", "expense", "repayment", "correction", "cancellation", "query"]
+
+
+@dataclass(frozen=True)
+class FinanceIntent:
+    type: RecordType
+    source: str | None = None
+    creditor: str | None = None
+    amount: int | None = None
+    occurred_date: str | None = None
+    payment_date: str | None = None
+    status: str | None = None
+    note: str = ""
+    confidence: float = 0.99
+    query: str | None = None
+    correction_amount: int | None = None
+
+    def as_record(self) -> dict:
+        return {
+            "type": self.type,
+            "source": self.source,
+            "creditor": self.creditor,
+            "amount": self.amount,
+            "occurred_date": self.occurred_date,
+            "payment_date": self.payment_date,
+            "status": self.status,
+            "note": self.note,
+            "confidence": self.confidence,
+        }
+
+
+_AMOUNT_RE = re.compile(r"([0-9０-９][0-9０-９,，]*)\s*円")
+
+def _normalize_digits(text: str) -> str:
+    return text.translate(str.maketrans("０１２３４５６７８９，", "0123456789,"))
+
+
+def parse_amount(text: str) -> int | None:
+    match = _AMOUNT_RE.search(_normalize_digits(text))
+    if not match:
+        return None
+    return int(match.group(1).replace(",", ""))
+
+
+def _today(now: datetime | None, timezone: str) -> date:
+    if now is not None:
+        return now.astimezone(ZoneInfo(timezone)).date() if now.tzinfo else now.replace(tzinfo=ZoneInfo(timezone)).date()
+    return datetime.now(ZoneInfo(timezone)).date()
+
+
+def _date_from_text(text: str, base: date) -> str | None:
+    if "今日" in text or "本日" in text:
+        return base.isoformat()
+    m = re.search(r"(\d{1,2})\s*月\s*(\d{1,2})\s*日", _normalize_digits(text))
+    if m:
+        month = int(m.group(1)); day = int(m.group(2))
+        year = base.year + (1 if month < base.month - 6 else 0)
+        return date(year, month, day).isoformat()
+    return None
+
+
+def parse_finance_message(text: str, *, now: datetime | None = None, timezone: str = "Asia/Tokyo") -> FinanceIntent | None:
+    """Parse supported Japanese finance messages into a strict record-like intent.
+
+    This parser is intentionally deterministic and conservative. It covers the
+    required examples and returns ``None`` for unrelated text so Hermes can run
+    normal dispatch.
+    """
+    raw = (text or "").strip()
+    if not raw:
+        return None
+    norm = _normalize_digits(raw)
+    today = _today(now, timezone)
+    occurred = _date_from_text(norm, today) or today.isoformat()
+
+    if "直近" in norm and "記録" in norm and ("5件" in norm or "五件" in norm):
+        return FinanceIntent(type="query", query="latest5", confidence=1.0)
+    if "今月" in norm and ("足りない" in norm or "不足" in norm):
+        return FinanceIntent(type="query", query="shortage", confidence=1.0)
+    if ("取り消" in norm or "取消" in norm or "キャンセル" in norm) and ("記録" in norm or "さっき" in norm):
+        return FinanceIntent(type="cancellation", confidence=0.99)
+
+    if "さっき" in norm and "だった" in norm:
+        amounts = [int(x.replace(",", "")) for x in _AMOUNT_RE.findall(norm)]
+        if amounts:
+            return FinanceIntent(type="correction", amount=amounts[0], correction_amount=amounts[-1], confidence=0.98)
+
+    amount = parse_amount(norm)
+    if amount is None:
+        return None
+
+    if "返した" in norm or "返済" in norm:
+        creditor_match = re.search(r"(?:今日|本日|さっき)?\s*([^でにへを\s]+)(?:に|へ).{0,12}?(?:返した|返済)", norm)
+        creditor = creditor_match.group(1) if creditor_match else None
+        return FinanceIntent(
+            type="repayment", creditor=creditor, amount=amount, occurred_date=occurred,
+            payment_date=occurred, status="paid", confidence=0.99,
+        )
+
+    if "使った" in norm or "払った" in norm or "支払" in norm:
+        source_match = re.search(r"(?:今日|本日)?\s*([^でにへを\s]+)で", norm)
+        source = source_match.group(1) if source_match else None
+        return FinanceIntent(
+            type="expense", source=source, amount=amount, occurred_date=occurred,
+            payment_date=occurred, status="paid", confidence=0.99,
+        )
+
+    if "稼いだ" in norm or "収入" in norm:
+        source_match = re.search(r"(?:今日|本日)?\s*([^でにへを\s]+)で", norm)
+        source = source_match.group(1) if source_match else None
+        payment_date = None
+        status = None
+        if "入金済" in norm or "入金されています" in norm or "もう使える" in norm:
+            payment_date = occurred
+            status = "received"
+        else:
+            m = re.search(r"(\d{1,2})\s*月\s*(\d{1,2})\s*日\s*入金予定", norm)
+            if m:
+                payment_date = _date_from_text(m.group(0), today)
+                status = "scheduled"
+            elif "入金予定" in norm or "後日入金" in norm:
+                status = "scheduled"
+        return FinanceIntent(
+            type="income", source=source, amount=amount, occurred_date=occurred,
+            payment_date=payment_date, status=status, confidence=0.99 if status else 0.72,
+        )
+
+    return None
+
+
+AMBIGUOUS_INCOME_REPLY = "その6,000円は、もう使える状態で入金されていますか？　それとも後日入金ですか？"

--- a/plugins/finance_records/plugin.yaml
+++ b/plugins/finance_records/plugin.yaml
@@ -1,0 +1,23 @@
+name: finance_records
+version: 0.1.0
+description: "Safe Telegram finance message recorder for Japanese income/expense/repayment messages. Dry-run by default; live Google Sheets writes fail closed unless explicitly enabled and mapped."
+author: NousResearch
+kind: backend
+hooks:
+  - pre_gateway_dispatch
+optional_env:
+  FINANCE_ALLOWED_TELEGRAM_CHAT_IDS:
+    description: "Comma-separated Telegram chat IDs allowed to be parsed/recorded. Unset means no finance processing."
+  FINANCE_TIMEZONE:
+    description: "IANA timezone for date parsing; defaults to Asia/Tokyo."
+  FINANCE_DRY_RUN:
+    description: "Defaults true. Keep true for fake/dry-run storage."
+  FINANCE_SHEETS_ENABLED:
+    description: "Defaults false. Must be true with FINANCE_DRY_RUN=false for live Sheets attempts."
+  CASHFLOW_SPREADSHEET_ID:
+    description: "Cashflow spreadsheet ID; defaults to the documented finance workbook ID."
+  REPAYMENT_SPREADSHEET_ID:
+    description: "Repayment spreadsheet ID; defaults to the documented repayment workbook ID."
+  GOOGLE_APPLICATION_CREDENTIALS:
+    description: "Path to a Google service-account JSON file for live mode. Do not commit this file."
+    password: true

--- a/plugins/finance_records/service.py
+++ b/plugins/finance_records/service.py
@@ -1,0 +1,176 @@
+"""Core processing service for finance_records."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from .parser import AMBIGUOUS_INCOME_REPLY, FinanceIntent, parse_finance_message
+from .sheets import AUDIT_HEADERS, FinanceSheetAdapter, FinanceSheetError
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    handled: bool
+    reply: str | None = None
+    success: bool = False
+    record: dict[str, Any] | None = None
+
+
+def event_id_for(chat_id: str, message_id: str) -> str:
+    digest = hashlib.sha256(f"telegram:{chat_id}:{message_id}".encode("utf-8")).hexdigest()[:16]
+    return f"fin_{digest}"
+
+
+def _now(timezone: str) -> datetime:
+    return datetime.now(ZoneInfo(timezone))
+
+
+def _audit_row(*, event_id: str, chat_id: str, message_id: str, received_at: str, intent: FinanceIntent, raw_text: str, status: str, error: str = "", correction_of: str | None = None, created_at: str | None = None) -> dict[str, Any]:
+    row = {
+        "event_id": event_id,
+        "telegram_chat_id": str(chat_id),
+        "telegram_message_id": str(message_id),
+        "received_at": received_at,
+        "type": intent.type,
+        "occurred_date": intent.occurred_date,
+        "payment_date": intent.payment_date,
+        "source": intent.source,
+        "creditor": intent.creditor,
+        "amount": intent.correction_amount if intent.type == "correction" else intent.amount,
+        "status": intent.status,
+        "raw_text": raw_text,
+        "correction_of": correction_of,
+        "processing_status": status,
+        "error": error,
+        "created_at": created_at or received_at,
+    }
+    return {h: row.get(h) for h in AUDIT_HEADERS}
+
+
+class FinanceProcessor:
+    def __init__(self, adapter: FinanceSheetAdapter, *, timezone: str = "Asia/Tokyo") -> None:
+        self.adapter = adapter
+        self.timezone = timezone
+
+    def parse(self, text: str, *, now: datetime | None = None) -> FinanceIntent | None:
+        return parse_finance_message(text, now=now, timezone=self.timezone)
+
+    def process(self, *, text: str, telegram_chat_id: str, telegram_message_id: str, received_at: datetime | None = None) -> ProcessResult:
+        received_dt = received_at or _now(self.timezone)
+        received_iso = received_dt.astimezone(ZoneInfo(self.timezone)).isoformat() if received_dt.tzinfo else received_dt.replace(tzinfo=ZoneInfo(self.timezone)).isoformat()
+        intent = self.parse(text, now=received_dt)
+        if intent is None:
+            return ProcessResult(handled=False)
+        eid = event_id_for(telegram_chat_id, telegram_message_id)
+        yyyy_mm = received_iso[:7]
+
+        if self.adapter.has_event(telegram_chat_id, telegram_message_id):
+            return ProcessResult(handled=True, success=True, reply="このTelegramメッセージは既に記録済みです（重複のため追記しません）。")
+
+        if intent.type == "income" and not intent.payment_date:
+            amount_text = f"{int(intent.amount or 0):,}円" if intent.amount else "その収入"
+            return ProcessResult(
+                handled=True,
+                success=False,
+                reply=AMBIGUOUS_INCOME_REPLY.replace("6,000円", amount_text),
+                record=intent.as_record(),
+            )
+
+        before = self.adapter.current_month_shortage(yyyy_mm)
+        try:
+            if intent.type == "query":
+                return self._process_query(intent, yyyy_mm)
+            if intent.type == "correction":
+                return self._process_correction(intent, eid, telegram_chat_id, telegram_message_id, received_iso, text, before)
+            if intent.type == "cancellation":
+                return self._process_cancellation(intent, eid, telegram_chat_id, telegram_message_id, received_iso, text, before)
+            return self._process_record(intent, eid, telegram_chat_id, telegram_message_id, received_iso, text, before)
+        except Exception as exc:
+            error = str(exc)
+            try:
+                if self.adapter.has_event(telegram_chat_id, telegram_message_id):
+                    self.adapter.update_audit_status(eid, "error", error)
+                else:
+                    self.adapter.append_audit(_audit_row(event_id=eid, chat_id=telegram_chat_id, message_id=telegram_message_id, received_at=received_iso, intent=intent, raw_text=text, status="error", error=error))
+            except Exception:
+                pass
+            return ProcessResult(handled=True, success=False, reply=f"記録に失敗しました。成功として扱いません。エラー: {error}")
+
+    def _preflight_checks(self) -> None:
+        errors = self.adapter.scan_formula_errors()
+        if errors:
+            raise FinanceSheetError("formula errors detected: " + ", ".join(errors))
+        if not self.adapter.check_pattern_1_to_1000():
+            raise FinanceSheetError("1..1000 pattern check failed")
+        if not self.adapter.check_repayment_linkage():
+            raise FinanceSheetError("repayment linkage check failed")
+
+    def _process_record(self, intent: FinanceIntent, eid: str, chat_id: str, message_id: str, received_iso: str, text: str, before: int) -> ProcessResult:
+        self._preflight_checks()
+        record = intent.as_record() | {"event_id": eid, "currency": "JPY"}
+        self.adapter.append_audit(_audit_row(event_id=eid, chat_id=chat_id, message_id=message_id, received_at=received_iso, intent=intent, raw_text=text, status="pending"))
+        self.adapter.append_cashflow(record)
+        if intent.type == "repayment":
+            self.adapter.append_repayment({
+                "event_id": f"{eid}_repayment",
+                "cashflow_event_id": eid,
+                "creditor": intent.creditor,
+                "amount": intent.amount,
+                "payment_date": intent.payment_date or intent.occurred_date,
+                "currency": "JPY",
+            })
+        self.adapter.update_audit_status(eid, "applied")
+        after = self.adapter.current_month_shortage(received_iso[:7])
+        reply = self._format_record_reply(intent, eid, before, after)
+        return ProcessResult(handled=True, success=True, reply=reply, record=record)
+
+    def _format_record_reply(self, intent: FinanceIntent, eid: str, before: int, after: int) -> str:
+        amount = f"{int(intent.amount or 0):,}円"
+        if intent.type == "income":
+            label = f"{intent.source or '収入'}{amount}"
+            state = "入金済み" if intent.status == "received" else "入金予定"
+            first = f"✅ {label}を{state}で記録しました"
+        elif intent.type == "expense":
+            first = f"✅ {intent.source or '支出'}{amount}の支出を記録しました"
+        elif intent.type == "repayment":
+            first = f"✅ {intent.creditor or '返済先'}への返済{amount}を記録しました"
+        else:
+            first = f"✅ {amount}を記録しました"
+        return f"{first}\n今月の不足：{before:,}円 → {after:,}円\n記録ID：{eid}"
+
+    def _process_correction(self, intent: FinanceIntent, eid: str, chat_id: str, message_id: str, received_iso: str, text: str, before: int) -> ProcessResult:
+        original = self.adapter.find_latest_applied(amount=intent.amount)
+        if not original or intent.correction_amount is None:
+            raise FinanceSheetError("correction target not found")
+        self._preflight_checks()
+        self.adapter.append_audit(_audit_row(event_id=eid, chat_id=chat_id, message_id=message_id, received_at=received_iso, intent=intent, raw_text=text, status="pending", correction_of=str(original["event_id"])))
+        self.adapter.mark_corrected(str(original["event_id"]), int(intent.correction_amount))
+        self.adapter.update_audit_status(eid, "applied")
+        after = self.adapter.current_month_shortage(received_iso[:7])
+        return ProcessResult(handled=True, success=True, reply=f"訂正しました。record_id: {eid}\n今月の不足: {before:,}円 → {after:,}円")
+
+    def _process_cancellation(self, intent: FinanceIntent, eid: str, chat_id: str, message_id: str, received_iso: str, text: str, before: int) -> ProcessResult:
+        original = self.adapter.find_latest_applied()
+        if not original:
+            raise FinanceSheetError("cancellation target not found")
+        self._preflight_checks()
+        self.adapter.append_audit(_audit_row(event_id=eid, chat_id=chat_id, message_id=message_id, received_at=received_iso, intent=intent, raw_text=text, status="pending", correction_of=str(original["event_id"])))
+        self.adapter.cancel_original(str(original["event_id"]))
+        self.adapter.update_audit_status(eid, "applied")
+        after = self.adapter.current_month_shortage(received_iso[:7])
+        return ProcessResult(handled=True, success=True, reply=f"取り消しました。record_id: {eid}\n今月の不足: {before:,}円 → {after:,}円")
+
+    def _process_query(self, intent: FinanceIntent, yyyy_mm: str) -> ProcessResult:
+        if intent.query == "latest5":
+            rows = self.adapter.latest_records(5)
+            if not rows:
+                return ProcessResult(handled=True, success=True, reply="直近の記録はありません。")
+            lines = ["直近の記録5件:"]
+            for row in rows:
+                lines.append(f"- {row.get('event_id')}: {row.get('type')} {int(row.get('amount') or 0):,}円")
+            return ProcessResult(handled=True, success=True, reply="\n".join(lines))
+        shortage = self.adapter.current_month_shortage(yyyy_mm)
+        return ProcessResult(handled=True, success=True, reply=f"今月あと {shortage:,}円 足りません。")

--- a/plugins/finance_records/sheets.py
+++ b/plugins/finance_records/sheets.py
@@ -1,0 +1,165 @@
+"""Sheet adapters for the finance_records plugin.
+
+The dry-run adapter is deterministic and in-memory for tests/development.  The
+live adapter is deliberately fail-closed unless Sheets are explicitly enabled and
+service-account based auth/mappings are available.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+AUDIT_HEADERS = [
+    "event_id", "telegram_chat_id", "telegram_message_id", "received_at", "type",
+    "occurred_date", "payment_date", "source", "creditor", "amount", "status",
+    "raw_text", "correction_of", "processing_status", "error", "created_at",
+]
+DEFAULT_CASHFLOW_SPREADSHEET_ID = "1QXrtN2MVNfvjIFYUlcpuI8yEPjrFDLCep07eMYOcc0Q"
+DEFAULT_REPAYMENT_SPREADSHEET_ID = "1ufERJYzKAMZUoErVFXN02eEXdzd4FHivS17gCrFNoiI"
+
+
+class FinanceSheetError(RuntimeError):
+    """Raised when a sheet read/write cannot be completed safely."""
+
+
+class FinanceSheetAdapter:
+    def has_event(self, chat_id: str, message_id: str) -> bool: raise NotImplementedError
+    def append_audit(self, row: dict[str, Any]) -> None: raise NotImplementedError
+    def update_audit_status(self, event_id: str, status: str, error: str = "") -> None: raise NotImplementedError
+    def append_cashflow(self, record: dict[str, Any]) -> None: raise NotImplementedError
+    def append_repayment(self, record: dict[str, Any]) -> None: raise NotImplementedError
+    def current_month_shortage(self, yyyy_mm: str) -> int: raise NotImplementedError
+    def latest_records(self, limit: int = 5) -> list[dict[str, Any]]: raise NotImplementedError
+    def find_latest_applied(self, *, amount: int | None = None) -> dict[str, Any] | None: raise NotImplementedError
+    def mark_corrected(self, original_event_id: str, new_amount: int) -> None: raise NotImplementedError
+    def cancel_original(self, original_event_id: str) -> None: raise NotImplementedError
+    def scan_formula_errors(self) -> list[str]: return []
+    def check_pattern_1_to_1000(self) -> bool: return True
+    def check_repayment_linkage(self) -> bool: return True
+
+
+@dataclass
+class DryRunSheetAdapter(FinanceSheetAdapter):
+    initial_shortage: int = 100_000
+    audit_rows: list[dict[str, Any]] = field(default_factory=list)
+    cashflow_rows: list[dict[str, Any]] = field(default_factory=list)
+    repayment_rows: list[dict[str, Any]] = field(default_factory=list)
+    formula_errors: list[str] = field(default_factory=list)
+    pattern_ok: bool = True
+    linkage_ok: bool = True
+
+    def has_event(self, chat_id: str, message_id: str) -> bool:
+        return any(
+            str(r.get("telegram_chat_id")) == str(chat_id)
+            and str(r.get("telegram_message_id")) == str(message_id)
+            and r.get("processing_status") in {"pending", "applied"}
+            for r in self.audit_rows
+        )
+
+    def append_audit(self, row: dict[str, Any]) -> None:
+        self.audit_rows.append({h: row.get(h) for h in AUDIT_HEADERS})
+
+    def update_audit_status(self, event_id: str, status: str, error: str = "") -> None:
+        for row in reversed(self.audit_rows):
+            if row.get("event_id") == event_id:
+                row["processing_status"] = status
+                row["error"] = error
+                return
+        raise FinanceSheetError("audit event not found")
+
+    def append_cashflow(self, record: dict[str, Any]) -> None:
+        self.cashflow_rows.append(dict(record))
+
+    def append_repayment(self, record: dict[str, Any]) -> None:
+        if any(r.get("cashflow_event_id") == record.get("cashflow_event_id") for r in self.repayment_rows):
+            return
+        self.repayment_rows.append(dict(record))
+
+    def _active_cashflow(self) -> list[dict[str, Any]]:
+        return [r for r in self.cashflow_rows if not r.get("cancelled")]
+
+    def current_month_shortage(self, yyyy_mm: str) -> int:
+        shortage = self.initial_shortage
+        for row in self._active_cashflow():
+            payment_date = str(row.get("payment_date") or row.get("occurred_date") or "")
+            if not payment_date.startswith(yyyy_mm):
+                continue
+            typ = row.get("type")
+            amount = int(row.get("amount") or 0)
+            status = row.get("status")
+            if typ == "income" and status == "received":
+                shortage -= amount
+            elif typ in {"expense", "repayment"}:
+                shortage += amount
+        return shortage
+
+    def latest_records(self, limit: int = 5) -> list[dict[str, Any]]:
+        return list(reversed(self.cashflow_rows))[:limit]
+
+    def find_latest_applied(self, *, amount: int | None = None) -> dict[str, Any] | None:
+        for row in reversed(self.cashflow_rows):
+            if row.get("cancelled"):
+                continue
+            if amount is None or int(row.get("amount") or 0) == int(amount):
+                return row
+        return None
+
+    def mark_corrected(self, original_event_id: str, new_amount: int) -> None:
+        for row in reversed(self.cashflow_rows):
+            if row.get("event_id") == original_event_id:
+                row["amount"] = int(new_amount)
+                row["corrected"] = True
+                return
+        raise FinanceSheetError("original record not found")
+
+    def cancel_original(self, original_event_id: str) -> None:
+        for row in reversed(self.cashflow_rows):
+            if row.get("event_id") == original_event_id:
+                row["cancelled"] = True
+                return
+        raise FinanceSheetError("original record not found")
+
+    def scan_formula_errors(self) -> list[str]:
+        return list(self.formula_errors)
+
+    def check_pattern_1_to_1000(self) -> bool:
+        return self.pattern_ok
+
+    def check_repayment_linkage(self) -> bool:
+        return self.linkage_ok and all(r.get("cashflow_event_id") for r in self.repayment_rows)
+
+
+class GoogleSheetsAdapter(FinanceSheetAdapter):
+    """Fail-closed Google Sheets adapter skeleton.
+
+    Live writes require FINANCE_SHEETS_ENABLED=true, FINANCE_DRY_RUN=false,
+    GOOGLE_APPLICATION_CREDENTIALS pointing to a service-account file, and a
+    future explicit SheetLayout mapping. Until mappings are confirmed, methods
+    raise FinanceSheetError instead of guessing ranges/columns.
+    """
+
+    def __init__(self, *, cashflow_spreadsheet_id: str, repayment_spreadsheet_id: str) -> None:
+        self.cashflow_spreadsheet_id = cashflow_spreadsheet_id
+        self.repayment_spreadsheet_id = repayment_spreadsheet_id
+        credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        if not credentials_path or not os.path.exists(credentials_path):
+            raise FinanceSheetError("Google service-account credentials are not configured")
+        try:
+            __import__("google.oauth2.service_account")
+            __import__("googleapiclient.discovery")
+        except Exception as exc:  # pragma: no cover - depends on optional Google packages
+            raise FinanceSheetError("Google Sheets client libraries are unavailable") from exc
+        raise FinanceSheetError("Live SheetLayout mappings are not confirmed; refusing live writes")
+
+
+def build_adapter_from_env() -> FinanceSheetAdapter:
+    dry_run = os.getenv("FINANCE_DRY_RUN", "true").strip().lower() not in {"0", "false", "no", "off"}
+    enabled = os.getenv("FINANCE_SHEETS_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+    if dry_run or not enabled:
+        return DryRunSheetAdapter()
+    return GoogleSheetsAdapter(
+        cashflow_spreadsheet_id=os.getenv("CASHFLOW_SPREADSHEET_ID", DEFAULT_CASHFLOW_SPREADSHEET_ID),
+        repayment_spreadsheet_id=os.getenv("REPAYMENT_SPREADSHEET_ID", DEFAULT_REPAYMENT_SPREADSHEET_ID),
+    )

--- a/tests/plugins/test_finance_records_plugin.py
+++ b/tests/plugins/test_finance_records_plugin.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from plugins.finance_records import on_pre_gateway_dispatch, set_test_adapter
+from plugins.finance_records.parser import AMBIGUOUS_INCOME_REPLY, parse_finance_message
+from plugins.finance_records.service import FinanceProcessor
+from plugins.finance_records.sheets import DryRunSheetAdapter, FinanceSheetError
+
+TOKYO_NOW = datetime(2026, 8, 10, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+
+def processor(adapter: DryRunSheetAdapter | None = None) -> FinanceProcessor:
+    return FinanceProcessor(adapter or DryRunSheetAdapter(), timezone="Asia/Tokyo")
+
+
+def test_duplicate_message_only_applied_once() -> None:
+    adapter = DryRunSheetAdapter(initial_shortage=100_000)
+    p = processor(adapter)
+    first = p.process(text="今日シェアフルで6,000円稼いだ。今日入金済み", telegram_chat_id="1", telegram_message_id="m1", received_at=TOKYO_NOW)
+    second = p.process(text="今日シェアフルで6,000円稼いだ。今日入金済み", telegram_chat_id="1", telegram_message_id="m1", received_at=TOKYO_NOW)
+    assert first.success is True
+    assert second.success is True
+    assert len(adapter.cashflow_rows) == 1
+    assert len([r for r in adapter.audit_rows if r["processing_status"] == "applied"]) == 1
+    assert "重複" in (second.reply or "")
+
+
+def test_same_day_received_income_reduces_shortage_by_6000() -> None:
+    adapter = DryRunSheetAdapter(initial_shortage=100_000)
+    p = processor(adapter)
+    before = adapter.current_month_shortage("2026-08")
+    result = p.process(text="今日シェアフルで6,000円稼いだ。今日入金済み", telegram_chat_id="1", telegram_message_id="m2", received_at=TOKYO_NOW)
+    after = adapter.current_month_shortage("2026-08")
+    assert result.success is True
+    assert before - after == 6000
+    assert adapter.cashflow_rows[0]["currency"] == "JPY"
+
+
+def test_future_income_does_not_change_current_month_shortage() -> None:
+    adapter = DryRunSheetAdapter(initial_shortage=100_000)
+    p = processor(adapter)
+    before = adapter.current_month_shortage("2026-08")
+    result = p.process(text="今日シェアフルで6,000円稼いだ。9月15日入金予定", telegram_chat_id="1", telegram_message_id="m3", received_at=TOKYO_NOW)
+    after = adapter.current_month_shortage("2026-08")
+    assert result.success is True
+    assert after == before
+    assert adapter.cashflow_rows[0]["status"] == "scheduled"
+
+
+def test_expense_sign_increases_shortage_and_is_expense() -> None:
+    adapter = DryRunSheetAdapter(initial_shortage=100_000)
+    p = processor(adapter)
+    p.process(text="今日松屋で750円使った", telegram_chat_id="1", telegram_message_id="m4", received_at=TOKYO_NOW)
+    assert adapter.cashflow_rows[0]["type"] == "expense"
+    assert adapter.cashflow_rows[0]["amount"] == 750
+    assert adapter.current_month_shortage("2026-08") == 100_750
+
+
+def test_repayment_writes_cashflow_and_repayment_once() -> None:
+    adapter = DryRunSheetAdapter(initial_shortage=100_000)
+    p = processor(adapter)
+    result = p.process(text="今日ぼんに70,000円返した", telegram_chat_id="1", telegram_message_id="m5", received_at=TOKYO_NOW)
+    duplicate = p.process(text="今日ぼんに70,000円返した", telegram_chat_id="1", telegram_message_id="m5", received_at=TOKYO_NOW)
+    assert result.success is True
+    assert duplicate.success is True
+    assert len(adapter.cashflow_rows) == 1
+    assert len(adapter.repayment_rows) == 1
+    assert adapter.repayment_rows[0]["cashflow_event_id"] == adapter.cashflow_rows[0]["event_id"]
+    assert adapter.cashflow_rows[0]["type"] == "repayment"
+    assert adapter.cashflow_rows[0]["creditor"] == "ぼん"
+
+
+def test_ambiguous_income_asks_confirmation_and_does_not_write() -> None:
+    adapter = DryRunSheetAdapter()
+    p = processor(adapter)
+    result = p.process(text="今日シェアフルで6,000円稼いだ", telegram_chat_id="1", telegram_message_id="m6", received_at=TOKYO_NOW)
+    assert result.handled is True
+    assert result.success is False
+    assert result.reply == AMBIGUOUS_INCOME_REPLY
+    assert adapter.cashflow_rows == []
+    assert adapter.audit_rows == []
+
+
+def test_correction_and_cancellation_append_audit_trail() -> None:
+    adapter = DryRunSheetAdapter(initial_shortage=100_000)
+    p = processor(adapter)
+    original = p.process(text="今日シェアフルで6,000円稼いだ。今日入金済み", telegram_chat_id="1", telegram_message_id="m7", received_at=TOKYO_NOW)
+    assert original.record is not None
+    corrected = p.process(text="さっきの6,000円は5,800円だった", telegram_chat_id="1", telegram_message_id="m8", received_at=TOKYO_NOW)
+    assert corrected.success is True
+    assert adapter.cashflow_rows[0]["amount"] == 5800
+    assert adapter.audit_rows[-1]["correction_of"] == original.record["event_id"]
+    cancelled = p.process(text="さっきの記録を取り消して", telegram_chat_id="1", telegram_message_id="m9", received_at=TOKYO_NOW)
+    assert cancelled.success is True
+    assert adapter.cashflow_rows[0]["cancelled"] is True
+    assert [r["type"] for r in adapter.audit_rows] == ["income", "correction", "cancellation"]
+    assert adapter.audit_rows[-1]["correction_of"] == original.record["event_id"]
+
+
+class FailingAdapter(DryRunSheetAdapter):
+    def append_cashflow(self, record):  # type: ignore[no-untyped-def]
+        raise FinanceSheetError("simulated google failure")
+
+
+def test_google_failure_no_success_reply_and_error_audit() -> None:
+    adapter = FailingAdapter()
+    p = processor(adapter)
+    result = p.process(text="今日松屋で750円使った", telegram_chat_id="1", telegram_message_id="m10", received_at=TOKYO_NOW)
+    assert result.success is False
+    assert "記録しました" not in (result.reply or "")
+    assert "失敗" in (result.reply or "")
+    assert adapter.audit_rows[-1]["processing_status"] == "error"
+
+
+def test_latest_5_query() -> None:
+    adapter = DryRunSheetAdapter()
+    p = processor(adapter)
+    for i in range(6):
+        p.process(text=f"今日松屋で{i + 1},000円使った", telegram_chat_id="1", telegram_message_id=f"q{i}", received_at=TOKYO_NOW)
+    result = p.process(text="直近の記録を5件見せて", telegram_chat_id="1", telegram_message_id="q-latest", received_at=TOKYO_NOW)
+    assert result.success is True
+    assert (result.reply or "").count("- fin_") == 5
+    assert "6,000円" in (result.reply or "")
+    assert "1,000円" not in (result.reply or "")
+
+
+def test_formula_error_check_blocks_write() -> None:
+    adapter = DryRunSheetAdapter(formula_errors=["取引実績!C2 #REF!"])
+    result = processor(adapter).process(text="今日松屋で750円使った", telegram_chat_id="1", telegram_message_id="m11", received_at=TOKYO_NOW)
+    assert result.success is False
+    assert adapter.cashflow_rows == []
+    assert adapter.audit_rows[-1]["processing_status"] == "error"
+    assert "formula errors" in adapter.audit_rows[-1]["error"]
+
+
+def test_pattern_1_to_1000_preservation_check_blocks_write() -> None:
+    adapter = DryRunSheetAdapter(pattern_ok=False)
+    result = processor(adapter).process(text="今日松屋で750円使った", telegram_chat_id="1", telegram_message_id="m12", received_at=TOKYO_NOW)
+    assert result.success is False
+    assert adapter.cashflow_rows == []
+    assert "1..1000 pattern" in adapter.audit_rows[-1]["error"]
+
+
+def test_repayment_linkage_consistency_check_blocks_write() -> None:
+    adapter = DryRunSheetAdapter(linkage_ok=False)
+    result = processor(adapter).process(text="今日ぼんに70,000円返した", telegram_chat_id="1", telegram_message_id="m13", received_at=TOKYO_NOW)
+    assert result.success is False
+    assert adapter.cashflow_rows == []
+    assert adapter.repayment_rows == []
+    assert "repayment linkage" in adapter.audit_rows[-1]["error"]
+
+
+def test_parser_preserves_required_strict_shape() -> None:
+    intent = parse_finance_message("今日シェアフルで6,000円稼いだ。今日入金済み", now=TOKYO_NOW)
+    assert intent is not None
+    assert intent.as_record() == {
+        "type": "income",
+        "source": "シェアフル",
+        "creditor": None,
+        "amount": 6000,
+        "occurred_date": "2026-08-10",
+        "payment_date": "2026-08-10",
+        "status": "received",
+        "note": "",
+        "confidence": 0.99,
+    }
+
+
+@pytest.mark.asyncio
+async def test_hook_allows_unrelated_or_unallowed_and_replies_for_allowed(monkeypatch) -> None:
+    adapter = DryRunSheetAdapter()
+    set_test_adapter(adapter)
+    monkeypatch.setenv("FINANCE_ALLOWED_TELEGRAM_CHAT_IDS", "123")
+    source = SimpleNamespace(platform="telegram", chat_id="123")
+    event = SimpleNamespace(text="今日松屋で750円使った", message_id="hm1", source=source, timestamp=TOKYO_NOW, metadata={})
+    gateway = SimpleNamespace(adapters={source.platform: SimpleNamespace(send=AsyncMock())})
+    result = on_pre_gateway_dispatch(event=event, gateway=gateway)
+    await asyncio_sleep()
+    assert result == {"action": "skip", "reason": "finance_records_handled"}
+    gateway.adapters[source.platform].send.assert_awaited_once()
+
+    unrelated = SimpleNamespace(text="こんにちは", message_id="hm2", source=source, timestamp=TOKYO_NOW, metadata={})
+    assert on_pre_gateway_dispatch(event=unrelated, gateway=gateway) == {"action": "allow"}
+    unallowed = SimpleNamespace(text="今日松屋で750円使った", message_id="hm3", source=SimpleNamespace(platform="telegram", chat_id="999"), timestamp=TOKYO_NOW, metadata={})
+    assert on_pre_gateway_dispatch(event=unallowed, gateway=gateway) == {"action": "allow"}
+    set_test_adapter(None)
+
+
+@pytest.mark.asyncio
+async def test_hook_skips_with_failure_reply_when_live_adapter_init_fails(monkeypatch) -> None:
+    set_test_adapter(None)
+    monkeypatch.setenv("FINANCE_ALLOWED_TELEGRAM_CHAT_IDS", "123")
+    monkeypatch.setenv("FINANCE_DRY_RUN", "false")
+    monkeypatch.setenv("FINANCE_SHEETS_ENABLED", "true")
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    source = SimpleNamespace(platform="telegram", chat_id="123")
+    event = SimpleNamespace(text="今日松屋で750円使った", message_id="hm-live-fail", source=source, timestamp=TOKYO_NOW, metadata={})
+    gateway = SimpleNamespace(adapters={source.platform: SimpleNamespace(send=AsyncMock())})
+
+    result = on_pre_gateway_dispatch(event=event, gateway=gateway)
+    await asyncio_sleep()
+
+    assert result == {"action": "skip", "reason": "finance_records_init_failed"}
+    gateway.adapters[source.platform].send.assert_awaited_once()
+    reply = gateway.adapters[source.platform].send.await_args.args[1]
+    assert "初期化に失敗" in reply
+    assert "成功として扱いません" in reply
+
+
+async def asyncio_sleep() -> None:
+    import asyncio
+    await asyncio.sleep(0)


### PR DESCRIPTION
## 変更内容
- Telegramの日本語財務メッセージを処理する `finance_records` プラグインを追加しました。
- `pre_gateway_dispatch` hookで、許可されたTelegram chat_idからの収入・支出・返済・訂正・取消・照会メッセージだけを横取りします。
- dry-run/mockのシートアダプタ、Google Sheets live adapterのfail-closed骨組み、監査履歴、二重登録防止を追加しました。
- セットアップ手順とロールバック手順を `docs/finance-records.md` と plugin README に記載しました。

## 実装方法
- AI/LLMにセルや範囲を決めさせない前提で、まず決定的な日本語パーサを実装しました。
- 書き込み先は `FinanceSheetAdapter` 抽象化に閉じ込め、テストは `DryRunSheetAdapter` で実行します。
- `FINANCE_DRY_RUN=true` または `FINANCE_SHEETS_ENABLED=false` の場合は実シートへ書きません。
- live modeは `GOOGLE_APPLICATION_CREDENTIALS` と明示的な有効化が必要ですが、現時点ではシート列マッピング未確認のためfail-closedで止まります。
- `telegram_chat_id + telegram_message_id` を監査履歴キーにして、同じTelegramメッセージの二重処理を防ぎます。
- 訂正・取消は既存行削除ではなく、元event_id参照つきの監査行を残します。

## 実行したテスト
- `python -m pytest tests/plugins/test_finance_records_plugin.py` → 15 passed
- `python -m compileall -q plugins/finance_records tests/plugins/test_finance_records_plugin.py` → passed
- `git diff --check` → passed
- 追加行のsecret-like scan → 実秘密なし（環境変数名と `***` ダミーのみ）
- Codex read-only review → APPROVED

## 影響範囲
- `plugins/finance_records/` 新規追加
- `tests/plugins/test_finance_records_plugin.py` 新規追加
- `docs/finance-records.md` 新規追加
- 既存のTelegram platform実装・Gateway本体コード・既存Google認証コードには変更なし

## 注意点
- 本PRは安全なdry-run/mock実装までです。
- Google Sheets本番書き込みは、認証設定と実シート列/数式確認が終わるまで有効化しないでください。
- live adapterは現時点でfail-closedです。誤った列や範囲へ書き込むより、明示的に止まる設計にしています。
- 実運用開始時はまずユーザー本人のTelegram chat_idだけを `FINANCE_ALLOWED_TELEGRAM_CHAT_IDS` に設定してください。

## 手動設定
1. Google Cloudでサービスアカウントを作成する。
2. Google Sheets APIを有効化する。
3. 認証JSONをVPS上の安全な場所に配置する。Telegram/GitHubには貼らない。
4. 収支管理・返済管理の2スプレッドシートをサービスアカウントのメールアドレスへ編集者共有する。
5. 環境変数を設定する。
   - `GOOGLE_APPLICATION_CREDENTIALS`
   - `CASHFLOW_SPREADSHEET_ID`
   - `REPAYMENT_SPREADSHEET_ID`
   - `FINANCE_ALLOWED_TELEGRAM_CHAT_IDS`
   - `FINANCE_TIMEZONE=Asia/Tokyo`
   - `FINANCE_DRY_RUN=true`
   - `FINANCE_SHEETS_ENABLED=false`
6. dry-run確認後、実シートの列/数式マッピングを確認してからlive書き込みを有効化する。

## ロールバック
- 即時停止: `FINANCE_SHEETS_ENABLED=false` に戻す。
- 完全停止: `FINANCE_ALLOWED_TELEGRAM_CHAT_IDS` を空にする、またはプラグインを無効化する。
- デプロイ済みコードの戻し: このPRのコミットをrevertする。
- 既存スプレッドシートの既存データは本PRのdry-run状態では変更されません。

## 判断理由
- 既存Hermesの `pre_gateway_dispatch` hookを使うことで、Gateway本体やTelegram adapterを直接変更せずに実装できます。
- n8nを追加せず、VPS負荷を増やさない方針に合わせました。
- 実シートの列・数式・不足額セルを未確認のまま書くのは危険なので、live書き込みはfail-closedにしました。
- 他の選択肢としてHermes core tool化も可能ですが、個人財務連携はプラグインの方が既存機能への影響が小さいと判断しました。
