### PR TITLE
docs(desktop): document HUD mode

### DIFF
--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -123,6 +123,12 @@ The **Memory Graph** (command palette → *Memory Graph*, or the status-bar item
 
 Quick Entry is a small always-available composer summoned by a **global hotkey from anywhere on your system** — fire off a prompt without switching to (or even opening) the main window. Enable it in **Settings → Advanced → Quick Entry**; the default shortcut is **Ctrl/Cmd+Shift+Space** and you can set your own (it needs at least one modifier). If another app already owns the chord, the settings row tells you so you can pick a different one.
 
+### HUD mode
+
+HUD mode turns the current chat into a transparent, frameless, always-on-top floating window so you can keep using Hermes while working in another app. Open or close it with the HUD button in the Desktop title bar or **Cmd/Ctrl+Shift+H**.
+
+The HUD uses the real Hermes composer rather than a separate quick-entry client. Attachments, slash commands, the prompt queue, voice controls, and the model picker stay available, while the transcript appears as a compact floating reply band around the composer.
+
 ### Voice
 
 Talk to Hermes and hear it back, the same [voice mode](./features/voice-mode.md) available elsewhere. On macOS the OS will prompt once for microphone access.


### PR DESCRIPTION
## Summary

Document the shipped Hermes Desktop HUD mode in the Desktop user guide.

HUD is already implemented on `main` as a transparent, frameless, always-on-top chat window that uses the real Hermes composer. This PR adds the missing user-facing explanation without changing behavior.

## What changed

- add a short HUD mode section next to Quick Entry and Voice
- document the titlebar entry point and the default `Cmd/Ctrl+Shift+H` toggle
- clarify that HUD uses the real composer, so attachments, slash commands, queue controls, voice, and the model picker remain available

## Verification

- Based on upstream `main` at `2afa4be9326ea9d655768ba78bfbbeb43c414dc1`
- Verified the transparent / frameless / always-on-top HUD contract in `apps/desktop/src/store/hud.ts`
- Verified the `view.toggleHud` default binding is `mod+shift+h`
- Verified the titlebar HUD control dispatches the same toggle action
- Inspected open docs-remediation PR #74010's exact `desktop.md` patch; it does not document HUD mode
- Inspected open HUD PRs; they change HUD behavior/fixes rather than adding user documentation
- One documentation file changed, +6 lines; no runtime, config, or dependency changes
