### PR TITLE
test(hooks): make the hook test surface pass on native Windows

### DIFF
--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -9,6 +9,7 @@ covered in ``test_shell_hooks_consent.py``.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,25 @@ def _write_script(tmp_path: Path, name: str, body: str) -> Path:
     path.write_text(body)
     path.chmod(0o755)
     return path
+
+
+def _exec_command(tmp_path: Path, name: str, py_body: str) -> str:
+    """Write a hook script that actually runs, and return its command string.
+
+    ``_write_script`` is fine for tests that only need a path on disk, but a
+    ``#!/usr/bin/env bash`` shebang is not honoured on Windows: the bridge
+    spawns with ``shell=False``, so CreateProcess rejects a ``.sh`` file with
+    ``WinError 193 (%1 is not a valid Win32 application)`` no matter how the
+    path is written.  Hook bodies that must execute are therefore Python,
+    invoked through ``sys.executable``.
+
+    Paths are emitted with forward slashes and quoted so the command string
+    round-trips through the POSIX ``shlex`` tokenizer on every platform.
+    """
+    path = tmp_path / name
+    path.write_text(py_body, encoding="utf-8")
+    path.chmod(0o755)
+    return f'"{Path(sys.executable).as_posix()}" "{path.as_posix()}"'
 
 
 def _allowlist_pair(monkeypatch, tmp_path, event: str, command: str) -> None:
@@ -153,14 +173,13 @@ class TestCallbackSubprocess:
         must translate it to the canonical Hermes block shape so that
         get_pre_tool_call_block_message() surfaces the block.
         """
-        script = _write_script(
-            tmp_path, "blocker.sh",
-            "#!/usr/bin/env bash\n"
-            'printf \'{"decision": "block", "reason": "no terminal"}\\n\'\n',
+        command = _exec_command(
+            tmp_path, "blocker.py",
+            'print(\'{"decision": "block", "reason": "no terminal"}\')\n',
         )
         spec = shell_hooks.ShellHookSpec(
             event="pre_tool_call",
-            command=str(script),
+            command=command,
             matcher="terminal",
         )
         cb = shell_hooks._make_callback(spec)
@@ -173,10 +192,9 @@ class TestCallbackSubprocess:
         end-to-end control flow used by run_agent._invoke_tool."""
         from hermes_cli import plugins
 
-        script = _write_script(
-            tmp_path, "block.sh",
-            "#!/usr/bin/env bash\n"
-            'printf \'{"decision": "block", "reason": "blocked-by-shell"}\\n\'\n',
+        command = _exec_command(
+            tmp_path, "block.py",
+            'print(\'{"decision": "block", "reason": "blocked-by-shell"}\')\n',
         )
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
@@ -188,7 +206,7 @@ class TestCallbackSubprocess:
         cfg = {
             "hooks": {
                 "pre_tool_call": [
-                    {"matcher": "terminal", "command": str(script)},
+                    {"matcher": "terminal", "command": command},
                 ],
             },
         }
@@ -204,15 +222,16 @@ class TestCallbackSubprocess:
     def test_matcher_regex_filters_callback(self, tmp_path, monkeypatch):
         """A matcher set to 'terminal' must not fire for 'web_search'."""
         calls = tmp_path / "calls.log"
-        script = _write_script(
-            tmp_path, "log.sh",
-            f"#!/usr/bin/env bash\n"
-            f"echo \"$(cat -)\" >> {calls}\n"
-            f"printf '{{}}\\n'\n",
+        command = _exec_command(
+            tmp_path, "log.py",
+            "import sys\n"
+            f"with open(r'{calls.as_posix()}', 'a', encoding='utf-8') as fh:\n"
+            "    fh.write(sys.stdin.read() + '\\n')\n"
+            "print('{}')\n",
         )
         spec = shell_hooks.ShellHookSpec(
             event="pre_tool_call",
-            command=str(script),
+            command=command,
             matcher="terminal",
         )
         cb = shell_hooks._make_callback(spec)
@@ -225,12 +244,15 @@ class TestCallbackSubprocess:
 
     def test_payload_schema_delivered(self, tmp_path):
         capture = tmp_path / "payload.json"
-        script = _write_script(
-            tmp_path, "capture.sh",
-            f"#!/usr/bin/env bash\ncat - > {capture}\nprintf '{{}}\\n'\n",
+        command = _exec_command(
+            tmp_path, "capture.py",
+            "import sys\n"
+            f"with open(r'{capture.as_posix()}', 'w', encoding='utf-8') as fh:\n"
+            "    fh.write(sys.stdin.read())\n"
+            "print('{}')\n",
         )
         spec = shell_hooks.ShellHookSpec(
-            event="pre_tool_call", command=str(script),
+            event="pre_tool_call", command=command,
         )
         cb = shell_hooks._make_callback(spec)
         cb(
@@ -632,14 +654,14 @@ class TestEvaluateResult:
 
 class TestFailSemanticsEndToEnd:
     def test_exit_2_script_blocks(self, tmp_path):
-        script = _write_script(
-            tmp_path, "exit2.sh",
-            "#!/usr/bin/env bash\n"
-            'echo "rm -rf is not permitted" >&2\n'
-            "exit 2\n",
+        command = _exec_command(
+            tmp_path, "exit2.py",
+            "import sys\n"
+            "sys.stderr.write('rm -rf is not permitted\\n')\n"
+            "sys.exit(2)\n",
         )
         spec = shell_hooks.ShellHookSpec(
-            event="pre_tool_call", command=str(script),
+            event="pre_tool_call", command=command,
         )
         cb = shell_hooks._make_callback(spec)
         result = cb(tool_name="terminal", args={"command": "rm -rf /"})
@@ -660,14 +682,14 @@ class TestFailSemanticsEndToEnd:
 
     def test_run_once_reflects_exit_2_block(self, tmp_path):
         """hermes hooks test must mirror production semantics."""
-        script = _write_script(
-            tmp_path, "exit2.sh",
-            "#!/usr/bin/env bash\n"
-            'echo "denied" >&2\n'
-            "exit 2\n",
+        command = _exec_command(
+            tmp_path, "exit2.py",
+            "import sys\n"
+            "sys.stderr.write('denied\\n')\n"
+            "sys.exit(2)\n",
         )
         spec = shell_hooks.ShellHookSpec(
-            event="pre_tool_call", command=str(script),
+            event="pre_tool_call", command=command,
         )
         result = shell_hooks.run_once(
             spec, {"tool_name": "terminal", "args": {"command": "ls"}},
@@ -676,12 +698,12 @@ class TestFailSemanticsEndToEnd:
         assert result["parsed"] == {"action": "block", "message": "denied"}
 
     def test_run_once_reflects_fail_closed_timeout(self, tmp_path):
-        script = _write_script(
-            tmp_path, "sleepy.sh",
-            "#!/usr/bin/env bash\nsleep 5\n",
+        command = _exec_command(
+            tmp_path, "sleepy.py",
+            "import time\ntime.sleep(5)\n",
         )
         spec = shell_hooks.ShellHookSpec(
-            event="pre_tool_call", command=str(script),
+            event="pre_tool_call", command=command,
             timeout=1, fail_closed=True,
         )
         result = shell_hooks.run_once(

--- a/tests/agent/test_shell_hooks_consent.py
+++ b/tests/agent/test_shell_hooks_consent.py
@@ -146,7 +146,12 @@ class TestAllowlistOps:
 
     def test_tilde_path_approval_records_resolvable_mtime(self, tmp_path, monkeypatch):
         """If the command uses ~ the approval must still find the file."""
+        # ntpath.expanduser() consults USERPROFILE (then HOMEDRIVE+HOMEPATH)
+        # and never HOME, so pointing only HOME at tmp_path leaves ~ resolving
+        # to the real profile directory on Windows — where hook.sh does not
+        # exist, so the stat() silently yields a None mtime.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         target = tmp_path / "hook.sh"
         target.write_text("#!/usr/bin/env bash\n")
         target.chmod(0o755)

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import sys
 from contextlib import redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
@@ -29,6 +30,23 @@ def _hook_script(tmp_path: Path, body: str, name: str = "hook.sh") -> Path:
     p.write_text(body)
     p.chmod(0o755)
     return p
+
+
+def _exec_command(tmp_path: Path, py_body: str, name: str = "hook.py") -> str:
+    """Write a hook script that actually runs, and return its command string.
+
+    ``_hook_script`` is fine where only a path on disk is needed, but a
+    ``#!/usr/bin/env bash`` shebang is not honoured on Windows: hooks spawn
+    with ``shell=False``, so CreateProcess rejects a ``.sh`` file with
+    ``WinError 193 (%1 is not a valid Win32 application)``.  Bodies that
+    must execute are Python, invoked through ``sys.executable``, with
+    quoted forward-slash paths so the command round-trips through the
+    POSIX ``shlex`` tokenizer on every platform.
+    """
+    p = tmp_path / name
+    p.write_text(py_body, encoding="utf-8")
+    p.chmod(0o755)
+    return f'"{Path(sys.executable).as_posix()}" "{p.as_posix()}"'
 
 
 def _run(sub_args: SimpleNamespace) -> str:
@@ -87,11 +105,15 @@ class TestHooksTest:
         scripts tested with `hermes hooks test` saw different top-level
         keys than at runtime, silently breaking in production."""
         capture = tmp_path / "captured.json"
-        script = _hook_script(
+        command = _exec_command(
             tmp_path,
-            f"#!/usr/bin/env bash\ncat - > {capture}\nprintf '{{}}\\n'\n",
+            "import sys\n"
+            f"with open(r'{(tmp_path / 'captured.json').as_posix()}', 'w', "
+            "encoding='utf-8') as fh:\n"
+            "    fh.write(sys.stdin.read())\n"
+            "print('{}')\n",
         )
-        cfg = {"hooks": {"subagent_stop": [{"command": str(script)}]}}
+        cfg = {"hooks": {"subagent_stop": [{"command": command}]}}
         with patch("hermes_cli.config.load_config", return_value=cfg):
             _run(SimpleNamespace(
                 hooks_action="test", event="subagent_stop",
@@ -112,16 +134,15 @@ class TestHooksTest:
         assert seen["tool_input"] is None
 
     def test_fires_real_subprocess_and_parses_block(self, tmp_path):
-        block_script = _hook_script(
+        block_command = _exec_command(
             tmp_path,
-            "#!/usr/bin/env bash\n"
-            'printf \'{"decision": "block", "reason": "nope"}\\n\'\n',
-            name="block.sh",
+            'print(\'{"decision": "block", "reason": "nope"}\')\n',
+            name="block.py",
         )
         cfg = {
             "hooks": {
                 "pre_tool_call": [
-                    {"matcher": "terminal", "command": str(block_script)},
+                    {"matcher": "terminal", "command": block_command},
                 ],
             },
         }
@@ -189,11 +210,14 @@ class TestHooksDoctor:
         script must not be executed during `doctor`."""
         sentinel = tmp_path / "executed"
         # Script would touch the sentinel if executed; we assert it wasn't.
-        script = _hook_script(
+        # It must be genuinely runnable, or the gate cannot fail: a script
+        # the platform refuses to exec leaves the sentinel absent either way.
+        command = _exec_command(
             tmp_path,
-            f"#!/usr/bin/env bash\ntouch {sentinel}\nprintf '{{}}\\n'\n",
+            f"open(r'{sentinel.as_posix()}', 'w').close()\n"
+            "print('{}')\n",
         )
-        cfg = {"hooks": {"on_session_start": [{"command": str(script)}]}}
+        cfg = {"hooks": {"on_session_start": [{"command": command}]}}
         with patch("hermes_cli.config.load_config", return_value=cfg):
             out = _run(SimpleNamespace(hooks_action="doctor"))
 


### PR DESCRIPTION
Makes the hook test surface pass on native Windows. **Test-only — no production code is touched.** Two independent causes, 10 tests.

## 1. Shebang scripts can't be exec'd on Windows (9 tests)

Hook fixtures that need to *execute* are written as `#!/usr/bin/env bash` scripts, with `ShellHookSpec.command` pointed at the `.sh` file. The bridge spawns with `shell=False`, so CreateProcess rejects the file outright:

```
[WinError 193] %1 is not a valid Win32 application
```

The shebang is never consulted — this is independent of how the path is written (confirmed with a clean forward-slash path). Failing tests:

- `tests/agent/test_shell_hooks.py` — 4 in `TestCallbackSubprocess`, 3 in `TestFailSemanticsEndToEnd`
- `tests/hermes_cli/test_hooks_cli.py` — 2 in `TestHooksTest`

Adds `_exec_command()` alongside the existing `_write_script` / `_hook_script` helpers. Fixtures that must run are written as Python and invoked via `sys.executable`, with quoted forward-slash paths so the command string round-trips through the POSIX `shlex` tokenizer on every platform:

```python
return f'"{Path(sys.executable).as_posix()}" "{p.as_posix()}"'
```

`_write_script` / `_hook_script` are unchanged, and still used by the many tests that only need a path on disk. Behaviour under test is identical — same stdout payloads, same stderr + `exit 2`, same timeout semantics.

### A regression gate that could not fail

`TestHooksDoctor::test_unallowlisted_script_is_not_executed` (the M4 gate) *passes* on Windows, but vacuously. It asserts a sentinel file was **not** created by an un-allowlisted script — and a script the platform refuses to exec leaves the sentinel absent whether or not `doctor` tried to run it. Making the fixture genuinely runnable restores the gate.

## 2. `~` doesn't resolve via `HOME` on Windows (1 test)

`test_tilde_path_approval_records_resolvable_mtime` points only `HOME` at `tmp_path`, but `ntpath.expanduser()` consults `USERPROFILE` (then `HOMEDRIVE`+`HOMEPATH`) and never `HOME`. So `~/hook.sh` resolved to the real profile directory, where the file doesn't exist, and `script_mtime_at_approval` came back `None`.

Production `expanduser` handling is correct — the fixture was simply setting the wrong variable for the platform. Fixed by also setting `USERPROFILE`.

## Verification

Native Windows 10, CPython 3.11, `win32`:

| | before | after |
|---|---|---|
| `tests/agent/test_shell_hooks.py` | 7 failed, 36 passed | **43 passed** |
| `tests/hermes_cli/test_hooks_cli.py` | 3 failed, 14 passed | 1 failed, 16 passed |
| `tests/agent/test_shell_hooks_consent.py` | 1 failed | **all passed** |

No change on Linux/macOS — these already pass there, and the helper resolves to `"/usr/bin/python3" "/tmp/.../hook.py"`.

## Relationship to #78324

Complementary, not overlapping — this PR touches no production code, #78324 touches no fixture bodies.

The one remaining `test_hooks_cli.py` failure above is `TestHooksDoctor::test_flags_mtime_drift`, which **#78324 fixes** (its `_command_script_path` change — `doctor` can't resolve the backslash path, so it can't detect drift).

With **both** applied on current `main`, across `test_shell_hooks.py`, `test_hooks_cli.py`, `test_shell_hooks_consent.py` and `test_subdirectory_hints.py`: **89 passed, 0 failed.** Together the two PRs take the Windows hook surface fully green.

Merging them produces exactly **one trivial conflict**: adjacent import lines (`import sys` here, `import subprocess` there). Both are needed; resolution is to keep both. Happy to rebase on top of #78324 if you'd prefer it land in that order.
