### PR TITLE
fix(session-search): preserve resumed continuity

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -107,6 +107,82 @@ class TestBrowseShape:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
 
+    def test_browse_ranks_and_dedupes_resumed_lineage_by_latest_segment(self, db):
+        base = time.time() - 1_000
+
+        db.create_session("resume_root", source="telegram", session_key="lane")
+        db.append_message(
+            "resume_root", role="user", content="old segment", timestamp=base + 100
+        )
+        db.end_session("resume_root", "session_reset")
+        db.create_session(
+            "resume_tip",
+            source="telegram",
+            session_key="lane",
+            parent_session_id="resume_root",
+        )
+        db.append_message(
+            "resume_tip", role="user", content="resumed latest segment", timestamp=base + 900
+        )
+
+        db.create_session("independent", source="cli")
+        db.append_message(
+            "independent", role="user", content="independent work", timestamp=base + 800
+        )
+        db.create_session("fresh", source="cli")
+        db.append_message(
+            "fresh", role="user", content="fresh work", timestamp=base + 700
+        )
+
+        result = json.loads(session_search(db=db, limit=10))
+        ids = [row["session_id"] for row in result["results"]]
+
+        assert ids[:3] == ["resume_tip", "independent", "fresh"]
+        assert "resume_root" not in ids
+        assert ids.count("resume_tip") == 1
+        resumed = result["results"][0]
+        assert resumed["last_active"] == pytest.approx(base + 900)
+        assert resumed["preview"] == "resumed latest segment"
+
+    def test_browse_keeps_branches_separate_and_delegate_children_hidden(self, db):
+        base = time.time() - 500
+        db.create_session("branch_root", source="cli")
+        db.append_message(
+            "branch_root", role="user", content="root conversation", timestamp=base + 10
+        )
+        db.end_session("branch_root", "branched")
+        db.create_session(
+            "branch_child",
+            source="cli",
+            parent_session_id="branch_root",
+            model_config={"_branched_from": "branch_root"},
+        )
+        db.append_message(
+            "branch_child", role="user", content="branch conversation", timestamp=base + 30
+        )
+
+        db.create_session("delegate_parent", source="cli")
+        db.append_message(
+            "delegate_parent", role="user", content="parent work", timestamp=base + 20
+        )
+        db.create_session(
+            "delegate_child",
+            source="cli",
+            parent_session_id="delegate_parent",
+            model_config={"_delegate_from": "delegate_parent"},
+        )
+        db.append_message(
+            "delegate_child", role="assistant", content="private delegate work", timestamp=base + 40
+        )
+
+        result = json.loads(session_search(db=db, limit=10))
+        ids = [row["session_id"] for row in result["results"]]
+
+        assert "branch_root" in ids
+        assert "branch_child" in ids
+        assert "delegate_parent" in ids
+        assert "delegate_child" not in ids
+
 
 # =========================================================================
 # Discovery shape (with query)
@@ -157,6 +233,69 @@ class TestDiscoveryShape:
         result = json.loads(session_search(query="modpack", db=db, current_session_id="s_newest"))
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
+
+    def test_discovery_role_filter_applies_to_window_and_bookends(self, db):
+        db.create_session("s_roles", source="cli")
+        db.append_message("s_roles", role="user", content="needle from the user")
+        db.append_message("s_roles", role="assistant", content="assistant context")
+        db.append_message("s_roles", role="tool", content="tool context")
+        db.append_message("s_roles", role="user", content="user tail")
+
+        result = json.loads(session_search(
+            query="needle", role_filter="user", db=db, limit=1
+        ))
+
+        hit = result["results"][0]
+        returned = hit["bookend_start"] + hit["messages"] + hit["bookend_end"]
+        assert returned
+        assert {message["role"] for message in returned} == {"user"}
+
+    def test_discovery_bounds_large_tool_calls_in_bookends(self, db):
+        db.create_session("s_bounded", source="cli")
+        db.append_message(
+            "s_bounded", role="user", content="large opening " + "o" * 50_000
+        )
+        db.append_message(
+            "s_bounded",
+            role="assistant",
+            content="preparing a tool call",
+            tool_calls=[{
+                "id": "call-large",
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "arguments": json.dumps({"command": "x" * 100_000}),
+                },
+            }],
+        )
+        db.append_message("s_bounded", role="tool", content="t" * 50_000)
+        for i in range(8):
+            db.append_message("s_bounded", role="user", content=f"setup {i}")
+            db.append_message("s_bounded", role="assistant", content=f"ready {i}")
+        db.append_message(
+            "s_bounded", role="user", content="bounded payload needle"
+        )
+        for i in range(8):
+            db.append_message("s_bounded", role="assistant", content=f"tail {i}")
+            db.append_message("s_bounded", role="user", content=f"followup {i}")
+
+        raw = session_search(
+            query="bounded payload needle",
+            role_filter="user,assistant,tool",
+            db=db,
+            limit=1,
+        )
+        result = json.loads(raw)
+        hit = result["results"][0]
+        shaped_tool_call = next(
+            message
+            for message in hit["bookend_start"]
+            if message.get("tool_calls_truncated")
+        )
+
+        assert shaped_tool_call["original_tool_calls_chars"] > 100_000
+        assert len(json.dumps(shaped_tool_call["tool_calls"])) < 5_000
+        assert len(raw) < 40_000
 
 
 class TestDiscoverySort:
@@ -209,6 +348,46 @@ class TestScrollShape:
             session_id=anchor_sid, around_message_id=anchor_mid, window=999, db=db
         ))
         assert result["window"] == 20
+
+    def test_scroll_role_filter_applies_to_returned_messages(self, db):
+        db.create_session("s_scroll_roles", source="cli")
+        db.append_message("s_scroll_roles", role="user", content="ask")
+        db.append_message("s_scroll_roles", role="assistant", content="calling tool")
+        tool_id = db.append_message(
+            "s_scroll_roles", role="tool", content="tool-only payload"
+        )
+        db.append_message("s_scroll_roles", role="assistant", content="answer")
+
+        result = json.loads(session_search(
+            session_id="s_scroll_roles",
+            around_message_id=tool_id,
+            window=3,
+            role_filter="tool",
+            db=db,
+        ))
+
+        assert [message["role"] for message in result["messages"]] == ["tool"]
+
+    def test_scroll_bounds_large_requested_tool_payload(self, db):
+        db.create_session("s_scroll_bounded", source="cli")
+        db.append_message("s_scroll_bounded", role="user", content="ask")
+        tool_id = db.append_message(
+            "s_scroll_bounded", role="tool", content="z" * 100_000
+        )
+
+        raw = session_search(
+            session_id="s_scroll_bounded",
+            around_message_id=tool_id,
+            role_filter="tool",
+            db=db,
+        )
+        result = json.loads(raw)
+        message = result["messages"][0]
+
+        assert message["content_truncated"] is True
+        assert message["original_content_chars"] == 100_000
+        assert len(message["content"]) <= 4_001
+        assert len(raw) < 10_000
 
 
     def test_scroll_rejects_active_delegation_child_in_current_lineage(self, db):

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -15,8 +15,8 @@ mode parameter):
      scroll forward / backward, re-anchor on the last / first message id of
      the returned window.
 
-  3. BROWSE — no args. Returns recent sessions chronologically (titles,
-     previews, timestamps).
+  3. BROWSE — no args. Returns recent logical conversations ranked by the
+     newest resumed/reset/compression segment (titles, previews, timestamps).
 
 All three modes operate on the SQLite session DB via the FTS5 index and
 the get_anchored_view / get_messages_around primitives in hermes_state.
@@ -55,6 +55,12 @@ _DEMOTED_SESSION_SOURCES = ("cron",)
 # the handful of distinct sessions a typical query returns.
 _DISCOVER_SCAN_LIMIT = 300
 
+# How many recent session segments browse scans before lineage deduplication.
+# Gateway resets create a fresh child segment linked to the prior session, so
+# fetching only ``limit + 5`` raw roots can hide the newest work or return fewer
+# than ``limit`` logical conversations when one lineage has many segments.
+_BROWSE_SCAN_LIMIT = 300
+
 # Raw FTS rows are only a discovery-plan input. The final response hydrates
 # its own anchored message window and bookends after lineage deduplication.
 _DISCOVER_SEARCH_FIELDS = (
@@ -76,6 +82,10 @@ _COMPACTION_PREFIXES = (
     "[CONTEXT COMPACTION",
     "[CONTEXT SUMMARY]:",
 )
+
+_BOOKEND_CONTENT_LIMIT = 1_200
+_MESSAGE_CONTENT_LIMIT = 4_000
+_TOOL_CALLS_LIMIT = 4_000
 
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
@@ -149,6 +159,69 @@ def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
 def _resolve_lineage(db, session_id: str) -> str:
     """Convenience: return only the lineage root (ignores compression hop)."""
     return _resolve_to_parent(db, session_id)[0]
+
+
+def _session_model_config(session: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Decode the small lineage markers stored in ``sessions.model_config``."""
+    raw = (session or {}).get("model_config")
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            decoded = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
+def _is_delegate_segment(session: Optional[Dict[str, Any]]) -> bool:
+    """Return True for a durable delegate child, even if its source is legacy."""
+    return bool(_session_model_config(session).get("_delegate_from"))
+
+
+def _resolve_browse_lineage(
+    db,
+    session_id: str,
+    session_cache: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> str:
+    """Resolve reset/compression continuation segments to one browse lineage.
+
+    ``parent_session_id`` also represents user-created branches and delegate
+    children. Those are boundaries, not resumed segments: branches remain
+    independently browseable and delegates stay hidden. Gateway reset children
+    carry neither marker, so they continue walking to the prior segment.
+    """
+    if not session_id:
+        return session_id
+    cache = session_cache if session_cache is not None else {}
+
+    def _get(sid: str) -> Dict[str, Any]:
+        if sid not in cache:
+            try:
+                cache[sid] = db.get_session(sid) or {}
+            except Exception:
+                cache[sid] = {}
+        return cache[sid]
+
+    current = session_id
+    visited: set[str] = set()
+    while current and current not in visited:
+        visited.add(current)
+        session = _get(current)
+        parent_id = session.get("parent_session_id")
+        if not parent_id:
+            break
+        config = _session_model_config(session)
+        if config.get("_branched_from") or config.get("_delegate_from"):
+            break
+        parent = _get(parent_id)
+        # Legacy branches predate the durable _branched_from marker. The
+        # parent's end reason is their remaining discriminator.
+        if parent.get("end_reason") == "branched":
+            break
+        current = parent_id
+    return current
 
 
 def _is_compression_ended(db, session_id: str) -> bool:
@@ -251,6 +324,7 @@ def _shape_message(
     m: Dict[str, Any],
     anchor_id: Optional[int] = None,
     max_content_len: Optional[int] = None,
+    max_tool_calls_len: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Slim a message row for the tool response. Keeps content even if empty.
 
@@ -273,6 +347,29 @@ def _shape_message(
         content = raw_content
         truncated = False
         original_chars = None
+    raw_tool_calls = m.get("tool_calls")
+    tool_calls = raw_tool_calls
+    tool_calls_truncated = False
+    original_tool_calls_chars = None
+    if max_tool_calls_len and raw_tool_calls:
+        try:
+            encoded_tool_calls = json.dumps(
+                raw_tool_calls, ensure_ascii=False, separators=(",", ":")
+            )
+        except (TypeError, ValueError):
+            encoded_tool_calls = str(raw_tool_calls)
+        if len(encoded_tool_calls) > max_tool_calls_len:
+            # Preserve the historical list shape while making the truncation
+            # explicit. A compact JSON preview is enough to identify the call;
+            # session_search scroll can retrieve adjacent prose without
+            # injecting a multi-megabyte argument block into the active turn.
+            tool_calls = [{
+                "truncated": True,
+                "preview": encoded_tool_calls[:max_tool_calls_len] + "…",
+            }]
+            tool_calls_truncated = True
+            original_tool_calls_chars = len(encoded_tool_calls)
+
     entry = {
         "id": m.get("id"),
         "role": m.get("role"),
@@ -281,8 +378,8 @@ def _shape_message(
     }
     if m.get("tool_name"):
         entry["tool_name"] = m.get("tool_name")
-    if m.get("tool_calls"):
-        entry["tool_calls"] = m.get("tool_calls")
+    if tool_calls:
+        entry["tool_calls"] = tool_calls
     if m.get("tool_call_id"):
         entry["tool_call_id"] = m.get("tool_call_id")
     if anchor_id is not None and m.get("id") == anchor_id:
@@ -290,6 +387,9 @@ def _shape_message(
     if truncated:
         entry["content_truncated"] = True
         entry["original_content_chars"] = original_chars
+    if tool_calls_truncated:
+        entry["tool_calls_truncated"] = True
+        entry["original_tool_calls_chars"] = original_tool_calls_chars
     # Strip None values to keep payload tight, but always keep content
     # (absent content is meaningful — tool-call-only assistant turns).
     return {k: v for k, v in entry.items() if v is not None or k in ("content",)}
@@ -435,30 +535,57 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
 
 
 def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
-    """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
+    """Return recent logical conversations, ranked by their freshest segment."""
     try:
+        # Reset and compression continuations are durable child rows. Read raw
+        # segments (rather than root-only projection) so a fresh continuation's
+        # activity can rank the lineage and provide the preview/link returned to
+        # the model. The rows already arrive newest-first.
         sessions = db.list_sessions_rich(
-            limit=limit + 5,
+            limit=max(_BROWSE_SCAN_LIMIT, limit + 5),
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            include_children=True,
+            project_compression_tips=False,
             order_by_last_active=True,
-        )  # fetch extra so we can skip current
+            compact_rows=True,
+        )
+        session_cache = {
+            str(s.get("id")): s for s in sessions if s.get("id")
+        }
+        current_root = (
+            _resolve_browse_lineage(db, current_session_id, session_cache)
+            if current_session_id
+            else None
+        )
 
-        current_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-
-        results = []
+        # Insertion order is recall order: the first row for a lineage is its
+        # freshest segment because list_sessions_rich sorted raw segments by
+        # last_active. Later rows only back-fill stable root metadata such as a
+        # title and original started_at.
+        grouped: Dict[str, Dict[str, Any]] = {}
         for s in sessions:
             sid = s.get("id", "")
-            if current_root and (sid == current_root or sid == current_session_id):
+            if not sid or _is_delegate_segment(s):
                 continue
-            # Skip child / delegation sessions
-            if s.get("parent_session_id"):
+            lineage_root = _resolve_browse_lineage(db, sid, session_cache)
+            if current_root and lineage_root == current_root:
                 continue
+            existing = grouped.get(lineage_root)
+            if existing is None:
+                grouped[lineage_root] = dict(s)
+            elif not existing.get("title") and s.get("title"):
+                existing["title"] = s.get("title")
+
+        results = []
+        for lineage_root, s in grouped.items():
+            sid = s.get("id", "")
+            root_meta = session_cache.get(lineage_root) or {}
             results.append({
                 "session_id": sid,
                 "link": _session_link(sid, link_profile),
-                "title": s.get("title") or None,
+                "title": s.get("title") or root_meta.get("title") or None,
                 "source": s.get("source", ""),
-                "started_at": s.get("started_at", ""),
+                "started_at": root_meta.get("started_at", s.get("started_at", "")),
                 "last_active": s.get("last_active", ""),
                 "message_count": s.get("message_count", 0),
                 "preview": s.get("preview", ""),
@@ -484,6 +611,7 @@ def _scroll(
     around_message_id: int,
     window: int = 5,
     current_session_id: str = None,
+    role_filter: Optional[List[str]] = None,
 ) -> str:
     """Scroll shape: return a window of messages centered on an anchor.
 
@@ -594,6 +722,10 @@ def _scroll(
             success=False,
         )
 
+    if role_filter:
+        allowed_roles = set(role_filter)
+        messages = [m for m in messages if m.get("role") in allowed_roles]
+
     response = {
         "success": True,
         "mode": "scroll",
@@ -606,7 +738,15 @@ def _scroll(
             "title": session_meta.get("title"),
         },
         "window": window,
-        "messages": [_shape_message(m, anchor_id=around_message_id) for m in messages],
+        "messages": [
+            _shape_message(
+                m,
+                anchor_id=around_message_id,
+                max_content_len=_MESSAGE_CONTENT_LIMIT,
+                max_tool_calls_len=_TOOL_CALLS_LIMIT,
+            )
+            for m in messages
+        ],
         "messages_before": view.get("messages_before", 0),
         "messages_after": view.get("messages_after", 0),
     }
@@ -624,6 +764,7 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    role_filter: List[str],
 ) -> Optional[Dict[str, Any]]:
     """Return a discovery-shaped result when the query matches a session title."""
     title_query = _normalize_title_query(query)
@@ -656,10 +797,18 @@ def _title_match_result(
         logging.debug("get_messages failed for title match %s", session_id, exc_info=True)
         messages = []
 
-    anchor_id = messages[0].get("id") if messages else None
+    allowed_roles = set(role_filter)
+    eligible_messages = [m for m in messages if m.get("role") in allowed_roles]
+    anchor_id = eligible_messages[0].get("id") if eligible_messages else None
     if anchor_id is not None:
         try:
-            view = db.get_anchored_view(session_id, anchor_id, window=5, bookend=3)
+            view = db.get_anchored_view(
+                session_id,
+                anchor_id,
+                window=5,
+                bookend=3,
+                keep_roles=tuple(role_filter),
+            )
         except Exception:
             logging.debug("get_anchored_view failed for title match %s/%s", session_id, anchor_id, exc_info=True)
             view = {}
@@ -675,9 +824,34 @@ def _title_match_result(
         "matched_role": "session_title",
         "match_message_id": anchor_id,
         "snippet": f"Session title matched: {session_meta.get('title') or title_query}",
-        "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or messages[:3])],
-        "messages": [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or messages[:5])],
-        "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or messages[-3:])],
+        "bookend_start": [
+            _shape_message(
+                m,
+                max_content_len=_BOOKEND_CONTENT_LIMIT,
+                max_tool_calls_len=_TOOL_CALLS_LIMIT,
+            )
+            for m in (view.get("bookend_start") or eligible_messages[:3])
+            if m.get("role") in allowed_roles
+        ],
+        "messages": [
+            _shape_message(
+                m,
+                anchor_id=anchor_id,
+                max_content_len=_MESSAGE_CONTENT_LIMIT,
+                max_tool_calls_len=_TOOL_CALLS_LIMIT,
+            )
+            for m in (view.get("window") or eligible_messages[:5])
+            if m.get("role") in allowed_roles
+        ],
+        "bookend_end": [
+            _shape_message(
+                m,
+                max_content_len=_BOOKEND_CONTENT_LIMIT,
+                max_tool_calls_len=_TOOL_CALLS_LIMIT,
+            )
+            for m in (view.get("bookend_end") or eligible_messages[-3:])
+            if m.get("role") in allowed_roles
+        ],
         "messages_before": view.get("messages_before", 0),
         "messages_after": view.get("messages_after", max(len(messages) - 5, 0)),
         "_lineage_root": lineage_root,
@@ -699,7 +873,7 @@ def _discover(
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    title_result = _title_match_result(db, query, current_lineage_root, role_list)
 
     try:
         raw_results = db.search_messages(
@@ -791,7 +965,13 @@ def _discover(
         hit_sid = match_info.get("session_id") or lineage_root
         msg_id = match_info.get("id")
         try:
-            view = db.get_anchored_view(hit_sid, msg_id, window=5, bookend=3)
+            view = db.get_anchored_view(
+                hit_sid,
+                msg_id,
+                window=5,
+                bookend=3,
+                keep_roles=tuple(role_list),
+            )
         except Exception as e:
             logging.warning("get_anchored_view failed for %s/%s: %s", hit_sid, msg_id, e, exc_info=True)
             continue
@@ -813,13 +993,29 @@ def _discover(
             "match_message_id": msg_id,
             "snippet": match_info.get("snippet") or "",
             "bookend_start": [
-                _shape_message(m, max_content_len=1200)
+                _shape_message(
+                    m,
+                    max_content_len=_BOOKEND_CONTENT_LIMIT,
+                    max_tool_calls_len=_TOOL_CALLS_LIMIT,
+                )
                 for m in (view.get("bookend_start") or [])
                 if not _is_compaction_summary(m.get("content", ""))
             ],
-            "messages": [_shape_message(m, anchor_id=msg_id, max_content_len=4000) for m in (view.get("window") or [])],
+            "messages": [
+                _shape_message(
+                    m,
+                    anchor_id=msg_id,
+                    max_content_len=_MESSAGE_CONTENT_LIMIT,
+                    max_tool_calls_len=_TOOL_CALLS_LIMIT,
+                )
+                for m in (view.get("window") or [])
+            ],
             "bookend_end": [
-                _shape_message(m, max_content_len=1200)
+                _shape_message(
+                    m,
+                    max_content_len=_BOOKEND_CONTENT_LIMIT,
+                    max_tool_calls_len=_TOOL_CALLS_LIMIT,
+                )
                 for m in (view.get("bookend_end") or [])
                 if not _is_compaction_summary(m.get("content", ""))
             ],
@@ -904,6 +1100,12 @@ def session_search(
             db = profile_db
             current_session_id = None
 
+    # Parse once before shape dispatch so scroll and discovery share the same
+    # semantics. Read/browse keep their historical unfiltered behavior.
+    role_list: Optional[List[str]] = None
+    if isinstance(role_filter, str) and role_filter.strip():
+        role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
+
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
         return _scroll(
@@ -912,6 +1114,7 @@ def session_search(
             around_message_id=around_message_id,
             window=window,
             current_session_id=current_session_id,
+            role_filter=role_list,
         )
 
     # Read shape: a session_id with no anchor → dump the whole session.
@@ -946,11 +1149,6 @@ def session_search(
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
         return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
-
-    # Parse role_filter
-    role_list: Optional[List[str]] = None
-    if isinstance(role_filter, str) and role_filter.strip():
-        role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 
     # Normalise sort
     sort_norm: Optional[str] = None
@@ -1108,16 +1306,18 @@ SESSION_SEARCH_SCHEMA = {
             "window": {
                 "type": "integer",
                 "description": (
-                    "Scroll shape only. Messages to return on each side of the anchor "
-                    "(anchor itself always included). Clamped to [1, 20]. Default 5."
+                    "Scroll shape only. Raw messages to inspect on each side of the anchor "
+                    "before role filtering. The anchor is included when its role matches "
+                    "role_filter (or no filter is set). Clamped to [1, 20]. Default 5."
                 ),
                 "default": 5,
             },
             "role_filter": {
                 "type": "string",
                 "description": (
-                    "Optional. Comma-separated roles to include. Discovery defaults to "
-                    "'user,assistant' (tool output is usually noise). Pass "
+                    "Optional. Comma-separated roles to include in discovery and scroll "
+                    "payloads. Discovery defaults to 'user,assistant' (tool output is "
+                    "usually noise); scroll remains unfiltered when omitted. Pass "
                     "'user,assistant,tool' to include tool output (debugging tool "
                     "behaviour) or 'tool' to search tool output only."
                 ),


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining `session_search` continuity/payload failure class:

- browse now treats gateway reset/compression children as continuation segments, ranks the logical conversation by its freshest segment, and returns the fresh preview/link once;
- user-created branches remain separate and delegate children remain hidden;
- explicit `role_filter` is parsed before scroll dispatch and applies to hydrated scroll/discovery context;
- scroll message content and serialized `tool_calls` are bounded with explicit truncation metadata.

The old browse path projected roots and then skipped child rows, so resumed Telegram conversations could disappear from recent-session browse. The old scroll path dispatched before parsing `role_filter`, allowing large tool rows through despite `role_filter="user,assistant"`.

## Related Issue

Fixes #82988

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/session_search_tool.py`
  - scan/dedupe continuation segments by freshest activity;
  - preserve branch/delegate boundaries;
  - apply scroll/discovery role filters consistently;
  - cap message content and serialized tool-call arguments.
- `tests/tools/test_session_search.py`
  - resumed-lineage ranking/dedup regression;
  - branch/delegate boundary regression;
  - hydrated discovery/scroll role-filter regressions;
  - 100k content/tool-call payload bounds.

## How to Test

1. Run `pytest tests/tools/test_session_search.py -q`.
2. Create a reset/compression parent plus newer continuation child and confirm browse returns the child once, ahead of older independent sessions.
3. Scroll across a `user → assistant → tool` window with `role_filter="tool"` or `role_filter="user,assistant"` and confirm only requested roles return.
4. Hydrate 100k message content/tool-call arguments and confirm the response carries truncation metadata and remains bounded.

Local verification performed:

- canonical runner over the targeted regression set: **8 files, 124 tests passed, 0 failed**;
- `ruff check tools/session_search_tool.py tests/tools/test_session_search.py`: **All checks passed**;
- `python3 -m py_compile tools/session_search_tool.py tests/tools/test_session_search.py`;
- `git diff --check`;
- real `SessionDB` smoke script covering resumed browse ordering, strict scroll role filtering, 100k content truncation, 100k tool-call truncation, and response-size bounds.

GitHub did not report automatic checks for this fork PR at submission; the canonical local runner and real-`SessionDB` smoke tests above are the executed evidence rather than a synthetic green badge.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation update — N/A; the existing tool schema description is updated in code
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered: SQLite/session ordering and JSON shaping are platform-independent
- [x] Tool description/schema updated for scroll role-filter semantics