### PR TITLE
fix(desktop): show approvals for protected file writes

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -75,6 +75,14 @@ describe('PendingToolApproval', () => {
     expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
   })
 
+  it.each(['patch', 'write_file'])('renders inline approval controls for protected %s writes', toolName => {
+    setRequest('Update protected agent instructions')
+    render(<PendingToolApproval part={part(toolName)} />)
+
+    expect(screen.getByRole('button', { name: /Run/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
+  })
+
   it('sends approval.respond {choice: "once"} and clears the request on Run', async () => {
     const request = mockGateway()
     setRequest()

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -38,12 +38,12 @@ import type { ToolPart } from './fallback-model'
 // Binding is POSITIONAL, not command-matched: the desktop `tool.start` payload
 // carries no structured args (only tool_id/name/context — see
 // tui_gateway/server.py::_on_tool_start), so we cannot join the approval to the
-// row by command string. But `approval.request` only ever fires from the
-// `terminal` / `execute_code` guards and the agent thread blocks on exactly one
+// row by command string. `approval.request` can fire from the command guards
+// and protected-instruction file writes. The agent thread blocks on exactly one
 // approval at a time, so the single pending row of those tools IS the row that
 // raised it. The command/description text comes from `$approvalRequest` (the
 // event payload), which is the only place that data reliably exists.
-export const APPROVAL_TOOLS = new Set(['terminal', 'execute_code'])
+export const APPROVAL_TOOLS = new Set(['terminal', 'execute_code', 'patch', 'write_file'])
 
 // Canonical gateway choices (ui-tui/src/components/prompts.tsx).
 type ApprovalChoice = 'once' | 'session' | 'always' | 'deny'


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop approval UI for protected instruction-file writes. The gateway can emit `approval.request` while `patch` or `write_file` is pending, but the renderer only mounted inline approval controls for `terminal` and `execute_code`. That left the request unanswered until it failed closed on timeout.

The change adds the two file-write tools to the existing approval whitelist and updates the positional-binding comment to match the actual event producers.

## Related Issue

Fixes #82976

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Allow `PendingToolApproval` to render for `patch` and `write_file`.
- Add parameterized renderer coverage proving both protected-write tool rows show Run and Reject controls.
- Keep non-writing tools such as `read_file` outside the approval whitelist.

## How to Test

1. Start Hermes Desktop with protected instruction files enabled.
2. Ask the agent to update a project-local `AGENTS.md` using `patch` or `write_file`.
3. Confirm the pending tool row renders Run/Reject controls and can answer the gateway approval instead of timing out.

Automated verification on macOS 26.4.1 arm64 with temporary Node 24.13.0 / npm 11.17.0:

```text
npm run --workspace apps/desktop test:ui -- src/components/assistant-ui/tool/approval.test.tsx
  1 file passed, 14 tests passed

npm run --workspace apps/desktop test:ui
  406 files passed, 3632 tests passed

npm run --workspace apps/desktop typecheck
  passed

npm run --workspace apps/desktop lint
  passed with 0 errors (88 pre-existing warnings in unrelated files)

prettier --check approval.tsx approval.test.tsx
  passed
```

Live packaged Desktop E2E was not run.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed PRs and issue cross-references for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` — N/A for this Desktop TypeScript-only change; the complete Desktop UI Vitest suite was run instead
- [x] I've added tests for the bug fix
- [x] I've tested on macOS 26.4.1 arm64

### Documentation & Housekeeping

- [x] Documentation update — N/A; the behavior and code comment are updated
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered; the change is renderer-only and has no platform-specific branch
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

No screenshot: the regression is covered at the renderer contract level, and a packaged Desktop E2E environment was not available.

AI assistance disclosure: Codex assisted with the focused implementation, repository searches, and test execution. The PR description reports only commands and results actually observed.
