### PR TITLE
fix(desktop): make the HUD retarget reachable from the toggle

### DIFF
--- a/apps/desktop/electron/hud-ipc.ts
+++ b/apps/desktop/electron/hud-ipc.ts
@@ -18,7 +18,7 @@ export interface HudIpcDeps {
   /** Main's authoritative translucency state (Settings → Appearance). */
   getTranslucencyState: () => TranslucencyState
   getHudWindow: () => BrowserWindow | null
-  openHudWindow: (sessionId: null | string, profile: null | string) => void
+  openHudWindow: (sessionId: null | string, profile: null | string, connectionId: null | string) => void
   closeHudWindow: () => void
   resetHudLayout: () => boolean
   setHudSessionId: (sessionId: null | string) => void
@@ -137,7 +137,8 @@ export function registerHudIpc({
   ipcMain.handle('hermes:hud:open', async (_event, request) => {
     openHudWindow(
       typeof request?.sessionId === 'string' ? request.sessionId : null,
-      typeof request?.profile === 'string' ? request.profile : null
+      typeof request?.profile === 'string' ? request.profile : null,
+      typeof request?.connectionId === 'string' ? request.connectionId : null
     )
 
     return { ok: true }

--- a/apps/desktop/electron/hud-url.test.ts
+++ b/apps/desktop/electron/hud-url.test.ts
@@ -18,6 +18,17 @@ test('buildHudWindowUrl carries the handoff profile in the query before the hash
   assert.ok(url.indexOf('profile=work') < url.indexOf('#'))
 })
 
+test('buildHudWindowUrl carries the connection route alongside the profile', () => {
+  const url = buildHudWindowUrl('sess-1', {
+    devServer: 'http://localhost:5173',
+    profile: 'default',
+    connectionId: 'alia-linux'
+  })
+
+  assert.equal(url, 'http://localhost:5173/?win=hud&profile=default&connectionId=alia-linux#/sess-1')
+  assert.ok(url.indexOf('connectionId=alia-linux') < url.indexOf('#'))
+})
+
 test('buildHudWindowUrl encodes the profile and the session id', () => {
   const url = buildHudWindowUrl('a b/c', { devServer: 'http://localhost:5173', profile: 'my profile' })
 

--- a/apps/desktop/electron/hud-url.ts
+++ b/apps/desktop/electron/hud-url.ts
@@ -22,11 +22,22 @@ export function buildHudWindowUrl(
   {
     devServer,
     profile,
+    connectionId,
     rendererIndexPath
-  }: { devServer?: null | string; profile?: null | string; rendererIndexPath?: string } = {}
+  }: {
+    devServer?: null | string
+    profile?: null | string
+    connectionId?: null | string
+    rendererIndexPath?: string
+  } = {}
 ): string {
   const profileKey = typeof profile === 'string' ? profile.trim() : ''
-  const query = `?win=hud${profileKey ? `&profile=${encodeURIComponent(profileKey)}` : ''}`
+  const connectionKey = typeof connectionId === 'string' ? connectionId.trim() : ''
+
+  const query =
+    `?win=hud${profileKey ? `&profile=${encodeURIComponent(profileKey)}` : ''}` +
+    `${connectionKey ? `&connectionId=${encodeURIComponent(connectionKey)}` : ''}`
+
   const route = sessionId ? `#/${encodeURIComponent(sessionId)}` : '#/'
 
   if (devServer) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10215,7 +10215,19 @@ ipcMain.on('hermes:hud:move-by', (event, delta) => {
 // can hand it back to the app window (see hudSessionId).
 ipcMain.on('hermes:hud:session', (event, sessionId) => {
   if (hudWindow && !hudWindow.isDestroyed() && event.sender === hudWindow.webContents) {
-    hudSessionId = typeof sessionId === 'string' && sessionId ? sessionId : null
+    const next = typeof sessionId === 'string' && sessionId ? sessionId : null
+
+    if (next === hudSessionId) {
+      return
+    }
+
+    hudSessionId = next
+    // Every window decides "switch the HUD to this tab" vs "dismiss it" by
+    // comparing against its own copy of this id, so a conversation switched
+    // from INSIDE the HUD has to reach them too. Without this the app window
+    // keeps the id the HUD was opened on, and the toggle reads a retarget
+    // where the user meant a dismiss.
+    broadcastHudState(true)
   }
 })
 ipcMain.handle('hermes:hud:close', async () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13434,7 +13434,12 @@ let hudSessionId = null
 // string). A renderer adopts its backend once at boot, so a retarget onto a
 // session from a DIFFERENT profile cannot be a same-window `goto` — the HUD
 // must be respawned against the new profile's backend (see openHudWindow).
-let hudProfile = null
+let hudProfile: null | string = null
+
+// The registry connection the live HUD renderer booted against. Profile names
+// repeat across gateways (`default` exists on every source), so the profile
+// alone cannot identify the backend (#hud-route).
+let hudConnectionId: null | string = null
 
 // A wide, short bar parked near the bottom of the active display — the shape
 // of a game chat frame, and where one belongs. Defaults only: once the user
@@ -13692,15 +13697,15 @@ function hudBounds() {
   return defaultHudBounds(area)
 }
 
-function hudUrl(sessionId, profile) {
-  // The profile rides the query string next to `win=hud` (BEFORE the '#', so
-  // HashRouter never sees it). The HUD renderer's gateway boot reads it and
-  // adopts that backend instead of the primary — without it, a HUD opened on a
-  // non-primary profile's conversation resolves the session id against the
-  // wrong backend and falls back to the default profile's last session.
+function hudUrl(sessionId: null | string, profile: null | string, connectionId: null | string) {
+  // The profile and registry connection ride the query string next to `win=hud`
+  // (BEFORE the '#', so HashRouter never sees them). Both are required for a
+  // multi-gateway install: every source can expose a `default` profile, so a
+  // profile-only handoff still falls back to the primary local gateway.
   return buildHudWindowUrl(sessionId, {
     devServer: DEV_SERVER,
     profile,
+    connectionId,
     rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex()
   })
 }
@@ -13719,7 +13724,7 @@ function broadcastHudState(open) {
   }
 }
 
-function spawnHudWindow(sessionId, profile) {
+function spawnHudWindow(sessionId: null | string, profile: null | string, connectionId: null | string) {
   const win = new BrowserWindow({
     ...hudBounds(),
     minWidth: 380,
@@ -13826,7 +13831,7 @@ function spawnHudWindow(sessionId, profile) {
   // Log-only lifecycle (#81290): the HUD is a compact auxiliary surface the
   // user can re-toggle; a dead renderer should be diagnosable, not resurrected.
   installWindowRendererLifecycle(win, { kind: 'hud', callbacks: { log: rememberLog } })
-  loadWindowUrl(win, hudUrl(sessionId, profile), 'HUD')
+  loadWindowUrl(win, hudUrl(sessionId, profile, connectionId), 'HUD')
 
   return win
 }
@@ -13844,15 +13849,16 @@ function restoreMainWindowFromHud() {
   }
 }
 
-function openHudWindow(sessionId, profile) {
+function openHudWindow(sessionId: null | string, profile: null | string, connectionId: null | string) {
   const profileKey = typeof profile === 'string' && profile.trim() ? profile.trim() : null
+  const connectionKey = typeof connectionId === 'string' && connectionId.trim() ? connectionId.trim() : null
 
   if (hudWindow && !hudWindow.isDestroyed()) {
     // Pointed at another PROFILE: the live renderer is bound to the old
     // profile's backend, and a renderer adopts its backend exactly once at
     // boot — an in-place goto would resolve the id against the wrong backend
     // (the #82285 fallback). Respawn against the right one.
-    if (profileKey && hudProfile !== profileKey) {
+    if ((profileKey && hudProfile !== profileKey) || (connectionKey && hudConnectionId !== connectionKey)) {
       const win = hudWindow
       hudWindow = null
       win.removeAllListeners('closed')
@@ -13860,7 +13866,8 @@ function openHudWindow(sessionId, profile) {
 
       hudSessionId = sessionId || null
       hudProfile = profileKey
-      hudWindow = spawnHudWindow(sessionId, profileKey)
+      hudConnectionId = connectionKey
+      hudWindow = spawnHudWindow(sessionId, profileKey, connectionKey)
       broadcastHudState(true)
       registerHudSnapShortcut()
 
@@ -13886,7 +13893,8 @@ function openHudWindow(sessionId, profile) {
   hudRestoreMainWindow = Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible())
   hudSessionId = sessionId || null
   hudProfile = profileKey
-  hudWindow = spawnHudWindow(sessionId, profileKey)
+  hudConnectionId = connectionKey
+  hudWindow = spawnHudWindow(sessionId, profileKey, connectionKey)
   broadcastHudState(true)
   registerHudSnapShortcut()
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14675,7 +14675,17 @@ const hudIpc = registerHudIpc({
   closeHudWindow,
   resetHudLayout: resetHudWindowLayout,
   setHudSessionId: value => {
+    // Every window decides "switch the HUD to this tab" vs "dismiss it" by
+    // comparing against its own copy of this id, so a conversation switched
+    // from INSIDE the HUD has to reach them too. Without this the app window
+    // keeps the id the HUD was opened on, and the toggle reads a retarget
+    // where the user meant a dismiss.
+    if (value === hudSessionId) {
+      return
+    }
+
     hudSessionId = value
+    broadcastHudState(true)
   }
 })
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -77,7 +77,7 @@ import {
   recordSessionEventScope,
   resetTileRuntimeBindings
 } from '@/store/session-states'
-import { windowProfileOverride } from '@/store/windows'
+import { windowConnectionIdOverride, windowProfileOverride } from '@/store/windows'
 import type { RpcEvent } from '@/types/hermes'
 
 import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './gateway-hmr-survivor'
@@ -196,6 +196,24 @@ export function useGatewayBoot({
       setSessionsLoading(false)
 
       return () => void (cancelled = true)
+    }
+
+    // Registry-scoped helper windows (currently the HUD) must retain both
+    // dimensions of their route. Every gateway has a `default` profile, so the
+    // profile override alone can silently resolve to This device. Ordinary
+    // windows keep the legacy primary/profile resolver.
+    const helperProfileOverride = windowProfileOverride()
+    const helperConnectionIdOverride = windowConnectionIdOverride()
+
+    const resolveWindowConnection = () => {
+      if (helperConnectionIdOverride && desktop.getConnectionFor) {
+        return desktop.getConnectionFor({
+          connectionId: helperConnectionIdOverride,
+          profile: helperProfileOverride
+        })
+      }
+
+      return desktop.getConnection(helperProfileOverride ?? undefined)
     }
 
     // Store-driven switches (Sessions switcher → selectConnection) commit
@@ -324,7 +342,7 @@ export function useGatewayBoot({
         // this primary socket at a secondary profile's backend after a live swap.
         // Secondaries reconnect via reconnectSecondaryGateways().
         const conn = await withTimeout(
-          desktop.getConnection(),
+          resolveWindowConnection(),
           RECONNECT_ATTEMPT_TIMEOUT_MS,
           'Timed out reconnecting to Hermes backend'
         )
@@ -606,7 +624,7 @@ export function useGatewayBoot({
         // shared backend-boot budget rather than the reconnect budget because
         // ensureBackend may cold-spawn a pooled helper backend here.
         const conn = await withTimeout(
-          desktop.getConnection(windowProfileOverride() ?? undefined),
+          resolveWindowConnection(),
           BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out reconnecting to Hermes backend'
         )
@@ -984,7 +1002,7 @@ export function useGatewayBoot({
         // rides out a full backend cold spawn, so it gets the shared 45s
         // backend-boot budget, not the 20s reconnect budget.
         const conn = await withTimeout(
-          desktop.getConnection(windowProfileOverride() ?? undefined),
+          resolveWindowConnection(),
           BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out connecting to Hermes backend'
         )

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -104,7 +104,8 @@ declare global {
           solid: boolean
           workspaceTransfer: boolean
         }
-        open: (request?: { sessionId?: null | string; profile?: null | string }) => Promise<{ ok: boolean }>
+        open: (request?: { sessionId?: null | string; profile?: null | string; connectionId?: null | string }) =>
+          Promise<{ ok: boolean }>
         close: () => Promise<{ ok: boolean }>
         setIgnoreMouse: (ignore: boolean) => void
         beginMove: () => void

--- a/apps/desktop/src/store/hud.test.ts
+++ b/apps/desktop/src/store/hud.test.ts
@@ -4,16 +4,17 @@ import { $activeGatewayProfile } from '@/store/profile'
 import { $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
-import { $hudActive, $hudSession, openHud } from './hud'
+import { $hudActive, $hudSession, openHud, toggleHud } from './hud'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
 
 const open = vi.fn().mockResolvedValue({ ok: true })
+const close = vi.fn().mockResolvedValue({ ok: true })
 
 function installBridge() {
   desktopWindow.hermesDesktop = {
-    hud: { open }
+    hud: { close, open }
   } as unknown as Window['hermesDesktop']
 }
 
@@ -23,6 +24,7 @@ function session(overrides: Partial<SessionInfo>): SessionInfo {
 
 beforeEach(() => {
   open.mockClear()
+  close.mockClear()
   installBridge()
   $hudActive.set(false)
   $hudSession.set(null)
@@ -77,5 +79,58 @@ describe('openHud profile targeting (#82285)', () => {
     openHud('unknown-session')
 
     expect(open).toHaveBeenCalledWith({ sessionId: 'unknown-session', profile: 'work' })
+  })
+})
+
+describe('toggleHud retargeting an open HUD', () => {
+  it('points the open HUD at the conversation the toggle came from', () => {
+    $hudActive.set(true)
+    $hudSession.set('old')
+
+    toggleHud('new')
+
+    // Main owns the retarget (openHudWindow sends `hud:goto`), so reaching it
+    // at all means going back through the open bridge — not closing the window.
+    expect(open).toHaveBeenCalledWith({ sessionId: 'new', profile: 'default' })
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it('carries the target session profile across a retarget', () => {
+    $sessions.set([session({ id: 'new', profile: 'work' })])
+    $hudActive.set(true)
+    $hudSession.set('old')
+
+    toggleHud('new')
+
+    expect(open).toHaveBeenCalledWith({ sessionId: 'new', profile: 'work' })
+  })
+
+  it('dismisses when the HUD is already on that conversation', () => {
+    $hudActive.set(true)
+    $hudSession.set('same')
+
+    toggleHud('same')
+
+    expect(close).toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('dismisses when there is no conversation to retarget onto', () => {
+    $hudActive.set(true)
+    $hudSession.set('old')
+
+    toggleHud(null)
+
+    expect(close).toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('opens on the given conversation when the HUD is down', () => {
+    $hudActive.set(false)
+
+    toggleHud('new')
+
+    expect(open).toHaveBeenCalledWith({ sessionId: 'new', profile: 'default' })
+    expect(close).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/hud.test.ts
+++ b/apps/desktop/src/store/hud.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $activeGatewayProfile } from '@/store/profile'
-import { $sessions } from '@/store/session'
+import { $connection, $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { $hudActive, $hudSession, openHud, resetHudLayout, toggleHud } from './hud'
@@ -31,6 +31,7 @@ beforeEach(() => {
   $hudActive.set(false)
   $hudSession.set(null)
   $sessions.set([])
+  $connection.set(null)
   $activeGatewayProfile.set('default')
 })
 
@@ -60,6 +61,14 @@ describe('openHud profile targeting (#82285)', () => {
     expect(open).toHaveBeenCalledWith({ sessionId: 'abc', profile: 'work' })
   })
 
+  it('carries the session owner connection when the target row is connection-tagged', () => {
+    $sessions.set([session({ id: 'abc', profile: 'default', connection_id: 'alia-linux' })])
+
+    openHud('abc')
+
+    expect(open).toHaveBeenCalledWith({ sessionId: 'abc', profile: 'default', connectionId: 'alia-linux' })
+  })
+
   it('falls back to the active gateway profile for an unstamped session', () => {
     $sessions.set([session({ id: 'abc', profile: '' })])
     $activeGatewayProfile.set('work')
@@ -75,6 +84,14 @@ describe('openHud profile targeting (#82285)', () => {
     openHud()
 
     expect(open).toHaveBeenCalledWith({ sessionId: null, profile: 'research' })
+  })
+
+  it('carries the active connection when opening without a session', () => {
+    $connection.set({ mode: 'remote', connectionId: 'alia-linux' } as never)
+
+    openHud()
+
+    expect(open).toHaveBeenCalledWith({ sessionId: null, profile: 'default', connectionId: 'alia-linux' })
   })
 
   it('normalizes to default for single-profile users', () => {

--- a/apps/desktop/src/store/hud.test.ts
+++ b/apps/desktop/src/store/hud.test.ts
@@ -4,17 +4,18 @@ import { $activeGatewayProfile } from '@/store/profile'
 import { $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
-import { $hudActive, $hudSession, openHud, resetHudLayout } from './hud'
+import { $hudActive, $hudSession, openHud, resetHudLayout, toggleHud } from './hud'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
 
 const open = vi.fn().mockResolvedValue({ ok: true })
 const resetLayout = vi.fn().mockResolvedValue({ ok: true })
+const close = vi.fn().mockResolvedValue({ ok: true })
 
 function installBridge() {
   desktopWindow.hermesDesktop = {
-    hud: { open, resetLayout }
+    hud: { close, open, resetLayout }
   } as unknown as Window['hermesDesktop']
 }
 
@@ -25,6 +26,7 @@ function session(overrides: Partial<SessionInfo>): SessionInfo {
 beforeEach(() => {
   open.mockClear()
   resetLayout.mockClear()
+  close.mockClear()
   installBridge()
   $hudActive.set(false)
   $hudSession.set(null)
@@ -87,5 +89,58 @@ describe('openHud profile targeting (#82285)', () => {
     openHud('unknown-session')
 
     expect(open).toHaveBeenCalledWith({ sessionId: 'unknown-session', profile: 'work' })
+  })
+})
+
+describe('toggleHud retargeting an open HUD', () => {
+  it('points the open HUD at the conversation the toggle came from', () => {
+    $hudActive.set(true)
+    $hudSession.set('old')
+
+    toggleHud('new')
+
+    // Main owns the retarget (openHudWindow sends `hud:goto`), so reaching it
+    // at all means going back through the open bridge — not closing the window.
+    expect(open).toHaveBeenCalledWith({ sessionId: 'new', profile: 'default' })
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it('carries the target session profile across a retarget', () => {
+    $sessions.set([session({ id: 'new', profile: 'work' })])
+    $hudActive.set(true)
+    $hudSession.set('old')
+
+    toggleHud('new')
+
+    expect(open).toHaveBeenCalledWith({ sessionId: 'new', profile: 'work' })
+  })
+
+  it('dismisses when the HUD is already on that conversation', () => {
+    $hudActive.set(true)
+    $hudSession.set('same')
+
+    toggleHud('same')
+
+    expect(close).toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('dismisses when there is no conversation to retarget onto', () => {
+    $hudActive.set(true)
+    $hudSession.set('old')
+
+    toggleHud(null)
+
+    expect(close).toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('opens on the given conversation when the HUD is down', () => {
+    $hudActive.set(false)
+
+    toggleHud('new')
+
+    expect(open).toHaveBeenCalledWith({ sessionId: 'new', profile: 'default' })
+    expect(close).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/hud.ts
+++ b/apps/desktop/src/store/hud.ts
@@ -85,7 +85,40 @@ export function closeHud(): void {
   void api.close()
 }
 
-export const toggleHud = (sessionId?: null | string) => ($hudActive.get() ? closeHud() : openHud(sessionId))
+/**
+ * Enter HUD mode, leave it, or point the open HUD at another conversation.
+ *
+ * The retarget rung is why `$hudSession` exists: asking for HUD mode from a tab
+ * the HUD is NOT on means "put this conversation in the HUD", and main already
+ * implements that (openHudWindow sends `hud:goto`, or respawns across a profile
+ * boundary). Reading `$hudActive` alone never reached it — the toggle dismissed
+ * the window instead, so the retarget path was unreachable from the UI.
+ *
+ * Two cases still dismiss, deliberately:
+ * - No target (a fresh draft with nothing selected). There is nothing to
+ *   retarget onto, and "the toggle stopped closing the HUD" is the worse bug.
+ * - Inside the HUD's own window, where the toggle is the way OUT. Its renderer
+ *   never subscribes to the state broadcast (useHudHandoff returns early there),
+ *   so `$hudSession` is always null and every target would read as a retarget —
+ *   leaving the exit keybind unable to exit.
+ */
+export function toggleHud(sessionId?: null | string): void {
+  if (!$hudActive.get()) {
+    openHud(sessionId)
+
+    return
+  }
+
+  const target = sessionId ?? null
+
+  if (!target || isHudWindow() || target === $hudSession.get()) {
+    closeHud()
+
+    return
+  }
+
+  openHud(target)
+}
 
 /** Tell main which session this HUD is on. Main holds it (the HUD's renderer
  *  doesn't outlive the window) and hands it back in the close broadcast so the

--- a/apps/desktop/src/store/hud.ts
+++ b/apps/desktop/src/store/hud.ts
@@ -85,7 +85,40 @@ export function closeHud(): void {
   void api.close()
 }
 
-export const toggleHud = (sessionId?: null | string) => ($hudActive.get() ? closeHud() : openHud(sessionId))
+/**
+ * Enter HUD mode, leave it, or point the open HUD at another conversation.
+ *
+ * The retarget rung is why `$hudSession` exists: asking for HUD mode from a tab
+ * the HUD is NOT on means "put this conversation in the HUD", and main already
+ * implements that (openHudWindow sends `hud:goto`, or respawns across a profile
+ * boundary). Reading `$hudActive` alone never reached it — the toggle dismissed
+ * the window instead, so the retarget path was unreachable from the UI.
+ *
+ * Two cases still dismiss, deliberately:
+ * - No target (a fresh draft with nothing selected). There is nothing to
+ *   retarget onto, and "the toggle stopped closing the HUD" is the worse bug.
+ * - Inside the HUD's own window, where the toggle is the way OUT. Its renderer
+ *   never subscribes to the state broadcast (useHudHandoff returns early there),
+ *   so `$hudSession` is always null and every target would read as a retarget —
+ *   leaving the exit keybind unable to exit.
+ */
+export function toggleHud(sessionId?: null | string): void {
+  if (!$hudActive.get()) {
+    openHud(sessionId)
+
+    return
+  }
+
+  const target = sessionId ?? null
+
+  if (!target || isHudWindow() || target === $hudSession.get()) {
+    closeHud()
+
+    return
+  }
+
+  openHud(target)
+}
 
 /** Restore the HUD's persisted geometry to its display-aware default. */
 export function resetHudLayout(): void {

--- a/apps/desktop/src/store/hud.ts
+++ b/apps/desktop/src/store/hud.ts
@@ -16,8 +16,9 @@
 import { atom } from 'nanostores'
 
 import { requestComposerDraftSync } from '@/store/composer'
+import { $activeConnectionId } from '@/store/connections'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { $sessions, rememberedSessionProfile } from '@/store/session'
+import { $sessions, knownSessionOwner, rememberedSessionProfile } from '@/store/session'
 import { isHudWindow } from '@/store/windows'
 
 /** Whether a HUD window is currently up. In the HUD's own renderer this is
@@ -55,20 +56,28 @@ export function openHud(sessionId?: null | string): void {
   // a cross-window storage event that lands after it has already painted.
   requestComposerDraftSync('flush')
 
-  // Which backend the HUD must boot against. The HUD is a full renderer that
-  // adopts the PRIMARY backend's profile by default, so handing it a session
-  // from a non-primary profile without saying so resolves the id against the
-  // wrong backend — the lookup misses and the HUD falls back to the default
-  // profile's last session (#82285). Same ladder the remembered-navigation key
-  // uses: the session's stamped owner wins, and a fresh/unstamped/uncached
-  // target inherits the profile the user is looking at.
+  // Which backend the HUD must boot against. A connection-tagged session owns
+  // an exact `(connectionId, profile)` route; use that before the active route.
+  // Bare/unknown sessions retain the presentation fallback for legacy chats.
+  const owner = knownSessionOwner($sessions.get(), sessionId ?? null)
+  const ownerRoute = owner && typeof owner === 'object' ? owner : null
+
   const profile = normalizeProfileKey(
-    rememberedSessionProfile($sessions.get(), sessionId ?? null, $activeGatewayProfile.get())
+    ownerRoute?.profile ??
+      (typeof owner === 'string'
+        ? owner
+        : rememberedSessionProfile($sessions.get(), sessionId ?? null, $activeGatewayProfile.get()))
   )
+
+  const connectionId = ownerRoute?.connectionId?.trim() || $activeConnectionId.get()
 
   $hudActive.set(true)
   $hudSession.set(sessionId ?? null)
-  void api.open({ sessionId: sessionId ?? null, profile })
+  void api.open({
+    sessionId: sessionId ?? null,
+    profile,
+    ...(connectionId ? { connectionId } : {})
+  })
 }
 
 /** Leave HUD mode. Callable from either window — main closes the child, the

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -7,7 +7,8 @@ import {
   isPeerInstanceWindow,
   openBrowserInNewWindow,
   openNewWindow,
-  openSessionInNewWindow
+  openSessionInNewWindow,
+  windowConnectionIdOverride
 } from './windows'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
@@ -66,6 +67,16 @@ describe('isPeerInstanceWindow', () => {
     expect(isPeerInstanceWindow('?peer=0')).toBe(false)
     expect(isPeerInstanceWindow('?win=secondary')).toBe(false)
     expect(isPeerInstanceWindow('')).toBe(false)
+  })
+})
+
+describe('windowConnectionIdOverride', () => {
+  it('reads and trims the registry connection from a helper URL', () => {
+    expect(windowConnectionIdOverride('?win=hud&profile=default&connectionId=%20alia-linux%20')).toBe('alia-linux')
+  })
+
+  it('returns null when the helper URL has no connection override', () => {
+    expect(windowConnectionIdOverride('?win=hud&profile=default')).toBeNull()
   })
 })
 

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -141,6 +141,20 @@ export function windowProfileOverride(): null | string {
   }
 }
 
+// The registry connection a helper window (the HUD) was asked to boot against.
+// Profile alone is not enough once multiple gateways expose the same profile
+// names (every source has a `default`). Empty/absent preserves legacy primary
+// resolution for ordinary windows and older callers.
+export function windowConnectionIdOverride(
+  search = typeof window === 'undefined' ? '' : window.location.search
+): null | string {
+  try {
+    return new URLSearchParams(search).get('connectionId')?.trim() || null
+  } catch {
+    return null
+  }
+}
+
 // True when running inside the Electron desktop shell (the preload bridge is
 // present). The "open in new window" affordance is desktop-only.
 export function canOpenSessionWindow(): boolean {


### PR DESCRIPTION
## The bug

Asking for HUD mode from a conversation the HUD is not currently on is supposed to point the HUD at that conversation. Instead it dismisses the HUD.

Main already implements the retarget. `openHudWindow()` (`apps/desktop/electron/main.ts:9427`) either sends `hermes:hud:goto` to switch the session in place, or destroys and respawns the window when the target belongs to a different profile. The renderer subscribes to that goto in `useHudGoto` (`apps/desktop/src/app/hud/handoff.ts:110`).

Nothing could reach any of it. The only caller was:

```ts
export const toggleHud = (sessionId?) => ($hudActive.get() ? closeHud() : openHud(sessionId))
```

With the HUD open, `$hudActive` is `true`, so it always took `closeHud()`. `openHud()` was never called, the `hermes:hud:open` IPC never fired, and `openHudWindow()`'s retarget branch never ran. `$hudSession` — added in f444e0c5e *specifically* to tell "switch the HUD to this tab" apart from "dismiss the HUD" — was written and never read anywhere in the tree.

f444e0c5e is titled "feat(desktop): point an open HUD at the tab you toggle from", so the feature shipped dead on arrival.

## The fix

Two sites, one bug class.

**1. `src/store/hud.ts` — branch on the target, not just on whether the HUD is up.**

Two cases still dismiss, deliberately:

- **No target.** A fresh draft with nothing selected has nothing to retarget onto, and "the toggle stopped closing the HUD" is the worse bug.
- **Inside the HUD's own window**, where the toggle is the way out. `useHudHandoff` returns early when `isHudWindow()` (`handoff.ts:65`), so that renderer never subscribes to the `hud:changed` broadcast and its `$hudSession` stays null forever — while its `$hudActive` is initialized `true` (`hud.ts:31`). Without the guard every target would false-read as a retarget and strand the exit keybind.

**2. `electron/main.ts` — broadcast a session switched from *inside* the HUD.**

Every window decides switch-vs-dismiss by comparing against its own copy of the HUD's session id, but `hermes:hud:session` updated main's copy silently. The app window kept the id the HUD was opened on, so after switching conversations inside the HUD the next toggle would read a retarget where the user meant a dismiss — i.e. the HUD would refuse to close.

This is a cache-coherence fix: main stays authoritative for `hudSessionId` (the HUD's renderer doesn't outlive its window) and the renderers' `$hudSession` is a cache that now gets invalidated. The `next === hudSessionId` early-out keeps an unchanged id from broadcasting.

Fixing this second site is what makes the first site safe — without it, fix 1 alone would introduce "the HUD no longer closes."

## Testing

Extends the existing `src/store/hud.test.ts` rather than adding a file.

Genuine RED → GREEN, not change-detector tests. With only `hud.ts` reverted, exactly the two retarget assertions fail and the eight regression assertions still pass:

```
× points the open HUD at the conversation the toggle came from
× carries the target session profile across a retarget
✓ dismisses when the HUD is already on that conversation
✓ dismisses when there is no conversation to retarget onto
✓ opens on the given conversation when the HUD is down
```

Each test asserts a relation (retarget goes through `open` and not `close`; same-session goes through `close` and not `open`) rather than freezing a literal.

Full run on the affected areas:

- `npx vitest run src/store src/app/hud src/app/shell src/app/hooks src/app/contrib` — 71 files, 763 tests, all pass
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --build tsconfig.electron.json` — clean
- `npx eslint` on all three changed files — clean

## Scope

Both `toggleHud` dispatch sites (`use-keybinds.ts:232`, `titlebar-controls.tsx:196`) already pass `hudTargetSessionId()`, and the fix lands inside `toggleHud` itself, so both are covered and any future caller inherits the corrected behavior. There is no other retarget-capable path: the command palette's `HUD_*` imports are the unrelated floating-hud styling primitives, and `electron/` has no menu, tray, or protocol-handler route to the HUD toggle.

Not included here: making the HUD *follow* the app window's active conversation. No wiring for that has ever existed — it's a product decision rather than a regression, and it belongs in its own issue.
