### PR TITLE
fix(gateway): stop concurrent voice messages from being dropped as unauthorized

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13698,7 +13698,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._make_profile_fatal_error_handler(profile_name, platform)
         )
         adapter.set_session_store(self.session_store)
-        adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+        adapter.set_busy_session_handler(
+            self._make_profile_busy_session_handler(profile_name)
+        )
         _set_reaction = getattr(adapter, "set_reaction_handler", None)
         if callable(_set_reaction):
             _set_reaction(self._handle_reaction_event)
@@ -13900,6 +13902,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 with _profile_runtime_scope(profile_home):
                     return await self._handle_message(event)
             return await self._handle_message(event)
+
+        return _handler
+
+    def _make_profile_busy_session_handler(self, profile_name: str):
+        """Return a profile-scoped busy handler for a secondary adapter."""
+        from hermes_cli.profiles import get_profile_dir
+
+        try:
+            profile_home = get_profile_dir(profile_name)
+        except Exception:
+            profile_home = None
+
+        async def _handler(event, session_key):
+            try:
+                if getattr(event, "source", None) is not None and not event.source.profile:
+                    event.source.profile = profile_name
+            except Exception:
+                pass
+            if profile_home is not None:
+                with _profile_runtime_scope(profile_home):
+                    return await self._handle_active_session_busy_message(
+                        event, session_key
+                    )
+            return await self._handle_active_session_busy_message(event, session_key)
 
         return _handler
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -3,6 +3,7 @@ import logging
 import asyncio
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -143,6 +144,37 @@ def _secondary_recovery_runner(*, running=True):
     runner._adapter_disconnect_timeout_secs = lambda: 0
     runner._sync_voice_mode_state_to_adapter = lambda adapter: None
     return runner
+
+
+@pytest.mark.asyncio
+async def test_secondary_busy_handler_stamps_profile_before_authorization(monkeypatch):
+    runner = _secondary_recovery_runner()
+    adapter = _SecondaryRecoveryAdapter()
+    seen = {}
+    scoped_homes = []
+
+    @contextmanager
+    def fake_scope(profile_home):
+        scoped_homes.append(Path(profile_home))
+        yield
+
+    async def handle_busy(event, session_key):
+        seen["profile"] = event.source.profile
+        seen["session_key"] = session_key
+        return True
+
+    monkeypatch.setattr(gateway_run, "_profile_runtime_scope", fake_scope)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_profile_dir", lambda name: Path("/profiles") / name
+    )
+    runner._handle_active_session_busy_message = handle_busy
+
+    runner._configure_profile_adapter(adapter, "reviewer", Platform.DISCORD)
+    event = SimpleNamespace(source=SimpleNamespace(profile=None))
+
+    assert await adapter.busy_session_handler(event, "session-1") is True
+    assert seen == {"profile": "reviewer", "session_key": "session-1"}
+    assert scoped_homes == [Path("/profiles/reviewer")]
 
 
 def _install_secondary_reconnect_context(monkeypatch, runner, adapter, scoped_homes=None):


### PR DESCRIPTION
## What does this PR do?

This fixes a message-loss bug in multiplexed gateway sessions where a second distinct voice message could be rejected as unauthorized while the first message was still being transcribed or answered. The busy-session callback now applies the same profile identity and runtime scope as the normal ingress callback, so authorized follow-up messages reach the existing queue while messages from unauthorized senders remain blocked.

### Symptom

In a multiplexed Weixin session, sending a second voice message while the first one was still active downloaded both audio payloads, but the second message logged `Dropping message from unauthorized user in active session` and never entered STT.

### Impact

Authorized users could silently lose distinct voice input whenever it arrived during an active response. Verification reproduced the loss with production gateway, Weixin adapter, audio cache, pairing store, and STT entrypoint code, then confirmed the fix queues, drains, and transcribes the second message without weakening the unauthorized-sender boundary.

### Bug Cause

**Trigger:** `gateway/run.py:13701` in `_configure_profile_adapter`, when a secondary multiplex adapter dispatches a message through its busy-session callback.

**Causal chain:**
1. A second distinct voice event reaches a secondary adapter while the same session is active.
2. The adapter invokes the busy callback before the normal profile-scoped message handler can stamp `event.source.profile`.
3. `_handle_active_session_busy_message` checks authorization against the global pairing store, rejects the valid sender, and drops the message before STT or queueing.

**Why it is wrong:** The busy callback previously bypassed the secondary profile's runtime scope and profile identity even though authorization state is profile-specific.

**Working sibling / contrast:** Cold ingress already uses `_make_profile_message_handler`, which stamps the secondary profile and enters `_profile_runtime_scope` before authorization.

**Ruled out:** Weixin message ID deduplication and STT were not causal. Both distinct audio payloads were accepted and cached, but only the profile-less busy callback rejected the second event before STT.

### Fix

Add a profile-scoped busy-session handler alongside the existing profile-scoped normal handler. It stamps a missing source profile, enters the corresponding profile runtime scope, and then delegates to the unchanged busy-session authorization and queue logic. Regression coverage exercises the configured secondary adapter callback and asserts that both the profile and runtime scope are present before authorization.

## Related Issue

Closes #82858

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - route secondary multiplex busy events through a profile-stamping, profile-scoped wrapper.
- `tests/gateway/test_multiplex_adapter_registry.py` - verify secondary busy callbacks apply the profile identity and runtime scope before delegation.

## How to Test

1. Configure a multiplexed secondary Weixin profile with an authorized sender.
2. Send two distinct voice messages four seconds apart while the first session is still active; confirm the second message is queued, drained, and transcribed.
3. Send a busy-session message from a different unauthorized sender; confirm it is still rejected.
4. Run the related automated tests:

```bash
scripts/run_tests.sh tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_busy_session_auth_bypass.py
```

Result: 18 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A, no user-facing behavior or configuration contract changed
- [x] `cli-config.yaml.example`: N/A, no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A, no architecture or workflow contract changed
- [x] Cross-platform impact considered: the change uses existing profile and context-manager abstractions
- [x] Tool descriptions/schemas: N/A, no model tool behavior changed

## Screenshots / Logs

Not applicable. Verification details and the automated test result are included above.
