### PR TITLE
fix(file-ops): shell-layer non-regular-file guard for all read paths (salvage #82075)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -355,7 +355,7 @@ class TestShellFileOpsHelpers:
         )
 
         def side_effect(command, **kwargs):
-            if command.startswith("wc -c"):
+            if command.startswith("if [ -f ") or command.startswith("wc -c"):
                 return {"output": "12\n", "returncode": 0}
             if command.startswith("head -c"):
                 return {"output": "print('ok')\n", "returncode": 0}
@@ -383,7 +383,7 @@ class TestShellFileOpsHelpers:
         )
 
         def side_effect(command, **kwargs):
-            if command.startswith("wc -c"):
+            if command.startswith("if [ -f ") or command.startswith("wc -c"):
                 return {"output": "6\n", "returncode": 0}
             if command.startswith("head -c"):
                 return {"output": "alpha\n", "returncode": 0}
@@ -519,7 +519,7 @@ class TestPatchReplacePostWriteVerification:
             if command.startswith("mkdir "):
                 return {"output": "", "returncode": 0}
             # wc -c for byte count after write
-            if command.startswith("wc -c"):
+            if command.startswith("if [ -f ") or command.startswith("wc -c"):
                 for path in file_contents:
                     if path in command:
                         return {"output": str(len(file_contents[path].encode())), "returncode": 0}
@@ -556,7 +556,7 @@ class TestPatchReplacePostWriteVerification:
                 return {"output": "", "returncode": 1}
             if command.startswith("mkdir "):
                 return {"output": "", "returncode": 0}
-            if command.startswith("wc -c"):
+            if command.startswith("if [ -f ") or command.startswith("wc -c"):
                 return {"output": str(len(state["content"].encode())), "returncode": 0}
             return {"output": "", "returncode": 0}
 
@@ -776,7 +776,7 @@ class TestByteLayerBinaryDetection:
         import base64 as b64
 
         def side_effect(command, **kwargs):
-            if command.startswith("wc -c"):
+            if command.startswith("if [ -f ") or command.startswith("wc -c"):
                 return {"output": f"{len(cjk_bytes)}\n", "returncode": 0}
             if command.startswith("head -c") and "| base64" in command:
                 return {"output": b64.b64encode(cjk_bytes[:1000]).decode(), "returncode": 0}

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -303,7 +303,9 @@ class TestShellFileOpsHelpers:
 
         def side_effect(command, **kwargs):
             commands.append(command)
-            if command.startswith("wc -c"):
+            # The size probe gates `wc -c` behind `[ -f ]` so a FIFO or device
+            # cannot block the read; it still reports a plain byte count.
+            if command.startswith("if [ -f ") or command.startswith("wc -c"):
                 return {"output": "5\n", "returncode": 0}
             if command.startswith("head -c") and "| base64" in command:
                 import base64 as b64
@@ -321,7 +323,13 @@ class TestShellFileOpsHelpers:
         result = ops.read_file(r"C:\Users\alice\notes.txt")
 
         assert result.error is None
-        assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
+        assert commands[0] == (
+            "if [ -f '/c/Users/alice/notes.txt' ]; "
+            "then wc -c < '/c/Users/alice/notes.txt' 2>/dev/null; "
+            "elif [ -e '/c/Users/alice/notes.txt' ]; "
+            "then echo __hermes_not_regular__; "
+            "else exit 1; fi"
+        )
         assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64"
         assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
         assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -205,7 +205,7 @@ class TestPaginationBounds:
 
         def fake_exec(command, *args, **kwargs):
             commands.append(command)
-            if command.startswith("wc -c"):
+            if command.startswith("if [ -f ") or command.startswith("wc -c"):
                 return MagicMock(exit_code=0, stdout="12")
             if command.startswith("head -c"):
                 return MagicMock(exit_code=0, stdout="line1\nline2\n")

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -212,6 +212,92 @@ class TestDevicePathBlocking(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Non-regular files (FIFOs, sockets, directories)
+# ---------------------------------------------------------------------------
+
+class TestNonRegularFileReads(unittest.TestCase):
+    """Blocking paths the device blocklist structurally cannot cover.
+
+    The blocklist matches literal ``/dev/*`` names. A FIFO is a file *type*
+    and can sit at any path, so no name list catches it. Reading one with no
+    writer blocks in the size probe, and the read helpers pass no timeout, so
+    the turn wedges until the process is killed.
+
+    Each read runs on a worker thread with a wall clock: a thread still alive
+    at the deadline means the call blocked, which fails as an assertion
+    instead of hanging the suite.
+    """
+
+    DEADLINE_SECONDS = 20.0
+
+    def _read_within_deadline(self, path, task_id):
+        import threading
+
+        box = {}
+
+        def call():
+            try:
+                box["raw"] = read_file_tool(path, task_id=task_id)
+            except BaseException as exc:  # noqa: BLE001
+                box["exc"] = exc
+
+        worker = threading.Thread(target=call, daemon=True)
+        worker.start()
+        worker.join(self.DEADLINE_SECONDS)
+        self.assertFalse(
+            worker.is_alive(),
+            f"read_file_tool({path!r}) still running after "
+            f"{self.DEADLINE_SECONDS:.0f}s — the read blocked",
+        )
+        if "exc" in box:
+            raise box["exc"]
+        return json.loads(box["raw"])
+
+    def test_read_file_tool_on_fifo_errors_instead_of_blocking(self):
+        if not hasattr(os, "mkfifo"):
+            self.skipTest("platform has no os.mkfifo")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fifo_path = os.path.join(tmpdir, "pipe")
+            try:
+                os.mkfifo(fifo_path)
+            except (OSError, NotImplementedError) as exc:
+                self.skipTest(f"mkfifo unavailable: {exc}")
+
+            result = self._read_within_deadline(fifo_path, "fifo_read_test")
+
+        self.assertIn("error", result)
+        self.assertIn("not a regular file", result["error"])
+
+    def test_read_file_tool_on_directory_errors_instead_of_blocking(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._read_within_deadline(tmpdir, "dir_read_test")
+
+        self.assertIn("error", result)
+        self.assertIn("not a regular file", result["error"])
+
+    def test_regular_file_still_reads(self):
+        """The guard must not cost ordinary reads their content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "notes.txt")
+            with open(target, "w", encoding="utf-8") as handle:
+                handle.write("first line\nsecond line\n")
+
+            result = self._read_within_deadline(target, "regular_read_test")
+
+        self.assertNotIn("error", result)
+        self.assertIn("second line", result["content"])
+
+    def test_missing_file_still_reports_not_found(self):
+        """An absent path keeps the not-found wording, not the type error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = os.path.join(tmpdir, "no-such-file.txt")
+            result = self._read_within_deadline(missing, "missing_read_test")
+
+        self.assertIn("error", result)
+        self.assertNotIn("not a regular file", result["error"])
+
+
+# ---------------------------------------------------------------------------
 # Character-count limits
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -265,8 +265,12 @@ class TestNonRegularFileReads(unittest.TestCase):
 
             result = self._read_within_deadline(fifo_path, "fifo_read_test")
 
-        self.assertIn("error", result)
-        self.assertIn("not a regular file", result["error"])
+        # The tool layer intercepts first with a success=False NOTE (a fact
+        # about the file, not an error — merged stat-guard design); the
+        # shell-layer sentinel behind it errors. Accept either surface.
+        surface = result.get("error") or result.get("note") or ""
+        self.assertTrue(surface, f"expected error or note, got: {result}")
+        self.assertIn("not a regular file", surface)
 
     def test_read_file_tool_on_directory_errors_instead_of_blocking(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -732,6 +732,10 @@ DEFAULT_READ_LIMIT = 2000
 DEFAULT_SEARCH_OFFSET = 0
 DEFAULT_SEARCH_LIMIT = 50
 
+# Echoed by the size probe when the path exists but is not a regular file.
+# `wc -c` prints only digits, so this can never collide with a real size.
+NOT_REGULAR_SENTINEL = "__hermes_not_regular__"
+
 
 def _coerce_int(value: Any, default: int) -> int:
     """Best-effort integer coercion for tool pagination inputs."""
@@ -1220,6 +1224,40 @@ class ShellFileOperations(FileOperations):
     # READ Implementation
     # =========================================================================
     
+    def _size_probe_cmd(self, path: str) -> str:
+        """Byte size of a regular file, without opening one that never ends.
+
+        ``wc -c < path`` opens the path. On a FIFO with no writer, a socket,
+        or a character device like /dev/zero that never reaches EOF, that
+        read blocks forever — and the read helpers pass no timeout to
+        :meth:`_exec`, so the turn wedges until the process is killed. The
+        device blocklist in ``tools/file_tools.py`` cannot cover this: it
+        matches literal ``/dev/*`` names, while a FIFO is a file *type* and
+        can sit at any path.
+
+        ``[ -f ]`` is a stat, not an open — it answers exactly the question
+        the size probe needs (regular file, symlinks followed) without
+        touching the contents. Non-regular paths that exist report the
+        sentinel so callers can say so instead of claiming the file is
+        missing; a genuinely absent path still exits non-zero.
+        """
+        arg = self._escape_shell_arg(path)
+        return (
+            f"if [ -f {arg} ]; then wc -c < {arg} 2>/dev/null; "
+            f"elif [ -e {arg} ]; then echo {NOT_REGULAR_SENTINEL}; "
+            f"else exit 1; fi"
+        )
+
+    @staticmethod
+    def _not_regular_error(path: str) -> ReadResult:
+        """Error for a path that exists but would block if read."""
+        return ReadResult(
+            error=(
+                f"Cannot read '{path}': not a regular file (directory, FIFO, "
+                "socket, or device). Reading it could block indefinitely."
+            )
+        )
+
     def read_file(self, path: str, offset: int = 1, limit: int = 2000) -> ReadResult:
         """
         Read a file with pagination, binary detection, and line numbers.
@@ -1237,10 +1275,9 @@ class ShellFileOperations(FileOperations):
         
         offset, limit = normalize_read_pagination(offset, limit)
         
-        # Check if file exists and get size (wc -c is POSIX, works on Linux + macOS)
-        stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
-        stat_result = self._exec(stat_cmd)
-        
+        # Check if file exists and get size (POSIX, works on Linux + macOS)
+        stat_result = self._exec(self._size_probe_cmd(path))
+
         if stat_result.exit_code != 0:
             # File not found. Before failing, try unicode-equivalent
             # spellings — NFC/NFD, narrow no-break space, curly quotes
@@ -1260,8 +1297,10 @@ class ShellFileOperations(FileOperations):
                 return result
             # No equivalent spelling — suggest similar files
             return self._suggest_similar_files(path)
-        
+
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
+        if stat_output.strip() == NOT_REGULAR_SENTINEL:
+            return self._not_regular_error(path)
         try:
             file_size = int(stat_output.strip())
         except ValueError:
@@ -1473,11 +1512,12 @@ class ShellFileOperations(FileOperations):
         Uses cat so the full file is returned regardless of size.
         """
         path = self._expand_path(path)
-        stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
-        stat_result = self._exec(stat_cmd)
+        stat_result = self._exec(self._size_probe_cmd(path))
         if stat_result.exit_code != 0:
             return self._suggest_similar_files(path)
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
+        if stat_output.strip() == NOT_REGULAR_SENTINEL:
+            return self._not_regular_error(path)
         try:
             file_size = int(stat_output.strip())
         except ValueError:
@@ -1514,13 +1554,14 @@ class ShellFileOperations(FileOperations):
     def read_file_bytes(self, path: str, max_bytes: Optional[int] = None) -> ReadResult:
         """Read binary-safe bytes from any shell-backed environment."""
         path = self._expand_path(path)
-        stat_result = self._exec(
-            f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
-        )
+        stat_result = self._exec(self._size_probe_cmd(path))
         if stat_result.exit_code != 0:
             return ReadResult(error=f"File not found: {path}")
+        stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
+        if stat_output.strip() == NOT_REGULAR_SENTINEL:
+            return self._not_regular_error(path)
         try:
-            file_size = int(_strip_terminal_fence_leaks(stat_result.stdout).strip())
+            file_size = int(stat_output.strip())
         except ValueError:
             return ReadResult(error=f"Could not determine file size: {path}")
         if max_bytes is not None and file_size > max_bytes:


### PR DESCRIPTION
## Summary

Salvage of #82075 by @Drexuxux: the shell-layer complement to the merged stat-based guard (0e63ed1fe / #82792). `read_file`, `read_file_raw`, and `read_file_bytes` in `ShellFileOperations` all open the path via `wc -c` with no deadline — on a FIFO/socket/device that never reaches EOF, remote backends (docker/ssh/modal) still wedge, because the merged guard is host-only (`_file_ops_uses_host_paths` gate) and doesn't cover the raw/bytes paths.

Drexuxux's mechanism folds a `[ -f ]` check **into the existing size probe** (sentinel echo in the same shell invocation), so all three read paths on every backend refuse non-regular files with **zero added round-trips**. This beats the earlier #29428 approach (separate preflight exec = +1 round-trip per read); @haileymarshall was the earliest submitter on this bug class (May 20) — credit to both.

Eval check (evals/readtool fifo battery, 3 reps, this branch vs main): no per-read regression on regular-file tasks; fifo task unchanged vs merged guard (tool layer still intercepts first on host; the sentinel is the remote/raw safety net behind it).

## Changes

- `tools/file_operations.py` (authored by @Drexuxux, cherry-picked): combined `[ -f ]`/`wc -c` probe + `NOT_REGULAR_SENTINEL` handling in `read_file`, `read_file_raw`, `read_file_bytes`; `_not_regular_error()` helper.
- `tests/tools/test_file_operations.py`, `tests/tools/test_file_read_guards.py`: contributor's regression tests + follow-up commit adapting 5 stale `wc -c` mocks and reconciling the fifo tool-layer test with the merged note-based guard (tool layer notes, shell layer errors — either surface is a pass).

## Validation

| | result |
|---|---|
| E2E (real FIFO) | `read_file` 0.03s, `read_file_raw` 0.01s, `read_file_bytes` 0.01s — all refused instantly |
| Stack intact | normal read / empty note / past-EOF note / unicode retry all pass on top |
| Targeted tests | 164 passed, 0 failed across 6 files (`run_tests.sh`) |

Closes #82075 (salvaged, authorship preserved). Supersedes #29428 (same class, earlier submission, costlier mechanism — close with credit).

## Infographic

![shell-layer read guard](https://v3b.fal.media/files/b/0aa5bf50/eqra8obI3qfUwX1oGRJaY_fZRMWrcP.png)
