### PR TITLE
fix(telegram): reset failed primary transport pool

### DIFF
--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -71,6 +71,8 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         transport_kwargs.setdefault("limits", self._POOL_LIMITS)
         self._transport_kwargs = transport_kwargs
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
+        self._primary_lock = asyncio.Lock()
+        self._primary_closed = False
         # Built on demand and discarded on failure — see _reset_fallback.
         self._fallbacks: dict[str, httpx.AsyncHTTPTransport] = {}
         self._fallback_lock = asyncio.Lock()
@@ -84,6 +86,18 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                 transport = httpx.AsyncHTTPTransport(**self._transport_kwargs)
                 self._fallbacks[ip] = transport
             return transport
+
+    async def _reset_primary(self, transport: httpx.AsyncHTTPTransport) -> None:
+        # Retryable primary failures can leave half-closed sockets in the pool;
+        # replace and close the failed generation before trying fallback.
+        async with self._primary_lock:
+            if self._primary_closed or transport is not self._primary:
+                return
+            self._primary = httpx.AsyncHTTPTransport(**self._transport_kwargs)
+        try:
+            await transport.aclose()
+        except Exception as exc:
+            logger.debug("[Telegram] Error closing primary transport: %s", exc)
 
     async def _reset_fallback(self, ip: str) -> None:
         """Discard a failed fallback pool so its dead sockets are released.
@@ -142,6 +156,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                                 ip,
                             )
                 if ip is None:
+                    await self._reset_primary(transport)
                     logger.warning(
                         "[Telegram] Primary api.telegram.org connection failed (%s); trying fallback IPs %s",
                         exc,
@@ -157,7 +172,10 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         raise last_error
 
     async def aclose(self) -> None:
-        await self._primary.aclose()
+        async with self._primary_lock:
+            self._primary_closed = True
+            primary = self._primary
+        await primary.aclose()
         async with self._fallback_lock:
             transports = list(self._fallbacks.values())
             self._fallbacks.clear()

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -10,6 +10,7 @@ IPv4 addresses.
 from __future__ import annotations
 
 import asyncio
+import errno
 import ipaddress
 import logging
 import socket
@@ -129,12 +130,13 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                 attempt_order.append(ip)
 
         last_error: Exception | None = None
+        avoid_sticky_fallback = False
         for ip in attempt_order:
             candidate = request if ip is None else _rewrite_request_for_ip(request, ip)
             transport = self._primary if ip is None else await self._get_fallback(ip)
             try:
                 response = await transport.handle_async_request(candidate)
-                if ip is not None and self._sticky_ip != ip:
+                if ip is not None and self._sticky_ip != ip and not avoid_sticky_fallback:
                     async with self._sticky_lock:
                         if self._sticky_ip != ip:
                             self._sticky_ip = ip
@@ -156,6 +158,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                                 ip,
                             )
                 if ip is None:
+                    avoid_sticky_fallback = _is_local_dns_or_fd_error(exc)
                     await self._reset_primary(transport)
                     logger.warning(
                         "[Telegram] Primary api.telegram.org connection failed (%s); trying fallback IPs %s",
@@ -317,6 +320,25 @@ def _rewrite_request_for_ip(request: httpx.Request, ip: str) -> httpx.Request:
         stream=request.stream,
         extensions=extensions,
     )
+
+
+def _is_local_dns_or_fd_error(exc: Exception) -> bool:
+    """Return whether an error came from local DNS or descriptor exhaustion."""
+    fd_errnos = {errno.EMFILE}
+    enfile = getattr(errno, "ENFILE", None)
+    if enfile is not None:
+        fd_errnos.add(enfile)
+
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, socket.gaierror):
+            return True
+        if isinstance(current, OSError) and current.errno in fd_errnos:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 def _is_retryable_connect_error(exc: Exception) -> bool:

--- a/tests/gateway/test_telegram_closewait_limits_31599.py
+++ b/tests/gateway/test_telegram_closewait_limits_31599.py
@@ -16,13 +16,13 @@ The fix wires the shared ``gateway.platforms._http_client_limits``
 builds — the fallback-transport branch, the proxy branch, and the plain
 branch — so idle keepalive sockets drain aggressively.
 
-Contract asserted here (mutation-survivable)
----------------------------------------------
-Every ``HTTPXRequest`` constructed by ``TelegramAdapter.connect()`` must
-receive ``httpx_kwargs["limits"]`` that is an ``httpx.Limits`` with a
-``keepalive_expiry`` strictly below httpx's 5.0 default and a positive,
-bounded ``max_keepalive_connections``.  Reverting the limits wiring (so
-HTTPXRequest falls back to PTB's default 5.0s keepalive) fails this test.
+Contracts asserted here (mutation-survivable)
+----------------------------------------------
+Proxy and direct-DNS ``HTTPXRequest`` instances must receive
+``httpx_kwargs["limits"]`` with a ``keepalive_expiry`` strictly below
+httpx's 5.0 default.  The fallback-IP instances must pass equivalent
+limits into both inner ``AsyncHTTPTransport`` pools because httpx ignores
+client-level limits when a custom transport is supplied.
 """
 
 import asyncio
@@ -74,7 +74,7 @@ def _make_adapter() -> TelegramAdapter:
     return TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
 
 
-def _drive_connect(monkeypatch, *, proxy_url):
+def _drive_connect(monkeypatch, *, proxy_url, fallback_ips=None):
     """Run connect() far enough to build the HTTPXRequests, then abort.
 
     Returns the list of recorded _RecordingHTTPXRequest instances.
@@ -83,7 +83,7 @@ def _drive_connect(monkeypatch, *, proxy_url):
 
     # No DoH auto-discovery → exercise the proxy / plain branches, not fallback.
     async def _no_fallback():
-        return []
+        return list(fallback_ips or [])
 
     monkeypatch.setattr(tg_adapter, "discover_fallback_ips", _no_fallback)
     monkeypatch.setattr(
@@ -97,6 +97,9 @@ def _drive_connect(monkeypatch, *, proxy_url):
     monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *a, **k: True)
     # Ensure the adapter reports no statically-configured fallback IPs.
     monkeypatch.setattr(adapter, "_fallback_ips", lambda: [])
+
+    if fallback_ips is not None:
+        monkeypatch.setattr(adapter, "_fallback_ips", lambda: list(fallback_ips))
 
     # builder.request(...).get_updates_request(...).build() must be harmless;
     # make build() raise our sentinel so connect() stops right after the
@@ -160,3 +163,25 @@ def test_proxy_branch_general_pool_has_tight_keepalive(monkeypatch):
     assert any(inst.kwargs.get("proxy") == "http://127.0.0.1:9/" for inst in instances)
 
 
+def test_fallback_branch_forwards_tuned_limits_to_inner_transports(monkeypatch):
+    monkeypatch.delenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY", raising=False)
+
+    instances = _drive_connect(
+        monkeypatch,
+        proxy_url=None,
+        fallback_ips=["149.154.167.220"],
+    )
+
+    assert len(instances) >= 2
+    for instance in instances:
+        transport = instance.kwargs["httpx_kwargs"]["transport"]
+        assert isinstance(transport, tg_adapter.TelegramFallbackTransport)
+        limits = transport._transport_kwargs["limits"]
+        assert isinstance(limits, httpx.Limits)
+        assert limits.keepalive_expiry is not None
+        assert limits.keepalive_expiry < 5.0
+        assert limits.max_connections == 512
+
+    for instance in instances:
+        asyncio.run(instance.kwargs["httpx_kwargs"]["transport"].aclose())

--- a/tests/gateway/test_telegram_fallback_pool_release_71593.py
+++ b/tests/gateway/test_telegram_fallback_pool_release_71593.py
@@ -105,13 +105,44 @@ async def test_failed_fallback_pool_is_discarded_and_closed(monkeypatch):
         "CLOSE_WAIT sockets leak (revert of _reset_fallback? #71593)."
     )
 
-    # Each fallback pool that was built for a failing IP must have been
-    # aclose()d exactly once (two fallback IPs → two discards).
-    assert len(closed_log) == 2, (
-        f"Expected 2 discarded/closed fallback pools, got {len(closed_log)} — "
+    # The failed primary plus each fallback pool must be
+    # aclose()d exactly once (one primary + two fallback IPs).
+    assert len(closed_log) == 3, (
+        f"Expected 3 discarded/closed transports, got {len(closed_log)} — "
         "the discard-on-failure path did not aclose() the poisoned pools."
     )
     assert all(t.closed for t in closed_log)
+    await transport.aclose()
+
+
+@pytest.mark.asyncio
+async def test_failed_primary_pool_is_discarded_and_closed(monkeypatch):
+    """A failed primary attempt must release its pool before fallback (#82920)."""
+    for key in (
+        "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy",
+        "http_proxy", "all_proxy", "TELEGRAM_PROXY", "NO_PROXY", "no_proxy",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    behavior = {"api.telegram.org": "timeout", "149.154.167.220": "ok"}
+    instances = []
+
+    def factory(**kwargs):
+        transport = _CountingTransport(behavior, [])
+        instances.append(transport)
+        return transport
+
+    monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+    transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+    try:
+        response = await transport.handle_async_request(_telegram_request())
+        assert response.status_code == 200
+        assert len(instances) == 3
+        assert instances[0].closed
+        assert not instances[1].closed
+        assert not instances[2].closed
+    finally:
+        await transport.aclose()
 
 
 def test_caller_limits_win_over_pool_default(monkeypatch):

--- a/tests/gateway/test_telegram_fallback_pool_release_71593.py
+++ b/tests/gateway/test_telegram_fallback_pool_release_71593.py
@@ -29,6 +29,9 @@ Contract asserted here (mutation-survivable)
 2. A caller-supplied ``limits`` kwarg wins over the ``_POOL_LIMITS`` default.
 """
 
+import errno
+import socket
+
 import httpx
 import pytest
 
@@ -53,6 +56,14 @@ class _CountingTransport(httpx.AsyncBaseTransport):
             raise httpx.ConnectTimeout("timed out")
         if action == "connect_error":
             raise httpx.ConnectError("connect error")
+        if action == "dns_error":
+            cause = socket.gaierror(
+                getattr(socket, "EAI_AGAIN", -3), "temporary DNS failure"
+            )
+            raise httpx.ConnectError(str(cause)) from cause
+        if action == "fd_error":
+            cause = OSError(errno.EMFILE, "too many open files")
+            raise httpx.ConnectError(str(cause)) from cause
         return httpx.Response(200, request=request, text="ok")
 
     async def aclose(self) -> None:
@@ -141,6 +152,32 @@ async def test_failed_primary_pool_is_discarded_and_closed(monkeypatch):
         assert instances[0].closed
         assert not instances[1].closed
         assert not instances[2].closed
+    finally:
+        await transport.aclose()
+
+
+@pytest.mark.parametrize("failure", ["dns_error", "fd_error"])
+@pytest.mark.asyncio
+async def test_local_dns_or_fd_failure_does_not_make_fallback_sticky(
+    monkeypatch, failure
+):
+    """Local resolver/resource failures must not pin a fallback IP."""
+    behavior = {"api.telegram.org": failure, "149.154.167.220": "ok"}
+    instances = []
+
+    def factory(**kwargs):
+        transport = _CountingTransport(behavior, [])
+        instances.append(transport)
+        return transport
+
+    monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+    transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+    try:
+        response = await transport.handle_async_request(_telegram_request())
+        assert response.status_code == 200
+        assert len(instances) == 3
+        assert instances[0].closed
+        assert transport._sticky_ip is None
     finally:
         await transport.aclose()
 


### PR DESCRIPTION
## Summary

- Reset and close failed primary transport generations before fallback retries.
- Guard replacement and shutdown against reset/close races.
- Add regression coverage for primary pool release and fallback inner limits.

## Root cause

Issue premise is partly fixed on current `main`: #58790 already forwards tuned `httpx.Limits` into each `TelegramFallbackTransport` inner transport, because HTTPX ignores client-level limits when a custom transport is supplied.

Remaining leak: `TelegramFallbackTransport.handle_async_request()` reset per-IP fallback pools on retryable failures but retained the primary pool. Repeated primary failures left pooled sockets in `CLOSE_WAIT`; fallback retries continued while the abandoned primary pool stayed open, eventually consuming descriptors. This covers auto-discovered fallback IPs even when no fallback IPs are configured by the user.

## Validation

- `pytest tests/gateway/test_telegram_fallback_pool_release_71593.py tests/gateway/test_telegram_network.py tests/gateway/test_telegram_closewait_limits_31599.py -q` — 25 passed
- `pytest tests/gateway -k telegram -q` — 590 passed, 2 skipped
- `ruff check plugins/platforms/telegram/telegram_network.py tests/gateway/test_telegram_closewait_limits_31599.py tests/gateway/test_telegram_fallback_pool_release_71593.py` — passed
- `git diff --check` — passed

Fixes #82920
## Verification audit

Reviewed against [issue #82920](https://github.com/NousResearch/hermes-agent/issues/82920), the complete PR patch, inherited fallback-pool fix [#71593](https://github.com/NousResearch/hermes-agent/pull/71593), and current CI results.

### Architecture and failure

1. TelegramAdapter.connect() builds separate general and polling HTTPXRequest instances.
2. With no configured fallback IPs, DoH discovery activates TelegramFallbackTransport; each request first uses the primary api.telegram.org transport, then retries through rewritten fallback-IP requests.
3. The custom transport owns one primary httpx.AsyncHTTPTransport plus lazy per-IP fallback pools. Because HTTPX ignores client-level limits when a custom transport is supplied, tuned httpx.Limits must be forwarded into this transport's inner pools. That contract was already supplied by the earlier #58790 follow-up and remains intact here.
4. Before this PR, retryable primary failures retained the failed primary generation. Its half-closed sockets stayed owned by the pool while fallback retries continued, matching the issue's measured CLOSE_WAIT growth, descriptor exhaustion, and RSS increase.

### Why this patch fixes issue #82920

- _reset_primary() swaps the failed primary generation before fallback retry and closes the old generation.
- Transport identity checking prevents an older failing request from closing a newer replacement.
- _primary_lock serializes replacement and shutdown.
- _primary_closed prevents a late failure handler from replacing a transport after shutdown has claimed it.
- aclose() captures and closes the current primary generation, then drains the fallback map.
- Existing _reset_fallback() behavior still discards and closes failed per-IP pools.
- Regression coverage now proves primary release, fallback release, inner-pool limits, caller-supplied limit precedence, and the bounded default.

### Bottleneck and regression audit

No additional production bottleneck was found:

- The new primary lock is absent from the successful request path; it is acquired only during failure recovery and shutdown.
- No new unbounded pool, retry loop, or blocking operation was introduced.
- The secondary issue suggestion—distinguishing local DNS/FD exhaustion from a genuinely unreachable Telegram primary before selecting a sticky fallback—is a separate hardening change and is intentionally outside this focused pool-lifecycle fix.
- Historical comments inherited from #71593 mention issue #63311; that number currently refers to an unrelated desktop issue. This has no runtime effect and can be cleaned up separately.

### Validation

- PR CI run 31364623006: all required Python test slices, e2e, macOS/Windows checks, full Ruff enforcement, type/lint diff checks, and repository guard jobs passed.
- Docker run 31364622395: amd64 and arm64 image builds plus Docker integration tests passed.
- Independent targeted Ruff check on all three changed files: passed.
- Independent git diff --check on the PR-specific diff: passed.
- No open review threads or review submissions were present at audit time.
- Local pytest execution was unavailable because this Windows checkout's uv Python launcher cannot spawn its managed interpreter (permission denied); remote CI supplied the executable test validation.

## Infographic :

<img width="1024" height="1024" alt="infographic" src="https://github.com/user-attachments/assets/a70a7dd1-6e18-415e-bb36-95af966803f2" />


### Decision

Issue #82920 is addressed by PR #83001. No further code commit is warranted from this audit.
## Follow-up hardening requested

Requested follow-up hardening for the optional issue suggestion:

- Detect socket.gaierror and local EMFILE/ENFILE failures through the HTTPX exception cause chain.
- Continue using configured fallback IPs for the current request so transient connectivity is not needlessly dropped.
- Do not set _sticky_ip after those resolver/resource failures; retry primary DNS on later requests instead of permanently amplifying a local FD-pressure condition.
- Keep existing behavior for ordinary ConnectError/ConnectTimeout failures, where a reachable fallback may still become sticky.
- Add parametrized regression coverage for DNS and file-descriptor failure causes.

An isolated candidate passed targeted Ruff validation. Focused pytest could not run in this Windows checkout because the uv Python launcher fails to spawn its managed interpreter with permission denied.

Commit status: pending. The connected GitHub integration returned HTTP 403 Resource not accessible by integration for both Git Data API and Contents API writes on the upstream repository and JoaoMarcos44 fork. PR HEAD remains unchanged at 4bb29560caef8cb18b696388bd838529b41a5655. This section supersedes the earlier no-follow-up decision.

## Implementation attempt

Optional hardening was implemented against PR HEAD `4bb29560caef8cb18b696388bd838529b41a5655` and verified in an isolated checkout:

- Candidate commit: `cf3e511f5d0a4b998ea779212f72140bf290257e` (local object only; not published).
- `ruff check plugins/platforms/telegram/telegram_network.py tests/gateway/test_telegram_fallback_pool_release_71593.py` — passed.
- `git diff --cached --check` — passed.
- Focused pytest remained blocked by the Windows launcher: `uv trampoline failed to spawn Python child process ... permission denied (os error 5)`.
- GitHub Data API writes returned HTTP 403 `Resource not accessible by integration`; configured `git push` was blocked by network access to github.com:443.
- Remote PR HEAD remains unchanged.