### PR TITLE
fix(desktop): paint the active backend skin in newly opened windows

### DIFF
--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
+import {
+  $backendThemes,
+  $pendingSkinApply,
+  __BACKEND_THEMES_KEY,
+  __resetBackendSkinSync,
+  ingestBackendSkin
+} from './backend-sync'
 
 const skin = (name: string) => ({
   name,
@@ -105,5 +111,59 @@ describe('ingestBackendSkin', () => {
     ingestBackendSkin({ name: '' }, { apply: true })
 
     expect($pendingSkinApply.get()).toBeNull()
+  })
+})
+
+// The desktop persists the active skin's NAME and resolves it against the theme
+// registry on a window's first paint. A backend skin used to exist only in the
+// connected renderer's memory, so a newly opened window (HUD, session pop-out)
+// resolved that name to nothing and fell back to the default palette. Caching
+// the CONVERTED theme is what lets a fresh renderer paint the right skin before
+// — or without — its own gateway ever announcing it.
+describe('converted backend skins survive a reload', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    __resetBackendSkinSync()
+  })
+
+  it('persists a registered skin so another window can resolve it cold', () => {
+    ingestBackendSkin(skin('neon'), { apply: false })
+
+    const cached = JSON.parse(window.localStorage.getItem(__BACKEND_THEMES_KEY) ?? '{}')
+
+    expect(cached.neon?.name).toBe('neon')
+    // A cached entry must be complete enough for the boot paint to use it —
+    // the same bar `installUserTheme` holds a stored theme to.
+    expect(typeof cached.neon?.colors?.background).toBe('string')
+    expect(typeof cached.neon?.colors?.foreground).toBe('string')
+    expect(typeof cached.neon?.colors?.primary).toBe('string')
+  })
+
+  it('a later switch replaces the cached palette rather than stacking a stale one', () => {
+    ingestBackendSkin(skin('neon'), { apply: true })
+    ingestBackendSkin({ ...skin('neon'), colors: { background: '#ffffff', ui_accent: '#101010' } }, { apply: true })
+
+    const cached = JSON.parse(window.localStorage.getItem(__BACKEND_THEMES_KEY) ?? '{}')
+
+    expect(cached.neon.colors.background).toBe('#ffffff')
+  })
+
+  // The backend only ever announces the ACTIVE skin, so nothing can refresh a
+  // cached entry for any other one. Keeping them would strand a skin deleted
+  // from disk in Appearance / `/skin` forever, offering a palette that no
+  // longer exists — and grow the cache without bound as skins are authored.
+  it('caches only the active skin, so a superseded one cannot linger', () => {
+    ingestBackendSkin(skin('neon'), { apply: true })
+    ingestBackendSkin(skin('forest'), { apply: true })
+
+    const cached = JSON.parse(window.localStorage.getItem(__BACKEND_THEMES_KEY) ?? '{}')
+
+    expect(Object.keys(cached)).toEqual(['forest'])
+  })
+
+  it('never caches a built-in name (the desktop palette stays authoritative)', () => {
+    ingestBackendSkin(skin('mono'), { apply: true })
+
+    expect(JSON.parse(window.localStorage.getItem(__BACKEND_THEMES_KEY) ?? '{}').mono).toBeUndefined()
   })
 })

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -19,12 +19,56 @@
 import type { HermesSkin } from '@hermes/shared/skin'
 import { atom } from 'nanostores'
 
+import { readJson, writeJson } from '@/lib/storage'
+
 import { BUILTIN_THEMES } from './presets'
 import { skinToDesktopTheme } from './skin'
 import type { DesktopTheme } from './types'
+import { isValidTheme } from './validity'
+
+// Converted backend skins are CACHED, not just held in memory. The desktop
+// persists the active skin's NAME (`hermes-desktop-theme-v2`), and every window
+// resolves that name against the theme registry on its very first paint — but a
+// backend skin only entered the registry once ITS OWN gateway connection
+// announced it. A freshly opened window (HUD, session pop-out, ⌘⇧N) therefore
+// booted with the right name and no palette to resolve it to, fell back to
+// `nous`, and painted the wrong theme until its socket caught up (which for the
+// HUD is never: `gateway.ready` seeds WITHOUT applying, by design).
+//
+// Only the ACTIVE skin is persisted, because that is the only one this cache
+// exists to resolve. The backend announces one skin — the active one — so
+// keeping the others would be a store of entries nothing can refresh: a skin
+// deleted from disk would linger in Appearance and `/skin` forever, offering a
+// palette that no longer exists. One entry keeps the cache honest (it is at
+// most one connect behind the backend, never authoritative over it) and bounds
+// it, while the in-memory registry still accumulates normally within a session.
+const BACKEND_THEMES_KEY = 'hermes-desktop-backend-themes-v1'
+
+function readStored(): Record<string, DesktopTheme> {
+  const parsed = readJson<unknown>(BACKEND_THEMES_KEY)
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {}
+  }
+
+  const out: Record<string, DesktopTheme> = {}
+
+  for (const [key, value] of Object.entries(parsed)) {
+    // Never let a cached skin shadow a built-in name — same rule the live
+    // ingest path applies below.
+    if (!BUILTIN_THEMES[key] && isValidTheme(value)) {
+      out[key] = value
+    }
+  }
+
+  return out
+}
 
 /** Skins pushed by the backend, keyed by name. Merged by `listAllThemes`. */
-export const $backendThemes = atom<Record<string, DesktopTheme>>({})
+export const $backendThemes = atom<Record<string, DesktopTheme>>(typeof window === 'undefined' ? {} : readStored())
+
+/** Persist a single converted skin as the cold-boot cache, replacing any prior. */
+const cacheActiveSkin = (name: string, theme: DesktopTheme) => writeJson(BACKEND_THEMES_KEY, { [name]: theme })
 
 /** One-shot skin name the ThemeProvider should switch to (it clears this). */
 export const $pendingSkinApply = atom<string | null>(null)
@@ -43,6 +87,9 @@ export function __resetBackendSkinSync(): void {
   $backendThemes.set({})
   $pendingSkinApply.set(null)
 }
+
+/** Test-only: the localStorage key the converted-skin cache lives under. */
+export const __BACKEND_THEMES_KEY = BACKEND_THEMES_KEY
 
 /**
  * Fold a resolved skin into the desktop. `apply: false` (connect-time seed) only
@@ -75,6 +122,12 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
     if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
       $backendThemes.set({ ...current, [name]: theme })
     }
+
+    // This skin is the backend's active one by definition — it only announces
+    // the skin in force — so it is what a cold-booting window has to resolve.
+    // Written on every announcement, including a re-seed carrying an in-place
+    // palette edit, so the cache tracks the file rather than only the name.
+    cacheActiveSkin(name, theme)
   }
 
   if (!apply) {

--- a/apps/desktop/src/themes/user-themes.ts
+++ b/apps/desktop/src/themes/user-themes.ts
@@ -16,7 +16,8 @@ import { registry } from '@/contrib/registry'
 
 import { $backendThemes } from './backend-sync'
 import { BUILTIN_THEMES } from './presets'
-import type { DesktopTheme, DesktopThemeColors } from './types'
+import type { DesktopTheme } from './types'
+import { isValidTheme } from './validity'
 
 const USER_THEMES_KEY = 'hermes-desktop-user-themes-v1'
 
@@ -24,27 +25,6 @@ const USER_THEMES_KEY = 'hermes-desktop-user-themes-v1'
 // (see `convertVscodeColorTheme`). This is the one place that convention is read
 // back out, so every install surface can tell what's already installed.
 const MARKETPLACE_DESC_PREFIX = 'VS Code · '
-
-// The minimal set of color keys a stored theme must carry to be usable. We keep
-// this loose — `applyTheme` tolerates missing optionals via fallbacks — but a
-// theme with no background/foreground/primary is junk and gets dropped.
-const REQUIRED_COLOR_KEYS: ReadonlyArray<keyof DesktopThemeColors> = ['background', 'foreground', 'primary']
-
-function isValidTheme(value: unknown): value is DesktopTheme {
-  if (!value || typeof value !== 'object') {
-    return false
-  }
-
-  const theme = value as Partial<DesktopTheme>
-
-  if (typeof theme.name !== 'string' || typeof theme.label !== 'string' || !theme.colors) {
-    return false
-  }
-
-  const colors = theme.colors as unknown as Record<string, unknown>
-
-  return REQUIRED_COLOR_KEYS.every(key => typeof colors[key] === 'string')
-}
 
 function readStored(): Record<string, DesktopTheme> {
   try {

--- a/apps/desktop/src/themes/validity.ts
+++ b/apps/desktop/src/themes/validity.ts
@@ -1,0 +1,30 @@
+/**
+ * Runtime validity bar for a `DesktopTheme` arriving from OUTSIDE the bundle —
+ * a stored user install, a cached backend skin, a plugin contribution.
+ *
+ * Its own module so every consumer shares one bar without an import cycle:
+ * `user-themes` imports `backend-sync` (for the merged registry), so the guard
+ * cannot live in either of them.
+ */
+
+import type { DesktopTheme, DesktopThemeColors } from './types'
+
+// Kept loose on purpose — `applyTheme` tolerates missing optionals via
+// fallbacks — but a theme with no background/foreground/primary is junk.
+const REQUIRED_COLOR_KEYS: ReadonlyArray<keyof DesktopThemeColors> = ['background', 'foreground', 'primary']
+
+export function isValidTheme(value: unknown): value is DesktopTheme {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const theme = value as Partial<DesktopTheme>
+
+  if (typeof theme.name !== 'string' || typeof theme.label !== 'string' || !theme.colors) {
+    return false
+  }
+
+  const colors = theme.colors as unknown as Record<string, unknown>
+
+  return REQUIRED_COLOR_KEYS.every(key => typeof colors[key] === 'string')
+}


### PR DESCRIPTION
## The bug

A window opened after boot — HUD mode, a session pop-out, ⌘⇧N — paints the default `nous` palette while the main window wears the user's active skin.

Reproduced on a packaged Linux build with `display.skin` set to a YAML skin in `$HERMES_HOME/skins/`, read over CDP:

| | main window | HUD |
|---|---|---|
| `dataset.hermesTheme` | `alia-admiral-v3` | **`nous`** |
| `--theme-background-seed` | `#1a1a2e` | **`#F8FAFF`** |
| `localStorage['hermes-desktop-theme-v2']` | `alia-admiral-v3` | `alia-admiral-v3` |

Both windows agree on the skin NAME. Only one of them can paint it.

## Root cause

The desktop persists the active skin's **name** and resolves it against the theme registry on the very first paint (`normalizeSkin` → `resolveTheme`, `themes/context.tsx`).

Built-ins ship in the bundle, and user-installed VS Code themes are persisted to `hermes-desktop-user-themes-v1` — so both resolve cold. Backend skins did not: `$backendThemes` was an in-memory atom, populated only once *that renderer's own* gateway connection announced the skin. A fresh window therefore booted with the right name and nothing to resolve it to, and fell back to `DEFAULT_SKIN_NAME`.

For the HUD it never recovers, and that part is by design:

```ts
// gateway-event.ts — gateway.ready
ingestBackendSkin(payload?.skin, { apply: false })
```

The connect-time seed deliberately does not apply, so a reconnect can't stomp a theme picked in the GUI. The HUD's own connection registers the skin and never applies it, so the HUD stays on the default palette for its whole life. The other windows are a race the user sees as a flash-then-correct; the HUD is permanent.

## The fix

Cache the converted palette so a cold boot resolves a backend skin like any other theme — the same mechanism installed themes already use.

Only the **active** skin is stored. It is the only one this cache exists to resolve, and the only one the backend ever announces, so keeping the others would build a store nothing can refresh: a skin deleted from disk would linger in Appearance and `/skin` forever, offering a palette that no longer exists. One entry also bounds the cache as skins are authored. The in-memory registry still accumulates normally within a session.

The entry is validated on read, can never shadow a built-in name, and is rewritten on every announcement (including a re-seed carrying an in-place palette edit) — so the cache is at most one connect behind the backend and never authoritative over it.

`isValidTheme` moves into its own module so the stored-theme and cached-skin paths share one validity bar. It could not live in either existing file without an import cycle: `user-themes` already imports `backend-sync`.

## Verification

Rebuilt the packaged app and drove it over CDP.

**Cold boot with the cache cleared** (simulating a first run) → repopulates with exactly one entry:
```
theme: "nous", cached: ["alia-admiral-v3"]
```
**Next boot** → resolves correctly on the first frame:
```
theme: "alia-admiral-v3", bg: "#1a1a2e"
```
**HUD opened from that window** → matches the app exactly:
```
main: theme "alia-admiral-v3", bg "#1a1a2e", midground "#d4a5ff"
hud:  theme "alia-admiral-v3", bg "#1a1a2e", midground "#d4a5ff"
```
The HUD's glass computes to `color(srgb 0.104 0.104 0.139 / 0.92)` — the skin surface, not the default.

**Tests.** RED confirmed first: with persistence disabled, exactly the new cache tests fail and the rest pass. Then `npm run test:ui` → 406 files / 3634 tests pass, and `npm run check:lint` (tsc ×3 + eslint) is clean with 0 errors.

Three added tests assert behavior contracts rather than snapshots: the cached entry is complete enough for the boot paint to use, a later switch replaces rather than stacks, and a built-in name is never cached.

## Notes

- The fix covers the whole class, not just the HUD — session pop-outs and ⌘⇧N windows had the same cold-resolve gap.
- The registry is keyed by skin name **globally**, not per profile. That is pre-existing (`gateway.ready` already ingested from background-profile sockets into the same store) and is unchanged here. Happy to scope it per profile in a follow-up if you'd prefer; it seemed like a separate concern from this bug.
