### PR TITLE
fix(web): clear stale key environment on provider switch

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1592,6 +1592,10 @@ def _apply_main_model_assignment(
         clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
     if new_provider != prev_provider:
         clear_model_endpoint_credentials(model_cfg, clear_api_key=False)
+        # ``key_env`` names the previous endpoint's credential. It has the
+        # same provider-bound lifecycle as base_url: retain it for a
+        # same-provider re-pick, but do not let it reach a different provider.
+        model_cfg.pop("key_env", None)
     model_cfg.pop("context_length", None)
     return model_cfg
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -234,6 +234,42 @@ class TestSessionTokenInjection:
 
 
 # ---------------------------------------------------------------------------
+# Main model assignment tests
+# ---------------------------------------------------------------------------
+
+
+class TestMainModelAssignment:
+    def test_switching_provider_clears_stale_key_env(self):
+        """A custom endpoint's credential reference cannot route a new provider."""
+        from hermes_cli.web_server import _apply_main_model_assignment
+
+        model_cfg = {
+            "provider": "custom",
+            "default": "custom-model",
+            "base_url": "https://custom.example.test/v1",
+            "key_env": "CUSTOM_ENDPOINT_API_KEY",
+        }
+
+        _apply_main_model_assignment(model_cfg, "openai", "gpt-5.6")
+
+        assert "key_env" not in model_cfg
+
+    def test_reselecting_same_provider_preserves_key_env(self):
+        """Changing a model under the same endpoint keeps its credential reference."""
+        from hermes_cli.web_server import _apply_main_model_assignment
+
+        model_cfg = {
+            "provider": "custom",
+            "default": "custom-model",
+            "key_env": "CUSTOM_ENDPOINT_API_KEY",
+        }
+
+        _apply_main_model_assignment(model_cfg, "custom", "other-custom-model")
+
+        assert model_cfg["key_env"] == "CUSTOM_ENDPOINT_API_KEY"
+
+
+# ---------------------------------------------------------------------------
 # web_server tests (FastAPI endpoints)
 # ---------------------------------------------------------------------------
 
@@ -1472,6 +1508,28 @@ class TestWebServerEndpoints:
         assert _parse_model_ids(FakeResp({"data": []}, ok=False)) == []
         assert _parse_model_ids(FakeResp({"nope": 1})) == []
         assert _parse_model_ids(FakeResp(ValueError("bad json"))) == []
+
+
+    def test_set_model_main_provider_switch_clears_stale_key_env(self):
+        """A dashboard switch away from an endpoint drops its key reference."""
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["model"] = {
+            "provider": "custom",
+            "default": "custom-model",
+            "base_url": "https://custom.example.test/v1",
+            "key_env": "CUSTOM_ENDPOINT_API_KEY",
+        }
+        save_config(cfg)
+
+        response = self.client.post(
+            "/api/model/set",
+            json={"scope": "main", "provider": "openai", "model": "gpt-5.6"},
+        )
+
+        assert response.status_code == 200
+        assert "key_env" not in load_config()["model"]
 
 
     def test_set_model_main_custom_persists_api_key_and_registers_provider(self):


### PR DESCRIPTION
## Summary
- Clear `model.key_env` when changing the main model provider.
- Preserve the credential reference when only the model changes under the same provider.
- Cover both the assignment helper and the dashboard model-setting API.

## Testing
- `/tmp/hermes-82963-venv/bin/python -m pytest tests/hermes_cli/test_web_server.py tests/hermes_cli/test_update_config_clears_custom_fields.py tests/hermes_cli/test_custom_provider_model_switch.py -q`
- `/tmp/hermes-82963-venv/bin/python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`

Fixes #82963