### PR TITLE
fix(skills): reject colon in bundle path components (NTFS ADS bypass)

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -880,6 +880,63 @@ class TestQuarantineBundleBinaryAssets:
 
         assert not absolute_target.exists()
 
+    def test_quarantine_bundle_rejects_ads_colon_file_paths(self, tmp_path):
+        """F-02: a bundle member with a colon in a component (``file.py:payload``)
+        is an NTFS Alternate Data Stream marker — the visible file passes
+        ``rglob``-based review while hidden, scanner-invisible bytes are written
+        into it. Reject it before it reaches disk, on any OS."""
+        import tools.skills_hub as hub
+
+        hub_dir = tmp_path / "skills" / ".hub"
+        with patch.object(hub, "SKILLS_DIR", tmp_path / "skills"), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            bundle = SkillBundle(
+                name="demo",
+                files={
+                    "SKILL.md": "---\nname: demo\n---\n",
+                    "scripts/helper.py:payload": "print(24680)",
+                },
+                source="well-known",
+                identifier="well-known:https://example.com/.well-known/skills/demo",
+                trust_level="community",
+            )
+
+            with pytest.raises(ValueError, match="Unsafe bundle file path"):
+                quarantine_bundle(bundle)
+
+        assert not (tmp_path / "skills" / "scripts").exists()
+
+    def test_normalize_bundle_path_rejects_colon_anywhere(self):
+        """The colon guard covers the whole class, not just ``helper.py:payload``:
+        a colon in any component (leading drive letter, mid-path, or bare) is
+        rejected, while ordinary portable paths still normalize."""
+        from tools.skills_hub import _normalize_bundle_path
+
+        rejected = (
+            "scripts/helper.py:payload",   # trailing-component ADS marker
+            "scripts/a:b.py",              # mid-component colon
+            "a:b/scripts/helper.py",       # leading-component colon
+            "scripts/helper.py:",          # empty stream name
+            "C:",                          # bare Windows drive letter
+            "C:/Windows/System32",         # drive-qualified absolute-ish path
+        )
+        for bad in rejected:
+            with pytest.raises(ValueError, match="Unsafe bundle file path"):
+                _normalize_bundle_path(bad, field_name="bundle file path", allow_nested=True)
+
+        # Legitimate portable paths are unaffected.
+        assert _normalize_bundle_path(
+            "scripts/helper.py", field_name="bundle file path", allow_nested=True
+        ) == "scripts/helper.py"
+        assert _normalize_bundle_path(
+            "assets/data/sample.wav", field_name="bundle file path", allow_nested=True
+        ) == "assets/data/sample.wav"
+
 
 # ---------------------------------------------------------------------------
 # GitHubSource._download_directory — tree API + fallback (#2940)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -209,7 +209,13 @@ def _normalize_bundle_path(path_value: str, *, field_name: str, allow_nested: bo
         raise ValueError(f"Unsafe {field_name}: {path_value}")
     if not parts or any(part == ".." for part in parts):
         raise ValueError(f"Unsafe {field_name}: {path_value}")
-    if re.fullmatch(r"[A-Za-z]:", parts[0]):
+    # Reject a colon in any component. On Windows a colon marks either a drive
+    # (``C:`` / ``C:foo``) or an NTFS Alternate Data Stream: a bundle member
+    # named ``file.py:payload`` writes hidden, scanner-invisible bytes into the
+    # visible ``file.py`` (rglob-based review never enumerates the stream).
+    # ``/`` is the only legal separator once normalized, so no portable bundle
+    # path needs a colon in a component.
+    if any(":" in part for part in parts):
         raise ValueError(f"Unsafe {field_name}: {path_value}")
     if not allow_nested and len(parts) != 1:
         raise ValueError(f"Unsafe {field_name}: {path_value}")


### PR DESCRIPTION
## What breaks today

When a skill bundle is installed, `_normalize_bundle_path` in `tools/skills_hub.py` validates every bundle-controlled file path before it touches disk. It already rejects absolute paths, `..` traversal, and a bare drive-letter component — but it permitted a **colon inside a path component**.

On NTFS (Windows), a bundle member named `scripts/helper.py:payload` does not create a file called `helper.py:payload`. The colon is the NTFS **Alternate Data Stream** separator, so those bytes are written as a *hidden stream* attached to the visible file `scripts/helper.py`.

The blind spot: the skill scanner walks the installed tree with `Path.rglob('*')`, which does **not** enumerate alternate data streams. So a bundle can ship executable bytes that:

- a human operator reviewing the visible files never sees, and
- the built-in Skills Guard scanner never sees,

yet which are present on disk and executable. This is a security-boundary bypass, not a cosmetic path-cleanliness issue.

### Who this affects / when
Anyone installing a community or well-known skill bundle on Windows. Both the ZIP-member extraction path and the well-known-skill file path run through this same validator (`_validate_bundle_rel_path`), so both are exposed.

## Reproduction (validator level, OS-independent)

Before this change, the real function accepts the ADS marker verbatim:

```
'scripts/helper.py:payload' -> 'scripts/helper.py:payload'   # accepted (BUG)
'C:/x'                      -> REJECTED
'../x'                      -> REJECTED
```

## The fix

Reject a colon in **any** component — the whole bug class, not just the trailing one:

```python
# Reject a colon in any component. On Windows a colon marks either a drive
# (``C:`` / ``C:foo``) or an NTFS Alternate Data Stream: a bundle member
# named ``file.py:payload`` writes hidden, scanner-invisible bytes into the
# visible ``file.py`` (rglob-based review never enumerates the stream).
# ``/`` is the only legal separator once normalized, so no portable bundle
# path needs a colon in a component.
if any(":" in part for part in parts):
    raise ValueError(f"Unsafe {field_name}: {path_value}")
```

`/` is the only legal separator once the path is normalized, so no portable bundle path ever needs a colon in a component — this is a safe, non-breaking tightening.

This single guard **subsumes** the previous bare drive-letter check (`re.fullmatch(r"[A-Za-z]:", parts[0])`): any `C:`-style component contains a colon and is now caught by the broader rule. The old two-line check was left strictly dead by the new one (same function, same `parts`, same raise — not independent defense-in-depth), so it is folded into the single colon guard rather than left as dead code. The drive-letter intent is preserved in the comment and pinned by the tests.

## Why not fullwidth / unicode colons?
Windows treats **only** the ASCII colon `:` as the ADS stream separator (the illegal-in-streamname set is `\ / :`, and the stream syntax is `filename:streamname`). A fullwidth colon `U+FF1A` is a legal ordinary filename character, not a stream marker — so leaving it alone is correct, not a gap.

## Tests

Two regression tests, both OS-independent (they assert on the validator/quarantine behavior, not on actually creating an NTFS stream, so they run in CI on Linux):

- `test_quarantine_bundle_rejects_ads_colon_file_paths` — E2E: builds a `SkillBundle` whose member is `scripts/helper.py:payload`, asserts `quarantine_bundle` raises `ValueError` and that no `scripts/` dir is written. Mirrors the existing `rejects_traversal` / `rejects_absolute` sibling tests, proving the guard is wired into the disk-writing path.
- `test_normalize_bundle_path_rejects_colon_anywhere` — direct unit test over leading / mid / trailing-component colons, empty stream name, and bare/qualified drive letters (`C:`, `C:/Windows/System32`); confirms legitimate paths (`scripts/helper.py`, `assets/data/sample.wav`) still normalize unchanged.

Verified: `tests/tools/test_skills_hub.py` + `tests/hermes_cli/test_skills_hub.py` all pass; ruff clean. Negative control confirmed: with the colon guard physically removed, both new tests fail (`DID NOT RAISE`); restored, all pass.

## Duplicate check
No existing issue or PR addresses this. The validator was introduced in #3986; no follow-up touches the colon gap.

## Credit
Reported by [@JoaoMarcos44](https://github.com/JoaoMarcos44), who identified the NTFS Alternate Data Stream bypass in skill-bundle path validation and disclosed it responsibly. Thank you! 🙏
