### PR TITLE
fix(feishu): restore env proxy for websocket connections

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1348,6 +1348,18 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
+        # Local fix: lark_oapi forces proxy=None on websockets>=15, but this
+        # machine can only reach Feishu through the local HTTP proxy, so
+        # restore environment-variable proxy discovery when the SDK removed it.
+        if kwargs.get("proxy") is None:
+            env_proxy = (
+                os.environ.get("HTTPS_PROXY")
+                or os.environ.get("https_proxy")
+                or os.environ.get("HTTP_PROXY")
+                or os.environ.get("http_proxy")
+            )
+            if env_proxy:
+                kwargs["proxy"] = env_proxy
         return original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:


### PR DESCRIPTION
## Summary

lark-oapi forces `proxy=None` on websockets>=15 (which enables environment proxy discovery by default), so machines that can only reach Feishu through an HTTP proxy fail with `feishu connect timed out after 30s`.

This patch restores environment-variable proxy discovery in the Feishu adapter's websocket connect override: when the SDK passes `proxy=None`, fall back to `HTTPS_PROXY`/`http_proxy` from the environment. Environments without a proxy keep the SDK's direct-connection behavior unchanged.

## Motivation

Reported on Windows with a local HTTP proxy (127.0.0.1:7897): the gateway connected to the Feishu REST API fine (requests honors env proxies) but the WebSocket long-connection timed out because lark_oapi's `_ws_connect_kwargs()` (lark_oapi/ws/client.py) explicitly returns `{"proxy": None}` when the parameter exists.

## Test Plan

- Targeted unit tests: proxy injected when env var set; `proxy=None` preserved when no proxy env (2/2 pass)
- Existing feishu suite: 41 passed / 39 failed — identical to baseline without this patch (the 39 failures are a pre-existing Windows-only env issue: `patch.dict(clear=True)` + `Path("~").expanduser()` has no pwd fallback on Windows)
- Live verification: gateway connected to `wss://msg-frontier.feishu.cn/ws/v2` successfully
