### PR TITLE
fix(agent): stop repaired sessions from repeatedly missing cache prefixes

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8711,6 +8711,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
             )
 
+        if not removed_ids and not updates:
+            return
+
         def _do(conn):
             if removed_ids:
                 placeholders = ",".join("?" for _ in removed_ids)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8649,7 +8649,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             for msg in repaired_messages
             if isinstance(msg, dict) and msg.get("_row_id") in pre_repair
         }
-        removed_ids = sorted(set(pre_repair) - set(survivors))
+        # Verification candidates are collapsed only from MODEL replay; their
+        # substantive answer must remain active in the persisted DISPLAY
+        # transcript (#65919). repair_message_sequence deliberately replaces
+        # the candidate with the verified assistant without mutating either
+        # durable row, so do not treat that model-only replacement as archival.
+        verification_finish_reasons = {
+            "verification_required",
+            "verify_hook_continue",
+        }
+        removed_ids = sorted(
+            row_id
+            for row_id, original in pre_repair.items()
+            if row_id not in survivors
+            and original.get("finish_reason") not in verification_finish_reasons
+        )
         updates = []
 
         for row_id, msg in survivors.items():

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8431,8 +8431,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         LIVE REPLAY should pass it: a durable alternation violation (e.g. a
         ``user;user`` pair left by a turn that persisted no assistant row)
         otherwise re-triggers the pre-request defensive repair on every
-        single request for the rest of the session's life — the repair
-        mutates only the per-request list, never the stored transcript.
+        single request for the rest of the session's life. A repair-enabled
+        load reconciles the changed survivors and archived-away rows back to
+        the stored transcript before returning.
         Inspection/export consumers keep the default and see the transcript
         verbatim.
         """
@@ -8464,6 +8465,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             include_ancestors=include_ancestors,
             repair_alternation=repair_alternation,
             include_row_ids=include_row_ids,
+            reconcile_repair=not include_inactive,
         )
 
     # Columns every conversation projection decodes. Shared by
@@ -8484,6 +8486,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_ancestors: bool,
         repair_alternation: bool,
         include_row_ids: bool = False,
+        reconcile_repair: bool = True,
     ) -> List[Dict[str, Any]]:
         """Decode fetched message rows into the OpenAI conversation format.
 
@@ -8504,7 +8507,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # inspection) gets the transcript in its historical shape.
             # Underscore-prefixed so every transport's convert_messages()
             # strips it before the wire.
-            if include_row_ids and row["id"] is not None:
+            if (include_row_ids or repair_alternation) and row["id"] is not None:
                 msg["_row_id"] = row["id"]
             # api_content is the byte-fidelity sidecar: the exact string sent
             # to the API when it differed from the clean content. Returned
@@ -8593,6 +8596,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # to keep emitting the marker. No-op for unaffected sessions.
         messages = _strip_stale_tool_call_markers(messages)
         if repair_alternation and messages:
+            # Snapshot AFTER load-only sanitation so reconciliation covers
+            # only mutations made by repair_message_sequence. Surviving
+            # messages retain object/row identity; removed identities are the
+            # exact durable rows to archive.
+            pre_repair = {
+                msg["_row_id"]: dict(msg)
+                for msg in messages
+                if isinstance(msg, dict) and "_row_id" in msg
+            }
             # Lazy import: hermes_state already depends on agent.* (see
             # sanitize_context above), but keep this optional path from
             # widening the import surface at module load.
@@ -8600,14 +8612,108 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             repaired = repair_message_sequence(None, messages)
             if repaired:
+                if reconcile_repair:
+                    self._reconcile_repaired_conversation(pre_repair, messages)
                 logger.info(
-                    "Repaired %d message-alternation violation(s) while "
-                    "restoring session %s — durable transcript kept them, "
-                    "see repair_message_sequence",
+                    "Repaired %d message-alternation violation(s) while restoring "
+                    "session %s%s",
                     repaired,
                     session_id,
+                    (
+                        " and reconciled the durable transcript"
+                        if reconcile_repair
+                        else " without changing inactive audit rows"
+                    ),
                 )
+        if not include_row_ids:
+            for msg in messages:
+                if isinstance(msg, dict):
+                    msg.pop("_row_id", None)
         return messages
+
+    def _reconcile_repaired_conversation(
+        self,
+        pre_repair: Dict[int, Dict[str, Any]],
+        repaired_messages: List[Dict[str, Any]],
+    ) -> None:
+        """Persist one identity-preserving alternation repair atomically.
+
+        Rows removed by the repair are soft-archived for audit. Surviving
+        rows keep their durable identity while repair-mutated provider fields
+        are updated in place. Updating content/tool_calls also drives the
+        existing FTS triggers, while an ``active``-only write deliberately
+        leaves archived text searchable only through inactive/audit paths.
+        """
+        survivors = {
+            msg["_row_id"]: msg
+            for msg in repaired_messages
+            if isinstance(msg, dict) and msg.get("_row_id") in pre_repair
+        }
+        removed_ids = sorted(set(pre_repair) - set(survivors))
+        updates = []
+
+        for row_id, msg in survivors.items():
+            original = pre_repair[row_id]
+            content_changed = msg.get("content") != original.get("content")
+            tool_calls_changed = msg.get("tool_calls") != original.get("tool_calls")
+            reasoning_changed = (
+                msg.get("reasoning_content") != original.get("reasoning_content")
+            )
+
+            # api_content is the exact wire form of the old content. Any
+            # content merge invalidates it even on assistant rows, whose
+            # direct repair path historically retained the stale sidecar.
+            if content_changed:
+                msg.pop("api_content", None)
+            api_content_changed = (
+                msg.get("api_content") != original.get("api_content")
+            )
+
+            if not (
+                content_changed
+                or tool_calls_changed
+                or reasoning_changed
+                or api_content_changed
+            ):
+                continue
+
+            tool_calls = msg.get("tool_calls")
+            if isinstance(tool_calls, str):
+                try:
+                    tool_calls = json.loads(tool_calls)
+                except (json.JSONDecodeError, TypeError):
+                    tool_calls = []
+            updates.append(
+                (
+                    self._encode_content(msg.get("content")),
+                    json.dumps(tool_calls) if tool_calls else None,
+                    _scrub_surrogates(msg.get("reasoning_content")),
+                    (
+                        _scrub_surrogates(msg.get("api_content"))
+                        if isinstance(msg.get("api_content"), str)
+                        else None
+                    ),
+                    row_id,
+                )
+            )
+
+        def _do(conn):
+            if removed_ids:
+                placeholders = ",".join("?" for _ in removed_ids)
+                conn.execute(
+                    f"UPDATE messages SET active = 0 "
+                    f"WHERE active = 1 AND id IN ({placeholders})",
+                    removed_ids,
+                )
+            if updates:
+                conn.executemany(
+                    "UPDATE messages SET content = ?, tool_calls = ?, "
+                    "reasoning_content = ?, api_content = ? "
+                    "WHERE id = ? AND active = 1",
+                    updates,
+                )
+
+        self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
 
     def get_resume_conversations(
         self, session_id: str

--- a/tests/hermes_state/test_restore_alternation_repair.py
+++ b/tests/hermes_state/test_restore_alternation_repair.py
@@ -7,8 +7,9 @@ suppressed, or two concurrent turns interleaved their flushes) leaves a
 pre-request ``repair_message_sequence`` re-fires on EVERY request for the
 rest of the session's life, because it mutates only the per-request list.
 
-Default (``repair_alternation=False``) must stay verbatim: inspection and
-export consumers (trace upload, context guard) read the transcript as-is.
+Default (``repair_alternation=False``) never initiates repair: inspection and
+export consumers read the current active transcript as stored. Rows archived
+by an earlier live repair remain available through ``include_inactive=True``.
 """
 
 import pytest
@@ -55,6 +56,106 @@ def test_repaired_load_is_stable_under_prerequest_repair(db):
     _seed_wedged_session(db)
     messages = db.get_messages_as_conversation("s1", repair_alternation=True)
     assert repair_message_sequence(None, messages) == 0
+
+
+def test_repaired_load_reconciles_durable_rows_and_fts(db):
+    """A repair-enabled restore heals state.db, not only its return value."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    db.create_session("durable", "system prompt")
+    db.append_message("durable", "user", "first ask")
+    db.append_message("durable", "assistant", "first reply")
+    survivor_id = db.append_message(
+        "durable",
+        "user",
+        "unanswered turn",
+        api_content="WIRE-SIDECAR: unanswered turn + injected context",
+    )
+    merged_away_id = db.append_message("durable", "user", "next turn")
+    db.append_message(
+        "durable",
+        "assistant",
+        "calling tool",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "demo", "arguments": "{}"},
+            }
+        ],
+    )
+    db.append_message(
+        "durable", "tool", "valid result", tool_call_id="call-1"
+    )
+    orphan_id = db.append_message(
+        "durable", "tool", "duplicate result", tool_call_id="call-1"
+    )
+    assistant_survivor_id = db.append_message(
+        "durable",
+        "assistant",
+        "next reply",
+        reasoning_content="first reasoning",
+        api_content="WIRE-SIDECAR: next reply",
+    )
+    assistant_merged_away_id = db.append_message(
+        "durable",
+        "assistant",
+        "continued reply",
+        tool_calls=[
+            {
+                "id": "call-2",
+                "type": "function",
+                "function": {"name": "next_demo", "arguments": "{}"},
+            }
+        ],
+        reasoning_content="later reasoning",
+    )
+
+    first = db.get_messages_as_conversation(
+        "durable", repair_alternation=True, include_row_ids=True
+    )
+
+    assert [message["_row_id"] for message in first] == [
+        row["id"]
+        for row in db.get_messages("durable")
+    ]
+    assert first[2]["_row_id"] == survivor_id
+    assert first[2]["content"] == "unanswered turn\n\nnext turn"
+    assert "api_content" not in first[2]
+    assert first[-1]["_row_id"] == assistant_survivor_id
+    assert first[-1]["content"] == "next reply\ncontinued reply"
+    assert [call["id"] for call in first[-1]["tool_calls"]] == ["call-2"]
+    assert first[-1]["reasoning_content"] == "first reasoning"
+    assert "api_content" not in first[-1]
+
+    all_rows = {
+        row["id"]: row
+        for row in db.get_messages("durable", include_inactive=True)
+    }
+    assert all_rows[survivor_id]["content"] == "unanswered turn\n\nnext turn"
+    assert all_rows[survivor_id]["api_content"] is None
+    assert all_rows[merged_away_id]["active"] == 0
+    assert all_rows[orphan_id]["active"] == 0
+    assert all_rows[assistant_survivor_id]["content"] == (
+        "next reply\ncontinued reply"
+    )
+    assert [
+        call["id"] for call in all_rows[assistant_survivor_id]["tool_calls"]
+    ] == ["call-2"]
+    assert all_rows[assistant_survivor_id]["reasoning_content"] == (
+        "first reasoning"
+    )
+    assert all_rows[assistant_survivor_id]["api_content"] is None
+    assert all_rows[assistant_merged_away_id]["active"] == 0
+
+    raw_reload = db.get_messages_as_conversation("durable")
+    assert repair_message_sequence(None, raw_reload) == 0
+    assert raw_reload == db.get_messages_as_conversation(
+        "durable", repair_alternation=True
+    )
+
+    search_hits = db.search_messages("unanswered next")
+    assert [hit["id"] for hit in search_hits] == [survivor_id]
 
 
 


### PR DESCRIPTION
## What does this PR do?

Sessions with persisted alternation violations were repaired only in memory, so every resume could repair the same rows again and repeatedly lose the stable prompt-cache prefix. This change atomically reconciles repair results back to SessionDB while retaining removed rows as inactive audit records and preserving display-only verification candidates.

### Symptom

After a malformed transcript is restored, consecutive requests repeatedly report the same message-sequence repairs. Repaired turns repeatedly fall back to an older prompt-cache prefix instead of reusing the stable repaired history.

### Impact

Affected resumed sessions pay the repair and cache-miss cost on every subsequent turn. The reported trace showed the repaired requests reusing only about 30-38% of the prompt while adjacent clean requests reused 88-99%.

### Bug Cause

**Trigger:** `hermes_state.py:8413` / `SessionDB.get_messages_as_conversation(..., repair_alternation=True)`

**Causal chain:**
1. A persisted transcript contains consecutive user or assistant rows, duplicate tool responses, or another repairable alternation violation.
2. `repair_message_sequence` fixes only the decoded in-memory message list and the restore path does not update the corresponding SessionDB rows.
3. A fresh load reads the original malformed rows and stale `api_content`, repeats the repair, and changes the replay prefix again.

**Why it is wrong:** Live replay treats the repaired list as authoritative for the current request but leaves durable state inconsistent with that list, so the same defensive repair cannot converge across resumes.

**Working sibling / contrast:** Clean transcripts already reload byte-stably because no repair mutation separates the in-memory replay from the persisted active rows. Inspection paths with `repair_alternation=False` intentionally remain read-only.

**Ruled out:** Compression alone is not the cause. A disposable SessionDB seeded directly with malformed rows reproduced repair counts `[2, 2]` across close and reopen before this fix.

### Fix

Repair-enabled active restores now retain internal row identity, atomically update changed survivor content, tool calls, reasoning content, and `api_content`, and soft-archive rows removed from model replay. Existing FTS update triggers keep merged content searchable. Display-only verification candidates remain active, inactive audit loads do not reconcile, and internal row IDs are stripped unless requested by the caller.

## Related Issue

Closes #82863

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` - reconcile identity-preserving replay repairs into active durable rows and archive repair-removed rows without deleting audit history.
- `tests/hermes_state/test_restore_alternation_repair.py` - cover load-repair-reload stability, stale sidecar clearing, FTS updates, archived rows, and read-only restore behavior.

## How to Test

1. Seed a disposable SessionDB with consecutive user and assistant rows, a duplicate tool response, and stale `api_content` sidecars.
2. Load with `repair_alternation=True`, close and reopen the database, then confirm the second load performs zero repairs and returns the same active replay bytes.
3. Run the relevant suites:

```bash
scripts/run_tests.sh tests/test_hermes_state.py
scripts/run_tests.sh tests/hermes_state/test_restore_alternation_repair.py
uvx ruff check hermes_state.py tests/hermes_state/test_restore_alternation_repair.py
```

All 227 targeted tests passed on the final commit, including three focused real-SessionDB display/resume regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

REAL_ENV verification on the final commit repaired three violations on the first load and zero after close/reopen. The active sequence was byte-stable; survivor fields, inactive audit rows, stale sidecar clearing, FTS results, unrelated-session isolation, and read-only restore behavior all matched the expected contracts.
