### PR TITLE
fix(docker): warn when disk quota is silently ignored on macOS

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1488,3 +1488,60 @@ def test_extra_args_set_shm_size_helper():
     assert docker_env._extra_args_set_shm_size(None) is False
     # non-string entries must not crash (config.yaml can be malformed)
     assert docker_env._extra_args_set_shm_size([42, None, "--shm-size=1g"]) is True
+
+
+# ── disk quota handling (macOS silent-skip regression) ────────────────────
+
+
+def _disk_run_args(calls):
+    for cmd, _kwargs in calls:
+        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[1] == "run":
+            return cmd
+    return []
+
+
+def test_disk_quota_warns_on_macos_and_skips_storage_opt(monkeypatch, caplog):
+    """macOS Docker must not silently ignore a configured disk quota.
+
+    Regression: ``disk > 0`` on darwin previously fell through with no log
+    line at all — the user's configured limit did nothing and nothing told
+    them. Now it logs a warning explaining the limit is unsupported, and
+    still must NOT emit ``--storage-opt`` (Docker Desktop would reject it).
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(docker_env.sys, "platform", "darwin")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    with caplog.at_level(logging.WARNING):
+        _make_dummy_env(disk=4096)
+
+    run_args = _disk_run_args(calls)
+    assert "--storage-opt" not in run_args
+    joined = " ".join(run_args)
+    assert "--storage-opt" not in joined
+    assert any(
+        "disk quotas are not supported on macOS" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_disk_quota_linux_still_applies_storage_opt(monkeypatch, caplog):
+    """On Linux with overlay2/XFS support the quota path is unchanged."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr(docker_env.sys, "platform", "linux")
+    docker_env._storage_opt_ok = True
+    calls = _mock_subprocess_run(monkeypatch)
+
+    with caplog.at_level(logging.WARNING):
+        _make_dummy_env(disk=4096)
+
+    run_args = _disk_run_args(calls)
+    assert "--storage-opt" in run_args
+    joined = " ".join(run_args)
+    assert "--storage-opt" in joined and "size=4096m" in joined
+    assert not any(
+        "disk quotas are not supported on macOS" in record.getMessage()
+        for record in caplog.records
+    )

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -941,6 +941,16 @@ class DockerEnvironment(BaseEnvironment):
                     "Docker storage driver does not support per-container disk limits "
                     "(requires overlay2 on XFS with pquota). Container will run without disk quota."
                 )
+        elif disk > 0:
+            # Docker Desktop for macOS has no --storage-opt support (the driver
+            # is a VM-backed filesystem, not overlay2), so a configured disk
+            # quota silently does nothing. Surface it instead of pretending the
+            # limit was applied.
+            logger.warning(
+                "Per-container disk quotas are not supported on macOS Docker "
+                "(Docker Desktop exposes no --storage-opt size=). The configured "
+                "disk limit (%dm) will be ignored.", disk,
+            )
         if not network:
             resource_args.append("--network=none")
 


### PR DESCRIPTION
## Bug Description

Fixes a silent configuration failure on macOS: a configured Docker container disk quota does nothing, with **no warning at all**.

In `DockerEnvironment` resource-arg construction:

```python
if disk > 0 and sys.platform != "darwin":
    if self._storage_opt_supported():
        resource_args.extend(["--storage-opt", f"size={disk}m"])
    else:
        logger.warning("Docker storage driver does not support ...")
```

On macOS the whole block is skipped — the user's `disk` setting (e.g. `container_disk: 51200` in config) is silently ignored. Docker Desktop for macOS exposes no `--storage-opt size=` (the driver is a VM-backed filesystem, not overlay2), so the limit genuinely cannot be applied — but the user is never told, and may believe their sandbox is disk-quota-limited when it isn't.

Note the inconsistency this fixes: on Linux, when the driver *doesn't* support quotas there's a `logger.warning`; on macOS the same situation produces nothing.

## Root Cause

The `sys.platform != "darwin"` guard was added to skip a flag Docker Desktop would reject, but the skip path has no feedback — a silent no-op for the entire macOS user base.

## Fix

Add an explicit `elif disk > 0:` branch that logs a warning explaining the limit is unsupported on macOS and will be ignored. The behavior (no `--storage-opt`) is unchanged; the user now knows.

## How to Verify

```bash
PATH="$PWD/venv/bin:$PATH" python3 -m pytest tests/tools/test_docker_environment.py -k disk_quota -v -o 'addopts='
```

## Test Plan

2 new tests in `tests/tools/test_docker_environment.py`:

1. `test_disk_quota_warns_on_macos_and_skips_storage_opt` — with `sys.platform == "darwin"` and `disk=4096`: asserts a warning containing "disk quotas are not supported on macOS" is logged, and no `--storage-opt` is passed to docker run.
2. `test_disk_quota_linux_still_applies_storage_opt` — with `sys.platform == "linux"` and storage-opt supported: asserts `--storage-opt size=4096m` **is** passed and the macOS warning is absent (no regression to the Linux path).

Also verified: full `test_docker_environment.py` suite passes (53 passed).

## Risk Assessment

**Low.** Adds a warning branch only; the docker run argv is byte-identical on macOS (no `--storage-opt` before or after). Linux behavior unchanged and covered by a regression test.
