### PR TITLE
fix(cron): reject a silent prompt collapse to bare name on agent jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1380,6 +1380,86 @@ def _save_jobs_unlocked(
         raise
 
 
+def _guard_against_prompt_collapsed_to_name(
+    jobs: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Reject a silent prompt -> name collapse on agent-type jobs.
+
+    Compares each incoming job's prompt against its own PRIOR on-disk
+    value (by id). A name is not a prompt: no legitimate write path
+    intentionally shrinks an agent job's prompt down to exactly its own
+    name field. If that shape appears -- the prior prompt existed, was
+    materially different from the name, and the incoming prompt now
+    equals the name exactly -- restore the prior prompt and log a
+    warning instead of persisting the collapse (issue #82990).
+
+    Read-only against disk (via ``_peek_jobs_unlocked``, itself
+    repair-free); returns a list, leaving the input unmodified. No-op
+    when the disk read is empty/unreadable, so this never blocks a
+    fresh install or degrades the existing failure mode for a genuinely
+    corrupt store -- that's ``restore_cron_jobs_if_emptied``'s job.
+    """
+    disk_jobs = _peek_jobs_unlocked()
+    if not disk_jobs:
+        return jobs
+
+    disk_by_id = {
+        str(dj["id"]): dj
+        for dj in disk_jobs
+        if isinstance(dj, dict) and dj.get("id")
+    }
+    if not disk_by_id:
+        return jobs
+
+    guarded: List[Dict[str, Any]] = []
+    for job in jobs:
+        if not isinstance(job, dict) or not job.get("id"):
+            guarded.append(job)
+            continue
+
+        prior = disk_by_id.get(str(job["id"]))
+        if not prior:
+            guarded.append(job)
+            continue
+
+        # Only agent-type jobs have a meaningful prompt to protect --
+        # no_agent (script) jobs' prompt is expected to stay "".
+        if job.get("no_agent") or prior.get("no_agent"):
+            guarded.append(job)
+            continue
+
+        incoming_prompt = _coerce_job_text(job.get("prompt")).strip()
+        incoming_name = _coerce_job_text(job.get("name")).strip()
+        prior_prompt = _coerce_job_text(prior.get("prompt")).strip()
+
+        collapsed = (
+            incoming_prompt
+            and incoming_name
+            and incoming_prompt == incoming_name
+            and prior_prompt
+            and prior_prompt != incoming_prompt
+            # A short existing prompt that already matched its name is a
+            # legitimate, if unusual, user configuration -- only guard
+            # against a genuine SHRINK from a materially longer prompt.
+            and len(prior_prompt) > len(incoming_name) + 10
+        )
+        if collapsed:
+            logger.warning(
+                "cron job %s: rejecting prompt collapse to bare name "
+                "(%d chars -> %d chars); restoring prior prompt "
+                "(issue #82990)",
+                job["id"],
+                len(prior_prompt),
+                len(incoming_prompt),
+            )
+            job = dict(job)
+            job["prompt"] = prior.get("prompt")
+
+        guarded.append(job)
+
+    return guarded
+
+
 def save_jobs(
     jobs: List[Dict[str, Any]],
     *,
@@ -1392,6 +1472,8 @@ def save_jobs(
     (shrink-merge guard against concurrent-create clobber, #80624).
     """
     with _jobs_lock():
+        if not replace:
+            jobs = _guard_against_prompt_collapsed_to_name(jobs)
         _save_jobs_unlocked(jobs, removed_ids=removed_ids, replace=replace)
 
 

--- a/tests/cron/test_jobs_prompt_collapse_guard_82990.py
+++ b/tests/cron/test_jobs_prompt_collapse_guard_82990.py
@@ -1,0 +1,143 @@
+"""Regression for #82990 — an agent-type job's prompt silently collapsing
+to its own name field.
+
+restore_cron_jobs_if_emptied() (hermes_cli/backup.py) only compares job
+COUNT against the pre-update snapshot, so it correctly does not fire when
+the same number of jobs survive an update but one job's ``prompt`` gets
+overwritten with its own ``name`` -- field-level degradation, not job
+loss. save_jobs() now guards against this specific shape at the central
+write path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import hermes_constants
+    import cron.jobs
+
+    importlib.reload(hermes_constants)
+    importlib.reload(cron.jobs)
+    return home
+
+
+def test_prompt_collapsed_to_name_is_rejected_and_prior_prompt_restored(hermes_env):
+    """The exact reported shape: a long, real prompt gets overwritten with
+    the job's own short name. The write must be rejected and the prior
+    prompt restored rather than persisted."""
+    from cron.jobs import create_job, load_jobs, save_jobs
+
+    long_prompt = (
+        "Generate the daily research brief. Format: markdown with three "
+        "sections (Overview, Key Findings, Sources). Source from the "
+        "configured RSS feeds and the last 24h of tracked repos. " * 3
+    )
+    job = create_job(
+        prompt=long_prompt,
+        schedule="every 1d",
+        name="daily research brief",
+        deliver="local",
+        repeat=0,
+    )
+    assert load_jobs()[0]["prompt"] == long_prompt
+
+    # Simulate the reported corruption: some other writer (e.g. the
+    # desktop scheduler's own internally-tracked-crons sync, #52144)
+    # persists the same job with prompt collapsed to its own name.
+    corrupted = dict(job)
+    corrupted["prompt"] = corrupted["name"]
+    save_jobs([corrupted])
+
+    restored = load_jobs()
+    assert len(restored) == 1
+    assert restored[0]["prompt"] == long_prompt, (
+        "the prior, real prompt must survive -- a name is not a prompt"
+    )
+
+
+def test_no_agent_jobs_are_not_guarded(hermes_env):
+    """Script (no_agent) jobs legitimately keep prompt == "" -- the guard
+    must not interfere with that class at all."""
+    from cron.jobs import create_job, load_jobs, save_jobs
+
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="check.sh",
+        no_agent=True,
+        name="check",
+        deliver="local",
+        repeat=0,
+    )
+    assert load_jobs()[0]["prompt"] == ""
+
+    unchanged = dict(job)
+    save_jobs([unchanged])
+    assert load_jobs()[0]["prompt"] == ""
+
+
+def test_short_prompt_already_matching_name_is_a_legitimate_edit(hermes_env):
+    """A user intentionally setting a SHORT prompt that happens to equal
+    the name (or editing an already-short prompt) is a legitimate,
+    unusual configuration, not a collapse -- the guard only protects
+    against shrinking from a MATERIALLY LONGER prior prompt."""
+    from cron.jobs import create_job, load_jobs, save_jobs
+
+    job = create_job(
+        prompt="ping",
+        schedule="every 1h",
+        name="ping",
+        deliver="local",
+        repeat=0,
+    )
+    assert load_jobs()[0]["prompt"] == "ping"
+
+    unchanged = dict(job)
+    save_jobs([unchanged])
+    assert load_jobs()[0]["prompt"] == "ping"
+
+
+def test_genuine_prompt_edit_to_a_different_longer_text_is_allowed(hermes_env):
+    """The guard must not block a real, intentional prompt edit -- only
+    the specific collapse-to-bare-name shape."""
+    from cron.jobs import create_job, load_jobs, update_job
+
+    job = create_job(
+        prompt="Check disk usage and report if over 80%.",
+        schedule="every 1h",
+        name="disk check",
+        deliver="local",
+        repeat=0,
+    )
+    updated = update_job(job["id"], {"prompt": "Check disk usage and report if over 90%, with a breakdown by mount point."})
+    assert updated is not None
+    assert load_jobs()[0]["prompt"].endswith("mount point.")
+
+
+def test_replace_mode_bypasses_the_guard(hermes_env):
+    """save_jobs(..., replace=True) is disaster recovery / test rewrite --
+    matching the existing shrink-merge guard's own bypass, the prompt
+    guard must not block a deliberate wholesale rewrite either."""
+    from cron.jobs import create_job, load_jobs, save_jobs
+
+    job = create_job(
+        prompt="A genuinely long and detailed prompt for the daily job.",
+        schedule="every 1d",
+        name="daily job",
+        deliver="local",
+        repeat=0,
+    )
+    corrupted = dict(job)
+    corrupted["prompt"] = corrupted["name"]
+    save_jobs([corrupted], replace=True)
+
+    assert load_jobs()[0]["prompt"] == "daily job"


### PR DESCRIPTION
Fixes #82990.

## Root cause

`restore_cron_jobs_if_emptied()` is a count-only safety net: it correctly does not fire when the same number of jobs survive an update but one job's `prompt` field gets clobbered with its own `name` -- field-level degradation, not job loss, exactly matching the reported incident.

The reporter's own investigation ruled out `hermes cron edit` (None-guarded) and pointed at the documented "desktop scheduler can overwrite jobs.json with its own small set of internally-tracked crons" class (#52144) as the likely mechanism, without pinning the exact call site.

## Fix

Implemented the issue's suggested fix #1 ("never persist prompt == name as a fallback") as a field-level integrity guard at the central write path (`save_jobs`), so it applies regardless of which caller triggers the write. For each incoming agent-type job, compares against its own prior on-disk prompt: if the incoming prompt now exactly equals the job's name AND the prior prompt was materially longer, the prior prompt is restored and a warning is logged instead of persisting the collapse. Skipped under `replace=True`, matching the existing shrink-merge guard's own disaster-recovery bypass.

## Verification

Added 5 regression tests covering the exact reported shape, the no_agent exemption, a legitimate short-prompt-equals-name edit, a genuine longer prompt edit staying untouched, and the `replace=True` bypass. Verified as a genuine regression by reverting the guard and confirming the collapse test fails with the corrupted value.

22/22 pass across the new test file plus three directly related existing test files; 520/521 across the full `tests/cron/` directory (1 pre-existing unrelated skip; no regression).