### PR TITLE
fix(safety): refuse destructive commands targeting filesystem roots via tokenization + span overlap

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -670,3 +670,120 @@ def test_sudo_stdin_guard_container_bypass(clean_session):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+
+
+# -------------------------------------------------------------------------
+# Filesystem-root guard (issue #82842)
+# -------------------------------------------------------------------------
+#
+# Issue #82842 (Hermes Agent) executed ``rd /s /q`` against the ``C:\\``
+# drive root after a user-approved scoped folder deletion. The
+# destructive command's target resolved to ``C:\\`` after a
+# multi-layer quote-escape collapse. The hardline floor must reject
+# any destructive command whose target is a filesystem root, regardless
+# of approval state — yolo, mode=off, smart-approval, and the permanent
+# allowlist cannot bypass it.
+#
+# Previous regression coverage only included POSIX root (``rm -rf /``)
+# via HARDLINE_PATTERNS; the Windows drive-root case was zero-covered.
+# This block adds the missing tests so the bug cannot return under any
+# of the bypasses.
+
+_WINDOWS_DESTRUCTIVE_ROOT_BLOCK = [
+    # Direct Windows cmd-destructive shapes targeting a drive root.
+    "rd /s /q C:\\",
+    'rd /s /q "C:\\"',
+    "rd /s /q C:\\.",
+    "rd /s /q C:\\..",
+    "rd /s /q C:\\/",
+    "rd /s /q c:\\",
+    # Bare-backslash root — collapses to current-drive root in cmd.exe.
+    "rd /s /q \\",
+    "rd /s /q \\\\",
+    # Cross-drive spelling — every drive-letter root is unsafe.
+    "rd /s /q D:\\",
+    "rd /s /q H:\\",
+    "rd /s /q Z:\\",
+    # PowerShell Remove-Item / Set-Volume / Format-Volume spelling.
+    "powershell Remove-Item -Recurse -Force C:\\",
+    "Remove-Item -Recurse -Force H:\\",
+    # Format-volume is destructive of the drive itself — the root-target
+    # guard fires because the PowerShell ``-DriveLetter H:`` argument
+    # identifies the drive-letter root as the implicit target.
+    "format-volume D:",
+    "Format-Volume -DriveLetter H:",
+]
+# Note: ``Initialize-Disk`` and ``Clear-Disk`` wipe numbered *disks*
+# (not filesystem roots); they fall under the disk-wipe floor and are
+# out of scope for the filesystem-root guard.
+
+
+_WINDOWS_DESTRUCTIVE_USER_FOLDER_ALLOW = [
+    # The original shell-wrapper form from issue #82842 with a real
+    # (non-root) target. These reach the softer ``DANGEROUS_PATTERNS``
+    # layer (which prompts the user) but must NOT be hardline-blocked.
+    'cmd /c "rd /s /q C:\\Users\\tester"',
+]
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)
+def test_filesystem_root_guard_blocks_windows_destructive(command):
+    """Any Windows destructive command resolving to a drive root is
+    hardline-blocked even with a normal non-root target alongside it."""
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"root-target command slipped past the floor: {command!r}"
+    assert desc, "expected a non-empty hardline description"
+    # Either the new root-target guard or an existing recursive-delete
+    # pattern should fire — but the new guard is the one that catches
+    # ``rd /s /q C:\\`` on its own and is the regression target for #82842.
+    assert "filesystem root" in desc.lower() or "recursive delete" in desc.lower(), (
+        f"unexpected description {desc!r} for {command!r}"
+    )
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)
+def test_root_target_guard_unaffected_by_yolo(command, clean_session, monkeypatch):
+    """yolo mode is *not* allowed to bypass the root-target guard.
+
+    Regression for issue #82842: the destructive command had been
+    auto-approved by smart approval earlier in the session and would
+    have run unchallenged if yolo had been active. Both states must keep
+    the hardline floor intact.
+    """
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    enable_session_yolo("hardline_test")
+    try:
+        is_hl, desc = detect_hardline_command(command)
+        assert is_hl, f"yolo bypassed the root-target guard: {command!r}"
+        assert desc
+    finally:
+        disable_session_yolo("hardline_test")
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_USER_FOLDER_ALLOW)
+def test_root_target_guard_does_not_block_user_folder_target(command):
+    """A destructive command targeting a real user folder must reach the
+    softer ``DANGEROUS_PATTERNS`` layer (which prompts the user), NOT
+    the hardline floor. This is the regression target for the original
+    #82842 shell-wrapper form whose *correct* target was user-controlled.
+    """
+    is_hl, _ = detect_hardline_command(command)
+    assert not is_hl, f"user-folder target wrongly hardline-blocked: {command!r}"
+
+
+def test_root_target_guard_does_not_block_benign_root_tokens():
+    """Defensive: an echo / cat with a literal ``/`` or ``C:\\`` token
+    must NOT be hardline-blocked. The guard fires only on destructive
+    verbs (rm, rd, Remove-Item, etc.), not on every command whose
+    argument string happens to mention a root.
+    """
+    benign = [
+        "echo /",
+        "echo C:\\Users",
+        "ls /home",
+        "cat /etc/passwd",
+        "grep -r C:\\Users\\tester .",
+    ]
+    for cmd in benign:
+        is_hl, _ = detect_hardline_command(cmd)
+        assert not is_hl, f"benign command wrongly blocked: {cmd!r}"

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -712,10 +712,11 @@ _WINDOWS_DESTRUCTIVE_ROOT_BLOCK = [
     # identifies the drive-letter root as the implicit target.
     "format-volume D:",
     "Format-Volume -DriveLetter H:",
-]
-# Note: ``Initialize-Disk`` and ``Clear-Disk`` wipe numbered *disks*
-# (not filesystem roots); they fall under the disk-wipe floor and are
-# out of scope for the filesystem-root guard.
+    # UNC share roots and Windows device namespace forms.
+    "rd /s /q \\\\server\\share\\",
+    "Remove-Item -Recurse -Force \\\\?\\C:\\",
+    "Remove-Item -Recurse -Force \\\\server\\share",
+]  # noqa: E501
 
 
 _WINDOWS_DESTRUCTIVE_USER_FOLDER_ALLOW = [
@@ -733,12 +734,64 @@ def test_filesystem_root_guard_blocks_windows_destructive(command):
     is_hl, desc = detect_hardline_command(command)
     assert is_hl, f"root-target command slipped past the floor: {command!r}"
     assert desc, "expected a non-empty hardline description"
-    # Either the new root-target guard or an existing recursive-delete
-    # pattern should fire — but the new guard is the one that catches
-    # ``rd /s /q C:\\`` on its own and is the regression target for #82842.
-    assert "filesystem root" in desc.lower() or "recursive delete" in desc.lower(), (
-        f"unexpected description {desc!r} for {command!r}"
+    # The new root-target guard is the only rule that returns the
+    # literal ``destructive command targets a filesystem root``
+    # description — a stale assertion on ``recursive delete`` lets
+    # pre-existing patterns shadow the new guard and silently break
+    # the regression for #82842. Tighten the assertion to the exact
+    # string so a future pattern-layer edit cannot mask the fix.
+    assert "filesystem root" in desc.lower(), (
+        f"description {desc!r} lacks the filesystem-root signature for {command!r}"
     )
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)
+def test_filesystem_root_guard_endtoend_blocks_windows_destructive(command, monkeypatch):
+    """End-to-end through ``check_all_command_guards``: the candidate
+    command must come back ``approved=False`` regardless of the
+    yolo / session-allowlist / smart-approval path that follows.
+
+    MoA (independent full-diff review) flagged that the yolo test in
+    the previous version only invoked ``detect_hardline_command`` and
+    bypassed the surrounding approval chain — leaving the question
+    open whether the floor actually fires before the user-facing
+    pipeline can run. This test pins the end-to-end contract.
+    """
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    # No callback ⇒ hardline floor should still refuse; the user is
+    # never consulted for a hardline block.
+    for env_type in ("posix", "windows", "wsl", "cmd"):
+        result = check_all_command_guards(command, env_type=env_type, approval_callback=None)
+        assert result["approved"] is False, (
+            f"check_all_command_guards wrongly approved {command!r} on {env_type!r}: {result!r}"
+        )
+        # Hardline path must surface explicitly — a regular
+        # non-hardline block (for example the *softer* approval
+        # prompt path) would let the user consent and silently bypass
+        # the floor.
+        assert result.get("hardline") is True, (
+            f"root-target command must trigger the hardline floor on {env_type!r}: {result!r}"
+        )
+        assert "filesystem root" in (result.get("message") or "").lower(), (
+            f"hardline block reason must name the filesystem root on {env_type!r}: {result!r}"
+        )
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)
+def test_filesystem_root_guard_unaltered_by_yolo_in_full_pipeline(command, clean_session, monkeypatch):
+    """With yolo=1 in the full approval pipeline, root-target destructive
+    commands still come back rejected."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    enable_session_yolo("hardline_test")
+    try:
+        for env_type in ("posix", "windows", "wsl", "cmd"):
+            result = check_all_command_guards(command, env_type=env_type, approval_callback=None)
+            assert result["approved"] is False, (
+                f"yolo bypassed the root-target guard in full pipeline on {env_type!r}: {command!r}: {result!r}"
+            )
+    finally:
+        disable_session_yolo("hardline_test")
 
 
 @pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)
@@ -758,6 +811,40 @@ def test_root_target_guard_unaffected_by_yolo(command, clean_session, monkeypatc
         assert desc
     finally:
         disable_session_yolo("hardline_test")
+
+
+def test_filesystem_root_guard_preserves_existing_posix_root_coverage():
+    """Regression for the existing POSIX-root detection: the
+    filesystem-root guard fix must not regress ``rm -rf /`` (and
+    its quoted / brace-extension equivalents).
+
+    All forms resolve to ``/`` under the shell and were already
+    covered by HARDLINE_PATTERNS; this test pins that the new guard
+    cooperates rather than replaces the legacy behaviour, and that
+    each form's description remains non-empty.
+    """
+    cases = [
+        'rm -rf /',
+        'rm -rf /*',
+        'rm -rf //',
+        'rm -rf /.',
+        'rm -rf /..',
+        'rm -rf "/"',
+        'rm -rf "${HOME}"',
+        'sudo rm -rf /',
+    ]
+    for cmd in cases:
+        is_h, desc = detect_hardline_command(cmd)
+        assert is_h, f"existing POSIX root coverage regressed for {cmd!r}"
+        assert desc, f"empty hardline description for {cmd!r}"
+        desc_lower = desc.lower()
+        assert (
+            "filesystem root" in desc_lower
+            or "system directory" in desc_lower
+            or "home directory" in desc_lower
+            or "recursive delete of root filesystem" in desc_lower
+            or "home" in desc_lower
+        ), f"unexpected description {desc!r} for {cmd!r}"
 
 
 @pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_USER_FOLDER_ALLOW)

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -751,11 +751,13 @@ def test_filesystem_root_guard_endtoend_blocks_windows_destructive(command, monk
     command must come back ``approved=False`` regardless of the
     yolo / session-allowlist / smart-approval path that follows.
 
-    MoA (independent full-diff review) flagged that the yolo test in
-    the previous version only invoked ``detect_hardline_command`` and
-    bypassed the surrounding approval chain — leaving the question
-    open whether the floor actually fires before the user-facing
-    pipeline can run. This test pins the end-to-end contract.
+    MoA (independent full-diff review round 6, 2026-08-10) flagged
+    that the previous yolo test only invoked
+    ``detect_hardline_command`` and bypassed the surrounding approval
+    chain — leaving the question open whether the floor actually
+    fires before the user-facing pipeline can run. This test pins
+    the end-to-end contract for every env-type so a future pattern-
+    layer edit cannot mask the fix.
     """
     monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
@@ -781,7 +783,9 @@ def test_filesystem_root_guard_endtoend_blocks_windows_destructive(command, monk
 @pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)
 def test_filesystem_root_guard_unaltered_by_yolo_in_full_pipeline(command, clean_session, monkeypatch):
     """With yolo=1 in the full approval pipeline, root-target destructive
-    commands still come back rejected."""
+    commands still come back rejected *via the hardline floor*, not via
+    a softer 'requires_user_consent=False' short-circuit.
+    """
     monkeypatch.setenv("HERMES_YOLO_MODE", "1")
     enable_session_yolo("hardline_test")
     try:
@@ -790,8 +794,63 @@ def test_filesystem_root_guard_unaltered_by_yolo_in_full_pipeline(command, clean
             assert result["approved"] is False, (
                 f"yolo bypassed the root-target guard in full pipeline on {env_type!r}: {command!r}: {result!r}"
             )
+            assert result.get("hardline") is True, (
+                f"yolo path must still surface hardline=True on {env_type!r}: {result!r}"
+            )
+            assert "filesystem root" in (result.get("message") or "").lower(), (
+                f"yolo path must still name 'filesystem root' on {env_type!r}: {result!r}"
+            )
     finally:
         disable_session_yolo("hardline_test")
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)
+def test_filesystem_root_guard_unaffected_by_mode_off(command, monkeypatch):
+    """``approvals.mode=off`` must NOT bypass the root-target floor.
+    Round-6 MoA review flagged that the test matrix would only cover
+    yolo + the default path; mode=off is the same effective disable
+    surface and must be pinned explicitly.
+    """
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    monkeypatch.setenv("HERMES_APPROVALS_MODE", "off")
+    try:
+        for env_type in ("posix", "windows", "wsl", "cmd"):
+            result = check_all_command_guards(command, env_type=env_type, approval_callback=None)
+            assert result["approved"] is False, (
+                f"mode=off bypassed the root-target guard on {env_type!r}: {command!r}: {result!r}"
+            )
+            assert result.get("hardline") is True, (
+                f"mode=off must still surface hardline=True on {env_type!r}: {result!r}"
+            )
+    finally:
+        monkeypatch.delenv("HERMES_APPROVALS_MODE", raising=False)
+
+
+@pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)
+def test_filesystem_root_guard_unaffected_by_smart_approval_callback(command, monkeypatch):
+    """Even when smart-approval returns ``approved=True`` from its
+    callback, the floor must still refuse root-target destructive
+    commands. The hardline layer is run *before* the smart-approval
+    callback ever sees the command.
+    """
+
+    def _pretend_smart_callback(command_to_approve: str) -> bool:
+        # Smart approval says YES to anything. This MUST NOT bypass
+        # the hardline floor.
+        return True
+
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    for env_type in ("posix", "windows", "wsl", "cmd"):
+        result = check_all_command_guards(
+            command, env_type=env_type, approval_callback=_pretend_smart_callback,
+        )
+        assert result["approved"] is False, (
+            f"smart-approval callback YES bypassed the root-target guard on {env_type!r}: "
+            f"{command!r}: {result!r}"
+        )
+        assert result.get("hardline") is True, (
+            f"smart-approval callback YES must still surface hardline=True on {env_type!r}: {result!r}"
+        )
 
 
 @pytest.mark.parametrize("command", _WINDOWS_DESTRUCTIVE_ROOT_BLOCK)

--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -264,7 +264,7 @@ class TestExtractFilesystemTargets:
         )
 
     def test_outer_quoted_unc_non_root_does_not_block(self):
-        """Round-7 MoA flagged that ``cmd /c \"rd /s /q \\\\server\\share\\folder\"``
+        r"""Round-7 MoA flagged that ``cmd /c \"rd /s /q \\\\server\\share\\folder\"``
         (UNC non-root wrapped in outer quotes) was being incorrectly
         classified as a root target via the new outer-quote re-tokenize
         pass.
@@ -274,14 +274,31 @@ class TestExtractFilesystemTargets:
         is correctly classified as non-root because the trailing
         ``\\folder`` segment turns it into a child path of the share,
         not the share-root itself.
+
+        Round-9 MoA review (2026-08-10) flagged that the previous
+        version of this test assigned ``cmd`` but never used it — the
+        assertion only checked :func:`is_filesystem_root` directly
+        instead of exercising the outer-quote re-tokenize pipeline.
+        The regression now runs the FULL pipeline::
+
+          cmd -> extract_filesystem_targets -> is_filesystem_root on each
+              AND detect_hardline_command on the original.
         """
         cmd = r'cmd /c "rd /s /q \\server\share\folder"'
+        from tools.approval import detect_hardline_command
         from tools.path_security import is_filesystem_root
 
-        # Sanity: the primary helper must NOT classify the wrapped
-        # UNC non-root target as a filesystem root.
-        assert not is_filesystem_root(r'\\server\share\folder'), (
-            "UNC non-root '\\\\server\\share\\folder' must not be a root"
+        # Outer-quote re-tokenize must surface the inner UNC token.
+        tokens = extract_filesystem_targets(cmd)
+        # The extracted token must classify as non-root (the inner
+        # share is followed by ``\\folder``, not the share root).
+        assert not any(is_filesystem_root(t) for t in tokens), (
+            f"wrapped UNC non-root must not yield a root token, got {tokens!r}"
+        )
+        # End-to-end hardline must NOT fire.
+        is_hl, desc = detect_hardline_command(cmd)
+        assert not is_hl, (
+            f"wrapped UNC non-root must not be hardline-blocked, got desc={desc!r}"
         )
 
     def test_unconditional_fallback_emits_root_when_only_drive_seen(self):

--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -1,0 +1,198 @@
+"""Tests for ``tools.path_security`` filesystem-root detection helpers.
+
+Regression: Hermes executed ``rd /s /q`` against the ``C:\\`` drive root
+after a user-approved scoped folder deletion (issue #82842). The quote
+escapes collapsed under nested bash → PowerShell → cmd and a bare
+``\\`` ended up as one of the destructive command's argument tokens.
+
+Root-target commands like ``rd /s /q C:\\``, ``rd /s /q \\``, or
+``rm -rf /`` must be rejected **independent of approval state** — no
+yolo flag, no session allowlist, no smart-approval verdict can let a
+destructive command resolve to a filesystem root.
+
+These helpers give the approval / detection layer a portable "is this
+a filesystem root?" and "extract path-like argument tokens" pair, so
+the hardline floor can guard every destructive command (cmd, PowerShell,
+bash, zsh, WSL) under one rule instead of relying on per-shell regexes.
+"""
+
+import pytest
+
+from tools.path_security import (
+    extract_filesystem_targets,
+    is_filesystem_root,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_filesystem_root
+# ---------------------------------------------------------------------------
+
+class TestIsFilesystemRootPosix:
+    """POSIX root paths resolve to ``/``."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/",
+            "//",
+            "///",
+            "/.",
+            "/./",
+            "/..",
+            "/../",
+            "/./..",
+            "/../../..",
+            "/.//",
+            "/../..",
+            "  /  ",  # surrounding whitespace tolerated
+        ],
+    )
+    def test_posix_roots_are_filesystem_roots(self, path):
+        assert is_filesystem_root(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/tmp",
+            "/home",
+            "/etc",
+            "/usr",
+            "/.ssh",
+            "/.config",
+            "/...",  # a dir literally named "...", not root
+            "/var/log",
+            "/usr/local/bin",
+        ],
+    )
+    def test_non_root_posix_paths_are_not_filesystem_roots(self, path):
+        assert not is_filesystem_root(path)
+
+
+class TestIsFilesystemRootWindows:
+    """Windows drive roots (drive-letter or bare ``\\``) are filesystem roots."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "C:\\",
+            "c:\\",
+            "C:\\",
+            "C:",
+            "c:",
+            "H:\\",
+            "Z:\\",
+            "\\",
+            "\\\\",  # two literal backslashes ⇒ current drive root
+            "\\\\?",  # UNC device namespace opener — treated as root-ish
+            "C:\\.",
+            "C:\\..",
+            "C:\\/",
+            "  C:\\  ",
+        ],
+    )
+    def test_windows_roots_are_filesystem_roots(self, path):
+        assert is_filesystem_root(path), f"{path!r} should be filesystem root"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "C:\\Users",
+            "C:\\Users\\tester",
+            "C:\\tmp\\hermes-victim",
+            "C:\\Program Files",
+            "D:\\data",
+            "C:\\Users\\tester\\Documents",
+        ],
+    )
+    def test_windows_subdirs_are_not_filesystem_roots(self, path):
+        assert not is_filesystem_root(path)
+
+
+class TestIsFilesystemRootUnc:
+    """UNC roots (``\\\\server\\share``) are filesystem roots."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "\\\\server\\share",
+            "\\\\server\\share\\",
+            "\\\\NAS01\\backups",
+            "\\\\?\\C:\\",
+        ],
+    )
+    def test_unc_roots_are_filesystem_roots(self, path):
+        assert is_filesystem_root(path), f"{path!r} should be filesystem root"
+
+    def test_unc_deeper_path_is_not_a_filesystem_root(self):
+        assert not is_filesystem_root("\\\\server\\share\\folder")
+
+
+class TestIsFilesystemRootEdgeCases:
+    """Defensive: empty / None / non-path inputs must not crash and must
+    classify empty string as "not a root" (no path, no risk)."""
+
+    @pytest.mark.parametrize("path", ["", " ", None, "  ", "relative/path", "no-leading-slash"])
+    def test_non_absolute_paths_are_not_filesystem_roots(self, path):
+        assert not is_filesystem_root(path)
+
+
+# ---------------------------------------------------------------------------
+# extract_filesystem_targets
+# ---------------------------------------------------------------------------
+
+class TestExtractFilesystemTargets:
+    """The helper parses a destructive command string and returns every
+    path-like argument token it can identify, so the approval layer can
+    call ``is_filesystem_root`` on each token instead of reinventing the
+    shell-tokenisation rules in every regex pattern.
+
+    The function is intentionally permissive: a return value of
+    ``["C:\\Users\\tester"]`` is fine even when the real command was
+    interpreted as something else by the shell, because the caller only
+    uses it to fail-closed (any suspect token triggers root-refusal).
+    """
+
+    def test_single_user_path_returns_single_target(self):
+        assert extract_filesystem_targets('rd /s /q "C:\\Users\\tester\\folder"') == [
+            "C:\\Users\\tester\\folder",
+        ]
+
+    def test_unquoted_user_path(self):
+        assert extract_filesystem_targets("rd /s /q C:\\Users\\tester") == [
+            "C:\\Users\\tester",
+        ]
+
+    def test_drive_root_token_is_returned(self):
+        # The exact shell-construction from issue #82842: PowerShell
+        # receives ``cmd /c "rd /s /q \\""C:\\Users\\tester\\""\"""`` and
+        # the PowerShell/cmd layer collapses the escape into two
+        # arguments — ``\\`` and ``C:\\Users\\tester``.  The agent-side
+        # approval layer sees the inner part (after PowerShell strips the
+        # outer single quotes), so we feed the helper just that fragment
+        # to assert it surfaces the real Windows target.
+        ps_inner = 'cmd /c "rd /s /q \\\\\\"C:\\\\Users\\\\tester\\\\\""'
+        tokens = extract_filesystem_targets(ps_inner)
+        # At minimum the real Windows path target must be present.
+        assert any("tester" in t for t in tokens), (
+            f"expected the human-readable target to surface from the collapsed command, got {tokens!r}"
+        )
+
+    def test_posix_root_command(self):
+        assert extract_filesystem_targets("rm -rf /") == ["/"]
+
+    def test_posix_chained_root(self):
+        tokens = extract_filesystem_targets("rm -rf /  etc")
+        assert "/" in tokens
+
+    def test_no_path_returns_empty(self):
+        assert extract_filesystem_targets("echo hello world") == []
+
+    def test_no_false_positive_on_flags(self):
+        # /S and /Q are flags, not paths.
+        assert extract_filesystem_targets("cmd /c del /s /q C:\\Users\\tester") == [
+            "C:\\Users\\tester",
+        ]
+
+    def test_empty_command(self):
+        assert extract_filesystem_targets("") == []

--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -191,45 +191,48 @@ class TestExtractFilesystemTargets:
         )
 
     def test_quote_collapse_with_drive_path_does_not_swallow_root_token(self):
-        """Round-7 MoA review (2026-08-10) flagged a span-overlap bug:
-        when both a normal drive path and a stray bare ``\\`` coexist
-        in the same collapsed command, the bare-root must still be
-        emitted as a root token (drive-path substring check would
-        otherwise swallow it).
+        """Round-7 / Round-8 MoA review (2026-08-10) flagged a
+        span-overlap bug: when both a normal drive path and a stray
+        bare ``\\`` coexist in the same collapsed command, the bare
+        root residue must still be emitted as a root token, not
+        silently swallowed because of a substring-membership check.
+
+        Uses the EXACT issue #82842 echo-reproduction that the
+        iterative commits closed: a ``cmd /c \"...\\\"C:\\Users\"
+        \"form where PowerShell/cmd layer collapses the escaping
+        into a ``\\`` and a real ``C:\\Users\\tester\\`` token. The
+        span-overlap + outer-quote re-tokenize must surface the bare
+        ``\\`` residue as a root-classified token alongside the user
+        path token.
         """
-        # ``cmd /c \"rd /s /q \\\\\"C:\\\\Users\\\\tester\"`` after PowerShell
-        # strips the outer single-quotes surfaces:
-        #   - ``C:\\Users\\tester`` (real user path)
-        #   - one or more bare ``\\`` tokens (root residue)
-        cmd = 'cmd /c "rd /s /q C:\\Users\\tester\\folder"'
+        cmd = 'cmd /c "rd /s /q \\"C:\\Users\\tester\\""'
         tokens = extract_filesystem_targets(cmd)
-        # The user-folder string must be present.
-        assert any("tester" in t for t in tokens), (
-            f"expected user-folder token in {tokens!r}"
-        )
-        # Independent of the user folder, the bare-backslash sweep
-        # must not over-emit: ``\\server\\share\\folder`` is NOT root,
-        # so the inner-form drive match must not be double-counted.
-        # No spurious UNC root here, so the only root candidate would
-        # be a bare ``\`` if it appeared, which it does NOT in this
-        # case (no collapse). Verify by ensuring no token classifies
-        # as root:
         from tools.path_security import is_filesystem_root
 
-        assert not any(is_filesystem_root(t) for t in tokens), (
-            f"command with normal path should not yield a root token, got {tokens!r}"
+        # The drive-path substring must be present (defence in depth
+        # for the user folder part).
+        assert any("tester" in t for t in tokens), (
+            f"expected drive-path substring in {tokens!r}"
+        )
+        # Regression target: at least one token classifies as a
+        # filesystem root — the bare ``\\`` residue is the dangerous
+        # one, NOT the user folder.
+        root_tokens = [t for t in tokens if is_filesystem_root(t)]
+        assert root_tokens, (
+            f"expected at least one root token to surface from the "
+            f"issue #82842 echo reproduction, got {tokens!r}"
         )
 
     def test_unc_non_root_path_does_not_yield_root_token(self):
-        """Round-7 MoA review flagged that ``\\\\server\\share\\folder``
-        (a UNC non-root) was being decomposed into ``\\\\server\\share\\folder``,
-        plus ``\\\\`` plus ``\\``, and the leading ``\\`` inside the
+        r"""Round-7 MoA review flagged that ``\\server\share\folder``
+        (a UNC non-root) was being decomposed into ``\\server\share\folder``,
+        plus ``\\server\share`` plus ``\``, and the leading ``\`` inside the
         UNC span was incorrectly classified as a filesystem root.
         After the span-overlap fix this should leave only the
         non-root drive-substring token (which classifies as False),
         no bare-root residue.
         """
-        cmd = 'rd /s /q \\\\server\\share\\folder'
+        cmd = r'rd /s /q \\server\share\folder'
         from tools.path_security import is_filesystem_root
 
         tokens = extract_filesystem_targets(cmd)
@@ -239,23 +242,62 @@ class TestExtractFilesystemTargets:
             f"UNC non-root path should not yield a root token, got {tokens!r}"
         )
 
-    def test_unconditional_fallback_emits_root_when_only_drive_seen(self):
-        """The fix-#82842 echo-reproduction surfaces BOTH a drive-path
-        substring AND a bare-root residue. After the round-6 +
-        round-7 fixes, ``extract_filesystem_targets`` must surface
-        one of each AND at least one of them must classify as root.
+    def test_outer_quoted_unc_root_is_blocked(self):
+        """Round-8 MoA review flagged: ``cmd /c \"rd /s /q \\\\server\\share\"``
+        (UNC root wrapped in an outer ``cmd /c "..."`` quote form) was
+        silently NOT classified as a root target because the primary
+        tokenizer returns a single outer token, leaving the UNC root
+        inside a non-target outer span.
+
+        After the round-8 outer-quote re-tokenize fix, this exact
+        issue #82842-class failure mode must surface the bare UNC root
+        as a root-classified token.
         """
-        # A cmd fragment simulating the post-collapse form.
-        cmd = 'cmd /c "rd /s /q C:\\Users\\tester \\rdrt"'
+        cmd = r'cmd /c "rd /s /q \\server\share"'
         tokens = extract_filesystem_targets(cmd)
         from tools.path_security import is_filesystem_root
 
-        # Force a deliberate bare backslash into the command to mimic the
-        # quote-collapse residue:
-        coll = 'cmd /c "rd /s /q \\C:\\Users\\tester"'
-        coll_tokens = extract_filesystem_targets(coll)
-        assert any(is_filesystem_root(t) for t in coll_tokens), (
-            f"standalone bare '\\\\' adjacent to a drive-path must produce a root token, got {coll_tokens!r}"
+        root_tokens = [t for t in tokens if is_filesystem_root(t)]
+        assert root_tokens, (
+            f"outer-quoted UNC root must produce a root token from the "
+            f"issue #82842 failure class, got {tokens!r}"
+        )
+
+    def test_outer_quoted_unc_non_root_does_not_block(self):
+        """Round-7 MoA flagged that ``cmd /c \"rd /s /q \\\\server\\share\\folder\"``
+        (UNC non-root wrapped in outer quotes) was being incorrectly
+        classified as a root target via the new outer-quote re-tokenize
+        pass.
+
+        After the fix, the outer-quote re-tokenize only fires on
+        backslash-bearing tokens; even then, the inner UNC share target
+        is correctly classified as non-root because the trailing
+        ``\\folder`` segment turns it into a child path of the share,
+        not the share-root itself.
+        """
+        cmd = r'cmd /c "rd /s /q \\server\share\folder"'
+        from tools.path_security import is_filesystem_root
+
+        # Sanity: the primary helper must NOT classify the wrapped
+        # UNC non-root target as a filesystem root.
+        assert not is_filesystem_root(r'\\server\share\folder'), (
+            "UNC non-root '\\\\server\\share\\folder' must not be a root"
+        )
+
+    def test_unconditional_fallback_emits_root_when_only_drive_seen(self):
+        """When the only path-like token in the command is a drive
+        root (e.g. ``C:\\``) AND an unrelated naked ``\\`` appears
+        elsewhere, both survive the unconditional fallback sweep —
+        no longer swallowed by the round-7 substring-skip bug.
+        """
+        cmd = r'cmd /c "rd /s /q C:\\ doc \\stuff"'
+        tokens = extract_filesystem_targets(cmd)
+        from tools.path_security import is_filesystem_root
+
+        root_tokens = [t for t in tokens if is_filesystem_root(t)]
+        assert root_tokens, (
+            f"drive root adjacent to bare-backslash artifacts must "
+            f"surface a root token, got {tokens!r}"
         )
 
     def test_posix_root_command(self):

--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -165,17 +165,29 @@ class TestExtractFilesystemTargets:
 
     def test_drive_root_token_is_returned(self):
         # The exact shell-construction from issue #82842: PowerShell
-        # receives ``cmd /c "rd /s /q \\""C:\\Users\\tester\\""\"""`` and
+        # receives ``cmd /c "rd /s /q \""C:\Users\tester\""\""""`` and
         # the PowerShell/cmd layer collapses the escape into two
-        # arguments — ``\\`` and ``C:\\Users\\tester``.  The agent-side
+        # arguments — ``\`` and ``C:\Users\tester``.  The agent-side
         # approval layer sees the inner part (after PowerShell strips the
         # outer single quotes), so we feed the helper just that fragment
-        # to assert it surfaces the real Windows target.
+        # to assert it surfaces the real Windows target AND the
+        # bare-root residue (so the root-target guard catches it).
         ps_inner = 'cmd /c "rd /s /q \\\\\\"C:\\\\Users\\\\tester\\\\\""'
         tokens = extract_filesystem_targets(ps_inner)
-        # At minimum the real Windows path target must be present.
+        # The real Windows path target must be present (defence-in-depth
+        # for the user folder part).
         assert any("tester" in t for t in tokens), (
             f"expected the human-readable target to surface from the collapsed command, got {tokens!r}"
+        )
+        # Round-6 MoA review (2026-08-10) demanded explicit token-level
+        # assertion: at least ONE returned token must classify as a
+        # filesystem root, so that :func:`is_filesystem_root` cannot
+        # silently fail to extract the dangerous bare ``\`` residue.
+        from tools.path_security import is_filesystem_root
+
+        root_tokens = [t for t in tokens if is_filesystem_root(t)]
+        assert root_tokens, (
+            f"expected at least one token classifying as a filesystem root, got {tokens!r}"
         )
 
     def test_posix_root_command(self):

--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -190,6 +190,74 @@ class TestExtractFilesystemTargets:
             f"expected at least one token classifying as a filesystem root, got {tokens!r}"
         )
 
+    def test_quote_collapse_with_drive_path_does_not_swallow_root_token(self):
+        """Round-7 MoA review (2026-08-10) flagged a span-overlap bug:
+        when both a normal drive path and a stray bare ``\\`` coexist
+        in the same collapsed command, the bare-root must still be
+        emitted as a root token (drive-path substring check would
+        otherwise swallow it).
+        """
+        # ``cmd /c \"rd /s /q \\\\\"C:\\\\Users\\\\tester\"`` after PowerShell
+        # strips the outer single-quotes surfaces:
+        #   - ``C:\\Users\\tester`` (real user path)
+        #   - one or more bare ``\\`` tokens (root residue)
+        cmd = 'cmd /c "rd /s /q C:\\Users\\tester\\folder"'
+        tokens = extract_filesystem_targets(cmd)
+        # The user-folder string must be present.
+        assert any("tester" in t for t in tokens), (
+            f"expected user-folder token in {tokens!r}"
+        )
+        # Independent of the user folder, the bare-backslash sweep
+        # must not over-emit: ``\\server\\share\\folder`` is NOT root,
+        # so the inner-form drive match must not be double-counted.
+        # No spurious UNC root here, so the only root candidate would
+        # be a bare ``\`` if it appeared, which it does NOT in this
+        # case (no collapse). Verify by ensuring no token classifies
+        # as root:
+        from tools.path_security import is_filesystem_root
+
+        assert not any(is_filesystem_root(t) for t in tokens), (
+            f"command with normal path should not yield a root token, got {tokens!r}"
+        )
+
+    def test_unc_non_root_path_does_not_yield_root_token(self):
+        """Round-7 MoA review flagged that ``\\\\server\\share\\folder``
+        (a UNC non-root) was being decomposed into ``\\\\server\\share\\folder``,
+        plus ``\\\\`` plus ``\\``, and the leading ``\\`` inside the
+        UNC span was incorrectly classified as a filesystem root.
+        After the span-overlap fix this should leave only the
+        non-root drive-substring token (which classifies as False),
+        no bare-root residue.
+        """
+        cmd = 'rd /s /q \\\\server\\share\\folder'
+        from tools.path_security import is_filesystem_root
+
+        tokens = extract_filesystem_targets(cmd)
+        # No token should classify as a filesystem root — the target is a
+        # child folder under the share, NOT a root.
+        assert not any(is_filesystem_root(t) for t in tokens), (
+            f"UNC non-root path should not yield a root token, got {tokens!r}"
+        )
+
+    def test_unconditional_fallback_emits_root_when_only_drive_seen(self):
+        """The fix-#82842 echo-reproduction surfaces BOTH a drive-path
+        substring AND a bare-root residue. After the round-6 +
+        round-7 fixes, ``extract_filesystem_targets`` must surface
+        one of each AND at least one of them must classify as root.
+        """
+        # A cmd fragment simulating the post-collapse form.
+        cmd = 'cmd /c "rd /s /q C:\\Users\\tester \\rdrt"'
+        tokens = extract_filesystem_targets(cmd)
+        from tools.path_security import is_filesystem_root
+
+        # Force a deliberate bare backslash into the command to mimic the
+        # quote-collapse residue:
+        coll = 'cmd /c "rd /s /q \\C:\\Users\\tester"'
+        coll_tokens = extract_filesystem_targets(coll)
+        assert any(is_filesystem_root(t) for t in coll_tokens), (
+            f"standalone bare '\\\\' adjacent to a drive-path must produce a root token, got {coll_tokens!r}"
+        )
+
     def test_posix_root_command(self):
         assert extract_filesystem_targets("rm -rf /") == ["/"]
 

--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -297,8 +297,9 @@ class TestExtractFilesystemTargets:
         )
         # End-to-end hardline must NOT fire.
         is_hl, desc = detect_hardline_command(cmd)
-        assert not is_hl, (
-            f"wrapped UNC non-root must not be hardline-blocked, got desc={desc!r}"
+        assert (is_hl, desc) == (False, None), (
+            f"wrapped UNC non-root must hardline to (False, None), "
+            f"got ({is_hl!r}, {desc!r})"
         )
 
     def test_unconditional_fallback_emits_root_when_only_drive_seen(self):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -531,12 +531,86 @@ def detect_hardline_command(command: str) -> tuple:
     _, malformed_grep = _grep_safe_detection_variant(normalized)
     if malformed_grep:
         return (True, _MALFORMED_EXEC_DESCRIPTION)
+    # Filesystem-root guard (issue #82842): any token that resolves to a
+    # filesystem root (POSIX ``/``, Windows ``C:\\`` / ``\\``, UNC root)
+    # is rejected unconditionally here. The hardline patterns cover
+    # ``rm -rf /`` for POSIX; this guard catches the equivalent
+    # Windows-native spellings (``rd /s /q C:\\``, ``Remove-Item
+    # -Recurse -Force H:\\``, ``del /s /q \\``, ``format-volume D:``)
+    # plus any future shell variant that already-resolved targets a
+    # root. Run BEFORE the pattern loop so a quote-collapse that
+    # surfaces a stray bare ``\\`` (the exact issue #82842 failure
+    # mode) cannot fall through to the softer DANGEROUS_PATTERNS layer.
+    root_desc = _filesystem_root_guard(command)
+    if root_desc is not None:
+        return (True, root_desc)
     for command_variant in _command_detection_variants(command):
         variant_lower = command_variant.lower()
         for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
             if pattern_re.search(variant_lower):
                 return (True, description)
     return (False, None)
+
+
+# Description emitted when the root-target guard rejects a command. Kept
+# consistent with the surrounding ``hardline_delete_...`` phrasing so the
+# approval-rendering layer does not need to special-case it.
+_ROOT_TARGET_DESCRIPTION = "destructive command targets a filesystem root"
+
+
+def _filesystem_root_guard(command: str) -> Optional[str]:
+    """Return ``"destructive command targets a filesystem root"`` when any
+    path-like token extracted from *command* resolves to a filesystem
+    root, otherwise ``None``.
+
+    Defence-in-depth helper for :func:`detect_hardline_command`. The
+    classifier is conservative: tokens that cannot be classified as
+    paths (e.g. ``/s`` and ``/q`` cmd flags) are not considered. The
+    helper only fires on the destructive-command shells
+    (``rm``, ``rmdir``, ``rd``, ``del``, ``erase``, ``Remove-Item``,
+    ``Remove-Item`` aliases) so a soft command with a literal ``/``
+    argument (e.g. ``echo /``) is not wrongly blocked; see
+    ``_DESTRUCTIVE_VERB_RE`` below for the trigger set.
+    """
+    if not command:
+        return None
+    # Only fire on commands whose first token (modulo wrappers) looks
+    # like a known destructive verb. This keeps ``echo /`` and similar
+    # benign commands flowing through to the normal approval pipeline.
+    destructive_match = _DESTRUCTIVE_VERB_RE.search(command)
+    if not destructive_match:
+        return None
+    from tools.path_security import (
+        extract_filesystem_targets,
+        is_filesystem_root,
+    )
+    for token in extract_filesystem_targets(command):
+        if is_filesystem_root(token):
+            return _ROOT_TARGET_DESCRIPTION
+    return None
+
+
+# Recognised destructive-verb triggers, matched as a word boundary
+# against the leading verb of the destructive command. Keeping the set
+# small and explicit prevents false positives on commands that simply
+# quote a literal ``/`` (e.g. ``echo /foo``).
+_DESTRUCTIVE_VERB_RE = re.compile(
+    r"(?<![A-Za-z0-9_/])"                                    # word-break before the verb
+    r"(?:"
+    r"rm\b"
+    r"|rmdir\b"
+    r"|rd\b"
+    r"|del\b"
+    r"|erase\b"
+    r"|(?:remove-item|ri|rm|rmdir|erase|del|rd)\b"          # PowerShell aliases
+    r"|format-volume\b"
+    r"|set-volume\b"
+    r"|initialize-disk\b"
+    r"|clear-disk\b"
+    r"|format\b"
+    r")",
+    re.IGNORECASE,
+)
 
 
 def _match_user_deny_rule(command: str) -> str | None:

--- a/tools/path_security.py
+++ b/tools/path_security.py
@@ -241,12 +241,15 @@ def extract_filesystem_targets(command: Optional[str]) -> list[str]:
             continue
         if _looks_like_filesystem_target(stripped):
             targets.append(stripped)
-    # Defence in depth: if shell quoting collapsed the parsed tokens
-    # into a single opaque blob (issue #82842 echo reproduction), fall
-    # back to a regex sweep that surfaces any drive-root or bare-slash
-    # substrings so :func:`is_filesystem_root` can classify them.
-    if not targets:
-        targets = _fallback_extract_windows_paths(command)
+    # Defence in depth: shell quoting can collapse bare backslashes
+    # into adjacent non-root tokens (issue #82842 echo reproduction),
+    # so we *always* merge the fallback regex sweep regardless of
+    # whether the token-stream path yielded targets. A drive-rooted
+    # string that surfaces only in the fallback and is missed by
+    # tokenize must still reach :func:`is_filesystem_root`.
+    for fb in _fallback_extract_windows_paths(command):
+        if fb not in targets:
+            targets.append(fb)
     # Deduplicate while preserving order.
     seen = set()
     out = []
@@ -317,32 +320,59 @@ def _looks_like_filesystem_target(token: str) -> bool:
 
 # Windows path extractors — used when shell quoting collapses bare
 # backslashes into adjacent characters and a ``"\\""`` artifact surfaces.
-_DRIVE_ROOT_RE = __import__("re").compile(r"[A-Za-z]:\\[A-Za-z0-9_. -\\]*")
+_DRIVE_ROOT_RE = __import__("re").compile(r"[A-Za-z]:\\[A-Za-z0-9_. \\-]*")
 _BACKSLASH_RE = __import__("re").compile(r"\\+")
 
 
 def _fallback_extract_windows_paths(s: str) -> list[str]:
-    """Best-effort extraction of Windows-looking paths from *s*.
+    """Best-effort extraction of Windows-looking paths and bare
+    separators from *s*.
 
-    Used when :func:`_command_tokenize` cannot yield a clean list
-    because shell quoting collapsed bare backslashes and ``"`` chars
-    (the exact failure mode in issue #82842).
+    Always merged into the regular token-stream output (not only on
+    empty targets), because the failure mode from issue #82842 can
+    surface bare-backslash roots embedded between regular tokens after
+    bash → PowerShell → cmd quote-escape collapse. The function
+    surfaces:
+
+    * Drive-rooted substrings (``C:\\Users\\tester``) via
+      ``_DRIVE_ROOT_RE``.
+    * Bare backslash sequences that are NOT inside an already-matched
+      drive path (``\\server\\share`` after collapse, ``\\`` alone).
+
+    The returned list is deduplicated while preserving order so the
+    downstream :func:`is_filesystem_root` classifier sees each
+    candidate at most once.
     """
-    out = []
+    out: list[str] = []
     # Drive-rooted absolute paths: ``C:\\Users\\tester`` etc.
-    for m in _DRIVE_ROOT_RE.findall(s):
-        # Trim any trailing backslash + adjacent artifacts left by
-        # collapsed quoting — but keep a single trailing backslash
-        # because that *is* the drive root.
-        cleaned = m
-        # If the match ends with multiple backslashes or with the
-        # collapse artifacts of PowerShell nested-quoting (``\"``
-        # surfaces as ``"`` adjacent to a backslash), we still keep
-        # the entire drive-rooted string because the approval layer
-        # will downclassify the bare-root suffix via
-        # :func:`is_filesystem_root`.
-        if cleaned not in out:
-            out.append(cleaned)
+    drive_matches = list(_DRIVE_ROOT_RE.findall(s))
+    for m in drive_matches:
+        if m not in out:
+            out.append(m)
+    drive_joined = " ".join(drive_matches)
+    for m_match in _BACKSLASH_RE.finditer(s):
+        m = m_match.group(0)
+        if m in drive_joined or m in out:
+            continue
+        # Skip the single-backslash continuation artefact
+        # ``\\<whitespace>*<newline>`` — that is a shell line-continuation
+        # token, not a filesystem-root target. The shell will silently
+        # strip it before argument parsing. Issue #82842's collapse
+        # always surfaces `\` adjacent to a `\\<drive>` substring,
+        # not `\` before a newline, so this skip is safe.
+        if len(m) == 1:
+            pos = m_match.start()
+            tail = s[pos + len(m):]
+            stripped = tail.lstrip(" \t")
+            if stripped.startswith("\n"):
+                continue
+            # Also skip if the bare backslash is between command
+            # separator characters (`;` or `&`) and an alphanumeric
+            # argument — same shell-line-continuation pattern.
+            head = s[:pos].rstrip(" \t")
+            if head.endswith((";", "&", "|")) and stripped and (stripped[0].isalpha() or stripped[0] == "_"):
+                continue
+        out.append(m)
     return out
 
 

--- a/tools/path_security.py
+++ b/tools/path_security.py
@@ -250,6 +250,42 @@ def extract_filesystem_targets(command: Optional[str]) -> list[str]:
     for fb in _fallback_extract_windows_paths(command):
         if fb not in targets:
             targets.append(fb)
+    # Outer-quote wrap-around: when ``cmd /c "..."`` or
+    # ``powershell -Command '...'`` collapses to a single outer
+    # token, the inner structure of the wrapped command can still
+    # contain a root-target destructive verb on a root path
+    # containing backslashes (Windows UNC roots, device-namespace
+    # roots). Round-8 MoA review flagged that these slipped through
+    # the primary pass.
+    #
+    # Restricting the re-tokenize trigger to tokens that contain a
+    # backslash (``\\``) — and not just any path separator — avoids
+    # false positives such as ``git commit -m "rm -rf /"`` where the
+    # quoted segment is *string data* (a commit message) but the
+    # forward slash inside would otherwise be re-tokenized into a
+    # root-target. Pure POSIX forward-slash paths are already
+    # handled by the primary tokenizer + the drive-root fallback.
+    for token in tokens:
+        if not token:
+            continue
+        t = token.strip().strip('"').strip("'")
+        if not t or "\\" not in t:
+            continue
+        for inner in _command_tokenize(t):
+            inner = inner.strip().strip('"').strip("'")
+            if not inner:
+                continue
+            if not _looks_like_filesystem_target(inner):
+                continue
+            if inner in targets:
+                continue
+            added_any = False
+            for inner_fb in _fallback_extract_windows_paths(inner):
+                if inner_fb not in targets:
+                    targets.append(inner_fb)
+                added_any = True
+            if not added_any:
+                targets.append(inner)
     # Deduplicate while preserving order.
     seen = set()
     out = []
@@ -351,12 +387,14 @@ def _fallback_extract_windows_paths(s: str) -> list[str]:
             out.append(m)
     drive_joined = " ".join(drive_matches)
     # Build the set of source-string spans covered by path-like
-    # candidates the primary tokenizer already emitted, so the
-    # bare-backslash filter only emits a backslash that is NOT inside
-    # any path-already-shadowed region.  This handles both:
-    #   - drive matches from _DRIVE_ROOT_RE (above), and
-    #   - UNC / drive-root tokens from _command_tokenize that did not
-    #     match the _DRIVE_ROOT_RE regex (e.g. ``\\server\share\folder``).
+    # candidates. Drives come from _DRIVE_ROOT_RE; UNC and other
+    # backslash-bearing tokens come from the primary tokenizer
+    # stage. The tokenizer sometimes returns a token that wraps an
+    # entire quoted body (when outer ``cmd /c "..."`` or
+    # ``powershell -Command '...'`` collapse ate the inner structure)
+    # — when such a token contains a backslash we still treat it as
+    # a path-bearing span so the bare backslash inside it is NOT
+    # re-emitted as a fresh root residue.
     spans: list[tuple[int, int]] = []
     cursor = 0
     for m in drive_matches:
@@ -364,18 +402,18 @@ def _fallback_extract_windows_paths(s: str) -> list[str]:
         if idx != -1:
             spans.append((idx, idx + len(m)))
             cursor = idx + len(m)
-    # Tokenize-and-locate path spans in the source string.
-    # _BACKSLASH_RE-isolated matches inside any of those spans are
-    # inside a path-already-classified region, so they are NOT bare
-    # root residue.
     cursor2 = 0
     for tok in _command_tokenize(s):
-        if not _looks_like_filesystem_target(tok):
-            continue
         idx = s.find(tok, cursor2)
         if idx == -1:
             continue
-        spans.append((idx, idx + len(tok)))
+        # Register a span for a tokenizer-emitted token when either:
+        # (a) the token is itself path-like (``_looks_like_filesystem_target``),
+        # OR (b) the token contains a backslash — implying it wraps
+        #     a quoted path-segment and its bare separators are NOT
+        #     new bare-root residue from outer-quote collapse.
+        if _looks_like_filesystem_target(tok) or ("\\" in tok or "/" in tok):
+            spans.append((idx, idx + len(tok)))
         cursor2 = idx + len(tok)
     for bmatch in _BACKSLASH_RE.finditer(s):
         m = bmatch.group(0)
@@ -394,7 +432,7 @@ def _fallback_extract_windows_paths(s: str) -> list[str]:
             if stripped.startswith("\n"):
                 continue
             head = s[:pos].rstrip(" \t")
-            if head.endswith((";", "&", "|")) and stripped and (stripped[0].isalpha() or stripped[0] == "_"):
+            if head.endswith((";", "&", "|")) and stripped and (stripped[0].isalnum() or stripped[0] == "_"):
                 continue
         out.append(m)
     return out

--- a/tools/path_security.py
+++ b/tools/path_security.py
@@ -350,25 +350,49 @@ def _fallback_extract_windows_paths(s: str) -> list[str]:
         if m not in out:
             out.append(m)
     drive_joined = " ".join(drive_matches)
-    for m_match in _BACKSLASH_RE.finditer(s):
-        m = m_match.group(0)
-        if m in drive_joined or m in out:
+    # Build the set of source-string spans covered by path-like
+    # candidates the primary tokenizer already emitted, so the
+    # bare-backslash filter only emits a backslash that is NOT inside
+    # any path-already-shadowed region.  This handles both:
+    #   - drive matches from _DRIVE_ROOT_RE (above), and
+    #   - UNC / drive-root tokens from _command_tokenize that did not
+    #     match the _DRIVE_ROOT_RE regex (e.g. ``\\server\share\folder``).
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for m in drive_matches:
+        idx = s.find(m, cursor)
+        if idx != -1:
+            spans.append((idx, idx + len(m)))
+            cursor = idx + len(m)
+    # Tokenize-and-locate path spans in the source string.
+    # _BACKSLASH_RE-isolated matches inside any of those spans are
+    # inside a path-already-classified region, so they are NOT bare
+    # root residue.
+    cursor2 = 0
+    for tok in _command_tokenize(s):
+        if not _looks_like_filesystem_target(tok):
+            continue
+        idx = s.find(tok, cursor2)
+        if idx == -1:
+            continue
+        spans.append((idx, idx + len(tok)))
+        cursor2 = idx + len(tok)
+    for bmatch in _BACKSLASH_RE.finditer(s):
+        m = bmatch.group(0)
+        if m in out:
+            continue
+        pos, end = bmatch.span()
+        # Skip "\" inside any path-already-classified span.
+        if any(sp <= pos and end <= ep for sp, ep in spans):
             continue
         # Skip the single-backslash continuation artefact
         # ``\\<whitespace>*<newline>`` — that is a shell line-continuation
-        # token, not a filesystem-root target. The shell will silently
-        # strip it before argument parsing. Issue #82842's collapse
-        # always surfaces `\` adjacent to a `\\<drive>` substring,
-        # not `\` before a newline, so this skip is safe.
+        # token, not a filesystem-root target.
         if len(m) == 1:
-            pos = m_match.start()
             tail = s[pos + len(m):]
             stripped = tail.lstrip(" \t")
             if stripped.startswith("\n"):
                 continue
-            # Also skip if the bare backslash is between command
-            # separator characters (`;` or `&`) and an alphanumeric
-            # argument — same shell-line-continuation pattern.
             head = s[:pos].rstrip(" \t")
             if head.endswith((";", "&", "|")) and stripped and (stripped[0].isalpha() or stripped[0] == "_"):
                 continue

--- a/tools/path_security.py
+++ b/tools/path_security.py
@@ -6,8 +6,8 @@ skills_hub, cronjob_tools, and credential_files.
 """
 
 import logging
-from pathlib import Path
-from typing import Optional
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Iterable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +41,363 @@ def has_traversal_component(path_str: str) -> bool:
     """
     parts = Path(path_str).parts
     return ".." in parts
+
+
+# ---------------------------------------------------------------------------
+# Filesystem-root detection (issue #82842)
+# ---------------------------------------------------------------------------
+#
+# Hermes executed ``rd /s /q`` against the ``C:\\`` drive root after a
+# user-approved scoped folder deletion (issue #82842). The destructive
+# command's target resolved to ``C:\\`` after a multi-layer quote-escape
+# collapse, so the approval flow saw the literal command but the *target*
+# was a filesystem root. The hardline floor must reject root-target
+# destructive commands *independent* of approval state — no yolo flag,
+# no session allowlist, no smart-approval verdict can let ``rm -rf /``
+# or ``rd /s /q C:\\`` run.
+#
+# ``is_filesystem_root`` classifies any path-like token as "this token
+# resolves to a filesystem root" or "it does not". It covers POSIX
+# (slash, repeated slashes, ``.``/``..`` collapse), Windows drive roots
+# (``C:\\``, ``c:``, bare ``\\``) and UNC roots (``\\\\server\\share``),
+# plus the ``\\\\?\\`` Windows device namespace.
+#
+# ``extract_filesystem_targets`` returns every path-like argument token
+# that a destructive command actually carries so the approval layer can
+# call ``is_filesystem_root`` on each token instead of reinventing the
+# shell-tokenisation rules in every regex pattern.
+#
+# The implementations are deliberately conservative (fail-closed):
+# ambiguous inputs default to "not a root" so the helper never causes a
+# false-positive block on a legitimate non-root target. The hardline
+# floor and softer approval layers still apply on top, so a permissive
+# classification here does not weaken safety — it only means the
+# root-target guard fires less often than it could.
+
+
+# Explicit root forms that *must* be classified as filesystem roots.
+# Listing them is safer than pattern-matching because the set is small,
+# closed, and the consequences of a permissive classifier are limited
+# (softer layers still apply).
+_POSIX_FORMS_BARE_ROOT = {
+    "",
+    "/",
+    "//",
+    "///",
+    "////",
+    "/.",
+    "/./",
+    "/..",
+    "/../",
+    "/./..",
+    "/../../..",
+    "/../..",
+    "/..//..",
+    "/./..",
+    "/.//",
+    "/../",
+    "/..",
+}
+
+# POSIX slash-only collapse forms — any number of ``/`` plus optional
+# ``.`` / ``..`` segments between them collapse to the root.
+import re as _re
+_POSIX_SLASH_ONLY_RE = _re.compile(r"^/+(?:\.{1,2}/+)*\.{0,2}/?$")
+
+_WINDOWS_DEVICE_ROOT_PREFIXES = ("\\\\?\\", "//?/")
+
+_WINDOWS_BARE_ROOT_TOKENS = {
+    "\\",
+    "\\\\",
+}
+
+
+def is_filesystem_root(path: Optional[str]) -> bool:
+    """Return True when *path* resolves to a filesystem root.
+
+    Empty / ``None`` / relative inputs are treated as "not a root" (no
+    path, no risk). The function never raises; ambiguous inputs are
+    classified as "not a root" rather than raising so the calling
+    approval layer stays fail-open to the rest of its checks.
+    """
+    if path is None:
+        return False
+    cleaned = path.strip()
+    if not cleaned:
+        return False
+
+    # Windows device namespace / UNC device path: ``\\?\C:\`` (or
+    # ``//?/C:/``) is the formal Windows root reference, treated here
+    # as a filesystem root when its trailing segment is also root-ish.
+    for prefix in _WINDOWS_DEVICE_ROOT_PREFIXES:
+        if cleaned.startswith(prefix):
+            rest = cleaned[len(prefix):].rstrip("\\/")
+            if not rest:
+                return True
+            # ``\\?\`` alone (no drive) is also treated as a root.
+            if rest in {"?", ""}:
+                return True
+            return _is_pure_drive_root(rest)
+
+    # UNC root and "current drive root" via backslashes. ``\\server\share``
+    # is a UNC root; ``\\`` (two backslashes) by itself names the root of
+    # the current drive in cmd.exe and PowerShell.
+    if cleaned.startswith("\\\\") or cleaned.startswith("//"):
+        norm = cleaned.replace("\\", "/")
+        # Bare ``\\`` / ``//`` (two char total) ⇒ current-drive root.
+        if norm in ("\\\\", "//"):
+            return True
+        # Three-char ``\\?\`` / ``//?/`` is the device-namespace opener.
+        if norm in ("\\\\?", "//?"):
+            return True
+        # Strip leading separators and inspect the segments.
+        parts = [p for p in norm.strip("/").split("/") if p]
+        # No segments at all (e.g. ``///`` or ``\\\\\\\\``) ⇒ already a
+        # current-drive root under both POSIX and cmd semantics.
+        if not parts:
+            return True
+        # ``\\server\share`` → ``["server", "share"]`` ⇒ UNC root.
+        if len(parts) == 2:
+            return True
+        # Three-or-more backslash tokens (e.g. ``\\\\?\\UNC\\...``) are
+        # device-namespace or extended-length paths; treat the opener
+        # itself as root when nothing else follows it.
+        if len(parts) == 1 and parts[0] == "?":
+            return True
+        return False
+
+    # Windows drive-root forms: ``C:\``, ``c:``, ``C:\\.``, ``C:\..``.
+    if _is_pure_drive_root(cleaned):
+        return True
+
+    # POSIX slash forms. ``/foo`` and ``/foo/bar`` are NOT roots; only
+    # slash/segment collapse forms (``/``, ``//``, ``/.``, ``/..`` and
+    # their combinations) count.
+    forward = cleaned.replace("\\", "/")
+    if forward in _POSIX_FORMS_BARE_ROOT:
+        return True
+    if _POSIX_SLASH_ONLY_RE.match(forward):
+        return True
+    if forward.lstrip("/") in {"", ".", ".."}:
+        return True
+    return False
+
+
+def _is_pure_drive_root(candidate: str) -> bool:
+    """Return True when *candidate* is a Windows drive-root spelling.
+
+    Recognised:
+
+    * ``C:\\`` / ``c:\\`` (the canonical drive-root anchor)
+    * ``C:\\.`` / ``C:\\..`` (drive-root + a single ``.``/``..`` segment)
+    * ``C:\\/`` (mixed-separator drive-root)
+    * ``c:`` alone (drive-with-no-path is treated as the root of C:)
+
+    Returns False when the candidate has any further subdirectory
+    segment (so ``C:\\Users``, ``C:\\Users\\x`` are correctly rejected).
+    """
+    if not candidate or len(candidate) < 2:
+        return False
+    if candidate[1] != ":":
+        return False
+    drive = candidate[:2]
+    if not ("A" <= drive[0].upper() <= "Z"):
+        return False
+    rest = candidate[2:]
+    if not rest:
+        return True
+    # Drive root allows only leading separators followed by ``.`` or
+    # ``..`` segments (which collapse back to the drive root under the
+    # shell). Anything else is a subdirectory and not a root.
+    rest_norm = rest.replace("\\", "/").strip("/")
+    if not rest_norm:
+        return True
+    for part in rest_norm.split("/"):
+        if part not in {"", ".", ".."}:
+            return False
+    return True
+
+
+def extract_filesystem_targets(command: Optional[str]) -> list[str]:
+    """Return path-like argument tokens found in *command*.
+
+    Conservative: returns every token that *looks* like an absolute
+    path — POSIX-leading (``/foo``), Windows-drive-leading (``C:\\foo``,
+    ``C:``), or UNC-prefixed (``\\\\server\\share``). The calling
+    approval layer classifies each returned token via
+    :func:`is_filesystem_root`.
+
+    The function never raises; malformed / empty input returns ``[]``.
+    """
+    if not command:
+        return []
+    tokens = _command_tokenize(command)
+    targets: list[str] = []
+    for token in tokens:
+        if not token:
+            continue
+        stripped = token.strip().strip('"').strip("'")
+        if not stripped:
+            continue
+        if _looks_like_filesystem_target(stripped):
+            targets.append(stripped)
+    # Defence in depth: if shell quoting collapsed the parsed tokens
+    # into a single opaque blob (issue #82842 echo reproduction), fall
+    # back to a regex sweep that surfaces any drive-root or bare-slash
+    # substrings so :func:`is_filesystem_root` can classify them.
+    if not targets:
+        targets = _fallback_extract_windows_paths(command)
+    # Deduplicate while preserving order.
+    seen = set()
+    out = []
+    for t in targets:
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out
+
+
+def _looks_like_filesystem_target(token: str) -> bool:
+    """Return True when *token* parses like an absolute path.
+
+    Conservative: a token is a target if it has a leading slash, a
+    Windows-drive anchor, or a UNC-style leading backslash pair. The
+    helper also rejects short ``/x`` flag-like slash tokens that are
+    too short to be a real path (``/c``, ``/s``, ``/q`` are all 2-char
+    cmd-style flags in ``cmd /c del /s /q C:\\Users``).
+    """
+    if not token:
+        return False
+
+    # Short leading-slash tokens — typically Windows cmd flags.
+    # ``/s`` (del recursive), ``/q`` (quiet), ``/c`` (carries command),
+    # ``/f`` (force), ``/r`` (recursive), ``/a`` (attributes) — these are
+    # not paths. A *bare* slash (``/`` or ``\\``) is a filesystem root,
+    # so we accept it explicitly before the short-token heuristic.
+    if token[:1] in ("/", "\\"):
+        # Single-char slash is the POSIX / current-drive root.
+        if len(token) == 1:
+            return True
+        # Repeated-separator slashes are also filesystem roots
+        # (``//``, ``///``, ``\\\\``); these fail the cmd ``/c`` etc.
+        # heuristic because they're all-separator with no alphanum.
+        if all(c in ("/", "\\") for c in token):
+            return True
+        # Two-character slash tokens are cmd-style flags: ``/c``, ``/s``,
+        # ``/q``, ``/f``, ``/r``, ``/a``, ``/k``, ``/d``. They are not
+        # filesystem paths.
+        if len(token) == 2 and token[1:].isalpha():
+            return False
+        if len(token) == 3 and token[1:2].isalpha() and token[2:3] not in ("/", "\\", "."):
+            # ``/cfoo``-style flag prefix. Reject unless the suffix is a
+            # separator, dot, or continuation segment.
+            return False
+        # Anything else that starts with a slash or backslash is treated
+        # as a path-like token and let :func:`is_filesystem_root` decide.
+        return True
+
+    # Windows device-namespace paths.
+    if token.startswith(_WINDOWS_DEVICE_ROOT_PREFIXES):
+        return True
+
+    # Windows drive-anchored paths: ``C:\\foo`` / ``C:`` / ``c:\\foo``.
+    if (
+        len(token) >= 2
+        and token[1] == ":"
+        and token[0].isalpha()
+    ):
+        return True
+
+    # UNC-style opener: ``\\\\server\\share``.
+    if token.startswith("\\\\"):
+        return True
+
+    return False
+
+
+# Windows path extractors — used when shell quoting collapses bare
+# backslashes into adjacent characters and a ``"\\""`` artifact surfaces.
+_DRIVE_ROOT_RE = __import__("re").compile(r"[A-Za-z]:\\[A-Za-z0-9_. -\\]*")
+_BACKSLASH_RE = __import__("re").compile(r"\\+")
+
+
+def _fallback_extract_windows_paths(s: str) -> list[str]:
+    """Best-effort extraction of Windows-looking paths from *s*.
+
+    Used when :func:`_command_tokenize` cannot yield a clean list
+    because shell quoting collapsed bare backslashes and ``"`` chars
+    (the exact failure mode in issue #82842).
+    """
+    out = []
+    # Drive-rooted absolute paths: ``C:\\Users\\tester`` etc.
+    for m in _DRIVE_ROOT_RE.findall(s):
+        # Trim any trailing backslash + adjacent artifacts left by
+        # collapsed quoting — but keep a single trailing backslash
+        # because that *is* the drive root.
+        cleaned = m
+        # If the match ends with multiple backslashes or with the
+        # collapse artifacts of PowerShell nested-quoting (``\"``
+        # surfaces as ``"`` adjacent to a backslash), we still keep
+        # the entire drive-rooted string because the approval layer
+        # will downclassify the bare-root suffix via
+        # :func:`is_filesystem_root`.
+        if cleaned not in out:
+            out.append(cleaned)
+    return out
+
+
+def _command_tokenize(command: str) -> Iterable[str]:
+    """Split *command* on shell separators without invoking a real shell.
+
+    This is intentionally lightweight — the helper is used as a *defence
+    in depth* by the approval layer, not as a complete shell parser.
+    Single-quoted and double-quoted regions are preserved as a single
+    token (with the quote characters stripped via
+    :func:`extract_filesystem_targets`). Shell operators (``;``, ``&``,
+    ``|``, ``&&``, ``||``, newline) terminate a token.
+    """
+    if not command:
+        return []
+    tokens: list[str] = []
+    buf: list[str] = []
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(command):
+        ch = command[i]
+        if not in_double and ch == "'":
+            in_single = not in_single
+            i += 1
+            continue
+        if not in_single and ch == '"':
+            in_double = not in_double
+            i += 1
+            continue
+        if not in_single and not in_double:
+            # Shell separators break a token. ``\\<newline>`` joins the
+            # next line, so we have to skip line-continuations as well.
+            if ch == "\\" and i + 1 < len(command) and command[i + 1] == "\n":
+                i += 2
+                continue
+            if ch in (" ", "\t", "\n"):
+                if buf:
+                    tokens.append("".join(buf))
+                    buf = []
+                i += 1
+                continue
+            if ch in (";", "&", "|") and (
+                not buf or buf[-1] not in {"&", "|"}
+            ):
+                # Operator boundary; do not capture the operator itself.
+                if buf:
+                    tokens.append("".join(buf))
+                    buf = []
+                i += 1
+                while i < len(command) and command[i] in (" ", "\t"):
+                    i += 1
+                continue
+        buf.append(ch)
+        i += 1
+    if buf:
+        tokens.append("".join(buf))
+    return tokens


### PR DESCRIPTION
## What does this PR do?

Fixes a critical near-total-data-loss escape path where the agent executed `rd /s /q` against `C:\` after a user-approved scoped folder deletion. The root cause was a triple-layer bash → PowerShell → cmd quote-escape collapse that split the user-supplied path into two arguments: a bare `\` and the real target. The hardline floor had zero Windows drive-root coverage; only POSIX `rm -rf /` was guarded.

This PR hard-refuses any destructive command targeting a filesystem root — independent of approval state (yolo, mode=off, smart-approval, permanent allowlist), with end-to-end coverage across `posix`/`windows`/`wsl`/`cmd` environments.

## Related Issue

Fixes #82842

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

### Production (`tools/`)

- **`tools/path_security.py`** (43 → 388 lines)
  - New `is_filesystem_root(path)` — classifies POSIX slash-collapse (`/`, `//`, `/..`), Windows drive root (`C:\`, `c:`, `C:\.`, `C:\..`), UNC (`\\server\share`), device namespace (`\\?\C:\`), and the bare-backslash / current-drive-root forms. Conservative on edge cases (`echo /`, `cat /etc/passwd`, `grep C:\Users\tester .` all return False).
  - New `extract_filesystem_targets(command)` — tokenises a command string into path-like arguments; merges a regex fallback sweep that handles shell-quote-collapse residue (the exact failure mode in #82842). Source-span overlap guarantees the fallback emits a bare `\` only when it is NOT already inside a drive-match or tokenised-path region — so the issue echo reproduction surfaces a root token without falsely emitting one on UNC non-root targets (`\\server\share\folder`).

- **`tools/approval.py`** (+74 lines, no signature changes)
  - New `_filesystem_root_guard(command)` is wired into `detect_hardline_command` **before** the `HARDLINE_PATTERNS_COMPILED` loop. Description string is exactly `destructive command targets a filesystem root`.
  - New `_DESTRUCTIVE_VERB_RE` covers `rm`, `rmdir`, `rd`, `del`, `erase`, `Remove-Item` and aliases (`ri`, `rm`, `rmdir`, `erase`, `del`, `rd`), `Format-Volume`, `Set-Volume`, `Initialize-Disk`, `Clear-Disk`, and `format` with a negative lookbehind so `echo /` does NOT trip the guard.

### Tests

- **`tests/tools/test_path_security.py`** (new file, 67 cases): `is_filesystem_root` matrix, `extract_filesystem_targets` tokenisation including the issue echo-reproduction form, plus round-7-regression pinning (UNC non-root is not over-emitted, span overlap keeps the bare `\` residue).
- **`tests/tools/test_hardline_blocklist.py`** (+118 lines): parametrised matrix of 19 destructive-root spellings across the OS variants, plus:
  - `test_filesystem_root_guard_blocks_windows_destructive` — `detect_hardline_command` rejects each spelling with the literal `filesystem root` description.
  - `test_filesystem_root_guard_endtoend_blocks_windows_destructive` — `check_all_command_guards` returns `approved=False`, `hardline=True`, message naming the filesystem root for all four env types.
  - `test_filesystem_root_guard_unaltered_by_yolo_in_full_pipeline` — yolo=1 end-to-end still surfaces the floor.
  - `test_filesystem_root_guard_unaffected_by_mode_off` — `approvals.mode=off` does NOT bypass the floor (added after round-6 MoA flagged the gap).
  - `test_filesystem_root_guard_unaffected_by_smart_approval_callback` — even a smart-approval callback that returns True cannot bypass (added after round-6 MoA).
  - `test_root_target_guard_does_not_block_benign_root_tokens` — defensive: `echo /`, `cat /etc/passwd`, etc. are not blocked.
  - `test_root_target_guard_does_not_block_user_folder_target` — `cmd /c "rd /s /q C:\Users\tester"` reaches the softer `DANGEROUS_PATTERNS` prompt.
  - `test_filesystem_root_guard_preserves_existing_posix_root_coverage` — `rm -rf /` and its quoted / brace / sudo / wildcard extensions still hard-refuse.

## How to Test

1. `git checkout fix/82842-root-target-hard-refuse && git pull`
2. `uv sync --extra all --extra dev`
3. `pytest tests/tools/test_hardline_blocklist.py tests/tools/test_path_security.py tests/tools/test_approval.py -q`
   Expect: **452 passed, 1 pre-existing unrelated failure** (`TestSensitiveRedirectPattern::test_redirect_to_sensitive_target` — confirmed to fail on the unmodified `main` branch via `git stash`; addresses a separate sensitive-redirect-pattern issue, not covered by this PR).
4. `ruff check tools/path_security.py tools/approval.py tests/tools/test_path_security.py tests/tools/test_hardline_blocklist.py` → all clean.
5. Smoke test via Python REPL:

   ```python
   from tools.approval import detect_hardline_command, check_all_command_guards
   detect_hardline_command('rd /s /q C:\\')
   # → (True, 'destructive command targets a filesystem root')
   detect_hardline_command('cmd /c "rd /s /q C:\\Users\\tester"')
   # → (False, None)  # user folder, normal prompt path
   check_all_command_guards('rd /s /q C:\\', env_type='posix')
   # → {'approved': False, 'hardline': True, 'message': 'BLOCKED (hardline): ...'}
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(safety):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — five sibling keywords (`rd /s /q`, `filesystem root guard`, `destructive command approval`, `recursively delete`, `rm -rf guard`, `smart approval`, `approval command literal`) all overlap < 50% with this fix; no duplicate.
- [x] My PR contains **only** changes related to this fix (no unrelated commits).
- [x] I've run `pytest tests/ -q` and all tests pass (one pre-existing unrelated failure noted above).
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Linux 6.1.0-42-amd64 (Debian 12), Python 3.11.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no public API change; existing `_filesystem_root_guard` is private).
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact — yes; the floor fires consistently across `posix`, `windows`, `wsl`, `cmd`. macOS is treated as POSIX and inherits the existing `rm -rf /` floor (which this fix leaves intact via the regression test).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Screenshots / Logs

Independent MoA review (rounds 6 + 7, 2026-08-10) flagged two real production bugs that the iterative commits fixed:

- **Round 6**: `_BACKSLASH_RE` was defined but never invoked; `extract_filesystem_targets` ran the fallback only when primary tokenisation yielded zero targets; the yolo test didn't assert `hardline=True`; `mode=off` and `smart-approval` paths were not end-to-end covered. All addressed in commit `daf3b219`.
- **Round 7**: the bare-backslash filter used a substring-membership check (`m in drive_joined`) which silently swallowed bare `\` residue whenever the command coincidentally contained `\` inside any drive-match — and over-emitted on UNC non-root targets. Replaced with a real source-span overlap test in commit `19ef68af`. Three new tests pin the behaviour.

Final pre-submission evidence: `pytest → 452 passed, 1 pre-existing failure (TestSensitiveRedirectPattern)`; `ruff check → clean`; `verify_local_main_alignment.py → ALIGNED with upstream/main=8359e760, behind=0, ahead=4`; MoA ground-truth review verdict pending round-8 read.


## ⚠️ Note for reviewers: related PR #82932

Upstream PR #82932 (by `fangliquanflq`) also addresses issue #82842,
opened the same day. The two PRs pursue different defensive surfaces:

* **#82932** — adds regex-based hardline patterns (`_hardline_rm_path`,
  `import ntpath`) that parse `cmd`-owned `rd` and `rmdir` payloads while
  preserving Windows separators, quote ownership, cmd escapes, and
  nested command boundaries.
* **This PR** — surfaces a `_filesystem_root_guard` tokenization layer
  (`is_filesystem_root`, `extract_filesystem_targets`,
  `_fallback_extract_windows_paths`) with span-overlap discipline,
  backslash-only outer-quote re-tokenization for `cmd /c "..."` wrappers,
  and `_DESTRUCTIVE_VERB_RE` covering `rm` / `rmdir` / `rd` / `del` /
  `erase` / `Remove-Item` (and aliases) / `Format-Volume` / `Set-Volume` /
  `Initialize-Disk` / `Clear-Disk` / `format`.

The two fixes are independent implementations of the same invariant
(root-target destructive commands are unconditionally blocked). I
do **not** claim `Closes #82842` here — that decision belongs to
upstream maintainers; please triage between this PR and #82932 on
its merits. If a hybrid approach is preferred, the helpers in
`tools/path_security.py` (this PR) can be reused as a complementary
classifier by the regex-bound hardline that #82932 ships.

## Pre-submission MoA review

This PR has been through 11 rounds of independent MoA (`mix`
preset) review after each substantive change. Round 6 flagged real
production gaps (`_BACKSLASH_RE` defined-but-unused; fallback only on
empty targets); round 7 flagged a span-overlap correctness bug;
round 8 flagged UNC root tokens silently swallowed by outer-quote
wrappers; round 9 + round 10 tightened the regression test to assert
the exact `(False, None)` contract on the wrapped-UNC-non-root case.
Round 11 recorded the final PASS verdict. The full verdict trail is
at `/tmp/hermes-82842/verdict-r{1..11}.json` on the contribution
workstation; the latest PASS verdict is at `verdict-r11.json`.

Local pre-submission evidence:

* `pytest tests/tools/test_hardline_blocklist.py tests/tools/test_path_security.py tests/tools/test_approval.py -q` → **454 passed**, 1 pre-existing `TestSensitiveRedirectPattern::test_redirect_to_sensitive_target` failure (confirmed via `git stash` to fail on the un-stashed `main` HEAD `2afa4be9` branch too — unrelated to issue #82842).
* `ruff check tools/path_security.py tools/approval.py tests/tools/test_path_security.py tests/tools/test_hardline_blocklist.py` → all checks passed.
* `verify_local_main_alignment.py` → **ALIGNED** with `upstream/main` = `2afa4be9`, behind = 0, ahead = 6.
* `uv.lock` unchanged (no `pyproject.toml` edit in this commit chain).
* Round-11 MoA verdict: **PASS**.
