### PR TITLE
feat(memory): bound Hindsight recall results

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -37,6 +37,7 @@ import json
 import logging
 import os
 import queue
+import re
 import sys
 import threading
 
@@ -85,6 +86,70 @@ def _parse_int_setting(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
         return default
+
+
+def _parse_bool_setting(value: Any, default: bool = False) -> bool:
+    """Parse JSON/native booleans and common string/env representations."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    if isinstance(value, int) and value in {0, 1}:
+        return bool(value)
+    return default
+
+
+def _normalize_recall_text(text: str) -> str:
+    """Normalize a recalled fact for conservative typed-restatement collapse."""
+    # Hindsight world facts commonly append provenance after ``|`` while an
+    # observation repeats the same leading claim. Keep the claim for matching.
+    claim = str(text or "").split("|", 1)[0].strip().lower()
+    return " ".join("".join(ch if ch.isalnum() else " " for ch in claim).split())
+
+
+def _is_recall_restatement(left: str, right: str) -> bool:
+    """Collapse only exact claims plus one known benign typed-restatement suffix."""
+    a = _normalize_recall_text(left)
+    b = _normalize_recall_text(right)
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    shorter, longer = sorted((a, b), key=len)
+    suffix = longer[len(shorter):].strip() if longer.startswith(shorter + " ") else ""
+    return len(shorter) >= 32 and suffix == "check"
+
+
+_RECALL_QUERY_STOPWORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "by", "did", "do", "does",
+    "for", "from", "how", "i", "in", "is", "it", "me", "of", "on", "or",
+    "our", "please", "project", "tell", "that", "the", "this", "to",
+    "user", "was", "were", "what", "when", "where", "which", "who", "why",
+    "with", "you",
+}
+
+
+def _recall_query_terms(text: str) -> set[str]:
+    """Extract lightweight stemmed content terms for deterministic abstention."""
+    raw = _normalize_recall_text(text).split()
+    terms: set[str] = set()
+    for token in raw:
+        if token in _RECALL_QUERY_STOPWORDS or len(token) < 3:
+            continue
+        if token.endswith("ies") and len(token) > 4:
+            token = token[:-3] + "y"
+        else:
+            for suffix in ("ing", "ed", "es", "s"):
+                if token.endswith(suffix) and len(token) > len(suffix) + 3:
+                    token = token[:-len(suffix)]
+                    break
+        if token not in _RECALL_QUERY_STOPWORDS:
+            terms.add(token)
+    return terms
 
 
 # Env var the embedded daemon manager reads (at import time, as a module-level
@@ -718,6 +783,14 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_types: list[str] = ["observation"]
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
+        # Opt-in post-retrieval bounds. Zero preserves Hindsight's native
+        # response unchanged for existing installations.
+        self._recall_result_max_source_groups = 0
+        self._recall_result_max_items = 0
+        self._recall_result_max_chars = 0
+        self._recall_result_min_query_terms = 0
+        self._recall_source_tag_patterns: list[str] = []
+        self._recall_result_expand_conflicts = False
 
         # Bank
         self._bank_mission = ""
@@ -1014,6 +1087,12 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
+            {"key": "recall_result_max_source_groups", "description": "Opt-in maximum ranked source groups returned after recall (0 keeps all)", "default": 0},
+            {"key": "recall_result_max_items", "description": "Opt-in maximum canonical recall items after typed-restatement collapse (0 keeps all)", "default": 0},
+            {"key": "recall_result_max_chars", "description": "Opt-in hard character cap applied after recall serialization (0 disables)", "default": 0},
+            {"key": "recall_result_min_query_terms", "description": "Minimum shared stemmed content terms required between query and a returned source group (0 disables)", "default": 0},
+            {"key": "recall_source_tag_patterns", "description": "Regex list identifying source-specific tags used to join typed restatements", "default": []},
+            {"key": "recall_result_expand_conflicts", "description": "Preserve consecutive ranked conflict-tagged source groups beyond the source-group limit", "default": False},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
@@ -1324,7 +1403,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._config.get("observation_scopes")
             or os.environ.get("HINDSIGHT_RETAIN_OBSERVATION_SCOPES", "")
         )
-        self._recall_tags = self._config.get("recall_tags") or None
+        self._recall_tags = _normalize_retain_tags(self._config.get("recall_tags")) or None
         self._recall_tags_match = self._config.get("recall_tags_match", "any")
         self._retain_source = str(
             self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
@@ -1357,6 +1436,29 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._recall_result_max_source_groups = max(
+            0, _parse_int_setting(self._config.get("recall_result_max_source_groups"), 0)
+        )
+        self._recall_result_max_items = max(
+            0, _parse_int_setting(self._config.get("recall_result_max_items"), 0)
+        )
+        self._recall_result_max_chars = max(
+            0, _parse_int_setting(self._config.get("recall_result_max_chars"), 0)
+        )
+        self._recall_result_min_query_terms = max(
+            0, _parse_int_setting(self._config.get("recall_result_min_query_terms"), 0)
+        )
+        self._recall_source_tag_patterns = _normalize_retain_tags(
+            self._config.get("recall_source_tag_patterns")
+        )
+        for pattern in self._recall_source_tag_patterns:
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                raise ValueError(f"Invalid recall_source_tag_patterns regex {pattern!r}: {exc}") from exc
+        self._recall_result_expand_conflicts = _parse_bool_setting(
+            self._config.get("recall_result_expand_conflicts"), False
+        )
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
@@ -1469,6 +1571,161 @@ class HindsightMemoryProvider(MemoryProvider):
             f"hindsight_retain to store facts."
         )
 
+    def _recall_source_key(self, result: Any) -> tuple[str, ...]:
+        """Return a stable source grouping key for one ranked recall result."""
+        tags = {str(tag).strip().lower() for tag in (getattr(result, "tags", None) or []) if str(tag).strip()}
+        source_tags = tuple(sorted(
+            tag for tag in tags
+            if any(re.search(pattern, tag, flags=re.IGNORECASE) for pattern in self._recall_source_tag_patterns)
+        ))
+        if source_tags:
+            return ("source-tags", *source_tags)
+        document_id = str(getattr(result, "document_id", "") or "").strip()
+        if document_id:
+            return ("document", document_id)
+        result_id = str(getattr(result, "id", "") or "").strip()
+        return ("result", result_id or str(id(result)))
+
+    @staticmethod
+    def _recall_result_is_conflict(result: Any) -> bool:
+        return any(
+            str(tag).strip().lower() == "conflict"
+            for tag in (getattr(result, "tags", None) or [])
+        )
+
+    @classmethod
+    def _recall_group_is_conflict(cls, results: Any) -> bool:
+        return any(cls._recall_result_is_conflict(result) for result in results)
+
+    def _select_recall_results(self, results: Any, *, query: str = "") -> list[Any]:
+        """Bound ranked recall while preserving source-coherent and conflict facts."""
+        ranked = [r for r in (results or []) if str(getattr(r, "text", "") or "").strip()]
+        if not any((
+            self._recall_result_max_source_groups,
+            self._recall_result_max_items,
+            self._recall_result_max_chars,
+            self._recall_result_min_query_terms,
+        )):
+            return ranked
+
+        groups: dict[tuple[str, ...], list[Any]] = {}
+        order: list[tuple[str, ...]] = []
+        for result in ranked:
+            key = self._recall_source_key(result)
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append(result)
+
+        ranked_order = list(order)
+        if self._recall_result_min_query_terms and query:
+            query_terms = _recall_query_terms(query)
+            order = [
+                key for key in order
+                if len(
+                    query_terms
+                    & _recall_query_terms(" ".join(str(item.text) for item in groups[key]))
+                ) >= self._recall_result_min_query_terms
+            ]
+
+        selected_keys = order
+        group_limit = self._recall_result_max_source_groups
+        if group_limit and order:
+            selected_keys = order[:group_limit]
+            # Conflicts are evidence sets: if the highest-ranked source is
+            # explicitly tagged conflict, retain the consecutive competing
+            # conflict sources rather than presenting one side as authoritative.
+            if self._recall_result_expand_conflicts and self._recall_group_is_conflict(groups[order[0]]):
+                first_rank = ranked_order.index(order[0])
+                for key in ranked_order[first_rank + 1:]:
+                    if not self._recall_group_is_conflict(groups[key]):
+                        break
+                    if key not in selected_keys:
+                        selected_keys.append(key)
+
+        group_canonicals: list[list[Any]] = []
+        for key in selected_keys:
+            group_canonical: list[Any] = []
+            for result in groups[key]:
+                text = str(result.text).strip()
+                duplicate_index = next(
+                    (
+                        index for index, existing in enumerate(group_canonical)
+                        if _is_recall_restatement(text, str(existing.text))
+                    ),
+                    None,
+                )
+                if duplicate_index is not None:
+                    existing = group_canonical[duplicate_index]
+                    if (
+                        str(getattr(result, "type", "") or "").lower() == "world"
+                        and str(getattr(existing, "type", "") or "").lower() != "world"
+                    ):
+                        group_canonical[duplicate_index] = result
+                    continue
+                group_canonical.append(result)
+            if self._recall_group_is_conflict(group_canonical):
+                group_canonical.sort(key=lambda item: not self._recall_result_is_conflict(item))
+            group_canonicals.append(group_canonical)
+
+        conflict_group_indexes = [
+            index for index, group in enumerate(group_canonicals)
+            if self._recall_group_is_conflict(group)
+        ]
+        conflict_set = len(conflict_group_indexes) > 1
+        if (
+            conflict_set
+            and self._recall_result_max_items
+            and self._recall_result_max_items < len(conflict_group_indexes)
+        ):
+            return []
+
+        canonical: list[Any] = []
+        if conflict_set:
+            # Reserve one claim from every conflicting source before ordinary
+            # groups or secondary facts, so global caps cannot present one side.
+            canonical.extend(group_canonicals[index][0] for index in conflict_group_indexes)
+            conflict_indexes = set(conflict_group_indexes)
+            for index, group in enumerate(group_canonicals):
+                canonical.extend(group[1:] if index in conflict_indexes else group)
+        else:
+            for group in group_canonicals:
+                canonical.extend(group)
+        if self._recall_result_max_items:
+            return canonical[: self._recall_result_max_items]
+        return canonical
+
+    def _format_recall_results(self, results: Any, *, numbered: bool, query: str = "") -> str:
+        selected = self._select_recall_results(results, query=query)
+        selected_groups: dict[tuple[str, ...], list[Any]] = {}
+        for result in selected:
+            selected_groups.setdefault(self._recall_source_key(result), []).append(result)
+        conflict_source_keys = {
+            key for key, group in selected_groups.items()
+            if any(self._recall_result_is_conflict(result) for result in group)
+        }
+        complete_conflict_required = len(conflict_source_keys) > 1
+        lines: list[str] = []
+        serialized_source_keys: set[tuple[str, ...]] = set()
+        cap = self._recall_result_max_chars
+        for result in selected:
+            prefix = f"{len(lines) + 1}. " if numbered else "- "
+            line = prefix + str(result.text).strip()
+            candidate = "\n".join([*lines, line])
+            if cap and len(candidate) > cap:
+                # Never inject a partial memory: truncation can drop negation,
+                # provenance, or safety context and change the claim's meaning.
+                # A partial multi-source conflict is equally unsafe because it
+                # can present one side as authoritative.
+                if complete_conflict_required and not conflict_source_keys.issubset(serialized_source_keys):
+                    return ""
+                break
+            lines.append(line)
+            serialized_source_keys.add(self._recall_source_key(result))
+        if complete_conflict_required and not conflict_source_keys.issubset(serialized_source_keys):
+            return ""
+        return "\n".join(lines)
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
@@ -1522,7 +1779,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = self._format_recall_results(resp.results, numbered=False, query=query)
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1753,8 +2010,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_recall: %d results", num_results)
                 if not resp.results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
-                return json.dumps({"result": "\n".join(lines)})
+                text = self._format_recall_results(resp.results, numbered=True, query=query)
+                return json.dumps({"result": text or "No relevant memories found."})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to search memory: {e}")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -25,6 +25,7 @@ from plugins.memory.hindsight import (
     _load_config,
     _load_simple_env,
     _build_embedded_profile_env,
+    _is_recall_restatement,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -195,6 +196,7 @@ def provider_with_config(tmp_path, monkeypatch):
             "bank_id": "test-bank",
             "budget": "mid",
             "memory_mode": "hybrid",
+            "recall_source_tag_patterns": [r"^[A-Z]+-\d+$"],
         }
         config.update(overrides)
         config_path = tmp_path / "hindsight" / "config.json"
@@ -217,6 +219,22 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
         "agent:fakeassistantname",
         "source_system:hermes-agent",
     ]
+
+
+@pytest.mark.parametrize("left,right", [
+    ("Project Nimbus launch date is April 1", "Project Nimbus launch date is April 15"),
+    ("The production deployment region is us-east-1.", "The production deployment region is us-east-2."),
+    ("Project Nimbus launch color is purple.", "Project Nimbus launch color is orange."),
+])
+def test_recall_restatement_never_collapses_conflicting_values(left, right):
+    assert _is_recall_restatement(left, right) is False
+
+
+def test_recall_restatement_collapses_known_next_check_suffix():
+    assert _is_recall_restatement(
+        "Robert prefers Decision, Evidence, and Next",
+        "Robert prefers Decision, Evidence, and Next check",
+    ) is True
 
 
 # ---------------------------------------------------------------------------
@@ -317,6 +335,19 @@ class TestConfig:
         assert p._recall_max_input_chars == 500
         assert p._bank_mission == "Test agent mission"
 
+    def test_recall_tags_accept_csv_and_normalize_to_list(self, provider_with_config):
+        p = provider_with_config(recall_tags="pilot, robert, pilot")
+        assert p._recall_tags == ["pilot", "robert"]
+
+    @pytest.mark.parametrize("configured,expected", [
+        ("false", False), ("0", False), ("true", True), ("1", True),
+    ])
+    def test_recall_expand_conflicts_parses_string_booleans(
+        self, provider_with_config, configured, expected
+    ):
+        p = provider_with_config(recall_result_expand_conflicts=configured)
+        assert p._recall_result_expand_conflicts is expected
+
 
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
         env = _build_embedded_profile_env({
@@ -337,6 +368,7 @@ class TestConfig:
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
 
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"
@@ -446,6 +478,374 @@ class TestToolHandlers:
         ))
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
+
+    def test_recall_source_group_limit_collapses_typed_restatements(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_max_items=8,
+            recall_result_max_chars=600,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Cedar depends on service Finch for schema validation.",
+                type="observation", document_id=None,
+                tags=["pilot", "robert", "relationship", "REL-01"],
+            ),
+            SimpleNamespace(
+                text="Project Cedar depends on service Finch for schema validation. | Involving: Project Cedar, service Finch",
+                type="world", document_id="stage1-v1-REL-01",
+                tags=["pilot", "robert", "relationship", "REL-01"],
+            ),
+            SimpleNamespace(
+                text="Service Finch is maintained by Team Amber.",
+                type="observation", document_id=None,
+                tags=["pilot", "robert", "relationship", "REL-01"],
+            ),
+            SimpleNamespace(
+                text="Robert prefers teal charts and no pie charts.",
+                type="observation", document_id=None,
+                tags=["pilot", "robert", "stable_preference", "PREF-03"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "Who maintains the service Cedar depends on?"}
+        ))
+
+        assert "Project Cedar depends on service Finch" in payload["result"]
+        assert "Involving: Project Cedar, service Finch" in payload["result"]
+        assert "Service Finch is maintained by Team Amber" in payload["result"]
+        assert payload["result"].count("Project Cedar depends") == 1
+        assert "teal charts" not in payload["result"]
+        assert len(payload["result"]) <= 500
+
+    def test_recall_item_limit_applies_after_richer_world_restatement_wins(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_max_items=1,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Robert prefers a three-row table with Decision, Evidence, and Next.",
+                type="observation", document_id=None,
+                tags=["pilot", "preference", "PREF-01"],
+            ),
+            SimpleNamespace(
+                text="Robert prefers a three-row table with Decision, Evidence, and Next check. | Involving: Robert",
+                type="world", document_id="preference-source",
+                tags=["pilot", "preference", "PREF-01"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What table does Robert prefer?"}
+        ))
+
+        assert "Next check" in payload["result"]
+        assert "Involving: Robert" in payload["result"]
+
+    def test_recall_source_group_limit_preserves_ranked_conflict_groups(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_max_items=8,
+            recall_result_max_chars=600,
+            recall_result_expand_conflicts=True,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple.", type="world",
+                document_id="stage1-v1-CON-02",
+                tags=["pilot", "robert", "conflict", "CON-02"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is orange.", type="world",
+                document_id="stage1-v1-CON-01",
+                tags=["pilot", "robert", "conflict", "CON-01"],
+            ),
+            SimpleNamespace(
+                text="The cafeteria served violet macarons.", type="world",
+                document_id="stage1-v1-IRR-01",
+                tags=["pilot", "robert", "irrelevant", "IRR-01"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the unresolved Nimbus launch color?"}
+        ))
+
+        assert "purple" in payload["result"]
+        assert "orange" in payload["result"]
+        assert "macarons" not in payload["result"]
+
+    def test_recall_deduplication_does_not_collapse_claims_across_sources(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_expand_conflicts=True,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple. | Source: Alpha",
+                type="world", document_id="source-alpha",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple. | Source: Beta",
+                type="world", document_id="source-beta",
+                tags=["pilot", "conflict"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the Nimbus launch color?"}
+        ))
+
+        assert "Source: Alpha" in payload["result"]
+        assert "Source: Beta" in payload["result"]
+
+    @pytest.mark.parametrize("limit_name,limit_value", [
+        ("recall_result_max_items", 1),
+        ("recall_result_max_chars", 80),
+    ])
+    def test_recall_abstains_when_cap_cannot_preserve_complete_conflict_set(
+        self, provider_with_config, limit_name, limit_value
+    ):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_expand_conflicts=True,
+            **{limit_name: limit_value},
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple according to Source Alpha.",
+                type="world", document_id="source-alpha",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is orange according to Source Beta.",
+                type="world", document_id="source-beta",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Source Alpha also recorded a secondary rationale.",
+                type="world", document_id="source-alpha",
+                tags=["pilot"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the Nimbus launch color?"}
+        ))
+
+        assert payload["result"] == "No relevant memories found."
+
+    def test_recall_character_cap_drops_only_optional_conflict_secondary_facts(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_max_chars=150,
+            recall_result_expand_conflicts=True,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple according to Source Alpha.",
+                type="world", document_id="source-alpha",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Source Alpha also recorded a secondary rationale.",
+                type="world", document_id="source-alpha",
+                tags=["pilot"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is orange according to Source Beta.",
+                type="world", document_id="source-beta",
+                tags=["pilot", "conflict"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the Nimbus launch color?"}
+        ))
+
+        assert "purple" in payload["result"]
+        assert "orange" in payload["result"]
+        assert "secondary rationale" not in payload["result"]
+
+    def test_recall_query_gate_does_not_remove_consecutive_conflict_source(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_min_query_terms=2,
+            recall_result_expand_conflicts=True,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple according to Source Alpha.",
+                type="world", document_id="source-alpha",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Source Beta disagrees and says orange.",
+                type="world", document_id="source-beta",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Robert likes macarons.",
+                type="world", document_id="unrelated",
+                tags=["pilot", "irrelevant"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the Nimbus launch color?"}
+        ))
+
+        assert "purple" in payload["result"]
+        assert "orange" in payload["result"]
+        assert "macarons" not in payload["result"]
+
+    def test_recall_conflict_detection_checks_every_fact_in_source_group(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_expand_conflicts=True,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Nimbus launch color rationale from Source Alpha.",
+                type="world", document_id="source-alpha",
+                tags=["pilot"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple according to Source Alpha.",
+                type="world", document_id="source-alpha",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is orange according to Source Beta.",
+                type="world", document_id="source-beta",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Robert likes macarons.",
+                type="world", document_id="unrelated",
+                tags=["pilot", "irrelevant"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the Nimbus launch color?"}
+        ))
+
+        assert "purple" in payload["result"]
+        assert "orange" in payload["result"]
+        assert "macarons" not in payload["result"]
+
+    def test_recall_item_cap_prioritizes_conflict_claim_over_source_rationale(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_max_items=2,
+            recall_result_expand_conflicts=True,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Source Alpha rationale: the launch memo was revised after review.",
+                type="world", document_id="source-alpha",
+                tags=["pilot"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple according to Source Alpha.",
+                type="world", document_id="source-alpha",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is orange according to Source Beta.",
+                type="world", document_id="source-beta",
+                tags=["pilot", "conflict"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the Nimbus launch color?"}
+        ))
+
+        assert "purple" in payload["result"]
+        assert "orange" in payload["result"]
+        assert "rationale" not in payload["result"]
+
+    @pytest.mark.parametrize("limit_name,limit_value", [
+        ("recall_result_max_items", 2),
+        ("recall_result_max_chars", 140),
+    ])
+    def test_recall_conflict_subset_survives_caps_with_ordinary_selected_group(
+        self, provider_with_config, limit_name, limit_value
+    ):
+        p = provider_with_config(
+            recall_result_max_source_groups=3,
+            recall_result_expand_conflicts=True,
+            **{limit_name: limit_value},
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Nimbus launch color is purple according to Source Alpha.",
+                type="world", document_id="source-alpha",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Source Alpha rationale explaining evidence.",
+                type="world", document_id="source-alpha",
+                tags=["pilot"],
+            ),
+            SimpleNamespace(
+                text="Project Nimbus launch color is orange according to Source Beta.",
+                type="world", document_id="source-beta",
+                tags=["pilot", "conflict"],
+            ),
+            SimpleNamespace(
+                text="Robert likes macarons.",
+                type="world", document_id="ordinary-source",
+                tags=["pilot", "irrelevant"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the Nimbus launch color?"}
+        ))
+
+        assert "purple" in payload["result"]
+        assert "orange" in payload["result"]
+        assert "rationale" not in payload["result"]
+        assert "macarons" not in payload["result"]
+
+    def test_recall_query_term_gate_abstains_when_ranked_results_are_unrelated(self, provider_with_config):
+        p = provider_with_config(
+            recall_result_max_source_groups=1,
+            recall_result_min_query_terms=1,
+        )
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="Project Cedar chose SQLite for its prototype.", type="world",
+                document_id="cedar-decision", tags=["pilot", "robert", "decision"],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "What is the Lighthouse catering budget?"}
+        ))
+
+        assert payload["result"] == "No relevant memories found."
+
+    def test_recall_character_cap_omits_oversized_memory_instead_of_truncating_it(self, provider_with_config):
+        p = provider_with_config(recall_result_max_chars=24)
+        p._client.arecall.return_value = SimpleNamespace(results=[
+            SimpleNamespace(
+                text="A long memory whose partial text could change its meaning.",
+                type="world", document_id="long-source", tags=[],
+            ),
+        ])
+
+        payload = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "long memory meaning"}
+        ))
+
+        assert payload["result"] == "No relevant memories found."
 
 
     def test_reflect_success(self, provider):


### PR DESCRIPTION
## Summary

- add opt-in, source-aware post-processing for Hindsight recall results
- collapse near-identical observation/world restatements while preferring the richer world fact
- bound returned source groups, items, and final serialized characters
- add deterministic query-term abstention when ranked results are unrelated
- require explicit source-tag regexes before joining typed results by tag; otherwise fall back to document identity
- preserve consecutive explicitly tagged conflict sources
- abstain rather than emit a one-sided conflict when a cap cannot fit every source
- apply the same selection path to tool recall and automatic prefetch
- preserve existing behavior when all new settings remain at their zero/false defaults

## Motivation

Hindsight may return nearly an entire small bank even when `max_tokens` is set. It can also return both observation and world representations of the same source fact. That creates noisy context and can leak unrelated memory into otherwise correct recall.

## Test plan

### PR-admission checks

- [x] New behavior reproduced with failing tests before implementation
- [x] Canonical `uv run --extra dev pytest tests/plugins/memory -q`: 241 passed, 1 skipped
- [x] Installed-runtime expanded suite: 248 passed
- [x] `ruff check` passes for both changed files
- [x] `git diff --check` passes
- [x] Added-line security scan is clean
- [x] Independent code-review verdict passes
- [x] Read-only live-bank replay from the feature worktree: 11/11 direct retrieval rows pass, 0 forbidden facts, median 2 results / 57 estimated tokens, maximum 3 results / 121 estimated tokens, p95 0.900s

### Post-merge acceptance

- [ ] Deploy the exact merged revision to isolated profile `hindsightpilot`
- [ ] Verify default profile remains built-in-memory only
- [ ] Configure opt-in limits only in `hindsightpilot`
- [ ] Create or reset an explicitly approved empty qualification bank
- [ ] Disable observation consolidation for the Stage-1 qualification bank
- [ ] Run frozen Stage-1-r2 corpus and question suite
- [ ] Run stored-injection, secret-boundary, live-authority, isolation, deletion, and restart tests
- [ ] Complete ten fresh representative tools-only sessions
- [ ] Verify rollback/default-profile state and publish final acceptance report

## Compatibility

All new behavior is opt-in. Existing Hindsight configurations retain their current recall output unless one or more new post-retrieval settings are configured.
