### PR TITLE
docs(sessions): document repair-routing and the session-continuity guarantees

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1466,6 +1466,7 @@ Subcommands:
 | `optimize` | Reclaim disk space: merge FTS5 index segments + VACUUM. Non-destructive — no session data changes. |
 | `optimize-storage` | Migrate the full-text search index to the compact v23 external-content layout; on large databases this reclaims a large fraction of `state.db`. |
 | `repair` | Repair a malformed `state.db` schema (e.g. `table messages_fts already exists`) so hidden sessions reappear; a backup is made first. |
+| `repair-routing` | Re-attach gateway conversations stranded in session rows that lost their routing identity (a chat "jumping back in time" after a restart). Dry-run by default; `--apply` performs the adoptions (stop the gateway first); `--max-gap-seconds N` tunes the contiguity window. Only unambiguous cases are repaired. See [Sessions → Repair Stranded Gateway Sessions](../user-guide/sessions.md#repair-stranded-gateway-sessions). |
 | `recover` | Offline, non-destructive recovery of a damaged `state.db` into a separate clean database. |
 | `retitle-skills` | Regenerate titles for sessions opened with a `/skill`, using what the user actually typed; lists changes unless `--apply` is passed. |
 

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -567,6 +567,49 @@ Database size: 12.4 MB
 
 For deeper analytics — token usage, cost estimates, tool breakdown, and activity patterns — use [`hermes insights`](/reference/cli-commands#hermes-insights).
 
+### Repair Stranded Gateway Sessions
+
+If a gateway conversation ever "jumps back in time" after a restart — resuming
+a days-old topic as though recent messages never happened — the live
+conversation may be stranded in a session row that lost its routing identity
+(the damage class fixed in the v0.21 session-continuity work; current versions
+prevent it by construction and self-heal at runtime).
+
+`hermes sessions repair-routing` finds message-bearing session rows with no
+routing identity and re-attaches each one to the conversation it continues —
+but only when the evidence is unambiguous:
+
+```bash
+# Report only — shows each orphan, the proposed adoption, and the evidence
+hermes sessions repair-routing
+
+# Perform the adoptions (stop the gateway first — a running gateway holds
+# the old routing in memory and would write it back over the repair)
+hermes sessions repair-routing --apply
+
+# Widen/narrow the contiguity window (default 900 seconds)
+hermes sessions repair-routing --max-gap-seconds 300
+```
+
+Evidence rules:
+
+- **lineage** — the orphan's `parent_session_id` points at a keyed row of the
+  same platform (a recorded fact; no time window applies)
+- **contiguity** — exactly one keyed row of the same platform fell quiet
+  within the window of the orphan's start
+
+Anything ambiguous (two candidate predecessors, two orphans claiming the same
+predecessor) is reported with a reason and left untouched — a wrong adoption
+would splice one conversation into another chat. The superseded row is retired
+under `superseded_by_repair`, so restart recovery can never resurrect it.
+
+Repair is deliberately **not automatic**: if the chat has since built up a
+second history, choosing which thread it continues is your call. The stranded
+conversation stays readable via `/resume` and session search either way —
+routing is the only thing the repair changes. Back up first
+(`cp ~/.hermes/state.db ~/.hermes/state.db.bak`).
+
+
 ## Session Search Tool
 
 The agent has a built-in `session_search` tool that performs full-text search across all past conversations using SQLite's FTS5 engine — and lets the agent scroll through any session it finds. No LLM calls, no summarization, no truncation. Every shape returns actual messages from the DB.
@@ -683,6 +726,26 @@ in to automatic resets via the `session_reset` section in `config.yaml`:
 Before a session is auto-reset, the agent is given a turn to save any important memories or skills from the conversation.
 
 Sessions with **active background processes** are never auto-reset, regardless of policy.
+
+### Continuity After Crashes and Restarts
+
+A gateway chat is designed to be **one continuous session** — compacted
+repeatedly as it grows — until you explicitly run `/new` (or `/reset`). This
+holds across gateway crashes, restarts, and updates:
+
+- Session identity (routing key, chat, origin) is written **atomically** when
+  the session row is created, on every creation path (`/new`, first message,
+  `/branch` children). If that write ever fails, the very next turn's routing
+  refresh repairs the row automatically.
+- After a restart, the gateway re-resolves each chat to the session with the
+  most recent **actual activity** — an older, stale row can never win over the
+  conversation you were actually having.
+- Recovery **respects `/new` boundaries**: if the most recent event for a chat
+  is an intentional reset, recovery starts fresh rather than reaching behind
+  the reset to resurrect an older session. Recovered sessions also keep their
+  real idle time, so an opt-in idle/daily reset policy applies correctly to
+  them instead of treating every recovered session as brand new.
+
 
 ## Storage Locations
 


### PR DESCRIPTION
## Summary

Documents the user-visible surface from the #82616 session-continuity campaign: the `hermes sessions repair-routing` command shipped in #82712, and the continuity guarantees users now have after #82633/#82742/#82743.

## Changes

- `website/docs/user-guide/sessions.md`:
  - New **"Repair Stranded Gateway Sessions"** section — what a stranded conversation looks like ("chat jumping back in time" after a restart), dry-run-first workflow, evidence rules (lineage/contiguity, refuse-on-ambiguity), why adoption is deliberately not automatic
  - New **"Continuity After Crashes and Restarts"** section under Session Reset Policies — atomic identity at creation, self-healing refresh, recency-based restart resolution, `/new` reset-boundary fence, real-idle-time policy on recovered sessions
- `website/docs/reference/cli-commands.md`: `repair-routing` row in the `hermes sessions` subcommand table, cross-linked to the guide section

## Validation

| | Result |
|---|---|
| `docusaurus build` | SUCCESS, both locales (en + zh-Hans) |

Docs follow-up to #82633 / #82712 / #82718 / #82719 / #82742 / #82743 / #82744 (tracker #82616).

## Infographic

![Read the manual](https://v3b.fal.media/files/b/0aa5be46/rCI1xHMQRxEpHPHUBCNQX_MsjjdSqO.png)
