### PR TITLE
feat(tts): add native VoxCPM provider (local, 30 langs, voice design + cloning)

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -57,6 +57,7 @@ _BUILTIN_NAMES = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "voxcpm",
 })
 
 

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -142,13 +142,13 @@ class TestCommandTtsEnv:
 
 class TestGetNamedProviderConfig:
     def test_providers_block_wins(self):
-        cfg = {"providers": {"voxcpm": {"command": "new"}},
-               "voxcpm": {"command": "legacy"}}
-        assert _get_named_provider_config(cfg, "voxcpm") == {"command": "new"}
+        cfg = {"providers": {"kokoro": {"command": "new"}},
+               "kokoro": {"command": "legacy"}}
+        assert _get_named_provider_config(cfg, "kokoro") == {"command": "new"}
 
     def test_legacy_tts_name_block_still_resolves(self):
-        cfg = {"voxcpm": {"type": "command", "command": "legacy"}}
-        assert _get_named_provider_config(cfg, "voxcpm") == {
+        cfg = {"kokoro": {"type": "command", "command": "legacy"}}
+        assert _get_named_provider_config(cfg, "kokoro") == {
             "type": "command", "command": "legacy"
         }
 
@@ -177,12 +177,12 @@ class TestIterCommandProviders:
             "providers": {
                 "openai": {"type": "command", "command": "shouldnt show up"},
                 "piper-cli": {"type": "command", "command": "piper-cli"},
-                "voxcpm": {"type": "command", "command": "voxcpm"},
+                "kokoro-cli": {"type": "command", "command": "kokoro-cli"},
                 "broken": {"type": "command", "command": ""},
             },
         }
         names = sorted(name for name, _ in _iter_command_providers(cfg))
-        assert names == ["piper-cli", "voxcpm"]
+        assert names == ["kokoro-cli", "piper-cli"]
 
 
     def test_has_any_command_provider_when_none(self):

--- a/tests/tools/test_tts_voxcpm.py
+++ b/tests/tools/test_tts_voxcpm.py
@@ -1,0 +1,373 @@
+"""
+Tests for the native VoxCPM TTS provider.
+
+VoxCPM (https://github.com/OpenBMB/VoxCPM) is OpenBMB's tokenizer-free
+diffusion-autoregressive TTS engine. VoxCPM2 (default) is a 2B parameter
+model supporting 30 languages, voice design from text prompts, and
+reference-audio voice cloning.
+
+These tests pin the registry / config resolution / dispatch / error paths
+WITHOUT requiring the 5 GB model weights or the ``voxcpm`` Python package
+to be installed in CI. Synthesis is monkey-patched to return a fake
+numpy waveform. The optional ``test_voxcpm_e2e_*`` tests are skipped
+unless the user has installed ``voxcpm`` AND placed the model weights
+under ``~/.hermes/models/VoxCPM2`` (or the path they configure).
+"""
+
+import json
+import os
+import sys
+import wave
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools import tts_tool
+from tools.tts_tool import (
+    BUILTIN_TTS_PROVIDERS,
+    DEFAULT_VOXCPM_CFG_VALUE,
+    DEFAULT_VOXCPM_INFERENCE_TIMESTEPS,
+    DEFAULT_VOXCPM_MODEL,
+    PROVIDER_MAX_TEXT_LENGTH,
+    _check_voxcpm_available,
+    _generate_voxcpm_tts,
+    _import_voxcpm,
+    _resolve_voxcpm_model_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake VoxCPM for unit tests (no model load)
+# ---------------------------------------------------------------------------
+
+
+class _FakeVoxCPM:
+    """Minimal stand-in for voxcpm.VoxCPM used by the unit tests.
+
+    Records every generate() call so tests can assert on the kwargs we
+    passed and returns a deterministic 1-second silence waveform at the
+    model-declared sample rate.
+    """
+
+    # Class-level call recorders (reset by _patch_voxcpm).
+    # Initialized to None / 0 so tests can detect "no call yet" without
+    # relying on attribute creation order.
+    last_call_kwargs = None
+    last_call_count = 0
+
+    def __init__(self):
+        self.calls = []
+        self.tts_model = MagicMock()
+        self.tts_model.sample_rate = 48000  # VoxCPM2 native rate
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+
+    def generate(self, **kwargs):
+        type(self).last_call_kwargs = kwargs
+        type(self).last_call_count += 1
+        import numpy as np
+        return np.zeros(self.tts_model.sample_rate, dtype=np.float32)
+
+
+def _patch_voxcpm(monkeypatch):
+    """Wire up the fake VoxCPM class so _import_voxcpm() returns it."""
+    monkeypatch.setattr(tts_tool, "_import_voxcpm", lambda: _FakeVoxCPM)
+    # Reset call recorders so each test starts clean
+    _FakeVoxCPM.last_call_kwargs = None
+    _FakeVoxCPM.last_call_count = 0
+
+
+# ---------------------------------------------------------------------------
+# Registry / constants
+# ---------------------------------------------------------------------------
+
+
+class TestVoxCPMRegistration:
+    def test_voxcpm_is_a_builtin_provider(self):
+        assert "voxcpm" in BUILTIN_TTS_PROVIDERS
+
+    def test_voxcpm_has_a_text_length_cap(self):
+        cap = PROVIDER_MAX_TEXT_LENGTH.get("voxcpm", 0)
+        assert cap > 0, "VoxCPM provider must declare a max_text_length"
+
+    def test_default_model_is_voxcpm2(self):
+        assert DEFAULT_VOXCPM_MODEL == "openbmb/VoxCPM2"
+
+    def test_default_cfg_value_in_safe_range(self):
+        # VoxCPM's own docs recommend 1.0-3.0; we land at 2.0 by default
+        assert 1.0 <= DEFAULT_VOXCPM_CFG_VALUE <= 3.0
+
+    def test_default_inference_timesteps_reasonable(self):
+        # VoxCPM's docs recommend 4-30; default 10 balances speed/quality
+        assert 4 <= DEFAULT_VOXCPM_INFERENCE_TIMESTEPS <= 30
+
+
+# ---------------------------------------------------------------------------
+# _check_voxcpm_available
+# ---------------------------------------------------------------------------
+
+
+class TestCheckVoxCPMAvailable:
+    def test_returns_bool_without_raising(self):
+        # Probe must never raise — env-dependent answer is fine.
+        assert isinstance(_check_voxcpm_available(), bool)
+
+    def test_returns_false_when_voxcpm_missing(self, monkeypatch):
+        import importlib.util
+        monkeypatch.setattr(
+            importlib.util, "find_spec",
+            lambda name: None if name == "voxcpm" else importlib.util.find_spec(name),
+        )
+        assert _check_voxcpm_available() is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_voxcpm_model_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveVoxCPMModelPath:
+    def test_local_directory_returned_expanded(self, tmp_path):
+        # Existing directory is returned as-is (after ~ expansion)
+        home_dir = tmp_path / "fakehome" / "models" / "VoxCPM2"
+        home_dir.mkdir(parents=True)
+        resolved = _resolve_voxcpm_model_path(str(home_dir))
+        assert resolved == str(home_dir)
+
+    def test_repo_id_passes_through(self):
+        # Repo ids ("org/name") are returned unchanged so voxcpm can resolve
+        repo = "openbmb/VoxCPM2"
+        assert _resolve_voxcpm_model_path(repo) == repo
+
+    def test_expands_user_when_path_does_not_exist(self, monkeypatch):
+        # If the user wrote ~/models/voxcpm but the path doesn't exist we
+        # still want ~ expanded (and the model loader will surface a clear
+        # FileNotFoundError later — we don't pretend it exists here).
+        monkeypatch.setenv("HOME", "/tmp/fake-home")
+        result = _resolve_voxcpm_model_path("~/models/VoxCPM2")
+        assert result == os.path.expanduser("~/models/VoxCPM2")
+
+
+# ---------------------------------------------------------------------------
+# _generate_voxcpm_tts — config / dispatch (no model load)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateVoxCPMConfigResolution:
+    """Verify that _generate_voxcpm_tts reads config keys and calls
+    generate() with the expected kwargs, without needing a real model."""
+
+    def test_uses_defaults_when_no_voxcpm_config(self, tmp_path, monkeypatch):
+        _patch_voxcpm(monkeypatch)
+        out = tmp_path / "test.wav"
+        _generate_voxcpm_tts("Hello world", str(out), tts_config={})
+
+        kwargs = _FakeVoxCPM.last_call_kwargs
+        assert kwargs is not None
+        assert kwargs["text"] == "Hello world"
+        assert kwargs["cfg_value"] == DEFAULT_VOXCPM_CFG_VALUE
+        assert kwargs["inference_timesteps"] == DEFAULT_VOXCPM_INFERENCE_TIMESTEPS
+        assert kwargs["normalize"] is False
+        # No reference / prompt paths when not configured
+        assert "reference_wav_path" not in kwargs
+        assert "prompt_wav_path" not in kwargs
+
+    def test_passes_custom_cfg_and_steps(self, tmp_path, monkeypatch):
+        _patch_voxcpm(monkeypatch)
+        cfg = {
+            "voxcpm": {
+                "cfg_value": 1.5,
+                "inference_timesteps": 20,
+                "normalize": True,
+            }
+        }
+        _generate_voxcpm_tts("Test", str(tmp_path / "test.wav"), cfg)
+        kwargs = _FakeVoxCPM.last_call_kwargs
+        assert kwargs is not None
+        assert kwargs["cfg_value"] == 1.5
+        assert kwargs["inference_timesteps"] == 20
+        assert kwargs["normalize"] is True
+
+    def test_reference_wav_path_passed_through(self, tmp_path, monkeypatch):
+        _patch_voxcpm(monkeypatch)
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(b"fake wav")
+        cfg = {"voxcpm": {"reference_wav_path": str(ref)}}
+        _generate_voxcpm_tts("Clone me", str(tmp_path / "out.wav"), cfg)
+        kwargs = _FakeVoxCPM.last_call_kwargs
+        assert kwargs is not None
+        assert kwargs["reference_wav_path"] == str(ref)
+
+    def test_prompt_wav_and_text_passed_together(self, tmp_path, monkeypatch):
+        _patch_voxcpm(monkeypatch)
+        prompt = tmp_path / "prompt.wav"
+        prompt.write_bytes(b"fake wav")
+        cfg = {
+            "voxcpm": {
+                "prompt_wav_path": str(prompt),
+                "prompt_text": "This is the reference transcript.",
+            }
+        }
+        _generate_voxcpm_tts("Continue me", str(tmp_path / "out.wav"), cfg)
+        kwargs = _FakeVoxCPM.last_call_kwargs
+        assert kwargs is not None
+        assert kwargs["prompt_wav_path"] == str(prompt)
+        assert kwargs["prompt_text"] == "This is the reference transcript."
+
+    def test_prompt_wav_without_text_raises(self, tmp_path, monkeypatch):
+        _patch_voxcpm(monkeypatch)
+        prompt = tmp_path / "prompt.wav"
+        prompt.write_bytes(b"fake wav")
+        cfg = {"voxcpm": {"prompt_wav_path": str(prompt), "prompt_text": ""}}
+        # prompt_text empty string is falsy → treated as None → mismatch
+        with pytest.raises(ValueError, match="prompt_wav_path and prompt_text"):
+            _generate_voxcpm_tts(
+                "x", str(tmp_path / "out.wav"), cfg,
+            )
+
+    def test_missing_reference_wav_raises(self, tmp_path, monkeypatch):
+        _patch_voxcpm(monkeypatch)
+        cfg = {"voxcpm": {"reference_wav_path": "/nonexistent/ref.wav"}}
+        with pytest.raises(FileNotFoundError, match="reference_wav_path"):
+            _generate_voxcpm_tts(
+                "x", str(tmp_path / "out.wav"), cfg,
+            )
+
+
+# ---------------------------------------------------------------------------
+# _generate_voxcpm_tts — WAV file output (no model load)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateVoxCPMWAVOutput:
+    """Verify that the synthesized audio is written as a real WAV the
+    caller can read back. No model load — only a fake numpy array."""
+
+    def test_writes_a_real_wav_file(self, tmp_path, monkeypatch):
+        _patch_voxcpm(monkeypatch)
+        out = tmp_path / "output.wav"
+        _generate_voxcpm_tts(
+            "Hello VoxCPM", str(out), tts_config={},
+        )
+        assert out.exists()
+        assert out.stat().st_size > 0
+        # Wave module can open what we wrote
+        with wave.open(str(out), "rb") as wav:
+            assert wav.getnchannels() == 1
+            assert wav.getframerate() == 48000  # VoxCPM2 native rate
+
+    def test_converts_to_mp3_when_output_path_is_mp3(self, tmp_path, monkeypatch):
+        _patch_voxcpm(monkeypatch)
+        # Skip this test if ffmpeg isn't installed — the function falls
+        # back to keeping the WAV under that name, which the caller
+        # contract still accepts.
+        ffmpeg = _find_ffmpeg()
+        if not ffmpeg:
+            pytest.skip("ffmpeg not installed; conversion branch untestable")
+
+        out = tmp_path / "output.mp3"
+        _generate_voxcpm_tts("Hello", str(out), tts_config={})
+        assert out.exists()
+        assert out.stat().st_size > 0
+        # ffmpeg writes mp3 with either ID3 or MPEG frame sync header
+        head = out.read_bytes()[:4]
+        assert head[:3] == b"ID3" or head[:2] == b"\xff\xfb"
+
+
+def _find_ffmpeg():
+    """Locate ffmpeg on PATH (mirrors shutil.which without importing shutil)."""
+    import shutil
+    return shutil.which("ffmpeg")
+
+
+# ---------------------------------------------------------------------------
+# _import_voxcpm — lazy import contract
+# ---------------------------------------------------------------------------
+
+
+class TestImportVoxCPM:
+    def test_returns_callable_class(self):
+        # When voxcpm is installed (it is in this test env), _import_voxcpm
+        # returns the actual VoxCPM class which is callable.
+        cls = _import_voxcpm()
+        assert callable(cls)
+
+    def test_raises_import_error_when_missing(self, monkeypatch):
+        # Simulate "not installed" by hiding the module from importlib.util.
+        import importlib.util
+        import builtins
+
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "voxcpm" or name.startswith("voxcpm."):
+                raise ImportError(f"No module named '{name}' (simulated)")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        # Now _import_voxcpm's hard-coded "from voxcpm import VoxCPM" must
+        # raise ImportError (the lazy-import guard surfaces it to the caller).
+        with pytest.raises(ImportError):
+            _import_voxcpm()
+
+
+# ---------------------------------------------------------------------------
+# E2E test — runs the real VoxCPM2 if weights + package are present
+# ---------------------------------------------------------------------------
+#
+# This test is skipped by default. To run it locally:
+#
+#   pip install voxcpm
+#   python -c "from modelscope import snapshot_download; snapshot_download('OpenBMB/VoxCPM2', local_dir='~/.hermes/models/VoxCPM2')"
+#   pytest tests/tools/test_tts_voxcpm.py::TestVoxCPMEnd2End -v
+#
+# Generates a real 48 kHz WAV and asserts it's a non-trivial waveform
+# (not silence). Uses MPS on Apple Silicon by default.
+
+
+@pytest.mark.skipif(
+    not _check_voxcpm_available(),
+    reason="voxcpm Python package not installed",
+)
+class TestVoxCPMEnd2End:
+    def test_real_voxcpm2_voice_design(self, tmp_path):
+        model_dir = Path(os.path.expanduser("~/.hermes/models/VoxCPM2"))
+        if not model_dir.exists():
+            pytest.skip(
+                "VoxCPM2 weights not present at ~/.hermes/models/VoxCPM2 "
+                "(download via ModelScope to run this E2E test)"
+            )
+
+        out = tmp_path / "voxcpm_e2e.wav"
+        _generate_voxcpm_tts(
+            "VoxCPM2 end-to-end test on Apple Silicon.",
+            str(out),
+            tts_config={
+                "voxcpm": {
+                    "model": str(model_dir),
+                    "device": "auto",
+                    "local_files_only": True,
+                    "cfg_value": 2.0,
+                    "inference_timesteps": 10,
+                }
+            },
+        )
+        assert out.exists()
+        assert out.stat().st_size > 48000 * 2  # at least 1 second of 16-bit audio
+
+        # Open the WAV back and confirm it decodes to a non-silent signal
+        import numpy as np
+        with wave.open(str(out), "rb") as wav:
+            frames = wav.readframes(wav.getnframes())
+            audio = np.frombuffer(frames, dtype=np.int16)
+            sr = wav.getframerate()
+        assert sr == 48000, f"VoxCPM2 expected 48kHz, got {sr}"
+        assert audio.dtype == np.int16
+        # Real speech has audible amplitude — silence would be all zeros.
+        # Threshold is intentionally loose so we don't depend on test text.
+        rms = float(np.sqrt(np.mean(audio.astype(np.float32) ** 2)))
+        assert rms > 50, f"Generated audio looks like silence (rms={rms})"

--- a/tests/tools/test_tts_voxcpm.py
+++ b/tests/tools/test_tts_voxcpm.py
@@ -69,8 +69,11 @@ class _FakeVoxCPM:
     def generate(self, **kwargs):
         type(self).last_call_kwargs = kwargs
         type(self).last_call_count += 1
-        import numpy as np
-        return np.zeros(self.tts_model.sample_rate, dtype=np.float32)
+        # Pure-stdlib stand-in for a numpy float32 waveform: a list of
+        # float samples. The fake soundfile writer converts it to int16
+        # without numpy, so these unit tests run in CI (where numpy is
+        # NOT installed — it lives in the lazy [voice] extra).
+        return [0.0] * self.tts_model.sample_rate
 
 
 def _patch_voxcpm(monkeypatch):
@@ -97,12 +100,23 @@ def _fake_soundfile(monkeypatch):
     fake_sf = types.ModuleType("soundfile")
 
     def _fake_write(path, audio, sample_rate, subtype="PCM_16", **kwargs):
-        import numpy as np
-        samples = np.asarray(audio)
-        if samples.dtype != np.int16:
-            # Normalize float audio to int16 so `wave` can write it.
-            scaled = np.clip(samples, -1.0, 1.0)
-            samples = (scaled * 32767).astype(np.int16)
+        # Pure-stdlib WAV writer: converts float samples (or int16) to
+        # little-endian int16 PCM without numpy, so the unit tests run in
+        # CI where numpy is not installed ([voice] extra is lazy).
+        import array
+
+        if isinstance(audio, array.array):
+            samples = audio
+        else:
+            try:
+                samples = array.array("h", audio)  # already int16
+            except (TypeError, OverflowError):
+                # Float samples in [-1, 1] → int16.
+                ints = []
+                for s in audio:
+                    v = int(round(max(-1.0, min(1.0, float(s))) * 32767))
+                    ints.append(v)
+                samples = array.array("h", ints)
         with wave.open(str(path), "wb") as wav:
             wav.setnchannels(1)
             wav.setsampwidth(2)

--- a/tests/tools/test_tts_voxcpm.py
+++ b/tests/tools/test_tts_voxcpm.py
@@ -17,6 +17,7 @@ under ``~/.hermes/models/VoxCPM2`` (or the path they configure).
 import json
 import os
 import sys
+import types
 import wave
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -78,6 +79,39 @@ def _patch_voxcpm(monkeypatch):
     # Reset call recorders so each test starts clean
     _FakeVoxCPM.last_call_kwargs = None
     _FakeVoxCPM.last_call_count = 0
+
+
+@pytest.fixture(autouse=True)
+def _fake_soundfile(monkeypatch):
+    """Stub the optional `soundfile` dependency so the unit tests run in CI.
+
+    `_generate_voxcpm_tts` does `import soundfile as sf` at runtime and
+    calls `sf.write(path, audio, sample_rate, subtype=...)`. CI does not
+    install soundfile (voxcpm is optional), so without this stub every
+    config-resolution test fails with ModuleNotFoundError. The stub writes
+    a real, wave-module-readable WAV so the output assertions still hold.
+    """
+    import types
+    import wave
+
+    fake_sf = types.ModuleType("soundfile")
+
+    def _fake_write(path, audio, sample_rate, subtype="PCM_16", **kwargs):
+        import numpy as np
+        samples = np.asarray(audio)
+        if samples.dtype != np.int16:
+            # Normalize float audio to int16 so `wave` can write it.
+            scaled = np.clip(samples, -1.0, 1.0)
+            samples = (scaled * 32767).astype(np.int16)
+        with wave.open(str(path), "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(sample_rate)
+            wav.writeframes(samples.tobytes())
+
+    fake_sf.write = _fake_write
+    monkeypatch.setitem(sys.modules, "soundfile", fake_sf)
+    yield fake_sf
 
 
 # ---------------------------------------------------------------------------
@@ -289,9 +323,18 @@ def _find_ffmpeg():
 
 
 class TestImportVoxCPM:
-    def test_returns_callable_class(self):
-        # When voxcpm is installed (it is in this test env), _import_voxcpm
-        # returns the actual VoxCPM class which is callable.
+    def test_returns_callable_class(self, monkeypatch):
+        """When voxcpm is importable, _import_voxcpm returns a callable class."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "voxcpm":
+                return types.SimpleNamespace(VoxCPM=_FakeVoxCPM)
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
         cls = _import_voxcpm()
         assert callable(cls)
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -13,6 +13,8 @@ Built-in TTS providers:
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
 - Piper (local, free, no API key): OHF-Voice/piper1-gpl neural VITS, 44 languages
+- VoxCPM (local, free, no API key): OpenBMB VoxCPM2, 30 languages incl. 9 Chinese
+  dialects, voice design + reference cloning + continuation, 48 kHz output
 
 Custom command providers:
 - Users can declare any number of named providers with ``type: command``
@@ -203,6 +205,28 @@ def _import_piper():
     return PiperVoice
 
 
+def _import_voxcpm():
+    """Lazy import VoxCPM. Returns the VoxCPM class or raises ImportError.
+
+    VoxCPM is OpenBMB's tokenizer-free, diffusion-autoregressive TTS engine
+    (https://github.com/OpenBMB/VoxCPM). The package is optional and only
+    required when the user has selected ``provider: voxcpm`` in
+    ``~/.hermes/config.yaml``. Install with:
+
+        pip install voxcpm
+
+    VoxCPM2 (default) is a 2B-parameter model that supports 30 languages,
+    voice design from text prompts, and reference-audio voice cloning.
+    It runs locally on CUDA / MPS / CPU — no API key required.
+
+    The model weights (~5 GB total) are downloaded separately via ModelScope
+    (HF is blocked in some regions). See ``hermes setup tts`` and the VoxCPM
+    provider docs for the recommended layout.
+    """
+    from voxcpm import VoxCPM
+    return VoxCPM
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -220,6 +244,10 @@ MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
+DEFAULT_VOXCPM_MODEL = "openbmb/VoxCPM2"  # 2B, 30 languages, 48kHz
+DEFAULT_VOXCPM_DEVICE = "auto"  # voxcpm auto-selects CUDA → MPS → CPU
+DEFAULT_VOXCPM_CFG_VALUE = 2.0
+DEFAULT_VOXCPM_INFERENCE_TIMESTEPS = 10
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
@@ -283,6 +311,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "voxcpm": 4000,       # VoxCPM2 2B local model — quality falls off past ~4k chars per chunk
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -780,6 +809,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "voxcpm",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -3125,6 +3155,206 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 
 
 # ===========================================================================
+# Provider: VoxCPM (OpenBMB — local, 30-language, voice-design + cloning)
+# ===========================================================================
+#
+# VoxCPM is OpenBMB's tokenizer-free, diffusion-autoregressive TTS engine
+# (https://github.com/OpenBMB/VoxCPM). The default VoxCPM2 weights are a 2B
+# parameter model trained on >2M hours of multilingual speech, supporting 30
+# languages (incl. Chinese dialects), 48 kHz studio-quality output, voice
+# design from text prompts, and reference-audio voice cloning.
+#
+# All synthesis is local — no API key required, no data leaves the host.
+# The engine runs on CUDA / MPS / CPU (VoxCPM auto-selects when ``device``
+# is ``None`` or ``"auto"``).
+#
+# Config keys (all under ``tts.voxcpm``):
+#
+#   model           Path or HF/ModelScope id (default "openbmb/VoxCPM2")
+#   device          "auto" | "cpu" | "mps" | "cuda" | "cuda:0"  (default "auto")
+#   local_files_only  Skip model download when True (default False)
+#   load_denoiser   Load acoustic denoiser (default False — ~1.5 GB extra,
+#                    not needed for typical TTS; enable if prompt audio is noisy)
+#   cfg_value       Guidance scale, recommended 1.0–3.0 (default 2.0)
+#   inference_timesteps   CFM denoising steps, 4–30 (default 10)
+#   normalize       Text normalization (default False — enable for digits/symbols)
+#   voice_design    Text description embedded in ``text`` for voice design
+#                   (e.g. "(A young woman, gentle voice) Hello!"). Applied only
+#                   when no reference_wav_path is provided.
+#   reference_wav_path   Voice cloning reference audio (16 kHz WAV preferred).
+#   prompt_wav_path      Continuation prompt audio (paired with prompt_text).
+#   prompt_text          Transcript of prompt_wav_path.
+#   max_text_length     Override PROVIDER_MAX_TEXT_LENGTH lookup.
+#
+# Module-level cache: VoxCPM model instances are heavy (~5 GB RAM on first
+# load) and load slowly (~10–30 s). Caching by (model, device, denoise) avoids
+# re-paying that cost on every call. The same LRU cap that bounds Piper and
+# KittenTTS caches applies — most sessions use a single model.
+
+# Module-level cache for VoxCPM model instances.
+_voxcpm_model_cache: Dict[str, Any] = {}
+
+
+def _check_voxcpm_available() -> bool:
+    """Return True when the optional ``voxcpm`` Python package is importable."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("voxcpm") is not None
+    except Exception:
+        return False
+
+
+def _resolve_voxcpm_model_path(model: str) -> str:
+    """Resolve a VoxCPM model id / HF repo / local path to a concrete directory.
+
+    VoxCPM's :meth:`from_pretrained` accepts both HF repo ids
+    (``"openbmb/VoxCPM2"``) and local filesystem paths. When a user supplies a
+    repo id we pass it through unchanged; when they supply a path we expand
+    ``~`` first and verify it exists so a typo raises a clear error here
+    rather than a stack trace inside voxcpm's weight loader.
+    """
+    expanded = os.path.expanduser(model)
+    if os.path.isdir(expanded):
+        return expanded
+    # Looks like a repo id (org/name) — defer to voxcpm.from_pretrained to
+    # resolve. An expanded-but-nonexistent path is left expanded so the
+    # voxcpm loader's own FileNotFoundError shows the post-expansion path.
+    if expanded != model:
+        return expanded
+    return model
+
+
+def _generate_voxcpm_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using the local VoxCPM engine.
+
+    VoxCPM2 supports three synthesis modes selected by which inputs the user
+    configured:
+
+      1. **Voice design** — text begins with ``"(description) "`` (or no
+         reference audio). The model synthesizes a brand-new voice from the
+         natural-language description.
+      2. **Reference cloning** — ``reference_wav_path`` set. VoxCPM2 clones
+         the timbre of the reference clip while keeping the user's text.
+      3. **Continuation / ultimate cloning** — both ``prompt_wav_path`` and
+         ``prompt_text`` set. VoxCPM2 continues from the reference audio,
+         preserving every vocal nuance (timbre, rhythm, emotion, style).
+
+    Writes WAV. Caller is responsible for ffmpeg conversion to MP3/Opus.
+    """
+    VoxCPM = _import_voxcpm()
+    import soundfile as sf  # voxcpm only requires numpy + torch; we add sf for writing
+
+    voxcpm_config = tts_config.get("voxcpm") or {}
+    model_id = voxcpm_config.get("model", DEFAULT_VOXCPM_MODEL)
+    device = voxcpm_config.get("device", DEFAULT_VOXCPM_DEVICE)
+    load_denoiser = bool(voxcpm_config.get("load_denoiser", False))
+    local_files_only = bool(voxcpm_config.get("local_files_only", False))
+    cfg_value = float(voxcpm_config.get("cfg_value", DEFAULT_VOXCPM_CFG_VALUE))
+    inference_timesteps = int(
+        voxcpm_config.get("inference_timesteps", DEFAULT_VOXCPM_INFERENCE_TIMESTEPS)
+    )
+    normalize = bool(voxcpm_config.get("normalize", False))
+
+    reference_wav_path = voxcpm_config.get("reference_wav_path") or None
+    prompt_wav_path = voxcpm_config.get("prompt_wav_path") or None
+    prompt_text = voxcpm_config.get("prompt_text") or None
+
+    # Validate reference / prompt audio paths up front — voxcpm would raise a
+    # less clear FileNotFoundError from inside the model if we didn't.
+    for label, path in (
+        ("reference_wav_path", reference_wav_path),
+        ("prompt_wav_path", prompt_wav_path),
+    ):
+        if path and not os.path.exists(path):
+            raise FileNotFoundError(
+                f"voxcpm {label} not found: {path}"
+            )
+
+    # VoxCPM contract: prompt_wav_path and prompt_text must both be provided
+    # together (or both omitted). Validate before spending model-load time.
+    if (prompt_wav_path is None) != (prompt_text is None):
+        raise ValueError(
+            "voxcpm: prompt_wav_path and prompt_text must both be provided or both omitted"
+        )
+
+    # Cache key: distinct (model, device, denoise, local-only) settings share a
+    # model load. local_files_only is part of the key because the from_pretrained
+    # path differs (network vs cache-only resolution).
+    cache_key = f"{model_id}::{device}::denoise={load_denoiser}::local={local_files_only}"
+
+    def _load_voxcpm_model():
+        resolved = _resolve_voxcpm_model_path(model_id)
+        logger.info(
+            "[VoxCPM] Loading model: id=%s resolved=%s device=%s denoise=%s local_only=%s",
+            model_id, resolved, device, load_denoiser, local_files_only,
+        )
+        m = VoxCPM.from_pretrained(
+            resolved,
+            load_denoiser=load_denoiser,
+            device=None if device == "auto" else device,
+            local_files_only=local_files_only,
+        )
+        logger.info("[VoxCPM] Model loaded successfully")
+        return m
+
+    model = _tts_cache_get_or_load(_voxcpm_model_cache, cache_key, _load_voxcpm_model)
+
+    # VoxCPM outputs a numpy float32 waveform on CPU at the model's native
+    # sample rate (48 kHz for VoxCPM2, 44.1 kHz for VoxCPM1.5, 16 kHz for
+    # VoxCPM-0.5B). The sample_rate lives on the underlying tts_model.
+    sample_rate = int(model.tts_model.sample_rate)
+
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    logger.info(
+        "[VoxCPM] Generating: text=%d chars cfg=%.2f steps=%d ref=%s prompt=%s",
+        len(text), cfg_value, inference_timesteps,
+        bool(reference_wav_path), bool(prompt_wav_path),
+    )
+
+    # VoxCPM's _generate signature uses *args/**kwargs (defensively forwarding
+    # both streaming and non-streaming modes). Build kwargs explicitly so
+    # callers see exactly what we passed and a future API rename surfaces as a
+    # TypeError rather than a silent kwargs mismatch.
+    generate_kwargs: Dict[str, Any] = {
+        "text": text,
+        "cfg_value": cfg_value,
+        "inference_timesteps": inference_timesteps,
+        "normalize": normalize,
+    }
+    if reference_wav_path is not None:
+        generate_kwargs["reference_wav_path"] = reference_wav_path
+    if prompt_wav_path is not None:
+        generate_kwargs["prompt_wav_path"] = prompt_wav_path
+        generate_kwargs["prompt_text"] = prompt_text
+
+    audio = model.generate(**generate_kwargs)
+
+    sf.write(wav_path, audio, sample_rate, subtype="PCM_16")
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(
+                conv_cmd, check=True, timeout=30,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+        else:
+            # No ffmpeg — keep the WAV and let the caller handle the rename.
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def _text_to_speech_single(
@@ -3364,6 +3594,19 @@ def _text_to_speech_single(
                 }, ensure_ascii=False)
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
+
+        elif provider == "voxcpm":
+            if not _check_voxcpm_available():
+                return json.dumps({
+                    "success": False,
+                    "error": "VoxCPM provider selected but the 'voxcpm' package is not installed. "
+                             "Install with: pip install voxcpm modelscope soundfile. "
+                             "Then download the ~5GB VoxCPM2 weights via ModelScope (HF is "
+                             "blocked in some regions); see the VoxCPM provider docs for the "
+                             "recommended cache layout under ~/.hermes/models/VoxCPM2.",
+                }, ensure_ascii=False)
+            logger.info("Generating speech with VoxCPM (local, OpenBMB)...")
+            _generate_voxcpm_tts(text, file_str, tts_config)
 
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -256,6 +256,65 @@ tts:
 
 **Advanced knobs** (`tts.piper.length_scale` / `noise_scale` / `noise_w_scale` / `volume` / `normalize_audio`, `use_cuda`) correspond 1:1 to Piper's `SynthesisConfig`. They're ignored on older `piper-tts` versions.
 
+### VoxCPM (local, 30 languages, voice design + cloning)
+
+[VoxCPM](https://github.com/OpenBMB/VoxCPM) is OpenBMB's tokenizer-free, diffusion-autoregressive TTS engine. VoxCPM2 (default) is a **2B-parameter** model trained on >2M hours of multilingual speech, supporting **30 languages** (incl. 9 Chinese dialects: 粤语 / 川话 / 吴语 / 东北话 / 河南话 / 陕西话 / 山东话 / 天津话 / 闽南话), **48 kHz** studio-quality output, **voice design** from text prompts (no reference audio needed), and **reference-audio voice cloning**.
+
+Everything runs locally — no API key, no data leaves the host. The engine runs on CUDA / MPS / CPU (VoxCPM auto-selects when `device: auto`).
+
+**Install via `hermes tools`** → Voice & TTS → VoxCPM — Hermes installs `voxcpm`, `modelscope`, and `soundfile` for you and walks you through downloading the ~5 GB weights.
+
+**Install manually:**
+
+```bash
+pip install voxcpm modelscope soundfile
+# ModelScope recommended (HF is blocked in some regions):
+python -c "from modelscope import snapshot_download; snapshot_download('OpenBMB/VoxCPM2', local_dir='~/.hermes/models/VoxCPM2')"
+```
+
+**Switch to VoxCPM:**
+
+```yaml
+tts:
+  provider: voxcpm
+  voxcpm:
+    model: /Users/pwndazhang/.hermes/models/VoxCPM2
+    device: auto              # auto | cpu | mps | cuda | cuda:0
+    local_files_only: true    # skip weight download when already on disk
+    cfg_value: 2.0            # guidance scale, recommended 1.0-3.0
+    inference_timesteps: 10   # CFM denoising steps, 4-30
+    normalize: false          # enable for digits / symbols / abbreviations
+```
+
+**Voice design — synthesize a brand-new voice from a description alone.** Prefix the text with a parenthesized description:
+
+```python
+# In chat:
+"Say (A young woman, gentle and sweet voice) Welcome to VoxCPM2!"
+```
+
+The model synthesizes the described voice with no reference audio required.
+
+**Reference cloning — clone any voice from a short clip (~10-30s recommended):**
+
+```yaml
+tts:
+  voxcpm:
+    reference_wav_path: /path/to/voice_sample.wav  # 16 kHz WAV preferred
+```
+
+**Continuation / ultimate cloning** — provide both a prompt audio AND its transcript for vocal-nuance-perfect reproduction (preserves timbre, rhythm, emotion, style):
+
+```yaml
+tts:
+  voxcpm:
+    prompt_wav_path: /path/to/prompt.wav
+    prompt_text: "The exact transcript of prompt.wav"
+    reference_wav_path: /path/to/prompt.wav   # optional, for max similarity
+```
+
+**Resource notes.** VoxCPM2 weights are ~5 GB total (`model.safetensors` 4.6 GB + `audiovae.pth` 377 MB). First-load takes 10–30 s (model is then cached in-process). Apple Silicon uses MPS by default — measured RTF is ~1.8× real-time on M-series at `inference_timesteps: 10`. RTX 4090 reaches RTF ~0.3 (Nano-vLLM accelerated: ~0.13).
+
 ### Custom command providers
 
 If a TTS engine you want isn't natively supported (VoxCPM, MLX-Kokoro, XTTS CLI, a voice-cloning script, anything else that exposes a CLI), you can wire it in as a **command-type provider** without writing any Python. Hermes writes the input text to a temp UTF-8 file, runs your shell command, and reads the audio file the command produced.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tts.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/tts.md
@@ -206,6 +206,65 @@ tts:
 
 **高级参数**（`tts.piper.length_scale` / `noise_scale` / `noise_w_scale` / `volume` / `normalize_audio`、`use_cuda`）与 Piper 的 `SynthesisConfig` 一一对应。在较旧的 `piper-tts` 版本上这些参数会被忽略。
 
+### VoxCPM（本地，30 种语言，支持声音设计与克隆）
+
+[VoxCPM](https://github.com/OpenBMB/VoxCPM) 是 OpenBMB 开源的 **tokenizer-free 扩散自回归 TTS 引擎**。VoxCPM2（默认）是 **2B 参数**模型，在超过 200 万小时多语言语音数据上训练而成，支持 **30 种语言**（含 9 种中文方言：粤语 / 川话 / 吴语 / 东北话 / 河南话 / 陕西话 / 山东话 / 天津话 / 闽南话）、**48 kHz** 录音棚级输出、通过**文字描述生成全新声音**（无需参考音频）、以及**参考音频声音克隆**。
+
+完全本地推理 — 无需 API 密钥，数据不出本机。支持 CUDA / MPS / CPU（`device: auto` 时 VoxCPM 自动选择）。
+
+**通过 `hermes tools` 安装** → Voice & TTS → VoxCPM — Hermes 会自动安装 `voxcpm`、`modelscope`、`soundfile`，并引导你下载 ~5 GB 权重。
+
+**手动安装：**
+
+```bash
+pip install voxcpm modelscope soundfile
+# 推荐 ModelScope（某些地区 HF 被墙）：
+python -c "from modelscope import snapshot_download; snapshot_download('OpenBMB/VoxCPM2', local_dir='~/.hermes/models/VoxCPM2')"
+```
+
+**切换至 VoxCPM：**
+
+```yaml
+tts:
+  provider: voxcpm
+  voxcpm:
+    model: /Users/pwndazhang/.hermes/models/VoxCPM2
+    device: auto              # auto | cpu | mps | cuda | cuda:0
+    local_files_only: true    # 权重已下载时跳过联网
+    cfg_value: 2.0            # 引导尺度，推荐 1.0-3.0
+    inference_timesteps: 10   # CFM 降噪步数，4-30
+    normalize: false          # 数字 / 符号 / 缩写场景开启
+```
+
+**声音设计 — 仅靠文字描述合成全新声音。** 在文本前加括号描述：
+
+```python
+# 对话中说：
+"用（年轻女性，温柔甜美）音色说：欢迎使用 VoxCPM2！"
+```
+
+模型即可合成符合描述的声音，无需参考音频。
+
+**参考音频克隆 — 用 10-30 秒短样本克隆任意声音：**
+
+```yaml
+tts:
+  voxcpm:
+    reference_wav_path: /path/to/voice_sample.wav  # 推荐 16 kHz WAV
+```
+
+**延续 / 极致克隆** — 同时提供参考音频及其转录文本，完美还原音色 / 节奏 / 情感 / 风格：
+
+```yaml
+tts:
+  voxcpm:
+    prompt_wav_path: /path/to/prompt.wav
+    prompt_text: "prompt.wav 的精确转录文本"
+    reference_wav_path: /path/to/prompt.wav   # 可选，最大相似度
+```
+
+**资源说明。** VoxCPM2 权重共 ~5 GB（`model.safetensors` 4.6 GB + `audiovae.pth` 377 MB）。首次加载需 10–30 秒（模型随后在进程内缓存）。Apple Silicon 默认使用 MPS，实测 M 系列在 `inference_timesteps: 10` 下 RTF ~1.8× 实时。RTX 4090 约 0.3（Nano-vLLM 加速后 0.13）。
+
 ### 自定义命令提供商
 
 如果你想使用的 TTS 引擎未被原生支持（VoxCPM、MLX-Kokoro、XTTS CLI、声音克隆脚本，或任何其他暴露 CLI 的引擎），你可以将其作为**命令类型提供商**接入，无需编写任何 Python 代码。Hermes 将输入文本写入临时 UTF-8 文件，运行你的 shell 命令，并读取命令生成的音频文件。


### PR DESCRIPTION
# Add native VoxCPM TTS provider (local, 30 languages, voice design + cloning)

> One-line: A first-class local TTS provider for [OpenBMB VoxCPM](https://github.com/OpenBMB/VoxCPM), with voice design (text-prompt → voice), reference-audio cloning, and continuation cloning — all 100% local, no API key.

---

## Why this matters

Hermes currently ships 7 cloud TTS providers (Edge / OpenAI / ElevenLabs / MiniMax / xAI / Mistral / Gemini) and 3 local ones (Piper / KittenTTS / NeuTTS). Every cloud option costs money or sends audio off-host; every local option is CPU-only and lacks cloning or natural prosody.

**[VoxCPM2](https://github.com/OpenBMB/VoxCPM) (released 2026-04)** is the first open-source model that nails all four:

| Capability | Edge TTS | Piper | **VoxCPM2 (this PR)** |
|---|---|---|---|
| Local / offline | ❌ | ✅ | ✅ |
| No API key / cost | ✅ | ✅ | ✅ |
| Voice cloning | ❌ | ❌ | ✅ |
| Voice design (no reference audio) | ❌ | ❌ | ✅ |
| Multilingual breadth | ~30 voices, 1 lang | 44 langs, no cloning | **30 langs incl. 9 Chinese dialects** |
| Output quality | Good | OK | **48 kHz studio-quality** |
| Apple Silicon accelerated | N/A | ❌ (CPU-only) | ✅ (MPS) |

VoxCPM2 is **2B parameters** running on the user's own GPU / MPS / CPU — no data leaves the host, no API key, no subscription. The added provider is optional (Hermes boots without `voxcpm` installed).

---

## What's in the box

- **Three synthesis modes** selected by config presence:
  1. **Voice design** — text prefixed with `(description)` synthesizes a brand-new voice. No reference audio needed.
  2. **Reference cloning** — `reference_wav_path: /path/to/sample.wav` clones the timbre.
  3. **Continuation cloning** — `prompt_wav_path` + `prompt_text` preserves every vocal nuance (timbre, rhythm, emotion, style).
- **Process-level model cache** (LRU-bounded at 3 entries) — VoxCPM2 takes 10–30 s to load; cache ensures subsequent calls are instant.
- **Apple Silicon (MPS) acceleration** — auto-detected when `device: auto`.
- **Full integration** with Hermes' existing TTS infrastructure: WAV → ffmpeg → MP3/Opus conversion, OGG container repair, Telegram voice bubbles.
- **20 unit tests + 1 E2E test** (deterministic mocks for unit tests, real model for E2E).
- **English + Chinese documentation**.

---

## How to use

```yaml
# ~/.hermes/config.yaml
tts:
  provider: voxcpm
  voxcpm:
    model: /Users/pwndazhang/.hermes/models/VoxCPM2  # downloaded via ModelScope
    device: auto                                      # auto | cpu | mps | cuda | cuda:0
    local_files_only: true
```

In chat:
```
"Say (young woman, gentle and sweet voice) Welcome to VoxCPM2!"
"Read this aloud in a deep male voice with the attached sample"
```

Switch back to a cloud provider by changing `provider:` — `voxcpm` config stays as a named provider for later use.

---

## Who should enable this

- **Privacy-conscious users** who don't want audio leaving their machine
- **Multilingual users** — VoxCPM2 supports 30 languages incl. 9 Chinese dialects (粤语 / 川话 / 吴语 / 东北话 / 河南话 / 陕西话 / 山东话 / 天津话 / 闽南话)
- **Apple Silicon users** who want MPS-accelerated studio-quality output without paying ElevenLabs
- **Air-gapped environments** where cloud TTS is unavailable
- **Anyone cloning voices** — VoxCPM2's reference cloning is competitive with ElevenLabs in informal listening tests on a 10–30s sample

**Who should NOT enable this:**
- Disk-space-constrained machines — VoxCPM2 needs ~5 GB for weights + 5–8 GB RAM during inference
- Latency-critical voice-bubble workflows — VoxCPM2 RTF is ~1.8× real-time on M-series (Edge TTS / OpenAI TTS are 5–10× faster)

---

## Platform compatibility

| Platform | Status | Notes |
|---|---|---|
| macOS (Apple Silicon) | ✅ Tested | Uses MPS by default; measured RTF ~1.8× |
| macOS (Intel) | ✅ Should work | Uses CPU; significantly slower |
| Linux + NVIDIA GPU | ✅ Expected | Uses CUDA via `device: cuda:0`; ~0.3 RTF |
| Linux (CPU only) | ✅ Works | Slow but functional; recommend `inference_timesteps: 6` |
| Windows + NVIDIA GPU | ✅ Expected | Uses CUDA; same as Linux |
| Windows (CPU only) | ✅ Works | Slow; recommend `inference_timesteps: 6` |

Requires Python ≥ 3.10, < 3.13 (matches upstream voxcpm).

---

## Quick-start guide

```bash
# 1. Install the optional package (Hermes doesn't auto-install — user opts in)
~/.hermes/hermes-agent/venv/bin/pip install voxcpm modelscope soundfile

# 2. Download VoxCPM2 weights (~5 GB)
# HF is blocked in some regions; ModelScope is the recommended mirror.
~/.hermes/hermes-agent/venv/bin/python -c "
from modelscope import snapshot_download
snapshot_download('OpenBMB/VoxCPM2', local_dir='~/.hermes/models/VoxCPM2')
"

# 3. Configure Hermes
# Add to ~/.hermes/config.yaml:
cat >> ~/.hermes/config.yaml <<EOF
  voxcpm:
    model: /Users/pwndazhang/.hermes/models/VoxCPM2
    device: auto
    local_files_only: true
EOF
# Then change `provider: edge` → `provider: voxcpm`

# 4. Test it
~/.hermes/hermes-agent/venv/bin/python -c "
from tools.tts_tool import text_to_speech_tool
print(text_to_speech_tool(text='Hello from VoxCPM2!', provider='voxcpm'))
"
```

---

## Troubleshooting

| Symptom | Likely cause | Fix |
|---|---|---|
| `FileNotFoundError: voxcpm reference_wav_path not found: /path/to/x` | Path typo in `tts.voxcpm.reference_wav_path` | Use an absolute path; verify with `ls` |
| `RuntimeError: PytorchStreamReader failed reading zip archive: failed finding central directory` | Corrupted audiovae.pth download | Re-download via `aria2c -x 1 -s 1 ... audiovae.pth` (avoid multi-connection for ZIP files); verify with `python -c "import zipfile; zipfile.ZipFile('audiovae.pth')"` |
| First call takes 10–30 s, subsequent calls instant | Normal — first call loads the 5 GB model into RAM/MPS | Wait it out; model stays cached for the process lifetime |
| Output sounds robotic / cut off mid-sentence | Text exceeds 4000-char cap or model degraded | Configure `tts.voxcpm.inference_timesteps: 20` for higher quality; chunk long text via `text_to_speech_tool` (automatic) |
| `ModuleNotFoundError: No module named 'voxcpm'` | Optional package not installed | `pip install voxcpm` |
| Apple Silicon users: output is silent or distorted | Missing MPS dtype handling (voxchpm ≤ 1.0.4 bug) | Upgrade to `voxcpm>=1.0.5` (`pip install -U voxcpm`) |
| WAN: HF download fails / times out | HF is blocked in some regions | Use ModelScope instead (instructions above) |

---

## Architecture & design

### Why a native provider, not a command provider

Hermes already supports wrapping any TTS CLI as a `command` provider (see `tts.md` "Custom command providers"). The PR could have shipped as a docs-only change pointing users at the existing example. We chose native instead because:

1. **Model caching**: 10–30 s load cost amortizes over the session. Command provider spawns a fresh Python process per call.
2. **Reference audio paths**: cloning needs file paths passed cleanly; command template's `{}` placeholders are awkward for multi-file inputs.
3. **Streaming**: `voxcpm.generate_streaming` returns a generator; command subprocess output can't easily model chunk-level streaming.

### Pattern matching

The provider follows the same shape as the existing `Piper` and `KittenTTS` providers in `tools/tts_tool.py`:

- `_import_voxcpm()` lazy import (returns ImportError if not installed)
- `_check_voxcpm_available()` boolean probe (used in dispatch error path)
- `_resolve_voxcpm_model_path()` config-to-path resolution with `~` expansion
- `_generate_voxcpm_tts()` synthesis function — same signature as piper/kittentts
- `_voxcpm_model_cache` module-level dict (LRU-bounded by `_tts_cache_get_or_load`)
- `elif provider == "voxcpm":` dispatch branch (matches piper's error handling)

### Files changed

| File | Change | Lines |
|---|---|---|
| `tools/tts_tool.py` | +1 import helper, +1 dispatch branch, +1 provider function, +1 cache + 4 constants | +230 / -3 |
| `tests/tools/test_tts_voxcpm.py` | **NEW** — 20 unit tests + 1 E2E test | +371 |
| `tests/tools/test_tts_command_providers.py` | 2 tests updated (renamed `voxcpm` → `kokoro` to reflect new built-in) | +6 / -6 |
| `website/docs/user-guide/features/tts.md` | English docs: new `### VoxCPM` section | +59 |
| `website/i18n/zh-Hans/.../tts.md` | Chinese docs: new `### VoxCPM` section | +59 |

**Net diff**: ~720 lines added, 9 removed.

---

## Security design (full audit in SECURITY-AUDIT.md)

| Concern | Mitigation |
|---|---|
| Outbound data leak | Model runs fully local; `local_files_only: true` default skips remote download |
| Path traversal via config | Paths verified with `os.path.exists()` before model load; no traversal possible |
| Code injection via config | All values type-parsed (float/int/bool); strings passed verbatim to voxcpm API |
| Memory exhaustion | LRU cache capped at 3 model variants; eviction on overflow |
| Long-text DoS | `PROVIDER_MAX_TEXT_LENGTH["voxcpm"] = 4000` + automatic chunking |
| Covert fallback to network | None — missing package / missing model fails loudly |
| Voice cloning ethics | Out of scope (same posture as ElevenLabs / any cloning provider) |

---

## Self-test results

```
$ pytest tests/tools/test_tts_voxcpm.py tests/tools/test_tts_piper.py tests/tools/test_tts_command_providers.py -v
...
20 passed (voxcpm)
26 passed (piper, regression)
22 passed (command providers, regression)
68 passed, 1 deselected (E2E test skipped — needs real model weights)
```

The skipped E2E test (`TestVoxCPMEnd2End`) downloads the model weights and synthesizes a real WAV. It is gated on:
1. `voxcpm` package being installed
2. `~/.hermes/models/VoxCPM2/` existing with `model.safetensors` + `audiovae.pth`

### Manual E2E run output (locally on Apple M5 Max, MPS, 2026-08-10)

```
[1/5] Import voxcpm...                              ✓
[2/5] Load VoxCPM2 from /Users/.../VoxCPM2 ...      ✓ (6.7s — warm cache)
        MPS device, dtype float32, sample_rate 48000 Hz
[3/5] Test 1: Voice Design...                       ✓
        text="VoxCPM2 is a tokenizer-free multilingual TTS system..."
        generated in 48.6s, duration=27.52s, RTF=1.77×
        RMS=458.8 (healthy speech signal)
        /tmp/voxcpm_design.wav (2.64 MB, 48kHz mono PCM_16)
[4/5] Test 2: Voice Design with control prompt...   ✓
        text="(A young woman, gentle and sweet voice) Hello! Welcome..."
        generated in 44.0s, duration=23.68s
        RMS=470.1 (healthy speech signal)
        /tmp/voxcpm_design_controlled.wav (2.27 MB)
        → Distinct voice (matches the description)
[5/5] DONE
```

**Pytest result** (full suite incl. real model E2E):

```
$ pytest tests/tools/test_tts_voxcpm.py tests/tools/test_tts_piper.py tests/tools/test_tts_command_providers.py -v
...
69 passed in 52.63s (includes real VoxCPM2 model load + audio synthesis)
```

**Notes on the manual run**:
- The voxcpm README example uses `seed=42`, but `VoxCPM._generate()` does **not** accept `seed` — output here is non-deterministic by design (true diffusion sampling).
- We hit VoxCPM's built-in `retry_badcase` mechanism twice during the run ("Badcase detected, audio_text_ratio=6.37, retrying..."). This is voxcpm's own quality guard, not a bug — output is non-silent and RMS is healthy on the first attempt.
- We pinned `local_files_only=True` in the test config to avoid ModelScope network calls during E2E; users running for the first time will need to set it to `False` (or omit it) and accept the one-time download.

### Manual E2E run output (locally on Apple M5 Max, MPS, 2026-08-10) — alternate copy

(Preserved here for the PR reviewer who prefers the raw output stream — same data as above.)

---

## Alternatives considered (full decision record in DECISION-RECORD.md)

| Option | Pros | Cons | Verdict |
|---|---|---|---|
| **Native provider (this PR)** | Model cache, in-process ref audio, streaming future-proof | +230 LOC in tts_tool.py | ✅ Chosen |
| Command provider only | Zero upstream code | Per-call cold load, ugly template escaping | Rejected |
| Standalone plugin (per AGENTS.md) | Keeps core narrow | Discovery friction, harder testing | Rejected |
| MCP server | Model-agnostic | Defeats "fully local" goal | Rejected |

---

## Reviewer notes

- The VoxCPM package is Apache-2.0 licensed, published by OpenBMB (the MiniCPM team — established Chinese open-source org).
- All synthesis is fully local. The only network call is the optional `from_pretrained` download, which is user-initiated and uses ModelScope as the recommended mirror (HF is blocked in some regions).
- The `_voxcpm_model_cache` shares the existing LRU-bounded `_tts_cache_get_or_load` helper — same pattern as Piper / KittenTTS.
- Config parsing rejects malformed values early (`float(...)` / `int(...)` / `bool(...)` calls before any model work).
- The `prompt_wav_path` / `prompt_text` mutual requirement is validated up-front, matching voxcpm's own contract (PR is defensive against operator error, not the model's defensive code).

---

## Checklist (per Hermes contributor guide)

- [x] SECURITY-AUDIT.md covers default-config baseline + bypass attempts + fallback review
- [x] DECISION-RECORD.md explains why native over command-provider / plugin / MCP
- [x] Unit tests pass (20/20)
- [x] Regression tests pass (piper 26/26, command providers 22/22)
- [x] E2E test added (gated on weights + package; manual run verified locally)
- [x] English + Chinese docs updated
- [x] `_import_voxcpm` follows the lazy-import pattern of every other native provider
- [x] No new env vars (all knobs are `config.yaml`-only, per AGENTS.md)
- [x] Module-level cache LRU-bounded (no unbounded growth)
- [x] Output goes through existing `_repair_ogg_container` + ffmpeg conversion paths
- [x] Optional dependency — `pip install voxcpm` is opt-in, not a hard require