### PR TITLE
fix(terminal): allow explicit abandoned-turn persistence

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -98,6 +98,47 @@ def _model_switch_skew_guard() -> Optional[str]:
     )
 
 
+def _snapshot_processes_for_session_reset(session_key: str) -> tuple[str, ...]:
+    """Snapshot processes registered to one stable gateway session key."""
+    if not session_key:
+        return ()
+    try:
+        from tools.process_registry import process_registry
+
+        return process_registry.snapshot_running_ids_for_session(session_key)
+    except Exception:
+        logger.warning(
+            "Failed to snapshot background processes for session %s during reset",
+            session_key,
+            exc_info=True,
+        )
+        return ()
+
+
+def _kill_processes_for_session_reset(process_ids: tuple[str, ...]) -> int:
+    """Broadly kill a fixed reset-boundary process snapshot."""
+    from tools.process_registry import process_registry
+
+    killed = 0
+    for process_id in process_ids:
+        try:
+            result = process_registry.kill_process(
+                process_id,
+                source="kill_all",
+                consume_output=False,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to clean background process %s during session reset",
+                process_id,
+                exc_info=True,
+            )
+            continue
+        if result.get("status") in {"killed", "already_exited"}:
+            killed += 1
+    return killed
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -133,6 +174,40 @@ class GatewaySlashCommandsMixin:
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.
         old_entry = self.session_store._entries.get(session_key)
+
+        # Snapshot processes already registered at this reset boundary. Use
+        # the stable gateway session key so cleanup does not depend on a cached
+        # AIAgent (which may have been soft-evicted) or its compression-rotated
+        # session_id. Capturing IDs before the first await keeps a replacement
+        # turn's later processes out of this reset's broad cleanup.
+        _reset_process_ids = _snapshot_processes_for_session_reset(session_key)
+
+        # Process termination can block on remote backends and process-tree
+        # teardown, so run the fixed snapshot off-loop with the same bounded
+        # reset budget used for agent resource cleanup. The worker may continue
+        # after a timeout, but it can only touch the pre-reset IDs above.
+        if _reset_process_ids:
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(
+                        _kill_processes_for_session_reset,
+                        _reset_process_ids,
+                    ),
+                    timeout=_RESET_CLEANUP_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Background process cleanup for session %s exceeded %ss "
+                    "during reset; proceeding while the worker continues",
+                    session_key,
+                    _RESET_CLEANUP_TIMEOUT_S,
+                )
+            except Exception:
+                logger.warning(
+                    "Background process cleanup failed for session %s during reset",
+                    session_key,
+                    exc_info=True,
+                )
 
         # Close tool resources on the old agent (terminal sandboxes, browser
         # daemons, background processes) before evicting from cache.

--- a/tests/gateway/test_35994_reset_button_deadlock.py
+++ b/tests/gateway/test_35994_reset_button_deadlock.py
@@ -12,7 +12,10 @@ The fix offloads _cleanup_agent_resources to a worker thread with a bounded
 timeout, so the loop is never blocked and a stuck teardown degrades gracefully.
 """
 import asyncio
+import json
 import logging
+import shlex
+import sys
 import threading
 import time
 from datetime import datetime
@@ -38,6 +41,27 @@ def _make_source() -> SessionSource:
 
 def _make_event(text: str) -> MessageEvent:
     return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+@pytest.fixture(autouse=True)
+def _run_unrelated_reset_helpers_inline(monkeypatch):
+    """Inline only inert presentation helpers; keep cleanup off-loop."""
+    real_to_thread = asyncio.to_thread
+
+    async def selective_to_thread(func, *args, **kwargs):
+        if getattr(func, "_test_inline_reset_helper", False):
+            return func(*args, **kwargs)
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", selective_to_thread)
+
+
+def _inline_reset_helper(value):
+    def helper(_source):
+        return value
+
+    setattr(helper, "_test_inline_reset_helper", True)
+    return helper
 
 
 def _make_runner_with_cached_agent(close_fn):
@@ -79,6 +103,9 @@ def _make_runner_with_cached_agent(close_fn):
     runner._session_db = None
     runner._is_user_authorized = lambda _source: True
     runner._format_session_info = lambda: ""
+    runner._reset_notice_session_info = _inline_reset_helper("")
+    runner._telegram_topic_new_header = _inline_reset_helper("")
+    runner._is_telegram_topic_lane = _inline_reset_helper(False)
 
     # Enable the cache-lock path (this is what the button callback exercises)
     runner._agent_cache_lock = threading.RLock()
@@ -142,6 +169,229 @@ async def test_reset_does_not_block_event_loop_during_cleanup():
         f"{ticks_during_block} ticks while close() was running"
     )
     runner.session_store.reset_session.assert_called_once()
+
+
+def test_reset_broad_process_cleanup_uses_stable_session_key(monkeypatch):
+    """Reset cleans a stable-key snapshot without touching a replacement."""
+    import tools.process_registry as process_registry_module
+    from gateway.slash_commands import (
+        _kill_processes_for_session_reset,
+        _snapshot_processes_for_session_reset,
+    )
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    registry = ProcessRegistry()
+    target = ProcessSession(
+        id="proc_old_compression_owner",
+        command="sleep 60",
+        task_id="session-before-compression",
+        environment_task_id="default",
+        session_key=build_session_key(_make_source()),
+        persist_on_abandon=True,
+    )
+    foreign = ProcessSession(
+        id="proc_foreign",
+        command="sleep 60",
+        task_id="other-session",
+        environment_task_id="default",
+        session_key="agent:main:telegram:dm:other",
+        persist_on_abandon=True,
+    )
+    registry._running = {target.id: target, foreign.id: foreign}
+    kill_calls = []
+
+    def fake_kill(session_id, **kwargs):
+        kill_calls.append((session_id, kwargs))
+        registry._running[session_id].exited = True
+        return {"status": "killed"}
+
+    monkeypatch.setattr(registry, "kill_process", fake_kill)
+    monkeypatch.setattr(process_registry_module, "process_registry", registry)
+
+    reset_snapshot = _snapshot_processes_for_session_reset(target.session_key)
+    assert reset_snapshot == (target.id,)
+
+    replacement = ProcessSession(
+        id="proc_replacement_turn",
+        command="sleep 60",
+        task_id="replacement-session",
+        environment_task_id="default",
+        session_key=target.session_key,
+        persist_on_abandon=True,
+    )
+    registry._running[replacement.id] = replacement
+
+    assert _kill_processes_for_session_reset(reset_snapshot) == 1
+
+    assert target.exited is True
+    assert foreign.exited is False
+    assert replacement.exited is False
+    assert kill_calls == [
+        (
+            target.id,
+            {"source": "kill_all", "consume_output": False},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.linux_only
+async def test_busy_reset_kills_background_process_registered_after_snapshot(
+    monkeypatch,
+    tmp_path,
+):
+    """A busy /new and a blocked local spawn cannot straddle the reset boundary."""
+    import tools.process_registry as process_registry_module
+    import tools.terminal_tool as terminal_tool_module
+    from tools.interrupt import set_interrupt
+    from tools.process_registry import ProcessRegistry
+
+    registry = ProcessRegistry()
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+    monkeypatch.setattr(process_registry_module, "process_registry", registry)
+
+    spawn_entered = threading.Event()
+    release_spawn = threading.Event()
+    interrupt_requested = threading.Event()
+    reset_snapshots = []
+    created = {}
+    real_spawn_local = registry.spawn_local
+    real_snapshot = registry.snapshot_running_ids_for_session
+
+    def blocked_spawn_local(**kwargs):
+        spawn_entered.set()
+        if not release_spawn.wait(timeout=10):
+            raise RuntimeError("reset never released the blocked spawn")
+        session = real_spawn_local(**kwargs)
+        created["session"] = session
+        return session
+
+    def snapshot_then_release(session_key):
+        snapshot = real_snapshot(session_key)
+        reset_snapshots.append(snapshot)
+        # The process is deliberately still absent from this immutable reset
+        # snapshot. Its tool thread must own the complementary cleanup.
+        release_spawn.set()
+        return snapshot
+
+    monkeypatch.setattr(registry, "spawn_local", blocked_spawn_local)
+    monkeypatch.setattr(
+        registry,
+        "snapshot_running_ids_for_session",
+        snapshot_then_release,
+    )
+
+    config = {
+        "env_type": "local",
+        "cwd": str(tmp_path),
+        "timeout": 60,
+        "lifetime_seconds": 3600,
+    }
+    environment = SimpleNamespace(env={}, cwd=str(tmp_path))
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_active_environments",
+        {"default": environment},
+    )
+    monkeypatch.setattr(terminal_tool_module, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool_module, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool_module, "_container_aliases", {})
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    session_key = build_session_key(_make_source())
+    monkeypatch.setattr(
+        "tools.approval.get_current_session_key",
+        lambda default="": session_key,
+    )
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    tool_result = {}
+    command = (
+        f"{shlex.quote(sys.executable)} -c "
+        f"{shlex.quote('import time; time.sleep(60)')}"
+    )
+
+    def run_background_tool():
+        set_interrupt(False)
+        try:
+            tool_result["value"] = terminal_tool_module.terminal_tool(
+                command=command,
+                background=True,
+                notify_on_complete=True,
+                persist_on_abandon=True,
+                task_id="sess-old",
+            )
+        finally:
+            set_interrupt(False)
+
+    tool_thread = threading.Thread(target=run_background_tool, daemon=True)
+    tool_thread.start()
+    for _ in range(500):
+        if spawn_entered.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert spawn_entered.is_set(), "background tool never reached its spawn boundary"
+
+    class BusyAgent:
+        _gateway_turn_process_task_id = "sess-old"
+        _gateway_turn_process_baseline = frozenset()
+
+        def __init__(self):
+            self.interrupt_reasons = []
+
+        def hard_interrupt(self, reason=None):
+            self.interrupt_reasons.append(reason)
+            set_interrupt(True, thread_id=tool_thread.ident)
+            interrupt_requested.set()
+
+        def release_clients(self):
+            return None
+
+    agent = BusyAgent()
+    runner = _make_runner_with_cached_agent(lambda: None)
+    runner._agent_cache = {session_key: agent}
+    runner._session_state(session_key).turn.agent = agent
+    runner._persist_active_agents = lambda: None
+
+    try:
+        reset_result = await asyncio.wait_for(
+            runner._busy_new_command(
+                _make_event("/new"),
+                session_key,
+                _make_source(),
+            ),
+            timeout=10,
+        )
+    finally:
+        release_spawn.set()
+        tool_thread.join(timeout=15)
+        set_interrupt(False, thread_id=tool_thread.ident)
+        registry.kill_all()
+
+    assert not tool_thread.is_alive(), "background tool did not drain after /new"
+    assert interrupt_requested.is_set()
+    assert agent.interrupt_reasons
+    assert reset_snapshots == [()]
+    assert reset_result is not None
+
+    result = json.loads(tool_result["value"])
+    session = created["session"]
+    assert result["exit_code"] == 130, result
+    assert result["output"] == "[Command interrupted]"
+    assert "session_id" not in result
+    assert session.exited is True
+    assert session.completion_reason == "killed"
+    assert session.termination_source == "terminal_interrupt"
+    assert registry.is_completion_consumed(session.id) is True
+    assert registry.pending_watchers == []
+    assert registry.completion_queue.empty()
+    assert session.process is not None
+    assert session.process.wait(timeout=5) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -382,7 +382,13 @@ class TestStubSchemaDrift(unittest.TestCase):
     # Parameters that are internal (injected by the handler, not user-facing)
     _INTERNAL_PARAMS = {"task_id", "user_task"}
     # Parameters intentionally blocked in the sandbox
-    _BLOCKED_TERMINAL_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
+    _BLOCKED_TERMINAL_PARAMS = {
+        "background",
+        "pty",
+        "notify_on_complete",
+        "watch_patterns",
+        "persist_on_abandon",
+    }
 
     def test_stubs_cover_all_schema_params(self):
         """Every user-facing parameter in the real schema must appear in the

--- a/tests/tools/test_persist_on_abandon.py
+++ b/tests/tools/test_persist_on_abandon.py
@@ -1,0 +1,699 @@
+"""Behavioral contract for abandoned-turn background-process persistence."""
+
+import json
+import shlex
+import sys
+import time
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.process_registry import ProcessRegistry, ProcessSession
+
+
+def _session(session_id: str, *, persist_on_abandon: bool = False) -> ProcessSession:
+    return ProcessSession(
+        id=session_id,
+        command="sleep 60",
+        task_id="session-a",
+        environment_task_id="default",
+        session_key="gateway-session-a",
+        started_at=time.time(),
+        persist_on_abandon=persist_on_abandon,
+    )
+
+
+def test_abandoned_reap_honors_opt_in_without_weakening_broad_cleanup(
+    monkeypatch,
+):
+    registry = ProcessRegistry()
+    ordinary = _session("proc_ordinary")
+    explicit = _session("proc_explicit", persist_on_abandon=True)
+    broad = _session("proc_broad", persist_on_abandon=True)
+    registry._running = {
+        ordinary.id: ordinary,
+        explicit.id: explicit,
+        broad.id: broad,
+    }
+
+    calls = []
+
+    def fake_kill(
+        session_id,
+        *,
+        source="process.kill",
+        consume_output=True,
+    ):
+        calls.append(
+            (
+                session_id,
+                {"source": source, "consume_output": consume_output},
+            )
+        )
+        registry._running[session_id].exited = True
+        return {"status": "killed"}
+
+    monkeypatch.setattr(registry, "kill_process", fake_kill)
+
+    assert registry.kill_started_since(
+        "session-a",
+        frozenset(),
+        source="gateway_turn_timeout",
+    ) == 1
+    assert calls == [
+        (
+            ordinary.id,
+            {
+                "source": "gateway_turn_timeout",
+                "consume_output": True,
+            },
+        )
+    ]
+
+    assert registry.kill_process(explicit.id)["status"] == "killed"
+    assert calls[-1] == (
+        explicit.id,
+        {"source": "process.kill", "consume_output": True},
+    )
+
+    calls.clear()
+    assert registry.kill_all("session-a") == 1
+    assert calls == [
+        (
+            broad.id,
+            {
+                "source": "kill_all",
+                "consume_output": False,
+            },
+        )
+    ]
+
+
+def test_process_list_surfaces_abandoned_turn_opt_in():
+    registry = ProcessRegistry()
+    ordinary = _session("proc_ordinary")
+    persistent = _session("proc_persistent", persist_on_abandon=True)
+    registry._running = {
+        ordinary.id: ordinary,
+        persistent.id: persistent,
+    }
+
+    listed = {
+        entry["session_id"]: entry
+        for entry in registry.list_sessions(task_id="session-a")
+    }
+
+    assert "persist_on_abandon" not in listed[ordinary.id]
+    assert listed[persistent.id]["persist_on_abandon"] is True
+
+
+def test_shared_environment_key_stays_live_for_session_owned_process(
+    monkeypatch,
+):
+    import tools.process_registry as process_registry_module
+    import tools.terminal_tool as terminal_tool_module
+
+    registry = ProcessRegistry()
+    process = _session("proc_shared_environment")
+    registry._running[process.id] = process
+    environment = SimpleNamespace(cleanup=MagicMock())
+
+    monkeypatch.setattr(process_registry_module, "process_registry", registry)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_active_environments",
+        {"default": environment},
+    )
+    monkeypatch.setattr(terminal_tool_module, "_last_activity", {"default": 0.0})
+    monkeypatch.setattr(terminal_tool_module.time, "time", lambda: 100.0)
+
+    assert registry.has_active_processes("default") is True
+    terminal_tool_module._cleanup_inactive_envs(lifetime_seconds=10)
+
+    assert terminal_tool_module._active_environments["default"] is environment
+    assert terminal_tool_module._last_activity["default"] == 100.0
+    environment.cleanup.assert_not_called()
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+@pytest.mark.linux_only
+def test_local_opted_in_process_survives_reap_but_explicit_kill_still_works(
+    tmp_path,
+    monkeypatch,
+):
+    registry = ProcessRegistry()
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+    command = (
+        f"{shlex.quote(sys.executable)} -c "
+        f"{shlex.quote('import time; time.sleep(60)')}"
+    )
+    ordinary = registry.spawn_local(
+        command,
+        cwd=str(tmp_path),
+        task_id="session-a",
+        environment_task_id="default",
+    )
+    persistent = None
+    try:
+        persistent = registry.spawn_local(
+            command,
+            cwd=str(tmp_path),
+            task_id="session-a",
+            environment_task_id="default",
+            persist_on_abandon=True,
+        )
+
+        assert registry.kill_started_since(
+            "session-a",
+            frozenset(),
+            source="gateway_turn_timeout",
+        ) == 1
+        ordinary_process = ordinary.process
+        persistent_process = persistent.process
+        assert ordinary_process is not None
+        assert persistent_process is not None
+        assert _wait_until(lambda: ordinary_process.poll() is not None)
+        assert persistent_process.poll() is None
+
+        result = registry.kill_process(persistent.id)
+        assert result["status"] == "killed"
+        assert _wait_until(lambda: persistent_process.poll() is not None)
+    finally:
+        registry.kill_all()
+
+
+def test_non_local_spawn_records_abandoned_turn_opt_in(monkeypatch):
+    registry = ProcessRegistry()
+    fake_thread = MagicMock()
+
+    class FakeEnvironment:
+        def get_temp_dir(self):
+            return "/tmp"
+
+        def execute(self, command, **kwargs):
+            return {"output": "4242\n", "returncode": 0}
+
+    monkeypatch.setattr("tools.process_registry.threading.Thread", lambda **_kw: fake_thread)
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+
+    session = registry.spawn_via_env(
+        FakeEnvironment(),
+        "sleep 60",
+        task_id="session-a",
+        environment_task_id="default",
+        persist_on_abandon=True,
+    )
+
+    assert session.persist_on_abandon is True
+    assert session.environment_task_id == "default"
+    assert registry.get(session.id) is session
+    fake_thread.start.assert_called_once_with()
+
+
+def test_checkpoint_round_trip_and_old_checkpoint_default(monkeypatch, tmp_path):
+    import tools.process_registry as process_registry_module
+
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(process_registry_module, "CHECKPOINT_PATH", checkpoint)
+
+    original = ProcessRegistry()
+    persistent = _session("proc_checkpoint", persist_on_abandon=True)
+    persistent.pid = 4242
+    persistent.host_start_time = 123
+    original._running[persistent.id] = persistent
+    original._write_checkpoint()
+
+    encoded = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert encoded[0]["persist_on_abandon"] is True
+    assert encoded[0]["environment_task_id"] == "default"
+
+    recovered = ProcessRegistry()
+    monkeypatch.setattr(recovered, "_host_pid_is_ours", lambda *_args: True)
+    assert recovered.recover_from_checkpoint() == 1
+    recovered_session = recovered.get(persistent.id)
+    assert recovered_session is not None
+    assert recovered_session.persist_on_abandon is True
+    assert recovered_session.environment_task_id == "default"
+
+    encoded[0].pop("persist_on_abandon")
+    encoded[0].pop("environment_task_id")
+    checkpoint.write_text(json.dumps(encoded), encoding="utf-8")
+    old_checkpoint = ProcessRegistry()
+    monkeypatch.setattr(old_checkpoint, "_host_pid_is_ours", lambda *_args: True)
+    assert old_checkpoint.recover_from_checkpoint() == 1
+    old_session = old_checkpoint.get(persistent.id)
+    assert old_session is not None
+    assert old_session.persist_on_abandon is False
+    assert old_session.environment_task_id == old_session.task_id == "session-a"
+
+
+def test_foreground_opt_in_fails_before_environment_creation(monkeypatch):
+    import tools.terminal_tool as terminal_tool_module
+
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_get_env_config",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("invalid opt-in must fail before environment creation")
+        ),
+    )
+
+    result = json.loads(
+        terminal_tool_module.terminal_tool(
+            command="echo should-not-run",
+            persist_on_abandon=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "persist_on_abandon=true requires background=true" in result["error"]
+
+
+def test_terminal_schema_and_handler_expose_abandoned_turn_opt_in(monkeypatch):
+    import tools.terminal_tool as terminal_tool_module
+
+    schema = cast(dict[str, Any], terminal_tool_module.TERMINAL_SCHEMA)
+    parameters = cast(dict[str, Any], schema["parameters"])
+    properties = cast(dict[str, dict[str, Any]], parameters["properties"])
+    prop = properties["persist_on_abandon"]
+    assert prop["type"] == "boolean"
+    assert prop["default"] is False
+
+    captured = {}
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "terminal_tool",
+        lambda **kwargs: captured.update(kwargs) or "{}",
+    )
+    terminal_tool_module._handle_terminal(
+        {
+            "command": "sleep 60",
+            "background": True,
+            "persist_on_abandon": True,
+        },
+        task_id="session-a",
+    )
+
+    assert captured["persist_on_abandon"] is True
+
+
+def test_execute_code_keeps_background_persistence_out_of_foreground_stub():
+    from tools.code_execution_tool import _TERMINAL_BLOCKED_PARAMS
+
+    assert "persist_on_abandon" in _TERMINAL_BLOCKED_PARAMS
+
+
+def _configure_background_terminal(
+    monkeypatch,
+    tmp_path,
+    *,
+    env_type,
+    registry,
+    environment,
+):
+    import tools.process_registry as process_registry_module
+    import tools.terminal_tool as terminal_tool_module
+
+    config = {
+        "env_type": env_type,
+        "cwd": str(tmp_path),
+        "timeout": 60,
+        "lifetime_seconds": 3600,
+    }
+    monkeypatch.setattr(process_registry_module, "process_registry", registry)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_active_environments",
+        {"default": environment},
+    )
+    monkeypatch.setattr(terminal_tool_module, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool_module, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool_module, "_container_aliases", {})
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(
+        "tools.approval.get_current_session_key",
+        lambda default="": "agent:main:telegram:dm:race",
+    )
+    monkeypatch.setenv("TERMINAL_ENV", env_type)
+    return terminal_tool_module
+
+
+@pytest.mark.parametrize("env_type", ["local", "ssh"], ids=("local", "non-local"))
+def test_background_spawn_is_skipped_when_tool_thread_is_already_interrupted(
+    monkeypatch,
+    tmp_path,
+    env_type,
+):
+    from tools.interrupt import is_interrupted, set_interrupt
+
+    registry = SimpleNamespace(
+        pending_watchers=[],
+        spawn_local=MagicMock(side_effect=AssertionError("local spawn must not run")),
+        spawn_via_env=MagicMock(side_effect=AssertionError("remote spawn must not run")),
+    )
+    environment = SimpleNamespace(env={}, cwd=str(tmp_path))
+    terminal_tool_module = _configure_background_terminal(
+        monkeypatch,
+        tmp_path,
+        env_type=env_type,
+        registry=registry,
+        environment=environment,
+    )
+
+    set_interrupt(True)
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="sleep 60",
+                background=True,
+                task_id=f"session-{env_type}",
+                persist_on_abandon=True,
+            )
+        )
+        assert is_interrupted() is True
+    finally:
+        set_interrupt(False)
+
+    assert result["exit_code"] == 130, result
+    assert result["output"] == "[Command interrupted]"
+    assert "session_id" not in result
+    registry.spawn_local.assert_not_called()
+    registry.spawn_via_env.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("env_type", "spawn_method", "process_id", "pid"),
+    [
+        ("local", "spawn_local", "proc_local_race", 1234),
+        ("ssh", "spawn_via_env", "proc_remote_race", 4242),
+    ],
+    ids=("local", "non-local"),
+)
+def test_background_spawn_racing_interrupt_is_killed_and_consumed(
+    monkeypatch,
+    tmp_path,
+    env_type,
+    spawn_method,
+    process_id,
+    pid,
+):
+    from tools.interrupt import is_interrupted, set_interrupt
+
+    registry = ProcessRegistry()
+    monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+    host_kills = []
+    remote_commands = []
+
+    class FakeEnvironment:
+        env = {}
+        cwd = str(tmp_path)
+
+        def execute(self, command, **kwargs):
+            remote_commands.append((command, kwargs))
+            return {"output": "", "returncode": 0}
+
+    environment = FakeEnvironment()
+    created = {}
+
+    def fake_spawn(**kwargs):
+        session = ProcessSession(
+            id=process_id,
+            command=kwargs["command"],
+            task_id=kwargs["task_id"],
+            environment_task_id=kwargs["environment_task_id"],
+            session_key=kwargs["session_key"],
+            pid=pid,
+            persist_on_abandon=kwargs["persist_on_abandon"],
+        )
+        if env_type == "local":
+            session.process = cast(Any, SimpleNamespace(pid=pid))
+        else:
+            session.env_ref = kwargs["env"]
+            session.pid_scope = "sandbox"
+        registry._running[session.id] = session
+        created["session"] = session
+        # Deterministic race barrier: interruption lands after registration but
+        # before terminal_tool's post-spawn check.
+        set_interrupt(True)
+        return session
+
+    monkeypatch.setattr(registry, spawn_method, fake_spawn)
+    monkeypatch.setattr(
+        registry,
+        "_terminate_host_pid",
+        lambda process_pid, start_time: host_kills.append((process_pid, start_time)),
+    )
+    terminal_tool_module = _configure_background_terminal(
+        monkeypatch,
+        tmp_path,
+        env_type=env_type,
+        registry=registry,
+        environment=environment,
+    )
+
+    set_interrupt(False)
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="sleep 60",
+                background=True,
+                notify_on_complete=True,
+                task_id=f"session-{env_type}",
+                persist_on_abandon=True,
+            )
+        )
+        assert is_interrupted() is True
+    finally:
+        set_interrupt(False)
+
+    session = created["session"]
+    assert result["exit_code"] == 130
+    assert result["output"] == "[Command interrupted]"
+    assert "session_id" not in result
+    assert session.exited is True
+    assert session.completion_reason == "killed"
+    assert session.termination_source == "terminal_interrupt"
+    assert registry.is_completion_consumed(session.id) is True
+    assert registry.pending_watchers == []
+    assert registry.completion_queue.empty()
+    if env_type == "local":
+        assert host_kills == [(pid, None)]
+        assert remote_commands == []
+    else:
+        assert host_kills == []
+        assert remote_commands == [(f"kill {pid} 2>/dev/null", {"timeout": 5})]
+
+
+@pytest.mark.parametrize(
+    ("env_type", "spawn_method", "process_id", "pid"),
+    [
+        ("local", "spawn_local", "proc_local", 1234),
+        ("ssh", "spawn_via_env", "proc_remote", 4242),
+    ],
+    ids=("local", "non-local"),
+)
+@pytest.mark.parametrize(
+    "persist_on_abandon",
+    [False, True],
+    ids=("ordinary", "abandon-exempt"),
+)
+def test_terminal_background_spawn_receives_opt_in(
+    monkeypatch,
+    tmp_path,
+    env_type,
+    spawn_method,
+    process_id,
+    pid,
+    persist_on_abandon,
+):
+    import tools.process_registry as process_registry_module
+    import tools.terminal_tool as terminal_tool_module
+
+    task_id = f"session-{env_type}"
+    captured = {}
+
+    class FakeRegistry:
+        pending_watchers = []
+
+    fake_registry = FakeRegistry()
+
+    def fake_spawn(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id=process_id, pid=pid)
+
+    setattr(fake_registry, spawn_method, fake_spawn)
+
+    config = {
+        "env_type": env_type,
+        "cwd": str(tmp_path),
+        "timeout": 60,
+        "lifetime_seconds": 3600,
+    }
+    environment = SimpleNamespace(env={}, cwd=str(tmp_path))
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_active_environments",
+        {"default": environment},
+    )
+    monkeypatch.setattr(terminal_tool_module, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool_module, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setenv("TERMINAL_ENV", env_type)
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(
+        process_registry_module,
+        "process_registry",
+        fake_registry,
+    )
+
+    result = json.loads(
+        terminal_tool_module.terminal_tool(
+            command="sleep 60",
+            background=True,
+            task_id=task_id,
+            persist_on_abandon=persist_on_abandon,
+        )
+    )
+
+    assert captured["persist_on_abandon"] is persist_on_abandon
+    assert captured["task_id"] == task_id
+    assert captured["environment_task_id"] == "default"
+    assert terminal_tool_module._resolve_container_task_id(task_id) == "default"
+    assert result.get("persist_on_abandon", False) is persist_on_abandon
+    if env_type == "local":
+        assert captured["env_vars"] == {}
+    else:
+        assert captured["env"] is environment
+
+
+def test_delegate_background_processes_use_parent_cleanup_owner(
+    monkeypatch,
+    tmp_path,
+):
+    import tools.process_registry as process_registry_module
+    import tools.terminal_tool as terminal_tool_module
+
+    registry = ProcessRegistry()
+    next_id = iter(("proc_delegate_ordinary", "proc_delegate_persistent"))
+
+    def fake_spawn_local(**kwargs):
+        session = ProcessSession(
+            id=next(next_id),
+            command=kwargs["command"],
+            task_id=kwargs["task_id"],
+            environment_task_id=kwargs["environment_task_id"],
+            session_key=kwargs["session_key"],
+            persist_on_abandon=kwargs["persist_on_abandon"],
+        )
+        registry._running[session.id] = session
+        return session
+
+    kill_calls = []
+
+    def fake_kill(session_id, **kwargs):
+        kill_calls.append((session_id, kwargs))
+        registry._running[session_id].exited = True
+        return {"status": "killed"}
+
+    monkeypatch.setattr(registry, "spawn_local", fake_spawn_local)
+    monkeypatch.setattr(registry, "kill_process", fake_kill)
+
+    config = {
+        "env_type": "local",
+        "cwd": str(tmp_path),
+        "timeout": 60,
+        "lifetime_seconds": 3600,
+    }
+    environment = SimpleNamespace(env={}, cwd=str(tmp_path))
+    monkeypatch.setattr(process_registry_module, "process_registry", registry)
+    monkeypatch.setattr(terminal_tool_module, "_active_environments", {"default": environment})
+    monkeypatch.setattr(terminal_tool_module, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool_module, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool_module, "_container_aliases", {})
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        "tools.approval.get_current_session_key",
+        lambda default="": "agent:main:telegram:dm:parent",
+    )
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "_check_all_guards",
+        lambda *_args, **_kwargs: {"approved": True},
+    )
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    terminal_tool_module.register_container_alias("sa-child", "parent-session")
+
+    ordinary_result = json.loads(
+        terminal_tool_module.terminal_tool(
+            command="sleep 60",
+            background=True,
+            task_id="sa-child",
+        )
+    )
+    persistent_result = json.loads(
+        terminal_tool_module.terminal_tool(
+            command="sleep 60",
+            background=True,
+            task_id="sa-child",
+            persist_on_abandon=True,
+        )
+    )
+
+    ordinary = registry.get(ordinary_result["session_id"])
+    persistent = registry.get(persistent_result["session_id"])
+    assert ordinary is not None and persistent is not None
+    assert ordinary.task_id == persistent.task_id == "parent-session"
+    assert ordinary.environment_task_id == persistent.environment_task_id == "default"
+    assert (
+        ordinary.session_key
+        == persistent.session_key
+        == "agent:main:telegram:dm:parent"
+    )
+    assert registry.has_active_processes("default") is True
+
+    assert registry.kill_started_since(
+        "parent-session",
+        frozenset(),
+        source="gateway_turn_interrupt",
+    ) == 1
+    assert ordinary.exited is True
+    assert persistent.exited is False
+    assert kill_calls == [
+        (
+            ordinary.id,
+            {"source": "gateway_turn_interrupt", "consume_output": True},
+        )
+    ]
+
+    kill_calls.clear()
+    assert registry.kill_all("parent-session") == 1
+    assert persistent.exited is True
+    assert kill_calls == [
+        (
+            persistent.id,
+            {"source": "kill_all", "consume_output": False},
+        )
+    ]

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -167,9 +167,11 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         "command": "sleep 1",
         "cwd": "/workspace/live",
         "task_id": task_id,
+        "environment_task_id": task_id,
         "session_key": task_id,
         "env_vars": {},
         "use_pty": False,
+        "persist_on_abandon": False,
     }]
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -647,7 +647,13 @@ def _call(tool_name, args):
 # ---------------------------------------------------------------------------
 
 # Terminal parameters that must not be used from ephemeral sandbox scripts
-_TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
+_TERMINAL_BLOCKED_PARAMS = {
+    "background",
+    "pty",
+    "notify_on_complete",
+    "watch_patterns",
+    "persist_on_abandon",
+}
 
 
 def _rpc_server_loop(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -46,7 +46,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from hermes_cli.config import get_hermes_home
 
@@ -368,7 +368,8 @@ class ProcessSession:
     """A tracked background process with output buffering."""
     id: str                                     # Unique session ID ("proc_xxxxxxxxxxxx")
     command: str                                 # Original command string
-    task_id: str = ""                           # Task/sandbox isolation key
+    task_id: str = ""                           # Stable task-scoped cleanup owner
+    environment_task_id: str = ""               # Terminal environment/cache key
     session_key: str = ""                       # Gateway session key (for reset protection)
     pid: Optional[int] = None                   # OS process ID
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
@@ -394,6 +395,7 @@ class ProcessSession:
     watcher_message_id: str = ""                # Triggering message id — reply anchor for topic routing
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
+    persist_on_abandon: bool = False             # Skip kill_started_since() only
     # Watch patterns — trigger agent notification when output matches any pattern
     watch_patterns: List[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
@@ -966,11 +968,13 @@ class ProcessRegistry:
     def spawn_local(
         self,
         command: str,
-        cwd: str = None,
+        cwd: Optional[str] = None,
         task_id: str = "",
+        environment_task_id: str = "",
         session_key: str = "",
-        env_vars: dict = None,
+        env_vars: Optional[dict] = None,
         use_pty: bool = False,
+        persist_on_abandon: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -978,9 +982,15 @@ class ProcessRegistry:
         Only for TERMINAL_ENV=local. Other backends use spawn_via_env().
 
         Args:
+            task_id: Stable owner used by selective and task-scoped cleanup.
+            environment_task_id: Environment/cache key whose liveness this
+                                 process protects. Defaults to ``task_id`` for
+                                 backward-compatible direct callers.
             use_pty: If True, use a pseudo-terminal via ptyprocess for interactive
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
+            persist_on_abandon: Exempt this background process from abandoned-turn
+                                reaping. Broad cleanup and explicit kill still apply.
         """
         # Guard against the `A && B &` subshell-wait trap (issue #68915).
         # Bash parses ``A && B &`` as ``(A && B) &`` — a subshell that holds
@@ -995,9 +1005,11 @@ class ProcessRegistry:
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
             task_id=task_id,
+            environment_task_id=environment_task_id or task_id,
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            persist_on_abandon=persist_on_abandon,
         )
 
         pty_scope_attempted = False
@@ -1205,10 +1217,12 @@ class ProcessRegistry:
         self,
         env: Any,
         command: str,
-        cwd: str = None,
+        cwd: Optional[str] = None,
         task_id: str = "",
+        environment_task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        persist_on_abandon: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -1220,16 +1234,21 @@ class ProcessRegistry:
 
         This is less capable than local spawn (no live stdout pipe, no stdin),
         but it ensures the command runs in the correct sandbox context.
+
+        ``persist_on_abandon`` exempts the process only from abandoned-turn
+        reaping. Explicit kill and broad cleanup retain their normal behavior.
         """
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
             task_id=task_id,
+            environment_task_id=environment_task_id or task_id,
             session_key=session_key,
             cwd=cwd,
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            persist_on_abandon=persist_on_abandon,
         )
 
         # Run the command in the sandbox with output capture
@@ -2239,7 +2258,11 @@ class ProcessRegistry:
         except Exception:
             return 0
 
-    def list_sessions(self, task_id: str = None, session_key: str = None) -> list:
+    def list_sessions(
+        self,
+        task_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ) -> list:
         """List all running and recently-finished processes.
 
         When ``task_id`` is given, processes for that task are included. When
@@ -2253,7 +2276,12 @@ class ProcessRegistry:
         with self._lock:
             all_sessions = list(self._running.values()) + list(self._finished.values())
 
-        all_sessions = [self._refresh_detached_session(s) for s in all_sessions]
+        refreshed_sessions: List[ProcessSession] = []
+        for session in all_sessions:
+            refreshed = self._refresh_detached_session(session)
+            if refreshed is not None:
+                refreshed_sessions.append(refreshed)
+        all_sessions = refreshed_sessions
 
         if task_id or session_key:
             all_sessions = [
@@ -2262,9 +2290,9 @@ class ProcessRegistry:
                 or (session_key and s.session_key == session_key)
             ]
 
-        result = []
+        result: List[Dict[str, Any]] = []
         for s in all_sessions:
-            entry = {
+            entry: Dict[str, Any] = {
                 "session_id": s.id,
                 "command": s.command[:200],
                 "cwd": s.cwd,
@@ -2287,6 +2315,8 @@ class ProcessRegistry:
                 entry["watch_hit"] = s._watch_hits > 0
             if s.notify_on_complete:
                 entry["notify_on_complete"] = True
+            if s.persist_on_abandon:
+                entry["persist_on_abandon"] = True
             if s.exited:
                 entry["exit_code"] = s.exit_code
             if s.detached:
@@ -2296,8 +2326,8 @@ class ProcessRegistry:
 
     # ----- Session/Task Queries (for gateway integration) -----
 
-    def has_active_processes(self, task_id: str) -> bool:
-        """Check if there are active (running) processes for a task_id."""
+    def has_active_processes(self, environment_task_id: str) -> bool:
+        """Check for active processes using an environment/cache key."""
         with self._lock:
             sessions = list(self._running.values())
 
@@ -2306,7 +2336,8 @@ class ProcessRegistry:
 
         with self._lock:
             return any(
-                s.task_id == task_id and not s.exited
+                (s.environment_task_id or s.task_id) == environment_task_id
+                and not s.exited
                 for s in self._running.values()
             )
 
@@ -2374,6 +2405,17 @@ class ProcessRegistry:
                 if s.task_id == task_id and not s.exited
             )
 
+    def snapshot_running_ids_for_session(self, session_key: str) -> tuple[str, ...]:
+        """Capture process IDs registered to a stable gateway session key."""
+        if not session_key:
+            return ()
+        with self._lock:
+            return tuple(
+                session.id
+                for session in self._running.values()
+                if session.session_key == session_key and not session.exited
+            )
+
     def kill_started_since(
         self,
         task_id: str,
@@ -2381,18 +2423,48 @@ class ProcessRegistry:
         *,
         source: str,
     ) -> int:
-        """Kill processes created for ``task_id`` after a prior snapshot.
+        """Kill post-snapshot processes unless abandonment-exempt.
 
         ``consume_output`` is forced on: abandoned-turn output must not
         enqueue a synthetic follow-up that revives work the timeout
-        deliberately stopped.
+        deliberately stopped. Sessions explicitly marked
+        ``persist_on_abandon`` are the sole exception; broader cleanup APIs do
+        not honor that exemption.
         """
-        return self.kill_all(
-            task_id,
-            exclude_ids=frozenset(baseline_ids or ()),
+        baseline = frozenset(baseline_ids or ())
+        with self._lock:
+            targets = [
+                session
+                for session in self._running.values()
+                if session.task_id == task_id
+                and session.id not in baseline
+                and not session.exited
+                and not session.persist_on_abandon
+            ]
+        return self._kill_sessions(
+            targets,
             source=source,
             consume_output=True,
         )
+
+    def _kill_sessions(
+        self,
+        sessions: Iterable[ProcessSession],
+        *,
+        source: str,
+        consume_output: bool,
+    ) -> int:
+        """Kill a previously selected session snapshot."""
+        killed = 0
+        for session in sessions:
+            result = self.kill_process(
+                session.id,
+                source=source,
+                consume_output=consume_output,
+            )
+            if result.get("status") in {"killed", "already_exited"}:
+                killed += 1
+        return killed
 
     def kill_all(
         self,
@@ -2402,7 +2474,7 @@ class ProcessRegistry:
         source: str = "kill_all",
         consume_output: bool = False,
     ) -> int:
-        """Kill all running processes, optionally filtered by task_id. Returns count killed."""
+        """Kill all running processes, optionally filtered by cleanup owner."""
         with self._lock:
             targets = [
                 s for s in self._running.values()
@@ -2411,16 +2483,11 @@ class ProcessRegistry:
                 and not s.exited
             ]
 
-        killed = 0
-        for session in targets:
-            result = self.kill_process(
-                session.id,
-                source=source,
-                consume_output=consume_output,
-            )
-            if result.get("status") in {"killed", "already_exited"}:
-                killed += 1
-        return killed
+        return self._kill_sessions(
+            targets,
+            source=source,
+            consume_output=consume_output,
+        )
 
     # ----- Cleanup / Pruning -----
 
@@ -2491,6 +2558,7 @@ class ProcessRegistry:
                             "cwd": s.cwd,
                             "started_at": s.started_at,
                             "task_id": s.task_id,
+                            "environment_task_id": s.environment_task_id or s.task_id,
                             "session_key": s.session_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
@@ -2500,6 +2568,7 @@ class ProcessRegistry:
                             "watcher_message_id": s.watcher_message_id,
                             "watcher_interval": s.watcher_interval,
                             "notify_on_complete": s.notify_on_complete,
+                            "persist_on_abandon": s.persist_on_abandon,
                             "watch_patterns": s.watch_patterns,
                         })
                 if extra_entries:
@@ -2580,6 +2649,9 @@ class ProcessRegistry:
                 id=entry["session_id"],
                 command=entry.get("command", "unknown"),
                 task_id=entry.get("task_id", ""),
+                environment_task_id=(
+                    entry.get("environment_task_id") or entry.get("task_id", "")
+                ),
                 session_key=entry.get("session_key", ""),
                 pid=pid,
                 host_start_time=recorded_start,
@@ -2596,6 +2668,7 @@ class ProcessRegistry:
                 watcher_message_id=entry.get("watcher_message_id", ""),
                 watcher_interval=entry.get("watcher_interval", 0),
                 notify_on_complete=entry.get("notify_on_complete", False),
+                persist_on_abandon=entry.get("persist_on_abandon", False),
                 watch_patterns=entry.get("watch_patterns", []),
             )
             with self._lock:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1081,6 +1081,7 @@ Environment state persists: activate a virtualenv or export variables once per s
 
 Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.
 Background: set background=true (returns a session_id). Pair with notify_on_complete=true for bounded tasks; leave silent only for servers/daemons that never exit. Never use nohup/setsid/trailing '&' — use background=true so Hermes tracks the process. After starting a server, verify readiness with a health check, then act in a separate call; no blind sleep loops. Manage with process(action="poll"/"wait").
+Abandoned turns: add persist_on_abandon=true only to exempt this tracked background process from selective cleanup through kill_started_since(). The flag does not transfer ownership or provide durability. process(action="kill"), kill_all(), and other broad cleanup still terminate the process.
 Working directory: use 'workdir' for per-command cwd. When a command changes the session cwd (cd, pushd), the result includes a "cwd" field — trust it instead of prefixing every command with 'cd'.
 PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output to cat if it might page.
 """
@@ -1313,6 +1314,17 @@ def _resolve_container_alias(task_id: str) -> str:
             seen.add(key)
             key = _container_aliases[key]
     return key
+
+
+def _resolve_process_owner_task_id(task_id: Optional[str]) -> str:
+    """Resolve the stable cleanup owner for a tool-call task id.
+
+    Delegate children use their own ``sa-*`` task ids for file/event state but
+    register an existing child→parent container alias. Cleanup belongs to that
+    parent turn/session even when the environment itself collapses to the
+    shared ``"default"`` key.
+    """
+    return _resolve_container_alias(str(task_id or "default"))
 
 
 def _docker_session_isolation_enabled() -> bool:
@@ -2480,6 +2492,18 @@ def _resolve_notification_flag_conflict(
     return watch_patterns, ""
 
 
+def _background_interrupt_result(approval_note: Optional[str] = None) -> str:
+    """Return the standard terminal result for an interrupted background call."""
+    result = {
+        "output": "[Command interrupted]",
+        "exit_code": 130,
+        "error": None,
+    }
+    if approval_note:
+        result["approval"] = approval_note.rstrip(".") + ", then interrupted."
+    return json.dumps(result, ensure_ascii=False)
+
+
 def _resolve_command_cwd(
     *,
     workdir: Optional[str],
@@ -2531,6 +2555,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    persist_on_abandon: bool = False,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2546,6 +2571,9 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        persist_on_abandon: If True and background=True, skip only
+            kill_started_since(). Explicit process kill and broad cleanup still
+            apply; this does not transfer ownership or provide durability.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2576,6 +2604,14 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
+        if persist_on_abandon and not background:
+            return tool_error(
+                "persist_on_abandon=true requires background=true.",
+                status="error",
+                output="",
+                exit_code=-1,
+            )
+
         # Get configuration
         config = _get_env_config()
         env_type = config["env_type"]
@@ -2585,6 +2621,12 @@ def terminal_tool(
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
         effective_task_id = _resolve_container_task_id(task_id)
+        # Process cleanup ownership is independent from the environment key.
+        # Shared backends collapse many sessions onto ``"default"`` and
+        # delegate children alias their environment to the parent. Record both:
+        # the alias-resolved parent owns cleanup, while effective_task_id keeps
+        # the actual environment alive.
+        process_task_id = _resolve_process_owner_task_id(task_id)
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config. ``resolve_task_overrides``
@@ -2756,11 +2798,11 @@ def terminal_tool(
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
         assert env is not None  # all creation failure paths return above
+        process_environment_task_id = _existing_key or effective_task_id
 
-        # The session key that drives cwd records: get_current_session_key()'s
-        # contextvar doesn't cross tool-worker threads, so fall back to the raw
-        # task_id (which IS the session_key for the top-level agent) — a
-        # stable, thread-safe anchor.
+        # The session key that drives cwd records. Gateway tool executors
+        # propagate this context into worker threads; the task-id fallback keeps
+        # direct and legacy callers anchored when no session context is present.
         from tools.approval import get_current_session_key
 
         session_key = get_current_session_key(default="") or (task_id or "")
@@ -2986,23 +3028,62 @@ def terminal_tool(
                 env_type=env_type,
             )
             try:
+                # A hard interrupt can arrive while this tool thread is doing
+                # guard/environment setup. Background spawns do not have the
+                # foreground executor's polling loop, so honor the thread-local
+                # signal immediately before crossing the spawn boundary. Do not
+                # clear it here: the old turn owns this thread and must remain
+                # interrupted while it unwinds.
+                if is_interrupted():
+                    return _background_interrupt_result(approval_note)
+
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
                         command=command,
                         cwd=effective_cwd,
-                        task_id=effective_task_id,
+                        task_id=process_task_id,
+                        environment_task_id=process_environment_task_id,
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        persist_on_abandon=persist_on_abandon,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
                         env=env,
                         command=command,
                         cwd=effective_cwd,
-                        task_id=effective_task_id,
+                        task_id=process_task_id,
+                        environment_task_id=process_environment_task_id,
                         session_key=session_key,
+                        persist_on_abandon=persist_on_abandon,
                     )
+
+                # Close the complementary race with reset's fixed-ID snapshot.
+                # If interruption won while spawn was in flight, the process may
+                # have registered after reset took its snapshot. Kill it before
+                # attaching watcher metadata, and consume its output so neither
+                # the reader nor a completion watcher can resurrect the abandoned
+                # turn. If interruption lands after this check, registration
+                # necessarily preceded it and reset's subsequent snapshot sees
+                # the process instead.
+                if is_interrupted():
+                    kill_result = process_registry.kill_process(
+                        proc_session.id,
+                        source="terminal_interrupt",
+                        consume_output=True,
+                    )
+                    kill_status = kill_result.get("status")
+                    failed_start = (
+                        kill_status == "not_found"
+                        and bool(getattr(proc_session, "exited", False))
+                    )
+                    if kill_status not in {"killed", "already_exited"} and not failed_start:
+                        raise RuntimeError(
+                            "interrupt arrived after background spawn but cleanup failed: "
+                            f"{kill_result.get('error') or kill_status or 'unknown error'}"
+                        )
+                    return _background_interrupt_result(approval_note)
 
                 result_data = {
                     "output": "Background process started",
@@ -3011,9 +3092,8 @@ def terminal_tool(
                     "exit_code": 0,
                     "error": None,
                 }
-                # Background spawns detached and returns exit_code 0 immediately;
-                # it never inline-polls is_interrupted(), so the stale-bit kill
-                # cannot occur here and this note never co-occurs with rc=130.
+                if persist_on_abandon:
+                    result_data["persist_on_abandon"] = True
                 if approval_note:
                     result_data["approval"] = approval_note
                 if pty_disabled_reason:
@@ -3764,6 +3844,11 @@ TERMINAL_SCHEMA = {
                 "description": "With background=true: get exactly one notification when the process exits. The right choice for nearly every bounded long task — set it and keep working. MUTUALLY EXCLUSIVE with watch_patterns (watch_patterns is dropped when both are set).",
                 "default": False
             },
+            "persist_on_abandon": {
+                "type": "boolean",
+                "description": "With background=true: exempt this tracked process only from selective abandoned-turn cleanup through kill_started_since(). process(action='kill'), kill_all(), and other broad cleanup still terminate it. This does not transfer ownership or provide durability.",
+                "default": False
+            },
             "watch_patterns": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -3786,6 +3871,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        persist_on_abandon=args.get("persist_on_abandon", False),
     )
 
 

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -25,7 +25,7 @@ For the full feature reference, see [Subagent Delegation](/user-guide/features/d
 - Mechanical multi-step work with logic between steps → `execute_code`
 - Tasks needing user interaction → subagents can't use `clarify`
 - Quick file edits → do them directly
-- Durable long-running work that must survive session closure or process restart → `cronjob` or `terminal(background=True, notify_on_complete=True)`. Top-level delegation is asynchronous but still process-local.
+- A shell process that should be exempt only from selective abandoned-turn `kill_started_since()` cleanup → `terminal(background=True, notify_on_complete=True, persist_on_abandon=True)`. The flag does not transfer ownership or provide durability. For scheduled reruns use `cronjob`; top-level delegation and terminal processes remain process-local.
 
 ---
 
@@ -221,7 +221,7 @@ delegation:
 - **Separate terminals** — each subagent gets its own terminal session with separate working directory and state
 - **No conversation history** — subagents see only the `goal` and `context` the parent agent passes when calling `delegate_task`
 - **Default 50 iterations** — set `max_iterations` lower for simple tasks to save cost
-- **Not durable** — top-level delegation runs in the background and posts its result back later, but it remains tied to the owning session and Hermes process. Session closure, `/stop`, `/new`, or a process restart can cancel or strand in-progress work. Use `cronjob` or `terminal(background=True, notify_on_complete=True)` for work that must survive those boundaries.
+- **Not durable** — top-level delegation runs in the background and posts its result back later, but it remains tied to the owning session and Hermes process. Session closure, `/stop`, `/new`, or a process restart can cancel or strand in-progress work. Use `cronjob` for scheduled reruns. For a shell process, `persist_on_abandon=True` exempts it only from selective `kill_started_since()` cleanup. It does not transfer ownership, exempt explicit kill or broad `kill_all()` cleanup, or provide durability.
 
 ---
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -172,7 +172,7 @@ Tools for driving desktop [Projects](../user-guide/cli.md) — named, multi-fold
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `process` | Manage background processes started with terminal(background=true). Actions: 'list' (show all), 'poll' (check status + new output), 'log' (full output with pagination), 'wait' (block until done or timeout), 'kill' (terminate), 'write' (sen… | — |
-| `terminal` | Execute shell commands on a Linux environment. Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
+| `terminal` | Execute shell commands on a Linux environment. Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. With `background=true`, `persist_on_abandon=true` exempts the tracked process only from selective abandoned-turn cleanup through `kill_started_since()`. Explicit process kill, `kill_all()`, and other broad cleanup still terminate it. The flag does not transfer ownership or provide durability. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
 
 ## `desktop_ui` toolset
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -351,10 +351,15 @@ Top-level model-facing `delegate_task` calls run in the background automatically
 - A child that completed before restart but whose result was not delivered is restored and routed back through the owning session's normal checks.
 - Cancelled children return a structured result (`status="interrupted"`, `exit_reason="interrupted"`), but because the parent was interrupted too, that result often never makes it into a user-visible reply.
 
-For **durable execution** that must survive session closure or process restart, use:
+For work that must continue outside a delegation turn, choose between a
+scheduled rerun and a tracked shell process:
 
 - `cronjob` (action=`create`) — schedules a separate agent run; immune to parent-turn interrupts.
-- `terminal(background=True, notify_on_complete=True)` — long-running shell commands that keep running while the agent does other things.
+- `terminal(background=True, notify_on_complete=True)` — a tracked shell process that keeps running after a successful turn. Add `persist_on_abandon=True` only to exempt it from selective abandoned-turn cleanup through `kill_started_since()`.
+
+`persist_on_abandon` grants no exemption from explicit process kill, broad
+`kill_all()` cleanup, or other lifecycle cleanup. It does not transfer
+ownership or provide durability.
 :::
 
 ## Key Properties

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -530,7 +530,17 @@ display:
 | `error` | Only the final message when the exit code is non-zero |
 | `off` | No process watcher messages at all |
 
-You can also set this via environment variable:
+Process notifications do not change process lifetime. By default, the gateway
+may selectively reap background processes created by an abandoned turn. To
+exempt a tracked process only from that selective `kill_started_since()`
+cleanup, call `terminal(background=true, persist_on_abandon=true)`. The option
+is rejected without `background=true`.
+
+The flag grants no exemption from explicit process kill, broad `kill_all()`
+cleanup, or other lifecycle cleanup. It does not transfer ownership or provide
+durability.
+
+You can also set the notification mode via environment variable:
 
 ```bash
 HERMES_BACKGROUND_NOTIFICATIONS=result


### PR DESCRIPTION
## Summary

Add an explicit `persist_on_abandon` opt-in for tracked terminal background processes. When enabled, the process is skipped only by `ProcessRegistry.kill_started_since()`, the selective cleanup used when a turn is abandoned.

The default remains fail-safe: ordinary `background=true` processes created after the turn baseline are still reaped.

## API

```python
terminal(
    command="python long_job.py",
    background=True,
    notify_on_complete=True,
    persist_on_abandon=True,
)
```

`persist_on_abandon=true`:

- requires `background=true` and is rejected before environment creation or spawn otherwise;
- propagates through local and non-local background spawns;
- is checkpointed, while older checkpoints default safely to `false`;
- is visible through `process(action="list")` when enabled;
- changes only selective `kill_started_since()` cleanup.

## Lifecycle and ownership

This flag is not an ownership-transfer or durability API:

- `process(action="kill")` still terminates the process;
- broad `ProcessRegistry.kill_all()` cleanup still terminates opted-in processes;
- session reset, agent close/eviction, backend teardown, Gateway/host shutdown, OOM, and reboot receive no exemption;
- no survival guarantee is made for `/new`, `/reset`, Gateway restart, or host reboot.

A first-class system-owned process lifetime is a separate feature request tracked in #83081.

## Correctness details

- Separate process cleanup ownership from the terminal environment/cache key. Shared environments can retain their existing key, while selective cleanup uses the stable owning task/session ID.
- Resolve delegated-child aliases to the parent cleanup owner while retaining the actual environment key for sandbox liveness.
- On session reset, snapshot the IDs already associated with the stable Gateway session key before the first await, then perform bounded off-loop cleanup of only that fixed set. This preserves broad cleanup across agent eviction or session-ID rotation without killing processes started by a replacement turn.
- Preserve explicit-kill and broad-cleanup behavior for opted-in processes.

## Verification

Focused lifecycle, registry, terminal, code-execution, Gateway reset, API cleanup, delegation-alias, and sandbox-isolation coverage:

- `286 passed, 2 skipped, 0 failed`
- full `ruff check .`: passed
- differential Ruff/Ty comparison against current `upstream/main`: no new Ruff or actionable Ty diagnostics; both sides hit the same pre-existing `checkpoint_manager.py` Ty panic
- Windows footgun scan: passed (`8` changed Python files)
- Docusaurus English production build: passed (with the existing `/docs/llms*.txt` broken-link warning)
- `git diff --check`: clean

The full repository suite was also compared with the same environment on base `ee4bb75` immediately before the final non-overlapping upstream rebase:

- PR HEAD: `29,241 passed, 83 failed, 271 skipped`
- `upstream/main@ee4bb75`: `29,221 passed, 83 failed, 271 skipped`
- both had the same 35 failing files; this PR introduced no additional failing file or test.

## Related

- Refs #41225
- Preserves the broad abandoned-turn cleanup invariant added in #76687
- #83081 tracks system-owned process lifetime; this PR does not implement it
- #78473 touches adjacent ownership-matching code and may need mechanical conflict resolution if it lands first
