### PR TITLE
fix(desktop): stop transient remote ticket blips locking the chat

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -40,7 +40,8 @@ import {
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  withTransientRetries
 } from './connection-config'
 
 // --- connectionScopeKey / normAuthMode ---
@@ -662,6 +663,54 @@ test('gateway ticket failures classify only explicit auth rejection statuses as 
   const serverFailure = gatewayTicketFailure(new Error('network timeout'), 'sign in', 'retry connection') as any
   assert.equal(serverFailure.message, 'retry connection')
   assert.equal(serverFailure.needsOauthLogin, undefined)
+})
+
+test('withTransientRetries retries transport blips but not auth rejections', async () => {
+  const sleeps: number[] = []
+  let transportAttempts = 0
+
+  const ticket = await withTransientRetries(
+    async () => {
+      transportAttempts += 1
+
+      if (transportAttempts < 3) {
+        throw Object.assign(new Error('500: unavailable'), { statusCode: 500 })
+      }
+
+      return 'tkt-ok'
+    },
+    {
+      delaysMs: [10, 10],
+      sleep: async (ms: number) => {
+        sleeps.push(ms)
+      }
+    }
+  )
+
+  assert.equal(ticket, 'tkt-ok')
+  assert.equal(transportAttempts, 3)
+  assert.deepEqual(sleeps, [10, 10])
+
+  let authAttempts = 0
+  await assert.rejects(
+    () =>
+      withTransientRetries(
+        async () => {
+          authAttempts += 1
+          throw Object.assign(new Error('401: rejected'), { statusCode: 401 })
+        },
+        {
+          delaysMs: [10],
+          sleep: async () => undefined
+        }
+      ),
+    (err: any) => {
+      assert.equal(err.statusCode, 401)
+
+      return true
+    }
+  )
+  assert.equal(authAttempts, 1)
 })
 
 test('gateway WS URL IPC result serializes success and the auth-vs-transport matrix', async () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -125,6 +125,41 @@ function gatewayTicketFailure(error, authMessage, transportMessage) {
   return err
 }
 
+/**
+ * Retry a one-shot mint/fetch that can flap on brief network blips.
+ * Auth rejections (401/403 / needsOauthLogin) fail immediately — retrying those
+ * just hammers a dead session. Transport/server failures retry with short delays.
+ */
+async function withTransientRetries(run, options: any = {}) {
+  const attempts = Number.isInteger(options.attempts) && options.attempts > 0 ? options.attempts : 3
+  const delaysMs = Array.isArray(options.delaysMs) && options.delaysMs.length > 0 ? options.delaysMs : [250, 750]
+
+  const sleep =
+    typeof options.sleep === 'function' ? options.sleep : (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+  const isRetryable =
+    typeof options.isRetryable === 'function' ? options.isRetryable : (error: unknown) => !isGatewayAuthRejection(error)
+
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await run()
+    } catch (error) {
+      lastError = error
+
+      if (!isRetryable(error) || attempt >= attempts - 1) {
+        throw error
+      }
+
+      const delay = delaysMs[Math.min(attempt, delaysMs.length - 1)]
+      await sleep(delay)
+    }
+  }
+
+  throw lastError
+}
+
 /** Serialize a fresh-WS-URL attempt across Electron's IPC boundary. */
 async function gatewayWsUrlIpcResult(resolveWsUrl: () => Promise<string>) {
   try {
@@ -585,5 +620,6 @@ export {
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  withTransientRetries
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -74,7 +74,8 @@ import {
   resolveProfileBackendRoute,
   resolveTestWsUrl,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  withTransientRetries
 } from './connection-config'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
@@ -6487,15 +6488,33 @@ async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> 
 // falling back to the OAuth cookie partition otherwise.
 // Throws (with statusCode 401) if the session cookie is missing/expired —
 // callers treat that as "needs re-login".
+// Transient transport blips (brief host unreachable, 5xx, timeouts) are retried
+// a few times before failing — those 1–3s flaps were promoting into the
+// full-screen "couldn't start" lockout on reconnect.
 async function mintGatewayWsTicket(baseUrl) {
-  // Native flow: mint the ticket with the bearer token, no cookie involved.
-  const nativeAt = await ensureNativeAccessToken(baseUrl).catch(() => null)
+  return withTransientRetries(async () => {
+    // Native flow: mint the ticket with the bearer token, no cookie involved.
+    const nativeAt = await ensureNativeAccessToken(baseUrl).catch(() => null)
 
-  if (nativeAt) {
-    const body = (await fetchJson(`${baseUrl}/api/auth/ws-ticket`, null, {
+    if (nativeAt) {
+      const body = (await fetchJson(`${baseUrl}/api/auth/ws-ticket`, null, {
+        method: 'POST',
+        timeoutMs: 8_000,
+        bearer: nativeAt
+      })) as any
+
+      const ticket = body?.ticket
+
+      if (!ticket || typeof ticket !== 'string') {
+        throw new Error('Gateway did not return a WS ticket.')
+      }
+
+      return ticket
+    }
+
+    const body = (await fetchJsonViaOauthSession(`${baseUrl}/api/auth/ws-ticket`, {
       method: 'POST',
-      timeoutMs: 8_000,
-      bearer: nativeAt
+      timeoutMs: 8_000
     })) as any
 
     const ticket = body?.ticket
@@ -6505,20 +6524,7 @@ async function mintGatewayWsTicket(baseUrl) {
     }
 
     return ticket
-  }
-
-  const body = (await fetchJsonViaOauthSession(`${baseUrl}/api/auth/ws-ticket`, {
-    method: 'POST',
-    timeoutMs: 8_000
-  })) as any
-
-  const ticket = body?.ticket
-
-  if (!ticket || typeof ticket !== 'string') {
-    throw new Error('Gateway did not return a WS ticket.')
-  }
-
-  return ticket
+  })
 }
 
 // Build a fresh WS URL for the *current* connection. Critical for reconnects:
@@ -9952,7 +9958,7 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
         currentConnectionPromise: () => backendConnectionState.getPromise(),
         log: rememberLog,
         probe: fetchPublicJson,
-        resetConnection: resetHermesConnection,
+        resetConnection: () => resetHermesConnection({ soft: true }),
         tracker: remoteLiveness
       }),
       revalidatePool()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -297,8 +297,9 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     act(() => FakeWebSocket.instances[0].drop())
     await flushAsync()
 
-    // Walk the backoff past the ~45s escalation threshold.
-    for (let i = 0; i < 8; i += 1) {
+    // Walk the backoff well past the historical 45s threshold and into the
+    // current multi-minute escalate window. Chat must stay unlocked either way.
+    for (let i = 0; i < 24; i += 1) {
       await advanceBackoff()
     }
 
@@ -318,7 +319,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     act(() => FakeWebSocket.instances[0].drop())
     await flushAsync()
 
-    for (let i = 0; i < 8; i += 1) {
+    for (let i = 0; i < 24; i += 1) {
       await advanceBackoff()
     }
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -85,6 +85,8 @@ function fakeDesktop() {
     wsUrl: 'wss://vps.example.com/api/ws?token=t'
   }
 
+  let bootProgressHandler: ((payload: Record<string, unknown>) => void) | null = null
+
   return {
     getConnection: vi.fn(async () => conn),
     getGatewayWsUrl: vi.fn(async () => conn.wsUrl),
@@ -97,7 +99,17 @@ function fakeDesktop() {
       running: true,
       timestamp: Date.now()
     })),
-    onBootProgress: vi.fn(() => () => undefined),
+    onBootProgress: vi.fn(callback => {
+      bootProgressHandler = callback
+
+      return () => {
+        bootProgressHandler = null
+      }
+    }),
+    // Test helper: fire a post-boot progress event through the real subscription.
+    emitBootProgress(payload: Record<string, unknown>) {
+      bootProgressHandler?.(payload)
+    },
     onBackendExit: vi.fn(() => () => undefined),
     onConnectionApplied: vi.fn(callback => {
       connectionApplied = callback
@@ -265,11 +277,9 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     act(() => FakeWebSocket.instances[0].drop())
     await flushAsync()
 
-    // Burn a couple backoff cycles BEFORE the escalation threshold (<6 attempts,
-    // ~the first ~15s). This is the window where stock and fixed behave the
-    // same: socket down, hook retrying, gatewayState non-open, boot.error still
-    // null → CONNECTING covers the screen with no recovery surface. (Past ~45s
-    // the fix raises boot.error; that's asserted in the next test.)
+    // Burn a couple backoff cycles BEFORE the escalation threshold. Socket
+    // down, hook retrying, gatewayState non-open, boot.error still null so
+    // chat stays usable (no CONNECTING / no couldn't-start overlay).
     await advanceBackoff()
 
     expect($gatewayState.get()).not.toBe('open')
@@ -278,7 +288,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(FakeWebSocket.instances.length).toBeGreaterThan(1)
   })
 
-  it('FIX: after the prolonged drop the hook raises a recoverable boot error (the escape hatch)', async () => {
+  it('FIX: after a prolonged drop the chat stays unlocked (toast, not boot.error)', async () => {
     render(<Harness />)
     await flushAsync()
     expect($desktopBoot.get().error).toBeNull()
@@ -287,17 +297,20 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     act(() => FakeWebSocket.instances[0].drop())
     await flushAsync()
 
-    // Walk the backoff past the >=6 attempt threshold (~45s of failures).
+    // Walk the backoff past the ~45s escalation threshold.
     for (let i = 0; i < 8; i += 1) {
       await advanceBackoff()
     }
 
-    // The hook surfaced the recoverable error → BootFailureOverlay (Use local
-    // gateway / Sign in / Retry) becomes reachable instead of CONNECTING.
-    expect($desktopBoot.get().error).toBeTruthy()
+    // Transport blips must NOT take the full-screen "couldn't start" overlay —
+    // users were locked out of reading/drafting for the whole reconnect window.
+    expect($desktopBoot.get().error).toBeNull()
+    expect($gatewayState.get()).not.toBe('open')
+    // Still retrying.
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(1)
   })
 
-  it('FIX: a successful reconnect clears the recoverable error', async () => {
+  it('FIX: a successful reconnect after a prolonged drop restores the open gateway', async () => {
     render(<Harness />)
     await flushAsync()
 
@@ -309,7 +322,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
       await advanceBackoff()
     }
 
-    expect($desktopBoot.get().error).toBeTruthy()
+    expect($desktopBoot.get().error).toBeNull()
 
     // The remote comes back: next reconnect attempt opens.
     FakeWebSocket.mode = 'open'
@@ -317,6 +330,36 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($gatewayState.get()).toBe('open')
     expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('FIX: post-boot ticket-mint boot-progress errors do not lock the UI', async () => {
+    const desktop = fakeDesktop() as ReturnType<typeof fakeDesktop> & {
+      emitBootProgress: (payload: Record<string, unknown>) => void
+    }
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
+
+    // Main re-emits the exact transient ticket error after a liveness rebuild.
+    // That used to promote into BootFailureOverlay and lock reading/drafting.
+    act(() => {
+      desktop.emitBootProgress({
+        error:
+          'Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.',
+        message: 'Desktop boot failed',
+        phase: 'backend.error',
+        progress: 94,
+        running: false,
+        timestamp: Date.now()
+      })
+    })
+
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().visible).toBe(false)
   })
 
   it('FIX: a failed session-list fetch during boot is non-fatal — the app still boots', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -47,11 +47,15 @@ import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './ga
 
 // After the reconnect loop has been failing for this long, raise a NON-blocking
 // warning toast. Full-screen BootFailureOverlay used to lock the user out of
-// reading/drafting for the whole 1–3 minute blip even though the transcript is
-// still on screen underneath. Confirmed reauth still escalates to the overlay
-// (Sign in is required). Time-based (not attempt-count) because full-jitter
-// backoff makes attempt counts a meaningless clock.
-const RECONNECT_ESCALATE_AFTER_MS = 45_000
+// reading/drafting for the whole blip even though the transcript is still on
+// screen underneath. Confirmed reauth still escalates to the overlay (Sign in
+// is required). Time-based (not attempt-count) because full-jitter backoff
+// makes attempt counts a meaningless clock.
+//
+// 5 minutes (not the historical ~45s) so brief transport weather — ticket mint
+// flaps, sleep/wake, Wi‑Fi blips that self-heal in 1–3 minutes — never even
+// toast. Chat stays readable/draftable the whole time either way.
+const RECONNECT_ESCALATE_AFTER_MS = 300_000
 
 interface GatewayBootOptions {
   beforeConnectionSwitch: () => void
@@ -127,9 +131,8 @@ export function useGatewayBoot({
     // identical error toasts (and their haptics). Reset on the next clean open.
     let reauthNotified = false
     // Raised once the reconnect loop has been failing for
-    // RECONNECT_ESCALATE_AFTER_MS so the recovery overlay replaces the
-    // dead-end CONNECTING screen. Reset on a clean open or a manual/
-    // wake-driven reconnect.
+    // RECONNECT_ESCALATE_AFTER_MS so we fire a single non-blocking toast.
+    // Reset on a clean open or a manual/wake-driven reconnect.
     let escalated = false
 
     // Wrap the live getter in a call so TS control-flow analysis doesn't narrow

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -1,6 +1,7 @@
 import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
 import { useEffect, useRef } from 'react'
 
+import { shouldApplyPostBootProgressError } from '@/components/boot-failure-reauth'
 import type { HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
@@ -44,15 +45,12 @@ import type { RpcEvent } from '@/types/hermes'
 
 import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './gateway-hmr-survivor'
 
-// After the reconnect loop has been failing for this long, raise a recoverable
-// boot error. Otherwise a dropped remote gateway loops the backoff forever
-// behind the fullscreen CONNECTING overlay with no way to reach Settings /
-// sign in / switch to local — the "lost connection breaks the app" dead end.
-// The next successful reconnect clears it. Time-based (not attempt-count)
-// because the full-jitter backoff makes attempt counts a meaningless clock:
-// six jittered attempts can elapse in ~9s, while the old deterministic
-// 1→15s ladder took ~45s to reach six failures — this threshold keeps that
-// original ~45s calibration.
+// After the reconnect loop has been failing for this long, raise a NON-blocking
+// warning toast. Full-screen BootFailureOverlay used to lock the user out of
+// reading/drafting for the whole 1–3 minute blip even though the transcript is
+// still on screen underneath. Confirmed reauth still escalates to the overlay
+// (Sign in is required). Time-based (not attempt-count) because full-jitter
+// backoff makes attempt counts a meaningless clock.
 const RECONNECT_ESCALATE_AFTER_MS = 45_000
 
 interface GatewayBootOptions {
@@ -193,11 +191,14 @@ export function useGatewayBoot({
         await callbacksRef.current.refreshSessions().catch(() => undefined)
       } catch (err) {
         // OAuth session expired mid-reconnect: surface the actionable "sign in
-        // again" message once instead of silently looping the backoff against a
-        // ticket that can never succeed. Transport failures fall through to the
-        // backoff in the finally block below.
+        // again" recovery overlay once instead of silently looping the backoff
+        // against a ticket that can never succeed. Transport failures fall
+        // through to the backoff in the finally block below — they must NOT
+        // take the full-screen "couldn't start" path (locks reading/drafting).
         if (!cancelled && isGatewayReauthRequired(err) && !reauthNotified) {
           reauthNotified = true
+          const message = err instanceof Error ? err.message : String(err)
+          failDesktopBoot(message)
           notifyError(err, translateNow('boot.errors.gatewaySignInRequired'))
         }
       } finally {
@@ -210,7 +211,14 @@ export function useGatewayBoot({
 
           if (Date.now() - reconnectFailingSince >= RECONNECT_ESCALATE_AFTER_MS && !escalated) {
             escalated = true
-            failDesktopBoot(translateNow('boot.errors.gatewayConnectionLost'))
+            // Non-blocking: chat stays readable/draftable while we keep retrying.
+            // Settings / Gateway menu remain reachable without a modal lockout.
+            notify({
+              kind: 'warning',
+              title: translateNow('boot.errors.gatewayConnectionLost'),
+              message: translateNow('boot.errors.gatewayConnectionLostDetail'),
+              durationMs: 0
+            })
           }
 
           scheduleReconnect()
@@ -348,9 +356,12 @@ export function useGatewayBoot({
 
     const offBootProgress = desktop.onBootProgress(payload => {
       // Soft switch / post-boot startHermes re-emits progress — ignore so the
-      // cold-boot CONNECTING overlay stays down. Errors still surface.
+      // cold-boot CONNECTING overlay stays down. Post-boot errors are gated:
+      // only confirmed reauth takes the full-screen recovery surface. Transient
+      // ticket-mint / host-unreachable failures must stay in the reconnect loop
+      // (otherwise a 1–3 min blip bricks reading/drafting behind "couldn't start").
       if ($gatewaySwitching.get() || bootCompleted) {
-        if (payload.error) {
+        if (payload.error && shouldApplyPostBootProgressError(payload.error)) {
           applyDesktopBootProgress(payload)
         }
 

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -7,6 +7,7 @@ import {
   isRemoteConfig,
   isRemoteReauthError,
   isRemoteReauthFailure,
+  shouldApplyPostBootProgressError,
   signInLabel,
   sshFailureMessage
 } from './boot-failure-reauth'
@@ -109,6 +110,19 @@ describe('isRemoteReauthError', () => {
   it('ignores non-auth boot errors and nullish', () => {
     expect(isRemoteReauthError('Hermes background process exited during startup.')).toBe(false)
     expect(isRemoteReauthError(null)).toBe(false)
+  })
+})
+
+describe('shouldApplyPostBootProgressError', () => {
+  it('applies only confirmed reauth after a healthy boot — not transient ticket blips', () => {
+    expect(shouldApplyPostBootProgressError('Your remote gateway session has expired.')).toBe(true)
+    expect(
+      shouldApplyPostBootProgressError(
+        'Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.'
+      )
+    ).toBe(false)
+    expect(shouldApplyPostBootProgressError('Lost connection to the gateway')).toBe(false)
+    expect(shouldApplyPostBootProgressError(null)).toBe(false)
   })
 })
 

--- a/apps/desktop/src/components/boot-failure-reauth.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.ts
@@ -60,6 +60,18 @@ export function isRemoteReauthError(error: string | null | undefined): boolean {
   )
 }
 
+/**
+ * After a healthy cold boot, main may still re-emit boot-progress errors when a
+ * post-boot startHermes()/ticket mint fails (liveness reset → rebuild, wake
+ * recovery, etc.). Only CONFIRMED reauth should take over the full-screen
+ * recovery overlay then — transient "could not reach … WebSocket ticket"
+ * blips must stay in the reconnect loop so reading/drafting is not locked out
+ * for 1–3 minutes while the socket self-heals.
+ */
+export function shouldApplyPostBootProgressError(error: string | null | undefined): boolean {
+  return isRemoteReauthError(error)
+}
+
 // A remote, gated (oauth-bucket) gateway is a remote-reauth boot failure when the
 // session isn't connected OR the boot error is auth-shaped (connected-but-expired
 // — see isRemoteReauthError). Only re-establishing the remote session fixes it;

--- a/apps/desktop/src/components/gateway-connecting-overlay.test.tsx
+++ b/apps/desktop/src/components/gateway-connecting-overlay.test.tsx
@@ -170,14 +170,14 @@ describe('connecting overlay vs recovery surface', () => {
     expect(isRecoveryShown()).toBe(false)
   })
 
-  it('FIX: once the prolonged reconnect raises a recoverable boot error, the recovery overlay takes over', async () => {
-    // Mirrors what useGatewayBoot.scheduleReconnect() now does after ~45s of
-    // failed post-boot reconnects: it calls failDesktopBoot(), flipping the UI
-    // from the dead-end CONNECTING overlay to the recovery surface.
+  it('FIX: confirmed reauth boot.error still surfaces the recovery overlay (not CONNECTING)', async () => {
+    // Transport blips no longer set boot.error (toast + background retry).
+    // Confirmed OAuth reauth still does — and that recovery surface must win
+    // over any residual connecting state so Sign-in / Gateway settings stay reachable.
     setGatewayState('error')
     $desktopBoot.set({
       ...$desktopBoot.get(),
-      error: 'Lost connection to the Hermes gateway and could not reconnect.',
+      error: 'Your remote gateway session has expired. Sign in again.',
       running: false,
       visible: true
     })
@@ -191,7 +191,7 @@ describe('connecting overlay vs recovery surface', () => {
       )
     })
 
-    // Escape hatch is now reachable; the connecting overlay bows out.
+    // Escape hatch is reachable; the connecting overlay bows out.
     expect(isRecoveryShown()).toBe(true)
     expect(screen.getByRole('button', { name: /gateway settings/i })).toBeTruthy()
     expect(isConnectingShown()).toBe(false)

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -70,6 +70,8 @@ export const ar = defineLocale({
       backendStopped: 'توقف الخلفية',
       desktopBootFailed: 'فشل تشغيل سطح المكتب',
       gatewayConnectionLost: 'انقطع الاتصال بالبوابة',
+      gatewayConnectionLostDetail:
+        'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: 'تسجيل الدخول للبوابة مطلوب',
       ipcBridgeUnavailable: 'جسر IPC لسطح المكتب غير متاح.'
     },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -77,6 +77,8 @@ export const en: Translations = {
       backendStopped: 'Backend stopped',
       desktopBootFailed: 'Desktop boot failed',
       gatewayConnectionLost: 'Lost connection to the gateway',
+      gatewayConnectionLostDetail:
+        'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: 'Gateway sign-in required',
       ipcBridgeUnavailable: 'Desktop IPC bridge is unavailable.'
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -77,6 +77,8 @@ export const ja = defineLocale({
       backendStopped: 'バックエンドが停止しました',
       desktopBootFailed: 'デスクトップの起動に失敗しました',
       gatewayConnectionLost: 'ゲートウェイへの接続が切断されました',
+      gatewayConnectionLostDetail:
+        'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: 'ゲートウェイへのサインインが必要です',
       ipcBridgeUnavailable: 'デスクトップ IPC ブリッジが利用できません。'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -123,6 +123,7 @@ export interface Translations {
       backendStopped: string
       desktopBootFailed: string
       gatewayConnectionLost: string
+      gatewayConnectionLostDetail: string
       gatewaySignInRequired: string
       ipcBridgeUnavailable: string
     }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -77,6 +77,8 @@ export const zhHant = defineLocale({
       backendStopped: '後端已停止',
       desktopBootFailed: '桌面啟動失敗',
       gatewayConnectionLost: '與閘道的連線已中斷',
+      gatewayConnectionLostDetail:
+        'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: '需要閘道登入',
       ipcBridgeUnavailable: '桌面 IPC 橋接器不可用。'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -77,6 +77,8 @@ export const zh: Translations = {
       backendStopped: '后端已停止',
       desktopBootFailed: '桌面启动失败',
       gatewayConnectionLost: '与网关的连接已断开',
+      gatewayConnectionLostDetail:
+        'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: '需要登录网关',
       ipcBridgeUnavailable: '桌面 IPC 桥不可用。'
     },


### PR DESCRIPTION
## Summary

Fixes intermittent Desktop lockouts where a brief remote gateway blip (WebSocket ticket mint / reconnect) promoted into the full-screen **"Hermes couldn't start"** overlay and blocked reading/drafting for 1–3 minutes.

Closes #82906

## Root cause

On current `main`, after a healthy cold boot:

1. `useGatewayBoot`'s `onBootProgress` still applied **any** `payload.error` into `$desktopBoot`.
2. Remote liveness rebuild / reconnect re-ran `startHermes()` → `mintGatewayWsTicket()`. A transient transport failure emitted:
   `Could not reach the remote Hermes gateway while refreshing its WebSocket ticket…`
3. That error opened `BootFailureOverlay` (`fixed inset-0`), locking the chat even though the transcript was still on screen and the socket usually self-healed.
4. Prolonged reconnect escalation (~45s) also called `failDesktopBoot`, same lockout class.
5. Ticket mint was single-shot with no short retry for 5xx/network flaps.

Confirmed OAuth reauth is a different class and still needs the Sign-in overlay.

## Fix (minimal footprint)

| Change | Why |
|---|---|
| `shouldApplyPostBootProgressError` — only confirmed reauth post-boot | Transient ticket/network errors stay in the reconnect loop |
| Prolonged transport reconnect → non-blocking toast, not `failDesktopBoot` | Chat stays readable/draftable |
| Reauth during reconnect still `failDesktopBoot` | Sign-in recovery remains available |
| `revalidate` uses `resetHermesConnection({ soft: true })` | Don't reset boot UI on liveness rebuild |
| `withTransientRetries` around ticket mint | Absorb 1–3s flaps; auth 401/403 fail fast |

No new core tools, env vars, or protocol surface.

## Tests

- `shouldApplyPostBootProgressError` rejects the exact ticket transport string
- `useGatewayBoot`: post-boot ticket boot-progress does **not** set `boot.error`
- Prolonged reconnect keeps `boot.error` null and continues retrying
- `withTransientRetries` retries transport, not auth
- 108 tests green in targeted vitest run

```bash
cd apps/desktop
npx vitest run --environment jsdom \
  src/app/gateway/hooks/use-gateway-boot.test.tsx \
  src/components/boot-failure-reauth.test.ts \
  electron/connection-config.test.ts
```

## Test plan

- [ ] Point Desktop at a remote OAuth gateway; force a brief network flap (sleep/wake or block host ~30–90s)
- [ ] Confirm chat remains readable/draftable (no "couldn't start" modal)
- [ ] Confirm reconnect recovers without Reload
- [ ] Confirm expired session still shows Sign-in recovery
- [ ] Cold-boot hard failure still shows recovery overlay
