### PR TITLE
fix(mcp): make deferred tools callable from hyphenated servers

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -226,6 +226,23 @@ class TestAssembly:
 
 
 class TestBridgeDispatch:
+    @staticmethod
+    def _register(name, toolset="mcp-issue82876-graph"):
+        from tools.registry import registry
+
+        tool_def = _td(
+            name,
+            "Read a note from the connected graph.",
+            {"path": {"type": "string"}},
+        )
+        registry.register(
+            name=name,
+            handler=lambda args, **kwargs: json.dumps({"path": args.get("path")}),
+            schema=tool_def,
+            toolset=toolset,
+        )
+        return tool_def
+
     def test_tool_search_requires_query(self):
         from tools.tool_search import dispatch_tool_search
         result = dispatch_tool_search({}, current_tool_defs=[])
@@ -278,6 +295,51 @@ class TestBridgeDispatch:
         assert err is not None
         assert "bridge tool" in err.lower()
 
+    def test_hyphenated_mcp_name_resolves_for_describe_and_call(self):
+        from tools.tool_search import dispatch_tool_describe, resolve_underlying_call
+
+        canonical = "mcp__issue82876_graph__vault_read"
+        raw = "mcp__issue82876-graph__vault-read"
+        tool_def = self._register(canonical)
+
+        described = json.loads(dispatch_tool_describe(
+            {"name": raw},
+            current_tool_defs=[tool_def],
+        ))
+        assert described["name"] == canonical
+        assert described["parameters"] == tool_def["function"]["parameters"]
+
+        resolved, call_args, err = resolve_underlying_call({
+            "name": raw,
+            "arguments": {"path": "notes/demo.md"},
+        })
+        assert err is None
+        assert resolved == canonical
+        assert call_args == {"path": "notes/demo.md"}
+
+    def test_mcp_name_normalization_preserves_exact_entry_precedence(self):
+        from tools.tool_search import resolve_underlying_call
+
+        raw = "mcp__issue82876-precedence__vault_read"
+        canonical = "mcp__issue82876_precedence__vault_read"
+        self._register(raw, toolset="mcp-issue82876-raw")
+        self._register(canonical, toolset="mcp-issue82876-canonical")
+
+        resolved, _, err = resolve_underlying_call({"name": raw, "arguments": {}})
+        assert err is None
+        assert resolved == raw
+
+    def test_unregistered_hyphenated_mcp_name_remains_unresolved(self):
+        from tools.tool_search import resolve_underlying_call
+
+        resolved, _, err = resolve_underlying_call({
+            "name": "mcp__issue82876-missing__vault-read",
+            "arguments": {},
+        })
+        assert resolved is None
+        assert err is not None
+        assert "not a deferrable tool" in err
+
 
 # ---------------------------------------------------------------------------
 # End-to-end via the real handle_function_call (smoke test).
@@ -285,6 +347,29 @@ class TestBridgeDispatch:
 
 
 class TestHandleFunctionCallIntegration:
+    def test_hyphenated_mcp_tool_call_dispatches_canonical_entry(self):
+        import model_tools
+        from tools.registry import registry
+
+        canonical = "mcp__issue82876_integration__vault_read"
+        registry.register(
+            name=canonical,
+            handler=lambda args, **kwargs: json.dumps({"path": args["path"]}),
+            schema=_td(canonical, "Read a graph note.", {"path": {"type": "string"}}),
+            toolset="mcp-issue82876-integration",
+        )
+
+        result = model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={
+                "name": "mcp__issue82876-integration__vault-read",
+                "arguments": {"path": "notes/demo.md"},
+            },
+            enabled_toolsets=["mcp-issue82876-integration"],
+        )
+
+        assert json.loads(result) == {"path": "notes/demo.md"}
+
     def test_tool_search_dispatch_through_handle_function_call(self):
         """The dispatcher recognizes the bridge tool by name."""
         import model_tools

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -227,6 +227,36 @@ def is_deferrable_tool_name(name: str) -> bool:
         return False
 
 
+def _resolve_deferrable_tool_name(name: str) -> Optional[str]:
+    """Resolve a bridge-supplied name to its registered deferrable name.
+
+    MCP registration normalizes each server/tool component for provider-safe
+    wire names. Models can nevertheless reconstruct a name from the raw MCP
+    server or tool name, so retry unresolved ``mcp__`` names with that same
+    normalization. Exact registry entries always win, and a normalized alias
+    is accepted only when it resolves to a real MCP-owned entry.
+    """
+    try:
+        from tools.registry import registry
+
+        if registry.get_entry(name) is not None:
+            return name if is_deferrable_tool_name(name) else None
+        if not name.startswith("mcp__"):
+            return None
+
+        from tools.mcp_tool import MCP_TOOL_NAME_PREFIX, sanitize_mcp_name_component
+
+        normalized = MCP_TOOL_NAME_PREFIX + sanitize_mcp_name_component(
+            name[len(MCP_TOOL_NAME_PREFIX):]
+        )
+        entry = registry.get_entry(normalized)
+        if entry is None or not entry.toolset.startswith("mcp-"):
+            return None
+        return normalized if is_deferrable_tool_name(normalized) else None
+    except Exception:
+        return None
+
+
 def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable).
 
@@ -924,7 +954,8 @@ def dispatch_tool_describe(args: Dict[str, Any],
     name = str(args.get("name") or "").strip()
     if not name:
         return tool_error("name is required")
-    if not is_deferrable_tool_name(name):
+    resolved_name = _resolve_deferrable_tool_name(name)
+    if resolved_name is None:
         return tool_error(
             f"'{name}' is not a deferrable tool. If you see it in the tools list "
             "already, call it directly; otherwise check the spelling against tool_search."
@@ -932,9 +963,9 @@ def dispatch_tool_describe(args: Dict[str, Any],
     _, deferrable = classify_tools(current_tool_defs)
     for td in deferrable:
         fn = td.get("function") or {}
-        if fn.get("name") == name:
+        if fn.get("name") == resolved_name:
             return json.dumps({
-                "name": name,
+                "name": resolved_name,
                 "description": fn.get("description", ""),
                 "parameters": fn.get("parameters", {}),
             }, ensure_ascii=False)
@@ -1041,12 +1072,13 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
             return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
-    if not is_deferrable_tool_name(name):
+    resolved_name = _resolve_deferrable_tool_name(name)
+    if resolved_name is None:
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."
         )
-    return name, raw_args, None
+    return resolved_name, raw_args, None
 
 
 __all__ = [


### PR DESCRIPTION
## What does this PR do?

MCP tools from servers or tool names containing hyphens can now be described and called through deferred tool discovery. Before this fix, the server connected and its canonical tool was registered, but a model reconstruction using the configured hyphenated name was rejected as "not a deferrable tool", leaving the capability unusable through `tool_describe` and `tool_call`.

### Symptom

A connected server such as `obsidian-graph` registers `mcp__obsidian_graph__vault_read`, while a bridge request using `mcp__obsidian-graph__vault_read` fails with `not a deferrable tool`.

### Impact

Users with hyphens or other normalized characters in MCP server or tool names can discover the server but cannot reliably inspect or invoke its deferred tools. The affected blast radius beyond these names is unknown.

### Bug Cause

**Trigger:** `tools/tool_search.py` in `dispatch_tool_describe` and `resolve_underlying_call` performs an exact registry lookup on a bridge-supplied MCP name.

**Causal chain:**
1. MCP registration normalizes provider-unsafe characters in server and tool name components.
2. A model reconstructs the MCP wire name from the raw configured name and supplies hyphens to `tool_describe` or `tool_call`.
3. Exact registry classification cannot find that raw name and rejects the connected tool as not deferrable.

**Why it is wrong:** Bridge lookup used a different name representation from MCP registration, so equivalent user-facing names did not resolve to the registered wire name.

**Working sibling / contrast:** The canonical name returned by `tool_search` already succeeds because it exactly matches the registry entry. Exact registered names must therefore keep precedence.

**Ruled out:** MCP connectivity and dispatch are not the cause. A live credential-free stdio server registered the canonical tool, and canonical describe and call both succeeded before the fix.

### Fix

Retry only unresolved `mcp__` bridge names with the same safe-character normalization used during MCP registration. Accept the normalized result only when it maps to an existing MCP-owned registry entry, preserve exact-entry precedence, and keep unresolved names and session-scoped catalog checks fail closed. Regression coverage exercises describe, call resolution, end-to-end dispatch, exact-name precedence, and unresolved misses.

## Related Issue

Fixes #82876

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tool_search.py` - resolve raw MCP bridge names to existing canonical deferred entries before describe or call dispatch.
- `tests/tools/test_tool_search.py` - cover both bridge boundaries, integrated dispatch, exact-entry precedence, and unresolved names.

## How to Test

1. Connect a credential-free MCP server named `obsidian-graph` that exposes `vault-read`.
2. Describe and call `mcp__obsidian-graph__vault-read` through the deferred-tool bridges and confirm resolution to `mcp__obsidian_graph__vault_read`.
3. Run the targeted automated suite:

```bash
scripts/run_tests.sh tests/tools/test_tool_search.py
```

The targeted suite passed 34 tests. Independent live stdio verification passed all 8 checks for raw-name resolution, canonical dispatch, exact precedence, unresolved misses, and session-scoped gating.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because behavior and configuration interfaces are unchanged
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because architecture and workflows are unchanged
- [x] I've considered cross-platform impact; lookup normalization is platform independent and live verification ran on Windows 10
- [x] Tool description/schema updates are N/A because the bridge schemas are unchanged

## Screenshots / Logs

N/A - the failure and fix are covered by automated tests and live stdio MCP verification.
