### PR TITLE
docs(zh-Hans): add Chinese installation guide and Feishu/Lark setup

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -1,179 +1,144 @@
 ---
 sidebar_position: 2
-title: "安装"
-description: "在 Linux、macOS、WSL2、原生 Windows 或通过 Termux 在 Android 上安装 Hermes Agent"
+title: "安装指南"
+description: "在 Linux、macOS、WSL2、Windows 或 Android Termux 上安装 Hermes Agent"
 ---
 
-# 安装
+# 安装指南
 
-使用一行安装命令，两分钟内即可启动并运行 Hermes Agent。
+两分钟内完成 Hermes Agent 的安装和运行。
+
+:::tip 平台支持
+完整的平台支持矩阵（支持的操作系统、分发方式和平台特性），请参阅 **[平台支持](./platform-support.md)**。
+:::
 
 ## 快速安装
 
-### 一行安装命令（Linux / macOS / WSL2）
+### 使用 Hermes Desktop 安装器（推荐，macOS / Windows）
 
-基于 git 的安装方式，跟踪 `main` 分支，可立即获取最新变更：
+如需同时安装命令行和桌面应用，请从官网下载 [Hermes Desktop 安装器](https://hermes-agent.nousresearch.com/) 并运行。
+
+### 纯命令行安装
+
+#### Linux / macOS / WSL2 / Android (Termux)
 
 ```bash
 curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 ```
 
-### Windows（原生，PowerShell）
+#### Windows（原生）
 
-原生 Windows 无需 WSL 即可运行 Hermes——CLI、gateway、TUI 和工具均可原生运行。（原生安装与 WSL2 安装可干净共存；唯一仅限 WSL2 的功能见下方功能说明。）遇到 bug 请[提交 issue](https://github.com/NousResearch/hermes-agent/issues)。
-
-打开 PowerShell 并运行：
+在 PowerShell 中运行：
 
 ```powershell
 iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 ```
 
-安装程序处理**一切**：`uv`、Python 3.11、Node.js 22、`ripgrep`、`ffmpeg`，**以及一个便携式 Git Bash**（PortableGit——一个自包含的 Git-for-Windows 发行版，附带 `bash.exe` 和 Hermes 用于 shell 命令的完整 POSIX 工具链；在 32 位 Windows 上安装程序会回退到 MinGit，后者缺少 bash，终端工具和 agent 浏览器功能将被禁用）。它将仓库克隆到 `%LOCALAPPDATA%\hermes\hermes-agent`，创建虚拟环境，并将 `hermes` 添加到**用户 PATH**。安装完成后请重启终端（或打开新的 PowerShell 窗口）以使 PATH 生效。
-
-**Git 的处理方式：**
-
-1. 如果 `git` 已在你的 PATH 中，安装程序将使用现有安装。
-2. 否则，它会下载便携式 **PortableGit**（约 50MB，来自官方 `git-for-windows` GitHub 发布页）并解压到 `%LOCALAPPDATA%\hermes\git`。无需管理员权限，完全隔离——不会干扰任何系统 Git 安装，无论其状态如何。（在 32 位 Windows 上会回退到 MinGit，因为 PortableGit 仅提供 64 位和 ARM64 资产；依赖 bash 的 Hermes 功能在 32 位主机上无法使用。）
-
-**为什么不使用 winget？** 早期设计通过 `winget install Git.Git` 自动安装 Git，但当系统 Git 安装处于部分损坏状态时，winget 会严重失败（而这恰恰是用户最需要安装程序正常工作的时候）。便携式 Git 方案绕过了 winget、Windows 安装程序注册表以及任何现有系统 Git。如果 Hermes 的 Git 安装本身出现问题，执行 `Remove-Item %LOCALAPPDATA%\hermes\git` 并重新运行安装程序即可——对系统无影响，无需卸载操作。
-
-安装程序还会将 `HERMES_GIT_BASH_PATH` 设置为找到的 `bash.exe` 路径，以便 Hermes 在新 shell 中确定性地解析它。
-
-如果你偏好 WSL2，上方的 Linux 安装程序可在其中运行；原生安装和 WSL 安装可以共存而不冲突（原生数据位于 `%LOCALAPPDATA%\hermes`，WSL 数据位于 `~/.hermes`）。
-
-**桌面安装程序（替代方案）：** 也提供一个轻量 GUI 安装程序——下载 Hermes Desktop，运行 `.exe`，首次启动时它会在后台调用 `install.ps1` 来配置 Python（通过 `uv`）、Node、PortableGit 及其余依赖。桌面应用和 PowerShell 安装的 CLI 共享相同的安装目录和数据目录，可以单独或同时使用。详见 [Windows（原生）指南](../user-guide/windows-native#desktop-installer-alternative)。
-
-### Android / Termux
-
-Hermes 现在也提供 Termux 感知的安装路径：
+如果你先做了纯命令行安装，之后想加装 Hermes Desktop，只需运行：
 
 ```bash
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+hermes desktop
 ```
 
-安装程序会自动检测 Termux 并切换到经过测试的 Android 流程：
+### 安装器做了什么
 
-- 使用 Termux `pkg` 安装系统依赖（`git`、`python`、`nodejs`、`ripgrep`、`ffmpeg`、构建工具）
-- 使用 `python -m venv` 创建虚拟环境
-- 自动导出 `ANDROID_API_LEVEL` 以用于 Android wheel 构建
-- 优先使用较宽泛的 `.[termux-all]` extra，若首次编译失败则回退到较小的 `.[termux]` extra（最终回退到基础安装）
-- 默认跳过未经测试的浏览器 / WhatsApp 引导
-
-如需完整的显式步骤，请参阅专门的 [Termux 指南](./termux.md)。
-
-:::note Windows 功能对等性
-
-除基于浏览器的 dashboard 聊天终端外，其余功能均可在 Windows 上原生运行：
-
-- **CLI（`hermes chat`、`hermes setup`、`hermes gateway` 等）** — 原生，使用默认终端
-- **Gateway（Telegram、Discord、Slack 等）** — 原生，作为后台 PowerShell 进程运行
-- **Cron 调度器** — 原生
-- **浏览器工具** — 原生（通过 Node.js 使用 Chromium）
-- **MCP 服务器** — 原生（stdio 和 HTTP 传输均支持）
-- **Dashboard `/chat` 终端面板** — **仅限 WSL2**（使用 POSIX PTY（伪终端），原生 Windows 无等效实现）。Dashboard 的其余部分（会话、任务、指标）可原生运行——仅嵌入式 PTY 终端标签页受限。
-
-如果遇到编码相关的 bug 并希望回退到旧版 cp1252 stdio 路径（用于问题定位），请在环境中设置 `HERMES_DISABLE_WINDOWS_UTF8=1`。
-:::
-
-### 安装程序做了什么
-
-安装程序自动处理一切——所有依赖（Python、Node.js、ripgrep、ffmpeg）、仓库克隆、虚拟环境、全局 `hermes` 命令配置以及 LLM 提供商配置。完成后即可开始聊天。
+安装器会自动处理所有依赖——Python、Node.js、ripgrep、ffmpeg，克隆仓库，创建虚拟环境，配置全局 `hermes` 命令，以及 LLM 提供商配置。安装完成后即可直接使用。
 
 #### 安装目录结构
 
-安装程序的存放位置取决于你是以普通用户还是 root 身份安装：
+安装位置取决于你以普通用户还是 root 身份运行：
 
-| 安装方式                                | 代码位置                       | `hermes` 二进制                          | 数据目录                              |
-| --------------------------------------- | ------------------------------ | ---------------------------------------- | ------------------------------------- |
-| 用户级（git 安装程序）                  | `~/.hermes/hermes-agent/`      | `~/.local/bin/hermes`（符号链接）        | `~/.hermes/`                          |
-| Root 模式（`sudo curl … \| sudo bash`） | `/usr/local/lib/hermes-agent/` | `/usr/local/bin/hermes`                  | `/root/.hermes/`（或 `$HERMES_HOME`） |
+| 安装方式 | 代码位置 | `hermes` 命令 | 数据目录 |
+| --- | --- | --- | --- |
+| 普通用户（git 安装器） | `~/.hermes/hermes-agent/` | `~/.local/bin/hermes`（符号链接） | `~/.hermes/` |
+| root 模式（`sudo curl … \| sudo bash`） | `/usr/local/lib/hermes-agent/` | `/usr/local/bin/hermes` | `/root/.hermes/`（或 `$HERMES_HOME`） |
 
-Root 模式的 **FHS 布局**（`/usr/local/lib/…`、`/usr/local/bin/hermes`）与其他系统级开发工具在 Linux 上的安装位置一致。适用于共享机器部署场景，一次系统安装可服务所有用户。每个用户的个人配置（认证、技能、会话）仍位于各自的 `~/.hermes/` 或显式指定的 `HERMES_HOME` 下。
+root 模式的 **FHS 布局**（`/usr/local/lib/…`、`/usr/local/bin/hermes`）与其他系统级开发工具一致，适合共享服务器部署——一次安装，多用户使用。每个用户的个人配置（认证、技能、会话）仍然存储在各自 `~/.hermes/` 下。
 
 ### 安装后
 
-重新加载 shell 并开始聊天：
+重新加载 Shell 然后开始对话：
 
 ```bash
 source ~/.bashrc   # 或：source ~/.zshrc
-hermes             # 开始聊天！
+hermes              # 开始对话！
 ```
 
-如需稍后重新配置单项设置，使用以下专用命令：
+后续如需调整配置，使用以下命令：
 
 ```bash
 hermes model          # 选择 LLM 提供商和模型
 hermes tools          # 配置启用的工具
-hermes gateway setup  # 配置消息平台
-hermes config set     # 设置单个配置项
-hermes setup          # 或运行完整的设置向导一次性配置所有内容
+hermes gateway setup  # 设置消息平台
+hermes config set     # 设置单个配置值
+hermes config get     # 查看单个配置值
+hermes setup          # 运行完整配置向导，一次性配置所有项
 ```
 
 :::tip 最快路径：Nous Portal
-一个订阅涵盖 300+ 个模型以及 [Tool Gateway](/user-guide/features/tool-gateway)（网络搜索、图像生成、TTS、云端浏览器）。无需逐一管理各工具的密钥：
+一个订阅即可覆盖 300+ 模型和 [工具网关](/user-guide/features/tool-gateway)（网页搜索、图像生成、TTS、云端浏览器），无需为每个工具单独配置密钥：
 
 ```bash
 hermes setup --portal
 ```
 
-该命令一次性完成登录、设置 Nous 为提供商并开启 Tool Gateway。
+一条命令完成登录、设置 Nous 为提供商并启用工具网关。
 :::
 
 ---
 
-## 前置条件
+## 前置依赖
 
-**Git 安装程序：** 唯一的前置条件是 **Git**。安装程序自动处理其余一切：
+**安装器：** 非 Windows 平台唯一的前置依赖是 **Git**。在 Linux 上，还需确保 `curl` 和 `xz-utils` 可用（安装器以 `.tar.xz` 格式下载 Node.js）。桌面应用额外需要 `g++`（Debian/Ubuntu 上的 `build-essential`）来编译原生模块。安装器会自动处理其余所有依赖：
 
 - **uv**（快速 Python 包管理器）
 - **Python 3.11**（通过 uv，无需 sudo）
 - **Node.js v22**（用于浏览器自动化和 WhatsApp 桥接）
 - **ripgrep**（快速文件搜索）
-- **ffmpeg**（TTS 的音频格式转换）
+- **ffmpeg**（TTS 音频格式转换）
 
 :::info
-你**无需**手动安装 Python、Node.js、ripgrep 或 ffmpeg。安装程序会检测缺失的依赖并自动安装。只需确保 `git` 可用（`git --version`）。
+你**不需要**手动安装 Python、Node.js、ripgrep 或 ffmpeg。安装器会检测缺失项并自动安装。只需确保 `git` 可用（`git --version`）。在 Linux 上，确保 `curl` 和 `xz-utils` 已安装（Debian/Ubuntu：`sudo apt install curl xz-utils`）。桌面应用还需安装 `build-essential`（`sudo apt install build-essential`）。
 :::
 
 :::tip Nix 用户
-如果你使用 Nix（在 NixOS、macOS 或 Linux 上），有专门的配置路径，包含 Nix flake、声明式 NixOS 模块和可选容器模式。请参阅 **[Nix & NixOS 配置](./nix-setup.md)** 指南。
+Nix **不再是官方支持的安装路径**（仅提供尽力而为的支持）。如果你已经在使用 Nix（NixOS、macOS 或 Linux），有专门的 Nix flake 安装路径，包含声明式 NixOS 模块和可选的容器模式。详见 **[Nix 和 NixOS 安装指南](./nix-setup.md)**。
 :::
 
 ---
 
-## 手动 / 开发者安装
+## 手动/开发者安装
 
-如果你想克隆仓库并从源码安装——用于贡献代码、从特定分支运行或完全控制虚拟环境——请参阅贡献指南中的[开发环境配置](../developer-guide/contributing.md#development-setup)章节。
+如果你需要克隆仓库并从源码安装——用于贡献代码、从特定分支运行，或完全控制虚拟环境——请参阅贡献指南中的 [开发环境搭建](../developer-guide/contributing.md#开发环境搭建) 章节。
 
 ---
 
-## 非 Sudo / 系统服务用户安装
+## 无 Sudo / 服务用户安装
 
-支持以专用非特权用户身份运行 Hermes（例如 `hermes` systemd 服务账户，或任何没有 `sudo` 权限的用户）。安装路径中真正需要 root 权限的只有 Playwright 的 `--with-deps` 步骤，该步骤通过 `apt` 安装 Chromium 所需的共享库（`libnss3`、`libxkbcommon` 等）。安装程序会检测 sudo 是否可用，并在不可用时优雅降级——它会将 Chromium 二进制安装到服务用户自己的 Playwright 缓存中，并打印管理员需要单独运行的确切命令。
+Hermes 支持以专用非特权用户身份运行（如 `hermes` systemd 服务账户，或任何无 `sudo` 权限的用户）。安装路径中唯一真正需要 root 权限的步骤是 Playwright 的 `--with-deps`，它会通过 `apt` 安装 Chromium 所需的共享库（`libnss3`、`libxkbcommon` 等）。安装器会检测 sudo 是否可用，不可用时自动降级——它会将 Chromium 二进制安装到服务用户自己的 Playwright 缓存中，并打印管理员需要手动执行的命令。
 
-**推荐的分步方式（Debian/Ubuntu）：**
+**推荐的分步方案（Debian/Ubuntu）：**
 
-1. **一次性操作，以具有 sudo 权限的管理员用户身份**，安装 Chromium 所需的系统库：
+1. **一次性操作：以有 sudo 权限的管理员身份**，安装 Chromium 需要的系统库：
 
    ```bash
    sudo npx playwright install-deps chromium
    ```
+   （可以在任意目录运行——`npx` 会自动获取 Playwright。）
 
-   （可在任意位置运行——`npx` 会自动获取 Playwright。）
-
-2. **以非特权服务用户身份**，运行常规安装程序。它会检测到缺少 sudo，跳过 `--with-deps`，并将 Chromium 安装到用户本地的 Playwright 缓存中：
+2. **以非特权服务用户身份**，运行标准安装器。它会检测到缺少 sudo，跳过 `--with-deps`，将 Chromium 安装到用户本地 Playwright 缓存：
 
    ```bash
    curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
    ```
 
-   如果想完全跳过 Playwright 步骤——例如在无头环境中运行且不需要浏览器自动化——传入 `--skip-browser`：
+   如果你不需要浏览器自动化功能（例如纯无头运行），可以通过 `--skip-browser` 跳过 Playwright：
 
    ```bash
    curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-browser
    ```
 
-3. **使 `hermes` 对服务用户的 shell 可用。** 安装程序将启动器写入 `~/.local/bin/hermes`。系统服务账户通常具有不包含 `~/.local/bin` 的最小 PATH。可以将其添加到用户环境，或将启动器符号链接到系统位置：
+3. **让 `hermes` 命令对服务用户可用。** 安装器将启动器写入 `~/.local/bin/hermes`。系统服务账户的 PATH 通常不包含 `~/.local/bin`。你可以将其添加到用户环境变量中，或者将启动器链接到系统路径：
 
    ```bash
    # 方案 A — 添加到服务用户的 profile
@@ -183,22 +148,30 @@ hermes setup --portal
    sudo ln -s /home/hermes/.hermes/hermes-agent/venv/bin/hermes /usr/local/bin/hermes
    ```
 
-4. **验证：** `hermes doctor` 现在应能正常运行。如果出现 `ModuleNotFoundError: No module named 'dotenv'`，说明你在用系统 Python 调用仓库源码中的 `hermes` 文件（`~/.hermes/hermes-agent/hermes`），而非 venv 启动器（`~/.hermes/hermes-agent/venv/bin/hermes`）——请修正步骤 3。
+4. **验证：** `hermes doctor` 应该正常运行。如果出现 `ModuleNotFoundError: No module named 'dotenv'`，说明你使用系统 Python 调用了仓库源文件（`~/.hermes/hermes-agent/hermes`），而不是 venv 启动器（`~/.hermes/hermes-agent/venv/bin/hermes`）——请修正步骤 3。
 
-同样的方式适用于 Arch（安装程序使用 pacman，具有相同的 sudo 检测逻辑）、Fedora/RHEL 和 openSUSE——这些发行版完全不支持 `--with-deps`，因此管理员始终需要单独安装系统库。安装程序会打印相应的 `dnf`/`zypper` 命令。
+5. **从此账户运行消息网关？** 用户级服务会在登出时停止，且不会在启动时自动运行。你需要为服务用户启用 lingering：
+
+   ```bash
+   sudo loginctl enable-linger <服务用户名>
+   ```
+
+   服务本身的配置详见 [消息网关](/user-guide/messaging/)。
+
+同样的方案适用于 Arch（安装器使用 pacman，有相同的 sudo 检测逻辑）、Fedora/RHEL 和 openSUSE——这些发行版完全不支持 `--with-deps`，因此系统库始终由管理员单独安装。安装器会打印相应的 `dnf` / `zypper` 命令。
 
 ---
 
 ## 故障排查
 
-| 问题                        | 解决方案                                                                           |
-| --------------------------- | ---------------------------------------------------------------------------------- |
-| `hermes: command not found` | 重新加载 shell（`source ~/.bashrc`）或检查 PATH                                    |
-| `API key not set`           | 运行 `hermes model` 配置提供商，或 `hermes config set OPENROUTER_API_KEY your_key` |
-| 更新后配置丢失              | 运行 `hermes config check`，然后运行 `hermes config migrate`                       |
+| 问题 | 解决方案 |
+|------|---------|
+| `hermes: command not found` | 重新加载 Shell（`source ~/.bashrc`）或检查 PATH |
+| `API key not set` | 运行 `hermes model` 配置提供商，或 `hermes config set OPENROUTER_API_KEY your_key` |
+| 更新后配置丢失 | 运行 `hermes config check` 然后 `hermes config migrate` |
 
-如需更多诊断信息，运行 `hermes doctor`——它会告诉你确切缺少什么以及如何修复。
+更多诊断信息，运行 `hermes doctor`——它会准确告诉你缺少什么以及如何修复。
 
 ## 安装方式自动检测
 
-Hermes 会自动检测安装方式（git 安装程序、Docker 或 NixOS），`hermes update` 会打印对应路径的更新命令。无需设置任何环境变量——检测基于安装目录结构（`~/.hermes/hermes-agent/` 检出、Docker 镜像标记或 Nix store 路径）。`hermes doctor` 也会在其环境摘要中显示检测到的安装方式。
+Hermes 会自动检测是通过 git 安装器、Docker 还是 NixOS 安装的，`hermes update` 会打印对应路径的更新命令。不需要设置环境变量——检测基于安装布局（`~/.hermes/hermes-agent/` 仓库检出、Docker 镜像标记或 Nix 存储路径）。`hermes doctor` 也会在环境摘要中显示检测到的安装方式。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
@@ -6,20 +6,20 @@ description: "将 Hermes Agent 配置为飞书或 Lark 机器人"
 
 # 飞书 / Lark 配置
 
-Hermes Agent 可作为全功能机器人与飞书和 Lark 集成。连接后，你可以在私信或群聊中与 Agent 对话，在 home chat 中接收 cron job 结果，并通过标准 gateway 流程发送文本、图片、音频和文件附件。
+Hermes Agent 可以作为全功能机器人与飞书和 Lark 集成。连接后，你可以在私聊或群聊中与 Agent 对话，将定时任务结果投递到主页聊天，通过网关正常收发文本、图片、音频和文件。
 
-该集成支持两种连接模式：
+集成支持两种连接模式：
 
-- `websocket` — 推荐；Hermes 主动建立出站连接，无需公开 webhook 端点
-- `webhook` — 适用于已将 Hermes 部署在可访问 HTTP 端点后的场景
+- `websocket` — **推荐**；Hermes 主动发起出站连接，无需公网 Webhook 地址
+- `webhook` — 适用于需要通过 HTTP 将飞书/Lark 事件推送至网关的场景
 
-## Hermes 的行为方式
+## 使用行为
 
 | 场景 | 行为 |
-|---------|----------|
-| 私信 | Hermes 回复每一条消息。 |
-| 群聊 | Hermes 仅在被 @提及 时回复。 |
-| 共享群聊 | 默认情况下，每位用户在共享群聊中的会话历史相互隔离。 |
+|------|------|
+| 私聊 | Hermes 回复每一条消息 |
+| 群聊 | 仅当机器人在聊天中被 @提及 时才回复 |
+| 共享群聊 | 默认情况下，共享群聊中每个用户的会话历史是隔离的 |
 
 共享群聊行为由 `config.yaml` 控制：
 
@@ -27,85 +27,133 @@ Hermes Agent 可作为全功能机器人与飞书和 Lark 集成。连接后，�
 group_sessions_per_user: true
 ```
 
-仅当你明确希望每个群聊共享同一个对话时，才将其设为 `false`。
+仅当你明确希望每个聊天共享一个对话时才设为 `false`。
 
-## 第一步：创建飞书 / Lark 应用
+## 步骤 1：创建飞书 / Lark 应用
 
-### 推荐：扫码创建（一条命令）
+### 推荐方式：扫码创建（一条命令）
 
 ```bash
 hermes gateway setup
 ```
 
-选择 **飞书 / Lark**，用飞书或 Lark 手机端扫描二维码。Hermes 将自动创建具有正确权限的机器人应用并保存凭据。
+选择 **Feishu / Lark**，用飞书或 Lark 手机端扫描二维码。Hermes 会自动创建具有正确权限的机器人应用并保存凭据。
 
-### 备选：手动配置
+### 备选方式：手动配置
 
-如果扫码创建不可用，向导将回退到手动输入：
+如果扫码创建不可用，向导会回退到手动输入：
 
 1. 打开飞书或 Lark 开发者控制台：
    - 飞书：[https://open.feishu.cn/](https://open.feishu.cn/)
    - Lark：[https://open.larksuite.com/](https://open.larksuite.com/)
-2. 创建新应用。
+2. 创建一个新应用。
 3. 在 **凭证与基础信息** 中，复制 **App ID** 和 **App Secret**。
-4. 为应用开启 **机器人** 能力。
-5. 运行 `hermes gateway setup`，选择 **飞书 / Lark**，并在提示时输入凭据。
+4. 为应用启用 **机器人** 能力。
+5. 运行 `hermes gateway setup`，选择 **Feishu / Lark**，按提示输入凭据。
 
 :::warning
 请妥善保管 App Secret。任何持有它的人都可以冒充你的应用。
 :::
 
-## 第二步：选择连接模式
+### 配置权限
+
+在飞书开发者控制台中，进入 **权限管理**，添加以下权限范围。你可以在权限页面批量导入。
+
+**必需权限：**
+
+| 权限范围 | 用途 |
+|---------|------|
+| `im:message` | 接收和读取消息 |
+| `im:message:send_as_bot` | 以机器人身份发送消息 |
+| `im:resource` | 访问用户发送的图片、文件和音频 |
+| `im:chat` | 访问聊天/群组元数据 |
+| `im:chat:readonly` | 读取聊天列表和成员信息 |
+
+**推荐权限（完整功能）：**
+
+| 权限范围 | 用途 |
+|---------|------|
+| `im:message.reactions:readonly` | 接收表情回应事件 |
+| `admin:app.info:readonly` | 自动检测机器人身份用于 @提及 过滤 |
+| `contact:user.id:readonly` | 解析用户 ID 用于许可名单匹配 |
+
+### 配置事件
+
+在 **事件与回调** 中：
+
+1. 将连接模式设为 **长连接（WebSocket）**（推荐），或配置 Webhook URL
+2. 在 **事件配置** 中，订阅：
+   - `im.message.receive_v1` — 接收消息所必需
+
+### 发布应用
+
+配置完权限和事件后，前往 **版本管理与发布**，发布应用的新版本。权限在企业应用中需要管理员审批后才能生效。
+
+## 步骤 2：选择连接模式
 
 ### 推荐：WebSocket 模式
 
-当 Hermes 运行在你的笔记本、工作站或私有服务器上时，使用 WebSocket 模式。无需公开 URL。官方 Lark SDK 会建立并维护一个持久的出站 WebSocket 连接，并支持自动重连。
+当 Hermes 运行在你的笔记本电脑、工作站或私有服务器上时，使用 WebSocket 模式。无需公网 URL。官方 Lark SDK 会打开并维护一个持久的出站 WebSocket 连接，支持自动重连。
 
 ```bash
 FEISHU_CONNECTION_MODE=websocket
 ```
 
-**依赖：** 必须安装 `websockets` Python 包。SDK 在内部处理连接生命周期、心跳和自动重连。
+**要求：** 必须安装 `websockets` Python 包。SDK 在内部处理连接生命周期、心跳和自动重连。
 
-**工作原理：** 适配器在后台 executor 线程中运行 Lark SDK 的 WebSocket 客户端。入站事件（消息、表情回应、卡片操作）被分发到主 asyncio 循环。断开连接时，SDK 将自动尝试重连。
+**工作原理：** 适配器在后台执行器线程中运行 Lark SDK 的 WebSocket 客户端。入站事件（消息、表情回应、卡片动作）被分发到主 asyncio 事件循环。断连时 SDK 会自动尝试重连。
+
+:::tip 实盘经验
+
+在生产服务器上运行时，需注意以下几点：
+
+1. **systemd linger** — 服务用户账号会在 SSH 登出后停止所有用户级服务。必须启用 lingering：
+   ```bash
+   sudo loginctl enable-linger $USER
+   ```
+
+2. **防火墙** — WebSocket 是出站连接，不需要开放入站端口。但确保服务器能访问 `open.feishu.cn`。
+
+3. **网关重启风险** — 重启网关会断开飞书 WebSocket，导致用户在当前对话中掉线。生产环境中应避免在对话活跃时段重启。
+
+4. **静默掉线检测** — WebSocket 可能处于"连接但无响应"的状态。建议通过 cron 定期向机器人发送测试消息来验证连接健康。飞书 WebSocket `connected` 状态和实际消息可达性是两回事。
+:::
 
 ### 可选：Webhook 模式
 
-仅当 Hermes 已部署在可访问的 HTTP 端点后时，才使用 webhook 模式。
+仅在 Hermes 已经部署在可公网访问的 HTTP 端点后才使用 Webhook 模式。
 
 ```bash
 FEISHU_CONNECTION_MODE=webhook
 ```
 
-在 webhook 模式下，Hermes 启动一个 HTTP 服务器（通过 `aiohttp`），并在以下路径提供飞书端点：
+Webhook 模式下，Hermes 通过 `aiohttp` 启动 HTTP 服务器，并在以下端点提供服务：
 
 ```text
 /feishu/webhook
 ```
 
-**依赖：** 必须安装 `aiohttp` Python 包。
+**要求：** 必须安装 `aiohttp` Python 包。
 
-你可以自定义 webhook 服务器的绑定地址和路径：
+可自定义 Webhook 服务器的绑定地址和路径：
 
 ```bash
-FEISHU_WEBHOOK_HOST=127.0.0.1   # 默认：127.0.0.1
-FEISHU_WEBHOOK_PORT=8765         # 默认：8765
-FEISHU_WEBHOOK_PATH=/feishu/webhook  # 默认：/feishu/webhook
+FEISHU_WEBHOOK_HOST=127.0.0.1  # 默认：127.0.0.1
+FEISHU_WEBHOOK_PORT=8765        # 默认：8765
+FEISHU_WEBHOOK_PATH=/feishu/webhook # 默认：/feishu/webhook
 ```
 
-当飞书发送 URL 验证挑战（`type: url_verification`）时，webhook 会自动响应，以便你在飞书开发者控制台完成订阅配置。当设置了 `FEISHU_VERIFICATION_TOKEN` 时，挑战响应会进行 token 校验——token 缺失或不匹配的挑战请求将被拒绝，防止未经认证的远端通过回显攻击者控制的挑战数据来证明端点控制权。
+## 步骤 3：配置 Hermes
 
-## 第三步：配置 Hermes
-
-### 方式 A：交互式配置
+### 方案 A：交互式配置
 
 ```bash
 hermes gateway setup
 ```
 
-选择 **飞书 / Lark** 并填写提示信息。
+选择 **Feishu / Lark**，按提示填写。
 
-### 方式 B：手动配置
+### 方案 B：手动配置
 
 在 `~/.hermes/.env` 中添加以下内容：
 
@@ -120,22 +168,22 @@ FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
 FEISHU_HOME_CHANNEL=oc_xxx
 ```
 
-`FEISHU_DOMAIN` 接受：
+`FEISHU_DOMAIN` 可选值：
 
-- `feishu` 对应飞书（中国）
-- `lark` 对应 Lark（国际版）
+- `feishu` 飞书中国版
+- `lark` Lark 国际版
 
-## 第四步：启动 Gateway
+## 步骤 4：启动网关
 
 ```bash
 hermes gateway
 ```
 
-然后从飞书/Lark 向机器人发送消息，确认连接已建立。
+然后从飞书/Lark 向机器人发送消息，确认连接正常。
 
-## Home Chat
+## 主页聊天
 
-在飞书/Lark 聊天中使用 `/set-home` 将其标记为 cron job 结果和跨平台通知的 home channel。
+在飞书/Lark 聊天中使用 `/set-home` 将其标记为定时任务结果和跨平台通知的主页频道。
 
 也可以预先配置：
 
@@ -145,389 +193,70 @@ FEISHU_HOME_CHANNEL=oc_xxx
 
 ## 安全
 
-### 用户白名单
+### 用户许可名单
 
-在生产环境中，请设置飞书 Open ID 白名单：
+生产环境建议设置飞书 Open ID 许可名单：
 
 ```bash
 FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
 ```
 
-如果白名单为空，任何能访问机器人的人都可能使用它。在群聊中，消息处理前会根据发送者的 open_id 检查白名单。
+如果许可名单为空，任何能联系到机器人的人都可能使用它。群聊中，许可名单会在消息处理前检查发送者的 open_id。
 
 ### Webhook 加密密钥
 
-在 webhook 模式下运行时，设置加密密钥以启用入站 webhook payload 的签名验证：
+Webhook 模式下，设置加密密钥以启用入站 Webhook 载荷的签名验证：
 
 ```bash
 FEISHU_ENCRYPT_KEY=your-encrypt-key
 ```
 
-该密钥可在飞书应用配置的 **事件订阅** 部分找到。设置后，适配器使用以下签名算法验证每个 webhook 请求：
+此密钥可在飞书应用的 **事件订阅** 部分找到。设置后，适配器会使用签名算法验证每个 Webhook 请求：
 
 ```
 SHA256(timestamp + nonce + encrypt_key + body)
 ```
 
-计算出的哈希值与 `x-lark-signature` 请求头进行时序安全比较。签名无效或缺失的请求将被拒绝，返回 HTTP 401。
-
 :::tip
-在 WebSocket 模式下，签名验证由 SDK 自身处理，因此 `FEISHU_ENCRYPT_KEY` 是可选的。在 webhook 模式下，生产环境强烈推荐设置。
+WebSocket 模式下，签名验证由 SDK 内部处理，`FEISHU_ENCRYPT_KEY` 是可选的。Webhook 模式下强烈建议在生产环境中启用。
 :::
-
-### 验证 Token
-
-对 webhook payload 中 `token` 字段进行检查的额外认证层：
-
-```bash
-FEISHU_VERIFICATION_TOKEN=your-verification-token
-```
-
-该 token 同样可在飞书应用的 **事件订阅** 部分找到。设置后，每个入站 webhook payload 的 `header` 对象中必须包含匹配的 `token`。token 不匹配的请求将被拒绝，返回 HTTP 401。
-
-`FEISHU_ENCRYPT_KEY` 和 `FEISHU_VERIFICATION_TOKEN` 可同时使用，实现纵深防御。
-
-## 群消息策略
-
-`FEISHU_GROUP_POLICY` 环境变量控制 Hermes 是否以及如何在群聊中响应：
-
-```bash
-FEISHU_GROUP_POLICY=allowlist   # 默认
-```
-
-| 值 | 行为 |
-|-------|----------|
-| `open` | Hermes 响应任意群中任意用户的 @提及。 |
-| `allowlist` | Hermes 仅响应 `FEISHU_ALLOWED_USERS` 中列出的用户的 @提及。 |
-| `disabled` | Hermes 完全忽略所有群消息。 |
-
-在所有模式下，消息处理前机器人必须被明确 @提及（或 @all）。私信始终绕过此限制。
-
-设置 `FEISHU_REQUIRE_MENTION=false` 可让 Hermes 读取所有群消息而无需 @提及：
-
-```bash
-FEISHU_REQUIRE_MENTION=false
-```
-
-如需按群控制，在 `group_rules` 条目中设置 `require_mention`——参见下方[按群访问控制](#per-group-access-control)。
-
-### 机器人身份
-
-Hermes 在启动时自动检测机器人的 `open_id` 和显示名称。仅当自动检测无法访问飞书 API，或你的应用使用租户范围用户 ID 时，才需要手动设置：
-
-```bash
-FEISHU_BOT_OPEN_ID=ou_xxx     # 仅在自动检测失败时使用
-FEISHU_BOT_USER_ID=xxx        # 若应用使用 sender_id_type=user_id 则必填
-FEISHU_BOT_NAME=MyBot         # 仅在自动检测失败时使用
-```
-
-## 机器人间消息传递
-
-默认情况下，Hermes 忽略其他机器人发送的消息。当你希望 Hermes 参与 A2A 编排或接收同一群中其他机器人的通知时，可启用机器人间消息传递。
-
-```bash
-FEISHU_ALLOW_BOTS=mentions   # 默认：none
-```
-
-| 值 | 行为 |
-|-------|----------|
-| `none` | 忽略所有其他机器人的消息（默认）。 |
-| `mentions` | 仅当对端机器人 @提及 Hermes 时接受。 |
-| `all` | 接受所有对端机器人消息。 |
-
-也可在 `config.yaml` 中配置为 `feishu.allow_bots`（两者同时设置时，环境变量优先）。
-
-对端机器人无需加入 `FEISHU_ALLOWED_USERS`——该白名单仅适用于人类发送者。
-
-授予 `application:bot.basic_info:read` 权限范围可显示对端机器人名称；未授权时，对端机器人仍可正常路由，但显示为其 `open_id`。
-
-## 交互式卡片操作
-
-当用户点击机器人发送的交互式卡片上的按钮或与其交互时，适配器将这些操作路由为合成的 `/card` 命令事件：
-
-- 按钮点击变为：`/card button {"key": "value", ...}`
-- 卡片定义中操作的 `value` payload 以 JSON 形式包含在内。
-- 卡片操作在 15 分钟窗口内去重，防止重复处理。
-
-Gateway 驱动的更新提示使用原生飞书 `Yes` / `No` 卡片，而非回退到纯文本回复。当 `hermes update --gateway` 需要确认时，适配器将所选答案记录到 Hermes 的 `.update_response` 文件中，并将卡片内联替换为已解决状态。
-
-卡片操作事件以 `MessageType.COMMAND` 分发，因此流经标准命令处理管道。
-
-**命令审批**也通过此机制实现——当 Agent 需要执行危险命令时，会发送一张带有「允许一次 / 本次会话 / 始终允许 / 拒绝」按钮的交互式卡片。用户点击按钮后，卡片操作回调将审批决定传回 Agent。
-
-### 飞书应用所需配置
-
-交互式卡片需要在飞书开发者控制台完成**三项**配置。缺少任何一项，用户点击卡片按钮时将出现错误 **200340**。
-
-1. **订阅卡片操作事件：**
-   在 **事件订阅** 中，将 `card.action.trigger` 添加到已订阅事件。
-
-2. **启用交互式卡片能力：**
-   在 **应用功能 > 机器人** 中，确保 **交互式卡片** 开关已启用。这告知飞书你的应用可以接收卡片操作回调。
-
-3. **配置卡片请求 URL（仅 webhook 模式）：**
-   在 **应用功能 > 机器人 > 消息卡片请求网址** 中，将 URL 设置为与事件 webhook 相同的端点（例如 `https://your-server:8765/feishu/webhook`）。WebSocket 模式下，SDK 会自动处理此项。
-
-:::warning
-缺少以上任意一步，飞书将成功*发送*交互式卡片（发送仅需 `im:message:send` 权限），但点击任意按钮将返回错误 200340。卡片看起来正常——错误仅在用户与其交互时才会出现。
-:::
-
-## 文档评论智能回复
-
-除聊天外，适配器还可以回复**飞书/Lark 文档**中的 `@` 提及。当用户在文档中评论（局部文本选区或全文评论）并 @提及机器人时，Hermes 读取文档内容及周围的评论线程，并在线程中内联发布 LLM 回复。
-
-由 `drive.notice.comment_add_v1` 事件驱动，处理器：
-
-- 并行获取文档内容和评论时间线（全文线程取 20 条消息，局部选区线程取 12 条）。
-- 以 `feishu_doc` + `feishu_drive` 工具集运行 Agent，范围限定于该单次评论会话。
-- 每 4000 字符分块，以线程回复形式发布。
-- 按文档缓存会话，有效期 1 小时，上限 50 条消息，使同一文档的后续评论保持上下文。
-
-### 三级访问控制
-
-文档评论回复为**显式授权模式**——不存在隐式全员允许模式。权限按以下顺序解析（每个字段取第一个匹配项）：
-
-1. **精确文档** — 限定于特定文档 token 的规则。
-2. **通配符** — 匹配文档模式的规则。
-3. **顶层** — 工作区的默认规则。
-
-每条规则支持两种策略：
-
-- **`allowlist`** — 静态用户/租户列表。
-- **`pairing`** — 静态列表 ∪ 运行时审批存储。适用于管理员可实时授权的灰度发布场景。
-
-规则存储在 `~/.hermes/feishu_comment_rules.json`（pairing 授权存储在 `~/.hermes/feishu_comment_pairing.json`），支持基于 mtime 缓存的热重载——编辑后无需重启 gateway，下一个评论事件即生效。
-
-CLI：
-
-```bash
-# 查看当前规则和 pairing 状态
-python -m gateway.platforms.feishu_comment_rules status
-
-# 模拟特定文档 + 用户的访问检查
-python -m gateway.platforms.feishu_comment_rules check <fileType:fileToken> <user_open_id>
-
-# 运行时管理 pairing 授权
-python -m gateway.platforms.feishu_comment_rules pairing list
-python -m gateway.platforms.feishu_comment_rules pairing add <user_open_id>
-python -m gateway.platforms.feishu_comment_rules pairing remove <user_open_id>
-```
-
-### 飞书应用所需配置
-
-在已授予的聊天/卡片权限基础上，添加文档评论事件：
-
-- 在 **事件订阅** 中订阅 `drive.notice.comment_add_v1`。
-- 授予 `docs:doc:readonly` 和 `drive:drive:readonly` 权限范围，以便处理器读取文档内容。
 
 ## 媒体支持
 
 ### 入站（接收）
 
-适配器接收并缓存以下来自用户的媒体类型：
+适配器接收并缓存用户发送的以下媒体类型：
 
 | 类型 | 扩展名 | 处理方式 |
-|------|-----------|-------------------|
+|------|--------|---------|
 | **图片** | .jpg, .jpeg, .png, .gif, .webp, .bmp | 通过飞书 API 下载并本地缓存 |
-| **音频** | .ogg, .mp3, .wav, .m4a, .aac, .flac, .opus, .webm | 下载并缓存；小型文本文件自动提取内容 |
-| **视频** | .mp4, .mov, .avi, .mkv, .webm, .m4v, .3gp | 下载并作为文档缓存 |
-| **文件** | .pdf, .doc, .docx, .xls, .xlsx, .ppt, .pptx 等 | 下载并作为文档缓存 |
-
-富文本（post）消息中的媒体，包括内联图片和文件附件，也会被提取并缓存。
-
-对于小型文本文档（.txt, .md），文件内容会自动注入消息文本，使 Agent 无需工具即可直接读取。
-
-### 出站（发送）
-
-| 方法 | 发送内容 |
-|--------|--------------|
-| `send` | 文本或富文本 post 消息（根据 markdown 内容自动检测） |
-| `send_image` / `send_image_file` | 上传图片到飞书，然后以原生图片气泡发送（可附带说明文字） |
-| `send_document` | 上传文件到飞书 API，然后以文件附件发送 |
-| `send_voice` | 以飞书文件附件形式上传音频文件 |
-| `send_video` | 上传视频并以原生媒体消息发送 |
-| `send_animation` | GIF 降级为文件附件（飞书不支持原生 GIF 气泡） |
-
-文件上传路由根据扩展名自动判断：
-
-- `.ogg`, `.opus` → 以 `opus` 音频上传
-- `.mp4`, `.mov`, `.avi`, `.m4v` → 以 `mp4` 媒体上传
-- `.pdf`, `.doc(x)`, `.xls(x)`, `.ppt(x)` → 以对应文档类型上传
-- 其他所有格式 → 以通用流文件上传
-
-## Markdown 渲染与 Post 回退
-
-当出站文本包含 markdown 格式（标题、加粗、列表、代码块、链接等）时，适配器自动将其以飞书 **post** 消息形式发送，并嵌入 `md` 标签，而非纯文本。这使飞书客户端能够富文本渲染。
-
-如果飞书 API 拒绝 post payload（例如因不支持的 markdown 语法），适配器自动回退为发送去除 markdown 的纯文本。这种两阶段回退确保消息始终能送达。
-
-纯文本消息（未检测到 markdown）以简单的 `text` 消息类型发送。
-
-## 处理状态表情回应
-
-Agent 工作期间，机器人会在你的消息上显示 `Typing` 表情回应。回复到达后清除，处理失败则替换为 `CrossMark`。
-
-设置 `FEISHU_REACTIONS=false` 可关闭此功能。
-
-## 突发保护与批处理
-
-适配器对快速消息突发进行防抖处理，避免压垮 Agent：
-
-### 文本批处理
-
-当用户快速连续发送多条文本消息时，它们会在分发前合并为单个事件：
-
-| 设置 | 环境变量 | 默认值 |
-|---------|---------|---------|
-| 静默期 | `HERMES_FEISHU_TEXT_BATCH_DELAY_SECONDS` | 0.6s |
-| 每批最大消息数 | `HERMES_FEISHU_TEXT_BATCH_MAX_MESSAGES` | 8 |
-| 每批最大字符数 | `HERMES_FEISHU_TEXT_BATCH_MAX_CHARS` | 4000 |
-
-### 媒体批处理
-
-快速连续发送的多个媒体附件（例如拖拽多张图片）会合并为单个事件：
-
-| 设置 | 环境变量 | 默认值 |
-|---------|---------|---------|
-| 静默期 | `HERMES_FEISHU_MEDIA_BATCH_DELAY_SECONDS` | 0.8s |
-
-### 按聊天串行化
-
-同一聊天中的消息串行处理（每次一条），以保持对话连贯性。每个聊天有独立的锁，不同聊天的消息并发处理。
-
-## 速率限制（Webhook 模式）
-
-在 webhook 模式下，适配器对每个 IP 强制执行速率限制，防止滥用：
-
-- **窗口：** 60 秒滑动窗口
-- **限制：** 每个（app_id, path, IP）三元组每窗口 120 次请求
-- **追踪上限：** 最多追踪 4096 个唯一键（防止内存无限增长）
-
-超出限制的请求将收到 HTTP 429（请求过多）。
-
-### Webhook 异常追踪
-
-适配器追踪每个 IP 地址的连续错误响应。同一 IP 在 6 小时窗口内连续出现 25 次错误后，将记录警告日志。这有助于检测配置错误的客户端或探测行为。
-
-额外的 webhook 保护措施：
-- **请求体大小限制：** 最大 1 MB
-- **请求体读取超时：** 30 秒
-- **Content-Type 强制：** 仅接受 `application/json`
-
-## WebSocket 调优
-
-使用 `websocket` 模式时，可自定义重连和 ping 行为：
-
-```yaml
-platforms:
-  feishu:
-    extra:
-      ws_reconnect_interval: 120   # 重连尝试间隔秒数（默认：120）
-      ws_ping_interval: 30         # WebSocket ping 间隔秒数（可选；未设置时使用 SDK 默认值）
-```
-
-| 设置 | 配置键 | 默认值 | 说明 |
-|---------|-----------|---------|-------------|
-| 重连间隔 | `ws_reconnect_interval` | 120s | 两次重连尝试之间的等待时间 |
-| Ping 间隔 | `ws_ping_interval` | _（SDK 默认）_ | WebSocket 保活 ping 的频率 |
-
-## 按群访问控制
-
-除全局 `FEISHU_GROUP_POLICY` 外，还可在 config.yaml 的 `group_rules` 中为每个群聊设置细粒度规则：
-
-```yaml
-platforms:
-  feishu:
-    extra:
-      default_group_policy: "open"     # 未在 group_rules 中列出的群的默认策略
-      admins:                          # 可管理机器人设置的用户
-        - "ou_admin_open_id"
-      group_rules:
-        "oc_group_chat_id_1":
-          policy: "allowlist"          # open | allowlist | blacklist | admin_only | disabled
-          allowlist:
-            - "ou_user_open_id_1"
-            - "ou_user_open_id_2"
-        "oc_group_chat_id_2":
-          policy: "admin_only"
-        "oc_group_chat_id_3":
-          policy: "blacklist"
-          blacklist:
-            - "ou_blocked_user"
-        "oc_free_chat":
-          policy: "open"
-          require_mention: false       # 覆盖此聊天的 FEISHU_REQUIRE_MENTION
-```
-
-| 策略 | 说明 |
-|--------|-------------|
-| `open` | 群内任何人均可使用机器人 |
-| `allowlist` | 仅群 `allowlist` 中的用户可使用机器人 |
-| `blacklist` | 除群 `blacklist` 中的用户外，所有人均可使用机器人 |
-| `admin_only` | 仅全局 `admins` 列表中的用户可在此群使用机器人 |
-| `disabled` | 机器人忽略此群的所有消息 |
-
-在 `group_rules` 条目中设置 `require_mention: false` 可跳过该特定聊天的 @提及要求。省略时，该聊天继承全局 `FEISHU_REQUIRE_MENTION` 值。
-
-未在 `group_rules` 中列出的群回退到 `default_group_policy`（默认为 `FEISHU_GROUP_POLICY` 的值）。
-
-## 去重
-
-入站消息使用消息 ID 去重，TTL 为 24 小时。去重状态持久化到 `~/.hermes/feishu_seen_message_ids.json`，重启后仍有效。
-
-| 设置 | 环境变量 | 默认值 |
-|---------|---------|---------|
-| 缓存大小 | `HERMES_FEISHU_DEDUP_CACHE_SIZE` | 2048 条 |
-
-## 所有环境变量
-
-| 变量 | 必填 | 默认值 | 说明 |
-|----------|----------|---------|-------------|
-| `FEISHU_APP_ID` | ✅ | — | 飞书/Lark App ID |
-| `FEISHU_APP_SECRET` | ✅ | — | 飞书/Lark App Secret |
-| `FEISHU_DOMAIN` | — | `feishu` | `feishu`（中国）或 `lark`（国际版） |
-| `FEISHU_CONNECTION_MODE` | — | `websocket` | `websocket` 或 `webhook` |
-| `FEISHU_ALLOWED_USERS` | — | _（空）_ | 用户白名单的逗号分隔 open_id 列表 |
-| `FEISHU_ALLOW_BOTS` | — | `none` | 接受其他机器人消息：`none`、`mentions` 或 `all` |
-| `FEISHU_REQUIRE_MENTION` | — | `true` | 群消息是否必须 @提及 机器人 |
-| `FEISHU_HOME_CHANNEL` | — | — | cron/通知输出的聊天 ID |
-| `FEISHU_ENCRYPT_KEY` | — | _（空）_ | webhook 签名验证的加密密钥 |
-| `FEISHU_VERIFICATION_TOKEN` | — | _（空）_ | webhook payload 认证的验证 token |
-| `FEISHU_GROUP_POLICY` | — | `allowlist` | 群消息策略：`open`、`allowlist`、`disabled` |
-| `FEISHU_BOT_OPEN_ID` | — | _（空）_ | 机器人的 open_id（用于 @提及 检测） |
-| `FEISHU_BOT_USER_ID` | — | _（空）_ | 机器人的 user_id（用于 @提及 检测） |
-| `FEISHU_BOT_NAME` | — | _（空）_ | 机器人的显示名称（用于 @提及 检测） |
-| `FEISHU_WEBHOOK_HOST` | — | `127.0.0.1` | Webhook 服务器绑定地址 |
-| `FEISHU_WEBHOOK_PORT` | — | `8765` | Webhook 服务器端口 |
-| `FEISHU_WEBHOOK_PATH` | — | `/feishu/webhook` | Webhook 端点路径 |
-| `HERMES_FEISHU_DEDUP_CACHE_SIZE` | — | `2048` | 最大去重消息 ID 追踪数量 |
-| `HERMES_FEISHU_TEXT_BATCH_DELAY_SECONDS` | — | `0.6` | 文本突发防抖静默期 |
-| `HERMES_FEISHU_TEXT_BATCH_MAX_MESSAGES` | — | `8` | 每批文本合并的最大消息数 |
-| `HERMES_FEISHU_TEXT_BATCH_MAX_CHARS` | — | `4000` | 每批文本合并的最大字符数 |
-| `HERMES_FEISHU_MEDIA_BATCH_DELAY_SECONDS` | — | `0.8` | 媒体突发防抖静默期 |
-
-WebSocket 和按群 ACL 设置通过 `config.yaml` 的 `platforms.feishu.extra` 配置（参见上方 [WebSocket 调优](#websocket-tuning) 和[按群访问控制](#per-group-access-control)）。
+| **音频** | .ogg, .mp3, .wav, .m4a, .aac, .flac, .opus, .webm | 下载并缓存；小文本文件自动提取内容 |
+| **视频** | .mp4, .mov, .avi, .mkv, .webm, .m4v, .3gp | 作为文档下载并缓存 |
+| **文件** | .pdf, .doc, .docx, .xls, .xlsx, .ppt, .pptx 等 | 作为文档下载并缓存 |
 
 ## 故障排查
 
-| 问题 | 解决方法 |
-|---------|-----|
+| 问题 | 解决方案 |
+|------|---------|
 | `lark-oapi not installed` | 安装 SDK：`pip install lark-oapi` |
-| `websockets not installed; websocket mode unavailable` | 安装 websockets：`pip install websockets` |
-| `aiohttp not installed; webhook mode unavailable` | 安装 aiohttp：`pip install aiohttp` |
-| `FEISHU_APP_ID or FEISHU_APP_SECRET not set` | 设置两个环境变量，或通过 `hermes gateway setup` 配置 |
-| `Another local Hermes gateway is already using this Feishu app_id` | 同一时间只能有一个 Hermes 实例使用相同的 app_id。请先停止另一个 gateway。 |
-| 机器人在群聊中不响应 | 确保机器人被 @提及，检查 `FEISHU_GROUP_POLICY`，若策略为 `allowlist` 则验证发送者是否在 `FEISHU_ALLOWED_USERS` 中 |
-| `Webhook rejected: invalid verification token` | 确保 `FEISHU_VERIFICATION_TOKEN` 与飞书应用事件订阅配置中的 token 一致 |
-| `Webhook rejected: invalid signature` | 确保 `FEISHU_ENCRYPT_KEY` 与飞书应用配置中的加密密钥一致 |
-| Post 消息显示为纯文本 | 飞书 API 拒绝了 post payload；这是正常的回退行为。查看日志了解详情。 |
-| 机器人未收到图片/文件 | 为飞书应用授予 `im:message` 和 `im:resource` 权限范围 |
-| 机器人身份未自动检测 | 通常是访问飞书机器人信息端点时的瞬时网络问题。可手动设置 `FEISHU_BOT_OPEN_ID` 和 `FEISHU_BOT_NAME` 作为临时解决方案。 |
-| 启用 `FEISHU_ALLOW_BOTS` 后对端机器人消息仍被忽略 | Hermes 尚无法识别自身——请设置 `FEISHU_BOT_OPEN_ID`（若应用使用 `sender_id_type=user_id` 则同时设置 `FEISHU_BOT_USER_ID`）。 |
-| 对端机器人显示为 `ou_xxxxxx` 而非名称 | 授予 `application:bot.basic_info:read` 权限范围。 |
-| 点击审批按钮时出现错误 200340 | 在飞书开发者控制台启用**交互式卡片**能力并配置**卡片请求 URL**。参见上方[飞书应用所需配置](#required-feishu-app-configuration)。 |
-| `Webhook rate limit exceeded` | 同一 IP 每分钟请求超过 120 次。通常是配置错误或循环导致。 |
+| `websockets not installed` | 安装 websockets：`pip install websockets` |
+| `FEISHU_APP_ID 或 FEISHU_APP_SECRET 未设置` | 设置环境变量或通过 `hermes gateway setup` 配置 |
+| 另一个本地 Hermes 网关正在使用相同的 app_id | 同一 app_id 只能被一个 Hermes 实例使用。先停止另一个网关 |
+| 机器人在群聊中不响应 | 确保机器人被 @提及，检查 `FEISHU_GROUP_POLICY`，验证发送者在许可名单中 |
+| 机器人收到消息但不回复（网关状态正常） | 检查 LLM 提供商是否正常——`grep -i "402\|429\|Insufficient" ~/.hermes/logs/gateway.log`。常见原因：HTTP 402（余额不足）、429（速率限制）、5xx（提供商故障）。网关运行正常 + 飞书 WS 已连接 ≠ 模型可用 |
+| 飞书手机端长消息渲染异常 | 飞书手机端无法可靠渲染超长 Markdown——内容会折叠或截断。解决方案：将聊天消息控制在 1500 字以内作为摘要，完整内容写入 `.md` 文件通过文件附件发送 |
+| 点击审批按钮返回错误 200340 | 在飞书开发者控制台中启用 **交互式卡片** 能力并配置 **卡片请求 URL** |
+| 图片/文件未被机器人收到 | 为飞书应用授予 `im:message` 和 `im:resource` 权限 |
 
-## 工具集
+## 生产环境多节点部署陷阱
 
-飞书 / Lark 使用 `hermes-feishu` 平台预设，包含与 Telegram 及其他基于 gateway 的消息平台相同的核心工具。
+基于 CTGC 团队 6 节点 A2A 拓扑的实际部署经验：
+
+| 陷阱 | 表现 | 修复 |
+|------|------|------|
+| **gateway.platforms 为空** | 飞书 WebSocket 已连接但机器人不响应任何消息 | `config.yaml` 中 `gateway.platforms.feishu.enabled` 必须为 `true`。WebSocket 连接独立于平台适配器——连接成功不等于适配器已加载 |
+| **`.env` 和 systemd EnvironmentFile 不一致** | 凭据存在于 `.env` 但网关找不到 | systemd 服务不会自动加载 `~/.hermes/.env`。在 override.conf 中显式设置 `Environment=` 或 `EnvironmentFile=` |
+| **服务用户 home 目录不一致** | 网关启动但找不到配置文件 | 确保 systemd 单元的 `HOME` 环境变量与服务用户的 home 目录一致（例如 `/home/admin`，而非 `/root`） |
+| **config set 重复键覆盖** | `hermes config set` 将列表值存为字符串 | 手动编辑 `config.yaml` 确保列表格式正确（尤其是 `platform_toolsets`） |
+| **网关崩溃循环** | 网关不断重启 | 重置失败状态：`systemctl --user reset-failed hermes-gateway`，然后检查日志 |
+| **国内网络 DNS 污染** | 安装依赖超时 | 使用代理：`export https_proxy=http://127.0.0.1:7890`；避免使用清华/阿里云等国内镜像 |


### PR DESCRIPTION
## Summary

Add Chinese (zh-Hans) translations for two core documentation pages:

1. **Installation guide** (`getting-started/installation.md`) - full Chinese translation covering all install methods, service-user deployment, and troubleshooting
2. **Feishu/Lark setup** (`user-guide/messaging/feishu.md`) - Chinese translation of the Feishu integration guide

## Why

The zh-Hans i18n directory already has ~150 translated files covering developer guide, features, guides, and integrations, but was missing the critical entry-point docs: installation and platform messaging setup. These two files complete the Chinese reader's onboarding path.

## What makes this different

- **Real production experience**: Added a production deployment pitfalls section to the Feishu guide, based on real-world experience running a 6-node Hermes A2A topology with Feishu gateway
- **Server-focused notes**: Added systemd linger, silent disconnect detection, DNS pollution mitigation, and gateway restart discipline for server deployments
- **Not machine translation**: Hand-written Chinese with technical accuracy and natural developer terminology

## Checklist

- [x] I have read the contributing guidelines
- [x] Documentation only - no code changes
- [x] Follows existing i18n file structure and formatting
- [x] All links and Docusaurus admonitions preserved