### PR TITLE
feat(gateway): single-character scope aliases for plain-text approval replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -631,16 +631,21 @@ def _format_exec_approval_fallback(
         heading = "⚠️ **Smart DENY — owner override for one operation:**"
 
     choices = [f"Reply `{command_prefix}approve` to execute this one operation"]
+    shortcuts = ["`1`/`y`"]
     if not smart_denied and allow_session:
         choices.append(
             f"`{command_prefix}approve session` to approve this pattern for the session"
         )
+        shortcuts.append("`2`/`s`")
         if allow_permanent:
             choices.append(f"`{command_prefix}approve always` to approve permanently")
+            shortcuts.append("`3`/`a`")
     choices.append(f"`{command_prefix}deny` to cancel")
+    shortcuts.append("`4`/`n`")
     return (
         f"{heading}\n```\n{cmd_preview}\n```\nReason: {description}\n\n"
-        + ", ".join(choices[:-1]) + f", or {choices[-1]}."
+        + ", ".join(choices[:-1]) + f", or {choices[-1]}.\n"
+        + "Shortcuts: " + " · ".join(shortcuts) + "."
     )
 
 
@@ -9009,18 +9014,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from tools.approval import has_blocking_approval
             if has_blocking_approval(session_key):
                 _raw_text = (event.text or "").strip().lower()
-                _approve_words = {"approve", "yes", "ok", "okay", "confirm", "y", "👍"}
-                _deny_words = {"deny", "no", "reject", "cancel", "n", "👎"}
+                _approve_words = {"approve", "yes", "ok", "okay", "confirm", "y", "👍", "1"}
+                _deny_words = {"deny", "no", "reject", "cancel", "n", "👎", "4"}
                 _approval_handler = None
                 _normalized_args = ""
                 if _raw_text in _approve_words:
                     _approval_handler = self._handle_approve_command
                 elif _raw_text in _deny_words:
                     _approval_handler = self._handle_deny_command
-                elif _raw_text in {"always", "approve always", "always approve"}:
+                elif _raw_text in {"always", "approve always", "always approve", "3", "a"}:
                     _approval_handler = self._handle_approve_command
                     _normalized_args = "always"
-                elif _raw_text in {"session", "approve session", "session approve"}:
+                elif _raw_text in {"session", "approve session", "session approve", "2", "s"}:
                     _approval_handler = self._handle_approve_command
                     _normalized_args = "session"
                 if _approval_handler is not None:

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -135,4 +135,39 @@ class TestApprovalTextFallbackContract:
         assert "approve session" not in text
         assert "approve always" not in text
 
+    def test_full_prompt_advertises_all_shortcuts(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "rm -rf /tmp/test", "dangerous deletion", "/",
+        )
+        assert "Shortcuts:" in text
+        assert "`1`/`y`" in text
+        assert "`2`/`s`" in text
+        assert "`3`/`a`" in text
+        assert "`4`/`n`" in text
+
+    def test_smart_deny_shortcuts_omit_session_and_always(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "rm -rf /", "dangerous deletion", "/",
+            allow_permanent=False, smart_denied=True,
+        )
+        assert "Shortcuts:" in text
+        assert "`1`/`y`" in text
+        assert "`4`/`n`" in text
+        assert "`2`/`s`" not in text
+        assert "`3`/`a`" not in text
+
+    def test_no_permanent_shortcut_when_permanent_disallowed(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "rm -rf /", "dangerous deletion", "/",
+            allow_session=True, allow_permanent=False,
+        )
+        assert "`2`/`s`" in text
+        assert "`3`/`a`" not in text
+
 

--- a/tests/gateway/test_plaintext_approval_routing.py
+++ b/tests/gateway/test_plaintext_approval_routing.py
@@ -133,3 +133,36 @@ def test_no_pending_approval_does_not_consume_conversational_yes():
     _clear_approval_state()
 
 
+@pytest.mark.parametrize(
+    ("reply", "expected_result"),
+    [
+        ("1", "once"),
+        ("2", "session"),
+        ("3", "always"),
+        ("4", "deny"),
+        ("s", "session"),
+        ("a", "always"),
+    ],
+)
+def test_numeric_short_approval_scopes(reply, expected_result):
+    """Numeric/short aliases (1/2/3/4, s/a) map to the right approval scope.
+
+    Messaging users (WeCom/WeChat, SMS) approve from a phone where typing
+    "/approve always" is slow; a single character must express the full
+    scope matrix."""
+    _clear_approval_state()
+    runner, adapter = _make_runner()
+    session_key, entry = _register_blocking_approval(runner)
+
+    handled = asyncio.run(
+        runner._handle_active_session_busy_message(_make_event(reply), session_key)
+    )
+
+    assert handled is True
+    assert entry.event.is_set()
+    assert entry.result == expected_result
+    adapter._send_with_retry.assert_awaited()
+    _clear_approval_state()
+
+
+


### PR DESCRIPTION
# feat(gateway): single-character scope aliases for plain-text approval replies

## What does this PR do?

Messaging users (WeCom/WeChat, SMS, Signal) approve dangerous commands by
typing a reply. On a phone, typing `/approve always` before the approval
window fails closed is unreliable — users either miss the window (auto-deny)
or type `/approve` once when they actually wanted session/always semantics.

This PR adds single-character aliases to the existing plain-text approval
routing lane (#46866) and advertises them in the approval prompt:

| Reply | Scope |
|---|---|
| `1` / `y` | approve once |
| `2` / `s` | approve for session |
| `3` / `a` | approve always |
| `4` / `n` | deny |

All existing reply words are preserved (strictly additive). Aliases only
resolve when `has_blocking_approval()` is true, so a bare `1` in ordinary
conversation never triggers a command.

## Related Issue / PRs

This builds on and combines the approaches of two existing PRs:

- **#49881** (tt-a1i) — thorough multi-layer implementation (7 files, +178/-5).
  Covers adapter + runner layers and Matrix, but touches many core files.
- **#55398** (javawmw) — minimal single-file approach (1 file, +41/-2).
  Minimal but embeds logic inline in `_handle_message` without reusing the
  existing routing layer, and has no tests.

This PR aims for the middle ground: reuse the existing #46866 plain-text
routing layer (minimal footprint, 3 files), keep prompt text in
`_format_exec_approval_fallback`, add letter aliases alongside numeric ones,
and cover all mappings with tests.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py` — extend `_approve_words` / `_deny_words` and the
  `always` / `session` groups in the plain-text approval router with
  numeric/short aliases (`1`/`2`/`3`/`4`, `y`/`s`/`a`/`n`)
- `gateway/run.py` — `_format_exec_approval_fallback` appends a
  `Shortcuts:` line mirroring the conditionally-advertised choices
  (`smart_denied` omits session/always; `allow_permanent` gates always)
- `tests/gateway/test_plaintext_approval_routing.py` — parametrized
  scope-mapping tests for all 6 aliases
- `tests/gateway/test_approval_prompt_redaction.py` — 3 new contract tests
  for the Shortcuts line

## How to Test

```bash
# Run the affected test suites
pytest tests/gateway/test_plaintext_approval_routing.py \
       tests/gateway/test_approval_prompt_redaction.py \
       tests/gateway/test_approve_deny_commands.py -v
```

Manual verification on WeCom:
1. Trigger a dangerous command (e.g., `rm -rf /tmp/test`)
2. The approval prompt shows: `Shortcuts: 1/y · 2/s · 3/a · 4/n.`
3. Reply `2` — command resolves with session scope
4. Reply `4` — next command is denied

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`feat(gateway): ...`)
- [x] I searched for existing PRs (#49881, #55398) — this combines their
  approaches with a smaller footprint and adds letter aliases + tests
- [x] My PR contains only changes related to this feature
- [x] I've run the affected tests and all pass (37 passed (rebased on current main 8359e760))
- [x] I've added tests for my changes

### Documentation & Housekeeping
- [x] No config keys changed — N/A
- [x] No architecture changes — N/A
- [x] Cross-platform: string matching only, no platform-specific code — N/A
- [x] No tool descriptions/schemas changed — N/A
