### PR TITLE
fix(gateway): match the profile-namespaced session key in the clarify bypass lookup

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5952,10 +5952,12 @@ class BasePlatformAdapter(ABC):
         if needs_topic_recovery:
             await asyncio.to_thread(self._apply_topic_recovery, event)
 
+        _sk_store = getattr(self, "_session_store", None)
         session_key = build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            profile=_sk_store._resolve_profile_for_key(event.source) if _sk_store else None,
         )
 
         # On-entry self-heal: if the adapter still has an _active_sessions

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -1,7 +1,7 @@
 """Regression tests for clarify replies while a gateway session is busy."""
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -79,6 +79,59 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     )
     adapter._active_sessions[session_key] = asyncio.Event()
     cm.register("clarify-1", session_key, "Pick one", ["A", "B"])
+
+    await adapter.handle_message(event)
+
+    adapter._message_handler.assert_awaited_once_with(event)
+    adapter._busy_session_handler.assert_not_awaited()
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_active_session_bypass_uses_profile_namespaced_key_under_multiplex():
+    """Regression for issue #82975: under a named-profile multiplex, the
+    adapter's clarify bypass lookup must use the SAME profile-namespaced
+    session key that the runner registers pending clarifies under
+    (SessionStore._generate_session_key() includes
+    profile=self._resolve_profile_for_key(source)), not the legacy
+    unnamespaced key. Otherwise the lookup misses, and a user's answer to
+    a pending clarify is routed to the busy-session queue instead of
+    resolving it -- the turn then hangs until the clarify's 3600s timeout."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter()
+    adapter._message_handler = AsyncMock(return_value="")
+    adapter._busy_session_handler = AsyncMock(return_value=True)
+    event = _event("None of those are valid options")
+
+    # A session_store configured for profile multiplexing, matching what
+    # the runner's SessionStore._generate_session_key() actually produces.
+    session_store = MagicMock()
+    session_store._resolve_profile_for_key.return_value = "ops"
+    adapter._session_store = session_store
+
+    profile_namespaced_key = build_session_key(
+        event.source,
+        group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+        thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+        profile="ops",
+    )
+    # Sanity: the profile-namespaced key really is different from the
+    # legacy unnamespaced one -- otherwise this test wouldn't distinguish
+    # the fixed behavior from the bug.
+    legacy_key = build_session_key(
+        event.source,
+        group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+        thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+    )
+    assert profile_namespaced_key != legacy_key
+
+    adapter._active_sessions[profile_namespaced_key] = asyncio.Event()
+    # The runner registers the pending clarify under its own
+    # profile-namespaced key, exactly as it would in a real multiplexed
+    # deployment.
+    cm.register("clarify-1", profile_namespaced_key, "Pick one", ["A", "B"])
 
     await adapter.handle_message(event)
 


### PR DESCRIPTION
Fixes #82975.

## Root cause

The adapter-level clarify reply bypass in `gateway/platforms/base.py`'s `handle_message()` built its `session_key` via `build_session_key(...)` without a `profile=` argument, defaulting to the legacy `agent:main` namespace. The runner registers pending clarifies under `SessionStore._generate_session_key()`'s key, which DOES include `profile=self._resolve_profile_for_key(source)`. Under a named-profile multiplex these diverge, so the bypass lookup misses -- the user's answer to a pending `clarify()` gets routed to the adapter's busy-session queue instead of resolving it, and the turn hangs until the 3600s timeout. Matches the reported Telegram symptom exactly (no `inbound message:` log line, no clarify-intercept log line).

Verified the divergence directly by reading both key-construction sites. `_resolve_profile_for_key()` returns `None` when `multiplex_profiles` is off (default) -- byte-identical to the prior implicit `profile=None`, so this only changes behavior for multiplexed deployments, matching the issue's exact reported scope.

## Fix

Uses the same `self._session_store._resolve_profile_for_key()` the runner's key generator calls, guarded with `getattr()` + a `None` fallback since `_session_store` is set via a setter and can be unset for some adapters.

## Verification

Added a regression test alongside the existing bypass coverage. Verified as a genuine regression by reverting the fix and confirming the new test fails with the exact reported symptom.

21/21 pass across the five directly related clarify test files; 16/16 across broader multiplex/clarify-progress tests (no regression).