### PR TITLE
fix(gateway): warn when busy_input_mode is unrecognized instead of silently falling back

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8441,11 +8441,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not mode:
             cfg = _load_gateway_runtime_config()
             mode = str(cfg_get(cfg, "display", "busy_input_mode", default="") or "").strip().lower()
-        if mode == "queue":
-            return "queue"
-        if mode == "steer":
-            return "steer"
-        return "interrupt"
+        if mode not in {"queue", "steer", "interrupt"}:
+            if mode:
+                logger.warning(
+                    "Unrecognized busy_input_mode %r; falling back to 'interrupt'. "
+                    "Supported values: 'queue', 'steer', 'interrupt'.",
+                    mode,
+                )
+            return "interrupt"
+        return mode
 
     @staticmethod
     def _load_busy_text_mode() -> str:

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -359,3 +359,51 @@ def test_drain_continues_with_later_queued_prompt_after_dispatch_failure(monkeyp
     assert session.get("queued_prompts") is None
 
 
+def test_load_busy_input_mode_recognized_values(monkeypatch):
+    """Recognized busy_input_mode values are honored verbatim."""
+    for mode in ("queue", "steer", "interrupt"):
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda _mode=mode: {"display": {"busy_input_mode": _mode}}
+        )
+        assert server._load_busy_input_mode() == mode
+
+
+def test_load_busy_input_mode_unrecognized_falls_back_with_warning(monkeypatch, caplog):
+    """An unrecognized busy_input_mode logs a warning and falls back to interrupt.
+
+    Previously the fallback was silent, so a typo in config was invisible to the
+    operator (#82878).
+    """
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"display": {"busy_input_mode": "bogus"}}
+    )
+    with caplog.at_level("WARNING", logger=server.logger.name):
+        assert server._load_busy_input_mode() == "interrupt"
+    assert any("Unrecognized busy_input_mode" in r.message for r in caplog.records)
+
+
+def test_load_busy_input_mode_empty_no_warning(monkeypatch, caplog):
+    """An unset busy_input_mode defaults to interrupt without warning."""
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"display": {}})
+    with caplog.at_level("WARNING", logger=server.logger.name):
+        assert server._load_busy_input_mode() == "interrupt"
+    assert not any("Unrecognized busy_input_mode" in r.message for r in caplog.records)
+
+
+def test_gateway_runner_load_busy_input_mode(monkeypatch, caplog):
+    """gateway.run's loader mirrors tui_gateway: interrupt is recognized and
+    never warned about, while a bogus value warns and falls back."""
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "interrupt")
+    with caplog.at_level("WARNING", logger="hermes.gateway.run"):
+        assert GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert not any("Unrecognized busy_input_mode" in r.message for r in caplog.records)
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "bogus")
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="hermes.gateway.run"):
+        assert GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert any("Unrecognized busy_input_mode" in r.message for r in caplog.records)
+
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -470,7 +470,15 @@ def _load_busy_input_mode() -> str:
     if not isinstance(display, dict):
         display = {}
     raw = str(display.get("busy_input_mode", "") or "").strip().lower()
-    return raw if raw in {"queue", "steer", "interrupt"} else "interrupt"
+    if raw not in {"queue", "steer", "interrupt"}:
+        if raw:
+            logger.warning(
+                "Unrecognized busy_input_mode %r; falling back to 'interrupt'. "
+                "Supported values: 'queue', 'steer', 'interrupt'.",
+                raw,
+            )
+        return "interrupt"
+    return raw
 
 
 def _load_interim_assistant_messages() -> bool:


### PR DESCRIPTION
## What does this PR do?

Log a warning when `display.busy_input_mode` (or `HERMES_GATEWAY_BUSY_INPUT_MODE`) is set to an unrecognized value, instead of silently falling back to `interrupt`. Previously a typo in config was invisible to the operator: the gateway quietly behaved as `interrupt` with no log.

## Related Issue

Fixes #82878

## Type of Change

- [x] Bug fix

## Changes Made

- `gateway/run.py`: `_load_busy_input_mode()` now warns and falls back to `interrupt` only for values outside `{queue, steer, interrupt}`; explicit `interrupt` stays silent.
- `tui_gateway/server.py`: `_load_busy_input_mode()` mirrors the same warning for unrecognized config values.
- `tests/test_tui_gateway_queue_on_busy.py`: added tests for recognized values, unrecognized fallback + warning, empty default (no warning), and the `gateway.run` loader path (explicit `interrupt` never warns).

## How to Test

`uv run --with pytest python -m pytest tests/test_tui_gateway_queue_on_busy.py -q`

## Checklist

- [x] I have read the contributing guide
- [x] I have checked for duplicate PRs
- [x] Focused commits with conventional commit messages
- [x] Added tests for the change
- [x] Ran `pytest tests/ -q` (focused file: 19 passed)
- [x] Ruff check clean on changed files (repo-wide format check pre-existing on origin/main)
