### PR TITLE
fix(packaging): ship bundled plugin manifests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -408,6 +408,10 @@ hermes_cli = ["observability/schemas/*.json"]
 # topic-setup image disappears. Loaded via Path(__file__).parent / "assets"
 # in gateway/status_phrases.py and gateway/run.py.
 gateway = ["assets/**/*"]
+# Bundled plugin discovery reads these manifests at runtime. Keep them in
+# sealed wheels with the plugin Python modules; without this declaration the
+# wheel contains adapters but discovery finds zero bundled plugins.
+plugins = ["**/plugin.yaml", "**/plugin.yml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_packaging_build_guard.py
+++ b/tests/test_packaging_build_guard.py
@@ -3,6 +3,8 @@
 import os
 import subprocess
 import sys
+import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -69,4 +71,26 @@ def test_artifact_build_allows_explicit_nix_package_build_marker(kind, artifact_
     result = _build_artifact(kind, tmp_path, nix_build=True)
 
     assert result.returncode == 0, result.stderr
-    assert list(tmp_path.glob(artifact_glob))
+    artifacts = list(tmp_path.glob(artifact_glob))
+    assert artifacts
+
+    expected = {
+        path.relative_to(PROJECT_ROOT).as_posix()
+        for pattern in ("plugin.yaml", "plugin.yml")
+        for path in (PROJECT_ROOT / "plugins").rglob(pattern)
+    }
+    assert expected, "expected bundled plugin manifests under plugins/"
+
+    if kind == "wheel":
+        with zipfile.ZipFile(artifacts[0]) as wheel:
+            shipped = set(wheel.namelist())
+    else:
+        with tarfile.open(artifacts[0]) as sdist:
+            shipped = {
+                name.split("/", 1)[1]
+                for name in sdist.getnames()
+                if "/" in name
+            }
+
+    missing = sorted(expected - shipped)
+    assert not missing, f"{kind} omits bundled plugin manifests: {missing}"


### PR DESCRIPTION
## Summary

Fixes #82916.

Hermes 2026.8.3 could install bundled plugin Python modules without their runtime manifests. Platform adapters then existed on disk but were invisible to plugin discovery, so Feishu, Discord, Slack, Teams and other platform plugins never registered.

This PR fixes the packaging contract at its source and adds artifact-level regression coverage.

## User-visible failure

On the affected installation:

```text
HERMES_PLUGINS_DEBUG=1 hermes gateway run
[plugins] DEBUG bundled/platforms: 0 manifest(s)
WARNING gateway.run: No adapter available for feishu
```

The gateway is not missing a Feishu implementation. It is missing the metadata that tells Hermes to discover and defer-load that implementation.

## Root cause

Bundled plugin layout:

```text
plugins/platforms/<name>/
├── __init__.py       # register(ctx) entry point
├── adapter.py        # platform implementation
└── plugin.yaml       # discovery manifest
```

Packaging flow before this PR:

```text
plugins.* package discovery
        │
        ├── Python files included
        └── plugin.yaml/plugin.yml omitted by package-data allowlist
                                      │
                                      ▼
                         installed wheel/sdist has no manifests
                                      │
                                      ▼
PluginManager._scan_directory() skips plugin directories
                                      │
                                      ▼
_register_deferred_platform() never runs
                                      │
                                      ▼
platform_registry remains empty
                                      │
                                      ▼
gateway.run._create_adapter() returns no adapter
```
## Infographic : 

<img width="1024" height="1024" alt="infographic" src="https://github.com/user-attachments/assets/d44776cf-6a56-43b5-8553-709aaf0873e8" />


The specific metadata gap was in `[tool.setuptools.package-data]`: `plugins.*` was listed for Python package discovery, but no `plugins` data entry covered YAML manifests.

This regression appeared when packaging configuration was simplified in #68217. It reintroduced the same packaging failure class previously fixed by #34034 and #28149.

## Fix

`pyproject.toml` now declares:

```toml
[tool.setuptools.package-data]
plugins = ["**/plugin.yaml", "**/plugin.yml"]
```

This keeps manifest selection beside the package metadata that controls artifact contents. No gateway fallback, adapter duplication, import workaround, or platform-specific branch was added.

## Regression protection

`tests/test_packaging_build_guard.py` now:

1. Builds a real PEP 517 wheel.
2. Builds a real PEP 517 sdist.
3. Enumerates every `plugin.yaml` and `plugin.yml` under the source `plugins/` tree.
4. Verifies every source manifest exists in the generated artifact.
5. Continues testing the existing non-Nix build guard.

This catches both:
- Python code present but manifest absent.
- A future glob that matches only a subset of nested plugin categories.

## Validation evidence

### Pre-fix reproduction

Built from the affected packaging configuration:

```text
wheel plugin manifests: 0
sdist plugin manifests: 0
```

The new regression test failed with all bundled manifests reported missing.

### Fixed artifacts

```text
wheel plugin manifests: 97
sdist plugin manifests: 97
```

A clean extracted-wheel smoke test then executed the real scanner:

```text
platform manifests discovered: 22
required manifests discovered: feishu-platform, discord-platform
```

### Local tests

```text
pytest tests/test_packaging_build_guard.py
4 passed

pytest tests/test_project_metadata.py tests/test_packaging_metadata.py
13 passed

pytest tests/hermes_cli/test_plugins.py        tests/hermes_cli/test_plugin_scanner_recursion.py        tests/providers/test_plugin_discovery.py
57 passed

Combined focused validation
74 passed
```

Ruff passed for changed files.

### GitHub CI

PR checks completed successfully:

- 34 checks passed
- 0 failed
- Python test slices passed
- Python E2E passed
- Windows-only tests passed
- macOS-only tests passed
- Ruff/type checks passed
- uv.lock validation passed
- OSV/supply-chain checks passed
- Docker build/test workflow passed

## Scope and non-goals

- Preserves existing plugin discovery and deferred-loading behavior.
- Preserves the non-Nix wheel/sdist build guard.
- Does not re-enable Homebrew/PyPI as officially supported distribution methods.
- Does not modify gateway adapter selection.
- Does not alter plugin manifests or platform code.
- Does not change unrelated bundled assets such as dashboard/sidecar files.

The fix makes generated artifacts complete for the manifest contract without resurrecting removed distribution-policy paths.

## Files changed

- `pyproject.toml`: include bundled plugin manifests in setuptools package data.
- `tests/test_packaging_build_guard.py`: verify wheel and sdist contents against the complete source manifest set.

## Release note

The fix takes effect in artifacts built from the merged commit. Existing 2026.8.3 installations remain broken until upgraded to a release containing this change.

Related: #82916, #34034, #28149, #68217.
