### PR TITLE
fix(ci): review-comment poller trigger + autofix self-gating

### DIFF
--- a/.github/workflows/ci-review-comment.yml
+++ b/.github/workflows/ci-review-comment.yml
@@ -72,6 +72,6 @@ jobs:
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
         run: |
-          python3 scripts/ci/live_comment.py \
+          python3 -u scripts/ci/live_comment.py \
             --interval 15 \
             --timeout 3000

--- a/.github/workflows/ci-review-comment.yml
+++ b/.github/workflows/ci-review-comment.yml
@@ -17,7 +17,13 @@ name: CI review comment
 on:
   workflow_run:
     workflows: [CI]
-    types: [requested]
+    # ``in_progress``, not ``requested``: a first-time contributor's run
+    # sits in ``action_required`` until a maintainer approves it, and
+    # ``requested`` fires at creation — the poller would wait out its
+    # whole timeout on a run that never starts. ``in_progress`` fires
+    # when the run actually starts, and it also fires on re-runs, which
+    # ``requested`` does not.
+    types: [in_progress]
 
 permissions:
   contents: read
@@ -25,9 +31,11 @@ permissions:
   pull-requests: write
 
 # One poller per CI run. A new push starts a new CI run, and its poller
-# cancels the poller of the run that GitHub superseded.
+# cancels the poller of the run that GitHub superseded. The group keys
+# on the head repository too: fork PRs often share a branch name
+# (``main``, ``patch-1``), and two PRs must not cancel each other.
 concurrency:
-  group: ci-review-comment-${{ github.event.workflow_run.head_branch }}
+  group: ci-review-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/js-autofix.yml
+++ b/.github/workflows/js-autofix.yml
@@ -89,20 +89,33 @@ jobs:
       - name: Produce patch
         id: produce-patch
         run: |
-          if git diff --quiet; then
+          # Exclude every file that the dep-version-gate ruleset guards
+          # (package manifests, eslint configs, workflow files). A patch
+          # that contains one of these files makes the bot PR wait for a
+          # team review, and auto-merge then stops. The check step in
+          # typecheck.yml still reports their lint errors.
+          # The (glob) magic makes "**/" also match files at the repo
+          # root, which plain pathspec wildcards do not.
+          EXCLUDES=(
+            ':(exclude,glob)**/package.json'
+            ':(exclude,glob)**/package-lock.json'
+            ':(exclude,glob)**/eslint.config.*'
+            ':(exclude,glob).github/**'
+          )
+          if git diff --quiet -- . "${EXCLUDES[@]}"; then
             echo "No fixes needed."
             echo "has-fixes=false" >> "$GITHUB_OUTPUT"
             # Empty patch signals "nothing to do" to apply-patch.
             : > js-fix.patch
           else
-            git diff > js-fix.patch
+            git diff -- . "${EXCLUDES[@]}" > js-fix.patch
             echo "has-fixes=true" >> "$GITHUB_OUTPUT"
             echo "Patch size: $(wc -c < js-fix.patch) bytes"
 
             # Reject patches that touch anything outside JS/TS/JSON sources.
             # `npm run fix` should only ever modify those; anything else means
             # eslint/prettier or a plugin went rogue and we refuse to ship it.
-            BAD=$(git diff --name-only | grep -vE '\.(js|cjs|mjs|ts|tsx|json)$' || true)
+            BAD=$(git diff --name-only -- . "${EXCLUDES[@]}" | grep -vE '\.(js|cjs|mjs|ts|tsx|json)$' || true)
             if [ -n "$BAD" ]; then
               echo "::error::Refusing to upload patch — touches disallowed files:"
               echo "$BAD"


### PR DESCRIPTION
Two CI fixes that came out of the fork-PR safety review.

## Poller trigger and concurrency (`ci-review-comment.yml`)

- Start the poller on `in_progress`, not `requested`. The `requested` type fires when GitHub creates the run. A run from a first-time contributor waits in `action_required`, and the poller then polls a run that never starts until its 50-minute timeout. The `in_progress` type fires when the run starts, and it also fires on a re-run, which `requested` does not.
- Key the concurrency group on the head repository and the branch. Fork PRs frequently use the same branch name (`main`, `patch-1`). With the old key, a push to one fork PR cancelled the live poller of an unrelated PR and left a stale comment.

## Autofix patch exclusions (`js-autofix.yml`)

The `dep-version-gate` ruleset now requires a team review when a PR touches package manifests, eslint configs, `.prettierrc`, or `.github/` files. If the autofix patch contains one of these files, the bot PR waits for that review and auto-merge stops. The patch step now excludes them with `:(exclude,glob)` pathspecs, so a bot PR never gates itself. The eslint check in `typecheck.yml` still reports their lint errors.

Verified: the pathspec exclusion semantics (root-level and nested `package.json`, `eslint.config.*`, `.github/` files all excluded; `has-fixes=false` when only excluded files change) were exercised against a scratch git repo. `tests/ci/test_live_comment.py` passes (11/11).