### PR TITLE
fix: contain restricted Codex dynamic tools

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -30,20 +30,32 @@ logger = logging.getLogger(__name__)
 def _configured_mcp_dynamic_tools(agent) -> list[dict[str, Any]]:
     """Project this session's registered MCP schemas onto Codex dynamic tools.
 
-    ``agent.tools`` is already filtered by the platform toolset policy.  The
-    registered-name map is the extra provenance check: a registry/native tool
-    that merely resembles an MCP name never crosses this boundary.
+    ``agent.tools`` may be the tool-search bridge surface, so resolve the raw
+    catalog under the exact session policy first.  The registered-name map is
+    the extra provenance check: a registry/native tool that merely resembles
+    an MCP name never crosses this boundary.
     """
+    enabled_toolsets = getattr(agent, "enabled_toolsets", None)
+    if enabled_toolsets == []:
+        return []
+
     try:
+        from model_tools import get_tool_definitions
         from tools.mcp_tool import _mcp_tool_server_names
 
         registered = set(_mcp_tool_server_names)
+        raw_tools = get_tool_definitions(
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        ) or []
     except Exception:
         return []
 
     dynamic_tools: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for tool in getattr(agent, "tools", ()) or ():
+    for tool in raw_tools:
         function = tool.get("function") if isinstance(tool, dict) else None
         if not isinstance(function, dict):
             continue

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -27,6 +27,47 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 logger = logging.getLogger(__name__)
 
 
+def _configured_mcp_dynamic_tools(agent) -> list[dict[str, Any]]:
+    """Project this session's registered MCP schemas onto Codex dynamic tools.
+
+    ``agent.tools`` is already filtered by the platform toolset policy.  The
+    registered-name map is the extra provenance check: a registry/native tool
+    that merely resembles an MCP name never crosses this boundary.
+    """
+    try:
+        from tools.mcp_tool import _mcp_tool_server_names
+
+        registered = set(_mcp_tool_server_names)
+    except Exception:
+        return []
+
+    dynamic_tools: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for tool in getattr(agent, "tools", ()) or ():
+        function = tool.get("function") if isinstance(tool, dict) else None
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        parameters = function.get("parameters")
+        if (
+            not isinstance(name, str)
+            or name not in registered
+            or not isinstance(parameters, dict)
+            or name in seen
+        ):
+            continue
+        seen.add(name)
+        dynamic_tools.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": str(function.get("description") or ""),
+                "inputSchema": parameters,
+            }
+        )
+    return dynamic_tools
+
+
 def _coerce_usage_int(value: Any) -> int:
     if isinstance(value, bool):
         return 0
@@ -680,8 +721,32 @@ def run_codex_app_server_turn(
         # users see no live tool-progress or interim commentary while
         # codex_app_server is running — only the final answer (#33200).
         # Supersedes the narrower item/started-only bridge from #38835.
+        dynamic_tools = _configured_mcp_dynamic_tools(agent)
+        allowed_dynamic_tools = {tool["name"] for tool in dynamic_tools}
+
+        def dispatch_dynamic_tool(
+            tool_name: str, arguments: dict[str, Any], call_id: str
+        ) -> Any:
+            # The session validates the name and argument shape before this
+            # callback. Keep the dispatcher scoped to the same exact snapshot.
+            import model_tools
+
+            return model_tools.handle_function_call(
+                tool_name,
+                arguments,
+                effective_task_id,
+                tool_call_id=call_id,
+                session_id=getattr(agent, "session_id", "") or "",
+                enabled_tools=sorted(allowed_dynamic_tools),
+                enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+            )
+
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            developer_instructions=getattr(agent, "_cached_system_prompt", None),
+            dynamic_tools=dynamic_tools,
+            dynamic_tool_handler=dispatch_dynamic_tool,
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -16,6 +16,7 @@ compatibility.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import time
@@ -26,10 +27,19 @@ from agent.stream_single_writer import claim_stream_writer, stream_writer_is_cur
 
 logger = logging.getLogger(__name__)
 
+_OBLIGATION_TOOL_ALIASES = frozenset(
+    {
+        "list_email_obligations",
+        "get_email_obligation",
+        "get_email_obligation_monitor_status",
+    }
+)
+_OBLIGATION_SERVER_NAME = "law-firm-ops"
+
 
 def _configured_mcp_dynamic_tools(
     agent,
-) -> tuple[list[dict[str, Any]], Mapping[str, str]]:
+) -> tuple[list[dict[str, Any]], Mapping[str, str], bool, frozenset[str]]:
     """Project registered MCP schemas as safe aliases and their targets.
 
     ``agent.tools`` may be the tool-search bridge surface, so resolve the raw
@@ -37,10 +47,10 @@ def _configured_mcp_dynamic_tools(
     the extra provenance check: a registry/native tool that merely resembles
     an MCP name never crosses this boundary.
     """
-    empty_result = ([], MappingProxyType({}))
+    empty_result = ([], MappingProxyType({}), False, frozenset())
     enabled_toolsets = getattr(agent, "enabled_toolsets", None)
     if enabled_toolsets == []:
-        return empty_result
+        return [], MappingProxyType({}), True, frozenset()
 
     try:
         from model_tools import get_tool_definitions
@@ -56,8 +66,16 @@ def _configured_mcp_dynamic_tools(
     except Exception:
         return empty_result
 
+    mcp_only = enabled_toolsets is not None and all(
+        isinstance(tool, dict)
+        and isinstance(tool.get("function"), dict)
+        and isinstance(tool["function"].get("name"), str)
+        and tool["function"]["name"] in registered
+        for tool in raw_tools
+    )
     dynamic_tools: list[dict[str, Any]] = []
     aliases: dict[str, str] = {}
+    origin_session_targets: set[str] = set()
     seen: set[str] = set()
     for tool in raw_tools:
         function = tool.get("function") if isinstance(tool, dict) else None
@@ -88,15 +106,50 @@ def _configured_mcp_dynamic_tools(
             return empty_result
         seen.add(name)
         aliases[alias] = name
+        input_schema = parameters
+        properties = parameters.get("properties")
+        hidden_fields: set[str] = set()
+        if (
+            server_name == _OBLIGATION_SERVER_NAME
+            and
+            alias in _OBLIGATION_TOOL_ALIASES
+            and isinstance(properties, dict)
+            and "origin_session_id" in properties
+        ):
+            origin_session_targets.add(name)
+            hidden_fields.add("origin_session_id")
+        if (
+            server_name == _OBLIGATION_SERVER_NAME
+            and alias == "list_email_obligations"
+        ):
+            hidden_fields.update({"limit", "offset"})
+        if hidden_fields:
+            input_schema = copy.deepcopy(parameters)
+            properties = input_schema.get("properties")
+            if isinstance(properties, dict):
+                for field in hidden_fields:
+                    properties.pop(field, None)
+            required = input_schema.get("required")
+            if isinstance(required, list):
+                input_schema["required"] = [
+                    field
+                    for field in required
+                    if field not in hidden_fields
+                ]
         dynamic_tools.append(
             {
                 "type": "function",
                 "name": alias,
                 "description": str(function.get("description") or ""),
-                "inputSchema": parameters,
+                "inputSchema": input_schema,
             }
         )
-    return dynamic_tools, MappingProxyType(aliases)
+    return (
+        dynamic_tools,
+        MappingProxyType(aliases),
+        mcp_only,
+        frozenset(origin_session_targets),
+    )
 
 
 def _coerce_usage_int(value: Any) -> int:
@@ -752,7 +805,14 @@ def run_codex_app_server_turn(
         # users see no live tool-progress or interim commentary while
         # codex_app_server is running — only the final answer (#33200).
         # Supersedes the narrower item/started-only bridge from #38835.
-        dynamic_tools, dynamic_tool_targets = _configured_mcp_dynamic_tools(agent)
+        (
+            dynamic_tools,
+            dynamic_tool_targets,
+            restrict_native_tools,
+            origin_session_targets,
+        ) = (
+            _configured_mcp_dynamic_tools(agent)
+        )
         allowed_dynamic_tools = frozenset(dynamic_tool_targets.values())
 
         def dispatch_dynamic_tool(
@@ -765,13 +825,20 @@ def run_codex_app_server_turn(
             registered_name = dynamic_tool_targets.get(tool_name)
             if registered_name is None:
                 raise ValueError("unknown Codex dynamic tool")
+            trusted_session_id = getattr(agent, "session_id", "") or ""
+            if registered_name in origin_session_targets:
+                if "origin_session_id" in arguments:
+                    raise ValueError("model-supplied origin_session_id is not allowed")
+                if not isinstance(trusted_session_id, str) or not trusted_session_id.strip():
+                    raise ValueError("missing trusted Hermes session id")
+                arguments = {**arguments, "origin_session_id": trusted_session_id}
 
             return model_tools.handle_function_call(
                 registered_name,
                 arguments,
                 effective_task_id,
                 tool_call_id=call_id,
-                session_id=getattr(agent, "session_id", "") or "",
+                session_id=trusted_session_id,
                 enabled_tools=sorted(allowed_dynamic_tools),
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
@@ -782,6 +849,7 @@ def run_codex_app_server_turn(
             developer_instructions=getattr(agent, "_cached_system_prompt", None),
             dynamic_tools=dynamic_tools,
             dynamic_tool_handler=dispatch_dynamic_tool,
+            restrict_native_tools=restrict_native_tools,
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -19,31 +19,34 @@ from __future__ import annotations
 import json
 import logging
 import time
-from types import SimpleNamespace
-from typing import Any, Callable, Dict, List
+from types import MappingProxyType, SimpleNamespace
+from typing import Any, Callable, Dict, List, Mapping
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
 logger = logging.getLogger(__name__)
 
 
-def _configured_mcp_dynamic_tools(agent) -> list[dict[str, Any]]:
-    """Project this session's registered MCP schemas onto Codex dynamic tools.
+def _configured_mcp_dynamic_tools(
+    agent,
+) -> tuple[list[dict[str, Any]], Mapping[str, str]]:
+    """Project registered MCP schemas as safe aliases and their targets.
 
     ``agent.tools`` may be the tool-search bridge surface, so resolve the raw
     catalog under the exact session policy first.  The registered-name map is
     the extra provenance check: a registry/native tool that merely resembles
     an MCP name never crosses this boundary.
     """
+    empty_result = ([], MappingProxyType({}))
     enabled_toolsets = getattr(agent, "enabled_toolsets", None)
     if enabled_toolsets == []:
-        return []
+        return empty_result
 
     try:
         from model_tools import get_tool_definitions
-        from tools.mcp_tool import _mcp_tool_server_names
+        from tools.mcp_tool import _mcp_tool_server_names, mcp_prefixed_tool_name
 
-        registered = set(_mcp_tool_server_names)
+        registered = dict(_mcp_tool_server_names)
         raw_tools = get_tool_definitions(
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=getattr(agent, "disabled_toolsets", None),
@@ -51,9 +54,10 @@ def _configured_mcp_dynamic_tools(agent) -> list[dict[str, Any]]:
             skip_tool_search_assembly=True,
         ) or []
     except Exception:
-        return []
+        return empty_result
 
     dynamic_tools: list[dict[str, Any]] = []
+    aliases: dict[str, str] = {}
     seen: set[str] = set()
     for tool in raw_tools:
         function = tool.get("function") if isinstance(tool, dict) else None
@@ -63,21 +67,36 @@ def _configured_mcp_dynamic_tools(agent) -> list[dict[str, Any]]:
         parameters = function.get("parameters")
         if (
             not isinstance(name, str)
-            or name not in registered
             or not isinstance(parameters, dict)
-            or name in seen
         ):
             continue
+        if name not in registered:
+            continue
+        if name in seen:
+            continue
+        server_name = registered[name]
+        if not isinstance(server_name, str):
+            return empty_result
+        prefix = mcp_prefixed_tool_name(server_name, "")
+        alias = name.removeprefix(prefix)
+        if (
+            not alias
+            or alias.startswith("mcp__")
+            or mcp_prefixed_tool_name(server_name, alias) != name
+            or alias in aliases
+        ):
+            return empty_result
         seen.add(name)
+        aliases[alias] = name
         dynamic_tools.append(
             {
                 "type": "function",
-                "name": name,
+                "name": alias,
                 "description": str(function.get("description") or ""),
                 "inputSchema": parameters,
             }
         )
-    return dynamic_tools
+    return dynamic_tools, MappingProxyType(aliases)
 
 
 def _coerce_usage_int(value: Any) -> int:
@@ -733,8 +752,8 @@ def run_codex_app_server_turn(
         # users see no live tool-progress or interim commentary while
         # codex_app_server is running — only the final answer (#33200).
         # Supersedes the narrower item/started-only bridge from #38835.
-        dynamic_tools = _configured_mcp_dynamic_tools(agent)
-        allowed_dynamic_tools = {tool["name"] for tool in dynamic_tools}
+        dynamic_tools, dynamic_tool_targets = _configured_mcp_dynamic_tools(agent)
+        allowed_dynamic_tools = frozenset(dynamic_tool_targets.values())
 
         def dispatch_dynamic_tool(
             tool_name: str, arguments: dict[str, Any], call_id: str
@@ -743,8 +762,12 @@ def run_codex_app_server_turn(
             # callback. Keep the dispatcher scoped to the same exact snapshot.
             import model_tools
 
+            registered_name = dynamic_tool_targets.get(tool_name)
+            if registered_name is None:
+                raise ValueError("unknown Codex dynamic tool")
+
             return model_tools.handle_function_call(
-                tool_name,
+                registered_name,
                 arguments,
                 effective_task_id,
                 tool_call_id=call_id,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -284,6 +284,7 @@ class CodexAppServerSession:
         developer_instructions: Optional[str] = None,
         dynamic_tools: Optional[list[dict[str, Any]]] = None,
         dynamic_tool_handler: Optional[Callable[[str, dict[str, Any], str], Any]] = None,
+        restrict_native_tools: bool = False,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
@@ -313,6 +314,7 @@ class CodexAppServerSession:
         self._developer_instructions = developer_instructions
         self._dynamic_tools = list(dynamic_tools) if dynamic_tools is not None else None
         self._dynamic_tool_handler = dynamic_tool_handler
+        self._restrict_native_tools = restrict_native_tools
         self._dynamic_call_ids: set[str] = set()
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
@@ -374,6 +376,10 @@ class CodexAppServerSession:
             params["developerInstructions"] = self._developer_instructions
         if self._dynamic_tools is not None:
             params["dynamicTools"] = self._dynamic_tools
+        if self._restrict_native_tools:
+            # Codex app-server derives shell/write tools from environments;
+            # an explicit MCP-only Hermes selection has none.
+            params["environments"] = []
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -24,6 +24,7 @@ call is synchronous and behaves like AIAgent's existing chat_completions loop.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -395,6 +396,20 @@ class CodexAppServerSession:
                 ),
             )
         self._thread_id = thread_id
+        scope_receipt = {
+            "thread_id": thread_id,
+            "developer_instructions_present": bool(self._developer_instructions),
+            "dynamic_tools_explicit": self._dynamic_tools is not None,
+            "dynamic_tool_names": [
+                tool["name"]
+                for tool in self._dynamic_tools or ()
+                if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+            ],
+        }
+        logger.info(
+            "codex app-server thread/start scope receipt=%s",
+            json.dumps(scope_receipt, sort_keys=True),
+        )
         logger.info(
             "codex app-server thread started: id=%s profile=%s cwd=%s",
             self._thread_id[:8],

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -26,6 +26,9 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
+import stat
+import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
@@ -277,6 +280,9 @@ class CodexAppServerSession:
         cwd: Optional[str] = None,
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
+        developer_instructions: Optional[str] = None,
+        dynamic_tools: Optional[list[dict[str, Any]]] = None,
+        dynamic_tool_handler: Optional[Callable[[str, dict[str, Any], str], Any]] = None,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
@@ -285,7 +291,28 @@ class CodexAppServerSession:
     ) -> None:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
-        self._codex_home = codex_home
+        # CODEX_HOME is Codex's connector/config root. Always create a private
+        # home and copy only optional auth material; never inherit config or
+        # connector state (for example a user-wide Outlook installation).
+        auth_home = codex_home or os.path.expanduser("~/.codex")
+        self._owns_codex_home = True
+        self._codex_home = tempfile.mkdtemp(prefix="hermes-codex-")
+        try:
+            os.chmod(self._codex_home, 0o700)
+            auth_source = os.path.join(auth_home, "auth.json")
+            auth_target = os.path.join(self._codex_home, "auth.json")
+            if os.path.exists(auth_source):
+                if os.path.islink(auth_source) or not stat.S_ISREG(os.stat(auth_source).st_mode):
+                    raise RuntimeError("Codex auth isolation could not be established")
+                shutil.copyfile(auth_source, auth_target)
+                os.chmod(auth_target, 0o600)
+        except Exception:
+            shutil.rmtree(self._codex_home, ignore_errors=True)
+            raise
+        self._developer_instructions = developer_instructions
+        self._dynamic_tools = list(dynamic_tools) if dynamic_tools is not None else None
+        self._dynamic_tool_handler = dynamic_tool_handler
+        self._dynamic_call_ids: set[str] = set()
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
                 os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
@@ -343,6 +370,10 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
+        if self._developer_instructions:
+            params["developerInstructions"] = self._developer_instructions
+        if self._dynamic_tools is not None:
+            params["dynamicTools"] = self._dynamic_tools
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's
@@ -385,6 +416,8 @@ class CodexAppServerSession:
                 pass
             self._client = None
         self._thread_id = None
+        if self._owns_codex_home:
+            shutil.rmtree(self._codex_home, ignore_errors=True)
 
     def __enter__(self) -> "CodexAppServerSession":
         return self
@@ -1013,7 +1046,9 @@ class CodexAppServerSession:
         rid = req.get("id")
         params = req.get("params") or {}
 
-        if method == "item/commandExecution/requestApproval":
+        if method == "item/tool/call":
+            self._respond_dynamic_tool_call(rid, params)
+        elif method == "item/commandExecution/requestApproval":
             decision = self._decide_exec_approval(params)
             self._client.respond(rid, {"decision": decision})
         elif method == "item/fileChange/requestApproval":
@@ -1052,6 +1087,54 @@ class CodexAppServerSession:
             self._client.respond_error(
                 rid, code=-32601, message=f"Unsupported method: {method}"
             )
+
+    def _respond_dynamic_tool_call(self, request_id: Any, params: Any) -> None:
+        """Dispatch one registered dynamic tool call, otherwise fail closed."""
+        failure = {
+            "success": False,
+            "contentItems": [{"type": "inputText", "text": "Tool call unavailable."}],
+        }
+        if (
+            not isinstance(params, dict)
+            or params.get("threadId") != self._thread_id
+            or params.get("turnId") != self._active_turn_id
+        ):
+            self._client.respond(request_id, failure)
+            return
+        call_id = params.get("callId")
+        tool_name = params.get("tool")
+        arguments = params.get("arguments")
+        allowed = {
+            tool.get("name")
+            for tool in self._dynamic_tools or ()
+            if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+        }
+        if (
+            not isinstance(call_id, str)
+            or not call_id
+            or call_id in self._dynamic_call_ids
+            or not isinstance(tool_name, str)
+            or tool_name not in allowed
+            or not isinstance(arguments, dict)
+            or self._dynamic_tool_handler is None
+        ):
+            self._client.respond(request_id, failure)
+            return
+        self._dynamic_call_ids.add(call_id)
+        try:
+            output = self._dynamic_tool_handler(tool_name, arguments, call_id)
+            output_text = str(output)
+        except Exception:
+            logger.warning("Codex dynamic tool dispatch failed: %s", tool_name)
+            self._client.respond(request_id, failure)
+            return
+        self._client.respond(
+            request_id,
+            {
+                "success": True,
+                "contentItems": [{"type": "inputText", "text": output_text}],
+            },
+        )
 
     def _decide_exec_approval(self, params: dict) -> str:
         """Decide a Codex exec approval request.

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -354,16 +354,15 @@ class CodexAppServerSession:
             client_name="hermes",
             client_title="Hermes Agent",
             client_version=_get_hermes_version(),
+            capabilities=(
+                {"experimentalApi": True}
+                if self._dynamic_tools is not None
+                else {}
+            ),
         )
-        # Permission selection is intentionally NOT sent on thread/start.
-        # Two reasons (live-tested against codex 0.130.0):
-        #   1. `thread/start.permissions` is gated behind the experimentalApi
-        #      capability on this codex version — we'd have to opt in during
-        #      initialize and accept the unstable surface.
-        #   2. Even with experimentalApi declared and the correct shape
-        #      (`{"type": "profile", "id": "..."}`, not `{"profileId": ...}`),
-        #      codex requires a matching `[permissions]` table in
-        #      ~/.codex/config.toml or it fails the request with
+        # Explicit dynamicTools requires only experimentalApi (Codex 0.147).
+        # Permissions are intentionally omitted: Codex requires a matching
+        # `[permissions]` table in ~/.codex/config.toml or it fails with
         #      'default_permissions requires a [permissions] table'.
         # Letting codex pick its default (`:read-only` unless the user has
         # configured otherwise in their codex config.toml) is the standard

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -114,8 +114,164 @@ class TestCodexAppServerModule:
 
 
 class TestConfiguredMcpDynamicTools:
-    def test_only_registered_mcp_schemas_are_projected(self, monkeypatch) -> None:
+    def test_raw_authorized_mcp_schemas_are_projected(self, monkeypatch) -> None:
         from agent.codex_runtime import _configured_mcp_dynamic_tools
+        import model_tools
+        from tools import mcp_tool
+
+        monkeypatch.setattr(
+            mcp_tool,
+            "_mcp_tool_server_names",
+            {
+                "mcp__law_firm_ops__list_email_obligations": "law_firm_ops",
+                "mcp__law_firm_ops__get_email_obligation": "law_firm_ops",
+                "mcp__law_firm_ops__list_obligation_receipts": "law_firm_ops",
+                "mcp__other__unconfigured": "other",
+            },
+        )
+        calls = []
+
+        def raw_catalog(**kwargs):
+            calls.append(kwargs)
+            return [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__law_firm_ops__list_email_obligations",
+                        "description": "List canonical obligations.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "description": "Native tool.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "tool_search",
+                        "description": "Bridge tool.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__law_firm_ops__get_email_obligation",
+                        "description": "Get one canonical obligation.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "tool_call",
+                        "description": "Bridge tool.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__law_firm_ops__list_obligation_receipts",
+                        "description": "List canonical receipts.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__law_firm_ops__list_email_obligations",
+                        "description": "Duplicate must not cross.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+            ]
+
+        monkeypatch.setattr(model_tools, "get_tool_definitions", raw_catalog)
+        agent = SimpleNamespace(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "tool_search",
+                        "description": "Bridge-only assembled surface.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "tool_describe",
+                        "description": "Bridge-only assembled surface.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "tool_call",
+                        "description": "Bridge-only assembled surface.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+            ],
+            enabled_toolsets=["law-firm-ops"],
+            disabled_toolsets=["outlook"],
+        )
+
+        dynamic_tools = _configured_mcp_dynamic_tools(agent)
+
+        assert calls == [
+            {
+                "enabled_toolsets": ["law-firm-ops"],
+                "disabled_toolsets": ["outlook"],
+                "quiet_mode": True,
+                "skip_tool_search_assembly": True,
+            }
+        ]
+        assert dynamic_tools == [
+            {
+                "type": "function",
+                "name": "mcp__law_firm_ops__list_email_obligations",
+                "description": "List canonical obligations.",
+                "inputSchema": {"type": "object", "properties": {}},
+            },
+            {
+                "type": "function",
+                "name": "mcp__law_firm_ops__get_email_obligation",
+                "description": "Get one canonical obligation.",
+                "inputSchema": {"type": "object", "properties": {}},
+            },
+            {
+                "type": "function",
+                "name": "mcp__law_firm_ops__list_obligation_receipts",
+                "description": "List canonical receipts.",
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        ]
+
+    def test_explicit_empty_toolsets_are_deny_all(self, monkeypatch) -> None:
+        from agent.codex_runtime import _configured_mcp_dynamic_tools
+        import model_tools
+
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **kwargs: pytest.fail("deny-all must not resolve tools"),
+        )
+
+        assert _configured_mcp_dynamic_tools(
+            SimpleNamespace(enabled_toolsets=[], disabled_toolsets=None)
+        ) == []
+
+    def test_catalog_or_registry_errors_fail_closed(self, monkeypatch) -> None:
+        from agent.codex_runtime import _configured_mcp_dynamic_tools
+        import model_tools
         from tools import mcp_tool
 
         monkeypatch.setattr(
@@ -123,43 +279,26 @@ class TestConfiguredMcpDynamicTools:
             "_mcp_tool_server_names",
             {"mcp__law_firm_ops__list_email_obligations": "law_firm_ops"},
         )
-        agent = SimpleNamespace(
-            tools=[
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "mcp__law_firm_ops__list_email_obligations",
-                        "description": "Canonical obligations.",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
-                },
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "outlook_list_messages",
-                        "description": "Must not leak.",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
-                },
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "mcp__spoofed__tool",
-                        "description": "Not registered.",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
-                },
-            ]
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **kwargs: (_ for _ in ()).throw(RuntimeError("unavailable")),
         )
 
-        assert _configured_mcp_dynamic_tools(agent) == [
-            {
-                "type": "function",
-                "name": "mcp__law_firm_ops__list_email_obligations",
-                "description": "Canonical obligations.",
-                "inputSchema": {"type": "object", "properties": {}},
-            }
-        ]
+        assert _configured_mcp_dynamic_tools(
+            SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
+        ) == []
+
+        monkeypatch.setattr(mcp_tool, "_mcp_tool_server_names", object())
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **kwargs: pytest.fail("registry errors must resolve no tools"),
+        )
+
+        assert _configured_mcp_dynamic_tools(
+            SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
+        ) == []
 
 
 class TestSpawnEnvIsolation:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -7,7 +7,7 @@ covered by a separate live test gated on `codex --version`.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 
 import pytest
 
@@ -125,7 +125,7 @@ class TestConfiguredMcpDynamicTools:
             {
                 "mcp__law_firm_ops__list_email_obligations": "law_firm_ops",
                 "mcp__law_firm_ops__get_email_obligation": "law_firm_ops",
-                "mcp__law_firm_ops__list_obligation_receipts": "law_firm_ops",
+                "mcp__law_firm_ops__get_email_obligation_monitor_status": "law_firm_ops",
                 "mcp__other__unconfigured": "other",
             },
         )
@@ -177,8 +177,16 @@ class TestConfiguredMcpDynamicTools:
                 {
                     "type": "function",
                     "function": {
-                        "name": "mcp__law_firm_ops__list_obligation_receipts",
-                        "description": "List canonical receipts.",
+                        "name": "mcp__spoofed__tool",
+                        "description": "Unregistered MCP-looking tool.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__law_firm_ops__get_email_obligation_monitor_status",
+                        "description": "Get monitor status.",
                         "parameters": {"type": "object", "properties": {}},
                     },
                 },
@@ -224,7 +232,7 @@ class TestConfiguredMcpDynamicTools:
             disabled_toolsets=["outlook"],
         )
 
-        dynamic_tools = _configured_mcp_dynamic_tools(agent)
+        dynamic_tools, targets = _configured_mcp_dynamic_tools(agent)
 
         assert calls == [
             {
@@ -237,23 +245,32 @@ class TestConfiguredMcpDynamicTools:
         assert dynamic_tools == [
             {
                 "type": "function",
-                "name": "mcp__law_firm_ops__list_email_obligations",
+                "name": "list_email_obligations",
                 "description": "List canonical obligations.",
                 "inputSchema": {"type": "object", "properties": {}},
             },
             {
                 "type": "function",
-                "name": "mcp__law_firm_ops__get_email_obligation",
+                "name": "get_email_obligation",
                 "description": "Get one canonical obligation.",
                 "inputSchema": {"type": "object", "properties": {}},
             },
             {
                 "type": "function",
-                "name": "mcp__law_firm_ops__list_obligation_receipts",
-                "description": "List canonical receipts.",
+                "name": "get_email_obligation_monitor_status",
+                "description": "Get monitor status.",
                 "inputSchema": {"type": "object", "properties": {}},
             }
         ]
+        assert dict(targets) == {
+            "list_email_obligations": "mcp__law_firm_ops__list_email_obligations",
+            "get_email_obligation": "mcp__law_firm_ops__get_email_obligation",
+            "get_email_obligation_monitor_status": (
+                "mcp__law_firm_ops__get_email_obligation_monitor_status"
+            ),
+        }
+        with pytest.raises(TypeError):
+            targets["other"] = "mcp__other__tool"
 
     def test_explicit_empty_toolsets_are_deny_all(self, monkeypatch) -> None:
         from agent.codex_runtime import _configured_mcp_dynamic_tools
@@ -267,7 +284,7 @@ class TestConfiguredMcpDynamicTools:
 
         assert _configured_mcp_dynamic_tools(
             SimpleNamespace(enabled_toolsets=[], disabled_toolsets=None)
-        ) == []
+        ) == ([], {})
 
     def test_catalog_or_registry_errors_fail_closed(self, monkeypatch) -> None:
         from agent.codex_runtime import _configured_mcp_dynamic_tools
@@ -287,7 +304,7 @@ class TestConfiguredMcpDynamicTools:
 
         assert _configured_mcp_dynamic_tools(
             SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
-        ) == []
+        ) == ([], {})
 
         monkeypatch.setattr(mcp_tool, "_mcp_tool_server_names", object())
         monkeypatch.setattr(
@@ -298,7 +315,162 @@ class TestConfiguredMcpDynamicTools:
 
         assert _configured_mcp_dynamic_tools(
             SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
-        ) == []
+        ) == ([], {})
+
+    @pytest.mark.parametrize(
+        ("registered", "raw_name"),
+        [
+            (
+                {
+                    "mcp__one__shared": "one",
+                    "mcp__two__shared": "two",
+                },
+                None,
+            ),
+            ({"mcp__law_firm_ops__": "law_firm_ops"}, "mcp__law_firm_ops__"),
+            (
+                {"mcp__law_firm_ops__tool": "other"},
+                "mcp__law_firm_ops__tool",
+            ),
+        ],
+    )
+    def test_ambiguous_or_malformed_aliases_fail_closed(
+        self, monkeypatch, registered, raw_name
+    ) -> None:
+        from agent.codex_runtime import _configured_mcp_dynamic_tools
+        import model_tools
+        from tools import mcp_tool
+
+        monkeypatch.setattr(mcp_tool, "_mcp_tool_server_names", registered)
+        raw_names = list(registered) if raw_name is None else [raw_name]
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **kwargs: [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+                for name in raw_names
+            ],
+        )
+
+        assert _configured_mcp_dynamic_tools(
+            SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
+        ) == ([], {})
+
+    def test_alias_dispatches_registered_name_and_rejects_unknown(self, monkeypatch) -> None:
+        from agent import codex_runtime
+        from agent.transports.codex_app_server_session import TurnResult
+        import model_tools
+
+        captured = {}
+        dispatched = []
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def run_turn(self, **kwargs):
+                return TurnResult(
+                    final_text="done",
+                    projected_messages=[],
+                    tool_iterations=0,
+                    turn_id="turn-1",
+                    thread_id="thread-1",
+                )
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+        monkeypatch.setattr(
+            codex_runtime,
+            "_configured_mcp_dynamic_tools",
+            lambda agent: (
+                [
+                    {
+                        "type": "function",
+                        "name": "list_email_obligations",
+                        "description": "Canonical obligations.",
+                        "inputSchema": {"type": "object", "properties": {}},
+                    }
+                ],
+                MappingProxyType(
+                    {
+                        "list_email_obligations": (
+                            "mcp__law_firm_ops__list_email_obligations"
+                        )
+                    }
+                ),
+            ),
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "handle_function_call",
+            lambda *args, **kwargs: dispatched.append((args, kwargs)) or "ok",
+        )
+        agent = SimpleNamespace(
+            session_cwd=None,
+            _codex_session=None,
+            _cached_system_prompt=None,
+            enabled_toolsets=["law-firm-ops"],
+            disabled_toolsets=None,
+            session_id="session-1",
+            tool_progress_callback=None,
+            _fire_stream_delta=lambda *_: None,
+            _fire_reasoning_delta=lambda *_: None,
+            _emit_interim_assistant_message=lambda *_: None,
+            _iters_since_skill=0,
+            _skill_nudge_interval=0,
+            valid_tool_names=set(),
+            _sync_external_memory_for_turn=lambda **_: None,
+            _spawn_background_review=lambda **_: None,
+            session_api_calls=0,
+            session_prompt_tokens=0,
+            session_completion_tokens=0,
+            session_reasoning_tokens=0,
+            session_cached_tokens=0,
+            session_total_tokens=0,
+            context_compressor=None,
+            event_callback=None,
+            _session_db=None,
+        )
+
+        codex_runtime.run_codex_app_server_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="task-1",
+        )
+
+        handler = captured["dynamic_tool_handler"]
+        assert handler("list_email_obligations", {"status": "open"}, "call-1") == "ok"
+        assert dispatched == [
+            (
+                ("mcp__law_firm_ops__list_email_obligations", {"status": "open"}, "task-1"),
+                {
+                    "tool_call_id": "call-1",
+                    "session_id": "session-1",
+                    "enabled_tools": ["mcp__law_firm_ops__list_email_obligations"],
+                    "enabled_toolsets": ["law-firm-ops"],
+                    "disabled_toolsets": None,
+                },
+            )
+        ]
+        with pytest.raises(ValueError, match="unknown Codex dynamic tool"):
+            handler("unknown", {}, "call-2")
+        assert len(dispatched) == 1
+        assert [tool["name"] for tool in captured["dynamic_tools"]] == [
+            "list_email_obligations"
+        ]
 
 
 class TestSpawnEnvIsolation:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -123,9 +123,9 @@ class TestConfiguredMcpDynamicTools:
             mcp_tool,
             "_mcp_tool_server_names",
             {
-                "mcp__law_firm_ops__list_email_obligations": "law_firm_ops",
-                "mcp__law_firm_ops__get_email_obligation": "law_firm_ops",
-                "mcp__law_firm_ops__get_email_obligation_monitor_status": "law_firm_ops",
+                "mcp__law_firm_ops__list_email_obligations": "law-firm-ops",
+                "mcp__law_firm_ops__get_email_obligation": "law-firm-ops",
+                "mcp__law_firm_ops__get_email_obligation_monitor_status": "law-firm-ops",
                 "mcp__other__unconfigured": "other",
             },
         )
@@ -232,7 +232,9 @@ class TestConfiguredMcpDynamicTools:
             disabled_toolsets=["outlook"],
         )
 
-        dynamic_tools, targets = _configured_mcp_dynamic_tools(agent)
+        dynamic_tools, targets, mcp_only, origin_session_targets = (
+            _configured_mcp_dynamic_tools(agent)
+        )
 
         assert calls == [
             {
@@ -271,6 +273,85 @@ class TestConfiguredMcpDynamicTools:
         }
         with pytest.raises(TypeError):
             targets["other"] = "mcp__other__tool"
+        assert mcp_only is False
+        assert origin_session_targets == frozenset()
+
+    def test_mcp_only_selection_projects_the_restricted_obligation_schema(
+        self, monkeypatch
+    ) -> None:
+        from agent.codex_runtime import _configured_mcp_dynamic_tools
+        import model_tools
+        from tools import mcp_tool
+
+        name = "mcp__law_firm_ops__list_email_obligations"
+        get_name = "mcp__law_firm_ops__get_email_obligation"
+        status_name = "mcp__law_firm_ops__get_email_obligation_monitor_status"
+        schema = {
+            "type": "object",
+            "properties": {
+                "view": {"type": "string"},
+                "matter_query": {"type": "string"},
+                "origin_session_id": {"type": "string"},
+                "limit": {"type": "integer"},
+                "offset": {"type": "integer"},
+            },
+            "required": ["origin_session_id", "view", "limit", "offset"],
+        }
+        get_schema = {
+            "type": "object",
+            "properties": {"obligation_id": {"type": "string"}, "origin_session_id": {"type": "string"}},
+            "required": ["obligation_id", "origin_session_id"],
+        }
+        status_schema = {
+            "type": "object",
+            "properties": {"origin_session_id": {"type": "string"}},
+            "required": ["origin_session_id"],
+        }
+        monkeypatch.setattr(
+            mcp_tool,
+            "_mcp_tool_server_names",
+            {name: "law-firm-ops", get_name: "law-firm-ops", status_name: "law-firm-ops"},
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **kwargs: [
+                {"function": {"name": name, "parameters": schema}},
+                {"function": {"name": get_name, "parameters": get_schema}},
+                {"function": {"name": status_name, "parameters": status_schema}},
+            ],
+        )
+
+        dynamic_tools, targets, mcp_only, origin_session_targets = (
+            _configured_mcp_dynamic_tools(
+                SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
+            )
+        )
+
+        assert mcp_only is True
+        assert [tool["name"] for tool in dynamic_tools] == [
+            "list_email_obligations",
+            "get_email_obligation",
+            "get_email_obligation_monitor_status",
+        ]
+        assert dict(targets) == {
+            "list_email_obligations": name,
+            "get_email_obligation": get_name,
+            "get_email_obligation_monitor_status": status_name,
+        }
+        assert origin_session_targets == frozenset({name, get_name, status_name})
+        assert dynamic_tools[0]["inputSchema"] == {
+            "type": "object",
+            "properties": {
+                "view": {"type": "string"},
+                "matter_query": {"type": "string"},
+            },
+            "required": ["view"],
+        }
+        for tool in dynamic_tools:
+            assert "origin_session_id" not in tool["inputSchema"]["properties"]
+            assert "origin_session_id" not in tool["inputSchema"].get("required", [])
+        assert "origin_session_id" in schema["properties"]
 
     def test_explicit_empty_toolsets_are_deny_all(self, monkeypatch) -> None:
         from agent.codex_runtime import _configured_mcp_dynamic_tools
@@ -284,7 +365,39 @@ class TestConfiguredMcpDynamicTools:
 
         assert _configured_mcp_dynamic_tools(
             SimpleNamespace(enabled_toolsets=[], disabled_toolsets=None)
-        ) == ([], {})
+        ) == ([], {}, True, frozenset())
+
+    def test_unrelated_mcp_origin_schema_is_unchanged(self, monkeypatch) -> None:
+        from agent.codex_runtime import _configured_mcp_dynamic_tools
+        import model_tools
+        from tools import mcp_tool
+
+        name = "mcp__other__list_email_obligations"
+        schema = {
+            "type": "object",
+            "properties": {
+                "origin_session_id": {"type": "string"},
+                "limit": {"type": "integer"},
+                "offset": {"type": "integer"},
+            },
+            "required": ["origin_session_id", "limit", "offset"],
+        }
+        monkeypatch.setattr(mcp_tool, "_mcp_tool_server_names", {name: "other"})
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **kwargs: [{"function": {"name": name, "parameters": schema}}],
+        )
+
+        dynamic_tools, _targets, mcp_only, origin_session_targets = (
+            _configured_mcp_dynamic_tools(
+                SimpleNamespace(enabled_toolsets=["other"], disabled_toolsets=None)
+            )
+        )
+
+        assert mcp_only is True
+        assert dynamic_tools[0]["inputSchema"] == schema
+        assert origin_session_targets == frozenset()
 
     def test_catalog_or_registry_errors_fail_closed(self, monkeypatch) -> None:
         from agent.codex_runtime import _configured_mcp_dynamic_tools
@@ -304,7 +417,7 @@ class TestConfiguredMcpDynamicTools:
 
         assert _configured_mcp_dynamic_tools(
             SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
-        ) == ([], {})
+        ) == ([], {}, False, frozenset())
 
         monkeypatch.setattr(mcp_tool, "_mcp_tool_server_names", object())
         monkeypatch.setattr(
@@ -315,7 +428,7 @@ class TestConfiguredMcpDynamicTools:
 
         assert _configured_mcp_dynamic_tools(
             SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
-        ) == ([], {})
+        ) == ([], {}, False, frozenset())
 
     @pytest.mark.parametrize(
         ("registered", "raw_name"),
@@ -360,7 +473,7 @@ class TestConfiguredMcpDynamicTools:
 
         assert _configured_mcp_dynamic_tools(
             SimpleNamespace(enabled_toolsets=["law-firm-ops"], disabled_toolsets=None)
-        ) == ([], {})
+        ) == ([], {}, False, frozenset())
 
     def test_alias_dispatches_registered_name_and_rejects_unknown(self, monkeypatch) -> None:
         from agent import codex_runtime
@@ -400,13 +513,34 @@ class TestConfiguredMcpDynamicTools:
                         "name": "list_email_obligations",
                         "description": "Canonical obligations.",
                         "inputSchema": {"type": "object", "properties": {}},
-                    }
+                    },
+                    {
+                        "type": "function",
+                        "name": "get_email_obligation",
+                        "description": "Canonical obligation.",
+                        "inputSchema": {"type": "object", "properties": {}},
+                    },
+                    {
+                        "type": "function",
+                        "name": "unrelated",
+                        "description": "Unrelated MCP tool.",
+                        "inputSchema": {"type": "object", "properties": {}},
+                    },
                 ],
                 MappingProxyType(
                     {
                         "list_email_obligations": (
                             "mcp__law_firm_ops__list_email_obligations"
-                        )
+                        ),
+                        "get_email_obligation": "mcp__law_firm_ops__get_email_obligation",
+                        "unrelated": "mcp__other__unrelated",
+                    }
+                ),
+                True,
+                frozenset(
+                    {
+                        "mcp__law_firm_ops__list_email_obligations",
+                        "mcp__law_firm_ops__get_email_obligation",
                     }
                 ),
             ),
@@ -452,25 +586,72 @@ class TestConfiguredMcpDynamicTools:
         )
 
         handler = captured["dynamic_tool_handler"]
-        assert handler("list_email_obligations", {"status": "open"}, "call-1") == "ok"
+        assert handler("list_email_obligations", {"view": "open"}, "call-1") == "ok"
         assert dispatched == [
             (
-                ("mcp__law_firm_ops__list_email_obligations", {"status": "open"}, "task-1"),
+                (
+                    "mcp__law_firm_ops__list_email_obligations",
+                    {"view": "open", "origin_session_id": "session-1"},
+                    "task-1",
+                ),
                 {
                     "tool_call_id": "call-1",
                     "session_id": "session-1",
-                    "enabled_tools": ["mcp__law_firm_ops__list_email_obligations"],
+                    "enabled_tools": [
+                        "mcp__law_firm_ops__get_email_obligation",
+                        "mcp__law_firm_ops__list_email_obligations",
+                        "mcp__other__unrelated",
+                    ],
                     "enabled_toolsets": ["law-firm-ops"],
                     "disabled_toolsets": None,
                 },
-            )
+            ),
         ]
         with pytest.raises(ValueError, match="unknown Codex dynamic tool"):
             handler("unknown", {}, "call-2")
-        assert len(dispatched) == 1
+        with pytest.raises(ValueError, match="model-supplied origin_session_id"):
+            handler(
+                "list_email_obligations",
+                {"origin_session_id": "model-supplied"},
+                "call-3",
+            )
+        with pytest.raises(ValueError, match="model-supplied origin_session_id"):
+            handler(
+                "get_email_obligation",
+                {"origin_session_id": "caller-supplied"},
+                "call-4",
+            )
+        assert handler("get_email_obligation", {}, "call-5") == "ok"
+        assert dispatched[1] == (
+            (
+                "mcp__law_firm_ops__get_email_obligation",
+                {"origin_session_id": "session-1"},
+                "task-1",
+            ),
+            {
+                "tool_call_id": "call-5",
+                "session_id": "session-1",
+                "enabled_tools": [
+                    "mcp__law_firm_ops__get_email_obligation",
+                    "mcp__law_firm_ops__list_email_obligations",
+                    "mcp__other__unrelated",
+                ],
+                "enabled_toolsets": ["law-firm-ops"],
+                "disabled_toolsets": None,
+            },
+        )
+        assert handler("unrelated", {"origin_session_id": "caller-supplied"}, "call-6") == "ok"
+        assert dispatched[2][0][1] == {"origin_session_id": "caller-supplied"}
+        agent.session_id = ""
+        with pytest.raises(ValueError, match="missing trusted Hermes session id"):
+            handler("list_email_obligations", {"view": "open"}, "call-4")
+        assert len(dispatched) == 3
         assert [tool["name"] for tool in captured["dynamic_tools"]] == [
-            "list_email_obligations"
+            "list_email_obligations",
+            "get_email_obligation",
+            "unrelated",
         ]
+        assert captured["restrict_native_tools"] is True
 
 
 class TestSpawnEnvIsolation:

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -7,6 +7,8 @@ covered by a separate live test gated on `codex --version`.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from hermes_cli.runtime_provider import (
@@ -109,6 +111,55 @@ class TestCodexAppServerModule:
         assert isinstance(err, RuntimeError)
         assert "boom" in str(err)
         assert "-32600" in str(err)
+
+
+class TestConfiguredMcpDynamicTools:
+    def test_only_registered_mcp_schemas_are_projected(self, monkeypatch) -> None:
+        from agent.codex_runtime import _configured_mcp_dynamic_tools
+        from tools import mcp_tool
+
+        monkeypatch.setattr(
+            mcp_tool,
+            "_mcp_tool_server_names",
+            {"mcp__law_firm_ops__list_email_obligations": "law_firm_ops"},
+        )
+        agent = SimpleNamespace(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__law_firm_ops__list_email_obligations",
+                        "description": "Canonical obligations.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "outlook_list_messages",
+                        "description": "Must not leak.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__spoofed__tool",
+                        "description": "Not registered.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+            ]
+        )
+
+        assert _configured_mcp_dynamic_tools(agent) == [
+            {
+                "type": "function",
+                "name": "mcp__law_firm_ops__list_email_obligations",
+                "description": "Canonical obligations.",
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        ]
 
 
 class TestSpawnEnvIsolation:
@@ -339,4 +390,3 @@ class TestSpawnEnvSecretStripping:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-codex-needs-this")
         env = self._capture_spawn_env(monkeypatch)
         assert env.get("OPENAI_API_KEY") == "sk-codex-needs-this"
-

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -45,6 +45,7 @@ class FakeClient:
 
     # API matching CodexAppServerClient
     def initialize(self, **kwargs):
+        self.initialize_kwargs = kwargs
         self._initialized = True
         return {"userAgent": "fake/0.0.0", "codexHome": "/tmp",
                 "platformOs": "linux", "platformFamily": "unix"}
@@ -172,14 +173,13 @@ class TestLifecycle:
         assert len(method_calls) == 1
 
     def test_thread_start_passes_cwd_only(self, caplog):
-        """thread/start carries cwd. We intentionally do NOT pass `permissions`
-        on this codex version (experimentalApi-gated + requires matching
-        config.toml [permissions] table). Letting codex use its default
-        (read-only unless user configures otherwise) is the documented path."""
+        """Omitted dynamic tools initialize with no capabilities or permissions."""
         client = FakeClient()
         s = make_session(client, permission_profile="workspace-write")
         caplog.set_level(logging.INFO, logger=session_mod.__name__)
         s.ensure_started()
+        assert client.initialize_kwargs["capabilities"] == {}
+        assert "permissions" not in client.initialize_kwargs
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
@@ -217,6 +217,8 @@ class TestLifecycle:
         assert params["developerInstructions"] == "SENSITIVE INSTRUCTIONS"
         assert params["dynamicTools"] == dynamic_tools
         assert "outlook" not in str(params["dynamicTools"]).lower()
+        assert client.initialize_kwargs["capabilities"] == {"experimentalApi": True}
+        assert "permissions" not in client.initialize_kwargs
         receipt_records = [
             record.message
             for record in caplog.records
@@ -239,6 +241,8 @@ class TestLifecycle:
         s.ensure_started()
         _, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["dynamicTools"] == []
+        assert client.initialize_kwargs["capabilities"] == {"experimentalApi": True}
+        assert "permissions" not in client.initialize_kwargs
         receipt = next(
             json.loads(record.message.partition("=")[2])
             for record in caplog.records

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -183,6 +183,7 @@ class TestLifecycle:
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+        assert "environments" not in params
         receipt = next(
             json.loads(record.message.partition("=")[2])
             for record in caplog.records
@@ -217,6 +218,7 @@ class TestLifecycle:
         assert params["developerInstructions"] == "SENSITIVE INSTRUCTIONS"
         assert params["dynamicTools"] == dynamic_tools
         assert "outlook" not in str(params["dynamicTools"]).lower()
+        assert "environments" not in params
         assert client.initialize_kwargs["capabilities"] == {"experimentalApi": True}
         assert "permissions" not in client.initialize_kwargs
         receipt_records = [
@@ -250,6 +252,29 @@ class TestLifecycle:
         )
         assert receipt["dynamic_tools_explicit"] is True
         assert receipt["dynamic_tool_names"] == []
+
+    def test_thread_start_disables_native_environments_for_mcp_only_selection(self):
+        client = FakeClient()
+        s = make_session(
+            client,
+            dynamic_tools=[
+                {"type": "function", "name": "list_email_obligations"},
+                {"type": "function", "name": "get_email_obligation"},
+                {"type": "function", "name": "get_email_obligation_monitor_status"},
+            ],
+            restrict_native_tools=True,
+        )
+        s.ensure_started()
+        _, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert params["dynamicTools"] == [
+            {"type": "function", "name": "list_email_obligations"},
+            {"type": "function", "name": "get_email_obligation"},
+            {"type": "function", "name": "get_email_obligation_monitor_status"},
+        ]
+        assert {tool["name"] for tool in params["dynamicTools"]}.isdisjoint(
+            {"exec_command", "shell", "terminal", "tool_search", "tool_describe", "tool_call"}
+        )
+        assert params["environments"] == []
 
     def test_session_uses_private_codex_home(self):
         client = FakeClient()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -7,6 +7,8 @@ deadline timeouts. These tests pin all of that without spawning real codex.
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 import time
 from unittest.mock import patch
 from typing import Any, Optional
@@ -119,9 +121,14 @@ class FakeClient:
 
 
 def make_session(client: FakeClient, **kwargs) -> CodexAppServerSession:
+    def client_factory(**factory_kwargs):
+        client.factory_kwargs = factory_kwargs
+        return client
+
+    kwargs.setdefault("codex_home", "/tmp/no-codex-auth")
     return CodexAppServerSession(
         cwd="/tmp",
-        client_factory=lambda **kw: client,
+        client_factory=client_factory,
         **kwargs,
     )
 
@@ -173,6 +180,61 @@ class TestLifecycle:
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+
+    def test_thread_start_forwards_profile_and_exact_dynamic_tools(self):
+        client = FakeClient()
+        dynamic_tools = [
+            {
+                "type": "function",
+                "name": "mcp__law_firm_ops__list_email_obligations",
+                "description": "List obligations.",
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        ]
+        s = make_session(
+            client,
+            developer_instructions="Use the Legal Assistant profile.",
+            dynamic_tools=dynamic_tools,
+        )
+        s.ensure_started()
+        _, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert params["developerInstructions"] == "Use the Legal Assistant profile."
+        assert params["dynamicTools"] == dynamic_tools
+        assert "outlook" not in str(params["dynamicTools"]).lower()
+
+    def test_thread_start_keeps_explicit_empty_dynamic_tools(self):
+        client = FakeClient()
+        s = make_session(client, dynamic_tools=[])
+        s.ensure_started()
+        _, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert params["dynamicTools"] == []
+
+    def test_session_uses_private_codex_home(self):
+        client = FakeClient()
+        s = make_session(client)
+        assert s._codex_home != os.path.expanduser("~/.codex")
+        s.ensure_started()
+        assert client.factory_kwargs["codex_home"] == s._codex_home
+        s.close()
+        assert not os.path.exists(client.factory_kwargs["codex_home"])
+
+    def test_session_copies_only_restricted_auth_material(self, tmp_path):
+        auth_home = tmp_path / "codex-source"
+        auth_home.mkdir()
+        auth = auth_home / "auth.json"
+        auth.write_text('{"token":"test"}', encoding="utf-8")
+        (auth_home / "config.toml").write_text(
+            "[mcp_servers.outlook]\n", encoding="utf-8"
+        )
+        client = FakeClient()
+        s = make_session(client, codex_home=str(auth_home))
+        s.ensure_started()
+        isolated = Path(s._codex_home)
+        assert (isolated / "auth.json").read_text(encoding="utf-8") == '{"token":"test"}'
+        assert (isolated / "auth.json").stat().st_mode & 0o777 == 0o600
+        assert isolated.stat().st_mode & 0o777 == 0o700
+        assert not (isolated / "config.toml").exists()
+        s.close()
 
     def test_close_idempotent(self):
         client = FakeClient()
@@ -505,6 +567,130 @@ class TestCompactThread:
 # ---- approval bridge ----
 
 class TestServerRequestRouting:
+
+    def test_dynamic_tool_request_dispatches_once(self):
+        client = FakeClient()
+        dispatched = []
+
+        def dispatch(name, arguments, call_id):
+            dispatched.append((name, arguments, call_id))
+            return "ok"
+
+        client.queue_server_request(
+            "item/tool/call",
+            request_id="dynamic-1",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            callId="call-1",
+            tool="mcp__law_firm_ops__list_email_obligations",
+            arguments={"status": "open"},
+        )
+        client.queue_notification(
+            "turn/completed", threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        s = make_session(
+            client,
+            dynamic_tools=[
+                {
+                    "name": "mcp__law_firm_ops__list_email_obligations",
+                    "type": "function",
+                }
+            ],
+            dynamic_tool_handler=dispatch,
+        )
+        s.run_turn("hi", turn_timeout=1.0)
+        assert dispatched == [
+            (
+                "mcp__law_firm_ops__list_email_obligations",
+                {"status": "open"},
+                "call-1",
+            )
+        ]
+        assert client.responses == [
+            (
+                "dynamic-1",
+                {
+                    "success": True,
+                    "contentItems": [{"type": "inputText", "text": "ok"}],
+                },
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"callId": "call-1", "tool": "unknown", "arguments": {}},
+            {
+                "callId": "call-1",
+                "tool": "mcp__law_firm_ops__list_email_obligations",
+                "arguments": [],
+            },
+            {
+                "callId": "",
+                "tool": "mcp__law_firm_ops__list_email_obligations",
+                "arguments": {},
+            },
+        ],
+    )
+    def test_dynamic_tool_request_rejects_unknown_or_malformed(self, params):
+        client = FakeClient()
+        dispatched = []
+        client.queue_server_request(
+            "item/tool/call",
+            request_id="dynamic-1",
+            threadId="thread-fake-001",
+            turnId="turn-fake-001",
+            **params,
+        )
+        client.queue_notification(
+            "turn/completed", threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        s = make_session(
+            client,
+            dynamic_tools=[
+                {
+                    "name": "mcp__law_firm_ops__list_email_obligations",
+                    "type": "function",
+                }
+            ],
+            dynamic_tool_handler=lambda *args: dispatched.append(args),
+        )
+        s.run_turn("hi", turn_timeout=1.0)
+        assert dispatched == []
+        assert client.responses[0][1]["success"] is False
+        assert client.responses[0][1]["contentItems"][0]["text"] == "Tool call unavailable."
+
+    def test_duplicate_dynamic_tool_request_is_not_redispatched(self):
+        client = FakeClient()
+        dispatched = []
+        params = {
+            "threadId": "thread-fake-001",
+            "turnId": "turn-fake-001",
+            "callId": "call-1",
+            "tool": "mcp__law_firm_ops__list_email_obligations",
+            "arguments": {},
+        }
+        client.queue_server_request("item/tool/call", request_id="dynamic-1", **params)
+        client.queue_server_request("item/tool/call", request_id="dynamic-2", **params)
+        client.queue_notification(
+            "turn/completed", threadId="thread-fake-001",
+            turn={"id": "turn-fake-001", "status": "completed", "error": None},
+        )
+        s = make_session(
+            client,
+            dynamic_tools=[
+                {
+                    "name": "mcp__law_firm_ops__list_email_obligations",
+                    "type": "function",
+                }
+            ],
+            dynamic_tool_handler=lambda *args: dispatched.append(args) or "ok",
+        )
+        s.run_turn("hi", turn_timeout=1.0)
+        assert len(dispatched) == 1
+        assert client.responses[1][1]["success"] is False
 
 
 
@@ -895,4 +1081,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -7,6 +7,8 @@ deadline timeouts. These tests pin all of that without spawning real codex.
 
 from __future__ import annotations
 
+import json
+import logging
 import os
 from pathlib import Path
 import time
@@ -169,45 +171,81 @@ class TestLifecycle:
         method_calls = [m for (m, _) in client.requests if m == "thread/start"]
         assert len(method_calls) == 1
 
-    def test_thread_start_passes_cwd_only(self):
+    def test_thread_start_passes_cwd_only(self, caplog):
         """thread/start carries cwd. We intentionally do NOT pass `permissions`
         on this codex version (experimentalApi-gated + requires matching
         config.toml [permissions] table). Letting codex use its default
         (read-only unless user configures otherwise) is the documented path."""
         client = FakeClient()
         s = make_session(client, permission_profile="workspace-write")
+        caplog.set_level(logging.INFO, logger=session_mod.__name__)
         s.ensure_started()
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+        receipt = next(
+            json.loads(record.message.partition("=")[2])
+            for record in caplog.records
+            if "thread/start scope receipt=" in record.message
+        )
+        assert receipt == {
+            "thread_id": "thread-fake-001",
+            "developer_instructions_present": False,
+            "dynamic_tools_explicit": False,
+            "dynamic_tool_names": [],
+        }
 
-    def test_thread_start_forwards_profile_and_exact_dynamic_tools(self):
+    def test_thread_start_forwards_profile_and_exact_dynamic_tools(self, caplog):
         client = FakeClient()
         dynamic_tools = [
             {
                 "type": "function",
                 "name": "mcp__law_firm_ops__list_email_obligations",
-                "description": "List obligations.",
-                "inputSchema": {"type": "object", "properties": {}},
+                "description": "SENSITIVE DESCRIPTION",
+                "inputSchema": {"secret_schema_field": "SENSITIVE SCHEMA"},
             }
         ]
         s = make_session(
             client,
-            developer_instructions="Use the Legal Assistant profile.",
+            developer_instructions="SENSITIVE INSTRUCTIONS",
             dynamic_tools=dynamic_tools,
         )
+        caplog.set_level(logging.INFO, logger=session_mod.__name__)
+        assert not caplog.records
         s.ensure_started()
         _, params = next(r for r in client.requests if r[0] == "thread/start")
-        assert params["developerInstructions"] == "Use the Legal Assistant profile."
+        assert params["developerInstructions"] == "SENSITIVE INSTRUCTIONS"
         assert params["dynamicTools"] == dynamic_tools
         assert "outlook" not in str(params["dynamicTools"]).lower()
+        receipt_records = [
+            record.message
+            for record in caplog.records
+            if "thread/start scope receipt=" in record.message
+        ]
+        assert len(receipt_records) == 1
+        assert json.loads(receipt_records[0].partition("=")[2]) == {
+            "thread_id": "thread-fake-001",
+            "developer_instructions_present": True,
+            "dynamic_tools_explicit": True,
+            "dynamic_tool_names": ["mcp__law_firm_ops__list_email_obligations"],
+        }
+        assert "SENSITIVE" not in receipt_records[0]
+        assert "inputSchema" not in receipt_records[0]
 
-    def test_thread_start_keeps_explicit_empty_dynamic_tools(self):
+    def test_thread_start_keeps_explicit_empty_dynamic_tools(self, caplog):
         client = FakeClient()
         s = make_session(client, dynamic_tools=[])
+        caplog.set_level(logging.INFO, logger=session_mod.__name__)
         s.ensure_started()
         _, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["dynamicTools"] == []
+        receipt = next(
+            json.loads(record.message.partition("=")[2])
+            for record in caplog.records
+            if "thread/start scope receipt=" in record.message
+        )
+        assert receipt["dynamic_tools_explicit"] is True
+        assert receipt["dynamic_tool_names"] == []
 
     def test_session_uses_private_codex_home(self):
         client = FakeClient()
@@ -1023,7 +1061,7 @@ class TestThreadStartCrossFill:
 
 
 
-    def test_missing_thread_id_raises(self):
+    def test_missing_thread_id_raises(self, caplog):
         from agent.transports.codex_app_server import CodexAppServerError
 
         client = FakeClient()
@@ -1033,8 +1071,13 @@ class TestThreadStartCrossFill:
             {"turn": {"id": "tu1"}}
         )
         s = make_session(client)
+        caplog.set_level(logging.INFO, logger=session_mod.__name__)
         with pytest.raises(CodexAppServerError, match="no thread id"):
             s.ensure_started()
+        assert not any(
+            "thread/start scope receipt=" in record.message
+            for record in caplog.records
+        )
 
 
 class TestHasTurnAbortedMarker:


### PR DESCRIPTION
## Root cause

`thread/start.dynamicTools` augmented Codex's native environment-backed tools instead of replacing them. Restricted Legal Assistant sessions therefore still exposed command execution. The canonical obligation schemas also exposed runtime-owned `origin_session_id` plus `limit`/`offset`; the model guessed session metadata and selected `limit=100`, which the wrapper rejected because its maximum was not represented in the schema.

## Changes

- Project only registered, policy-authorized MCP tools into Codex dynamic tools, using stable aliases and fail-closed provenance checks.
- Preserve unset/default tool selection versus explicit restricted selection.
- Send `thread/start.environments=[]` only for explicitly selected MCP-only sessions, removing Codex environment-backed command, stdin, patch, and image surfaces while leaving unrestricted Development/VPS-Ops sessions unchanged.
- Keep Tool Search bridges, deferred tools, native registry tools, spoofed MCP names, and unconfigured MCP tools out of the projected dynamic surface.
- For the canonical `law-firm-ops` obligation tools, remove model control of `origin_session_id`; additionally remove `limit` and `offset` from `list_email_obligations` while preserving API pagination internally.
- Reject model-supplied `origin_session_id` and inject the trusted active Hermes session ID at dispatch.
- Require both canonical server provenance and exact obligation aliases so similarly named tools from other MCP servers remain unchanged.
- Emit a sanitized `thread/start` scope receipt containing tool names only.

## Validation

- `scripts/run_tests.sh tests/agent/transports/test_codex_app_server_runtime.py tests/agent/transports/test_codex_app_server_session.py -q` — 76 passed
- Ruff on the four changed files — passed
- `git diff --check origin/main...HEAD` — passed
- Independent review — no remaining Blocking or Required findings

## Delivery boundary

This PR does not deploy or restart Hermes, change live configuration or credentials, call providers, or run a live canary.

After deployment, a separately authorized fresh one-turn canary is required. Its preflight must inspect the complete child model-visible tool surface, and the turn must call only `list_email_obligations(view="open")`, followed by API audit/readback and zero-provider-access verification.
