### PR TITLE
fix(profiles): surface osascript failures when opening Terminal on macOS

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -634,9 +634,37 @@ async def open_profile_terminal_endpoint(name: str):
                 'tell application "Terminal"\n'
                 "activate\n"
                 f'do script "{escaped}"\n'
-                "end tell"
+                "end tell\n"
+                'return "ok"\n'
             )
-            subprocess.Popen(["osascript", "-e", applescript])
+            try:
+                result = subprocess.run(
+                    ["osascript", "-e", applescript],
+                    capture_output=True, text=True, encoding="utf-8",
+                    errors="replace", timeout=15,
+                )
+            except FileNotFoundError:
+                raise HTTPException(
+                    status_code=500,
+                    detail="osascript not found — macOS Terminal integration unavailable",
+                )
+            except subprocess.TimeoutExpired:
+                raise HTTPException(
+                    status_code=504,
+                    detail="Timed out asking Terminal to open — is the Automation "
+                    "permission (System Settings → Privacy & Security → Automation) granted?",
+                )
+            if result.returncode != 0:
+                _log.warning(
+                    "osascript open-terminal failed (rc=%s): %s",
+                    result.returncode, (result.stderr or result.stdout).strip()[:300],
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail="Terminal failed to open the profile setup command. "
+                    "Check the Automation permission for Hermes in System Settings "
+                    "→ Privacy & Security → Automation.",
+                )
         else:
             terminal_commands = [
                 ("x-terminal-emulator", ["x-terminal-emulator", "-e", "sh", "-lc", command]),

--- a/tests/hermes_cli/test_profiles_open_terminal.py
+++ b/tests/hermes_cli/test_profiles_open_terminal.py
@@ -1,0 +1,78 @@
+"""Tests for the profile open-terminal endpoint (macOS osascript path).
+
+Regression: the darwin branch previously fire-and-forgot ``osascript`` via
+``subprocess.Popen`` with no returncode / timeout handling — when Terminal
+could not be activated (missing Automation permission, osascript error), the
+API still returned ``{"ok": true}`` while nothing opened on the user's screen.
+"""
+
+import subprocess
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from hermes_cli.web_routers import profiles as profiles_router
+
+
+def _invoke_endpoint(monkeypatch, *, subprocess_result=None, exc=None):
+    """Call the open-terminal endpoint with a stubbed osascript backend."""
+    command = "hermes setup"
+
+    calls = {}
+
+    def fake_run(argv, **kwargs):
+        calls["argv"] = argv
+        calls["kwargs"] = kwargs
+        if exc is not None:
+            raise exc
+        return subprocess_result
+
+    monkeypatch.setattr(profiles_router.sys, "platform", "darwin")
+    monkeypatch.setattr(profiles_router.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        profiles_router, "_profile_setup_command", lambda name: command
+    )
+    # Async endpoint — drive it synchronously via asyncio.
+    import asyncio
+    return asyncio.run(
+        profiles_router.open_profile_terminal_endpoint("default")
+    ), calls
+
+
+def test_darwin_osascript_success_returns_ok(monkeypatch):
+    result = subprocess.CompletedProcess(["osascript"], 0, stdout="ok", stderr="")
+    response, calls = _invoke_endpoint(monkeypatch, subprocess_result=result)
+    assert response == {"ok": True, "command": "hermes setup"}
+    # Must be a blocking run (not fire-and-forget Popen) with a timeout.
+    assert "timeout" in calls["kwargs"]
+    assert calls["kwargs"]["timeout"] > 0
+    assert "capture_output" in calls["kwargs"]
+
+
+def test_darwin_osascript_failure_raises_500(monkeypatch):
+    result = subprocess.CompletedProcess(
+        ["osascript"], 1, stdout="", stderr="execution error: Not authorized"
+    )
+    with pytest.raises(Exception) as excinfo:
+        _invoke_endpoint(monkeypatch, subprocess_result=result)
+    from fastapi import HTTPException
+    assert isinstance(excinfo.value, HTTPException)
+    assert excinfo.value.status_code == 500
+    assert "Automation" in excinfo.value.detail
+
+
+def test_darwin_osascript_timeout_raises_504(monkeypatch):
+    with pytest.raises(Exception) as excinfo:
+        _invoke_endpoint(monkeypatch, exc=subprocess.TimeoutExpired("osascript", 15))
+    from fastapi import HTTPException
+    assert isinstance(excinfo.value, HTTPException)
+    assert excinfo.value.status_code == 504
+
+
+def test_darwin_osascript_missing_raises_500(monkeypatch):
+    with pytest.raises(Exception) as excinfo:
+        _invoke_endpoint(monkeypatch, exc=FileNotFoundError("osascript"))
+    from fastapi import HTTPException
+    assert isinstance(excinfo.value, HTTPException)
+    assert excinfo.value.status_code == 500


### PR DESCRIPTION
## Bug Description

Fixes the macOS `open-terminal` profile API reporting success when nothing actually opened.

`POST /api/profiles/{name}/open-terminal` on the darwin branch fire-and-forgets osascript:

```python
subprocess.Popen(["osascript", "-e", applescript])
```

Three failure modes are silently swallowed:

1. **osascript failure** — if Terminal can't be activated (e.g. the Automation/TCC permission for Hermes is not granted, which is the *default* state on macOS), osascript exits non-zero with "execution error: Not authorized" — but `Popen` returns immediately with no returncode check, so the API answers `{"ok": true}` while nothing opened.
2. **Timeout** — a hung osascript never surfaces.
3. **Missing osascript** — a `FileNotFoundError` would be caught by the generic handler and reported as a confusing 500 with the raw error.

The Linux branch, by contrast, already has explicit error handling (`raise HTTPException(400, "No supported terminal emulator found")`), so the macOS branch is the outlier.

## Root Cause

Fire-and-forget `Popen` with no `returncode`/timeout/error handling on the macOS path. The endpoint's contract is "open a terminal on the user's machine" — a silent failure violates that contract and gives the dashboard no way to show the TCC permission prompt hint.

## Fix

Replace `Popen` with a blocking `subprocess.run(..., capture_output=True, timeout=15)` and:

- check `returncode` → raise `HTTPException(500)` with an actionable hint about the **Automation permission** in System Settings → Privacy & Security (the common cause),
- catch `TimeoutExpired` → `HTTPException(504)` with the same permission hint,
- catch `FileNotFoundError` → `HTTPException(500)` with a clear message,
- log the osascript stderr at `warning` for diagnosability.

The AppleScript now ends with `return "ok"` so a *successful* activation can be distinguished from a silent no-op.

## How to Verify

```bash
PATH="$PWD/venv/bin:$PATH" python3 -m pytest tests/hermes_cli/test_profiles_open_terminal.py -v -o 'addopts='
```

## Test Plan

4 new tests in `tests/hermes_cli/test_profiles_open_terminal.py` (new file — no prior coverage of this endpoint):

1. `test_darwin_osascript_success_returns_ok` — success path returns `{"ok": true}` and asserts the call is a blocking `run` with a timeout (guards against regression back to fire-and-forget).
2. `test_darwin_osascript_failure_raises_500` — non-zero returncode → 500 with Automation hint.
3. `test_darwin_osascript_timeout_raises_504` — `TimeoutExpired` → 504.
4. `test_darwin_osascript_missing_raises_500` — `FileNotFoundError` → 500 with clear message.

## Risk Assessment

**Low.** macOS-only branch; the endpoint is dashboard UI sugar ("open terminal for this profile"). Blocking `run` with a 15s timeout is acceptable for a user-initiated action; the timeout covers a hung osascript that previously would have hung the child process invisibly.
