### PR TITLE
fix(clarify): preserve resolved answers when clear_session races a button response

### DIFF
--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -92,6 +92,34 @@ class TestClarifyPrimitive:
             assert result == ""
 
 
+    def test_clear_session_preserves_resolved_response(self):
+        """clear_session must not clobber an answer that already won.
+
+        First-writer-wins (doryani-ai on PR #75732): a button callback that
+        resolved the entry before session cleanup must keep its response.
+        clear_session only cancels entries whose event is not yet set, so
+        the racing waiter observes the real answer, not the empty sentinel.
+        """
+        from tools import clarify_gateway as cm
+
+        cm.register("id-race", "sk-race", "Pick one", ["A", "B"])
+
+        def waiter():
+            return cm.wait_for_response("id-race", timeout=10.0)
+
+        with ThreadPoolExecutor(1) as pool:
+            fut = pool.submit(waiter)
+            time.sleep(0.05)
+            # Button wins the race first...
+            assert cm.resolve_gateway_clarify("id-race", "B") is True
+            # ...then session cleanup runs before the waiter wakes.
+            cancelled = cm.clear_session("sk-race")
+            assert cancelled == 0
+            result = fut.result(timeout=10.0)
+            # The real answer must survive cleanup, not the "" cancellation.
+            assert result == "B"
+
+
     def test_notify_register_unregister_clears_pending(self):
         """unregister_notify cancels any pending clarify so threads unwind."""
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -359,22 +359,39 @@ def clear_session(session_key: str) -> int:
 
     Used by session-boundary cleanup (e.g. ``/new``, gateway shutdown,
     cached-agent eviction) so blocked agent threads don't hang past the
-    end of their session.  Returns the number of entries cancelled.
+    end of their session.  Returns the number of entries actually
+    cancelled (i.e. whose event had not yet been set).  Already-resolved
+    entries are dropped from the registry but their response is preserved.
+
+    First-writer-wins: an entry whose event is already set has been resolved
+    by a real response (button callback or text intercept).  Session cleanup
+    must NOT overwrite that response with the empty cancellation sentinel —
+    the waiting agent thread would observe a cancelled prompt even though the
+    user answered.  Only unresolved entries are cancelled here.
     """
     with _lock:
         ids = list(_session_index.pop(session_key, []) or [])
         entries = [_entries.pop(cid, None) for cid in ids]
-    cancelled = 0
-    for entry in entries:
-        if entry is None:
-            continue
-        # Empty string sentinel — agent code can distinguish from a real
-        # response by inspecting the wait_for_response return value
-        # alongside its own timeout deadline.  Most callers just treat any
-        # falsy result as "user did not respond".
-        entry.response = ""
-        entry.event.set()
-        cancelled += 1
+        # The mutation loop must stay inside the lock: the pop above and the
+        # event.is_set() check below have to be atomic with respect to
+        # resolve_gateway_clarify, or a button callback could win between the
+        # pop and the check and have its answer clobbered by the sentinel.
+        cancelled = 0
+        for entry in entries:
+            if entry is None:
+                continue
+            # Entry is removed from the global registry regardless of its
+            # state — a cleared session must not be resurrected by late
+            # callbacks — but a resolved entry keeps its real response.
+            if entry.event.is_set():
+                continue
+            # Empty string sentinel — agent code can distinguish from a real
+            # response by inspecting the wait_for_response return value
+            # alongside its own timeout deadline.  Most callers just treat any
+            # falsy result as "user did not respond".
+            entry.response = ""
+            entry.event.set()
+            cancelled += 1
     return cancelled
 
 


### PR DESCRIPTION
## Summary

Session-boundary cleanup (`clear_session` in `tools/clarify_gateway.py`, called from `gateway/run.py` run-finalization and prompt-delivery-failure paths, plus `/new` and cached-agent eviction) unconditionally overwrote **every** pending entry's response with the empty cancellation sentinel — including entries already resolved by a button callback or text intercept. A waiter that had already observed the resolved event then returned `""`/`None` instead of the real answer, silently discarding the user's response.

This makes `clear_session` honor the same **first-writer-wins** contract the pending-clarify resolution path uses: only entries whose event is not yet set get cancelled; already-resolved entries are dropped from the registry but keep their response.

Reported by doryani-ai on #75732 (adversarial review of the clarify deadlock work); reproduced locally on current `main` before this change.

## Test plan

- [x] New regression test `test_clear_session_preserves_resolved_response` — button wins the race, then `clear_session` runs before the waiter wakes; asserts `cancelled == 0` and the waiter returns `"B"`. Verified it **fails on unfixed code** (`cancelled == 1`, answer clobbered) and **passes with the fix**.
- [x] Full clarify suite: 66 passed (tools + gateway + Telegram/Slack/Discord button tests) on the rebased branch.

## Notes

- Complements #75732 (first-writer-wins on `resolve_gateway_clarify`); this fix targets the `clear_session` path that PR does not touch. Both changes are mergeable independently.
- Related: #78069 (clarify free-text interception deadlock — the race class surfaced during that investigation), #71946 (native-choice clarify deadlock class).
