### PR TITLE
fix(terminal): normalize NUL-bearing script reads

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -457,7 +457,12 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         # WITHOUT reading the rest — reading a
         # megabyte of machine code just to discard it wastes the guard's
         # budget and (pre-#77703) fed decoded garbage into the recursion.
-        data = os.read(descriptor, _BINARY_SNIFF_BYTES)
+        # Keep accumulation amortized-linear when a filesystem returns short
+        # reads. Bytes concatenation can copy the full prefix on every chunk,
+        # turning a bounded read into quadratic work under that condition.
+        # bytearray avoids relying on implementation-specific concatenation
+        # optimizations.
+        data = bytearray(os.read(descriptor, _BINARY_SNIFF_BYTES))
         if data.startswith(_BINARY_MAGIC_PREFIXES):
             return None, False
         # Read the remainder (bounded). Loop because os.read may return

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -99,6 +99,11 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
+    # Shells discard NUL bytes in text scripts. Remove them before matching so
+    # ``hermes gateway rest\x00art`` cannot bypass the guard; removal can only
+    # splice tokens together, so this is fail-closed for the safety check.
+    if "\x00" in text:
+        text = text.replace("\x00", "")
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
 
@@ -131,9 +136,10 @@ _PIPE_TO_INTERPRETER = re.compile(
     r"\|\s*&?\s*(?:sudo\s+)?(?:sh|bash|dash|ksh|zsh|xargs|eval|source)\b"
 )
 
-# Executable-image magic numbers: ELF, PE/COFF, Mach-O (universal + thin,
-# both endiannesses). A referenced file starting with one of these is a
-# compiled binary, never a shell script — don't read or scan it at all.
+# Executable-image/archive magic numbers: ELF, PE/COFF, Mach-O (universal +
+# thin, both endiannesses), ar, gzip, and zip. A referenced file starting with
+# one of these is not shell text — don't read or scan it at all. NUL alone is
+# not a binary signal because bash executes NUL-bearing text scripts.
 _BINARY_MAGIC_PREFIXES = (
     b"\x7fELF",
     b"MZ",
@@ -142,6 +148,9 @@ _BINARY_MAGIC_PREFIXES = (
     b"\xce\xfa\xed\xfe",
     b"\xfe\xed\xfa\xce",
     b"\xfe\xed\xfa\xcf",
+    b"!<arch>\n",
+    b"\x1f\x8b",
+    b"PK\x03\x04",
 )
 _BINARY_SNIFF_BYTES = 4096
 
@@ -198,6 +207,8 @@ def contains_launchctl_submit_command(command: str) -> bool:
     semantics; ``bootstrap`` loads an arbitrary plist), which is never safe to
     do from inside the gateway process.
     """
+    if "\x00" in command:
+        command = command.replace("\x00", "")
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
         if index is None:
@@ -442,12 +453,12 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         if not stat.S_ISREG(metadata.st_mode):
             return None, True
         # Sniff a small prefix first: files that are clearly compiled
-        # binaries (executable magic, or NUL bytes in the head) are never
-        # shell scripts, so skip them WITHOUT reading the rest — reading a
+        # binaries (executable magic) are never shell scripts, so skip them
+        # WITHOUT reading the rest — reading a
         # megabyte of machine code just to discard it wastes the guard's
         # budget and (pre-#77703) fed decoded garbage into the recursion.
         data = os.read(descriptor, _BINARY_SNIFF_BYTES)
-        if data.startswith(_BINARY_MAGIC_PREFIXES) or b"\x00" in data:
+        if data.startswith(_BINARY_MAGIC_PREFIXES):
             return None, False
         # Read the remainder (bounded). Loop because os.read may return
         # short for non-regular-file-backed descriptors.
@@ -462,16 +473,14 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     finally:
         os.close(descriptor)
-    # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
-    # PE), not a shell script — scanning its decoded contents would
-    # tokenize machine code and feed junk paths into the recursion
-    # (including a `ValueError: embedded null byte` from Path.resolve,
-    # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
-    # executed by the user is not a referenced *shell script*.
-    if b"\x00" in data:
-        return None, False
+    # Check size BEFORE stripping NULs: otherwise an oversized NUL-padded
+    # script could shrink below the limit and skip the fail-closed branch.
+    # NUL-bearing text remains executable by bash, so normalize it before
+    # recursive scanning. Known binary formats were rejected by magic above.
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
+    if b"\x00" in data:
+        data = data.replace(b"\x00", b"")
     return data.decode("utf-8", errors="replace"), False
 
 
@@ -481,10 +490,11 @@ def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bo
     The recursion boundary must not trust its callbacks: any backend (SSH,
     Modal, Daytona, or a future one) can hand back raw binary bytes decoded
     as text, or arbitrarily large output. Mirror
-    ``_read_referenced_script``'s semantics exactly — NUL bytes mean binary
-    (nothing to scan, checked first, #77703), oversized text fails closed
-    like an oversized local file (#76762) — so remote and local reads can
-    never diverge again. The size check re-encodes to compare *bytes*
+    ``_read_referenced_script``'s semantics exactly — magic prefixes mean
+    binary (nothing to scan), NUL-bearing text is scanned after normalization,
+    and oversized text fails closed like an oversized local file (#76762) —
+    so remote and local reads can never diverge again. The size check
+    re-encodes to compare *bytes*
     (matching the local read and the ``head -c`` wire bound): a >1 MiB
     multibyte file truncated at the byte cap decodes to fewer characters
     than bytes, and a character-count check would scan the truncated text
@@ -494,10 +504,13 @@ def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bo
     """
     if not text:
         return None, False
-    if "\x00" in text:
+    encoded = text.encode("utf-8", errors="replace")
+    if encoded.startswith(_BINARY_MAGIC_PREFIXES):
         return None, False
-    if len(text.encode("utf-8", errors="replace")) > _MAX_REFERENCED_SCRIPT_BYTES:
+    if len(encoded) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
+    if "\x00" in text:
+        text = text.replace("\x00", "")
     return text, False
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1241,3 +1241,113 @@ class TestLifecycleGuardNeverRaises:
         for value in ("/dev/null", str(tmp_path)):
             with pytest.raises(GatewayLifecycleBlocked):
                 check_gateway_lifecycle("clean prompt", value)
+
+
+class TestLifecycleGuardNulPaddedText:
+    """NUL bytes do not prove a file is binary: bash executes NUL-padded
+    text, so referenced scripts must be normalized and scanned."""
+
+    @staticmethod
+    def _padded_text():
+        return (
+            "#!/bin/sh" + chr(10) + "# pad" + chr(0) + chr(10)
+            + "hermes gateway restart" + chr(10)
+        )
+
+    def test_nul_padded_script_is_blocked(self, tmp_path):
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+
+        script = tmp_path / "padded.sh"
+        script.write_bytes(self._padded_text().encode())
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))
+
+    def test_remote_terminal_callback_preserves_nul_text(self, monkeypatch):
+        import tools.terminal_tool as tt
+
+        calls = []
+        padded_text = self._padded_text()
+
+        class _RemoteEnv:
+            env = {}
+            cwd = "/remote/workspace"
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                if "head -c" in command:
+                    return {"output": padded_text, "returncode": 0}
+                raise AssertionError("referenced lifecycle script must be blocked")
+
+        monkeypatch.setattr(tt, "_active_environments", {"default": _RemoteEnv()})
+        monkeypatch.setattr(tt, "_last_activity", {"default": 0.0})
+        monkeypatch.setattr(tt, "_task_env_overrides", {})
+        monkeypatch.setattr(
+            tt,
+            "_get_env_config",
+            lambda: {
+                "env_type": "local",
+                "cwd": "/tmp",
+                "timeout": 60,
+                "lifetime_seconds": 3600,
+            },
+        )
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+        result = json.loads(
+            tt.terminal_tool(command="/bin/bash /remote/workspace/helper.sh")
+        )
+
+        assert result["exit_code"] == 1
+        assert "referenced script" in result["error"]
+        assert any("head -c" in call for call in calls)
+
+    def test_nul_spliced_prompt_lifecycle_command_is_blocked(self):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command
+
+        command = "hermes gateway rest" + chr(0) + "art"
+        assert contains_gateway_lifecycle_command(command) is True
+
+    def test_nul_spliced_launchctl_submit_is_blocked(self):
+        from cron.lifecycle_guard import contains_launchctl_submit_command
+
+        command = "launchctl sub" + chr(0) + "mit -l com.hermes -- /bin/true"
+        assert contains_launchctl_submit_command(command) is True
+
+    def test_nul_spliced_lifecycle_command_is_blocked(self, tmp_path):
+        from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
+
+        script = tmp_path / "spliced.sh"
+        script.write_bytes(
+            ("#!/bin/sh" + chr(10) + "hermes gateway rest" + chr(0)
+             + "art" + chr(10)).encode()
+        )
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))
+
+    def test_nul_padded_remote_script_is_blocked(self):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash /remote/helper.sh",
+            cwd="/remote",
+            read_remote_script=lambda _path: self._padded_text(),
+        )
+
+        assert result is True
+
+    def test_oversized_nul_padded_script_fails_closed(self, tmp_path):
+        from cron.lifecycle_guard import (
+            GatewayLifecycleBlocked,
+            _MAX_REFERENCED_SCRIPT_BYTES,
+            check_gateway_lifecycle,
+        )
+
+        script = tmp_path / "oversized.sh"
+        script.write_bytes(
+            b"# pad" + bytes([0]) + b"x" * _MAX_REFERENCED_SCRIPT_BYTES
+        )
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            check_gateway_lifecycle("daily ops", str(script))

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -761,6 +761,25 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
+    def test_referenced_script_handles_short_reads(self, tmp_path, monkeypatch):
+        import cron.lifecycle_guard as lifecycle_guard
+
+        script = tmp_path / "short-read.sh"
+        content = b"#!/bin/sh\n" + b"#" * (32 * 1024)
+        script.write_bytes(content)
+
+        real_read = lifecycle_guard.os.read
+
+        def short_read(descriptor, length):
+            return real_read(descriptor, min(length, 1))
+
+        monkeypatch.setattr(lifecycle_guard.os, "read", short_read)
+
+        text, unsafe = lifecycle_guard._read_referenced_script(script)
+
+        assert text == content.decode()
+        assert unsafe is False
+
     # -- Whole-class regression tests (tilllt's T1-T4 on PR #79454) --------
 
     def test_tilde_nul_candidate_does_not_crash_terminal_walk(self):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2774,6 +2774,7 @@ def terminal_tool(
         # but applies unconditionally (force=True cannot help here).
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from cron.lifecycle_guard import (
+                _BINARY_MAGIC_PREFIXES,
                 _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,
                 contains_launchctl_submit_command,
@@ -2818,13 +2819,12 @@ def terminal_tool(
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= _MAX_REFERENCED_SCRIPT_BYTES:
                             data = local_path.read_bytes()
                             if len(data) <= _MAX_REFERENCED_SCRIPT_BYTES:
-                                if b"\x00" in data:
-                                    # Binary (ELF/Mach-O/PE), not a shell script:
-                                    # feeding its decoded bytes back into the guard
-                                    # tokenizes machine code into bogus NUL-bearing
-                                    # paths and crashes the scanner (#77703). Mirror
-                                    # lifecycle_guard._read_referenced_script and
-                                    # treat it as nothing to scan.
+                                if data.startswith(_BINARY_MAGIC_PREFIXES):
+                                    # Known executable/archive bytes are not
+                                    # shell text. NUL-bearing text is passed to
+                                    # lifecycle_guard for normalization, so the
+                                    # callback cannot reintroduce #77927 while
+                                    # fixing the binary crash class (#82887).
                                     return None
                                 return data.decode("utf-8", errors="replace")
                 except Exception:
@@ -2846,10 +2846,9 @@ def terminal_tool(
                     )
                     if result.get("returncode", -1) == 0:
                         output = result.get("output", "")
-                        if output and "\x00" in output:
-                            # Binary content from a remote read: skip for the
-                            # same reason as the local branch above (#77703).
-                            return None
+                        # Keep NUL-bearing text intact. The lifecycle guard's
+                        # callback boundary classifies known binary prefixes,
+                        # strips NULs from text, and enforces the byte limit.
                         return output
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary

Fixes the terminal guard failure behind #82887 and closes the related NUL-padded script bypass in #77927.

## Root cause

The gateway lifecycle guard recursively reads command-referenced files. The terminal tool callback `_read_script_in_env()` decoded binary bytes with UTF-8 replacement while preserving embedded NULs. The scanner tokenized those bytes as shell text; a generated path containing NUL then reached `os.open()`, which raises `ValueError` rather than `OSError`.

The existing NUL check prevented the crash for common binaries, but it also treated every NUL-bearing file as a binary. Bash executes NUL-padded text scripts, so that classification silently allowed lifecycle commands hidden in such scripts. The remote callback had the same early discard.

## Fix

- Classify known binary/archive formats by magic prefix, not by NUL presence.
- Normalize NUL-bearing text before direct and recursive lifecycle scans.
- Keep the 1 MiB size check before NUL removal, preserving fail-closed behavior.
- Make local and remote callback reads follow the lifecycle guard's same contract.
- Use `bytearray` for bounded referenced-script accumulation, avoiding repeated prefix copies when filesystems return short reads.
- Add regression coverage for local/remote NUL-padded scripts, NUL-spliced commands, launchctl submit, oversized inputs, terminal callback reads, and one-byte short reads.

## Infographic :

<img width="1024" height="1024" alt="infographic" src="https://github.com/user-attachments/assets/fee5c787-0790-43fd-876a-d959bb777844" />


## Validation

- `.venv\\Scripts\\python.exe -m pytest tests/hermes_cli/test_gateway_restart_loop.py -q -k "NulPaddedText or binary_script or absolute_path_binary or nul_byte or read_referenced_script or remote_read_fallback_binary or tilde_nul or binary_from_remote or oversized_remote or command_referencing_elf or non_utf8 or magic_prefix or referenced_script_handles_short_reads"` — 20 passed
- `.venv\\Scripts\\ruff.exe check cron/lifecycle_guard.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py` — passed
- `.venv\\Scripts\\python.exe -m py_compile cron/lifecycle_guard.py tools/terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py` — passed
- Synthetic 128 KiB one-byte-read benchmark: 0.450s before optimization, 0.273s after; bounded read count and result unchanged.
- GitHub required checks: passed.

The full guard file has 10 unrelated Windows-baseline failures on this checkout because existing tests pass Windows paths through POSIX shell tokenization; `os.mkfifo` is also unavailable. New and related cases pass.

Closes #82887
Refs #77927