### PR TITLE
fix(gateway): preserve prose during native clarify

### DIFF
--- a/contributors/emails/260355617@qq.com
+++ b/contributors/emails/260355617@qq.com
@@ -1,0 +1,2 @@
+loulanyue
+# PR #75732 successor to #71997

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14982,7 +14982,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Intercept messages that are responses to a pending clarify.
         # Open-ended prompts and "Other" responses are captured as free text;
         # direct replies to multi-choice prompts are accepted too ("2" maps
-        # to the second option, arbitrary text becomes a custom answer). Slash
+        # to the second option). Slash
         # commands still bypass this path so /stop and friends keep working.
         _clarify_mod = None
         try:
@@ -15035,6 +15035,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+                # Native-choice prompts deliberately reject unmatched prose
+                # so it can continue through normal busy-message routing.
+                # Release this clarify first: redirect() degrades to steer()
+                # while tools are executing, and that steer cannot drain until
+                # the clarify tool returns.
+                _clarify_mod.resolve_gateway_clarify(
+                    _pending_clarify.clarify_id,
+                    "",
+                )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8863,10 +8863,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # still small enough to never threaten memory.
     _BUSY_QUEUE_MAX_PENDING = 32
 
-    def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
+    def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> bool:
         adapter = self._adapter_for_source(event.source)
         if not adapter:
-            return
+            return False
         # #28503 — Previously this called ``merge_pending_message_event``
         # with the default ``merge_text=False``, which silently OVERWROTE
         # the single pending slot when consecutive text messages arrived
@@ -8890,7 +8890,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 event,
                 merge_text=event.message_type == MessageType.TEXT,
             )
-            return
+            return True
 
         if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
             logger.warning(
@@ -8898,9 +8898,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key,
                 self._BUSY_QUEUE_MAX_PENDING,
             )
-            return
+            return False
 
         self._enqueue_fifo(session_key, event, adapter)
+        return True
 
     async def _prepare_busy_steer_text(self, event: MessageEvent) -> str:
         """Return steerable text for a busy follow-up, transcribing voice first.
@@ -15047,15 +15048,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     return ""
                 if _text_outcome == _clarify_mod.TEXT_REJECTED_PROSE:
-                    # Native-choice prompts deliberately reject unmatched
-                    # prose so it can continue through normal busy-message
-                    # routing. Release this clarify first: redirect()
-                    # degrades to steer() while tools are executing, and
-                    # that steer cannot drain until the clarify tool returns.
-                    _clarify_mod.resolve_gateway_clarify(
-                        _pending_clarify.clarify_id,
-                        "",
-                    )
+                    # Preserve unmatched prose as the next turn instead of
+                    # cancelling this native-choice clarify or routing the
+                    # prose into redirect→steer while the agent is blocked on
+                    # the clarify tool. The adapter sends this non-empty
+                    # guidance immediately; after a valid choice unblocks the
+                    # current turn, the normal FIFO drain handles the prose.
+                    _clarify_adapter = self._adapter_for_source(source)
+                    if _clarify_adapter is not None:
+                        _queued = self._queue_or_replace_pending_event(_quick_key, event)
+                        _choice_lines = "\n".join(
+                            f"{index}. {choice}"
+                            for index, choice in enumerate(
+                                _pending_clarify.choices,
+                                start=1,
+                            )
+                        )
+                        if not _queued:
+                            logger.warning(
+                                "Gateway could not preserve non-choice clarify reply "
+                                "(session=%s, id=%s)",
+                                _quick_key,
+                                _pending_clarify.clarify_id,
+                            )
+                            return (
+                                "I couldn't save that message because the pending queue "
+                                "is full. Please answer the current question first:\n"
+                                f"{_choice_lines}\n"
+                                "Then send that message again."
+                            )
+                        logger.info(
+                            "Gateway preserved non-choice clarify reply for the next turn "
+                            "(session=%s, id=%s)",
+                            _quick_key,
+                            _pending_clarify.clarify_id,
+                        )
+                        return (
+                            "I saved that message for the next turn. "
+                            "Please answer the current question first:\n"
+                            f"{_choice_lines}\n"
+                            "Reply with a number or the exact option text, or choose "
+                            "Other to enter a custom answer."
+                        )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15008,10 +15008,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # so the user can retry; if it times out, the agent unblocks
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
-                _resolved = _clarify_mod.resolve_text_response_for_session(
+                _text_outcome = _clarify_mod.attempt_text_response_for_session(
                     _quick_key, _raw_clarify_reply,
                 )
-                if _resolved:
+                if _text_outcome == _clarify_mod.TEXT_RESOLVED:
                     logger.info(
                         "Gateway intercepted clarify text response (session=%s, id=%s)",
                         _quick_key, _pending_clarify.clarify_id,
@@ -15035,15 +15035,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
-                # Native-choice prompts deliberately reject unmatched prose
-                # so it can continue through normal busy-message routing.
-                # Release this clarify first: redirect() degrades to steer()
-                # while tools are executing, and that steer cannot drain until
-                # the clarify tool returns.
-                _clarify_mod.resolve_gateway_clarify(
-                    _pending_clarify.clarify_id,
-                    "",
-                )
+                if _text_outcome == _clarify_mod.TEXT_REJECTED_SELECTION:
+                    # Selection-shaped but invalid (out-of-range number,
+                    # unrecognised comma-list). Keep the clarify armed so
+                    # the user can retry — do not cancel and do not treat
+                    # this as an unrelated follow-up turn.
+                    logger.info(
+                        "Gateway retained pending clarify after invalid "
+                        "selection attempt (session=%s, id=%s)",
+                        _quick_key, _pending_clarify.clarify_id,
+                    )
+                    return ""
+                if _text_outcome == _clarify_mod.TEXT_REJECTED_PROSE:
+                    # Native-choice prompts deliberately reject unmatched
+                    # prose so it can continue through normal busy-message
+                    # routing. Release this clarify first: redirect()
+                    # degrades to steer() while tools are executing, and
+                    # that steer cannot drain until the clarify tool returns.
+                    _clarify_mod.resolve_gateway_clarify(
+                        _pending_clarify.clarify_id,
+                        "",
+                    )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/tests/gateway/test_clarify_composed_pipeline.py
+++ b/tests/gateway/test_clarify_composed_pipeline.py
@@ -1,0 +1,179 @@
+"""Composed regression coverage for clarify replies crossing the adapter and runner.
+
+The narrow tests in this area cover the clarify state machine, the adapter's
+active-session bypass, and the runner's prose rejection independently.  This
+module keeps those seams connected: a native choice prompt is pending while
+both the adapter session guard and the runner's active-agent slot are live.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+class _CaptureAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.SLACK)
+        self.sent: list[str] = []
+
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        return SendResult(success=True, message_id=f"m{len(self.sent)}")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "im"}
+
+
+class _RunningAgent:
+    def __init__(self):
+        self.interrupts: list[str] = []
+        self._active_children: list[object] = []
+
+    def interrupt(self, text):
+        self.interrupts.append(text)
+
+    def get_activity_summary(self):
+        return {
+            "seconds_since_activity": 0,
+            "last_activity_desc": "waiting for clarify",
+            "api_call_count": 1,
+            "max_iterations": 10,
+        }
+
+
+def _event(text: str, message_id: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="D123",
+            chat_type="dm",
+            user_id="U1",
+            thread_id="1111.2222",
+        ),
+        message_id=message_id,
+    )
+
+
+def _clear_clarify_state():
+    from tools import clarify_gateway as cm
+
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+        cm._notify_cbs.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selection", ["2", "Beta"])
+async def test_native_choice_preserves_prose_then_drains_it_once_after_selection(selection):
+    """Rejected prose is acknowledged and saved without stealing the clarify turn."""
+    _clear_clarify_state()
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    adapter = _CaptureAdapter()
+    initial = _event("start", "initial")
+    session_key = build_session_key(
+        initial.source,
+        group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+        thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._startup_restore_in_progress = False
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._is_user_authorized = lambda source: True
+    runner._session_key_for_source = lambda source: session_key
+    runner._adapter_for_source = lambda source: adapter
+    runner._update_prompt_pending = {}
+    runner._draining = False
+    # The clarify reply must not inherit the operator's normal interrupt policy.
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+
+    running_agent = _RunningAgent()
+    prompt_ready = asyncio.Event()
+    followup_drained = asyncio.Event()
+    handled_followups: list[str] = []
+
+    async def composed_handler(event: MessageEvent):
+        if event.message_id == "initial":
+            state = runner._session_state(session_key)
+            state.turn.agent = running_agent
+            state.turn.started_ts = time.time()
+            cm.register(
+                "clarify-composed",
+                session_key,
+                "Choose a release channel",
+                ["Alpha", "Beta"],
+            )
+            prompt_ready.set()
+            answer = await asyncio.to_thread(
+                cm.wait_for_response,
+                "clarify-composed",
+                5.0,
+            )
+            runner._release_running_agent_state(session_key)
+            return f"selected:{answer}"
+
+        if runner._is_session_running(session_key):
+            return await runner._handle_message(event)
+
+        handled_followups.append(event.text)
+        followup_drained.set()
+        return f"handled:{event.text}"
+
+    adapter._message_handler = composed_handler
+
+    try:
+        await adapter.handle_message(initial)
+        await asyncio.wait_for(prompt_ready.wait(), timeout=5)
+
+        prose = "Please also include the migration notes"
+        await adapter.handle_message(_event(prose, "prose"))
+        await adapter.handle_message(_event(selection, "selection"))
+
+        await asyncio.wait_for(followup_drained.wait(), timeout=5)
+        expected_followup_reply = f"handled:{prose}"
+
+        async def _wait_for_followup_delivery():
+            while expected_followup_reply not in adapter.sent:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(_wait_for_followup_delivery(), timeout=5)
+
+        guidance = [message for message in adapter.sent if "saved" in message.lower()]
+        assert len(guidance) == 1
+        assert "1. Alpha" in guidance[0]
+        assert "2. Beta" in guidance[0]
+        assert "Other" in guidance[0]
+        assert handled_followups == [prose]
+        assert running_agent.interrupts == []
+        assert adapter._pending_messages == {}
+        assert adapter.sent.count("selected:Beta") == 1
+        assert adapter.sent.count(f"handled:{prose}") == 1
+        assert cm.get_pending_for_session(session_key, include_choice_prompts=True) is None
+    finally:
+        cm.clear_session(session_key)
+        await adapter.cancel_background_tasks()
+        _clear_clarify_state()

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -123,11 +123,13 @@ async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
     with pytest.raises(_FellThroughIntercept):
         await _dispatch(runner, _event("just checking the visual UI, no need to pass any data"))
 
-    # The clarify entry must still be pending and unresolved.
+    # The prose is not accepted as the answer, but the clarify must be
+    # released before normal busy routing so redirect-to-steer can drain.
     with cm._lock:
         entry = cm._entries.get("cl-native")
     assert entry is not None
-    assert not entry.event.is_set()
+    assert entry.event.is_set()
+    assert entry.response == ""
     _clear_clarify_state()
 
 

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -134,6 +134,30 @@ async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
 
 
 @pytest.mark.asyncio
+async def test_thread_prose_does_not_overwrite_concurrent_button_choice():
+    """A button result that wins the race remains the clarify response."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    entry = cm.register(
+        "cl-button-race",
+        SESSION_KEY,
+        "Pick a UI variant",
+        ["buttons", "dropdown"],
+    )
+    assert cm.resolve_gateway_clarify("cl-button-race", "buttons") is True
+
+    with pytest.raises(_FellThroughIntercept):
+        await _dispatch(runner, _event("one more unrelated thought"))
+
+    assert entry.event.is_set()
+    assert entry.response == "buttons"
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
 async def test_prose_still_accepted_after_other_flips_text_capture():
     """After the user taps 'Other', free text IS the answer — must resolve."""
     _clear_clarify_state()
@@ -153,5 +177,4 @@ async def test_prose_still_accepted_after_other_flips_text_capture():
     assert entry.event.is_set()
     assert entry.response == "a carousel actually"
     _clear_clarify_state()
-
 

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -158,6 +158,92 @@ async def test_thread_prose_does_not_overwrite_concurrent_button_choice():
 
 
 @pytest.mark.asyncio
+async def test_native_multi_select_out_of_range_keeps_clarify_pending():
+    """Out-of-range multi-select numbers must not cancel the pending prompt."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    entry = cm.register(
+        "cl-ms-oor",
+        SESSION_KEY,
+        "Pick some targets",
+        ["staging", "prod", "canary"],
+        multi_select=True,
+    )
+    assert entry.awaiting_text is False
+
+    result = await _dispatch(runner, _event("99"))
+
+    assert result == ""
+    with cm._lock:
+        still = cm._entries.get("cl-ms-oor")
+    assert still is not None
+    assert not still.event.is_set()
+    assert still.response is None
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
+async def test_native_multi_select_bad_comma_list_keeps_clarify_pending():
+    """Unrecognised comma-lists are retryable selection attempts, not prose."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    entry = cm.register(
+        "cl-ms-bad",
+        SESSION_KEY,
+        "Pick some targets",
+        ["staging", "prod", "canary"],
+        multi_select=True,
+    )
+    assert entry.awaiting_text is False
+
+    result = await _dispatch(runner, _event("1,99"))
+
+    assert result == ""
+    with cm._lock:
+        still = cm._entries.get("cl-ms-bad")
+    assert still is not None
+    assert not still.event.is_set()
+    assert still.response is None
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
+async def test_native_multi_select_prose_releases_clarify_before_routing():
+    """Free prose on multi-select still breaks the redirect/steer deadlock."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    cm.register(
+        "cl-ms-prose",
+        SESSION_KEY,
+        "Pick some targets",
+        ["staging", "prod"],
+        multi_select=True,
+    )
+
+    with pytest.raises(_FellThroughIntercept):
+        await _dispatch(
+            runner,
+            _event("just checking the visual UI, no need to pass any data"),
+        )
+
+    with cm._lock:
+        entry = cm._entries.get("cl-ms-prose")
+    assert entry is not None
+    assert entry.event.is_set()
+    assert entry.response == ""
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
 async def test_prose_still_accepted_after_other_flips_text_capture():
     """After the user taps 'Other', free text IS the answer — must resolve."""
     _clear_clarify_state()

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -110,7 +110,7 @@ async def _dispatch(runner, event):
 
 @pytest.mark.asyncio
 async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
-    """Arbitrary prose during a pending button-clarify continues as a normal turn."""
+    """Arbitrary prose is queued once while the pending choice stays armed."""
     _clear_clarify_state()
     from tools import clarify_gateway as cm
 
@@ -120,16 +120,19 @@ async def test_thread_prose_not_swallowed_by_native_multi_choice_clarify():
     entry = cm.register("cl-native", SESSION_KEY, "Pick a UI variant", ["buttons", "dropdown"])
     assert entry.awaiting_text is False
 
-    with pytest.raises(_FellThroughIntercept):
-        await _dispatch(runner, _event("just checking the visual UI, no need to pass any data"))
+    event = _event("just checking the visual UI, no need to pass any data")
+    result = await _dispatch(runner, event)
 
-    # The prose is not accepted as the answer, but the clarify must be
-    # released before normal busy routing so redirect-to-steer can drain.
     with cm._lock:
         entry = cm._entries.get("cl-native")
     assert entry is not None
-    assert entry.event.is_set()
-    assert entry.response == ""
+    assert not entry.event.is_set()
+    assert entry.response is None
+    assert result
+    assert "saved" in result.lower()
+    assert "1. buttons" in result
+    assert "2. dropdown" in result
+    assert adapter._pending_messages == {SESSION_KEY: event}
     _clear_clarify_state()
 
 
@@ -214,8 +217,8 @@ async def test_native_multi_select_bad_comma_list_keeps_clarify_pending():
 
 
 @pytest.mark.asyncio
-async def test_native_multi_select_prose_releases_clarify_before_routing():
-    """Free prose on multi-select still breaks the redirect/steer deadlock."""
+async def test_native_multi_select_prose_queues_without_releasing_clarify():
+    """Free prose queues once while a multi-select prompt remains retryable."""
     _clear_clarify_state()
     from tools import clarify_gateway as cm
 
@@ -229,17 +232,19 @@ async def test_native_multi_select_prose_releases_clarify_before_routing():
         multi_select=True,
     )
 
-    with pytest.raises(_FellThroughIntercept):
-        await _dispatch(
-            runner,
-            _event("just checking the visual UI, no need to pass any data"),
-        )
+    event = _event("just checking the visual UI, no need to pass any data")
+    result = await _dispatch(runner, event)
 
     with cm._lock:
         entry = cm._entries.get("cl-ms-prose")
     assert entry is not None
-    assert entry.event.is_set()
-    assert entry.response == ""
+    assert not entry.event.is_set()
+    assert entry.response is None
+    assert result
+    assert "saved" in result.lower()
+    assert "1. staging" in result
+    assert "2. prod" in result
+    assert adapter._pending_messages == {SESSION_KEY: event}
     _clear_clarify_state()
 
 
@@ -264,3 +269,24 @@ async def test_prose_still_accepted_after_other_flips_text_capture():
     assert entry.response == "a carousel actually"
     _clear_clarify_state()
 
+
+@pytest.mark.asyncio
+async def test_prose_reports_queue_full_without_claiming_it_was_saved():
+    """A dropped follow-up must not be reported as preserved."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    runner._queue_or_replace_pending_event = lambda _key, _event: False
+    entry = cm.register("cl-queue-full", SESSION_KEY, "Pick one", ["a", "b"])
+
+    result = await _dispatch(runner, _event("save this for later"))
+
+    assert not entry.event.is_set()
+    assert entry.response is None
+    assert result
+    assert "couldn't save" in result.lower()
+    assert "send that message again" in result.lower()
+    assert adapter._pending_messages == {}
+    _clear_clarify_state()

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -42,6 +42,16 @@ class TestClarifyPrimitive:
         result = cm.wait_for_response("id1", timeout=10.0)
         assert result == "B"
 
+    def test_first_resolution_wins(self):
+        """A late cancellation must not overwrite an already-selected choice."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("id-race", "sk-race", "Pick one", ["A", "B"])
+
+        assert cm.resolve_gateway_clarify("id-race", "A") is True
+        assert cm.resolve_gateway_clarify("id-race", "") is False
+        assert entry.response == "A"
+
     def test_open_ended_auto_awaits_text(self):
         """Clarify with no choices is in text-capture mode immediately."""
         from tools import clarify_gateway as cm

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -351,3 +351,84 @@ class TestMultiSelectTextFallback:
         from tools import clarify_gateway as cm
         entry = cm.register("s4", "sk", "Q?", ["A", "B"])
         assert cm._coerce_text_response(entry, "b") == "B"
+
+
+class TestNativeRejectClassification:
+    """Rejected typed replies must distinguish free prose from bad selections.
+
+    Free prose cancels/falls through (deadlock break). Selection-shaped but
+    invalid replies (out-of-range number, unrecognised comma-list) keep the
+    pending clarify armed so the user can retry.
+    """
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    def test_multi_select_out_of_range_is_invalid_selection(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "ms-oor", "sk-ms", "Pick some", ["A", "B", "C"], multi_select=True,
+        )
+        assert entry.awaiting_text is False
+        value, reason = cm._coerce_text_response_detailed(entry, "99")
+        assert value is None
+        assert reason == "invalid_selection"
+        assert cm.attempt_text_response_for_session("sk-ms", "99") == (
+            cm.TEXT_REJECTED_SELECTION
+        )
+        pending = cm.get_pending_for_session("sk-ms", include_choice_prompts=True)
+        assert pending is not None
+        assert not pending.event.is_set()
+
+    def test_multi_select_bad_comma_list_is_invalid_selection(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "ms-bad", "sk-ms2", "Pick some", ["A", "B", "C"], multi_select=True,
+        )
+        value, reason = cm._coerce_text_response_detailed(entry, "1,99")
+        assert value is None
+        assert reason == "invalid_selection"
+        assert cm.attempt_text_response_for_session("sk-ms2", "nope,nope") == (
+            cm.TEXT_REJECTED_SELECTION
+        )
+        pending = cm.get_pending_for_session("sk-ms2", include_choice_prompts=True)
+        assert pending is not None
+        assert not pending.event.is_set()
+
+    def test_multi_select_free_prose_is_rejected_prose(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "ms-prose", "sk-ms3", "Pick some", ["A", "B"], multi_select=True,
+        )
+        value, reason = cm._coerce_text_response_detailed(
+            entry, "just checking the visual UI, no need to pass any data",
+        )
+        assert value is None
+        assert reason == "prose"
+        assert cm.attempt_text_response_for_session(
+            "sk-ms3", "just checking the visual UI, no need to pass any data",
+        ) == cm.TEXT_REJECTED_PROSE
+
+    def test_single_select_out_of_range_is_invalid_selection(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("ss-oor", "sk-ss", "Pick one", ["A", "B"])
+        value, reason = cm._coerce_text_response_detailed(entry, "9")
+        assert value is None
+        assert reason == "invalid_selection"
+        assert cm.attempt_text_response_for_session("sk-ss", "9") == (
+            cm.TEXT_REJECTED_SELECTION
+        )
+
+    def test_single_select_prose_is_rejected_prose(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("ss-prose", "sk-ss2", "Pick one", ["A", "B"])
+        value, reason = cm._coerce_text_response_detailed(
+            entry, "one more unrelated thought",
+        )
+        assert value is None
+        assert reason == "prose"

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -169,11 +169,11 @@ def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
     """
     with _lock:
         entry = _entries.get(clarify_id)
-        if entry is None:
+        if entry is None or entry.event.is_set():
             return False
-    entry.response = str(response) if response is not None else ""
-    entry.event.set()
-    return True
+        entry.response = str(response) if response is not None else ""
+        entry.event.set()
+        return True
 
 
 def get_pending_for_session(

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -201,19 +201,111 @@ def get_pending_for_session(
         return None
 
 
+# Outcomes for typed clarify replies. Gateway uses these to decide whether to
+# cancel a pending prompt (free prose deadlock break) or keep it armed so the
+# user can retry a selection-like invalid reply (out-of-range / bad list).
+TEXT_RESOLVED = "resolved"
+TEXT_REJECTED_PROSE = "rejected_prose"
+TEXT_REJECTED_SELECTION = "rejected_selection"
+TEXT_NO_PENDING = "no_pending"
+
+
+def _selection_attempt_tokens(
+    text: str,
+    choices: Optional[List[str]] = None,
+) -> Optional[List[str]]:
+    """Return tokens when ``text`` looks like a typed selection attempt.
+
+    Selection-shaped input includes:
+      - a bare integer ("2", "99")
+      - comma-separated numbers/labels ("1,3", "staging, prod", "1,99")
+      - space-separated all-numeric lists ("1 3")
+
+    Free prose ("just checking the visual UI, no need to pass any data") returns
+    None even when it contains commas, so the gateway can release the clarify
+    and continue normal routing instead of forcing a retry.
+
+    Multi-word choice labels are allowed in comma-lists up to the longest
+    choice's word count (e.g. "Send to SOL, Keep with Enoch").
+    """
+    stripped = str(text).strip()
+    if not stripped:
+        return None
+
+    max_choice_words = 1
+    if choices:
+        max_choice_words = max(
+            (len(str(choice).split()) for choice in choices),
+            default=1,
+        )
+        max_choice_words = max(1, max_choice_words)
+
+    if "," in stripped:
+        tokens = [t.strip() for t in stripped.split(",") if t.strip()]
+        if not tokens:
+            return None
+        # Natural-language clauses with commas are not selection lists.
+        # Each selection token is either a number or at most as many words
+        # as the longest configured choice label.
+        for token in tokens:
+            if token.isdigit():
+                continue
+            words = token.split()
+            if len(words) == 0 or len(words) > max_choice_words:
+                return None
+        return tokens
+
+    parts = stripped.split()
+    if len(parts) > 1 and all(p.strip().isdigit() for p in parts):
+        return [p.strip() for p in parts]
+
+    # Bare integer (in-range or out-of-range) is always a selection attempt.
+    if stripped.isdigit() or (stripped.startswith("-") and stripped[1:].isdigit()):
+        return [stripped]
+
+    try:
+        int(stripped)
+        return [stripped]
+    except ValueError:
+        return None
+
+
 def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
     """Map typed choice replies to canonical choice text, otherwise keep or reject custom text.
+
+    Thin wrapper over :func:`_coerce_text_response_detailed` for callers that
+    only need the accepted value (or ``None`` on any rejection).
+    """
+    coerced, _reason = _coerce_text_response_detailed(entry, response)
+    return coerced
+
+
+def _coerce_text_response_detailed(
+    entry: _ClarifyEntry,
+    response: str,
+) -> tuple[Optional[str], Optional[str]]:
+    """Map typed replies and classify rejections.
+
+    Returns ``(value, None)`` when the reply is accepted.
+
+    Returns ``(None, reason)`` when rejected:
+      - ``"invalid_selection"`` — selection-shaped but unusable (out-of-range
+        number, unrecognised comma-list). Keep the pending clarify so the
+        user can retry.
+      - ``"prose"`` — free text that is not a selection attempt. Gateway may
+        cancel the clarify and continue normal busy-message routing so a
+        redirect-to-steer path cannot deadlock behind the waiting tool.
 
     For native interactive multi-choice clarifies (button UI, awaiting_text=False):
       - Accept numeric selections ("2" → choice[1])
       - Accept exact choice label matches (case-insensitive)
-      - Reject arbitrary prose (return None) so the message continues as a normal turn
+      - Reject arbitrary prose so the message can continue as a normal turn
 
     For multi-select clarifies (entry.multi_select=True):
       - Accept several numbers separated by commas and/or spaces ("1,3" / "1 3")
       - Accept exact choice label matches (single or comma-separated)
-      - Out-of-range numbers reject the whole reply (return None) so the user
-        can retry instead of silently getting a partial selection
+      - Out-of-range numbers / unrecognised lists reject the whole reply so the
+        user can retry instead of silently getting a partial selection
       - Selections are returned as a JSON array string, which the clarify
         tool's ``_parse_multi_select_response`` decodes back into a list
 
@@ -222,43 +314,50 @@ def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
 
     For open-ended clarifies (no choices):
       - Accept any text
-
-    Returns None when the response should be rejected (arbitrary prose for native multi-choice).
     """
     text = str(response).strip()
 
     if not entry.choices:
         # Open-ended: accept any text
-        return text
+        return text, None
 
     if entry.multi_select:
         coerced = _coerce_multi_select_text(entry, text)
         if coerced is not None:
-            return coerced
+            return coerced, None
         # Not a parseable selection — accept as custom text only in
-        # awaiting_text mode (the "Other" path); otherwise reject.
-        return text if entry.awaiting_text else None
+        # awaiting_text mode (the "Other" path); otherwise classify reject.
+        if entry.awaiting_text:
+            return text, None
+        if _selection_attempt_tokens(text, entry.choices) is not None:
+            return None, "invalid_selection"
+        return None, "prose"
 
     # Try numeric selection first (always valid for multi-choice)
     try:
         idx = int(text) - 1
+        is_int = True
     except ValueError:
         idx = -1
+        is_int = False
 
-    if 0 <= idx < len(entry.choices):
-        return entry.choices[idx]
+    if is_int and 0 <= idx < len(entry.choices):
+        return entry.choices[idx], None
 
     # Try exact choice label match (always valid for multi-choice)
     for choice in entry.choices:
         if text.casefold() == str(choice).strip().casefold():
-            return str(choice).strip()
+            return str(choice).strip(), None
 
     # For text fallback or awaiting_text mode, accept custom text
-    # For native interactive multi-choice mode, reject arbitrary prose
+    # For native interactive multi-choice mode, reject with a reason
     if entry.awaiting_text:
-        return text
+        return text, None
 
-    return None
+    # Out-of-range / non-canonical integer is a failed selection, not prose.
+    if is_int:
+        return None, "invalid_selection"
+    return None, "prose"
 
 
 def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
@@ -313,25 +412,42 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
     return _json.dumps(selected, ensure_ascii=False)
 
 
-def resolve_text_response_for_session(session_key: str, response: str) -> bool:
-    """Resolve the oldest pending clarify in ``session_key`` from typed text.
+def attempt_text_response_for_session(session_key: str, response: str) -> str:
+    """Try to resolve the oldest pending clarify in ``session_key`` from typed text.
 
-    Returns False if no pending clarify exists or if the response was rejected
-    (arbitrary prose for native interactive multi-choice clarifies).
+    Returns one of:
+      - ``TEXT_RESOLVED`` — accepted; waiter unblocked
+      - ``TEXT_REJECTED_PROSE`` — free prose on a native choice prompt; caller
+        may cancel the clarify and continue ordinary message routing
+      - ``TEXT_REJECTED_SELECTION`` — selection-shaped but invalid; leave the
+        pending clarify armed so the user can retry
+      - ``TEXT_NO_PENDING`` — no interceptable clarify for this session
     """
     entry = get_pending_for_session(session_key, include_choice_prompts=True)
     if entry is None:
-        return False
+        return TEXT_NO_PENDING
 
-    coerced = _coerce_text_response(entry, response)
+    coerced, reason = _coerce_text_response_detailed(entry, response)
     if coerced is None:
-        # Response rejected: message should continue as a normal turn
-        return False
+        if reason == "invalid_selection":
+            return TEXT_REJECTED_SELECTION
+        return TEXT_REJECTED_PROSE
 
-    return resolve_gateway_clarify(
-        entry.clarify_id,
-        coerced,
-    )
+    if resolve_gateway_clarify(entry.clarify_id, coerced):
+        return TEXT_RESOLVED
+    # Lost a race with a button/callback resolution — treat as no work left.
+    return TEXT_NO_PENDING
+
+
+def resolve_text_response_for_session(session_key: str, response: str) -> bool:
+    """Resolve the oldest pending clarify in ``session_key`` from typed text.
+
+    Returns True only when the reply was accepted and the waiter unblocked.
+    Rejected prose, rejected selections, and missing prompts all return False;
+    use :func:`attempt_text_response_for_session` when the caller must
+    distinguish those cases (gateway deadlock vs multi-select retry).
+    """
+    return attempt_text_response_for_session(session_key, response) == TEXT_RESOLVED
 
 
 def mark_awaiting_text(clarify_id: str) -> bool:

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -194,7 +194,7 @@ def get_pending_for_session(
         ids = _session_index.get(session_key) or []
         for cid in ids:
             entry = _entries.get(cid)
-            if entry is None:
+            if entry is None or entry.event.is_set():
                 continue
             if include_choice_prompts or entry.awaiting_text:
                 return entry


### PR DESCRIPTION
## What does this PR do?

When a native multi-choice clarify is pending, unrelated prose is preserved as the next FIFO turn instead of being accepted as the choice, cancelled, swallowed, or redirected into the busy-session steer path.

The gateway returns non-empty numbered guidance immediately, leaves the current clarify pending, accepts a later numeric or exact-label selection, and drains the preserved prose exactly once after that selection completes.

This branch preserves the four commits and original authorship from #75732, including typed-reply classification, invalid multi-select retry behavior, and the first-writer resolution guard. It changes only the rejected-**prose** outcome: queue + guidance instead of clarify cancellation + busy-path fall-through. It also adds a composed adapter → runner → clarify → FIFO-drain regression test. Final head: `cc3d4825a93334542d10776eb21c4a76f51700b2`.

Transplanted #75732 on current upstream `main` passes its own focused suite (`35 passed`) but fails both parametrizations of the new composed test. The additional commit turns those two failures green while retaining the original 35 tests.

## Related Issue

Related: #71946, #62034  
Builds on and preserves authorship from: #75732

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/clarify_gateway.py`: retain #75732's resolved / rejected-prose / rejected-selection / no-pending classifier and first-writer guard; exclude already-resolved entries from pending lookup.
- `gateway/run.py`: preserve rejected free prose in the existing bounded FIFO and return immediate numbered guidance without interrupting the agent blocked on clarify.
- `tests/tools/test_clarify_gateway.py`: retain #75732's classifier, multi-select, and race coverage.
- `tests/gateway/test_clarify_thread_followup_not_swallowed.py`: distinguish free prose queueing from invalid-selection retry and verify a concurrent button winner is unchanged.
- `tests/gateway/test_clarify_composed_pipeline.py`: exercise numeric and exact-label selections through the full adapter/runner path and assert one-time FIFO drain.
- `contributors/emails/260355617@qq.com`: retain #75732's original-author attribution mapping.

## How to Test

1. Transplant #75732's four commits onto upstream `main` at `893792c9934447e80f40519437e7c64b4479fc3a` and run its two focused modules.  
   Result: `35 passed`.
2. Add only `test_clarify_composed_pipeline.py` and run it before the rejected-prose adaptation.  
   RED result: `2 failed`.
3. Apply the queue + guidance adaptation and run classifier, runner, and composed modules together.  
   GREEN result: `38 passed`.
4. Run all ten clarify-related modules.  
   Result: `80 passed`.
5. Run six pending-queue consumption/drain/overwrite modules.  
   Result: `27 passed`.
6. Run Ruff, `compileall`, `git diff --check`, and an added-line security-pattern scan over the six-file branch diff.  
   Result: all pass; security-pattern matches `0`; final diff SHA-256 `d7bce608cbef935c402288363a447e3978cd2c81125541740193cee4e0714b0a`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls); this branch explicitly preserves and builds on #75732 rather than copying it without attribution
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not claimed; 106 narrowly targeted tests passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.3.0), Python 3.13.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; focused test docstrings document the composed contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — platform-agnostic async/session logic; no OS-specific APIs added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no public tool schema changed

## Screenshots / Logs

No UI screenshots. Automated RED/GREEN and regression evidence is listed in **How to Test** above.
