### PR TITLE
fix(terminal): stop scoped Windows deletes from wiping drive roots

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -259,6 +259,7 @@ _WINDOWS_DYNAMIC_ROOT_DELETE_BLOCK = [
     "cmd /c rd /s /q %TARGET%\\folder\\..",
     'cmd /c "echo ready && rd /s /q %SYSTEMDRIVE%\\"',
     "cmd /c r^d /s /q %TARGET%",
+    '''powershell -Command 'cmd /c "echo ready & rd /s /q $env:SystemDrive/"' ''',
 ]
 
 
@@ -268,6 +269,7 @@ _WINDOWS_DYNAMIC_ROOT_DELETE_ALLOW = [
     "cmd /c rd /s /q %SystemRoot%\\Temp",
     "cmd /c rd /s /q %TARGET%\\scoped",
     'cmd /c "echo ready & rd /s /q %TARGET%\\scoped"',
+    '''powershell -Command 'cmd /c "echo ready ^& rd /s /q $env:SystemDrive/"' ''',
 ]
 
 

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -260,6 +260,11 @@ _WINDOWS_DYNAMIC_ROOT_DELETE_BLOCK = [
     'cmd /c "echo ready && rd /s /q %SYSTEMDRIVE%\\"',
     "cmd /c r^d /s /q %TARGET%",
     '''powershell -Command 'cmd /c "echo ready & rd /s /q $env:SystemDrive/"' ''',
+    "powershell -Command 'cmd /c rd /s /q ${env:SystemDrive}\\'",
+    "powershell -Command 'cmd /c rd /s /q ${env:SystemRoot}\\..'",
+    "powershell -Command 'cmd /c rd /s /q ${env:TARGET}'",
+    "cmd /c rd /s /q %SYSTEMDRIVE:~0,1%:\\",
+    "cmd /c rd /s /q %TARGET%:\\",
 ]
 
 
@@ -270,6 +275,10 @@ _WINDOWS_DYNAMIC_ROOT_DELETE_ALLOW = [
     "cmd /c rd /s /q %TARGET%\\scoped",
     'cmd /c "echo ready & rd /s /q %TARGET%\\scoped"',
     '''powershell -Command 'cmd /c "echo ready ^& rd /s /q $env:SystemDrive/"' ''',
+    "powershell -Command 'cmd /c rd /s /q ${env:SystemDrive}\\scoped'",
+    "powershell -Command 'cmd /c rd /s /q ${env:TARGET}\\scoped'",
+    "cmd /c rd /s /q %SYSTEMDRIVE:~0,1%:\\scoped",
+    "cmd /c rd /s /q %TARGET%:\\scoped",
 ]
 
 

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -221,6 +221,8 @@ _WINDOWS_ROOT_DELETE_BLOCK = [
     "C:\\Windows\\System32\\cmd.exe /c rd /s /q P:/",
     "cmd /c rd /s /q Q:\\folder\\..",
     "cmd /c rd /s /q \\\\server\\share\\folder\\..",
+    'cmd /c "echo ready & rd /s /q R:\\"',
+    "cmd /c r^d /s /q S:\\",
     (
         r'''powershell -NoProfile -Command 'cmd /c \"rd /s /q '''
         r'''\\\"C:\Users\Art\Documents\ChatGPT\Software\clipsift-release\\\"\"' '''
@@ -242,6 +244,9 @@ _WINDOWS_ROOT_DELETE_ALLOW = [
     'echo "cmd /d /c rd /s /q D:\\"',
     'echo "powershell -NoProfile -Command cmd /c rd /s /q C:\\"',
     '''python -c "print('powershell -Command cmd /c rd /s /q C:\\')"''',
+    'cmd /c "echo rd /s /q J:\\"',
+    'cmd /c "echo ready ^& rd /s /q K:\\"',
+    'cmd /c "echo ready & rd /s /q L:\\scoped"',
 ]
 
 
@@ -252,6 +257,8 @@ _WINDOWS_DYNAMIC_ROOT_DELETE_BLOCK = [
     "cmd /c rd /s /q %SystemRoot%\\..",
     "cmd /c rd /s /q %TARGET%",
     "cmd /c rd /s /q %TARGET%\\folder\\..",
+    'cmd /c "echo ready && rd /s /q %SYSTEMDRIVE%\\"',
+    "cmd /c r^d /s /q %TARGET%",
 ]
 
 
@@ -260,6 +267,7 @@ _WINDOWS_DYNAMIC_ROOT_DELETE_ALLOW = [
     "cmd /v:on /c rd /s /q !SYSTEMDRIVE!\\scoped",
     "cmd /c rd /s /q %SystemRoot%\\Temp",
     "cmd /c rd /s /q %TARGET%\\scoped",
+    'cmd /c "echo ready & rd /s /q %TARGET%\\scoped"',
 ]
 
 

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -216,6 +216,11 @@ _WINDOWS_ROOT_DELETE_BLOCK = [
     "echo $(cmd /d /c rd /s /q K:/)",
     "cmd /c rd /s /q L:\\.",
     "cmd /c rd M:/.. /s /q",
+    'powershell -ExecutionPolicy Bypass -Command "cmd /c rd /s /q N:\\"',
+    "command -- cmd /c rd /s /q O:/",
+    "C:\\Windows\\System32\\cmd.exe /c rd /s /q P:/",
+    "cmd /c rd /s /q Q:\\folder\\..",
+    "cmd /c rd /s /q \\\\server\\share\\folder\\..",
     (
         r'''powershell -NoProfile -Command 'cmd /c \"rd /s /q '''
         r'''\\\"C:\Users\Art\Documents\ChatGPT\Software\clipsift-release\\\"\"' '''
@@ -230,6 +235,8 @@ _WINDOWS_ROOT_DELETE_ALLOW = [
     "cmd /d /c rd /s /q E:\\scoped",
     "cmd /c rd /s /q F:\\...",
     "cmd /c rd /s /q G:\\.config",
+    "cmd /c rd /s /q H:\\folder\\..\\kept",
+    'powershell -File script.ps1 -Command "cmd /c rd /s /q I:\\"',
     r'''cmd /c "rd /s /q \"C:\Users\Art\Documents\clipsift-release\""''',
     'echo "cmd /c rd /s /q C:\\"',
     'echo "cmd /d /c rd /s /q D:\\"',
@@ -271,6 +278,8 @@ def test_windows_scoped_or_non_recursive_delete_is_not_hardline(command):
     [
         _WINDOWS_ROOT_DELETE_BLOCK[2],
         _WINDOWS_ROOT_DELETE_BLOCK[5],
+        _WINDOWS_ROOT_DELETE_BLOCK[-6],
+        _WINDOWS_ROOT_DELETE_BLOCK[-3],
         _WINDOWS_ROOT_DELETE_BLOCK[-1],
     ],
 )

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -211,6 +211,11 @@ _WINDOWS_ROOT_DELETE_BLOCK = [
     "cmd /c rd F:\\ /s /q",
     'cmd /c rmdir "G:\\" /s /q',
     "cmd /c rd /q H:/ /s",
+    "cmd /d /s /c rd /s /q I:\\",
+    'cmd.exe /v:on /c "rmdir /s /q J:/"',
+    "echo $(cmd /d /c rd /s /q K:/)",
+    "cmd /c rd /s /q L:\\.",
+    "cmd /c rd M:/.. /s /q",
     (
         r'''powershell -NoProfile -Command 'cmd /c \"rd /s /q '''
         r'''\\\"C:\Users\Art\Documents\ChatGPT\Software\clipsift-release\\\"\"' '''
@@ -222,8 +227,12 @@ _WINDOWS_ROOT_DELETE_ALLOW = [
     "cmd /c rd /s /q C:\\Users\\Art\\Documents\\clipsift-release",
     "cmd /c rmdir /q /s D:/clipsift-release",
     "cmd /c rd /q C:\\",
+    "cmd /d /c rd /s /q E:\\scoped",
+    "cmd /c rd /s /q F:\\...",
+    "cmd /c rd /s /q G:\\.config",
     r'''cmd /c "rd /s /q \"C:\Users\Art\Documents\clipsift-release\""''',
     'echo "cmd /c rd /s /q C:\\"',
+    'echo "cmd /d /c rd /s /q D:\\"',
     'echo "powershell -NoProfile -Command cmd /c rd /s /q C:\\"',
     '''python -c "print('powershell -Command cmd /c rd /s /q C:\\')"''',
 ]

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -208,6 +208,9 @@ _WINDOWS_ROOT_DELETE_BLOCK = [
     "cmd.exe /c rmdir /q /s C:\\",
     "cmd /k rd /s D:/",
     "cmd /c rd /s /q \"E:\\\"",
+    "cmd /c rd F:\\ /s /q",
+    'cmd /c rmdir "G:\\" /s /q',
+    "cmd /c rd /q H:/ /s",
     (
         r'''powershell -NoProfile -Command 'cmd /c \"rd /s /q '''
         r'''\\\"C:\Users\Art\Documents\ChatGPT\Software\clipsift-release\\\"\"' '''
@@ -221,6 +224,8 @@ _WINDOWS_ROOT_DELETE_ALLOW = [
     "cmd /c rd /q C:\\",
     r'''cmd /c "rd /s /q \"C:\Users\Art\Documents\clipsift-release\""''',
     'echo "cmd /c rd /s /q C:\\"',
+    'echo "powershell -NoProfile -Command cmd /c rd /s /q C:\\"',
+    '''python -c "print('powershell -Command cmd /c rd /s /q C:\\')"''',
 ]
 
 
@@ -254,7 +259,11 @@ def test_windows_scoped_or_non_recursive_delete_is_not_hardline(command):
 
 @pytest.mark.parametrize(
     "command",
-    [_WINDOWS_ROOT_DELETE_BLOCK[2], _WINDOWS_ROOT_DELETE_BLOCK[-1]],
+    [
+        _WINDOWS_ROOT_DELETE_BLOCK[2],
+        _WINDOWS_ROOT_DELETE_BLOCK[5],
+        _WINDOWS_ROOT_DELETE_BLOCK[-1],
+    ],
 )
 def test_windows_root_delete_cannot_bypass_yolo(command, clean_session, monkeypatch):
     monkeypatch.setenv("HERMES_YOLO_MODE", "1")

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -202,6 +202,28 @@ _HARDLINE_ALLOW = [
 ]
 
 
+_WINDOWS_ROOT_DELETE_BLOCK = [
+    "cmd /c rd /s /q " + "\\",
+    "cmd /c rd /s /q /",
+    "cmd.exe /c rmdir /q /s C:\\",
+    "cmd /k rd /s D:/",
+    "cmd /c rd /s /q \"E:\\\"",
+    (
+        r'''powershell -NoProfile -Command 'cmd /c \"rd /s /q '''
+        r'''\\\"C:\Users\Art\Documents\ChatGPT\Software\clipsift-release\\\"\"' '''
+    ).rstrip(),
+]
+
+
+_WINDOWS_ROOT_DELETE_ALLOW = [
+    "cmd /c rd /s /q C:\\Users\\Art\\Documents\\clipsift-release",
+    "cmd /c rmdir /q /s D:/clipsift-release",
+    "cmd /c rd /q C:\\",
+    r'''cmd /c "rd /s /q \"C:\Users\Art\Documents\clipsift-release\""''',
+    'echo "cmd /c rd /s /q C:\\"',
+]
+
+
 @pytest.mark.parametrize("command", _HARDLINE_BLOCK)
 def test_hardline_detection_blocks(command):
     is_hl, desc = detect_hardline_command(command)
@@ -214,6 +236,33 @@ def test_hardline_detection_allows(command):
     is_hl, desc = detect_hardline_command(command)
     assert not is_hl, f"expected hardline NOT to match {command!r} (got: {desc})"
     assert desc is None
+
+
+@pytest.mark.parametrize("command", _WINDOWS_ROOT_DELETE_BLOCK)
+def test_windows_recursive_root_delete_is_hardline(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"Windows root delete bypassed hardline detection: {command!r}"
+    assert desc == "recursive delete of Windows filesystem root"
+
+
+@pytest.mark.parametrize("command", _WINDOWS_ROOT_DELETE_ALLOW)
+def test_windows_scoped_or_non_recursive_delete_is_not_hardline(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"scoped Windows delete was hardline-blocked: {command!r}"
+    assert desc is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [_WINDOWS_ROOT_DELETE_BLOCK[2], _WINDOWS_ROOT_DELETE_BLOCK[-1]],
+)
+def test_windows_root_delete_cannot_bypass_yolo(command, clean_session, monkeypatch):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    for guard in (check_dangerous_command, check_all_command_guards):
+        result = guard(command, "local")
+        assert result["approved"] is False
+        assert result.get("hardline") is True
 
 
 # Commands written with the ordinary quoting / brace shell idioms that

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -245,6 +245,24 @@ _WINDOWS_ROOT_DELETE_ALLOW = [
 ]
 
 
+_WINDOWS_DYNAMIC_ROOT_DELETE_BLOCK = [
+    "cmd /c rd /s /q %SYSTEMDRIVE%\\",
+    "cmd /c rd /s /q %HOMEDRIVE%/",
+    "cmd /v:on /c rd /s /q !SYSTEMDRIVE!\\",
+    "cmd /c rd /s /q %SystemRoot%\\..",
+    "cmd /c rd /s /q %TARGET%",
+    "cmd /c rd /s /q %TARGET%\\folder\\..",
+]
+
+
+_WINDOWS_DYNAMIC_ROOT_DELETE_ALLOW = [
+    "cmd /c rd /s /q %SYSTEMDRIVE%\\scoped",
+    "cmd /v:on /c rd /s /q !SYSTEMDRIVE!\\scoped",
+    "cmd /c rd /s /q %SystemRoot%\\Temp",
+    "cmd /c rd /s /q %TARGET%\\scoped",
+]
+
+
 @pytest.mark.parametrize("command", _HARDLINE_BLOCK)
 def test_hardline_detection_blocks(command):
     is_hl, desc = detect_hardline_command(command)
@@ -271,6 +289,32 @@ def test_windows_scoped_or_non_recursive_delete_is_not_hardline(command):
     is_hl, desc = detect_hardline_command(command)
     assert not is_hl, f"scoped Windows delete was hardline-blocked: {command!r}"
     assert desc is None
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DYNAMIC_ROOT_DELETE_BLOCK)
+def test_windows_dynamic_recursive_root_delete_is_hardline(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"dynamic Windows root delete bypassed hardline detection: {command!r}"
+    assert desc == "recursive delete of Windows filesystem root"
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DYNAMIC_ROOT_DELETE_ALLOW)
+def test_windows_scoped_dynamic_delete_is_not_hardline(command):
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"scoped dynamic Windows delete was hardline-blocked: {command!r}"
+    assert desc is None
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DYNAMIC_ROOT_DELETE_BLOCK)
+def test_windows_dynamic_root_delete_cannot_bypass_public_guards(
+    command, clean_session, monkeypatch
+):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    for guard in (check_dangerous_command, check_all_command_guards):
+        result = guard(command, "local")
+        assert result["approved"] is False
+        assert result.get("hardline") is True
 
 
 @pytest.mark.parametrize(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -432,13 +432,20 @@ _HARDLINE_SYSTEM_DIRS = (
 _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
 
 # Windows ``rd`` / ``rmdir`` root deletion must stay below every approval
-# bypass just like ``rm -rf /``.  The PowerShell prefix is intentionally
-# narrow: ``cmd`` must be the -Command payload, so quoted prose stays data.
-_WINDOWS_CMD_PREFIX = _CMDPOS + r'cmd(?:\.exe)?\s+/(?:c|k)\s+'
+# bypass just like ``rm -rf /``.  ``cmd`` accepts its own switches before
+# ``/c`` or ``/k``; those switches must be consumed by the cmd-owned prefix
+# rather than mistaken for the nested command payload.
+_WINDOWS_CMD_INVOKE = (
+    r'cmd(?:\.exe)?'
+    r'(?:\s+/(?:d|q|a|u|s|e:(?:on|off)|f:(?:on|off)|v:(?:on|off)))*'
+    r'\s+/(?:c|k)\s+'
+)
+_WINDOWS_CMD_PREFIX = _CMDPOS + _WINDOWS_CMD_INVOKE
 _WINDOWS_POWERSHELL_CMD_PREFIX = (
     _CMDPOS
     + r'(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+'
-    r'-(?:command|c)\s+["\']?cmd(?:\.exe)?\s+/(?:c|k)\s+'
+    + r'-(?:command|c)\s+["\']?'
+    + _WINDOWS_CMD_INVOKE
 )
 _WINDOWS_RD_PREFIX = (
     r'\\?["\']?(?:rd|rmdir)\b\s+'
@@ -447,9 +454,14 @@ _WINDOWS_RECURSIVE_FLAGS_PREFIX = (
     r'(?=(?:(?:/[sq])\s+)*/s(?:\s|$))'
     r'(?:(?:/[sq])\s+)+'
 )
+_WINDOWS_COLLAPSING_ROOT = (
+    r'(?:[a-z]:)?[\\/]+'
+    r'(?:(?:\.\.?)?[\\/]+)*(?:\.\.?)?'
+)
 _WINDOWS_ROOT_TARGET = (
-    r'(?:["\'](?:[a-z]:)?[\\/]+["\']|'
-    r'(?:[a-z]:)?[\\/]+(?=["\']?(?:[\s`;|&)]|$)))'
+    r'(?:["\'](?:' + _WINDOWS_COLLAPSING_ROOT + r')["\']|'
+    r'(?:' + _WINDOWS_COLLAPSING_ROOT
+    + r')(?=["\']?(?:[\s`;|&)]|$)))'
 )
 _WINDOWS_RECURSIVE_ROOT_ARGUMENTS = (
     r'(?:'

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -564,6 +564,20 @@ HARDLINE_PATTERNS_COMPILED = [
 _WINDOWS_ROOT_DELETE_RE = re.compile(_WINDOWS_ROOT_DELETE_PATTERN, _RE_FLAGS)
 _WINDOWS_RD_INVOCATION_RE = re.compile(_WINDOWS_RD_INVOCATION_PATTERN, _RE_FLAGS)
 _WINDOWS_ARGUMENT_TOKEN_RE = re.compile(r'"[^"]*"|\'[^\']*\'|\S+')
+_WINDOWS_DRIVE_VARIABLE_RE = re.compile(
+    r'%(?:systemdrive|homedrive)%|!(?:systemdrive|homedrive)!|'
+    r'\$env:(?:systemdrive|homedrive)\b',
+    re.IGNORECASE,
+)
+_WINDOWS_SYSTEM_DIR_VARIABLE_RE = re.compile(
+    r'%(?:systemroot|windir)%|!(?:systemroot|windir)!|'
+    r'\$env:(?:systemroot|windir)\b',
+    re.IGNORECASE,
+)
+_WINDOWS_DYNAMIC_PATH_RE = re.compile(
+    r'%[^%]+%|![^!]+!|\$(?:env:)?[a-z_][a-z0-9_]*|`',
+    re.IGNORECASE,
+)
 
 
 def _windows_literal_path_is_root(token: str) -> bool:
@@ -576,8 +590,30 @@ def _windows_literal_path_is_root(token: str) -> bool:
     return tail == "\\" and (bool(drive) or normalized == "\\")
 
 
+def _windows_path_is_root_or_unscoped_dynamic(token: str) -> bool:
+    """Classify roots and dynamic paths that cannot be proven scoped."""
+    token = token.strip().strip("\"'")
+    resolved = _WINDOWS_DRIVE_VARIABLE_RE.sub(lambda _: "C:", token)
+    resolved = _WINDOWS_SYSTEM_DIR_VARIABLE_RE.sub(lambda _: r"C:\Windows", resolved)
+    dynamic_matches = list(_WINDOWS_DYNAMIC_PATH_RE.finditer(resolved))
+    if not dynamic_matches:
+        return _windows_literal_path_is_root(resolved)
+
+    suffix = resolved[dynamic_matches[-1].end():].replace("/", "\\")
+    scoped_components = []
+    for component in suffix.split("\\"):
+        if component in {"", "."}:
+            continue
+        if component == "..":
+            if scoped_components:
+                scoped_components.pop()
+            continue
+        scoped_components.append(component)
+    return not scoped_components
+
+
 def _windows_recursive_delete_targets_root(command: str) -> bool:
-    """Parse cmd-owned rd arguments and classify literal normalized roots."""
+    """Parse cmd-owned rd arguments and classify root-equivalent targets."""
     for match in _WINDOWS_RD_INVOCATION_RE.finditer(command):
         tokens = _WINDOWS_ARGUMENT_TOKEN_RE.findall(match.group("arguments"))
         normalized_tokens = [token.strip("\"'").lower() for token in tokens]
@@ -586,7 +622,7 @@ def _windows_recursive_delete_targets_root(command: str) -> bool:
         for token, normalized_token in zip(tokens, normalized_tokens):
             if normalized_token in {"/s", "/q"}:
                 continue
-            if _windows_literal_path_is_root(token):
+            if _windows_path_is_root_or_unscoped_dynamic(token):
                 return True
     return False
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -585,16 +585,19 @@ _WINDOWS_CMD_PAYLOAD_RES = tuple(
 _WINDOWS_ARGUMENT_TOKEN_RE = re.compile(r'"[^"]*"|\'[^\']*\'|\S+')
 _WINDOWS_DRIVE_VARIABLE_RE = re.compile(
     r'%(?:systemdrive|homedrive)%|!(?:systemdrive|homedrive)!|'
-    r'\$env:(?:systemdrive|homedrive)\b',
+    r'\$env:(?:systemdrive|homedrive)\b|'
+    r'\$\{env:(?:systemdrive|homedrive)\}',
     re.IGNORECASE,
 )
 _WINDOWS_SYSTEM_DIR_VARIABLE_RE = re.compile(
     r'%(?:systemroot|windir)%|!(?:systemroot|windir)!|'
-    r'\$env:(?:systemroot|windir)\b',
+    r'\$env:(?:systemroot|windir)\b|'
+    r'\$\{env:(?:systemroot|windir)\}',
     re.IGNORECASE,
 )
 _WINDOWS_DYNAMIC_PATH_RE = re.compile(
-    r'%[^%]+%|![^!]+!|\$(?:env:)?[a-z_][a-z0-9_]*|`',
+    r'%[^%]+%|![^!]+!|\$\{(?:env:)?[a-z_][a-z0-9_]*\}|'
+    r'\$(?:env:)?[a-z_][a-z0-9_]*|`',
     re.IGNORECASE,
 )
 
@@ -619,6 +622,11 @@ def _windows_path_is_root_or_unscoped_dynamic(token: str) -> bool:
         return _windows_literal_path_is_root(resolved)
 
     suffix = resolved[dynamic_matches[-1].end():].replace("/", "\\")
+    if re.match(r'^:\\', suffix):
+        # Cmd substring/replacement syntax can produce just the drive letter,
+        # with the literal ``:\`` supplied after the expansion. The colon is
+        # drive syntax, not a path component proving the target is scoped.
+        suffix = suffix[1:]
     scoped_components = []
     for component in suffix.split("\\"):
         if component in {"", "."}:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -509,6 +509,16 @@ _WINDOWS_RD_INVOCATION_PATTERN = (
     + _WINDOWS_RD_PREFIX
     + r'(?P<arguments>[^;\n|&)]*)'
 )
+_WINDOWS_RD_PAYLOAD_PATTERN = (
+    _CMDPOS + _WINDOWS_RD_PREFIX + _WINDOWS_RECURSIVE_ROOT_ARGUMENTS
+)
+_WINDOWS_RD_PAYLOAD_INVOCATION_PATTERN = (
+    _CMDPOS + _WINDOWS_RD_PREFIX + r'(?P<arguments>[^;\n|&)]*)'
+)
+_WINDOWS_CMD_PAYLOAD_PATTERNS = (
+    _WINDOWS_CMD_PREFIX + r'(?P<payload>[^\n]*)',
+    _WINDOWS_POWERSHELL_CMD_PREFIX + r'(?P<payload>[^\n]*)',
+)
 
 HARDLINE_PATTERNS = [
     (_WINDOWS_ROOT_DELETE_PATTERN, "recursive delete of Windows filesystem root"),
@@ -563,6 +573,15 @@ HARDLINE_PATTERNS_COMPILED = [
 ]
 _WINDOWS_ROOT_DELETE_RE = re.compile(_WINDOWS_ROOT_DELETE_PATTERN, _RE_FLAGS)
 _WINDOWS_RD_INVOCATION_RE = re.compile(_WINDOWS_RD_INVOCATION_PATTERN, _RE_FLAGS)
+_WINDOWS_RD_PAYLOAD_RE = re.compile(_WINDOWS_RD_PAYLOAD_PATTERN, _RE_FLAGS)
+_WINDOWS_RD_PAYLOAD_INVOCATION_RE = re.compile(
+    _WINDOWS_RD_PAYLOAD_INVOCATION_PATTERN,
+    _RE_FLAGS,
+)
+_WINDOWS_CMD_PAYLOAD_RES = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in _WINDOWS_CMD_PAYLOAD_PATTERNS
+)
 _WINDOWS_ARGUMENT_TOKEN_RE = re.compile(r'"[^"]*"|\'[^\']*\'|\S+')
 _WINDOWS_DRIVE_VARIABLE_RE = re.compile(
     r'%(?:systemdrive|homedrive)%|!(?:systemdrive|homedrive)!|'
@@ -612,9 +631,58 @@ def _windows_path_is_root_or_unscoped_dynamic(token: str) -> bool:
     return not scoped_components
 
 
-def _windows_recursive_delete_targets_root(command: str) -> bool:
+def _windows_cmd_payload_variants(command: str):
+    """Yield cmd-owned payloads with cmd escapes and separators exposed."""
+    seen: set[str] = set()
+    for payload_re in _WINDOWS_CMD_PAYLOAD_RES:
+        for match in payload_re.finditer(command):
+            payload = match.group("payload").strip()
+            if (
+                len(payload) >= 2
+                and payload[0] == payload[-1]
+                and payload[0] in {"\"", "'"}
+            ):
+                payload = payload[1:-1]
+
+            chars: list[str] = []
+            quote = False
+            index = 0
+            while index < len(payload):
+                char = payload[index]
+                if char == "^" and index + 1 < len(payload):
+                    # cmd removes the caret and treats the next character as
+                    # literal.  In particular, an escaped ampersand is data,
+                    # while ``r^d`` still invokes the ``rd`` built-in.
+                    chars.append(payload[index + 1])
+                    index += 2
+                    continue
+                if char == '"':
+                    quote = not quote
+                    chars.append(char)
+                    index += 1
+                    continue
+                if not quote and char in "&|":
+                    chars.append("\n")
+                    if index + 1 < len(payload) and payload[index + 1] == char:
+                        index += 1
+                elif not quote and char == "(":
+                    chars.extend((char, "\n"))
+                else:
+                    chars.append(char)
+                index += 1
+
+            variant = "".join(chars)
+            if variant and variant not in seen:
+                seen.add(variant)
+                yield variant
+
+
+def _windows_recursive_delete_targets_root(
+    command: str,
+    invocation_re=_WINDOWS_RD_INVOCATION_RE,
+) -> bool:
     """Parse cmd-owned rd arguments and classify root-equivalent targets."""
-    for match in _WINDOWS_RD_INVOCATION_RE.finditer(command):
+    for match in invocation_re.finditer(command):
         tokens = _WINDOWS_ARGUMENT_TOKEN_RE.findall(match.group("arguments"))
         normalized_tokens = [token.strip("\"'").lower() for token in tokens]
         if "/s" not in normalized_tokens:
@@ -681,6 +749,15 @@ def detect_hardline_command(command: str) -> tuple:
         or _windows_recursive_delete_targets_root(windows_command)
     ):
         return (True, "recursive delete of Windows filesystem root")
+    for payload in _windows_cmd_payload_variants(windows_command):
+        if (
+            _WINDOWS_RD_PAYLOAD_RE.search(payload)
+            or _windows_recursive_delete_targets_root(
+                payload,
+                _WINDOWS_RD_PAYLOAD_INVOCATION_RE,
+            )
+        ):
+            return (True, "recursive delete of Windows filesystem root")
     normalized = _normalize_command_for_detection(command)
     _, malformed_grep = _grep_safe_detection_variant(normalized)
     if malformed_grep:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -14,6 +14,7 @@ import fnmatch
 import functools
 import hashlib
 import logging
+import ntpath
 import os
 import re
 import shlex
@@ -435,15 +436,30 @@ _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
 # bypass just like ``rm -rf /``.  ``cmd`` accepts its own switches before
 # ``/c`` or ``/k``; those switches must be consumed by the cmd-owned prefix
 # rather than mistaken for the nested command payload.
-_WINDOWS_CMD_INVOKE = (
-    r'cmd(?:\.exe)?'
-    r'(?:\s+/(?:d|q|a|u|s|e:(?:on|off)|f:(?:on|off)|v:(?:on|off)))*'
-    r'\s+/(?:c|k)\s+'
+_WINDOWS_CMD_EXECUTABLE = (
+    r'["\']?'
+    r'(?:(?:[a-z]:)?[\\/]+)?(?:[^\s\\/"\']+[\\/])*'
+    r'cmd(?:\.exe)?["\']?'
 )
-_WINDOWS_CMD_PREFIX = _CMDPOS + _WINDOWS_CMD_INVOKE
+_WINDOWS_COMMAND_WRAPPERS = (
+    r'(?:(?:command(?:\s+--)?|builtin\s+command(?:\s+--)?)\s+)*'
+)
+_WINDOWS_CMD_INVOKE = (
+    _WINDOWS_CMD_EXECUTABLE
+    + r'(?:\s+/(?:d|q|a|u|s|e:(?:on|off)|f:(?:on|off)|v:(?:on|off)))*'
+    + r'\s+/(?:c|k)\s+'
+)
+_WINDOWS_CMD_PREFIX = _CMDPOS + _WINDOWS_COMMAND_WRAPPERS + _WINDOWS_CMD_INVOKE
+_WINDOWS_POWERSHELL_OPTION_WITH_ARG = (
+    r'-(?:executionpolicy|inputformat|outputformat|windowstyle|workingdirectory|'
+    r'configurationname|settingsfile|version)\s+\S+'
+)
 _WINDOWS_POWERSHELL_CMD_PREFIX = (
     _CMDPOS
-    + r'(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+'
+    + _WINDOWS_COMMAND_WRAPPERS
+    + r'(?:powershell|pwsh)(?:\.exe)?\b'
+    + r'(?:\s+(?:' + _WINDOWS_POWERSHELL_OPTION_WITH_ARG
+    + r'|-(?!(?:command|c)\b)\S+))*\s+'
     + r'-(?:command|c)\s+["\']?'
     + _WINDOWS_CMD_INVOKE
 )
@@ -487,6 +503,11 @@ _WINDOWS_ROOT_DELETE_PATTERN = (
     + _WINDOWS_RECURSIVE_FLAGS_PREFIX
     + r'[\\/]+["\'][a-z]:[\\/]'
     + r')'
+)
+_WINDOWS_RD_INVOCATION_PATTERN = (
+    r'(?:' + _WINDOWS_CMD_PREFIX + r'|' + _WINDOWS_POWERSHELL_CMD_PREFIX + r')'
+    + _WINDOWS_RD_PREFIX
+    + r'(?P<arguments>[^;\n|&)]*)'
 )
 
 HARDLINE_PATTERNS = [
@@ -541,6 +562,33 @@ HARDLINE_PATTERNS_COMPILED = [
     for pattern, description in HARDLINE_PATTERNS
 ]
 _WINDOWS_ROOT_DELETE_RE = re.compile(_WINDOWS_ROOT_DELETE_PATTERN, _RE_FLAGS)
+_WINDOWS_RD_INVOCATION_RE = re.compile(_WINDOWS_RD_INVOCATION_PATTERN, _RE_FLAGS)
+_WINDOWS_ARGUMENT_TOKEN_RE = re.compile(r'"[^"]*"|\'[^\']*\'|\S+')
+
+
+def _windows_literal_path_is_root(token: str) -> bool:
+    """Return whether a literal cmd path token normalizes to a filesystem root."""
+    token = token.strip().strip("\"'")
+    if not token or any(marker in token for marker in ("%", "$", "`")):
+        return False
+    normalized = ntpath.normpath(token.replace("/", "\\"))
+    drive, tail = ntpath.splitdrive(normalized)
+    return tail == "\\" and (bool(drive) or normalized == "\\")
+
+
+def _windows_recursive_delete_targets_root(command: str) -> bool:
+    """Parse cmd-owned rd arguments and classify literal normalized roots."""
+    for match in _WINDOWS_RD_INVOCATION_RE.finditer(command):
+        tokens = _WINDOWS_ARGUMENT_TOKEN_RE.findall(match.group("arguments"))
+        normalized_tokens = [token.strip("\"'").lower() for token in tokens]
+        if "/s" not in normalized_tokens:
+            continue
+        for token, normalized_token in zip(tokens, normalized_tokens):
+            if normalized_token in {"/s", "/q"}:
+                continue
+            if _windows_literal_path_is_root(token):
+                return True
+    return False
 
 
 # =========================================================================
@@ -592,7 +640,10 @@ def detect_hardline_command(command: str) -> tuple:
     # deobfuscates command words but turns a quoted drive root such as ``C:\``
     # into ``C:`` before the hardline regex can classify its target.
     windows_command = _mark_command_starts(_mask_quoted_newlines(command))
-    if _WINDOWS_ROOT_DELETE_RE.search(windows_command):
+    if (
+        _WINDOWS_ROOT_DELETE_RE.search(windows_command)
+        or _windows_recursive_delete_targets_root(windows_command)
+    ):
         return (True, "recursive delete of Windows filesystem root")
     normalized = _normalize_command_for_detection(command)
     _, malformed_grep = _grep_safe_detection_variant(normalized)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -436,11 +436,14 @@ _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
 # narrow: ``cmd`` must be the -Command payload, so quoted prose stays data.
 _WINDOWS_CMD_PREFIX = _CMDPOS + r'cmd(?:\.exe)?\s+/(?:c|k)\s+'
 _WINDOWS_POWERSHELL_CMD_PREFIX = (
-    r'\b(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+'
+    _CMDPOS
+    + r'(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+'
     r'-(?:command|c)\s+["\']?cmd(?:\.exe)?\s+/(?:c|k)\s+'
 )
-_WINDOWS_RECURSIVE_RD_PREFIX = (
+_WINDOWS_RD_PREFIX = (
     r'\\?["\']?(?:rd|rmdir)\b\s+'
+)
+_WINDOWS_RECURSIVE_FLAGS_PREFIX = (
     r'(?=(?:(?:/[sq])\s+)*/s(?:\s|$))'
     r'(?:(?:/[sq])\s+)+'
 )
@@ -448,15 +451,28 @@ _WINDOWS_ROOT_TARGET = (
     r'(?:["\'](?:[a-z]:)?[\\/]+["\']|'
     r'(?:[a-z]:)?[\\/]+(?=["\']?(?:[\s`;|&)]|$)))'
 )
+_WINDOWS_RECURSIVE_ROOT_ARGUMENTS = (
+    r'(?:'
+    # Flags-first spellings: rd /s /q C:\
+    + _WINDOWS_RECURSIVE_FLAGS_PREFIX + _WINDOWS_ROOT_TARGET
+    # Windows documents the path before /s [/q], and cmd also accepts /q
+    # before the path. Require /s in the post-target flag run so a root operand
+    # without recursive deletion remains outside the hardline floor.
+    + r'|(?:(?:/[sq])\s+)*' + _WINDOWS_ROOT_TARGET + r'\s+'
+    + r'(?=(?:(?:/[sq])\s+)*/s(?:\s|$))'
+    + r'(?:(?:/[sq])(?:\s+|$))+'
+    + r')'
+)
 _WINDOWS_ROOT_DELETE_PATTERN = (
     r'(?:'
     + r'(?:' + _WINDOWS_CMD_PREFIX + r'|' + _WINDOWS_POWERSHELL_CMD_PREFIX + r')'
-    + _WINDOWS_RECURSIVE_RD_PREFIX + _WINDOWS_ROOT_TARGET
+    + _WINDOWS_RD_PREFIX + _WINDOWS_RECURSIVE_ROOT_ARGUMENTS
     # PowerShell does not interpret \" as an escaped quote.  In #82842 this
     # leaves the preceding backslash as a standalone cmd root operand before
     # the intended drive path; direct cmd under Bash does interpret \" and is
     # deliberately excluded from this quote-collapse alternative.
-    + r'|' + _WINDOWS_POWERSHELL_CMD_PREFIX + _WINDOWS_RECURSIVE_RD_PREFIX
+    + r'|' + _WINDOWS_POWERSHELL_CMD_PREFIX + _WINDOWS_RD_PREFIX
+    + _WINDOWS_RECURSIVE_FLAGS_PREFIX
     + r'[\\/]+["\'][a-z]:[\\/]'
     + r')'
 )
@@ -563,7 +579,8 @@ def detect_hardline_command(command: str) -> tuple:
     # normalizer treats backslashes as POSIX shell escapes, which correctly
     # deobfuscates command words but turns a quoted drive root such as ``C:\``
     # into ``C:`` before the hardline regex can classify its target.
-    if _WINDOWS_ROOT_DELETE_RE.search(command):
+    windows_command = _mark_command_starts(_mask_quoted_newlines(command))
+    if _WINDOWS_ROOT_DELETE_RE.search(windows_command):
         return (True, "recursive delete of Windows filesystem root")
     normalized = _normalize_command_for_detection(command)
     _, malformed_grep = _grep_safe_detection_variant(normalized)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -515,9 +515,9 @@ _WINDOWS_RD_PAYLOAD_PATTERN = (
 _WINDOWS_RD_PAYLOAD_INVOCATION_PATTERN = (
     _CMDPOS + _WINDOWS_RD_PREFIX + r'(?P<arguments>[^;\n|&)]*)'
 )
-_WINDOWS_CMD_PAYLOAD_PATTERNS = (
-    _WINDOWS_CMD_PREFIX + r'(?P<payload>[^\n]*)',
-    _WINDOWS_POWERSHELL_CMD_PREFIX + r'(?P<payload>[^\n]*)',
+_WINDOWS_CMD_PAYLOAD_SPECS = (
+    (_WINDOWS_CMD_PREFIX + r'(?P<payload>[^\n]*)', False),
+    (_WINDOWS_POWERSHELL_CMD_PREFIX + r'(?P<payload>[^\n]*)', True),
 )
 
 HARDLINE_PATTERNS = [
@@ -579,8 +579,8 @@ _WINDOWS_RD_PAYLOAD_INVOCATION_RE = re.compile(
     _RE_FLAGS,
 )
 _WINDOWS_CMD_PAYLOAD_RES = tuple(
-    re.compile(pattern, re.IGNORECASE)
-    for pattern in _WINDOWS_CMD_PAYLOAD_PATTERNS
+    (re.compile(pattern, re.IGNORECASE), strips_outer_quote)
+    for pattern, strips_outer_quote in _WINDOWS_CMD_PAYLOAD_SPECS
 )
 _WINDOWS_ARGUMENT_TOKEN_RE = re.compile(r'"[^"]*"|\'[^\']*\'|\S+')
 _WINDOWS_DRIVE_VARIABLE_RE = re.compile(
@@ -634,9 +634,14 @@ def _windows_path_is_root_or_unscoped_dynamic(token: str) -> bool:
 def _windows_cmd_payload_variants(command: str):
     """Yield cmd-owned payloads with cmd escapes and separators exposed."""
     seen: set[str] = set()
-    for payload_re in _WINDOWS_CMD_PAYLOAD_RES:
+    for payload_re, strips_outer_quote in _WINDOWS_CMD_PAYLOAD_RES:
         for match in payload_re.finditer(command):
             payload = match.group("payload").strip()
+            # The PowerShell prefix consumes the opening quote that owns its
+            # command string. Remove the corresponding trailing quote before
+            # checking whether cmd itself wrapped the whole /c payload.
+            if strips_outer_quote and payload.endswith(("\"", "'")):
+                payload = payload[:-1].rstrip()
             if (
                 len(payload) >= 2
                 and payload[0] == payload[-1]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -431,7 +431,38 @@ _HARDLINE_SYSTEM_DIRS = (
 # catching `rm -rf "/"`.
 _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
 
+# Windows ``rd`` / ``rmdir`` root deletion must stay below every approval
+# bypass just like ``rm -rf /``.  The PowerShell prefix is intentionally
+# narrow: ``cmd`` must be the -Command payload, so quoted prose stays data.
+_WINDOWS_CMD_PREFIX = _CMDPOS + r'cmd(?:\.exe)?\s+/(?:c|k)\s+'
+_WINDOWS_POWERSHELL_CMD_PREFIX = (
+    r'\b(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+'
+    r'-(?:command|c)\s+["\']?cmd(?:\.exe)?\s+/(?:c|k)\s+'
+)
+_WINDOWS_RECURSIVE_RD_PREFIX = (
+    r'\\?["\']?(?:rd|rmdir)\b\s+'
+    r'(?=(?:(?:/[sq])\s+)*/s(?:\s|$))'
+    r'(?:(?:/[sq])\s+)+'
+)
+_WINDOWS_ROOT_TARGET = (
+    r'(?:["\'](?:[a-z]:)?[\\/]+["\']|'
+    r'(?:[a-z]:)?[\\/]+(?=["\']?(?:[\s`;|&)]|$)))'
+)
+_WINDOWS_ROOT_DELETE_PATTERN = (
+    r'(?:'
+    + r'(?:' + _WINDOWS_CMD_PREFIX + r'|' + _WINDOWS_POWERSHELL_CMD_PREFIX + r')'
+    + _WINDOWS_RECURSIVE_RD_PREFIX + _WINDOWS_ROOT_TARGET
+    # PowerShell does not interpret \" as an escaped quote.  In #82842 this
+    # leaves the preceding backslash as a standalone cmd root operand before
+    # the intended drive path; direct cmd under Bash does interpret \" and is
+    # deliberately excluded from this quote-collapse alternative.
+    + r'|' + _WINDOWS_POWERSHELL_CMD_PREFIX + _WINDOWS_RECURSIVE_RD_PREFIX
+    + r'[\\/]+["\'][a-z]:[\\/]'
+    + r')'
+)
+
 HARDLINE_PATTERNS = [
+    (_WINDOWS_ROOT_DELETE_PATTERN, "recursive delete of Windows filesystem root"),
     # rm recursive targeting the root filesystem or protected roots.
     # `${HOME}` brace form and quoted paths (`rm -rf "/"`, `rm -rf "$HOME"`)
     # are handled via _hardline_rm_path so the floor cannot be bypassed with
@@ -481,6 +512,7 @@ HARDLINE_PATTERNS_COMPILED = [
     (re.compile(pattern, _RE_FLAGS), description)
     for pattern, description in HARDLINE_PATTERNS
 ]
+_WINDOWS_ROOT_DELETE_RE = re.compile(_WINDOWS_ROOT_DELETE_PATTERN, _RE_FLAGS)
 
 
 # =========================================================================
@@ -527,6 +559,12 @@ def detect_hardline_command(command: str) -> tuple:
     """
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION)
+    # Preserve raw Windows separators for this check.  The general detection
+    # normalizer treats backslashes as POSIX shell escapes, which correctly
+    # deobfuscates command words but turns a quoted drive root such as ``C:\``
+    # into ``C:`` before the hardline regex can classify its target.
+    if _WINDOWS_ROOT_DELETE_RE.search(command):
+        return (True, "recursive delete of Windows filesystem root")
     normalized = _normalize_command_for_detection(command)
     _, malformed_grep = _grep_safe_detection_variant(normalized)
     if malformed_grep:


### PR DESCRIPTION
## What does this PR do?

This prevents a malformed, recursively deleting Windows `cmd` command from turning a scoped folder deletion into a drive-root wipe. Recursive `rd` and `rmdir` targets that resolve to a Windows filesystem root are now rejected by the non-bypassable hardline guard before manual, smart, mode-off, or yolo approval can authorize them.

### Symptom

A user approved deletion of one copied and verified folder, but nested Bash -> PowerShell -> cmd quoting produced a standalone `\` operand. `rd /s /q \` then traversed the current drive root instead of the approved folder.

### Impact

The reported command attempted to recursively delete the system drive and produced 55,650 access-denied entries. No files were lost because the process was not elevated, but an elevated process could delete unprotected data outside the approved scope.

### Bug Cause

**Trigger:** `tools/approval.py:745-783` / `detect_hardline_command()`

**Causal chain:**
1. Nested shell quoting turns the intended folder operand into a standalone Windows root operand followed by the intended path.
2. The hardline guard recognizes recursive GNU `rm` root deletion but did not classify Windows `cmd` `rd` or `rmdir` root targets.
3. The command remains eligible for approval, and cmd resolves the root operand against the current drive before recursively deleting it.

**Why it is wrong:** Approval for a scoped destructive action must never authorize a command whose effective recursive-delete target is a filesystem root.

**Working sibling / contrast:** `rm -rf /` is already rejected by the same hardline floor regardless of approval mode.

**Ruled out:** Transport byte corruption is not required. The reporter's exact submitted string reproduces the standalone root operand with a non-destructive `echo` substitution.

### Fix

The hardline detector now parses cmd-owned `rd` and `rmdir` payloads while preserving Windows separators, quote ownership, cmd escapes, and nested command boundaries. It normalizes literal paths, blocks root-equivalent paths and unscoped dynamic targets such as drive variables, and allows demonstrably scoped directory targets. The same classification runs through both public approval guards, so yolo and other approval bypasses cannot override it.

## Related Issue

Closes #82842

## Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made

- `tools/approval.py` - detect recursive Windows root deletion across direct, nested, normalized, escaped, and dynamic cmd targets before approval policy is evaluated.
- `tests/tools/test_hardline_blocklist.py` - cover direct and nested root targets, dynamic variables, cmd payload parsing, scoped controls, and public-guard bypass attempts.

## How to Test

1. Use the issue's `echo` substitution to reproduce the standalone root operand without executing a delete command.
2. Call `detect_hardline_command()` with direct drive roots, normalized roots, nested PowerShell -> cmd payloads, and dynamic drive variables; confirm they are blocked while scoped controls remain approval-gated.
3. Run the focused CI-parity test module:

```bash
scripts/run_tests.sh tests/tools/test_hardline_blocklist.py -p no:cacheprovider
```

The final committed tip passed all 263 focused tests. Native Windows verification also passed 16 blocked cases, 11 safe controls, and 32 assertions across both public approval guards without executing a deletion subprocess.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the repository's focused CI-parity test entry and all 263 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: native Windows

### Documentation & Housekeeping

- [x] Documentation update is N/A; this changes an internal safety boundary without adding user-facing configuration
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; existing Unix hardline behavior remains covered
- [x] Tool description/schema update is N/A; no tool schema changed
