### PR TITLE
fix(discord): gate relay-only thread rename kwargs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20539,18 +20539,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "relay" if use_connector_guard else "native",
             thread_name,
         )
+        rename_kwargs = (
+            {
+                "prefer_connector_created": True,
+                "parent_chat_id": parent_chat_id,
+            }
+            if use_connector_guard
+            else {"only_if_current_name": guard_name}
+        )
         try:
             renamed = await rename_thread(
                 target_thread_id,
                 thread_name,
-                prefer_connector_created=use_connector_guard,
-                only_if_current_name=guard_name,
-                parent_chat_id=parent_chat_id,
+                **rename_kwargs,
             )
             logger.info(
                 "discord auto-thread rename result: thread=%s applied=%s",
                 target_thread_id,
                 bool(renamed),
+            )
+        except TypeError:
+            logger.warning(
+                "Discord semantic thread rename raised TypeError (adapter=%s)",
+                type(adapter).__name__,
+                exc_info=True,
             )
         except Exception:
             logger.debug("Failed to rename Discord auto-thread for generated session title", exc_info=True)

--- a/tests/gateway/test_session_title_rename_lane.py
+++ b/tests/gateway/test_session_title_rename_lane.py
@@ -14,7 +14,7 @@ import types
 import pytest
 
 from gateway.config import Platform
-from gateway.run import TurnRunner
+from gateway.run import GatewayRunner, TurnRunner
 
 
 def _attach(lane):
@@ -53,3 +53,51 @@ def test_the_rename_waits_for_the_model_title(lane):
 
     callback("Fix flaky auth test", "llm")
     assert renames == ["Fix flaky auth test"]
+
+
+@pytest.mark.asyncio
+async def test_native_thread_rename_passes_only_the_initial_name_guard():
+    """The shared rename lane must honor the strict native adapter contract."""
+    calls: list[tuple[str, str, str | None]] = []
+
+    class StrictNativeAdapter:
+        async def rename_thread(
+            self,
+            thread_id: str,
+            name: str,
+            *,
+            only_if_current_name: str | None = None,
+        ) -> bool:
+            calls.append((thread_id, name, only_if_current_name))
+            return True
+
+    class NativeRenameRunner:
+        _is_discord_auto_thread_lane = GatewayRunner._is_discord_auto_thread_lane
+        _sanitize_discord_thread_title = GatewayRunner._sanitize_discord_thread_title
+        _rename_discord_auto_thread_for_session_title = (
+            GatewayRunner._rename_discord_auto_thread_for_session_title
+        )
+
+        def __init__(self, adapter):
+            self.adapters = {Platform.DISCORD: adapter}
+
+        def _adapter_for_source(self, source):
+            return self.adapters[source.platform]
+
+    source = types.SimpleNamespace(
+        platform=Platform.DISCORD,
+        chat_id="999",
+        chat_type="thread",
+        thread_id="999",
+        auto_thread_created=True,
+        auto_thread_initial_name="Initial words",
+    )
+
+    runner = NativeRenameRunner(StrictNativeAdapter())
+    await runner._rename_discord_auto_thread_for_session_title(
+        source,
+        "session-1",
+        "Semantic Session Title",
+    )
+
+    assert calls == [("999", "Semantic Session Title", "Initial words")]


### PR DESCRIPTION
## What does this PR do?

Restores native Discord auto-thread semantic renames by passing each adapter only the keyword arguments its lane supports.

The shared gateway caller previously sent relay-only `prefer_connector_created` and `parent_chat_id` arguments to the native Discord adapter. Its strict `rename_thread` signature rejected those arguments with `TypeError`; the surrounding best-effort handler logged only at DEBUG, so the thread kept its placeholder title without an INFO-level result.

This change keeps one polymorphic invocation while building lane-specific kwargs:

- Native Discord receives only its existing `only_if_current_name` no-clobber guard.
- Relay receives `prefer_connector_created=True` and the parent-channel discriminator.
- Escaped `TypeError` contract failures are visible at WARNING; other cosmetic failures remain DEBUG-only.

This follows the call-site-gating direction discussed in #80869, but keeps the invocation single and adds one focused boundary regression to the existing title-rename test module. #78495 is the alternative adapter-tolerance approach.

## Related Issue

Fixes #78487

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: gate native and relay rename kwargs at the shared call site and surface unexpected `TypeError` contract failures.
- `tests/gateway/test_session_title_rename_lane.py`: cover the real gateway-to-native boundary with a signature-strict adapter stub.

## How to Test

1. Run the focused gateway modules:
   ```bash
   .venv/bin/python -m pytest -q \
     tests/gateway/test_session_title_rename_lane.py \
     tests/gateway/test_discord_slash_commands.py \
     tests/gateway/relay/test_relay_threads.py
   ```
2. Run static checks:
   ```bash
   .venv/bin/python -m py_compile gateway/run.py tests/gateway/test_session_title_rename_lane.py
   .venv/bin/python -m ruff check gateway/run.py tests/gateway/test_session_title_rename_lane.py
   git diff --check
   ```
3. For live acceptance, restart the gateway, trigger a native Discord auto-thread, and confirm `discord auto-thread rename result: ... applied=True` appears at INFO and the semantic title replaces the placeholder.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, deterministic gateway tests; live Discord acceptance remains pending

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior and protocol are unchanged
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python call-shape fix
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
34 passed, 2 unrelated websockets deprecation warnings
All checks passed! (Ruff)
py_compile: passed
git diff --check: passed
```

Live Discord acceptance was not performed as part of this deterministic test pass.
