### PR TITLE
fix(agent): support `model.tools: false` to suppress the tools payload

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2368,6 +2368,24 @@ def init_agent(
                 )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens
 
+    # Opt-in per-model tool suppression: `model.tools: false` drops the tools
+    # payload from API requests even when a toolset is loaded. Needed for
+    # endpoints whose tool-use template corrupts conversation history — e.g.
+    # Ollama drops prior non-tool turns for some models (Gemma 4, qwen3),
+    # making the model "forget" earlier context (#79639). Default is to send
+    # tools (existing behavior); only an explicit `false` suppresses them.
+    agent._suppress_tools = False
+    if isinstance(_model_cfg, dict):
+        _model_tools_cfg = _model_cfg.get("tools")
+        if _model_tools_cfg is False:
+            agent._suppress_tools = True
+        elif _model_tools_cfg is not None and not isinstance(_model_tools_cfg, bool):
+            _ra().logger.warning(
+                "Invalid model.tools in config.yaml: %r — "
+                "must be a boolean (e.g. `tools: false`). Ignoring.",
+                _model_tools_cfg,
+            )
+
     # Read explicit context_length override from model config
     if isinstance(_model_cfg, dict):
         _config_context_length = _model_cfg.get("context_length")

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2164,6 +2164,24 @@ def init_agent(
                 )
     agent._session_init_model_config["max_tokens"] = agent.max_tokens
 
+    # Opt-in per-model tool suppression: `model.tools: false` drops the tools
+    # payload from API requests even when a toolset is loaded. Needed for
+    # endpoints whose tool-use template corrupts conversation history — e.g.
+    # Ollama drops prior non-tool turns for some models (Gemma 4, qwen3),
+    # making the model "forget" earlier context (#79639). Default is to send
+    # tools (existing behavior); only an explicit `false` suppresses them.
+    agent._suppress_tools = False
+    if isinstance(_model_cfg, dict):
+        _model_tools_cfg = _model_cfg.get("tools")
+        if _model_tools_cfg is False:
+            agent._suppress_tools = True
+        elif _model_tools_cfg is not None and not isinstance(_model_tools_cfg, bool):
+            _ra().logger.warning(
+                "Invalid model.tools in config.yaml: %r — "
+                "must be a boolean (e.g. `tools: false`). Ignoring.",
+                _model_tools_cfg,
+            )
+
     # Read explicit context_length override from model config
     if isinstance(_model_cfg, dict):
         _config_context_length = _model_cfg.get("context_length")

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2054,6 +2054,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             cache_scope_id=_cache_scope_id,
             provider_profile=_profile,
             ollama_num_ctx=agent._ollama_num_ctx,
+            suppress_tools=getattr(agent, "_suppress_tools", False),
             # Context forwarded to profile hooks:
             provider_preferences=_prefs or None,
             openrouter_min_coding_score=agent.openrouter_min_coding_score,
@@ -2096,6 +2097,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         is_lmstudio=_is_lmstudio,
         is_custom_provider=agent.provider == "custom",
         ollama_num_ctx=agent._ollama_num_ctx,
+        suppress_tools=getattr(agent, "_suppress_tools", False),
         provider_preferences=_prefs or None,
         openrouter_min_coding_score=agent.openrouter_min_coding_score,
         qwen_prepare_fn=agent._qwen_prepare_chat_messages if _is_qwen else None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1551,6 +1551,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
             ollama_num_ctx=agent._ollama_num_ctx,
+            suppress_tools=getattr(agent, "_suppress_tools", False),
             # Context forwarded to profile hooks:
             provider_preferences=_prefs or None,
             openrouter_min_coding_score=agent.openrouter_min_coding_score,
@@ -1592,6 +1593,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         is_lmstudio=_is_lmstudio,
         is_custom_provider=agent.provider == "custom",
         ollama_num_ctx=agent._ollama_num_ctx,
+        suppress_tools=getattr(agent, "_suppress_tools", False),
         provider_preferences=_prefs or None,
         openrouter_min_coding_score=agent.openrouter_min_coding_score,
         qwen_prepare_fn=agent._qwen_prepare_chat_messages if _is_qwen else None,

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2238,7 +2238,11 @@ def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -
         "execute_code",
     }
 
-    if valid_names and not (valid_names & relevant_tool_names):
+    if not (valid_names & relevant_tool_names):
+        # No relevant Nous-managed tools are available — including the empty
+        # set (valid_tool_names=[] or suppressed via model.tools: false,
+        # #79639). An empty capability block would still read like the agent
+        # can use Nous tools, which it cannot.
         return ""
 
     features = get_nous_subscription_features()

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1985,7 +1985,11 @@ def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -
         "execute_code",
     }
 
-    if valid_names and not (valid_names & relevant_tool_names):
+    if not (valid_names & relevant_tool_names):
+        # No relevant Nous-managed tools are available — including the empty
+        # set (valid_tool_names=[] or suppressed via model.tools: false,
+        # #79639). An empty capability block would still read like the agent
+        # can use Nous tools, which it cannot.
         return ""
 
     features = get_nous_subscription_features()

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -471,7 +471,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     #   true  — always inject (all models)
     #   false — never inject
     #   list  — custom model-name substrings to match
-    if agent.valid_tool_names:
+    if agent.valid_tool_names and not getattr(agent, "_suppress_tools", False):
+        # When model.tools: false suppresses the tools payload, the request
+        # carries no tool definitions — telling the model it "must call tools"
+        # would only provoke hallucinated tool_calls that can't be dispatched
+        # (#79639). Skip the enforcement guidance in that case.
         _enforce = agent._tool_use_enforcement
         _inject = False
         if _enforce is True or (isinstance(_enforce, str) and _enforce.lower() in {"true", "always", "yes", "on"}):

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -521,7 +521,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     #   list  — custom model-name substrings to match
     # Resolved once at session start keyed on the (fixed) model name, so
     # the system prompt stays byte-stable for the life of the conversation.
-    if agent.valid_tool_names:
+    # Gated on the effective toolset so model.tools: false (which drops the
+    # tools payload) also drops this tool-oriented guidance (#79639).
+    if _effective_tools:
         _exec_guidance = getattr(agent, "_execution_guidance", "auto")
         _exec_inject = False
         if _exec_guidance is True or (isinstance(_exec_guidance, str) and _exec_guidance.lower() in {"true", "always", "yes", "on"}):

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -383,7 +383,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if getattr(agent, "_suppress_tools", False):
         _effective_tools: set = set()
     else:
-        _effective_tools = set(agent.valid_tool_names)
+        _effective_tools = set(agent.valid_tool_names or ())
 
     # Try SOUL.md as primary identity unless the caller explicitly skipped it.
     # Some execution modes (cron) still want HERMES_HOME persona while keeping

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -374,6 +374,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
+    # Effective toolset for prompt-guidance purposes. When model.tools: false
+    # suppresses the tools payload (#79639), the request carries no tool
+    # definitions — so every tool-related prompt block (task completion,
+    # parallel calls, tool guidance, steering notes, computer use, subscription
+    # hints, enforcement) must be gated off as a class, not one at a time.
+    # A single effective set keeps the gates consistent and future-proof.
+    if getattr(agent, "_suppress_tools", False):
+        _effective_tools: set = set()
+    else:
+        _effective_tools = set(agent.valid_tool_names)
+
     # Try SOUL.md as primary identity unless the caller explicitly skipped it.
     # Some execution modes (cron) still want HERMES_HOME persona while keeping
     # cwd project instructions disabled.
@@ -400,7 +411,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # path is blocked) are not model-family specific.  Gated only by
     # config.yaml ``agent.task_completion_guidance`` (default True) so
     # users who want a leaner prompt can turn it off.
-    if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
+    if getattr(agent, "_task_completion_guidance", True) and _effective_tools:
         stable_parts.append(TASK_COMPLETION_GUIDANCE)
 
     # Universal parallel-tool-call guidance.  Tells the model to batch
@@ -411,12 +422,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # round-trips and the resent-context cost that compounds over a long
     # conversation.  Gated by config.yaml ``agent.parallel_tool_call_guidance``
     # (default True) and only injected when tools are actually loaded.
-    if getattr(agent, "_parallel_tool_call_guidance", True) and agent.valid_tool_names:
+    if getattr(agent, "_parallel_tool_call_guidance", True) and _effective_tools:
         stable_parts.append(PARALLEL_TOOL_CALL_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []
-    # MEMORY_GUIDANCE instructs the model to save facts to the built-in
+# MEMORY_GUIDANCE instructs the model to save facts to the built-in
     # MEMORY.md/USER.md stores. With both disabled in config no store is built,
     # so the guidance would steer the model at a tool whose every call returns
     # "Memory is not available". Defaults to True for the rare code paths that
@@ -426,14 +437,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # model to write notes to a MEMORY.md store that does not exist.
     _mem_enabled = getattr(agent, "_memory_enabled", True)
     _profile_enabled = getattr(agent, "_user_profile_enabled", True)
-    if "memory" in agent.valid_tool_names:
+    if "memory" in _effective_tools:
         if _mem_enabled:
             tool_guidance.append(MEMORY_GUIDANCE)
         elif _profile_enabled:
             tool_guidance.append(USER_PROFILE_GUIDANCE)
-    if "session_search" in agent.valid_tool_names:
+    if "session_search" in _effective_tools:
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
-    if "skill_manage" in agent.valid_tool_names:
+    if "skill_manage" in _effective_tools:
         tool_guidance.append(SKILLS_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
@@ -442,7 +453,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
+    elif _kanban_guidance is None and "kanban_show" in _effective_tools:
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
@@ -450,18 +461,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Steering only lands inside tool results, so it's only reachable when the
     # agent has tools. Static text → byte-stable prompt (no cache hit).
-    if agent.valid_tool_names:
+    if _effective_tools:
         stable_parts.append(STEER_CHANNEL_NOTE)
 
     # Computer-use — goes in as its own block rather than being merged into
     # tool_guidance because the content is multi-paragraph. The guidance is
     # rendered for the host platform so Windows/Linux hosts don't see
     # macOS-only wording (Mac, Space, cmd+s).
-    if "computer_use" in agent.valid_tool_names:
+    if "computer_use" in _effective_tools:
         from agent.prompt_builder import computer_use_guidance
         stable_parts.append(computer_use_guidance())
 
-    nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
+    nous_subscription_prompt = _r.build_nous_subscription_prompt(_effective_tools)
     if nous_subscription_prompt:
         stable_parts.append(nous_subscription_prompt)
     # Tool-use enforcement: tells the model to actually call tools instead
@@ -471,7 +482,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     #   true  — always inject (all models)
     #   false — never inject
     #   list  — custom model-name substrings to match
-    if agent.valid_tool_names and not getattr(agent, "_suppress_tools", False):
+    if _effective_tools:
         # When model.tools: false suppresses the tools payload, the request
         # carries no tool definitions — telling the model it "must call tools"
         # would only provoke hallucinated tool_calls that can't be dispatched
@@ -527,12 +538,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         if _exec_inject:
             stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
-    has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
+    has_skills_tools = any(name in _effective_tools for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:
         avail_toolsets = {
             toolset
             for toolset in (
-                _r.get_toolset_for_tool(tool_name) for tool_name in agent.valid_tool_names
+                _r.get_toolset_for_tool(tool_name) for tool_name in _effective_tools
             )
             if toolset
         }
@@ -550,7 +561,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             _compact_cats = frozenset()
         skills_prompt = _r.build_skills_system_prompt(
-            available_tools=agent.valid_tool_names,
+            available_tools=_effective_tools,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
             skills_dir_override=_agent_skills_dir(agent),
@@ -586,7 +597,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # stay in their historical position after the workspace snapshot.
     coding_workspace_parts: List[str] = []
     coding_trailing_parts: List[str] = []
-    if agent.valid_tool_names:
+    if _effective_tools:
         try:
             from agent.coding_context import coding_system_prompt_parts
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -267,7 +267,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     #   true  — always inject (all models)
     #   false — never inject
     #   list  — custom model-name substrings to match
-    if agent.valid_tool_names:
+    if agent.valid_tool_names and not getattr(agent, "_suppress_tools", False):
+        # When model.tools: false suppresses the tools payload, the request
+        # carries no tool definitions — telling the model it "must call tools"
+        # would only provoke hallucinated tool_calls that can't be dispatched
+        # (#79639). Skip the enforcement guidance in that case.
         _enforce = agent._tool_use_enforcement
         _inject = False
         if _enforce is True or (isinstance(_enforce, str) and _enforce.lower() in {"true", "always", "yes", "on"}):

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -195,7 +195,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if getattr(agent, "_suppress_tools", False):
         _effective_tools: set = set()
     else:
-        _effective_tools = set(agent.valid_tool_names)
+        _effective_tools = set(agent.valid_tool_names or ())
 
     # Try SOUL.md as primary identity unless the caller explicitly skipped it.
     # Some execution modes (cron) still want HERMES_HOME persona while keeping

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -186,6 +186,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
+    # Effective toolset for prompt-guidance purposes. When model.tools: false
+    # suppresses the tools payload (#79639), the request carries no tool
+    # definitions — so every tool-related prompt block (task completion,
+    # parallel calls, tool guidance, steering notes, computer use, subscription
+    # hints, enforcement) must be gated off as a class, not one at a time.
+    # A single effective set keeps the gates consistent and future-proof.
+    if getattr(agent, "_suppress_tools", False):
+        _effective_tools: set = set()
+    else:
+        _effective_tools = set(agent.valid_tool_names)
+
     # Try SOUL.md as primary identity unless the caller explicitly skipped it.
     # Some execution modes (cron) still want HERMES_HOME persona while keeping
     # cwd project instructions disabled.
@@ -209,7 +220,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # path is blocked) are not model-family specific.  Gated only by
     # config.yaml ``agent.task_completion_guidance`` (default True) so
     # users who want a leaner prompt can turn it off.
-    if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
+    if getattr(agent, "_task_completion_guidance", True) and _effective_tools:
         stable_parts.append(TASK_COMPLETION_GUIDANCE)
 
     # Universal parallel-tool-call guidance.  Tells the model to batch
@@ -220,16 +231,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # round-trips and the resent-context cost that compounds over a long
     # conversation.  Gated by config.yaml ``agent.parallel_tool_call_guidance``
     # (default True) and only injected when tools are actually loaded.
-    if getattr(agent, "_parallel_tool_call_guidance", True) and agent.valid_tool_names:
+    if getattr(agent, "_parallel_tool_call_guidance", True) and _effective_tools:
         stable_parts.append(PARALLEL_TOOL_CALL_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []
-    if "memory" in agent.valid_tool_names:
+    if "memory" in _effective_tools:
         tool_guidance.append(MEMORY_GUIDANCE)
-    if "session_search" in agent.valid_tool_names:
+    if "session_search" in _effective_tools:
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
-    if "skill_manage" in agent.valid_tool_names:
+    if "skill_manage" in _effective_tools:
         tool_guidance.append(SKILLS_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
@@ -238,7 +249,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
+    elif _kanban_guidance is None and "kanban_show" in _effective_tools:
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
@@ -246,18 +257,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Steering only lands inside tool results, so it's only reachable when the
     # agent has tools. Static text → byte-stable prompt (no cache hit).
-    if agent.valid_tool_names:
+    if _effective_tools:
         stable_parts.append(STEER_CHANNEL_NOTE)
 
     # Computer-use — goes in as its own block rather than being merged into
     # tool_guidance because the content is multi-paragraph. The guidance is
     # rendered for the host platform so Windows/Linux hosts don't see
     # macOS-only wording (Mac, Space, cmd+s).
-    if "computer_use" in agent.valid_tool_names:
+    if "computer_use" in _effective_tools:
         from agent.prompt_builder import computer_use_guidance
         stable_parts.append(computer_use_guidance())
 
-    nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
+    nous_subscription_prompt = _r.build_nous_subscription_prompt(_effective_tools)
     if nous_subscription_prompt:
         stable_parts.append(nous_subscription_prompt)
     # Tool-use enforcement: tells the model to actually call tools instead
@@ -267,7 +278,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     #   true  — always inject (all models)
     #   false — never inject
     #   list  — custom model-name substrings to match
-    if agent.valid_tool_names and not getattr(agent, "_suppress_tools", False):
+    if _effective_tools:
         # When model.tools: false suppresses the tools payload, the request
         # carries no tool definitions — telling the model it "must call tools"
         # would only provoke hallucinated tool_calls that can't be dispatched
@@ -300,12 +311,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
-    has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
+    has_skills_tools = any(name in _effective_tools for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:
         avail_toolsets = {
             toolset
             for toolset in (
-                _r.get_toolset_for_tool(tool_name) for tool_name in agent.valid_tool_names
+                _r.get_toolset_for_tool(tool_name) for tool_name in _effective_tools
             )
             if toolset
         }
@@ -323,7 +334,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             _compact_cats = frozenset()
         skills_prompt = _r.build_skills_system_prompt(
-            available_tools=agent.valid_tool_names,
+            available_tools=_effective_tools,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
         )
@@ -358,7 +369,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # stay in their historical position after the workspace snapshot.
     coding_workspace_parts: List[str] = []
     coding_trailing_parts: List[str] = []
-    if agent.valid_tool_names:
+    if _effective_tools:
         try:
             from agent.coding_context import coding_system_prompt_parts
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -466,6 +466,9 @@ class ChatCompletionsTransport(ProviderTransport):
             request_overrides: dict | None
             session_id: str | None
             model_lower: str — lowercase model name for pattern matching
+            suppress_tools: bool — opt-in (per-model `model.tools: false`):
+                drop the tools payload even when a toolset is loaded. For
+                endpoints whose tool template corrupts history (#79639).
             # Provider profile path (all per-provider quirks live in providers/)
             provider_profile: ProviderProfile | None — when present, delegates to
                 _build_kwargs_from_profile(); all flag params below are bypassed.
@@ -538,7 +541,12 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs["timeout"] = timeout
 
         # Tools
-        if tools:
+        # suppress_tools (opt-in, per-model config `model.tools: false`) lets
+        # users disable the tools payload for endpoints whose models choke on
+        # it — e.g. Ollama's tool-use chat template drops prior non-tool turns
+        # for some models (Gemma 4, and reproduced on qwen3), so the model
+        # "forgets" earlier context the moment `tools` is present (#79639).
+        if tools and not params.get("suppress_tools", False):
             # Moonshot/Kimi uses a stricter flavored JSON Schema.  Rewriting
             # tool parameters here keeps aggregator routes (Nous, OpenRouter,
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
@@ -756,8 +764,11 @@ class ChatCompletionsTransport(ProviderTransport):
         if timeout is not None:
             api_kwargs["timeout"] = timeout
 
-        # Tools — apply Moonshot/Kimi schema sanitization regardless of path
-        if tools:
+        # Tools — apply Moonshot/Kimi schema sanitization regardless of path.
+        # suppress_tools: opt-in per-model config (`model.tools: false`) to drop
+        # the tools payload — Ollama's tool-use template drops prior non-tool
+        # turns for some models (#79639).
+        if tools and not params.get("suppress_tools", False):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -371,6 +371,9 @@ class ChatCompletionsTransport(ProviderTransport):
             request_overrides: dict | None
             session_id: str | None
             model_lower: str — lowercase model name for pattern matching
+            suppress_tools: bool — opt-in (per-model `model.tools: false`):
+                drop the tools payload even when a toolset is loaded. For
+                endpoints whose tool template corrupts history (#79639).
             # Provider profile path (all per-provider quirks live in providers/)
             provider_profile: ProviderProfile | None — when present, delegates to
                 _build_kwargs_from_profile(); all flag params below are bypassed.
@@ -443,7 +446,12 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs["timeout"] = timeout
 
         # Tools
-        if tools:
+        # suppress_tools (opt-in, per-model config `model.tools: false`) lets
+        # users disable the tools payload for endpoints whose models choke on
+        # it — e.g. Ollama's tool-use chat template drops prior non-tool turns
+        # for some models (Gemma 4, and reproduced on qwen3), so the model
+        # "forgets" earlier context the moment `tools` is present (#79639).
+        if tools and not params.get("suppress_tools", False):
             # Moonshot/Kimi uses a stricter flavored JSON Schema.  Rewriting
             # tool parameters here keeps aggregator routes (Nous, OpenRouter,
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
@@ -639,8 +647,11 @@ class ChatCompletionsTransport(ProviderTransport):
         if timeout is not None:
             api_kwargs["timeout"] = timeout
 
-        # Tools — apply Moonshot/Kimi schema sanitization regardless of path
-        if tools:
+        # Tools — apply Moonshot/Kimi schema sanitization regardless of path.
+        # suppress_tools: opt-in per-model config (`model.tools: false`) to drop
+        # the tools payload — Ollama's tool-use template drops prior non-tool
+        # turns for some models (#79639).
+        if tools and not params.get("suppress_tools", False):
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -427,6 +427,24 @@ class TestBuildNousSubscriptionPrompt:
 
         assert prompt == ""
 
+    def test_empty_toolset_returns_empty_prompt(self, monkeypatch):
+        """#79639: with no relevant tools available — including the empty set
+        (suppressed via model.tools: false) — the Nous capability block must
+        not render. A tool list that claims Nous-managed tools are usable when
+        none are loaded is misleading. Uses the real function path with the
+        feature flag on so the empty-set gate is actually exercised."""
+        monkeypatch.setattr("tools.tool_backend_helpers.managed_nous_tools_enabled", lambda: True)
+
+        prompt = build_nous_subscription_prompt(set())
+        assert prompt == ""
+
+    def test_no_relevant_tools_returns_empty_prompt(self, monkeypatch):
+        """Tools exist but none are Nous-managed → no block."""
+        monkeypatch.setattr("tools.tool_backend_helpers.managed_nous_tools_enabled", lambda: True)
+
+        prompt = build_nous_subscription_prompt({"read_file", "search_files"})
+        assert prompt == ""
+
 
 # =========================================================================
 # Context files prompt builder

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -484,3 +484,33 @@ class TestSkillsInVolatileBand:
         full = _build(build_system_prompt)
         assert full.index(_CONTEXT) < full.index(_SKILLS)
         assert full.index(_SKILLS) < full.index("Conversation started:")
+
+
+class TestToolUseEnforcementSuppress:
+    """#79639: when ``model.tools: false`` suppresses the tools payload, the
+    tool-use enforcement guidance must not be injected — the request carries no
+    tool definitions, so telling the model it "must call tools" would provoke
+    hallucinated tool_calls."""
+
+    def test_enforcement_injected_when_tools_active(self):
+        agent = _make_agent(
+            valid_tool_names=["search"],
+            _tool_use_enforcement=True,
+        )
+        assert "Tool-use enforcement" in _stable_prompt(agent)
+
+    def test_enforcement_suppressed_when_tools_disabled(self):
+        agent = _make_agent(
+            valid_tool_names=["search"],
+            _tool_use_enforcement=True,
+            _suppress_tools=True,
+        )
+        assert "Tool-use enforcement" not in _stable_prompt(agent)
+
+    def test_enforcement_still_injected_when_suppress_false(self):
+        agent = _make_agent(
+            valid_tool_names=["search"],
+            _tool_use_enforcement=True,
+            _suppress_tools=False,
+        )
+        assert "Tool-use enforcement" in _stable_prompt(agent)

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -514,3 +514,22 @@ class TestToolUseEnforcementSuppress:
             _suppress_tools=False,
         )
         assert "Tool-use enforcement" in _stable_prompt(agent)
+
+    def test_no_tool_prompt_blocks_when_suppressed(self):
+        """#79639 (review-agent follow-up): when model.tools: false suppresses
+        the tools payload, ALL tool-related prompt blocks must be gated off as
+        a class — not just enforcement. A prompt that still commands the model
+        to call tools it cannot dispatch would provoke hallucinated tool_calls."""
+        agent = _make_agent(
+            valid_tool_names=["memory", "session_search", "skill_manage", "search"],
+            _tool_use_enforcement=True,
+            _suppress_tools=True,
+        )
+        prompt = _stable_prompt(agent)
+        assert "Tool-use enforcement" not in prompt
+        assert "You have persistent memory across sessions" not in prompt
+        assert "use session_search to recall it" not in prompt
+        assert "save the approach as a" not in prompt
+        assert "batch independent tool calls" not in prompt
+        assert "# Parallel tool calls" not in prompt
+        assert "do not describe what you would do" not in prompt

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -533,3 +533,24 @@ class TestToolUseEnforcementSuppress:
         assert "batch independent tool calls" not in prompt
         assert "# Parallel tool calls" not in prompt
         assert "do not describe what you would do" not in prompt
+
+    def test_execution_guidance_gated_when_tools_suppressed(self):
+        """The execution-discipline block sits behind its own model-family
+        gate (gpt/codex/grok/…). When model.tools: false suppresses the tools
+        payload it must also be dropped — it instructs the model to lean on
+        tools that are no longer declared. This fixes a rebase gap where the
+        block still read agent.valid_tool_names instead of _effective_tools."""
+        # A model that matches EXECUTION_GUIDANCE_MODELS ("gpt") in auto mode.
+        suppressed = _make_agent(
+            valid_tool_names=["search"],
+            model="gpt-4o",
+            _suppress_tools=True,
+        )
+        assert "# Execution discipline" not in _stable_prompt(suppressed)
+
+        active = _make_agent(
+            valid_tool_names=["search"],
+            model="gpt-4o",
+            _suppress_tools=False,
+        )
+        assert "# Execution discipline" in _stable_prompt(active)

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -369,3 +369,22 @@ class TestToolUseEnforcementSuppress:
             _suppress_tools=False,
         )
         assert "Tool-use enforcement" in _stable_prompt(agent)
+
+    def test_no_tool_prompt_blocks_when_suppressed(self):
+        """#79639 (review-agent follow-up): when model.tools: false suppresses
+        the tools payload, ALL tool-related prompt blocks must be gated off as
+        a class — not just enforcement. A prompt that still commands the model
+        to call tools it cannot dispatch would provoke hallucinated tool_calls."""
+        agent = _make_agent(
+            valid_tool_names=["memory", "session_search", "skill_manage", "search"],
+            _tool_use_enforcement=True,
+            _suppress_tools=True,
+        )
+        prompt = _stable_prompt(agent)
+        assert "Tool-use enforcement" not in prompt
+        assert "You have persistent memory across sessions" not in prompt
+        assert "use session_search to recall it" not in prompt
+        assert "save the approach as a" not in prompt
+        assert "batch independent tool calls" not in prompt
+        assert "# Parallel tool calls" not in prompt
+        assert "do not describe what you would do" not in prompt

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -339,3 +339,33 @@ class TestSkillsInVolatileBand:
         full = _build(build_system_prompt)
         assert full.index(_CONTEXT) < full.index(_SKILLS)
         assert full.index(_SKILLS) < full.index("Conversation started:")
+
+
+class TestToolUseEnforcementSuppress:
+    """#79639: when ``model.tools: false`` suppresses the tools payload, the
+    tool-use enforcement guidance must not be injected — the request carries no
+    tool definitions, so telling the model it "must call tools" would provoke
+    hallucinated tool_calls."""
+
+    def test_enforcement_injected_when_tools_active(self):
+        agent = _make_agent(
+            valid_tool_names=["search"],
+            _tool_use_enforcement=True,
+        )
+        assert "Tool-use enforcement" in _stable_prompt(agent)
+
+    def test_enforcement_suppressed_when_tools_disabled(self):
+        agent = _make_agent(
+            valid_tool_names=["search"],
+            _tool_use_enforcement=True,
+            _suppress_tools=True,
+        )
+        assert "Tool-use enforcement" not in _stable_prompt(agent)
+
+    def test_enforcement_still_injected_when_suppress_false(self):
+        agent = _make_agent(
+            valid_tool_names=["search"],
+            _tool_use_enforcement=True,
+            _suppress_tools=False,
+        )
+        assert "Tool-use enforcement" in _stable_prompt(agent)

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -875,3 +875,72 @@ class TestPromptCacheKeyCapability:
             provider_profile=profile,
         )
         assert "prompt_cache_key" not in kwargs
+
+
+class TestSuppressTools:
+    """``suppress_tools`` opt-in (per-model ``model.tools: false``) drops the
+    tools payload even when a toolset is loaded. Regression for #79639:
+    Ollama's tool-use template drops prior non-tool turns for some models
+    (Gemma 4, reproduced on qwen3), so the model "forgets" earlier context
+    the moment ``tools`` is present. Default behavior must be unchanged:
+    tools are still sent unless the user explicitly opts out."""
+
+    TOOLS = [{"type": "function", "function": {"name": "get_weather",
+             "description": "Get the weather", "parameters": {"type": "object"}}}]
+    MSGS = [{"role": "user", "content": "The password is banana"}]
+
+    # ── Legacy path (no provider_profile) ──────────────────────
+
+    def test_tools_sent_by_default(self, transport):
+        """Default (no suppress flag) keeps sending tools — existing behavior."""
+        kw = transport.build_kwargs(model="gpt-4o", messages=self.MSGS, tools=self.TOOLS)
+        assert kw["tools"] == self.TOOLS
+
+    def test_suppress_tools_omits_tools_legacy(self, transport):
+        """``suppress_tools=True`` drops the tools payload (legacy path)."""
+        kw = transport.build_kwargs(
+            model="gemma4:12b", messages=self.MSGS, tools=self.TOOLS, suppress_tools=True
+        )
+        assert "tools" not in kw
+
+    def test_suppress_tools_false_still_sends(self, transport):
+        """Explicit ``suppress_tools=False`` keeps sending tools."""
+        kw = transport.build_kwargs(
+            model="gemma4:12b", messages=self.MSGS, tools=self.TOOLS, suppress_tools=False
+        )
+        assert kw["tools"] == self.TOOLS
+
+    def test_suppress_tools_no_tools_noop(self, transport):
+        """With no tools there is nothing to suppress — no tools key either way."""
+        kw = transport.build_kwargs(
+            model="gemma4:12b", messages=self.MSGS, tools=[], suppress_tools=True
+        )
+        assert "tools" not in kw
+
+    # ── Provider-profile path (Ollama resolves to custom profile) ──
+
+    def test_suppress_tools_omits_tools_profile(self, transport):
+        """``suppress_tools=True`` drops the tools payload on the profile path —
+        the path Ollama/custom endpoints actually use."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        kw = transport.build_kwargs(
+            model="gemma4:12b",
+            messages=self.MSGS,
+            tools=self.TOOLS,
+            suppress_tools=True,
+            provider_profile=profile,
+        )
+        assert "tools" not in kw
+
+    def test_profile_path_sends_tools_by_default(self, transport):
+        """Profile path keeps sending tools by default (no regression)."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        kw = transport.build_kwargs(
+            model="gemma4:12b",
+            messages=self.MSGS,
+            tools=self.TOOLS,
+            provider_profile=profile,
+        )
+        assert kw["tools"] == self.TOOLS

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -776,3 +776,72 @@ class TestPromptCacheKeyCapability:
             provider_profile=profile,
         )
         assert "prompt_cache_key" not in kwargs
+
+
+class TestSuppressTools:
+    """``suppress_tools`` opt-in (per-model ``model.tools: false``) drops the
+    tools payload even when a toolset is loaded. Regression for #79639:
+    Ollama's tool-use template drops prior non-tool turns for some models
+    (Gemma 4, reproduced on qwen3), so the model "forgets" earlier context
+    the moment ``tools`` is present. Default behavior must be unchanged:
+    tools are still sent unless the user explicitly opts out."""
+
+    TOOLS = [{"type": "function", "function": {"name": "get_weather",
+             "description": "Get the weather", "parameters": {"type": "object"}}}]
+    MSGS = [{"role": "user", "content": "The password is banana"}]
+
+    # ── Legacy path (no provider_profile) ──────────────────────
+
+    def test_tools_sent_by_default(self, transport):
+        """Default (no suppress flag) keeps sending tools — existing behavior."""
+        kw = transport.build_kwargs(model="gpt-4o", messages=self.MSGS, tools=self.TOOLS)
+        assert kw["tools"] == self.TOOLS
+
+    def test_suppress_tools_omits_tools_legacy(self, transport):
+        """``suppress_tools=True`` drops the tools payload (legacy path)."""
+        kw = transport.build_kwargs(
+            model="gemma4:12b", messages=self.MSGS, tools=self.TOOLS, suppress_tools=True
+        )
+        assert "tools" not in kw
+
+    def test_suppress_tools_false_still_sends(self, transport):
+        """Explicit ``suppress_tools=False`` keeps sending tools."""
+        kw = transport.build_kwargs(
+            model="gemma4:12b", messages=self.MSGS, tools=self.TOOLS, suppress_tools=False
+        )
+        assert kw["tools"] == self.TOOLS
+
+    def test_suppress_tools_no_tools_noop(self, transport):
+        """With no tools there is nothing to suppress — no tools key either way."""
+        kw = transport.build_kwargs(
+            model="gemma4:12b", messages=self.MSGS, tools=[], suppress_tools=True
+        )
+        assert "tools" not in kw
+
+    # ── Provider-profile path (Ollama resolves to custom profile) ──
+
+    def test_suppress_tools_omits_tools_profile(self, transport):
+        """``suppress_tools=True`` drops the tools payload on the profile path —
+        the path Ollama/custom endpoints actually use."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        kw = transport.build_kwargs(
+            model="gemma4:12b",
+            messages=self.MSGS,
+            tools=self.TOOLS,
+            suppress_tools=True,
+            provider_profile=profile,
+        )
+        assert "tools" not in kw
+
+    def test_profile_path_sends_tools_by_default(self, transport):
+        """Profile path keeps sending tools by default (no regression)."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        kw = transport.build_kwargs(
+            model="gemma4:12b",
+            messages=self.MSGS,
+            tools=self.TOOLS,
+            provider_profile=profile,
+        )
+        assert kw["tools"] == self.TOOLS

--- a/tests/run_agent/test_79639_model_tools_suppress.py
+++ b/tests/run_agent/test_79639_model_tools_suppress.py
@@ -1,0 +1,70 @@
+"""Regression test for #79639: `model.tools: false` suppresses the tools payload.
+
+Hermes unconditionally sends `tools` on every chat-completions request when a
+toolset is loaded. For Ollama-backed models whose tool-use template drops
+prior non-tool turns (Gemma 4, reproduced on qwen3), the presence of `tools`
+alone makes the model "forget" earlier context. This test pins the config
+parsing: an explicit `model.tools: false` sets ``agent._suppress_tools`` so
+the transport can drop the tools payload; default behavior is unchanged.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from run_agent import AIAgent
+from agent.agent_init import init_agent
+
+
+def _make_agent():
+    agent = object.__new__(AIAgent)
+    agent._base_url = "http://127.0.0.1:11434/v1"
+    agent._base_url_lower = ""
+    agent._base_url_hostname = ""
+    return agent
+
+
+def _run_init(agent, model_cfg: dict):
+    with patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)), \
+         patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("hermes_cli.config.load_config_readonly", return_value=model_cfg), \
+         patch("hermes_cli.config.load_config", return_value=model_cfg), \
+         patch("hermes_cli.config.cfg_get", return_value=None), \
+         patch("agent.credential_pool.load_pool", return_value=MagicMock()), \
+         patch("hermes_cli.config.get_compatible_custom_providers", return_value=[]), \
+         patch("agent.iteration_budget.IterationBudget"), \
+         patch("agent.agent_init.query_ollama_num_ctx", return_value=None), \
+         patch("agent.agent_init.is_local_endpoint", return_value=False):
+        init_agent(
+            agent,
+            base_url="http://127.0.0.1:11434/v1",
+            api_key="test-key",
+            provider="custom",
+            model="gemma4:12b",
+            skip_context_files=True,
+            skip_memory=True,
+            quiet_mode=True,
+        )
+
+
+class TestModelToolsSuppress:
+    """`model.tools: false` must set `_suppress_tools`; defaults must not."""
+
+    def test_tools_false_sets_suppress(self):
+        agent = _make_agent()
+        _run_init(agent, {"model": {"tools": False}})
+        assert agent._suppress_tools is True
+
+    def test_default_does_not_suppress(self):
+        agent = _make_agent()
+        _run_init(agent, {"model": {}})
+        assert getattr(agent, "_suppress_tools", False) is False
+
+    def test_tools_true_does_not_suppress(self):
+        agent = _make_agent()
+        _run_init(agent, {"model": {"tools": True}})
+        assert agent._suppress_tools is False
+
+    def test_no_model_section_does_not_suppress(self):
+        agent = _make_agent()
+        _run_init(agent, {})
+        assert getattr(agent, "_suppress_tools", False) is False


### PR DESCRIPTION
Closes #79639

---

## Problem

Hermes unconditionally sends `tools` on every chat-completions request whenever
a toolset is loaded. For some Ollama-served models this is actively harmful:
the presence of `tools` triggers Ollama's tool-use chat template, which drops
history turns that carry no `tool_calls` — so the model "forgets" earlier
context.

- Reporter (gemma4:12b): with `tools` the model cannot recall an earlier
  password; without it, it answers correctly.
- Also reproduced locally (qwen3:0.6b): same forget-the-past behavior with
  `tools` present.
- Reporter isolated the trigger to a single field: `tools` alone reproduces it;
  `max_tokens` / `reasoning_effort` / `num_ctx` are all inert.

There was previously no way to disable the tools payload for a single model
without `/tools disable` (which disables the whole toolset).

## Fix

Add an opt-in per-model config `model.tools: false` that suppresses the tools
payload. Default behavior is unchanged — tools are still sent unless a user
explicitly opts out.

Changed files:
1. `agent/agent_init.py` — read `model.tools`; when `false`, set
   `agent._suppress_tools = True` (non-bool values warn and are ignored).
2. `agent/chat_completion_helpers.py` — thread `suppress_tools` into both
   `build_kwargs` call sites.
3. `agent/transports/chat_completions.py` — both paths only attach tools when
   `tools and not suppress_tools`.
4. `agent/system_prompt.py` — gate all tool-related prompt blocks through a
   single `_effective_tools` set (empty when suppressed).
5. `agent/prompt_builder.py` — `build_nous_subscription_prompt` returns empty
   for an empty toolset (see design note 2).

> Rebased onto current main; `mergeable` verified, agent suites green (427 tests
> across system_prompt / chat_completions / prompt_builder / run_agent).

## Why config, not "disable tools for Ollama by default"

- vLLM / GLM / llama.cpp also route through the `custom` provider; a blanket
  "no tools on custom" would break them.
- Many Ollama users rely on agentic tool use; forcing tools off would regress
  working setups.
- Purely opt-in, matching the project's config-gating philosophy.
- The reporter's own suggestion points the same direction.

## Ecosystem alignment

This isn't an isolated switch in an empty niche — it sits in a family of
requests for *config-controlled* suppression of what Hermes ships to the model,
driven by context/cost bloat in scripted and high-frequency use:

- **#26806** — suppress the `<available_skills>` system-prompt injection for
  scripted/oneshot callers (tool-free, content-only runs).
- **#49316** — config option to suppress/truncate the patch/write_file unified
  diff returned to the agent, again to reduce context.

`model.tools: false` is the same pattern applied to the tool-definitions
payload: a per-model/user gate that drops a block the caller doesn't need. It's
also the enabling knob the fixed-`tools`-on-Ollama case (#79639) needs. Keeping
these as opt-in config (rather than auto-detecting and forcing) follows the
project's "behavioral settings live in config.yaml" line, and leaves every
existing setup byte-identical.

## Design considerations

**1. Payload and system prompt must stay consistent (whole-class gating).**

Removing `tools` from the request payload alone is not enough. Hermes' system
prompt carries several tool-related blocks (tool-use enforcement, parallel-call
guidance, memory/session_search/skill behavior guidance, steering, computer-use
guidance, the Nous-subscription capability block, the skills index, coding
context). If the payload has no tool definitions but the system prompt still
tells the model it "must call tools", a strongly tool-following model — exactly
the kind `model.tools: false` targets (e.g. Gemma 4) — will try to call
functions it cannot dispatch, i.e. hallucinate tool_calls.

So the implementation introduces `_effective_tools`: when `model.tools: false`
it is empty, and **all** tool-related prompt blocks are gated through it,
rather than patched one at a time. Any future tool block that follows
`_effective_tools` cannot leak past the empty set.

**2. A hidden assumption in the Nous-subscription block.**

`build_nous_subscription_prompt` did not early-return for an empty toolset —
`if valid_names and not (valid_names & relevant_tool_names)` is falsy for
`valid_names == set()`, so it fell through and rendered a full "available Nous
capabilities" block even when the agent has no tools. The system prompt would
then assert the model can use Nous-managed tools it does not have. Harmless
before, this becomes actively misleading under this change's semantics (an
empty toolset should be silent), so it is fixed here: an empty intersection now
returns an empty block.

**3. Default behavior is byte-identical.**

When `model.tools` is unset, behavior is unchanged from before the fix — tools
are sent, prompt blocks are injected. The change is a purely additive opt-in
that touches no existing user path.

## Tests

- `tests/agent/transports/test_chat_completions.py` — `TestSuppressTools`:
  default sends; suppressed legacy path omits; explicit `false` still sends;
  no-op when no tools; suppressed profile path omits (the path Ollama actually
  uses); profile default still sends.
- `tests/run_agent/test_79639_model_tools_suppress.py` — config parsing:
  `false` suppresses; default/`true`/missing model section do not.
- `tests/agent/test_system_prompt.py` — `TestToolUseEnforcementSuppress`:
  enforcement injected when active; suppress when `_suppress_tools`; a
  whole-class check that no tool block renders under suppression; and an
  execution-discipline block gated so it doesn't leak when tools are suppressed.
- `tests/agent/test_prompt_builder.py` — empty toolset and no-relevant-tools
  both return an empty Nous block.

All new tests pass; relevant suites (system_prompt, chat_completions,
prompt_builder, run_agent) are green.