### PR TITLE
fix(desktop-ssh): raise remote backend file limit

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -832,6 +832,12 @@ test('buildSpawnCommand always uses serve, never dashboard', () => {
   assert.doesNotMatch(cmd, /--no-open/)
 })
 
+test('buildSpawnCommand raises the SSH child file limit before execing Hermes', () => {
+  const cmd = buildSpawnCommand('/x/hermes', '', { logPath: spawnLogPath(OWNERSHIP_ID, SPAWN_NONCE) })
+  assert.match(cmd, /ulimit -n 65536 2>\/dev\/null \|\| true; exec env HERMES_DESKTOP=1/)
+  assert.ok(cmd.indexOf('ulimit -n 65536') < cmd.indexOf('serve --isolated'))
+})
+
 test('spawnRemoteDashboard removes a token file when upload reporting fails', async () => {
   const failure = new Error('channel closed')
 

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -37,6 +37,11 @@ const REMOTE_LOCK_DIR = '~/.hermes/desktop-ssh'
 const SUPPORTED_REMOTE_OS = new Set(['Linux', 'Darwin'])
 const DEFAULT_READY_TIMEOUT_MS = 45_000
 const READY_POLL_INTERVAL_MS = 750
+// macOS sshd starts non-interactive shells with a 256-FD soft limit even when
+// the hard limit is unlimited. A Desktop backend can legitimately exceed that
+// while serving several profiles/tools, so raise only the child process limit.
+// Keep startup portable: restricted hosts retain their existing limit.
+const REMOTE_NOFILE_SOFT_LIMIT = 65_536
 
 function mintToken() {
   return crypto.randomBytes(32).toString('hex')
@@ -442,7 +447,10 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   const tokenArg = tokenFilePath ? ` --ssh-session-token-file ${expandRemotePath(tokenFilePath)}` : ''
   const ownerArg = opts.spawnNonce ? ` --ssh-owner-nonce ${validateSpawnNonce(opts.spawnNonce)}` : ''
   const subCmd = `serve --isolated --host 127.0.0.1 --port 0${tokenArg}${ownerArg}`
-  const dashCmd = `env HERMES_DESKTOP=1 ${hermes} ${profileArgs}${subCmd}`
+
+  const dashCmd =
+    `ulimit -n ${REMOTE_NOFILE_SOFT_LIMIT} 2>/dev/null || true; ` +
+    `exec env HERMES_DESKTOP=1 ${hermes} ${profileArgs}${subCmd}`
 
   return (
     `mkdir -p "$(dirname ${logPath})" && ` +


### PR DESCRIPTION
## Summary

- raise the soft file-descriptor limit for SSH-launched Desktop backends before `exec`
- keep startup portable by falling back to the host's existing limit if the raise is rejected
- cover command ordering and the 65,536 limit with a regression test

## Root cause

On macOS, a non-interactive `sshd` shell can inherit a soft `nofile` limit of 256 even when the hard limit is unlimited. A long-lived `hermes serve --isolated` Desktop backend can exceed that limit while serving profiles and tools, after which unrelated reads fail with errors such as:

```text
OSError: [Errno 24] Too many open files: '~/.hermes/auth.json'
```

The credential file is not corrupt; it is simply the next file the exhausted process attempted to open.

## Fix

The detached SSH child now runs:

```sh
ulimit -n 65536 2>/dev/null || true
```

before `exec env HERMES_DESKTOP=1 ...`. This changes only the Desktop-owned backend process and preserves existing behavior on hosts that reject the requested limit.

## Verification

- `npm exec --workspace apps/desktop -- vitest run --project electron electron/remote-lifecycle.test.ts` — 67 passed
- `npm exec --workspace apps/desktop -- eslint electron/remote-lifecycle.ts electron/remote-lifecycle.test.ts` — passed
- `npm run typecheck --workspace apps/desktop` — passed
- reproduced MacBook → Mac mini SSH soft limit: 256
- deployed packaged macOS app raised the launch path to 65,536; fresh isolated backend started successfully and `/api/status` returned HTTP 200
