### PR TITLE
feat(vision): video_analyze extracts frames for local VLM endpoints

### DIFF
--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -263,6 +264,193 @@ class TestVideoAnalyzeTool:
         uploaded_bytes = base64.b64decode(video_url.split(",", 1)[1])
         assert uploaded_bytes == remote_bytes
         assert uploaded_bytes != host_video.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Local VLM endpoint detection + frame extraction
+# ---------------------------------------------------------------------------
+
+
+class TestLocalVisionEndpoint:
+    """``_is_local_vision_endpoint`` decides when video_analyze should
+    switch from whole-video base64 to frame extraction."""
+
+    def test_recognizes_localhost_base_url(self):
+        from tools.vision_tools import _is_local_vision_endpoint
+
+        cfg = {
+            "auxiliary": {
+                "vision": {"base_url": "http://127.0.0.1:8123/v1"},
+            }
+        }
+        assert _is_local_vision_endpoint(cfg) is True
+
+    def test_recognizes_localhost_name(self):
+        from tools.vision_tools import _is_local_vision_endpoint
+
+        cfg = {
+            "auxiliary": {
+                "vision": {"base_url": "http://localhost:11434/v1"},
+            }
+        }
+        assert _is_local_vision_endpoint(cfg) is True
+
+    def test_rejects_cloud_endpoint(self):
+        from tools.vision_tools import _is_local_vision_endpoint
+
+        cfg = {
+            "auxiliary": {
+                "vision": {"base_url": "https://api.openai.com/v1"},
+            }
+        }
+        assert _is_local_vision_endpoint(cfg) is False
+
+    def test_rejects_missing_vision_block(self):
+        from tools.vision_tools import _is_local_vision_endpoint
+
+        assert _is_local_vision_endpoint({"auxiliary": {}}) is False
+        assert _is_local_vision_endpoint(None) in (True, False)  # never raises
+
+
+class TestVideoToFrameDataUrls:
+    """``_video_to_frame_data_urls`` extracts evenly-spaced JPEG frames."""
+
+    def test_returns_none_without_ffmpeg(self, tmp_path, monkeypatch):
+        from tools.vision_tools import _video_to_frame_data_urls
+
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 100)
+        assert _video_to_frame_data_urls(video) is None
+
+    def test_extracts_frames_when_ffmpeg_available(self, tmp_path, monkeypatch):
+        from tools.vision_tools import _video_to_frame_data_urls
+
+        fake_urls = [
+            "data:image/jpeg;base64,AAAA",
+            "data:image/jpeg;base64,BBBB",
+        ]
+
+        real_run = __import__("subprocess").run
+        frames_written = []
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd and cmd[0] == "ffprobe":
+                return __import__("subprocess").CompletedProcess(
+                    cmd, 0,
+                    stdout='{"streams": [{"nb_frames": "240", "duration": "10.0"}]}',
+                    stderr="",
+                )
+            if cmd and cmd[0] == "ffmpeg":
+                # Simulate frame extraction: write the destination file.
+                for i, arg in enumerate(cmd):
+                    if arg == "-y" and i + 1 < len(cmd):
+                        out_path = cmd[-1]
+                        Path(out_path).write_bytes(b"JPEG-FRAME")
+                        frames_written.append(out_path)
+                return __import__("subprocess").CompletedProcess(cmd, 0, stdout="", stderr="")
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else "/usr/bin/ffprobe")
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "tools.vision_tools._image_to_base64_data_url",
+            lambda path, mime: fake_urls.pop(0) if fake_urls else "data:image/jpeg;base64,ZZZZ",
+        )
+
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 100)
+        urls = _video_to_frame_data_urls(video, num_frames=2)
+        assert urls is not None
+        assert len(urls) == 2
+        assert frames_written  # ffmpeg actually produced frame files
+        assert all(u.startswith("data:image/jpeg;base64,") for u in urls)
+
+
+class TestVideoAnalyzeLocalEndpoint:
+    """video_analyze_tool uses ordered frames for local VLM endpoints."""
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_local_endpoint_sends_frames_not_video_base64(self, tmp_path, monkeypatch):
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 100)
+
+        captured_kwargs = {}
+
+        async def capture_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = "two frames of a soccer match"
+            return mock_response
+
+        local_cfg = {
+            "auxiliary": {
+                "vision": {"base_url": "http://127.0.0.1:8123/v1"},
+            }
+        }
+
+        fake_urls = [
+            "data:image/jpeg;base64,FRAME1",
+            "data:image/jpeg;base64,FRAME2",
+        ]
+
+        with (
+            patch("tools.vision_tools.async_call_llm", side_effect=capture_llm),
+            patch("tools.vision_tools.extract_content_or_reasoning", return_value="two frames of a soccer match"),
+            patch("tools.vision_tools._is_local_vision_endpoint", return_value=True),
+            patch(
+                "tools.vision_tools._video_to_frame_data_urls",
+                return_value=fake_urls,
+            ),
+        ):
+            result = self._run(video_analyze_tool(str(video), "Describe this"))
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        messages = captured_kwargs["messages"]
+        assert len(messages) == 1
+        content = messages[0]["content"]
+        # 2 image frames + 1 text prompt
+        assert len(content) == 3
+        assert content[0]["type"] == "image_url"
+        assert content[1]["type"] == "image_url"
+        assert content[2]["type"] == "text"
+        assert "frames in chronological order" in content[2]["text"]
+        # No whole-video base64 was sent
+        assert not any(c.get("type") == "video_url" for c in content)
+
+    def test_frame_extraction_failure_falls_back_to_video_base64(self, tmp_path, monkeypatch):
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 100)
+
+        captured_kwargs = {}
+
+        async def capture_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = "ok"
+            return mock_response
+
+        with (
+            patch("tools.vision_tools.async_call_llm", side_effect=capture_llm),
+            patch("tools.vision_tools.extract_content_or_reasoning", return_value="ok"),
+            patch("tools.vision_tools._is_local_vision_endpoint", return_value=True),
+            patch("tools.vision_tools._video_to_frame_data_urls", return_value=None),
+        ):
+            result = self._run(video_analyze_tool(str(video), "Describe this"))
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        messages = captured_kwargs["messages"]
+        content = messages[0]["content"]
+        assert content[1]["type"] == "video_url"
+        assert content[1]["video_url"]["url"].startswith("data:video/mp4;base64,")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -260,6 +261,193 @@ class TestVideoAnalyzeTool:
         uploaded_bytes = base64.b64decode(video_url.split(",", 1)[1])
         assert uploaded_bytes == remote_bytes
         assert uploaded_bytes != host_video.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Local VLM endpoint detection + frame extraction
+# ---------------------------------------------------------------------------
+
+
+class TestLocalVisionEndpoint:
+    """``_is_local_vision_endpoint`` decides when video_analyze should
+    switch from whole-video base64 to frame extraction."""
+
+    def test_recognizes_localhost_base_url(self):
+        from tools.vision_tools import _is_local_vision_endpoint
+
+        cfg = {
+            "auxiliary": {
+                "vision": {"base_url": "http://127.0.0.1:8123/v1"},
+            }
+        }
+        assert _is_local_vision_endpoint(cfg) is True
+
+    def test_recognizes_localhost_name(self):
+        from tools.vision_tools import _is_local_vision_endpoint
+
+        cfg = {
+            "auxiliary": {
+                "vision": {"base_url": "http://localhost:11434/v1"},
+            }
+        }
+        assert _is_local_vision_endpoint(cfg) is True
+
+    def test_rejects_cloud_endpoint(self):
+        from tools.vision_tools import _is_local_vision_endpoint
+
+        cfg = {
+            "auxiliary": {
+                "vision": {"base_url": "https://api.openai.com/v1"},
+            }
+        }
+        assert _is_local_vision_endpoint(cfg) is False
+
+    def test_rejects_missing_vision_block(self):
+        from tools.vision_tools import _is_local_vision_endpoint
+
+        assert _is_local_vision_endpoint({"auxiliary": {}}) is False
+        assert _is_local_vision_endpoint(None) in (True, False)  # never raises
+
+
+class TestVideoToFrameDataUrls:
+    """``_video_to_frame_data_urls`` extracts evenly-spaced JPEG frames."""
+
+    def test_returns_none_without_ffmpeg(self, tmp_path, monkeypatch):
+        from tools.vision_tools import _video_to_frame_data_urls
+
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 100)
+        assert _video_to_frame_data_urls(video) is None
+
+    def test_extracts_frames_when_ffmpeg_available(self, tmp_path, monkeypatch):
+        from tools.vision_tools import _video_to_frame_data_urls
+
+        fake_urls = [
+            "data:image/jpeg;base64,AAAA",
+            "data:image/jpeg;base64,BBBB",
+        ]
+
+        real_run = __import__("subprocess").run
+        frames_written = []
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd and cmd[0] == "ffprobe":
+                return __import__("subprocess").CompletedProcess(
+                    cmd, 0,
+                    stdout='{"streams": [{"nb_frames": "240", "duration": "10.0"}]}',
+                    stderr="",
+                )
+            if cmd and cmd[0] == "ffmpeg":
+                # Simulate frame extraction: write the destination file.
+                for i, arg in enumerate(cmd):
+                    if arg == "-y" and i + 1 < len(cmd):
+                        out_path = cmd[-1]
+                        Path(out_path).write_bytes(b"JPEG-FRAME")
+                        frames_written.append(out_path)
+                return __import__("subprocess").CompletedProcess(cmd, 0, stdout="", stderr="")
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else "/usr/bin/ffprobe")
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "tools.vision_tools._image_to_base64_data_url",
+            lambda path, mime: fake_urls.pop(0) if fake_urls else "data:image/jpeg;base64,ZZZZ",
+        )
+
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 100)
+        urls = _video_to_frame_data_urls(video, num_frames=2)
+        assert urls is not None
+        assert len(urls) == 2
+        assert frames_written  # ffmpeg actually produced frame files
+        assert all(u.startswith("data:image/jpeg;base64,") for u in urls)
+
+
+class TestVideoAnalyzeLocalEndpoint:
+    """video_analyze_tool uses ordered frames for local VLM endpoints."""
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_local_endpoint_sends_frames_not_video_base64(self, tmp_path, monkeypatch):
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 100)
+
+        captured_kwargs = {}
+
+        async def capture_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = "two frames of a soccer match"
+            return mock_response
+
+        local_cfg = {
+            "auxiliary": {
+                "vision": {"base_url": "http://127.0.0.1:8123/v1"},
+            }
+        }
+
+        fake_urls = [
+            "data:image/jpeg;base64,FRAME1",
+            "data:image/jpeg;base64,FRAME2",
+        ]
+
+        with (
+            patch("tools.vision_tools.async_call_llm", side_effect=capture_llm),
+            patch("tools.vision_tools.extract_content_or_reasoning", return_value="two frames of a soccer match"),
+            patch("tools.vision_tools._is_local_vision_endpoint", return_value=True),
+            patch(
+                "tools.vision_tools._video_to_frame_data_urls",
+                return_value=fake_urls,
+            ),
+        ):
+            result = self._run(video_analyze_tool(str(video), "Describe this"))
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        messages = captured_kwargs["messages"]
+        assert len(messages) == 1
+        content = messages[0]["content"]
+        # 2 image frames + 1 text prompt
+        assert len(content) == 3
+        assert content[0]["type"] == "image_url"
+        assert content[1]["type"] == "image_url"
+        assert content[2]["type"] == "text"
+        assert "frames in chronological order" in content[2]["text"]
+        # No whole-video base64 was sent
+        assert not any(c.get("type") == "video_url" for c in content)
+
+    def test_frame_extraction_failure_falls_back_to_video_base64(self, tmp_path, monkeypatch):
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00" * 100)
+
+        captured_kwargs = {}
+
+        async def capture_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = "ok"
+            return mock_response
+
+        with (
+            patch("tools.vision_tools.async_call_llm", side_effect=capture_llm),
+            patch("tools.vision_tools.extract_content_or_reasoning", return_value="ok"),
+            patch("tools.vision_tools._is_local_vision_endpoint", return_value=True),
+            patch("tools.vision_tools._video_to_frame_data_urls", return_value=None),
+        ):
+            result = self._run(video_analyze_tool(str(video), "Describe this"))
+
+        data = json.loads(result)
+        assert data["success"] is True
+
+        messages = captured_kwargs["messages"]
+        content = messages[0]["content"]
+        assert content[1]["type"] == "video_url"
+        assert content[1]["video_url"]["url"].startswith("data:video/mp4;base64,")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -35,9 +35,10 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
+import shutil
 import uuid
 from pathlib import Path
-from typing import Any, Awaitable, Dict, Optional
+from typing import Any, Awaitable, Dict, List, Optional
 from urllib.parse import urlparse
 import httpx
 
@@ -1751,6 +1752,106 @@ def _video_to_base64_data_url(video_path: Path, mime_type: Optional[str] = None)
     return f"data:{mime};base64,{encoded}"
 
 
+def _is_local_vision_endpoint(cfg: Optional[Dict[str, Any]] = None) -> bool:
+    """True when the resolved ``auxiliary.vision`` endpoint is a local server.
+
+    Local OpenAI-compatible VLMs (Ollama, mlx-vlm server, llama.cpp server,
+    LM Studio, vLLM on localhost) cannot ingest a whole-video base64 payload
+    the way cloud providers can: their processors are built around images or
+    codec-sampled frames.  When the vision endpoint is local, ``video_analyze``
+    should extract frames and send them as ordered images instead.
+    """
+    if cfg is None:
+        try:
+            from hermes_cli.config import cfg_get, load_config
+            cfg = load_config()
+        except Exception:
+            return False
+    try:
+        aux = cfg.get("auxiliary") or {}
+        vision = aux.get("vision") or {}
+        base_url = str(vision.get("base_url") or "").strip().lower()
+        if not base_url:
+            return False
+        host = base_url.split("://")[-1].split("/")[0].split(":")[0]
+        return host in ("localhost", "127.0.0.1", "0.0.0.0", "::1", "::")
+    except Exception:
+        return False
+
+
+def _video_to_frame_data_urls(
+    video_path: Path,
+    num_frames: int = 16,
+    max_side: int = 448,
+) -> Optional[List[str]]:
+    """Extract evenly-spaced frames from a video as base64 JPEG data URLs.
+
+    Returns None when frame extraction is impossible (no ffmpeg, undecodable
+    video), so callers can fall back to the whole-video base64 path.
+    """
+    import io
+    import subprocess
+
+    if not shutil.which("ffmpeg"):
+        return None
+    import json as _json
+    try:
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=nb_frames,duration",
+             "-of", "json", str(video_path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        info = _json.loads(probe.stdout or "{}")
+        stream = (info.get("streams") or [{}])[0]
+        total = int(stream.get("nb_frames") or 0)
+        duration = float(stream.get("duration") or 0.0)
+        if total <= 0 and duration > 0:
+            total = max(1, int(duration * 24))  # fallback estimate
+        if total <= 0:
+            total = 240  # last-resort assumption for ffmpeg re-extraction
+    except Exception:
+        total, duration = 240, 10.0
+
+    step = max(1.0, total / max(num_frames, 1))
+    timestamps = [round(i * step / 24.0, 3) for i in range(min(num_frames, total))]
+
+    out_dir = Path(get_hermes_dir("cache/video", "temp_video_frames"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"frame_{uuid.uuid4().hex[:8]}"
+
+    urls: List[str] = []
+    for idx, ts in enumerate(timestamps):
+        out_path = out_dir / f"{prefix}_{idx:03d}.jpg"
+        try:
+            subprocess.run(
+                ["ffmpeg", "-v", "error", "-ss", str(ts), "-i", str(video_path),
+                 "-frames:v", "1", "-vf", f"scale='min({max_side},iw)':-2",
+                 "-q:v", "2", "-y", str(out_path)],
+                capture_output=True, timeout=30, check=True,
+            )
+        except Exception:
+            continue
+        if not out_path.exists():
+            continue
+        try:
+            urls.append(_image_to_base64_data_url(out_path, "image/jpeg"))
+        finally:
+            try:
+                out_path.unlink()
+            except Exception:
+                pass
+
+    # Clean up any stragglers from this prefix.
+    try:
+        for leftover in out_dir.glob(f"{prefix}_*.jpg"):
+            leftover.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+    return urls if urls else None
+
+
 def _terminal_backend_is_local() -> bool:
     backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
     return backend in ("", "local")
@@ -1936,35 +2037,70 @@ async def video_analyze_tool(
         if video_size_bytes > _VIDEO_SIZE_WARN_BYTES:
             logger.warning("Video is %.1f MB — may be slow or rejected", video_size_mb)
 
-        video_data_url = _video_to_base64_data_url(temp_video_path, mime_type=detected_mime)
-        data_size_mb = len(video_data_url) / (1024 * 1024)
+        # Local OpenAI-compatible VLM endpoints (Ollama, mlx-vlm server,
+        # llama.cpp server, LM Studio) cannot ingest a whole-video base64
+        # payload — their processors are image/codec-based.  When the
+        # configured vision endpoint is local, extract evenly-spaced frames
+        # and send them as ordered images instead (same contract the CLI
+        # ``mlx_vlm generate --video`` fallback uses).
+        vision_messages = None
+        local_endpoint = _is_local_vision_endpoint()
+        if local_endpoint:
+            logger.info("Local vision endpoint detected — extracting video frames")
+            frame_urls = _video_to_frame_data_urls(temp_video_path)
+            if frame_urls:
+                frame_content: List[Dict[str, Any]] = [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": u},
+                    }
+                    for u in frame_urls
+                ]
+                frame_content.append(
+                    {
+                        "type": "text",
+                        "text": (
+                            "Here is a video as a sequence of frames in "
+                            "chronological order.\n"
+                        ) + user_prompt,
+                    }
+                )
+                vision_messages = [{"role": "user", "content": frame_content}]
+                debug_call_data["local_frames"] = len(frame_urls)
+                logger.info("Extracted %d video frames for local VLM", len(frame_urls))
 
-        if len(video_data_url) > _MAX_VIDEO_BASE64_BYTES:
-            raise ValueError(
-                f"Video too large for API: base64 payload is {data_size_mb:.1f} MB "
-                f"(limit {_MAX_VIDEO_BASE64_BYTES / (1024 * 1024):.0f} MB). "
-                f"Compress or trim the video and retry."
-            )
+        if vision_messages is None:
+            video_data_url = _video_to_base64_data_url(temp_video_path, mime_type=detected_mime)
+            data_size_mb = len(video_data_url) / (1024 * 1024)
+
+            if len(video_data_url) > _MAX_VIDEO_BASE64_BYTES:
+                raise ValueError(
+                    f"Video too large for API: base64 payload is {data_size_mb:.1f} MB "
+                    f"(limit {_MAX_VIDEO_BASE64_BYTES / (1024 * 1024):.0f} MB). "
+                    f"Compress or trim the video and retry."
+                )
+
+            vision_messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": user_prompt,
+                        },
+                        {
+                            "type": "video_url",
+                            "video_url": {
+                                "url": video_data_url,
+                            },
+                        },
+                    ],
+                }
+            ]
 
         debug_call_data["video_size_bytes"] = video_size_bytes
 
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": user_prompt,
-                    },
-                    {
-                        "type": "video_url",
-                        "video_url": {
-                            "url": video_data_url,
-                        },
-                    },
-                ],
-            }
-        ]
+        messages = vision_messages
 
         vision_timeout = 180.0
         vision_temperature = 0.1

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -13,9 +13,10 @@ from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 import logging
 import os
+import shutil
 import uuid
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, NamedTuple, Optional
+from typing import Any, Awaitable, Callable, Dict, List, NamedTuple, Optional
 from urllib.parse import urlparse
 import httpx
 
@@ -920,6 +921,116 @@ def _detect_video_mime_type(video_path: Path) -> Optional[str]:
     """Video MIME type from extension, or None if unsupported."""
     return _VIDEO_MIME_TYPES.get(video_path.suffix.lower())
 
+def _is_local_vision_endpoint(cfg: Optional[Dict[str, Any]] = None) -> bool:
+    """True when the resolved ``auxiliary.vision`` endpoint is a local server.
+
+    Local OpenAI-compatible VLMs (Ollama, mlx-vlm server, llama.cpp server,
+    LM Studio, vLLM on localhost) cannot ingest a whole-video base64 payload
+    the way cloud providers can: their processors are built around images or
+    codec-sampled frames.  When the vision endpoint is local, ``video_analyze``
+    should extract frames and send them as ordered images instead.
+    """
+    if cfg is None:
+        try:
+            from hermes_cli.config import cfg_get, load_config
+            cfg = load_config()
+        except Exception:
+            return False
+    try:
+        aux = cfg.get("auxiliary") or {}
+        vision = aux.get("vision") or {}
+        base_url = str(vision.get("base_url") or "").strip().lower()
+        if not base_url:
+            return False
+        host = base_url.split("://")[-1].split("/")[0].split(":")[0]
+        return host in ("localhost", "127.0.0.1", "0.0.0.0", "::1", "::")
+    except Exception:
+        return False
+
+
+def _video_to_frame_data_urls(
+    video_path: Path,
+    num_frames: int = 16,
+    max_side: int = 448,
+) -> Optional[List[str]]:
+    """Extract evenly-spaced frames from a video as base64 JPEG data URLs.
+
+    Returns None when frame extraction is impossible (no ffmpeg, undecodable
+    video), so callers can fall back to the whole-video base64 path.
+    """
+    import io
+    import subprocess
+
+    if not shutil.which("ffmpeg"):
+        return None
+    import json as _json
+    try:
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=nb_frames,duration",
+             "-of", "json", str(video_path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        info = _json.loads(probe.stdout or "{}")
+        stream = (info.get("streams") or [{}])[0]
+        total = int(stream.get("nb_frames") or 0)
+        duration = float(stream.get("duration") or 0.0)
+        if total <= 0 and duration > 0:
+            total = max(1, int(duration * 24))  # fallback estimate
+        if total <= 0:
+            total = 240  # last-resort assumption for ffmpeg re-extraction
+    except Exception:
+        total, duration = 240, 10.0
+
+    step = max(1.0, total / max(num_frames, 1))
+    timestamps = [round(i * step / 24.0, 3) for i in range(min(num_frames, total))]
+
+    out_dir = Path(get_hermes_dir("cache/video", "temp_video_frames"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"frame_{uuid.uuid4().hex[:8]}"
+
+    urls: List[str] = []
+    for idx, ts in enumerate(timestamps):
+        out_path = out_dir / f"{prefix}_{idx:03d}.jpg"
+        try:
+            subprocess.run(
+                ["ffmpeg", "-v", "error", "-ss", str(ts), "-i", str(video_path),
+                 "-frames:v", "1", "-vf", f"scale='min({max_side},iw)':-2",
+                 "-q:v", "2", "-y", str(out_path)],
+                capture_output=True, timeout=30, check=True,
+            )
+        except Exception:
+            continue
+        if not out_path.exists():
+            continue
+        try:
+            urls.append(_image_to_base64_data_url(out_path, "image/jpeg"))
+        finally:
+            try:
+                out_path.unlink()
+            except Exception:
+                pass
+
+    # Clean up any stragglers from this prefix.
+    try:
+        for leftover in out_dir.glob(f"{prefix}_*.jpg"):
+            leftover.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+    return urls if urls else None
+
+
+def _terminal_backend_is_local() -> bool:
+    backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
+    return backend in ("", "local")
+
+
+def _is_path_like_video_source(value: str) -> bool:
+    lowered = (value or "").strip().lower()
+    if not lowered:
+        return False
+    return not lowered.startswith(("http://", "https://", "data:"))
 
 def _unsupported_video_format(suffix: str) -> str:
     return f"Unsupported video format: '{suffix}'. Supported: {', '.join(sorted(_VIDEO_MIME_TYPES.keys()))}"
@@ -990,15 +1101,42 @@ async def video_analyze_tool(
             raise ValueError(_unsupported_video_format(temp_video_path.suffix))
         if video_size_bytes > _VIDEO_SIZE_WARN_BYTES:
             logger.warning("Video is %.1f MB — may be slow or rejected", video_size_mb)
-        video_data_url = _video_to_base64_data_url(temp_video_path, mime_type=detected_mime)
-        if len(video_data_url) > _MAX_VIDEO_BASE64_BYTES:
-            raise ValueError(
-                f"Video too large for API: base64 payload is {len(video_data_url) / (1024 * 1024):.1f} MB "
-                f"(limit {_MAX_VIDEO_BASE64_BYTES / (1024 * 1024):.0f} MB). "
-                f"Compress or trim the video and retry.")
+        # Local OpenAI-compatible VLM endpoints (Ollama, mlx-vlm server,
+        # llama.cpp server, LM Studio) cannot ingest a whole-video base64
+        # payload — their processors are image/codec-based.  When the
+        # configured vision endpoint is local, extract evenly-spaced frames
+        # and send them as ordered images instead (same contract the CLI
+        # ``mlx_vlm generate --video`` fallback uses).
+        vision_messages = None
+        if _is_local_vision_endpoint():
+            logger.info("Local vision endpoint detected — extracting video frames")
+            frame_urls = _video_to_frame_data_urls(temp_video_path)
+            if frame_urls:
+                frame_content: List[Dict[str, Any]] = [
+                    {"type": "image_url", "image_url": {"url": u}}
+                    for u in frame_urls
+                ]
+                frame_content.append({
+                    "type": "text",
+                    "text": (
+                        "Here is a video as a sequence of frames in "
+                        "chronological order.\n"
+                    ) + prompt,
+                })
+                vision_messages = [{"role": "user", "content": frame_content}]
+                debug_call_data["local_frames"] = len(frame_urls)
+                logger.info("Extracted %d video frames for local VLM", len(frame_urls))
+
+        if vision_messages is None:
+            video_data_url = _video_to_base64_data_url(temp_video_path, mime_type=detected_mime)
+            if len(video_data_url) > _MAX_VIDEO_BASE64_BYTES:
+                raise ValueError(
+                    f"Video too large for API: base64 payload is {len(video_data_url) / (1024 * 1024):.1f} MB "
+                    f"(limit {_MAX_VIDEO_BASE64_BYTES / (1024 * 1024):.0f} MB). "
+                    f"Compress or trim the video and retry.")
+            vision_messages = _media_messages(prompt, "video_url", video_data_url)
         debug_call_data["video_size_bytes"] = video_size_bytes
-        messages = _media_messages(prompt, "video_url", video_data_url)
-        call_kwargs = _aux_call_kwargs(messages, model, 180.0, min_timeout=180.0)
+        call_kwargs = _aux_call_kwargs(vision_messages, model, 180.0, min_timeout=180.0)
         analysis = await _call_vision_llm(call_kwargs, "Empty video response, retrying once")
         return analysis, None
     return await _run_analysis("video", video_url, user_prompt, model, stage)


### PR DESCRIPTION
# feat(vision): video_analyze extracts frames for local VLM endpoints

## The problem

`video_analyze` sends the **whole video as one base64 `video_url` payload** to the
configured vision endpoint. That works for cloud multimodal providers (Gemini etc.)
but fails hard against **local OpenAI-compatible VLMs** — Ollama, `mlx-vlm server`,
llama.cpp server, LM Studio — whose processors are image/codec-based and reject or
silently drop the `video_url` content type (Hermes issue #72275 documents the cloud
side of this). Local VLMs are increasingly the privacy/zero-cost choice, and
codec-native streaming VLMs (Microsoft **Mage-VL**, 4B, Apache-2.0) now ship
Apple-Silicon MLX weights that run a full video analysis in seconds on a laptop.

**Who should enable this**
Anyone running a local OpenAI-compatible VLM as `auxiliary.vision` (Ollama,
mlx-vlm, llama.cpp, LM Studio) who wants `video_analyze` to actually work — plus
users of local privacy-first stacks where video bytes must never leave the machine.

## What changed

- **`_is_local_vision_endpoint(cfg)`** — detects `auxiliary.vision.base_url`
  pointing at localhost / 127.0.0.1 / 0.0.0.0 / ::1.
- **`_video_to_frame_data_urls(video_path)`** — ffmpeg `ffprobe`-based even
  frame sampling → up to 16 base64 JPEG data URLs (448px max side).
- **`video_analyze_tool`** — when the endpoint is local, sends the frames as
  ordered images (same contract `mlx_vlm generate --video` already uses for
  processors without native video support); falls back to the original
  whole-video base64 path when extraction fails or the endpoint is cloud.

**Platform compatibility**

| Platform | Status |
|---|---|
| macOS (Apple Silicon) | ✅ primary target — verified against mlx-vlm + Mage-VL-8bit |
| macOS (Intel) / Linux / Windows | ✅ works wherever ffmpeg + a local VLM server exist; frame extraction is OS-agnostic |
| Cloud endpoints | ✅ unchanged (whole-video base64 path preserved) |

**Quick-start guide**

```bash
# 1. Run any local OpenAI-compatible VLM server, e.g. mlx-vlm serving Mage-VL:
python -m mlx_vlm.server --model mlx-community/Mage-VL-8bit --port 8123

# 2. Point Hermes at it:
hermes config set auxiliary.vision.provider custom:local
hermes config set auxiliary.vision.model Mage-VL-8bit
hermes config set auxiliary.vision.base_url http://127.0.0.1:8123/v1

# 3. Ask the agent to analyze a video — frames are extracted automatically:
#    "analyze ~/clips/demo.mp4 and tell me what happens"
```

**Troubleshooting**

| Symptom | Fix |
|---|---|
| Still sends `video_url` (log shows base64 payload) | Endpoint isn't recognized as local — check `base_url` uses `localhost`/`127.0.0.1`; IPv6 `[::1]` currently falls back (safe direction) |
| Frames not extracted (log: no frame warning) | `ffmpeg`/`ffprobe` missing from PATH — `brew install ffmpeg` |
| Video too large errors | Now rare (16 frames ≈ 800KB vs 50MB cap); trims still respected |
| Local VLM still rejects request | Confirm server accepts multiple `image_url` parts in one message (mlx-vlm ≥0.6, Ollama, llama.cpp do) |

## Verification (self-tested, real output)

M5 Max 128GB, `mlx-vlm server` + `mlx-community/Mage-VL-8bit` (Microsoft Mage-VL,
codec-native streaming VLM):

```
$ hermes video_analyze → soccer-broadcast.mp4 (30s, 960×540)
→ "A group of four men are discussing a soccer match."   [16 frames, ~13s]

$ hermes vision_analyze → desktop screenshot
→ detected macOS dock, Finder/Safari/Mail, terminal title, server state

$ 4 sequential desktop captures (TextEdit window opened at frame 3)
→ "Yes, there was a change. In the third frame, a pop-up window appeared
   at the bottom right corner of the screen."
```

Test suite: `tests/tools/test_video_analyze.py` (+8 new tests),
`test_vision_tools.py`, `test_computer_use_vision_routing.py`,
`test_vision_region.py`, `test_vision_native_fast_path.py` — **99 passed**.

## Security design

- No new egress: frame base64 goes to the same configured vision endpoint as before.
- No new credential reads, no dynamic code execution, no shell interpolation
  (ffmpeg args are argv lists).
- Local-file reads still pass through `agent.file_safety.raise_if_read_blocked`;
  non-local terminal backends keep the sandbox media resolver.
- All failure paths close safely: unknown hosts → original base64 path;
  no ffmpeg → original path; extraction error → original path.

## Why this shape (footprint ladder)

Extending the existing `video_analyze` tool (option 1 on the ladder) instead of
adding a new core tool: zero new surface on every API call, fully backward
compatible, and it unblocks every local VLM at once rather than special-casing
one model. The frame-message contract mirrors what `mlx_vlm generate --video`
already does, so behavior matches ecosystem expectations.


## Companion upstream PR

This Hermes-side fix pairs with [Blaizzy/mlx-vlm PR #1836](https://github.com/Blaizzy/mlx-vlm/pull/1836), which adds the same frame-fallback inside `mlx-vlm`'s OpenAI-compatible server so any client (Hermes, Open WebUI, anything OpenAI-compatible) can send `video_url` content parts to a Mage-VL-class processor without a 500. Together they cover both ends of the wire.