### PR TITLE
fix(kanban): honor explicit reruns past PR guards

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8145,6 +8145,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        Like ``recent_success``, this is bypassed by a later explicit
+        re-queue event: the operator has deliberately asked for another run.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -8227,12 +8229,45 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    A later *explicit* re-queue supersedes historical PR evidence. Automatic
+    #    promotion/reclaim events do not: they are recovery machinery, not an
+    #    operator asking to duplicate prior work. Direct status changes only
+    #    count when they move the task to ready.
+    explicit_requeue_at = None
+    for event in conn.execute(
+        "SELECT kind, payload, created_at FROM task_events "
+        "WHERE task_id = ? "
+        "AND kind IN ('status', 'promoted_manual', 'unblocked') "
+        "ORDER BY id DESC",
+        (task_id,),
+    ):
+        if event["kind"] in ("promoted_manual", "unblocked"):
+            explicit_requeue_at = int(event["created_at"])
+            break
+        try:
+            payload = json.loads(event["payload"]) if event["payload"] else None
+        except (TypeError, ValueError):
+            payload = None
+        if isinstance(payload, dict) and payload.get("status") == "ready":
+            explicit_requeue_at = int(event["created_at"])
+            break
+
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+        if (
+            c["body"]
+            and _RESPAWN_GUARD_PR_URL_RE.search(c["body"])
+            # Cross-table timestamps have one-second resolution. Fail closed on
+            # equality rather than risk treating a same-second new PR as stale.
+            and (
+                explicit_requeue_at is None
+                or explicit_requeue_at <= int(c["created_at"])
+            )
+        ):
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_respawn_guard.py
+++ b/tests/hermes_cli/test_kanban_respawn_guard.py
@@ -1,0 +1,161 @@
+"""Regression coverage for Kanban dispatcher respawn guards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty Kanban database."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _blocked_task_with_historical_pr(conn, monkeypatch, *, now: int) -> str:
+    monkeypatch.setattr(kb.time, "time", lambda: now - 120)
+    task_id = kb.create_task(
+        conn,
+        title="resume after dependency",
+        assignee="reader",
+        initial_status="blocked",
+    )
+    kb.add_comment(
+        conn,
+        task_id,
+        "worker",
+        "Merged PR https://github.com/NousResearch/hermes-agent/pull/42",
+    )
+    monkeypatch.setattr(kb.time, "time", lambda: now - 60)
+    assert kb.unblock_task(conn, task_id)
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    return task_id
+
+
+def test_explicit_unblock_bypasses_historical_pr_comment(kanban_home, monkeypatch):
+    """An operator unblock is a deliberate rerun even when a recent comment
+    links a PR produced by an earlier run.
+    """
+    with kb.connect() as conn:
+        task_id = _blocked_task_with_historical_pr(conn, monkeypatch, now=2_000_000)
+
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_recent_pr_comment_still_blocks_ordinary_duplicate_spawn(
+    kanban_home, monkeypatch
+):
+    """Without a later explicit rerun request, a recent PR still guards the task."""
+    now = 2_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now - 60)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="avoid duplicate", assignee="reader")
+        kb.add_comment(
+            conn,
+            task_id,
+            "worker",
+            "Opened https://github.com/NousResearch/hermes-agent/pull/99",
+        )
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_automatic_reclaim_does_not_bypass_recent_pr_comment(kanban_home, monkeypatch):
+    """Automatic recovery is not an operator request to duplicate prior PR work."""
+    now = 2_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now - 120)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="reclaimed", assignee="reader")
+        kb.add_comment(
+            conn,
+            task_id,
+            "worker",
+            "Opened https://github.com/NousResearch/hermes-agent/pull/100",
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'reclaimed', ?)",
+            (task_id, now - 60),
+        )
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_manual_promotion_bypasses_historical_pr_comment(kanban_home, monkeypatch):
+    """The audited manual-promotion event is an explicit rerun request."""
+    now = 2_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now - 120)
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="promote deliberately",
+            assignee="reader",
+            initial_status="blocked",
+        )
+        kb.add_comment(
+            conn,
+            task_id,
+            "worker",
+            "Merged https://github.com/NousResearch/hermes-agent/pull/101",
+        )
+        monkeypatch.setattr(kb.time, "time", lambda: now - 60)
+        assert kb.promote_task(conn, task_id, actor="operator") == (True, None)
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_same_second_pr_comment_fails_closed_after_unblock(kanban_home, monkeypatch):
+    """Second-resolution timestamps must not let a later comment look historical."""
+    now = 2_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now - 60)
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="same-second ordering",
+            assignee="reader",
+            initial_status="blocked",
+        )
+        assert kb.unblock_task(conn, task_id)
+        kb.add_comment(
+            conn,
+            task_id,
+            "worker",
+            "Opened https://github.com/NousResearch/hermes-agent/pull/102",
+        )
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_dispatch_spawns_unblocked_task_instead_of_leaving_it_ready(
+    kanban_home, monkeypatch, all_assignees_spawnable
+):
+    """A historical PR comment cannot leave explicitly unblocked work ready forever."""
+    spawn_calls: list[str] = []
+
+    def spawn(task, _workspace):
+        spawn_calls.append(task.id)
+        return 4242
+
+    with kb.connect() as conn:
+        task_id = _blocked_task_with_historical_pr(conn, monkeypatch, now=2_000_000)
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn)
+
+        assert result.respawn_guarded == []
+        assert [task[0] for task in result.spawned] == [task_id]
+        assert spawn_calls == [task_id]
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"


### PR DESCRIPTION
## Summary
- let an explicit operator unblock, manual promotion, or direct move to `ready` supersede a historical recent PR comment in the Kanban respawn guard
- keep automatic dependency promotions and stale-worker reclaims guarded so they cannot create duplicate PR work
- fail closed for same-second comment/requeue timestamps and preserve existing `recent_success` behavior
- add real-SQL regression coverage for guard decisions and the dispatcher spawn path

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_respawn_guard.py --tb=short` (35 passed, 1 OS-specific skip)
- `.venv/bin/ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_respawn_guard.py`
- `.venv/bin/ruff format --check tests/hermes_cli/test_kanban_respawn_guard.py`
- full suite: 29,168 passed, 267 OS-specific skips; one unchanged host-specific GNU `sort --compress-program` test failed and reproduces independently of this diff

## Review
Independent pre-commit review passed after tightening the event classification and same-second ordering semantics.
