### PR TITLE
docs(desktop): document session sidebar controls

### DIFF
--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -97,6 +97,17 @@ Each session is tagged with its source platform:
 | `cron` | Scheduled cron jobs |
 | `batch` | Batch processing runs |
 
+## Desktop Session Sidebar
+
+Hermes Desktop's **Sessions** header has a **Filters** menu for shaping large session lists without deleting or changing the sessions themselves. The choices are remembered on that Desktop installation.
+
+- **Grouping** — Updated (the normal date buckets), Project, or Status.
+- **Ordering** — Updated, Created, Status, Tokens, or Cost. Drag session rows to establish a manual order; **Manual** then appears as the active ordering until you choose another sort.
+- **Show** — optionally pin Updated, Tokens, Cost, PR, and Profile metadata onto each row. Cost is shown when recorded session spend is at least $0.01; PR metadata is shown when Hermes has resolved the session's branch to a pull request.
+- **Filters** — narrow by session status (Needs input, Working, Unread, Draft, Idle), project, pull-request state (Open, Draft, Merged, Closed, No PR), or archived sessions. **Reset to defaults** clears the customized view.
+
+Pull-request lookups follow the Git checkout that owns the session. In remote mode, Desktop asks the backend's checkout through the remote-aware git facade. If a lookup fails, Hermes keeps any PR data it already has rather than replacing it with a fabricated state.
+
 ## CLI Session Resume
 
 Resume previous conversations from the CLI using `--continue` or `--resume`:


### PR DESCRIPTION
## Summary

Document the session-list controls that already ship in Hermes Desktop.

The current Sessions sidebar has a Filters menu for grouping, ordering, row metadata, and status/project/PR/archive filters. These controls are persisted but are not described in the Sessions guide today.

## What changed

- document Updated / Project / Status grouping
- document Updated / Created / Status / Tokens / Cost ordering and manual drag ordering
- document optional Updated / Tokens / Cost / PR / Profile row metadata
- document status, project, PR-state, and archived filters plus reset-to-defaults
- clarify that PR resolution follows the checkout that owns the session, including the backend checkout in remote mode

## Verification

- Based on upstream `main` at `2afa4be9326ea9d655768ba78bfbbeb43c414dc1`
- Verified menu labels and values in `apps/desktop/src/app/chat/sidebar/filter-menu.tsx`
- Verified persistence in `apps/desktop/src/store/layout.ts`
- Verified the cost threshold and row metadata rendering in `session-row.tsx`
- Verified remote-aware PR lookup and fail-soft behavior in `desktop-git.ts` and `store/pull-requests.ts`
- Open PR #82821 remains unmerged; this PR deliberately does not document its proposed Sessions / Projects / Profiles switcher
- Final branch is exactly one commit ahead of current upstream `main`, one docs file, +11 / -0
- No runtime, config, or dependency changes
