### PR TITLE
fix(file-ops): od hex fallback keeps read_file byte-layer detection without base64

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -778,6 +778,41 @@ class TestByteLayerBinaryDetection:
         ops = ShellFileOperations(mock_env)
         assert ops._sample_file_bytes("/tmp/cjk.md") == payload
 
+    def test_base64_garbled_output_falls_back_to_od(self, mock_env):
+        # base64 exits 0 but its stdout is not base64 (terminal fence leak /
+        # prompt contamination) — must fall through to od instead of giving
+        # up. Review ask on #83000.
+        payload = (b"a" * 999 + "中文字符".encode("utf-8"))[:1000]
+        hex_lines = " ".join(f"{b:02x}" for b in payload)
+
+        def side_effect(command, **kwargs):
+            if "| base64" in command:
+                return {"output": "not!base64@", "returncode": 0}
+            if "od -An -v -t x1" in command:
+                return {"output": hex_lines + "\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        assert ops._sample_file_bytes("/tmp/cjk.md") == payload
+
+    def test_base64_empty_output_falls_back_to_od(self, mock_env):
+        # base64 exits 0 but produces nothing (fence stripping emptied it) —
+        # must not short-circuit to b""; let od arbitrate the empty case.
+        payload = b"hello"
+        hex_lines = " ".join(f"{b:02x}" for b in payload)
+
+        def side_effect(command, **kwargs):
+            if "| base64" in command:
+                return {"output": "", "returncode": 0}
+            if "od -An -v -t x1" in command:
+                return {"output": hex_lines + "\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        assert ops._sample_file_bytes("/tmp/x.txt") == payload
+
     def test_od_transport_rejects_non_hex_shell_error(self, mock_env):
         # od itself missing: shell error text must not be parsed as bytes.
         def side_effect(command, **kwargs):

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -762,6 +762,33 @@ class TestByteLayerBinaryDetection:
         ops = ShellFileOperations(mock_env)
         assert ops._sample_file_bytes("/tmp/x.txt") is None
 
+    def test_sample_falls_back_to_od_hex_transport(self, mock_env):
+        # base64 unavailable (127); od hex transport must recover the bytes.
+        payload = (b"a" * 999 + "中文字符".encode("utf-8"))[:1000]
+        hex_lines = " ".join(f"{b:02x}" for b in payload)
+
+        def side_effect(command, **kwargs):
+            if "| base64" in command:
+                return {"output": "", "returncode": 127}
+            if "od -An -v -t x1" in command:
+                return {"output": hex_lines + "\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        assert ops._sample_file_bytes("/tmp/cjk.md") == payload
+
+    def test_od_transport_rejects_non_hex_shell_error(self, mock_env):
+        # od itself missing: shell error text must not be parsed as bytes.
+        def side_effect(command, **kwargs):
+            if "| base64" in command:
+                return {"output": "", "returncode": 127}
+            return {"output": "sh: od: command not found", "returncode": 127}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        assert ops._sample_file_bytes("/tmp/x.txt") is None
+
     # --- integration: read_file over the mocked terminal ------------------
 
     def _dispatch(self, cjk_bytes):
@@ -792,6 +819,41 @@ class TestByteLayerBinaryDetection:
     def test_read_file_still_blocks_nul_binaries(self, mock_env):
         content = b"\x7fELF\x00\x00binarybinary" + b"\x00" * 100
         mock_env.execute.side_effect = self._dispatch(content)
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/a.out")
+        assert result.is_binary is True
+
+    def _dispatch_no_base64(self, cjk_bytes):
+        """Terminal without base64 but with od (fallback path)."""
+
+        def side_effect(command, **kwargs):
+            if command.startswith("wc -c"):
+                return {"output": f"{len(cjk_bytes)}\n", "returncode": 0}
+            if "| base64" in command:
+                return {"output": "", "returncode": 127}
+            if "| od -An -v -t x1" in command:
+                hex_out = " ".join(f"{b:02x}" for b in cjk_bytes[:1000])
+                return {"output": hex_out + "\n", "returncode": 0}
+            if command.startswith("sed -n"):
+                return {"output": cjk_bytes.decode("utf-8", errors="replace"), "returncode": 0}
+            if command.startswith("wc -l"):
+                return {"output": "1\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        return side_effect
+
+    def test_read_file_od_fallback_reads_cjk_text(self, mock_env):
+        content = ("汉字测试" * 300).encode("utf-8")  # > 1000 bytes, cut mid-char
+        mock_env.execute.side_effect = self._dispatch_no_base64(content)
+        ops = ShellFileOperations(mock_env)
+        result = ops.read_file("/tmp/notes-中文.txt")
+        assert result.is_binary is False
+        assert result.error is None
+        assert "汉字测试" in (result.content or "")
+
+    def test_read_file_od_fallback_still_blocks_nul_binaries(self, mock_env):
+        content = b"\x7fELF\x00\x00binarybinary" + b"\x00" * 100
+        mock_env.execute.side_effect = self._dispatch_no_base64(content)
         ops = ShellFileOperations(mock_env)
         result = ops.read_file("/tmp/a.out")
         assert result.is_binary is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -910,7 +910,12 @@ class ShellFileOperations(FileOperations):
         When ``base64`` is unavailable (Windows cmd, minimal busybox
         variants, restricted remote shells), retry the same sample through
         the POSIX-standard ``od -An -v -t x1`` hex transport — strictly more
-        available than base64, and equally lossless (#82997).
+        available than base64, and equally lossless (#82997). The od
+        transport also catches the cases where base64 exists but its output
+        is not trustworthy (empty after fence stripping, non-base64
+        characters, decode failure) — every degraded path lands on the byte
+        layer, so the legacy text-sample heuristic only runs on shells
+        missing both tools.
 
         Returns the sample bytes, or ``None`` when neither transport could
         produce clean output (exotic shells without both tools); callers
@@ -922,9 +927,11 @@ class ShellFileOperations(FileOperations):
         if result.exit_code == 0:
             encoded = _strip_terminal_fence_leaks(result.stdout)
             encoded = "".join(encoded.split())
-            if not encoded:
-                return b""
-            if re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", encoded):
+            # Only a clean base64 payload is trusted: empty output, non-base64
+            # characters (terminal fence leaks, prompt contamination) and
+            # decode failures all fall through to the od transport, exactly
+            # like a missing base64 — every degraded path lands on bytes.
+            if encoded and re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", encoded):
                 try:
                     return base64.b64decode(encoded, validate=True)
                 except (binascii.Error, ValueError):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -907,24 +907,43 @@ class ShellFileOperations(FileOperations):
         survive the transport, so binary detection can happen at the byte
         layer where it is well-defined (#80308 and friends).
 
-        Returns the sample bytes, or ``None`` when the transport could not
-        produce clean base64 (exotic shells without ``base64``); callers fall
-        back to the legacy text-sample heuristic in that case.
+        When ``base64`` is unavailable (Windows cmd, minimal busybox
+        variants, restricted remote shells), retry the same sample through
+        the POSIX-standard ``od -An -v -t x1`` hex transport — strictly more
+        available than base64, and equally lossless (#82997).
+
+        Returns the sample bytes, or ``None`` when neither transport could
+        produce clean output (exotic shells without both tools); callers
+        fall back to the legacy text-sample heuristic in that case.
         """
-        result = self._exec(
-            f"head -c {length} {self._escape_shell_arg(path)} 2>/dev/null | base64"
-        )
+        escaped = self._escape_shell_arg(path)
+        # 1) base64 transport (preferred: single line of ASCII)
+        result = self._exec(f"head -c {length} {escaped} 2>/dev/null | base64")
+        if result.exit_code == 0:
+            encoded = _strip_terminal_fence_leaks(result.stdout)
+            encoded = "".join(encoded.split())
+            if not encoded:
+                return b""
+            if re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", encoded):
+                try:
+                    return base64.b64decode(encoded, validate=True)
+                except (binascii.Error, ValueError):
+                    pass
+        # 2) od hex transport (POSIX-1.2017; survives the lossy text transport)
+        result = self._exec(f"head -c {length} {escaped} 2>/dev/null | od -An -v -t x1")
         if result.exit_code != 0:
             return None
-        encoded = _strip_terminal_fence_leaks(result.stdout)
-        encoded = "".join(encoded.split())
-        if not encoded:
+        hex_output = _strip_terminal_fence_leaks(result.stdout)
+        tokens = hex_output.split()
+        if not tokens:
             return b""
-        if not re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", encoded):
+        # Every token must be exactly one hex byte; anything else means od
+        # itself failed (e.g. a shell error message) and must not be parsed.
+        if not all(re.fullmatch(r"[0-9a-fA-F]{2}", token) for token in tokens):
             return None
         try:
-            return base64.b64decode(encoded, validate=True)
-        except (binascii.Error, ValueError):
+            return bytes(int(token, 16) for token in tokens)
+        except ValueError:
             return None
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

`read_file` still misdetects valid UTF-8 CJK text as binary on the **fallback path**: `_sample_file_bytes()` only used `head -c 1000 | base64`, so on shells without `base64` (Windows cmd, minimal busybox variants, restricted remote shells) it returned `None` and `read_file` degraded to the legacy text-layer heuristic — which flags any sample containing `U+FFFD` as binary. That `U+FFFD` is manufactured by `head -c 1000` cutting a multibyte character at the byte boundary, exactly the misclassification class the byte-layer work (#80308 / #82115) eliminated on the primary path.

This PR adds a second lossless transport to `_sample_file_bytes`: `head -c N | od -An -v -t x1` (POSIX-1.2017, strictly more available than `base64`), parsed with strict token-level validation. The recovered bytes run through the same `_is_likely_binary_bytes` byte-layer check, so CJK files read as text and NUL/latin-1 binaries stay read-only. Only when both transports fail does the legacy text heuristic remain.

## Related Issue

Fixes #82997

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py` — `_sample_file_bytes` now falls back from the `base64` transport to the `od -An -v -t x1` hex transport before giving up; both produce lossless raw bytes so byte-layer detection works even without `base64`. Docstring updated.
- `tests/tools/test_file_operations.py` — 4 new tests in `TestByteLayerBinaryDetection`:
  - `test_sample_falls_back_to_od_hex_transport` — hex transport recovers exact sample bytes (including a mid-character cut)
  - `test_od_transport_rejects_non_hex_shell_error` — shell error text (od missing) is not parsed as bytes
  - `test_read_file_od_fallback_reads_cjk_text` — integration: base64-less terminal reads CJK files as text
  - `test_read_file_od_fallback_still_blocks_nul_binaries` — integration: NUL binaries still blocked on the fallback path

## Test Plan

- `pytest --noconftest tests/tools/test_file_operations.py -k "ByteLayer or NonUtf8 or likely_binary"` — 23 passed (incl. 4 new).
- Full `test_file_operations.py` — 64 passed; the only 2 failures are pre-existing Windows-path assertions (`C:\Users\alice` → `/c/Users/alice`) that fail on macOS regardless of this change (verified via `git stash`).
- `ruff check` on both changed files — clean.
- Manual repro: simulated base64-less terminal (stdout `errors="replace"`) — `okr.md`-style CJK file now reads as text (`is_binary=False`), while ELF and latin-1 files remain flagged binary.
