### PR TITLE
fix(plugins): report the active memory provider truthfully (#82898)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11729,6 +11729,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # using it alone made freshly-installed, not-yet-enabled plugins
                 # look like "nothing installed".
                 from hermes_cli.plugins_cmd import (
+                    PLUGIN_STATUS_ACTIVE,
+                    _active_memory_provider_dir,
                     _discover_all_plugins,
                     _get_disabled_set,
                     _get_enabled_set,
@@ -11738,6 +11740,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 entries = _discover_all_plugins()
                 enabled = _get_enabled_set()
                 disabled = _get_disabled_set()
+                active_provider_dir = _active_memory_provider_dir()
 
                 # `/plugins` is a quick glance — default to user-installed
                 # plugins (what the user actually added). Bundled provider/
@@ -11765,8 +11768,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
                     print(f"User plugins ({len(user_entries)}):")
                     for name, version, _desc, source, _dir, key in sorted(user_entries):
-                        state = _plugin_status(name, enabled, disabled, key=key)
-                        glyph = {"enabled": "✓", "disabled": "✗"}.get(state, "○")
+                        state = _plugin_status(
+                            name,
+                            enabled,
+                            disabled,
+                            key=key,
+                            dir_path=_dir,
+                            active_provider_dir=active_provider_dir,
+                        )
+                        glyph = {
+                            "enabled": "✓",
+                            PLUGIN_STATUS_ACTIVE: "✓",
+                            "disabled": "✗",
+                        }.get(state, "○")
                         ver = f" v{version}" if version else ""
                         info = loaded.get(name) or {}
                         bits = []

--- a/contributors/emails/chinmayrawat15@gmail.com
+++ b/contributors/emails/chinmayrawat15@gmail.com
@@ -1,0 +1,1 @@
+Chinmayrawat15

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -2315,7 +2315,14 @@ def cmd_show(name: str) -> None:
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
-    status = _plugin_status(pname, enabled, disabled, key=key)
+    status = _plugin_status(
+        pname,
+        enabled,
+        disabled,
+        key=key,
+        dir_path=dir_path,
+        active_provider_dir=_active_memory_provider_dir(),
+    )
 
     console.print()
     console.print(f"[bold]{pname}[/bold]" + (f" [dim]v{version}[/dim]" if version else ""))

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1928,24 +1928,99 @@ def _discover_entrypoint_plugins() -> list[tuple[str, str, str, str]]:
     return entries
 
 
-def _plugin_status(name: str, enabled: set, disabled: set, key: str = "") -> str:
-    """Return the user-facing activation state for a plugin name or key."""
+# Status token for a plugin that is live as the configured memory provider.
+# Kept a single word so ``--plain``/``--json`` consumers can still split on
+# whitespace; the rich table renders the longer human label.
+PLUGIN_STATUS_ACTIVE = "active"
+
+
+def _active_memory_provider_dir() -> Path | None:
+    """Resolve ``memory.provider`` to the directory the loader would use.
+
+    Returns None when no external provider is configured, or when the
+    configured name does not resolve. ``plugins.memory.load_memory_provider``
+    goes through this same ``find_provider_dir`` lookup, so a name that does
+    not resolve is not actually serving memory and must not be labelled
+    active.
+    """
+    name = _get_current_memory_provider()
+    if not name:
+        return None
+    try:
+        from plugins.memory import find_provider_dir
+
+        return find_provider_dir(name)
+    except Exception:
+        return None
+
+
+def _same_dir(left, right) -> bool:
+    """True when two path-ish values resolve to the same directory."""
+    if left is None or right is None:
+        return False
+    try:
+        return Path(left).resolve() == Path(right).resolve()
+    except Exception:
+        return False
+
+
+def _plugin_status(
+    name: str,
+    enabled: set,
+    disabled: set,
+    key: str = "",
+    dir_path=None,
+    active_provider_dir=None,
+) -> str:
+    """Return the user-facing activation state for a plugin name or key.
+
+    A plugin selected through ``memory.provider`` is live without ever being
+    listed in ``plugins.enabled``, so reporting it as "not enabled" is wrong
+    (#82898).
+
+    The active provider is matched by *resolved directory*, not by name.
+    ``_read_manifest_info`` derives ``key`` from the manifest name at depth 0
+    (``key = name`` when there is no prefix), while ``memory.provider`` names
+    the plugin's directory — ``_iter_provider_dirs`` yields ``child.name``. A
+    plugin installed at ``plugins/mnemosyne/`` whose manifest declares
+    ``name: mnemosyne-hermes`` therefore has no name-shaped tie to
+    ``memory.provider: mnemosyne``. Comparing directories also avoids
+    mislabelling an unrelated plugin that merely shares a name with the
+    configured provider.
+    """
     if name in disabled or key in disabled:
         return "disabled"
+    if _same_dir(dir_path, active_provider_dir):
+        return PLUGIN_STATUS_ACTIVE
     if name in enabled or key in enabled:
         return "enabled"
     return "not enabled"
 
 
-def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set) -> list:
+def _filter_plugin_entries(
+    entries: list,
+    args: Any,
+    enabled: set,
+    disabled: set,
+    active_provider_dir=None,
+) -> list:
     """Apply ``hermes plugins list`` CLI filters."""
     filtered = entries
     if getattr(args, "no_bundled", False) or getattr(args, "user", False):
         filtered = [entry for entry in filtered if entry[3] != "bundled"]
     if getattr(args, "enabled", False):
+        # An active memory provider is loaded and running, so it belongs in
+        # --enabled even though it is absent from `plugins.enabled`.
         filtered = [
             entry for entry in filtered
-            if _plugin_status(entry[0], enabled, disabled, key=entry[5]) == "enabled"
+            if _plugin_status(
+                entry[0],
+                enabled,
+                disabled,
+                key=entry[5],
+                dir_path=entry[4],
+                active_provider_dir=active_provider_dir,
+            ) in ("enabled", PLUGIN_STATUS_ACTIVE)
         ]
     return filtered
 
@@ -1964,25 +2039,42 @@ def cmd_list(args: Any | None = None) -> None:
 
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
-    entries = _filter_plugin_entries(entries, args, enabled, disabled)
+    active_provider_dir = _active_memory_provider_dir()
+    entries = _filter_plugin_entries(
+        entries, args, enabled, disabled, active_provider_dir=active_provider_dir
+    )
 
     if getattr(args, "json", False):
         payload = [
             {
                 "name": name,
-                "status": _plugin_status(name, enabled, disabled, key=key),
+                "status": _plugin_status(
+                    name,
+                    enabled,
+                    disabled,
+                    key=key,
+                    dir_path=dir_path,
+                    active_provider_dir=active_provider_dir,
+                ),
                 "version": str(version),
                 "description": description,
                 "source": source,
             }
-            for name, version, description, source, _dir, key in entries
+            for name, version, description, source, dir_path, key in entries
         ]
         print(json.dumps(payload, indent=2))
         return
 
     if getattr(args, "plain", False):
-        for name, version, _description, source, _dir, key in entries:
-            status = _plugin_status(name, enabled, disabled, key=key)
+        for name, version, _description, source, dir_path, key in entries:
+            status = _plugin_status(
+                name,
+                enabled,
+                disabled,
+                key=key,
+                dir_path=dir_path,
+                active_provider_dir=active_provider_dir,
+            )
             print(f"{status:12} {source:8} {str(version):8} {name}")
         return
 
@@ -1997,10 +2089,19 @@ def cmd_list(args: Any | None = None) -> None:
     table.add_column("Description")
     table.add_column("Source", style="dim")
 
-    for name, version, description, source, _dir, key in entries:
-        status_name = _plugin_status(name, enabled, disabled, key=key)
+    for name, version, description, source, dir_path, key in entries:
+        status_name = _plugin_status(
+            name,
+            enabled,
+            disabled,
+            key=key,
+            dir_path=dir_path,
+            active_provider_dir=active_provider_dir,
+        )
         if status_name == "disabled":
             status = "[red]disabled[/red]"
+        elif status_name == PLUGIN_STATUS_ACTIVE:
+            status = "[green]active (memory provider)[/green]"
         elif status_name == "enabled":
             status = "[green]enabled[/green]"
         else:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18199,8 +18199,6 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         dir_path = Path(dir_str)
         if aliases & disabled_set:
             runtime_status = "disabled"
-        elif aliases & enabled_set:
-            runtime_status = "enabled"
         elif _same_dir(dir_path, active_provider_dir):
             # Selected through `memory.provider`, which never populates
             # `plugins.enabled` — it is loaded and running, so "inactive" is
@@ -18209,7 +18207,14 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
             # membership in `plugins.enabled`, which does not govern the
             # provider, so the Plugins page must not offer Disable here — it
             # points at the memory-provider selector instead.
+            #
+            # Checked before `plugins.enabled` to match the CLI's
+            # `_plugin_status`. A plugin can be in both sets, and the provider
+            # is the stronger fact: it is what is actually serving memory, and
+            # it is the state whose lifecycle the toggle cannot govern.
             runtime_status = "active"
+        elif aliases & enabled_set:
+            runtime_status = "enabled"
         else:
             runtime_status = "inactive"
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18168,9 +18168,11 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         _get_current_context_engine,
         _get_current_memory_provider,
         _discover_context_engines,
+        _active_memory_provider_dir,
         _get_disabled_set,
         _get_enabled_set,
         _read_manifest as _read_plugin_manifest_at,
+        _same_dir,
     )
 
     dashboard_list = _get_dashboard_plugins()
@@ -18178,6 +18180,7 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
 
     disabled_set = _get_disabled_set()
     enabled_set = _get_enabled_set()
+    active_provider_dir = _active_memory_provider_dir()
 
     # Read user-hidden plugins from config for the user_hidden field.
     config = load_config()
@@ -18193,14 +18196,23 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
         aliases = {name}
         if key:
             aliases.add(key)
+        dir_path = Path(dir_str)
         if aliases & disabled_set:
             runtime_status = "disabled"
         elif aliases & enabled_set:
             runtime_status = "enabled"
+        elif _same_dir(dir_path, active_provider_dir):
+            # Selected through `memory.provider`, which never populates
+            # `plugins.enabled` — it is loaded and running, so "inactive" is
+            # wrong (#82898). Reported as a distinct "active" state (typed in
+            # web/src/lib/api.ts) rather than "enabled": enable/disable toggle
+            # membership in `plugins.enabled`, which does not govern the
+            # provider, so the Plugins page must not offer Disable here — it
+            # points at the memory-provider selector instead.
+            runtime_status = "active"
         else:
             runtime_status = "inactive"
 
-        dir_path = Path(dir_str)
         dm = dash_by_name.get(name)
         has_dash_manifest = dm is not None or (dir_path / "dashboard" / "manifest.json").exists()
 

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -387,3 +387,41 @@ def test_cmd_list_plain_status_column_stays_aligned(monkeypatch, capsys, tmp_pat
     ]
 
 
+def test_e2e_cmd_show_reports_active_provider(monkeypatch, tmp_path, capsys):
+    """`hermes plugins show` is the same surface as `list` and must agree.
+
+    `cmd_show` renders the same activation state for a single plugin, so a
+    provider-backed plugin reported as "active" by `cmd_list` must not read
+    "not enabled" here — the sibling call path of #82898.
+    """
+    home = tmp_path / "hermes_home"
+    home.mkdir(parents=True)
+    _install_real_provider_plugin(home, dir_name="mnemosyne", manifest_name="mnemosyne-hermes")
+    (home / "config.yaml").write_text("memory:\n  provider: mnemosyne\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    plugins_cmd.cmd_show("mnemosyne-hermes")
+
+    out = capsys.readouterr().out
+    assert f"Status: {plugins_cmd.PLUGIN_STATUS_ACTIVE}" in out
+    assert "not enabled" not in out
+
+
+def test_e2e_cmd_show_unrelated_plugin_still_not_enabled(monkeypatch, tmp_path, capsys):
+    """The directory match must not leak onto a plugin that is not the provider."""
+    home = tmp_path / "hermes_home"
+    home.mkdir(parents=True)
+    _install_real_provider_plugin(home, dir_name="mnemosyne", manifest_name="mnemosyne-hermes")
+    other = home / "plugins" / "unrelated"
+    other.mkdir(parents=True)
+    (other / "plugin.yaml").write_text(
+        "name: unrelated\nversion: 1.0.0\ndescription: Not a provider\n", encoding="utf-8"
+    )
+    (home / "config.yaml").write_text("memory:\n  provider: mnemosyne\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    plugins_cmd.cmd_show("unrelated")
+
+    assert "Status: not enabled" in capsys.readouterr().out
+
+

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -127,3 +127,263 @@ def test_declared_capabilities_for_entrypoint_uses_distribution_metadata(
     ]
 
 
+# ---------------------------------------------------------------------------
+# Active memory provider status (#82898)
+#
+# A plugin selected through `memory.provider` is live while appearing in
+# neither `plugins.enabled` nor `plugins.disabled`, so it used to render as
+# "not enabled" while actively serving memory.
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_status_active_provider_matched_by_directory_not_name(tmp_path):
+    """The provider is matched by directory, because the name cannot match.
+
+    `_read_manifest_info` derives `key` from the manifest name at depth 0, so a
+    plugin installed at `plugins/mnemosyne/` whose manifest declares
+    `name: mnemosyne-hermes` has *neither* a name nor a key equal to
+    `memory.provider: mnemosyne`. Only the directory ties them together.
+    """
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    provider_dir.mkdir(parents=True)
+
+    status = plugins_cmd._plugin_status(
+        "mnemosyne-hermes",
+        set(),
+        set(),
+        key="mnemosyne-hermes",
+        dir_path=provider_dir,
+        active_provider_dir=provider_dir,
+    )
+
+    assert status == plugins_cmd.PLUGIN_STATUS_ACTIVE
+
+
+def test_plugin_status_does_not_mislabel_unrelated_plugin(tmp_path):
+    """A different plugin must not inherit the active-provider label."""
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    other_dir = tmp_path / "plugins" / "unrelated"
+    provider_dir.mkdir(parents=True)
+    other_dir.mkdir(parents=True)
+
+    status = plugins_cmd._plugin_status(
+        "unrelated",
+        set(),
+        set(),
+        key="unrelated",
+        dir_path=other_dir,
+        active_provider_dir=provider_dir,
+    )
+
+    assert status == "not enabled"
+
+
+def test_plugin_status_without_active_provider_is_unchanged():
+    """Existing callers that pass no directory keep the old behaviour."""
+    assert plugins_cmd._plugin_status("p", set(), set(), key="p") == "not enabled"
+    assert plugins_cmd._plugin_status("p", {"p"}, set(), key="p") == "enabled"
+    assert plugins_cmd._plugin_status("p", set(), {"p"}, key="p") == "disabled"
+
+
+def test_plugin_status_explicit_disable_wins_over_active(tmp_path):
+    """An explicit `plugins.disabled` entry still reports disabled."""
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    provider_dir.mkdir(parents=True)
+
+    status = plugins_cmd._plugin_status(
+        "mnemosyne-hermes",
+        set(),
+        {"mnemosyne-hermes"},
+        key="mnemosyne-hermes",
+        dir_path=provider_dir,
+        active_provider_dir=provider_dir,
+    )
+
+    assert status == "disabled"
+
+
+def test_active_memory_provider_dir_none_when_name_unresolvable(monkeypatch):
+    """An unresolvable provider name is not serving memory, so not active.
+
+    `load_memory_provider` resolves through the same `find_provider_dir`
+    lookup — if that returns None the provider never loads, and nothing
+    should be labelled active.
+    """
+    monkeypatch.setattr(plugins_cmd, "_get_current_memory_provider", lambda: "ghost")
+    monkeypatch.setattr("plugins.memory.find_provider_dir", lambda name: None)
+
+    assert plugins_cmd._active_memory_provider_dir() is None
+
+
+def test_active_memory_provider_dir_none_when_unconfigured(monkeypatch):
+    monkeypatch.setattr(plugins_cmd, "_get_current_memory_provider", lambda: "")
+
+    assert plugins_cmd._active_memory_provider_dir() is None
+
+
+def test_filter_plugin_entries_enabled_includes_active_provider(tmp_path):
+    """`--enabled` must show the active provider — it is loaded and running."""
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    other_dir = tmp_path / "plugins" / "unrelated"
+    provider_dir.mkdir(parents=True)
+    other_dir.mkdir(parents=True)
+
+    entries = [
+        ("mnemosyne-hermes", "0.5.0", "Memory", "user", provider_dir, "mnemosyne-hermes"),
+        ("unrelated", "1.0.0", "Other", "user", other_dir, "unrelated"),
+    ]
+
+    filtered = plugins_cmd._filter_plugin_entries(
+        entries,
+        _args(enabled=True),
+        enabled=set(),
+        disabled=set(),
+        active_provider_dir=provider_dir,
+    )
+
+    assert [entry[0] for entry in filtered] == ["mnemosyne-hermes"]
+
+
+def test_cmd_list_json_reports_active_provider(monkeypatch, capsys, tmp_path):
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    provider_dir.mkdir(parents=True)
+    entries = [
+        ("mnemosyne-hermes", "0.5.0", "Memory", "user", provider_dir, "mnemosyne-hermes"),
+    ]
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(
+        plugins_cmd, "_active_memory_provider_dir", lambda: provider_dir
+    )
+
+    plugins_cmd.cmd_list(_args(json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["status"] == plugins_cmd.PLUGIN_STATUS_ACTIVE
+
+
+def _install_real_provider_plugin(home, *, dir_name, manifest_name):
+    """Write a real memory-provider plugin into a temp HERMES_HOME.
+
+    Directory name is what ``memory.provider`` refers to; the manifest name is
+    what the plugin listing displays. Keeping them different is the point of
+    the regression.
+    """
+    plugin_dir = home / "plugins" / dir_name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        f"name: {manifest_name}\nversion: 0.5.0\ndescription: Memory provider\n",
+        encoding="utf-8",
+    )
+    # plugins.memory._is_memory_provider_dir() scans __init__.py for these
+    # markers, so the directory must really look like a provider.
+    (plugin_dir / "__init__.py").write_text(
+        "from plugins.memory import MemoryProvider\n\n\n"
+        "class Provider(MemoryProvider):\n    pass\n",
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+def test_e2e_real_resolution_marks_provider_active(monkeypatch, tmp_path, capsys):
+    """End-to-end through the real resolution chain — nothing mocked.
+
+    config.yaml -> _get_current_memory_provider -> find_provider_dir ->
+    _is_memory_provider_dir -> directory match -> status, then out through
+    the real `cmd_list` JSON renderer. The unit tests above hand
+    `active_provider_dir` in directly; this one proves the lookup actually
+    resolves against a temp HERMES_HOME.
+    """
+    home = tmp_path / "hermes_home"
+    home.mkdir(parents=True)
+    _install_real_provider_plugin(home, dir_name="mnemosyne", manifest_name="mnemosyne-hermes")
+
+    other = home / "plugins" / "unrelated"
+    other.mkdir(parents=True)
+    (other / "plugin.yaml").write_text(
+        "name: unrelated\nversion: 1.0.0\ndescription: Not a provider\n", encoding="utf-8"
+    )
+
+    (home / "config.yaml").write_text(
+        "memory:\n  provider: mnemosyne\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # The real lookup must find the plugin's directory from the bare
+    # `memory.provider` name.
+    resolved = plugins_cmd._active_memory_provider_dir()
+    assert resolved is not None
+    assert resolved.name == "mnemosyne"
+
+    plugins_cmd.cmd_list(_args(json=True, user=True, no_bundled=True))
+
+    payload = {row["name"]: row for row in json.loads(capsys.readouterr().out)}
+    assert payload["mnemosyne-hermes"]["status"] == plugins_cmd.PLUGIN_STATUS_ACTIVE
+    assert payload["unrelated"]["status"] == "not enabled"
+
+
+def test_e2e_unresolvable_provider_is_not_marked_active(monkeypatch, tmp_path):
+    """A configured name that does not resolve is not serving memory.
+
+    `load_memory_provider` goes through the same `find_provider_dir` lookup,
+    so an unresolvable name must not be labelled active anywhere.
+    """
+    home = tmp_path / "hermes_home"
+    home.mkdir(parents=True)
+    _install_real_provider_plugin(home, dir_name="mnemosyne", manifest_name="mnemosyne-hermes")
+    (home / "config.yaml").write_text(
+        "memory:\n  provider: does-not-exist\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert plugins_cmd._active_memory_provider_dir() is None
+
+
+def test_e2e_plain_directory_without_provider_markers_is_not_active(monkeypatch, tmp_path):
+    """A same-named directory that is not a provider must not resolve.
+
+    Guards the directory match against a plugin that merely shares the
+    configured name without being a memory provider at all.
+    """
+    home = tmp_path / "hermes_home"
+    home.mkdir(parents=True)
+    impostor = home / "plugins" / "mnemosyne"
+    impostor.mkdir(parents=True)
+    (impostor / "plugin.yaml").write_text(
+        "name: mnemosyne\nversion: 1.0.0\ndescription: Not a provider\n", encoding="utf-8"
+    )
+    (impostor / "__init__.py").write_text("# no provider markers\n", encoding="utf-8")
+    (home / "config.yaml").write_text("memory:\n  provider: mnemosyne\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert plugins_cmd._active_memory_provider_dir() is None
+
+
+def test_cmd_list_plain_status_column_stays_aligned(monkeypatch, capsys, tmp_path):
+    """The active token stays within the 12-char status column."""
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    provider_dir.mkdir(parents=True)
+    entries = [
+        ("mnemosyne-hermes", "0.5.0", "Memory", "user", provider_dir, "mnemosyne-hermes"),
+    ]
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(
+        plugins_cmd, "_active_memory_provider_dir", lambda: provider_dir
+    )
+
+    plugins_cmd.cmd_list(_args(plain=True))
+
+    line = capsys.readouterr().out.strip()
+    assert line.split() == [
+        plugins_cmd.PLUGIN_STATUS_ACTIVE,
+        "user",
+        "0.5.0",
+        "mnemosyne-hermes",
+    ]
+
+

--- a/tests/hermes_cli/test_plugins_hub_active_memory_provider.py
+++ b/tests/hermes_cli/test_plugins_hub_active_memory_provider.py
@@ -152,3 +152,41 @@ def test_no_configured_provider_leaves_rows_inactive(monkeypatch, tmp_path):
     payload = web_server._merged_plugins_hub(force_refresh=True)
 
     assert _row_for(payload)["unrelated"]["runtime_status"] == "inactive"
+
+
+def test_provider_also_in_enabled_set_agrees_with_the_cli(monkeypatch, tmp_path):
+    """The hub and the CLI must not disagree when a provider is *also* enabled.
+
+    A plugin can be listed in `plugins.enabled` and selected through
+    `memory.provider` at once. The CLI's `_plugin_status` checks the provider
+    directory before `plugins.enabled`, so it reports "active"; the hub checked
+    `plugins.enabled` first, so it reported "enabled" and the Plugins page put
+    the Disable button back — the exact control this change removes, since
+    disabling only edits `plugins.enabled` and would not stop the provider.
+    """
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    provider_dir.mkdir(parents=True)
+    rows = [
+        ("mnemosyne-hermes", "0.5.0", "Memory", "user", str(provider_dir), "mnemosyne-hermes"),
+    ]
+    _patch_hub(
+        monkeypatch,
+        rows=rows,
+        active_provider_dir=provider_dir,
+        enabled={"mnemosyne-hermes"},
+    )
+
+    payload = web_server._merged_plugins_hub(force_refresh=True)
+    hub_status = _row_for(payload)["mnemosyne-hermes"]["runtime_status"]
+
+    cli_status = plugins_cmd._plugin_status(
+        "mnemosyne-hermes",
+        {"mnemosyne-hermes"},
+        set(),
+        key="mnemosyne-hermes",
+        dir_path=provider_dir,
+        active_provider_dir=provider_dir,
+    )
+
+    assert cli_status == plugins_cmd.PLUGIN_STATUS_ACTIVE
+    assert hub_status == cli_status

--- a/tests/hermes_cli/test_plugins_hub_active_memory_provider.py
+++ b/tests/hermes_cli/test_plugins_hub_active_memory_provider.py
@@ -1,0 +1,154 @@
+"""Dashboard plugins tab must not report the live memory provider as inactive.
+
+Regression test for #82898. `_merged_plugins_hub()` powers
+``/api/dashboard/plugins/hub``; it derived ``runtime_status`` purely from
+``plugins.enabled`` / ``plugins.disabled``, so a plugin selected through
+``memory.provider`` — which populates neither set — rendered as ``inactive``
+with an "Enable" button while it was already serving memory.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import plugins_cmd, web_server
+from tools import registry as tools_registry
+
+
+def _patch_hub(monkeypatch, *, rows, active_provider_dir, enabled=None, disabled=None):
+    monkeypatch.setattr(web_server, "_get_dashboard_plugins", lambda force_rescan=False: [])
+    monkeypatch.setattr(web_server, "_discover_memory_provider_statuses", lambda: [])
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: Path("/tmp/hermes-home"))
+    monkeypatch.setattr(
+        web_server, "load_config", lambda: {"dashboard": {"hidden_plugins": []}}
+    )
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: list(rows))
+    monkeypatch.setattr(plugins_cmd, "_get_current_context_engine", lambda: "compressor")
+    monkeypatch.setattr(plugins_cmd, "_get_current_memory_provider", lambda: "mnemosyne")
+    monkeypatch.setattr(plugins_cmd, "_discover_context_engines", lambda: [])
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: disabled or set())
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: enabled or set())
+    monkeypatch.setattr(
+        plugins_cmd, "_active_memory_provider_dir", lambda: active_provider_dir
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_read_manifest", lambda _path: {"provides_tools": []}
+    )
+    monkeypatch.setattr(
+        tools_registry.registry,
+        "get_entry",
+        lambda _name: SimpleNamespace(check_fn=None),
+    )
+    web_server._invalidate_plugins_hub_cache()
+
+
+def _row_for(name):
+    return {row["name"]: row for row in name["plugins"]}
+
+
+def test_active_memory_provider_is_not_reported_inactive(monkeypatch, tmp_path):
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    provider_dir.mkdir(parents=True)
+    rows = [
+        ("mnemosyne-hermes", "0.5.0", "Memory", "user", str(provider_dir), "mnemosyne-hermes"),
+    ]
+    _patch_hub(monkeypatch, rows=rows, active_provider_dir=provider_dir)
+
+    payload = web_server._merged_plugins_hub(force_refresh=True)
+
+    row = _row_for(payload)["mnemosyne-hermes"]
+    # "active" is a distinct state, typed in web/src/lib/api.ts alongside
+    # disabled/enabled/inactive. It must not be "enabled": the Plugins page
+    # offers Disable for enabled rows, and disabling only edits
+    # `plugins.enabled` — it would not stop the provider.
+    assert row["runtime_status"] == "active"
+
+
+def test_unrelated_plugin_still_reports_inactive(monkeypatch, tmp_path):
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    other_dir = tmp_path / "plugins" / "unrelated"
+    provider_dir.mkdir(parents=True)
+    other_dir.mkdir(parents=True)
+    rows = [
+        ("mnemosyne-hermes", "0.5.0", "Memory", "user", str(provider_dir), "mnemosyne-hermes"),
+        ("unrelated", "1.0.0", "Other", "user", str(other_dir), "unrelated"),
+    ]
+    _patch_hub(monkeypatch, rows=rows, active_provider_dir=provider_dir)
+
+    payload = web_server._merged_plugins_hub(force_refresh=True)
+
+    by_name = _row_for(payload)
+    assert by_name["mnemosyne-hermes"]["runtime_status"] == "active"
+    assert by_name["unrelated"]["runtime_status"] == "inactive"
+
+
+def test_explicitly_disabled_provider_still_reports_disabled(monkeypatch, tmp_path):
+    """An explicit opt-out keeps precedence over the active-provider signal."""
+    provider_dir = tmp_path / "plugins" / "mnemosyne"
+    provider_dir.mkdir(parents=True)
+    rows = [
+        ("mnemosyne-hermes", "0.5.0", "Memory", "user", str(provider_dir), "mnemosyne-hermes"),
+    ]
+    _patch_hub(
+        monkeypatch,
+        rows=rows,
+        active_provider_dir=provider_dir,
+        disabled={"mnemosyne-hermes"},
+    )
+
+    payload = web_server._merged_plugins_hub(force_refresh=True)
+
+    assert _row_for(payload)["mnemosyne-hermes"]["runtime_status"] == "disabled"
+
+
+def test_e2e_hub_resolves_provider_without_mocking_the_lookup(monkeypatch, tmp_path):
+    """End-to-end: the hub resolves the provider itself, against a real tree.
+
+    Only the dashboard-extension scan and the tool-registry probe are stubbed
+    (unrelated scaffolding, and the probe must stay off the request path).
+    Plugin discovery, config loading and the whole `memory.provider` ->
+    `find_provider_dir` chain run for real, so this cannot pass on a mocked
+    lookup alone.
+    """
+    home = tmp_path / "hermes_home"
+    plugin_dir = home / "plugins" / "mnemosyne"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: mnemosyne-hermes\nversion: 0.5.0\ndescription: Memory provider\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "from plugins.memory import MemoryProvider\n\n\n"
+        "class Provider(MemoryProvider):\n    pass\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "memory:\n  provider: mnemosyne\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    monkeypatch.setattr(web_server, "_get_dashboard_plugins", lambda force_rescan=False: [])
+    monkeypatch.setattr(web_server, "_discover_memory_provider_statuses", lambda: [])
+    monkeypatch.setattr(
+        tools_registry.registry,
+        "get_entry",
+        lambda _name: SimpleNamespace(check_fn=None),
+    )
+    web_server._invalidate_plugins_hub_cache()
+
+    payload = web_server._merged_plugins_hub(force_refresh=True)
+
+    row = _row_for(payload)["mnemosyne-hermes"]
+    assert row["runtime_status"] == "active"
+
+
+def test_no_configured_provider_leaves_rows_inactive(monkeypatch, tmp_path):
+    other_dir = tmp_path / "plugins" / "unrelated"
+    other_dir.mkdir(parents=True)
+    rows = [("unrelated", "1.0.0", "Other", "user", str(other_dir), "unrelated")]
+    _patch_hub(monkeypatch, rows=rows, active_provider_dir=None)
+
+    payload = web_server._merged_plugins_hub(force_refresh=True)
+
+    assert _row_for(payload)["unrelated"]["runtime_status"] == "inactive"

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2412,6 +2412,8 @@ def _(rid, params: dict) -> dict:
         return err
     try:
         from hermes_cli.plugins_cmd import (
+            PLUGIN_STATUS_ACTIVE,
+            _active_memory_provider_dir,
             _bundled_default_on,
             _discover_all_plugins,
             _get_disabled_set,
@@ -2423,11 +2425,25 @@ def _(rid, params: dict) -> dict:
         def _rows():
             enabled = _get_enabled_set()
             disabled = _get_disabled_set()
+            active_provider_dir = _active_memory_provider_dir()
             out = []
             for name, version, desc, source, _dir, key in sorted(
                 _discover_all_plugins()
             ):
-                status = _plugin_status(name, enabled, disabled, key=key)
+                status = _plugin_status(
+                    name,
+                    enabled,
+                    disabled,
+                    key=key,
+                    dir_path=_dir,
+                    active_provider_dir=active_provider_dir,
+                )
+                # A plugin selected via `memory.provider` is loaded and running
+                # without appearing in `plugins.enabled`. Report it with the
+                # existing vocabulary rather than a new status value, so
+                # clients switching on status keep working (#82898).
+                if status == PLUGIN_STATUS_ACTIVE:
+                    status = "enabled"
                 # Bundled backends/platforms/providers are active without an
                 # explicit enable (they "just work" — plugins.py). Reporting
                 # them "not enabled" reads as OFF in clients when they are in

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -380,6 +380,9 @@ export const en: Translations = {
   },
 
   pluginsPage: {
+    activeProvider: "active (memory provider)",
+    activeProviderHint: "Live memory provider (memory.provider in config.yaml)",
+    activeProviderManaged: "Managed via the memory provider selector above.",
     contextEngineLabel: "Context engine",
     dashboardSlots: "Dashboard slots",
     disableRuntime: "Disable",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2609,7 +2609,9 @@ export interface HubAgentPluginRow {
   version: string;
   description: string;
   source: string;
-  runtime_status: "disabled" | "enabled" | "inactive";
+  // "active": live memory provider selected via `memory.provider` — running
+  // without being in `plugins.enabled`, so enable/disable does not apply.
+  runtime_status: "disabled" | "enabled" | "inactive" | "active";
   has_dashboard_manifest: boolean;
   dashboard_manifest: PluginManifestResponse | null;
   path: string;

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -941,7 +941,7 @@ function PluginRowCard(props: PluginRowCardProps) {
   const [confirmRemove, setConfirmRemove] = useState(false);
 
   const badgeTone =
-    row.runtime_status === "enabled"
+    row.runtime_status === "enabled" || row.runtime_status === "active"
       ? "success"
       : row.runtime_status === "disabled"
         ? "destructive"
@@ -967,7 +967,16 @@ function PluginRowCard(props: PluginRowCardProps) {
 
             <Badge tone="outline">v{row.version || "—"}</Badge>
 
-            <Badge tone={badgeTone}>{row.runtime_status}</Badge>
+            <Badge
+              title={
+                row.runtime_status === "active"
+                  ? "Live memory provider (memory.provider in config.yaml)"
+                  : undefined
+              }
+              tone={badgeTone}
+            >
+              {row.runtime_status === "active" ? "active (memory provider)" : row.runtime_status}
+            </Badge>
 
             {row.auth_required ? (
               <Badge tone="destructive">{t.pluginsPage.authRequired}</Badge>
@@ -975,7 +984,16 @@ function PluginRowCard(props: PluginRowCardProps) {
           </div>
 
           <div className="flex flex-wrap items-center gap-2 shrink-0">
-            {row.runtime_status === "enabled" ? (
+            {row.runtime_status === "active" ? (
+              // The enable/disable toggle edits `plugins.enabled` /
+              // `plugins.disabled`, which does not govern the memory
+              // provider — offering Disable here would flip the label
+              // without stopping the provider. Provider lifecycle lives in
+              // the Providers card at the top of this page.
+              <span className="text-xs text-muted-foreground">
+                Managed via the memory provider selector above.
+              </span>
+            ) : row.runtime_status === "enabled" ? (
               <Button
                 disabled={busy}
                 ghost

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -969,13 +969,13 @@ function PluginRowCard(props: PluginRowCardProps) {
 
             <Badge
               title={
-                row.runtime_status === "active"
-                  ? "Live memory provider (memory.provider in config.yaml)"
-                  : undefined
+                row.runtime_status === "active" ? t.pluginsPage.activeProviderHint : undefined
               }
               tone={badgeTone}
             >
-              {row.runtime_status === "active" ? "active (memory provider)" : row.runtime_status}
+              {row.runtime_status === "active"
+                ? t.pluginsPage.activeProvider
+                : row.runtime_status}
             </Badge>
 
             {row.auth_required ? (
@@ -991,7 +991,7 @@ function PluginRowCard(props: PluginRowCardProps) {
               // without stopping the provider. Provider lifecycle lives in
               // the Providers card at the top of this page.
               <span className="text-xs text-muted-foreground">
-                Managed via the memory provider selector above.
+                {t.pluginsPage.activeProviderManaged}
               </span>
             ) : row.runtime_status === "enabled" ? (
               <Button


### PR DESCRIPTION
## What does this PR do?

`hermes plugins list` and the dashboard plugins tab report a plugin as **"not enabled"** / **"inactive"** while that same plugin is the live memory provider selected via `memory.provider`. The status is derived purely from `plugins.enabled` / `plugins.disabled`, and a provider-backed plugin is in neither set, so it falls through to the not-active label while actively serving memory.

Reproduced against `main` with a provider plugin at `$HERMES_HOME/plugins/mnemosyne/` (manifest `name: mnemosyne-hermes`) and `memory.provider: mnemosyne`, not listed under `plugins.enabled`:

```console
# before
$ hermes plugins list --plain --no-bundled
not enabled  user     0.5.0    mnemosyne-hermes
not enabled  user     1.0.0    unrelated

$ hermes plugins list --plain --no-bundled --enabled
(nothing — the running provider is filtered out)
```

```console
# after
$ hermes plugins list --plain --no-bundled
active       user     0.5.0    mnemosyne-hermes
not enabled  user     1.0.0    unrelated

$ hermes plugins list --plain --no-bundled --enabled
active       user     0.5.0    mnemosyne-hermes
```

On the dashboard the row also rendered an **"Enable"** button for a plugin that was already running, because `PluginsPage.tsx` branches on `runtime_status === "enabled"` to decide between Enable and Disable. Mapping the provider to `"enabled"` would fix the badge but swap one lie for another: a **Disable** button that edits `plugins.enabled` — which does not govern the provider — so clicking it would flip the label while memory keeps serving. This PR fixes the action, not just the label: the row reports a distinct `active` state, and instead of a toggle it points at the memory-provider selector that already lives in the Providers card at the top of the same page.

### Why match by directory rather than by name

This is the crux, and it is easy to get wrong. `_read_manifest_info()` derives `key` from the manifest name at depth 0 (`key = name` when there is no prefix), while `memory.provider` names the plugin's *directory* — `_iter_provider_dirs()` yields `child.name`. For the case above:

```
name='mnemosyne-hermes'  key='mnemosyne-hermes'  dir='mnemosyne'   memory.provider='mnemosyne'
```

Neither `name` nor `key` equals `mnemosyne`; only the directory ties them together. A fix that compared names would look correct and still report "not enabled" for this exact setup. Comparing resolved directories also prevents mislabelling an unrelated plugin that merely shares a name with the configured provider.

The directory is resolved through `find_provider_dir()` — the same lookup `load_memory_provider()` uses — so a configured name that does not resolve is never labelled active, because it is not serving memory either.

## Related Issue

Fixes #82898

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_cli/plugins_cmd.py`** — added `PLUGIN_STATUS_ACTIVE`, `_active_memory_provider_dir()` and `_same_dir()`. `_plugin_status()` gained optional `dir_path` / `active_provider_dir` and returns `active` for the live provider. `_filter_plugin_entries()` includes it under `--enabled`. `cmd_list()` resolves the directory once and threads it through the table, `--plain` and `--json`.
- **`cli.py`** — the `/plugins` slash command (`✓` instead of `○`).
- **`tui_gateway/methods_tools.py`** — the plugins gateway method.
- **`hermes_cli/web_server.py`** — `_merged_plugins_hub()`, which powers `/api/dashboard/plugins/hub` (the dashboard plugins tab named in the issue). It carried its own inlined copy of the enabled/disabled logic with the same blind spot. It now emits `runtime_status: "active"` for the provider row.
- **`web/src/lib/api.ts`** — `runtime_status` union extended to include `"active"`, in lockstep with the backend (this frontend is the hub endpoint's only consumer, verified by repo-wide grep, and ships from this repo).
- **`web/src/pages/PluginsPage.tsx`** — `active` renders a success-tone `active (memory provider)` badge with a tooltip, and the Enable/Disable toggle is replaced for that row by a pointer to the existing memory-provider selector — because the toggle edits `plugins.enabled`, which does not stop or start the provider.
- **Tests** — 17 added: 12 in `tests/hermes_cli/test_plugins_cmd_list.py`, 5 in a new `tests/hermes_cli/test_plugins_hub_active_memory_provider.py`.

  Four of them are **end-to-end against a temp `HERMES_HOME` with nothing mocked** — a real plugin directory and `config.yaml` driven through `_get_current_memory_provider` → `find_provider_dir` → `_is_memory_provider_dir` → directory match → status, and out through the real `cmd_list` JSON renderer and the real dashboard hub. Per AGENTS.md ("exercise the real path with real imports against a temp HERMES_HOME. Mocks hide integration bugs"), the unit tests that hand `active_provider_dir` in directly are backed by these. They include the negative cases: an unresolvable provider name, and a same-named directory that lacks provider markers — both must *not* be labelled active.

### Three decisions worth a reviewer's eye

1. **The CLI status token is `active`, rendered as `active (memory provider)` only in the rich table.** `--plain` prints a fixed-width status column and `--json` exposes `status` to scripts, so a single word keeps both parseable.

2. **The dashboard gets a real `active` state; the gateway keeps its existing vocabulary.** The split is principled, not convenient:
   - The web frontend is the hub endpoint's **only** consumer and ships from this repo, so the `runtime_status` union in `api.ts` is extended in lockstep — no stale-client risk. This is what lets the page stop offering a Disable button that wouldn't actually disable anything.
   - The **gateway** method maps `active` → `enabled` instead, mirroring the normalization directly above it (bundled default-on plugins are reported `enabled` because "not enabled" *"reads as OFF in clients when they are in fact running"*). TUI/desktop clients version separately from the server, so they keep a closed vocabulary.

3. **Security gates that also read `plugins.enabled` are deliberately untouched** — the `/api/plugins/` runtime middleware and dashboard asset serving (GHSA-5qr3-c538-wm9j / #46435). Being the memory provider must not cause a plugin's JS/CSS to be served or its API routes to open. Likewise `cmd_enable`/`cmd_disable` and the interactive toggle still operate purely on `plugins.enabled` membership, since unchecking there would not stop the provider.

The underlying design nuance, for the record: `PluginManager` gates plugin *loading* on `plugins.enabled`, while `load_memory_provider()` bypasses it. So an unlisted provider plugin has its tool/hook surface genuinely unloaded while its memory surface runs. That is why the label everywhere is "active (memory provider)" rather than a bare "enabled", and why the dashboard row defers to the provider selector instead of the enable/disable toggle. (A related residue is out of scope here: putting the provider plugin in `plugins.disabled` reports `disabled` while memory still serves — that opt-out path predates this PR and deserves its own decision.)

### Interaction with open PRs

I checked for duplicates and found none — but two open PRs touch the same call sites, so flagging for whoever sequences them:

- **#74825** (report enabled plugins missing from disk) adds a `missing` status token at the same three `cmd_list` renderers and also edits `tests/hermes_cli/test_plugins_cmd_list.py`. The changes are complementary — `missing` means the directory is gone, `active` means it is the live provider — but they will conflict textually. Happy to rebase on whichever lands first.
- **#82439** also edits `tests/hermes_cli/test_plugins_cmd_list.py`.

Neither addresses the memory-provider status, so this is not a duplicate of either. #74825 does establish precedent that a new status token in `hermes plugins list` is acceptable.

## How to Test

1. Create `$HERMES_HOME/plugins/mnemosyne/` with a `plugin.yaml` declaring a *different* manifest name (`name: mnemosyne-hermes`) and an `__init__.py` referencing `MemoryProvider`.
2. Set `memory.provider: mnemosyne` in `config.yaml`; leave `plugins.enabled` empty.
3. `hermes plugins list` — before: `not enabled`; after: `active (memory provider)`.
4. `hermes plugins list --json` → `"status": "active"`; `--enabled` now includes it.
5. Add a second unrelated plugin and confirm it still reports `not enabled`.
6. Dashboard: open the Plugins tab — the provider row shows a green **active (memory provider)** badge (was: grey `inactive` with an Enable button), no Enable/Disable toggle, and a note pointing at the memory-provider selector above. `GET /api/dashboard/plugins/hub` shows `"runtime_status": "active"` for the row.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` — **with one honest caveat**: the suite is not 100% green on my machine. Every failure is pre-existing and reproduces on clean `main`; none is in a file this PR touches. Evidence in the note below, so you can judge it rather than take my word.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.13.15 — including manually running `hermes plugins list` in table/`--plain`/`--json`/`--enabled` forms against the fixture above

> **Test run detail.** Full suite via `scripts/run_tests.sh` (the canonical per-file-isolated runner) on macOS: **2746 files, 28,724 passed, 100 failed, 299 skipped**. `tests/hermes_cli/` alone — the suite covering every file this PR changes — is **4,607 passed / 2 failed**, with both of my test files fully green (`test_plugins_cmd_list.py` 15✓, `test_plugins_hub_active_memory_provider.py` 5✓).
>
> None of the failures belong to this change. Verified rather than assumed:
> - **None of the 42 failing files reference** `plugins_cmd`, `_plugin_status`, `_merged_plugins_hub` or `PLUGIN_STATUS_ACTIVE`.
> - **Most are load-induced flakes, not real failures.** The runner uses 28 workers; re-running the suspicious files in isolation on this branch passes them — including `tests/cli/test_cli_light_mode.py`, which exercises the `cli.py` I touched (326 passed in isolation). The failure count is load-sensitive: two runs of the same commit produced 95 and 100.
> - **The genuinely reproducible ones reproduce identically on clean `main`**, run side by side: `test_readiness.py` and `test_systemd_notify.py` (the latter a `FileNotFoundError` — macOS has no systemd), plus a sampled set matching per-file counts exactly (`test_web_tools_config.py` 2, `test_file_tools.py` 2, `test_approval.py` 1, `test_streaming.py` 3, `test_api_server.py` 1, `test_execution_flag_detection.py` 3).
> - The one inside `tests/hermes_cli/` — `test_service_manager.py::test_seed_supervise_skeleton_creates_expected_layout` — also reproduces on clean `main` under the same runner. It is macOS-specific: the test wants mode `0o3730`, but macOS strips setgid when a non-root user chmods a directory whose group they do not belong to, yielding `0o1730`. It may deserve the repo's existing `linux_only` marker, but that is out of scope here.
>
> The remaining bulk sits in optional-dependency areas this machine lacks extras for (Daytona, fal, Modal, browser, voice/TTS, video-gen, Hindsight). I sampled rather than re-ran all 42 against `main`, so treat that portion as strongly evidenced rather than exhaustively proven.
>
> **Python 3.11** (the interpreter `tests.yml` uses, vs 3.13 above): the full `tests/hermes_cli/` suite and all plugin-focused files pass. Four files reported failures only under heavy parallel load and pass in isolation on both interpreters, so they are contention flakes rather than 3.11 regressions.
>
> **The blocking CI gates were run locally and pass**: `ruff check .` across the whole repo (not just changed files) and `scripts/check-windows-footguns.py --all` (942 files) — the two jobs in `lint.yml` whose exit codes gate merge. The `ruff + ty` diff job is advisory (`--exit-zero`); `ty check` reports **527 diagnostics across the four changed production files both with and without this change**, i.e. no new type diagnostics.
>
> **The new tests were mutation-checked.** Disabling the fix at its decision points makes the regression tests fail — including the end-to-end ones — so they genuinely pin the behaviour rather than passing incidentally. The tests that still pass under mutation are the ones asserting unchanged behaviour (explicit-disable precedence, unresolvable provider, unrelated plugin), which is correct.
>
> **Frontend lane** (this PR touches `web/src`, so `js-tests.yml` will run): all three of its scripts were run locally from a workspace-root `npm ci` — `npm run typecheck` clean, `npm run test` **197 passed (27 files)**, `npm run lint` **0 errors** with zero findings on the changed files (the 26 pre-existing warnings are all in untouched files). Verified the `Badge` component forwards `title` (its props extend `HTMLAttributes<HTMLSpanElement>`), and that hardcoded-English UI copy matches this page's existing style.

### Documentation & Housekeeping

- [x] N/A — no user-facing docs describe the plugin status vocabulary (checked `docs/` and top-level `*.md`); the new/changed helpers carry docstrings explaining the directory-vs-name subtlety
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] I've considered cross-platform impact — comparison goes through `Path.resolve()` rather than string equality, so Windows case/separator differences and symlinked `$HERMES_HOME` paths both compare correctly; no POSIX-only syscalls in the new tests
