### PR TITLE
test(tools): skip GNU-only binary probes on BSD userland

### DIFF
--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -32,6 +32,35 @@ def test_real_read_tool_binaries_confirm_option_ownership(
     assert completed.stdout == expected_output
 
 
+def _sort_is_gnu():
+    """GNU sort owns --buffer-size/--compress-program; BSD (macOS) sort does not."""
+    if shutil.which("sort") is None:
+        return False
+    try:
+        completed = subprocess.run(
+            ["sort", "--version"], capture_output=True, text=True, timeout=10
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "GNU" in completed.stdout
+
+
+def _script_supports_dash_c():
+    """util-linux script takes -c; BSD (macOS) script rejects it."""
+    if shutil.which("script") is None:
+        return False
+    try:
+        completed = subprocess.run(
+            ["script", "-qec", "true", "/dev/null"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return completed.returncode == 0
+
+
 @pytest.mark.parametrize(
     ("tool", "args", "stdin", "needs_tty"),
     [
@@ -49,6 +78,10 @@ def test_real_binaries_execute_leading_dash_program_payload(
     """A PATH marker proves these binaries do not reparse '-program' as an option."""
     if shutil.which(tool) is None or (needs_tty and shutil.which("script") is None):
         pytest.skip(f"{tool} or script is not installed")
+    if tool == "sort" and not _sort_is_gnu():
+        pytest.skip("sort is not GNU; --buffer-size/--compress-program are GNU options")
+    if needs_tty and not _script_supports_dash_c():
+        pytest.skip("script does not support -c (BSD script); cannot allocate a tty here")
 
     marker = tmp_path / "executed"
     payload = tmp_path / "-payload-marker"


### PR DESCRIPTION
## What and why

`tests/tools/test_execution_flag_detection.py::test_real_binaries_execute_leading_dash_program_payload` fails on macOS. Three of its six parametrizations assume GNU userland in the *probe scaffolding*, not in the code under test:

| case | failure on macOS | cause |
|---|---|---|
| `sort-args2` | `subprocess.TimeoutExpired` after 20s | `--buffer-size` is GNU-only; Apple `sort` (`2.3-Apple (199)`) rejects it, so the payload never runs |
| `man-args4` (`--pager`) | `FileNotFoundError` — marker never written | BSD `script` has no `-c`: `script: illegal option -- c` |
| `man-args5` (`-P`) | `FileNotFoundError` — marker never written | same `script -qec` wrapper, so `man` is never invoked |

Worth being explicit about the second and third: they are **not** a `man` problem. The `script -qec ... /dev/null` tty wrapper is util-linux-specific. On BSD it exits 1 before `man` runs, so the `-payload-marker` on `PATH` is never executed and the assertion fails on a missing file rather than on detector behavior.

The approval logic these cases exercise is correct on both platforms — only the probes are GNU-specific. Since the repo targets macOS as a supported platform (CONTRIBUTING.md line 12) and CI has no macOS runner for this suite, the failures are invisible upstream but hit every Mac contributor running `pytest tests/`.

## How this fixes it

Two capability probes, gating the affected cases on whether the tool actually supports the option rather than on `sys.platform`:

- `_sort_is_gnu()` — checks for `GNU` in `sort --version`
- `_script_supports_dash_c()` — checks `script -qec true /dev/null` exits 0

Both fail closed (returning `False`) on `OSError`/`SubprocessError`/missing binary. Capability probing rather than OS sniffing means the cases keep running anywhere the grammar supports them, including any future GNU-coreutils-on-macOS setup, and skip only where it genuinely differs.

## How to test

On macOS, before:

```
$ pytest tests/tools/test_execution_flag_detection.py -q
3 failed, 81 passed, 1 skipped
```

After:

```
$ pytest tests/tools/test_execution_flag_detection.py -q -rs
81 passed, 4 skipped

SKIPPED [1] sort is not GNU; --buffer-size/--compress-program are GNU options
SKIPPED [2] script does not support -c (BSD script); cannot allocate a tty here
SKIPPED [1] ag or script is not installed
```

The fourth skip (`ag`) is pre-existing and unrelated — `ag` is not installed here.

I verified the guards are load-bearing rather than blanket skips by forcing each probe to return `True` on this BSD machine and confirming the corresponding cases then run and fail:

```
[ARM1 force _sort_is_gnu=True]        1 failed, 2 passed, 3 skipped   -> sort-args2 runs and fails
[ARM2 force _script_supports_dash_c=True]  2 failed, 2 passed, 2 skipped   -> man-args4/5 run and fail
```

So on GNU userland, where both probes legitimately return `True`, all six parametrizations still execute.

## Platforms tested

- **macOS (Apple Silicon), Python 3.12** — full run above; `sort` is `2.3-Apple (199)`, `script` is BSD.
- **Linux** — not executed locally; I have no Linux runner or container available. The GNU-side behavior is reasoned from the probe conditions and demonstrated via the forced-`True` arms above, but CI is the real check for it. Flagging that explicitly rather than implying I ran it.

## Security considerations

None. This changes test scaffolding only — no change to `tools/approval.py` or any detection logic, and no case is weakened: the parametrizations still execute in full on GNU userland where the probes apply.

## Related

Found while reproducing #70838 on macOS. Independent of that bug and of PRs #70839 / #70880 — this reproduces on current `main` with no patches applied, and none of those changes touch this test function.
