### PR TITLE
fix(session-search): exclude active lineage before scan

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1328,6 +1328,48 @@ class SessionSearchMixin:
         ]
         return bool(tokens) and all(len(t) >= 3 for t in tokens)
 
+    def _active_lineage_session_ids(self, lineage_root: Optional[str]) -> List[str]:
+        """Return live session ids in a root's parent-linked tree.
+
+        Compression-ended segments stay searchable because their transcript is
+        no longer in the current live context. Other linked segments are live
+        context, so their active rows cannot consume recall's scan window.
+        """
+        if not lineage_root:
+            return []
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                """WITH RECURSIVE lineage(id) AS (
+                       SELECT id FROM sessions WHERE id = ?
+                       UNION
+                       SELECT child.id
+                       FROM sessions AS child
+                       JOIN lineage AS parent ON child.parent_session_id = parent.id
+                   )
+                   SELECT session.id
+                   FROM sessions AS session
+                   JOIN lineage ON lineage.id = session.id
+                   WHERE COALESCE(session.end_reason, '') != 'compression'
+                """,
+                (lineage_root,),
+            ).fetchall()
+        return [row["id"] for row in rows]
+
+    @staticmethod
+    def _exclude_live_lineage_rows(
+        where: List[str], params: List[Any], session_ids: Collection[str]
+    ) -> None:
+        """Exclude active rows from the live lineage.
+
+        With default visibility, the caller's active/compacted predicate still
+        admits only compaction archives among inactive rows.
+        """
+        if not session_ids:
+            return
+        placeholders = ",".join("?" for _ in session_ids)
+        where.append(f"(m.active = 0 OR m.session_id NOT IN ({placeholders}))")
+        params.extend(session_ids)
+
     def _run_trigram_search(
         self,
         raw_query: str,
@@ -1337,6 +1379,7 @@ class SessionSearchMixin:
         include_inactive: bool,
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
+        exclude_live_session_ids: Collection[str] = (),
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -1370,6 +1413,9 @@ class SessionSearchMixin:
         tri_params: list = [trigram_query]
         if not include_inactive:
             tri_where.append("(m.active = 1 OR m.compacted = 1)")
+        self._exclude_live_lineage_rows(
+            tri_where, tri_params, exclude_live_session_ids
+        )
         if source_filter is not None:
             tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
             tri_params.extend(source_filter)
@@ -1418,6 +1464,7 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        exclude_live_lineage_root: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
 
@@ -1434,6 +1481,7 @@ class SessionSearchMixin:
                 query,
                 source_filter=source_filter,
                 exclude_sources=exclude_sources,
+                exclude_live_lineage_root=exclude_live_lineage_root,
                 role_filter=role_filter,
                 limit=limit,
                 offset=offset,
@@ -1544,6 +1592,7 @@ class SessionSearchMixin:
         *,
         source_filter: Optional[List[str]],
         exclude_sources: Optional[List[str]],
+        exclude_live_session_ids: Collection[str],
         role_filter: Optional[List[str]],
         limit: int,
         offset: int,
@@ -1558,6 +1607,7 @@ class SessionSearchMixin:
         where = [f"({predicate})"]
         if not include_inactive:
             where.append("(m.active = 1 OR m.compacted = 1)")
+        self._exclude_live_lineage_rows(where, params, exclude_live_session_ids)
         if source_filter is not None:
             where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
             params.extend(source_filter)
@@ -1701,6 +1751,7 @@ class SessionSearchMixin:
         query: str,
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
+        exclude_live_lineage_root: Optional[str] = None,
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -1748,12 +1799,16 @@ class SessionSearchMixin:
         if not query:
             return []
 
+        exclude_live_session_ids = self._active_lineage_session_ids(
+            exclude_live_lineage_root
+        )
         self._refresh_fts_stale_state()
         if self._fts_stale:
             matches = self._search_messages_like_fallback(
                 query,
                 source_filter=source_filter,
                 exclude_sources=exclude_sources,
+                exclude_live_session_ids=exclude_live_session_ids,
                 role_filter=role_filter,
                 limit=limit,
                 offset=offset,
@@ -1793,6 +1848,9 @@ class SessionSearchMixin:
             # are discoverable; only rewind/undo rows (active=0, compacted=0)
             # are hidden. See archive_and_compact() / #38763.
             where_clauses.append("(m.active = 1 OR m.compacted = 1)")
+        self._exclude_live_lineage_rows(
+            where_clauses, params, exclude_live_session_ids
+        )
 
         if source_filter is not None:
             source_placeholders = ",".join("?" for _ in source_filter)
@@ -1893,6 +1951,9 @@ class SessionSearchMixin:
                 cjk_params: list = [cjk_query]
                 if not include_inactive:
                     cjk_where.append("(m.active = 1 OR m.compacted = 1)")
+                self._exclude_live_lineage_rows(
+                    cjk_where, cjk_params, exclude_live_session_ids
+                )
                 if source_filter is not None:
                     cjk_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     cjk_params.extend(source_filter)
@@ -1982,6 +2043,9 @@ class SessionSearchMixin:
                 tri_params: list = [trigram_query]
                 if not include_inactive:
                     tri_where.append("(m.active = 1 OR m.compacted = 1)")
+                self._exclude_live_lineage_rows(
+                    tri_where, tri_params, exclude_live_session_ids
+                )
                 if source_filter is not None:
                     tri_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     tri_params.extend(source_filter)
@@ -2076,6 +2140,9 @@ class SessionSearchMixin:
                     # compaction-archived rows are discoverable; rewind/undo
                     # rows (active=0, compacted=0) are hidden (#38763).
                     like_where.append("(m.active = 1 OR m.compacted = 1)")
+                self._exclude_live_lineage_rows(
+                    like_where, like_params, exclude_live_session_ids
+                )
                 if source_filter is not None:
                     like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     like_params.extend(source_filter)
@@ -2143,6 +2210,7 @@ class SessionSearchMixin:
                     include_inactive=include_inactive,
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
+                    exclude_live_session_ids=exclude_live_session_ids,
                     role_filter=role_filter,
                 )
                 seen_ids = {m["id"] for m in matches}
@@ -2181,6 +2249,7 @@ class SessionSearchMixin:
                     include_inactive=include_inactive,
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
+                    exclude_live_session_ids=exclude_live_session_ids,
                     role_filter=role_filter,
                     limit=limit,
                     offset=offset,
@@ -2198,6 +2267,7 @@ class SessionSearchMixin:
                     include_inactive=include_inactive,
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
+                    exclude_live_session_ids=exclude_live_session_ids,
                     role_filter=role_filter,
                     limit=limit,
                     offset=offset,
@@ -2215,6 +2285,7 @@ class SessionSearchMixin:
         include_inactive: bool = False,
         source_filter: Optional[List[str]] = None,
         exclude_sources: Optional[List[str]] = None,
+        exclude_live_session_ids: Collection[str] = (),
         role_filter: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         """LIKE-scan the rows the deferred rebuild hasn't indexed yet.
@@ -2252,6 +2323,7 @@ class SessionSearchMixin:
             params += [f"%{esc}%"] * 3
         if not include_inactive:
             where.append("(m.active = 1 OR m.compacted = 1)")
+        self._exclude_live_lineage_rows(where, params, exclude_live_session_ids)
         if source_filter is not None:
             where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
             params.extend(source_filter)

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -158,6 +158,46 @@ class TestDiscoveryShape:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_newest" not in sids
 
+    def test_active_lineage_is_excluded_before_newest_fetch_window(self, db):
+        """Live parent/child rows must not consume the discovery scan window."""
+        _seed_modpack_sessions(db)
+        now = int(time.time())
+        db.create_session("s_parent", source="cli")
+        db.create_session("s_current", source="cli", parent_session_id="s_parent")
+
+        # More than the 300-row discovery scan limit, split across both active
+        # lineage members. Post-hoc filtering is too late: it would return no
+        # historical sessions because all fetched rows are later discarded.
+        for idx in range(151):
+            db.append_message(
+                "s_parent",
+                role="user",
+                content=f"modpack parent live context {idx}",
+                timestamp=now + idx,
+            )
+            db.append_message(
+                "s_current",
+                role="user",
+                content=f"modpack child live context {idx}",
+                timestamp=now + 1000 + idx,
+            )
+        db._conn.commit()
+
+        result = json.loads(
+            session_search(
+                query="modpack",
+                limit=2,
+                sort="newest",
+                db=db,
+                current_session_id="s_current",
+            )
+        )
+
+        assert result["count"] == 2
+        assert [entry["session_id"] for entry in result["results"]] == [
+            "s_newest", "s_middle"
+        ]
+
 
 class TestDiscoverySort:
     def test_sort_newest_orders_by_recency(self, db):

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -706,6 +706,7 @@ def _discover(
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            exclude_live_lineage_root=current_lineage_root,
             limit=_DISCOVER_SCAN_LIMIT,  # widen so dedup-by-lineage can find
             # distinct sessions AND so interactive matches buried under a wall
             # of cron rows are still in hand for the demotion pass below.


### PR DESCRIPTION
## Summary
- exclude active messages from the entire current parent-linked lineage in SQL before the discovery fetch window is applied
- retain compaction-archived messages and legacy compression-ended segments for recall
- apply the predicate to FTS, CJK/trigram, stale-index, and deferred-rebuild fallback paths

## Regression coverage
- seed more than the 300-row discovery window across a live parent/current-child lineage
- verify historical sessions remain discoverable instead of being removed only after the SQL window is exhausted
- retain existing in-place and legacy compression discovery coverage

## Validation
- `uv run --no-sync pytest -o addopts= tests/tools/test_session_search.py -q` (40 passed)
- `uv run --with ruff ruff check hermes_state_search.py tools/session_search_tool.py tests/tools/test_session_search.py`
- `uv run --no-sync python -m compileall -q hermes_state_search.py tools/session_search_tool.py tests/tools/test_session_search.py`

Closes #36238.

Supersedes the stale exact-current-session approach in #49404 with a full active-lineage predicate.