### PR TITLE
fix(cron): load .env on no_agent path so standalone ticks resolve delivery home channels

### DIFF
--- a/contributors/emails/aameobius@gmail.com
+++ b/contributors/emails/aameobius@gmail.com
@@ -1,0 +1,2 @@
+francialisomlimoeiro
+# PR #82682 salvage (cron: load .env on no_agent path + delivery error diagnostics)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2231,11 +2231,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
             if result and result.get("error"):
                 # Include target context (platform/chat) so a bare error string
-                # like "Discord send failed: TimeoutError: " is attributable;
-                # no active exception here (error comes from the send result),
-                # so exc_info is only attached when one is in flight.
+                # like "Discord send failed: TimeoutError: " is attributable.
+                # Not inside an except block — the error comes from the send
+                # result dict, so there is no traceback to attach.
                 msg = f"delivery error: {result['error']} (target {platform_name}:{chat_id})"
-                logger.error("Job '%s': %s", job["id"], msg, exc_info=sys.exc_info()[0] is not None)
+                logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
                 continue

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3207,6 +3207,22 @@ def run_job(
     #                               the whole point of no_agent is that there
     #                               is no agent to wake
     if job.get("no_agent"):
+        # Load .env before the script runs so auto-delivery can resolve home
+        # channels. A standalone cron tick process typically starts WITHOUT
+        # TELEGRAM_HOME_CHANNEL/DISCORD_HOME_CHANNEL in its environment, and
+        # the agent path's per-run dotenv reload below never executes for
+        # no_agent jobs — every deliver=telegram/all script job failed with
+        # "no delivery target resolved". load_hermes_dotenv does not override
+        # already-set vars, so the gateway's in-process tick is unaffected.
+        try:
+            from hermes_cli.env_loader import load_hermes_dotenv
+
+            load_hermes_dotenv(hermes_home=_get_hermes_home())
+        except Exception:
+            logger.debug(
+                "Job '%s': no_agent .env reload failed", job_id, exc_info=True
+            )
+
         script_path = job.get("script")
         if not script_path:
             err = "no_agent=True but no script is set for this job"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2230,8 +2230,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             if result and result.get("error"):
-                msg = f"delivery error: {result['error']}"
-                logger.error("Job '%s': %s", job["id"], msg)
+                # Include target context (platform/chat) so a bare error string
+                # like "Discord send failed: TimeoutError: " is attributable;
+                # no active exception here (error comes from the send result),
+                # so exc_info is only attached when one is in flight.
+                msg = f"delivery error: {result['error']} (target {platform_name}:{chat_id})"
+                logger.error("Job '%s': %s", job["id"], msg, exc_info=sys.exc_info()[0] is not None)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
                 continue

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9805,7 +9805,10 @@ async def _standalone_send(
             result["warnings"] = warnings
         return result
     except Exception as e:
-        return {"error": _standalone_sanitize_error(f"Discord send failed: {e}")}
+        # Include the exception type: TimeoutError().str() is empty, so
+        # "Discord send failed: " alone gave no diagnostic signal.
+        logger.error("Discord standalone send failed", exc_info=True)
+        return {"error": _standalone_sanitize_error(f"Discord send failed: {type(e).__name__}: {e}")}
 
 
 # ── Plugin entry point ────────────────────────────────────────────────────────

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -105,6 +105,36 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+def test_run_job_no_agent_reloads_dotenv_before_script(hermes_env, monkeypatch):
+    """Regression: a standalone cron tick process starts without home-channel
+    vars in its environment, and the agent path's per-run dotenv reload never
+    executes for no_agent jobs — delivery home channels stayed unresolved.
+    run_job must load .env at the top of the no_agent branch."""
+    import hermes_cli.env_loader as env_loader
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    loaded_homes: list = []
+
+    def fake_load(*, hermes_home=None, project_env=None):
+        loaded_homes.append(hermes_home)
+        return []
+
+    monkeypatch.setattr(env_loader, "load_hermes_dotenv", fake_load)
+
+    script_path = hermes_env / "scripts" / "probe.sh"
+    script_path.write_text('#!/bin/bash\necho "ok"\n')
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="probe.sh", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert error is None
+    assert loaded_homes, "load_hermes_dotenv was not called on the no_agent path"
+    assert str(loaded_homes[0]) == str(hermes_env)
+
+
 # ---------------------------------------------------------------------------
 # _run_job_script: shell-script support
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Standalone `no_agent` cron jobs (script-only watchdogs) with `deliver=telegram/all` now resolve delivery home channels correctly — previously every such job failed with "no delivery target resolved" because the dotenv reload lived only on the agent path.

Root cause: `hermes-cron-tick.service` starts without `TELEGRAM_HOME_CHANNEL`/`DISCORD_HOME_CHANNEL` in its environment. The per-run `load_hermes_dotenv` reload at scheduler.py:3656 only runs on the agent path (after the `no_agent` short-circuit returns), so `_get_home_target_chat_id()` reads empty `os.getenv` values and delivery fails.

## Changes
- `cron/scheduler.py`: Load `.env` at the top of the `no_agent` branch so delivery channels resolve in standalone tick processes.
- `cron/scheduler.py`: Include target context `(platform:chat_id)` in delivery error logs for attributability.
- `plugins/platforms/discord/adapter.py`: Include exception type in `_standalone_send` error string (`TimeoutError().__str__()` is empty, so "Discord send failed: " alone gave no signal) + log full traceback.
- Follow-up: Dropped dead `sys.exc_info()[0] is not None` condition (always False — not inside an except block).

## Attribution
Based on #82682 by @francialisomlimoeiro (aameobius <aameobius@gmail.com>). Cherry-picked with authorship preserved.

Closes #82682

## Test plan
- [x] `tests/cron/test_cron_no_agent.py` — 7 passed (incl. new `test_run_job_no_agent_reloads_dotenv_before_script`)
- [x] `tests/cron/test_run_one_job.py` — 3 passed
- [x] ruff — clean
- [x] py_compile — clean
