### PR TITLE
docs(desktop-sdk): document shared model catalog

### DIFF
--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -450,6 +450,57 @@ formatters `relativeTime` / `fmtDateTime` / `fmtDayTime` / `coarseElapsed`,
 `useI18n` (localized copy — your plugin stays translatable), and
 `evaluateRuntimeReadiness`.
 
+### Shared model picker (`ModelCatalogMenu`)
+
+Use `ModelCatalogMenu` when a plugin needs to choose a Hermes model. It is the
+same searchable, provider-grouped picker used by the chat composer, including
+collapsed `-fast` model families, keyboard selection, and per-model
+thinking/effort/fast controls. The menu owns presentation and navigation; a
+`ModelMenuController` decides what a selection means for your surface.
+
+```javascript
+import {
+  ModelCatalogMenu,
+  ModelMenuCloseContext
+} from '@hermes/plugin-sdk'
+
+const controller = {
+  current: { provider, model, effort, fast },
+  presetFor: () => ({}),
+  select: (nextModel, nextProvider) => {
+    setProvider(nextProvider)
+    setModel(nextModel)
+  },
+  applyPreset: (preset, row) => {
+    setProvider(row.provider)
+    setModel(row.model)
+    setEffort(preset.effort ?? '')
+    setFast(preset.fast ?? false)
+  },
+  setOptions: (patch, row) => {
+    if (row.isActive) {
+      if (patch.effort !== undefined) setEffort(patch.effort)
+      if (patch.fast !== undefined) setFast(patch.fast)
+    }
+  }
+}
+
+jsx(ModelMenuCloseContext.Provider, {
+  value: closeMenu,
+  children: jsx(ModelCatalogMenu, { controller })
+})
+```
+
+`current` is a `ModelChoice` (`provider`, `model`, `effort`, `fast`). `select`
+commits a model row and may return `false` to abort a failed switch.
+`presetFor` supplies remembered settings for a row, `applyPreset` applies that
+preset after selection, and `setOptions` handles a single effort/fast edit.
+
+A surface bound to a live session should pass that `sessionId` to
+`ModelCatalogMenu`, because a session's model catalog can differ from the
+profile-global catalog. Detached surfaces such as per-task overrides omit it.
+The bundled Kanban model override is an in-tree example of that detached pattern.
+
 **Style with theme variables, never hardcoded colors.** Panes already sit on the
 app's editor background — leave the background alone and use vars for everything
 else: `var(--ui-text-secondary)`, `var(--ui-text-tertiary)`,
@@ -618,6 +669,7 @@ not treat this pipeline as a trust boundary.
 | Plugin contract | `HermesPlugin`, `PluginContext`, `PluginContribution`, `PluginStorage`, `PluginOs`, `PluginRestOptions`, `PluginNativeNotificationInput`, `Contribution` |
 | Area constants | `PANES_AREA`, `ROUTES_AREA`, `SIDEBAR_NAV_AREA`, `STATUSBAR_AREAS`, `TITLEBAR_AREAS`, `PALETTE_AREA`, `KEYBINDS_AREA`, `THEMES_AREA`, `COMPOSER_AREAS` |
 | Area payloads | `RouteContribution`, `SidebarNavContribution`, `StatusbarItem`, `TitlebarTool`, `PaletteContribution`, `KeybindContribution`, `ComposerMiddleware`, `ComposerAttachmentProvider` |
+| Model picker | `ModelCatalogMenu`, `ModelChoice`, `ModelMenuCloseContext`, `ModelMenuController` |
 | React / state | `useValue`, `atom`, `computed`, `useQuery`, `useMutation`, `useQueryClient`, `queryClient`, `Contribute` |
 | UI kit | `Button`, `Input`, `Textarea`, `Select*`, `Switch`, `Checkbox`, `SegmentedControl`, `Tabs*`, `Dialog*`, `ConfirmDialog`, `DropdownMenu*`, `ContextMenu*`, `Popover*`, `Tip`/`Tooltip*`, `Badge`, `Kbd`/`KbdGroup`, `SearchField`, `ScrollArea`, `Separator`, `Skeleton`, `GlyphSpinner`, `Loader`, `EmptyState`, `ErrorState`, `CopyButton`, `StatusDot`, `LogView`, `Codicon`, `DecodeText` |
 | Helpers | `cn`, `icons`, `haptic`, `useI18n`, `profileColor`, `profileColorSoft`, `relativeTime`, `fmtDateTime`, `fmtDayTime`, `coarseElapsed`, `evaluateRuntimeReadiness` |


### PR DESCRIPTION
## Summary

Document the existing `ModelCatalogMenu` surface exported by `@hermes/plugin-sdk`.

The Desktop SDK already exposes the same searchable model picker used by the chat composer, together with `ModelChoice`, `ModelMenuController`, and `ModelMenuCloseContext`. Kanban already consumes that shared component for detached per-task model overrides. This PR makes that supported seam discoverable to plugin authors.

## What changed

- document what `ModelCatalogMenu` owns versus what `ModelMenuController` owns
- describe the `current`, `select`, `presetFor`, `applyPreset`, and `setOptions` controller contract
- document the `select(...)=false` abort behavior
- document why live-session consumers should pass `sessionId`, while detached consumers omit it
- point to the bundled Kanban model override as an in-tree consumer
- add the model-picker exports to the SDK reference table

## Verification

- Based on upstream `main` at `2afa4be9326ea9d655768ba78bfbbeb43c414dc1`
- Verified the controller and prop contracts directly in `model-catalog-menu.tsx`
- Verified all four public exports in `apps/desktop/src/sdk/index.ts`
- Verified real detached usage in `apps/desktop/src/plugins/kanban/model-override.tsx`
- Searched open PRs; active picker PRs change behavior but do not document this SDK surface
- One documentation file changed; no runtime, config, or dependency changes
