### PR TITLE
fix(auxiliary): skip text-only vision fallback models (#82534)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5171,6 +5171,13 @@ def _try_main_agent_model_fallback(
         # The thing that failed IS the main model (or the failure was
         # provider-wide) — nothing to fall back to.
         return None, None, ""
+    if task == "vision" and not _main_model_supports_vision(main_provider, main_model):
+        logger.warning(
+            "Auxiliary vision fallback: skipping text-only main model %s/%s",
+            main_provider, main_model,
+        )
+        return None, None, ""
+
     if _is_provider_unhealthy(main_provider):
         _log_skip_unhealthy(main_provider, task)
         return None, None, ""

--- a/tests/run_agent/test_auxiliary_vision_fallback.py
+++ b/tests/run_agent/test_auxiliary_vision_fallback.py
@@ -1,0 +1,21 @@
+"""Regression tests for auxiliary vision fallback capability checks."""
+
+from agent import auxiliary_client as aux
+
+
+def test_main_agent_fallback_skips_text_only_model_for_vision(monkeypatch):
+    monkeypatch.setattr(aux, "_read_main_provider", lambda: "opencode-go")
+    monkeypatch.setattr(aux, "_read_main_model", lambda: "deepseek-v4-flash")
+    monkeypatch.setattr(aux, "_main_model_supports_vision", lambda provider, model: False)
+    monkeypatch.setattr(aux, "_is_provider_unhealthy", lambda provider: False)
+    monkeypatch.setattr(
+        aux,
+        "resolve_provider_client",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("text-only model was resolved")),
+    )
+
+    client, model, label = aux._try_main_agent_model_fallback(
+        "openrouter", task="vision", reason="rate limit", failed_model="vision-model"
+    )
+
+    assert (client, model, label) == (None, None, "")


### PR DESCRIPTION
## Summary
- Skip the main-agent fallback when auxiliary vision falls back to a model known to be text-only.
- Preserve the original vision failure instead of sending `image_url` content to an incompatible model.

## Verification
- `pytest -q tests/run_agent/test_auxiliary_vision_fallback.py tests/run_agent/test_provider_parity.py` (55 passed)
- `python3 -m py_compile agent/auxiliary_client.py tests/run_agent/test_auxiliary_vision_fallback.py`

Closes #82534
