### PR TITLE
fix(redact): mask cookie-shaped credentials (assignment + header forms)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -349,6 +349,26 @@ _SECRET_HEADER_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Cookie credentials are bearer credentials: possession alone can
+# authenticate (a session cookie grants access). They leak verbatim through
+# the assignment and header redactors because ``cookie`` is deliberately NOT
+# in the shared secret-keyword set (_KEY_KEYWORD_RE) — adding it there would
+# misclassify prose (``cookie_policy: strict``, ``mycookiejar=1``,
+# ``cookies enabled``). So cookie credentials get their own narrow patterns,
+# keyed on a word-bounded ``cookie`` marker followed by an ``=`` (assignment)
+# or ``:`` (header). The false-positive prose never matches: ``cookie_policy``
+# and ``cookiejar`` have letters after ``cookie`` (not ``=``/``:``),
+# ``cookies`` is a different word, and ``mycookiejar=1`` has no word boundary
+# before ``cookie``.
+_COOKIE_ASSIGN_RE = re.compile(
+    r"(\bcookie\s*=\s*)(\S+)",
+    re.IGNORECASE,
+)
+_COOKIE_HEADER_RE = re.compile(
+    r"((?:Set-?Cookie|Cookie)\s*:\s*)(\S+)",
+    re.IGNORECASE,
+)
+
 # Telegram bot tokens: bot<digits>:<token> or <digits>:<token>,
 # where token part is restricted to [-A-Za-z0-9_] and length >= 30
 _TELEGRAM_RE = re.compile(
@@ -930,6 +950,25 @@ def redact_sensitive_text(
             lambda m: m.group(1) + _mask_token(m.group(2)),
             text,
         )
+
+    # Cookie credentials — assignment (`cookie=…`) and header
+    # (`Set-Cookie: …` / `Cookie: …`) forms. Cookie values are bearer
+    # credentials, so they must not appear verbatim in logs/tool output.
+    # Run outside the `code_file` guard like the other header patterns: a
+    # real Set-Cookie/assignment in tool output is a credential, not source
+    # (the word-bounded marker + `=`/`:` shapes never match `Cookie.set` or
+    # `cookiejar`). See #80936.
+    if "cookie" in text.lower():
+        if "=" in text:
+            text = _COOKIE_ASSIGN_RE.sub(
+                lambda m: m.group(1) + _mask_token(m.group(2)),
+                text,
+            )
+        if ":" in text:
+            text = _COOKIE_HEADER_RE.sub(
+                lambda m: m.group(1) + _mask_token(m.group(2)),
+                text,
+            )
 
     # Telegram bot tokens — pattern requires ":<token>" with digits prefix
     if ":" in text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -295,6 +295,51 @@ class TestApiKeyHeaders:
         assert "anotherOpaqueSecret" not in result
 
 
+class TestCookieCredentials:
+    def test_cookie_assignment_masked(self):
+        text = "cookie=opaque-session-value"
+        result = redact_sensitive_text(text)
+        assert "opaque-session-value" not in result
+
+    def test_set_cookie_header_masked(self):
+        text = "set-cookie: opaque-session-value"
+        result = redact_sensitive_text(text)
+        assert "opaque-session-value" not in result
+
+    def test_set_cookie_camelcase_header_masked(self):
+        text = "Set-Cookie: opaque-session-value"
+        result = redact_sensitive_text(text)
+        assert "opaque-session-value" not in result
+
+    def test_cookie_header_masked(self):
+        text = "Cookie: sid=opaque-value"
+        result = redact_sensitive_text(text)
+        assert "sid=opaque-value" not in result
+
+    def test_cookie_assignment_keeps_other_assignments(self):
+        # A cookie line can carry multiple attributes; only the value is masked.
+        text = "cookie=opaque-value; Path=/"
+        result = redact_sensitive_text(text)
+        assert "opaque-value" not in result
+        assert "Path=/" in result
+
+    def test_prose_unchanged(self):
+        # Ordinary prose must never be mangled (#80936 false positives).
+        for text in (
+            "cookies enabled now",
+            "cookie_policy: strict",
+            "mycookiejar=1",
+            'Cookie.set("name", value)',
+        ):
+            assert redact_sensitive_text(text) == text, text
+
+    def test_cookie_not_in_prose_word_masked(self):
+        # A word that merely EMBEDS ``cookie`` followed by ``=`` is not a
+        # credential marker — the word boundary guard must hold.
+        text = "mycookiejar=1"
+        assert redact_sensitive_text(text) == text
+
+
 class TestTelegramTokens:
     def test_bot_token(self):
         text = "bot123456789:ABCDEfghij-KLMNopqrst_UVWXyz12345"


### PR DESCRIPTION
Fixes #80936

## Problem

`redact_sensitive_text()` masks most credential forms but lets session-cookie credentials pass through verbatim:

- `cookie=<value>`
- `set-cookie: <value>` / `Set-Cookie: <value>`
- `Cookie: <name>=<value>`

Cookie values are bearer credentials — possession alone can authenticate — so they must not appear verbatim in logs, tool output, or events.

## Root cause

The shared secret-keyword set (`_KEY_KEYWORD_RE`) deliberately excludes `cookie` to avoid prose false positives (`cookie_policy: strict`, `mycookiejar=1`, `cookies enabled`, `Cookie.set(...)`). Adding it there would mangle ordinary text. So cookie credentials need their own narrow, word-bounded patterns keyed on the `=` (assignment) or `:` (header) shapes.

## Fix

Two focused regexes, applied in `redact_sensitive_text()` after the existing header patterns:

- `_COOKIE_ASSIGN_RE` — `\bcookie\s*=\s*(\S+)` masks `cookie=<value>`.
- `_COOKIE_HEADER_RE` — `(?:Set-?Cookie|Cookie)\s*:\s*(\S+)` masks `Set-Cookie:` / `Cookie:` values.

Both use `_mask_token` (head/tail-preserving) like the other credential patterns. The word boundary + `=`/`:` gating means prose never matches: `cookie_policy` and `cookiejar` have letters after `cookie` (not `=`/`:`), `cookies` is a different word, and `mycookiejar=1` has no word boundary before `cookie`.

## Verification

- `cookie=<value>` → `cookie=opac...lue` (masked)
- `set-cookie: <value>` / `Set-Cookie: <value>` → masked
- `Cookie: sid=<value>` → `Cookie: ***` (masked)
- `session_token=<value>` → still masked (unchanged)
- `cookies enabled now`, `cookie_policy: strict`, `mycookiejar=1`, `Cookie.set("name", value)` → unchanged
- New focused tests in `tests/agent/test_redact.py::TestCookieCredentials` cover all forms and the false-positive cases.
- Full `tests/agent/test_redact.py` passes (104 tests); dependent redaction suites (compaction boundaries, terminal error, browser type, export redaction, config bridge) pass.