### PR TITLE
fix(agent): keep thinking-prefill marker so drop pass can strip trailing stubs

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2353,7 +2353,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         for msg in messages:
             api_msg = msg.copy()
             agent._copy_reasoning_content_for_api(msg, api_msg)
-            for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
+            for internal_field in ("reasoning", "finish_reason"):
                 api_msg.pop(internal_field, None)
             # Strict OpenAI-compatible gateways (Fireworks-backed OpenCode Go,
             # Mistral, Moonshot/Kimi) reject any message key outside the Chat
@@ -2376,8 +2376,6 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # sidecar-carrying message and re-prefilling the whole transcript
             # at exactly the moment the context is largest.
             substitute_api_content(api_msg)
-            for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
-                api_msg.pop(internal_key, None)
             if _needs_sanitize:
                 # In MoA mode, agent.model is the virtual preset name,
                 # not the actual aggregator model.  Resolve the real
@@ -2411,7 +2409,17 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
         # Same safety net as the main loop: drop thinking-only assistant
         # turns so Anthropic-family providers don't 400 the summary call.
+        # _thinking_prefill must survive until here so the drop pass can
+        # recognize stubs after reasoning fields are stripped.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+
+        # Strip all remaining underscore-prefixed scaffolding keys before the
+        # wire. The summary path calls chat.completions.create() directly,
+        # bypassing the transport's universal underscore-key sweeper.
+        for api_msg in api_messages:
+            if isinstance(api_msg, dict):
+                for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
+                    api_msg.pop(internal_key, None)
 
         summary_extra_body = {}
         try:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1907,8 +1907,13 @@ def run_conversation(
             # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
             if "finish_reason" in api_msg:
                 api_msg.pop("finish_reason")
-            # Strip internal thinking-prefill marker
-            api_msg.pop("_thinking_prefill", None)
+            # ``_thinking_prefill`` deliberately survives here. The reasoning
+            # fields it accompanies were just stripped above, which leaves
+            # ``_is_thinking_only_assistant`` no way to recognize the stub, so
+            # ``_drop_thinking_only_and_merge_users`` below could never fire on
+            # it. The transport strips every leading-underscore key before the
+            # wire (agent/transports/chat_completions.py), so keeping it costs
+            # nothing.
             # Strip length-continuation marks; not every transport drops underscore keys.
             api_msg.pop("_length_continuation_fragment", None)
             api_msg.pop("_length_continuation_nudge", None)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1907,13 +1907,8 @@ def run_conversation(
             # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
             if "finish_reason" in api_msg:
                 api_msg.pop("finish_reason")
-            # ``_thinking_prefill`` deliberately survives here. The reasoning
-            # fields it accompanies were just stripped above, which leaves
-            # ``_is_thinking_only_assistant`` no way to recognize the stub, so
-            # ``_drop_thinking_only_and_merge_users`` below could never fire on
-            # it. The transport strips every leading-underscore key before the
-            # wire (agent/transports/chat_completions.py), so keeping it costs
-            # nothing.
+            # _thinking_prefill survives here intentionally: the drop pass below
+            # needs it. The transport strips all underscore keys before the wire.
             # Strip length-continuation marks; not every transport drops underscore keys.
             api_msg.pop("_length_continuation_fragment", None)
             api_msg.pop("_length_continuation_nudge", None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4626,6 +4626,16 @@ class AIAgent:
             return False
         if msg.get("tool_calls"):
             return False
+        # A prefill stub is thinking-only by construction: the loop only sets
+        # ``_thinking_prefill`` on a turn that had reasoning and no visible
+        # text. It has to be checked ahead of the content inspection below,
+        # because both things this function would otherwise key on are gone by
+        # the time the drop pass runs. The reasoning fields are stripped from
+        # the API copy for providers that don't echo them back, and
+        # ``repair_empty_non_final_messages`` rewrites a non-final stub's empty
+        # content to a placeholder, which would read here as real output.
+        if msg.get("_thinking_prefill"):
+            return True
         # Does it have any actual output?
         content = msg.get("content")
         if isinstance(content, str):
@@ -4649,13 +4659,6 @@ class AIAgent:
                 return False
         elif content is not None and content != "":
             return False
-        # Content is empty-ish. A prefill stub is thinking-only by construction:
-        # the loop only sets ``_thinking_prefill`` on a turn that had reasoning
-        # and no visible text. Check it first, because the per-call copy has its
-        # reasoning fields stripped for providers that don't echo them back,
-        # which would otherwise leave nothing here to key on.
-        if msg.get("_thinking_prefill"):
-            return True
         reasoning = msg.get("reasoning_content") or msg.get("reasoning")
         if isinstance(reasoning, str) and reasoning.strip():
             return True

--- a/run_agent.py
+++ b/run_agent.py
@@ -4649,7 +4649,13 @@ class AIAgent:
                 return False
         elif content is not None and content != "":
             return False
-        # Content is empty-ish. Is there reasoning to make it thinking-only?
+        # Content is empty-ish. A prefill stub is thinking-only by construction:
+        # the loop only sets ``_thinking_prefill`` on a turn that had reasoning
+        # and no visible text. Check it first, because the per-call copy has its
+        # reasoning fields stripped for providers that don't echo them back,
+        # which would otherwise leave nothing here to key on.
+        if msg.get("_thinking_prefill"):
+            return True
         reasoning = msg.get("reasoning_content") or msg.get("reasoning")
         if isinstance(reasoning, str) and reasoning.strip():
             return True

--- a/run_agent.py
+++ b/run_agent.py
@@ -4626,14 +4626,8 @@ class AIAgent:
             return False
         if msg.get("tool_calls"):
             return False
-        # A prefill stub is thinking-only by construction: the loop only sets
-        # ``_thinking_prefill`` on a turn that had reasoning and no visible
-        # text. It has to be checked ahead of the content inspection below,
-        # because both things this function would otherwise key on are gone by
-        # the time the drop pass runs. The reasoning fields are stripped from
-        # the API copy for providers that don't echo them back, and
-        # ``repair_empty_non_final_messages`` rewrites a non-final stub's empty
-        # content to a placeholder, which would read here as real output.
+        # Prefill stubs are thinking-only by construction; check before content
+        # inspection since repair_empty_non_final_messages may have healed content.
         if msg.get("_thinking_prefill"):
             return True
         # Does it have any actual output?

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -52,8 +52,25 @@ class TestIsThinkingOnlyAssistant:
         on_wire = {"role": "assistant", "content": "", "_thinking_prefill": True}
         assert AIAgent._is_thinking_only_assistant(on_wire)
 
-    def test_prefill_marker_does_not_override_visible_content(self):
-        msg = {"role": "assistant", "content": "real text", "_thinking_prefill": True}
+    def test_healed_prefill_stub_is_still_detected(self):
+        # repair_empty_non_final_messages runs before the drop pass and rewrites
+        # a non-final stub's empty content to a placeholder. The marker has to
+        # outrank that, or the healed stub survives and the request still ends
+        # on a model turn.
+        healed = {
+            "role": "assistant",
+            "content": "[response interrupted]",
+            "_thinking_prefill": True,
+        }
+        assert AIAgent._is_thinking_only_assistant(healed)
+
+    def test_prefill_marker_does_not_override_tool_calls(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "t", "arguments": "{}"}}],
+            "_thinking_prefill": True,
+        }
         assert not AIAgent._is_thinking_only_assistant(msg)
 
 

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -45,6 +45,17 @@ class TestIsThinkingOnlyAssistant:
         assert not AIAgent._is_thinking_only_assistant(None)
         assert not AIAgent._is_thinking_only_assistant("hello")
 
+    def test_prefill_stub_detected_after_reasoning_stripped(self):
+        # The per-call copy for a provider that doesn't echo reasoning back has
+        # had reasoning_content/reasoning removed, leaving _thinking_prefill as
+        # the only evidence the turn was ever a thinking-only stub.
+        on_wire = {"role": "assistant", "content": "", "_thinking_prefill": True}
+        assert AIAgent._is_thinking_only_assistant(on_wire)
+
+    def test_prefill_marker_does_not_override_visible_content(self):
+        msg = {"role": "assistant", "content": "real text", "_thinking_prefill": True}
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
 
 # ---------------------------------------------------------------------------
 # _drop_thinking_only_and_merge_users — the full pass
@@ -121,6 +132,22 @@ class TestDropThinkingOnlyAndMergeUsers:
             {"type": "text", "text": "second"},
         ]
 
+
+    def test_trailing_prefill_stubs_dropped_so_request_ends_on_user(self):
+        # Regression for the Gemini 400 "Requests ending with a model turn are
+        # not supported". Two thinking-only responses in a row queue two prefill
+        # stubs, and on a provider that doesn't echo reasoning back both arrive
+        # here with their reasoning fields already stripped. Before the fix the
+        # pass couldn't see them and the request went out ending on assistant.
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "do the thing"},
+            {"role": "assistant", "content": "", "_thinking_prefill": True},
+            {"role": "assistant", "content": "", "_thinking_prefill": True},
+        ]
+        out = AIAgent._drop_thinking_only_and_merge_users(msgs)
+        assert [m["role"] for m in out] == ["system", "user"]
+        assert out[-1]["role"] != "assistant"
 
     def test_system_messages_ignored_by_pass(self):
         msgs = [

--- a/tests/run_agent/test_thinking_prefill_trailing_turn.py
+++ b/tests/run_agent/test_thinking_prefill_trailing_turn.py
@@ -1,0 +1,146 @@
+"""Regression test for the thinking-only prefill reaching the wire.
+
+A thinking-only response (reasoning tokens, no visible text) makes the loop
+append an empty assistant turn and re-send so the model continues its own
+reasoning. On providers that don't echo reasoning back, the API copy has its
+reasoning fields stripped before ``_drop_thinking_only_and_merge_users`` runs,
+so the drop pass used to see a bare ``{"role": "assistant", "content": ""}``
+and let it through. Gemini rejects that with
+
+    400 INVALID_ARGUMENT: Requests ending with a model turn are not supported.
+
+classified as non-retryable, so the turn aborts outright.
+
+Unlike the unit tests in ``test_thinking_only_sanitizer.py``, this drives
+``run_conversation`` and asserts on the payload actually handed to the client,
+so it exercises the API-copy build that decides whether ``_thinking_prefill``
+survives as far as the drop pass.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent with a mocked OpenAI client, mirroring the fixture in
+    ``test_dropped_tool_call_recovery.py``."""
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+
+def _thinking_only_response():
+    """Reasoning tokens, no visible text — what triggers the prefill retry."""
+    from tests.run_agent.test_run_agent import _mock_response
+    return _mock_response(
+        content="",
+        finish_reason="stop",
+        reasoning="Let me work through the request step by step.",
+    )
+
+
+def _final_response(text="Here is the answer."):
+    """An ordinary text turn that ends the loop."""
+    from tests.run_agent.test_run_agent import _mock_response
+    return _mock_response(content=text, finish_reason="stop")
+
+
+def _sent_messages(create_mock, call_index):
+    call = create_mock.call_args_list[call_index]
+    return call.kwargs.get("messages") or call.args[0].get("messages")
+
+
+class TestThinkingPrefillTrailingTurn:
+
+    def test_request_after_prefills_does_not_end_on_assistant(self, loop_agent):
+        # Two thinking-only responses queue two prefill stubs, then the model
+        # finally produces text. The third request is the one that used to go
+        # out ending on a model turn.
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_response(),
+            _thinking_only_response(),
+            _final_response(),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            loop_agent.run_conversation("do the thing")
+
+        create = loop_agent.client.chat.completions.create
+        assert create.call_count >= 3, (
+            "Two thinking-only responses should each trigger a prefill retry."
+        )
+
+        final_request = _sent_messages(create, 2)
+        assert final_request[-1]["role"] != "assistant", (
+            "Request ends on a model turn, which Gemini rejects with a "
+            "non-retryable 400. The thinking-only prefill stubs must be "
+            f"dropped before send. Got roles: {[m['role'] for m in final_request]}"
+        )
+
+    def test_prefill_stubs_are_absent_from_the_wire_payload(self, loop_agent):
+        """The stubs should be gone entirely, not merely trailed by a nudge."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_response(),
+            _final_response(),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            loop_agent.run_conversation("do the thing")
+
+        sent = _sent_messages(loop_agent.client.chat.completions.create, 1)
+        empty_assistants = [
+            m for m in sent
+            if m.get("role") == "assistant" and not (m.get("content") or "").strip()
+        ]
+        assert not empty_assistants, (
+            f"Empty assistant stub(s) reached the wire: {empty_assistants}"
+        )
+
+    def test_internal_marker_never_reaches_the_wire(self, loop_agent):
+        """``_thinking_prefill`` survives the API-copy build on purpose, but the
+        transport must still keep it off the wire."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _thinking_only_response(),
+            _final_response(),
+        ]
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            loop_agent.run_conversation("do the thing")
+
+        sent = _sent_messages(loop_agent.client.chat.completions.create, 1)
+        leaked = [m for m in sent if any(str(k).startswith("_") for k in m)]
+        assert not leaked, f"Internal scaffolding keys reached the wire: {leaked}"


### PR DESCRIPTION
## Summary
Thinking-only prefill stubs no longer reach the wire on non-echo-back providers (Gemini, etc.), preventing the non-retryable 400 "Requests ending with a model turn are not supported." Root cause: `_thinking_prefill` was popped from the API copy before `_drop_thinking_only_and_merge_users` could use it, so after reasoning fields were stripped the drop pass couldn't recognize the stub.

## Changes
- `agent/conversation_loop.py`: stop popping `_thinking_prefill` from the per-call API copy; the transport strips all underscore keys before the wire
- `run_agent.py`: `_is_thinking_only_assistant` treats `_thinking_prefill` as a thinking-only marker, checked before content inspection (repair pass may have healed empty content to a placeholder)
- `agent/chat_completion_helpers.py`: same fix for the compression summary path — removed `_thinking_prefill` from the explicit pop tuple and moved the generic underscore-key sweep to after the drop pass, so the marker survives long enough for the drop pass to recognize stubs there too
- `tests/run_agent/test_thinking_only_sanitizer.py`: 4 new unit tests (stripped-reasoning detection, healed-stub detection, tool_calls precedence, trailing-stub drop)
- `tests/run_agent/test_thinking_prefill_trailing_turn.py`: 3 integration tests driving `run_conversation` (request ends on user, stubs absent from wire, no internal keys leak)

## Validation
| | Before | After |
|---|---|---|
| PR tests | — | 16/16 pass |
| Compression tests | — | 136/136 pass |
| E2E (drop pass + transport strip) | stubs survive to wire | stubs dropped, no underscore keys leak |

Salvage of #75142 by @Jefftree. Cherry-picked onto current main with conflict resolved (main added `_length_continuation_*` pops). Follow-up commit trims comments and fixes the same bug class in the summary path.

Closes #75121
