### PR TITLE
fix(security): scope multiplex subprocess secrets to target profile

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9091,7 +9091,17 @@ def _default_spawn(
     profile_arg = normalize_profile_name(task.assignee)
 
     prompt = f"work kanban task {task.id}"
-    env = dict(os.environ)
+    # A kanban worker is a model-driving child process.  Start from the
+    # centralized non-terminal spawn environment rather than copying the
+    # gateway's process environment wholesale: gateway / relay credentials
+    # never belong in a worker, and provider credentials may only be inherited
+    # by a single-profile deployment.  In multiplex mode the worker reloads
+    # its assignee profile's .env at startup instead.
+    from agent.secret_scope import is_multiplex_active
+    from tools.environments.local import hermes_subprocess_env
+
+    multiplex_active = is_multiplex_active()
+    env = hermes_subprocess_env(inherit_credentials=not multiplex_active)
     # The dispatcher is detached from every conversation. Its worker must never
     # inherit routing mirrored by a previous gateway turn, even before the first
     # session binds ContextVars in this process.
@@ -9109,14 +9119,31 @@ def _default_spawn(
     # profile-specific config entirely.  Fixes profile-scoped fallback_providers
     # being invisible to kanban workers.
     from hermes_cli.profiles import resolve_profile_env
+    from tools.env_passthrough import scope_subprocess_env_to_profile
+
+    profile_secrets: dict[str, str] = {}
     try:
-        env["HERMES_HOME"] = resolve_profile_env(profile_arg)
+        profile_home = resolve_profile_env(profile_arg)
+        env["HERMES_HOME"] = profile_home
+        from agent.secret_scope import build_profile_secret_scope
+        from hermes_constants import apply_subprocess_home_env
+
+        profile_secrets = build_profile_secret_scope(Path(profile_home))
+        # hermes_subprocess_env() applied the HOME policy before the assignee
+        # profile was known. Reapply it after HERMES_HOME is finalized so
+        # terminal.home_mode=profile points at the worker's profile, not the
+        # dispatcher's.
+        apply_subprocess_home_env(env)
     except FileNotFoundError:
         # Profile dir doesn't exist — defer resolution to the CLI's
         # _apply_profile_override() via HERMES_PROFILE (set below).
         # This only happens in test fixtures where the isolated
         # HERMES_HOME never had profiles created.
         pass
+    # A missing profile has no authorized secrets: in multiplex mode this
+    # still removes credential-shaped leftovers from the dispatcher rather
+    # than letting an eventual CLI fallback inherit another profile's value.
+    env = scope_subprocess_env_to_profile(env, profile_secrets)
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -89,6 +89,158 @@ agent:
         assert required in pinned
 
 
+def test_default_spawn_uses_secondary_profile_secret_not_default(monkeypatch, tmp_path):
+    """A multiplex dispatcher may have booted with the default profile's
+    environment.  A worker assigned to another profile must not inherit an
+    undeclared arbitrary password from that parent process (GH #82936)."""
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    profile.joinpath(".env").write_text("SERVICE_PASSWORD=elias-secret\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("SERVICE_PASSWORD", "default-profile-secret")
+
+    from agent import secret_scope as ss
+    ss.set_multiplex_active(True)
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4243
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    try:
+        kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert captured["env"]["SERVICE_PASSWORD"] == "elias-secret"
+
+
+def test_default_spawn_drops_undeclared_default_profile_secret(monkeypatch, tmp_path):
+    """A worker for a profile with no matching secret must fail closed rather
+    than inherit the default profile's process-global value (GH #82936)."""
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "elias").mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("SERVICE_PASSWORD", "default-profile-secret")
+
+    from agent import secret_scope as ss
+    from hermes_cli import kanban_db as kb
+
+    ss.set_multiplex_active(True)
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4245
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    try:
+        kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert "SERVICE_PASSWORD" not in captured["env"]
+
+
+def test_default_spawn_multiplex_strips_gateway_and_provider_credentials(monkeypatch, tmp_path):
+    """A worker must not inherit dispatcher credentials for another profile."""
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "elias").mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    leaked = {
+        "ANTHROPIC_API_KEY": "default-provider-key",
+        "TELEGRAM_BOT_TOKEN": "gateway-bot-token",
+        "GATEWAY_RELAY_SECRET": "relay-secret",
+        "GH_TOKEN": "github-token",
+        "AUXILIARY_VISION_API_KEY": "auxiliary-key",
+        "_HERMES_FORCE_ANTHROPIC_API_KEY": "forced-provider-key",
+    }
+    for name, value in leaked.items():
+        monkeypatch.setenv(name, value)
+
+    from agent import secret_scope as ss
+    from hermes_cli import kanban_db as kb
+
+    ss.set_multiplex_active(True)
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4246
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    try:
+        kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    finally:
+        ss.set_multiplex_active(False)
+
+    for name in leaked:
+        assert name not in captured["env"]
+
+
+def test_default_spawn_single_profile_keeps_provider_but_not_gateway_secrets(monkeypatch, tmp_path):
+    """Single-profile deployments may legitimately source provider auth from
+    the service environment, but workers never need gateway credentials."""
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "elias").mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "service-provider-key")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "gateway-bot-token")
+    monkeypatch.setenv("GATEWAY_RELAY_SECRET", "relay-secret")
+    monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "auxiliary-key")
+
+    from agent import secret_scope as ss
+    from hermes_cli import kanban_db as kb
+
+    ss.set_multiplex_active(False)
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4247
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+
+    assert captured["env"]["ANTHROPIC_API_KEY"] == "service-provider-key"
+    for name in ("TELEGRAM_BOT_TOKEN", "GATEWAY_RELAY_SECRET", "AUXILIARY_VISION_API_KEY"):
+        assert name not in captured["env"]
+
+
 def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_path):
     """The dispatcher's pre-``chat`` model flag must reach ``args.model``.
 

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -314,6 +314,84 @@ class TestActiveVenvMarkerStripping:
 
 
 class TestProfileScopedPassthrough:
+    def test_make_run_env_drops_foreign_secret_shaped_value_in_multiplex(self, monkeypatch):
+        """A secondary profile must not hand a default profile's arbitrary
+        password to a terminal child merely because its name is not in the
+        provider-specific blocklist (GH #82936)."""
+        from agent import secret_scope as ss
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.setenv("SERVICE_PASSWORD", "default-profile-secret")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({})
+        try:
+            result = _make_run_env({})
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
+        assert "SERVICE_PASSWORD" not in result
+
+    def test_make_run_env_uses_current_profile_secret_shaped_value(self, monkeypatch):
+        """The isolation guard must not prevent a terminal from receiving a
+        same-named credential explicitly defined by the routed profile."""
+        from agent import secret_scope as ss
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.setenv("SERVICE_PASSWORD", "default-profile-secret")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"SERVICE_PASSWORD": "secondary-profile-secret"})
+        try:
+            result = _make_run_env({})
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
+        assert result["SERVICE_PASSWORD"] == "secondary-profile-secret"
+
+    def test_background_subprocess_env_also_drops_foreign_secret(self):
+        """The shared background/PTY environment factory must use the same
+        profile boundary as foreground terminal execution."""
+        from agent import secret_scope as ss
+        from tools.environments.local import _sanitize_subprocess_env
+
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({})
+        try:
+            result = _sanitize_subprocess_env(
+                {"PATH": "/usr/bin", "SERVICE_PASSWORD": "default-profile-secret"}
+            )
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
+        assert "SERVICE_PASSWORD" not in result
+
+    def test_multiplex_drops_ambient_ssh_and_aws_credentials(self, monkeypatch):
+        """Multiplexing is a profile boundary, not the trusted single-user
+        operator shell exception that normally permits ssh-agent and AWS."""
+        from agent import secret_scope as ss
+        from tools.environments.local import _make_run_env
+
+        inherited = {
+            "SSH_AUTH_SOCK": "/private/tmp/agent.sock",
+            "AWS_ACCESS_KEY_ID": "AKIADEFAULTPROFILE",
+            "AWS_SECRET_ACCESS_KEY": "default-profile-secret",
+            "AWS_SESSION_TOKEN": "default-profile-token",
+        }
+        for name, value in inherited.items():
+            monkeypatch.setenv(name, value)
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({})
+        try:
+            result = _make_run_env({})
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
+        for name in inherited:
+            assert name not in result
+
     def test_make_run_env_uses_active_profile_for_passthrough(self, monkeypatch):
         """Allowlisted values must come from the routed profile, not os.environ."""
         from agent import secret_scope as ss

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -28,6 +28,66 @@ from hermes_cli.config import cfg_get
 
 logger = logging.getLogger(__name__)
 
+
+# Keep this conservative, and aligned with the established execute_code
+# subprocess boundary.  In a multiplexed gateway an unrecognised value with
+# one of these names may belong to the profile that booted the process, not
+# the profile whose child is being spawned.
+_SECRET_ENV_NAME_PARTS = (
+    "KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "PASSWD", "AUTH",
+    "DSN", "WEBHOOK", "CREDS", "BEARER", "APIKEY",
+)
+
+
+def is_secret_shaped_env_name(name: str) -> bool:
+    """Whether ``name`` conventionally carries a credential value."""
+    return any(part in name.upper() for part in _SECRET_ENV_NAME_PARTS)
+
+
+def resolve_profile_scoped_subprocess_value(name: str, fallback: str | None) -> str | None:
+    """Resolve a secret-shaped child env value without crossing profiles.
+
+    Multiplexed terminal children may inherit the default profile's process
+    environment.  For credential-shaped names, the routed profile's scope is
+    authoritative; a miss therefore removes the value rather than falling
+    back to a potentially foreign ``os.environ`` entry.  Ordinary variables
+    keep the historical shell environment behavior.
+    """
+    from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+    if not is_multiplex_active() or not is_secret_shaped_env_name(name):
+        return fallback
+    scope = current_secret_scope()
+    if scope is None:
+        return None
+    return scope.get(name)
+
+
+def scope_subprocess_env_to_profile(
+    env: dict[str, str], profile_secrets: dict[str, str]
+) -> dict[str, str]:
+    """Replace multiplexed child credentials with a named profile's values.
+
+    Used before Kanban starts a fresh worker process: unlike an in-turn
+    terminal it has no active ContextVar scope yet, but it knows the assignee
+    profile.  Only secret-shaped values are changed; ordinary environment
+    compatibility stays intact.  Outside multiplexing this is a no-op.
+    """
+    from agent.secret_scope import is_multiplex_active
+
+    if not is_multiplex_active():
+        return env
+    scoped = dict(env)
+    for name in tuple(scoped):
+        if not is_secret_shaped_env_name(name):
+            continue
+        value = profile_secrets.get(name)
+        if value is None:
+            scoped.pop(name, None)
+        else:
+            scoped[name] = value
+    return scoped
+
 # Session-scoped set of env var names that should pass through to sandboxes.
 # Backed by ContextVar to prevent cross-session data bleed in the gateway pipeline.
 _allowed_env_vars_var: ContextVar[set[str]] = ContextVar("_allowed_env_vars")

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -216,7 +216,11 @@ _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
 # the agent terminal — not just Bedrock users, since the registry is iterated
 # unconditionally — and (b) be unrecoverable, because env_passthrough.py
 # refuses to re-allow anything in this blocklist (GHSA-rhgp-j443-p4rf).  See
-# issue #32314 discussion.
+# issue #32314 discussion.  One deliberate exception exists: when profile
+# multiplexing is active, credential-shaped ambient values are resolved only
+# from the routed profile's secret scope.  They are no longer the user's one
+# trusted shell; carrying them into another profile would defeat multiplex
+# isolation (#82936).
 _AWS_SDK_CREDENTIAL_ENV_VARS = frozenset({
     "AWS_BEARER_TOKEN_BEDROCK",
 })
@@ -458,10 +462,12 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     try:
         from tools.env_passthrough import (
             is_env_passthrough as _is_passthrough,
+            resolve_profile_scoped_subprocess_value as _resolve_profile_scoped_value,
             resolve_passthrough_value as _resolve_passthrough_value,
         )
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
+        _resolve_profile_scoped_value = lambda _name, fallback: fallback  # noqa: E731
         _resolve_passthrough_value = lambda _name, fallback: fallback  # noqa: E731
 
     sanitized: dict[str, str] = {}
@@ -474,7 +480,11 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         passthrough = _is_passthrough(key)
         if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
             continue
-        resolved = _resolve_passthrough_value(key, value) if passthrough else value
+        resolved = (
+            _resolve_passthrough_value(key, value)
+            if passthrough
+            else _resolve_profile_scoped_value(key, value)
+        )
         if resolved is not None:
             sanitized[key] = resolved
 
@@ -490,7 +500,11 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             passthrough = _is_passthrough(key)
             if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
                 continue
-            resolved = _resolve_passthrough_value(key, value) if passthrough else value
+            resolved = (
+                _resolve_passthrough_value(key, value)
+                if passthrough
+                else _resolve_profile_scoped_value(key, value)
+            )
             if resolved is not None:
                 sanitized[key] = resolved
 
@@ -1270,10 +1284,12 @@ def _make_run_env(env: dict) -> dict:
     try:
         from tools.env_passthrough import (
             is_env_passthrough as _is_passthrough,
+            resolve_profile_scoped_subprocess_value as _resolve_profile_scoped_value,
             resolve_passthrough_value as _resolve_passthrough_value,
         )
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
+        _resolve_profile_scoped_value = lambda _name, fallback: fallback  # noqa: E731
         _resolve_passthrough_value = lambda _name, fallback: fallback  # noqa: E731
 
     merged = dict(os.environ | env)
@@ -1290,7 +1306,11 @@ def _make_run_env(env: dict) -> dict:
             passthrough = _is_passthrough(k)
             if k in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
                 continue
-            value = _resolve_passthrough_value(k, v) if passthrough else v
+            value = (
+                _resolve_passthrough_value(k, v)
+                if passthrough
+                else _resolve_profile_scoped_value(k, v)
+            )
             if value is not None:
                 run_env[k] = value
     path_key = _path_env_key(run_env)


### PR DESCRIPTION
## Summary

Fixes the subprocess side of #82936.

- Build Kanban worker environments through `hermes_subprocess_env`, so gateway, relay, GitHub, and internal auxiliary credentials never reach workers.
- In multiplex mode, resolve credential-shaped environment variables from the assigned profile only; missing values fail closed instead of inheriting the dispatcher/default profile.
- Apply the same profile boundary to terminal and PTY subprocess paths.
- Preserve provider credentials for single-profile service deployments, while still stripping Tier-1 gateway and internal secrets.
- Reapply the subprocess HOME policy after selecting the worker profile.

## Validation

- `121 passed, 2 skipped` across targeted Kanban, terminal environment, and secret-scope tests
- `ruff check` and `git diff --check` pass

Multiplex intentionally does not inherit ambient `SSH_AUTH_SOCK` or general AWS credential variables across profiles; those credentials must be explicitly available in the target profile scope. Single-profile terminal behavior remains unchanged.