### PR TITLE
fix(agent): let sessions resume after partial tool result persistence

### DIFF
--- a/agent/replay_cleanup.py
+++ b/agent/replay_cleanup.py
@@ -18,6 +18,7 @@ of the WebUI path silently skipping it.
 from __future__ import annotations
 
 import logging
+from collections import Counter, defaultdict
 from typing import Any, Dict, List
 
 from agent.tool_dispatch_helpers import make_tool_result_message
@@ -39,6 +40,61 @@ def is_interrupted_tool_result(content: Any) -> bool:
     return False
 
 
+def _recovered_tool_result(name: str, call_id: str) -> Dict[str, Any]:
+    """Build a non-executing result for a call lost during persistence."""
+    disposition = "unknown" if tool_may_have_side_effect(name) else "none"
+    content = (
+        "[Orphan recovery: this tool may have executed before Hermes stopped; "
+        "its effect is UNKNOWN. Inspect current state before retrying.]"
+        if disposition == "unknown"
+        else "[Orphan recovery: this read-only tool did not complete and had no effect.]"
+    )
+    return make_tool_result_message(
+        name,
+        content,
+        call_id,
+        effect_disposition=disposition,
+    )
+
+
+def _complete_side_effecting_tool_batch(
+    assistant: Dict[str, Any],
+    tool_results: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return a provider-complete batch without re-executing missing calls."""
+    results_by_id: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for result in tool_results:
+        results_by_id[str(result.get("tool_call_id") or "")].append(result)
+
+    recovered_batch = [assistant]
+    for call in assistant.get("tool_calls") or []:
+        function = call.get("function") or {}
+        name = str(function.get("name") or "unknown")
+        call_id = str(call.get("id") or call.get("call_id") or "")
+        available = results_by_id[call_id]
+        if not available:
+            recovered_batch.append(_recovered_tool_result(name, call_id))
+            continue
+
+        result = available.pop(0)
+        if not is_interrupted_tool_result(result.get("content", "")):
+            recovered_batch.append(result)
+            continue
+
+        recovered = dict(result)
+        recovered["effect_disposition"] = (
+            "unknown" if tool_may_have_side_effect(name) else "none"
+        )
+        recovered["content"] = (
+            "[Orphan recovery: interrupted side-effecting tool may have "
+            "executed; its effect is UNKNOWN. Inspect state before retrying.]"
+            if recovered["effect_disposition"] == "unknown"
+            else "[Orphan recovery: interrupted read-only tool did not complete.]"
+        )
+        recovered_batch.append(recovered)
+    return recovered_batch
+
+
 def strip_interrupted_tool_tails(
     agent_history: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
@@ -47,8 +103,11 @@ def strip_interrupted_tool_tails(
     Older interrupted gateway turns can be followed by a queued real user
     message, so the interrupted assistant/tool block is not necessarily the
     final tail by the time we rebuild replay history.  Remove any contiguous
-    assistant(tool_calls) + tool-result block that contains an interrupted tool
-    result, while preserving successful tool-call sequences intact.
+    assistant(tool_calls) + tool-result block that is interrupted or incomplete,
+    while preserving successful completed tool-call sequences intact. Read-only
+    blocks are safe to erase and retry. A block containing any side-effecting
+    call is completed with non-executing recovery results so unknown effects are
+    preserved without violating provider tool-call/result pairing.
     """
     if not agent_history:
         return agent_history
@@ -64,50 +123,43 @@ def strip_interrupted_tool_tails(
             while j < n and agent_history[j].get("role") == "tool":
                 tool_results.append(agent_history[j])
                 j += 1
-            if tool_results and any(
-                is_interrupted_tool_result(m.get("content", ""))
-                for m in tool_results
-            ):
-                calls = msg.get("tool_calls") or []
+            calls = msg.get("tool_calls") or []
+            call_counts = Counter(
+                str(call.get("id") or call.get("call_id") or "") for call in calls
+            )
+            result_counts = Counter(
+                str(result.get("tool_call_id") or "") for result in tool_results
+            )
+            incomplete = any(
+                result_counts[call_id] < count for call_id, count in call_counts.items()
+            )
+            interrupted = any(
+                is_interrupted_tool_result(m.get("content", "")) for m in tool_results
+            )
+            if incomplete or interrupted:
                 if any(
                     tool_may_have_side_effect(
                         str((call.get("function") or {}).get("name") or "")
                     )
                     for call in calls
                 ):
-                    call_names = {
-                        str(call.get("id") or call.get("call_id") or ""): str(
-                            (call.get("function") or {}).get("name") or ""
-                        )
-                        for call in calls
-                    }
-                    cleaned.append(msg)
-                    for tool_result in tool_results:
-                        if not is_interrupted_tool_result(tool_result.get("content", "")):
-                            cleaned.append(tool_result)
-                            continue
-                        recovered = dict(tool_result)
-                        name = call_names.get(str(tool_result.get("tool_call_id") or ""), "")
-                        recovered["effect_disposition"] = (
-                            "unknown" if tool_may_have_side_effect(name) else "none"
-                        )
-                        recovered["content"] = (
-                            "[Orphan recovery: interrupted side-effecting tool may have "
-                            "executed; its effect is UNKNOWN. Inspect state before retrying.]"
-                            if recovered["effect_disposition"] == "unknown"
-                            else "[Orphan recovery: interrupted read-only tool did not complete.]"
-                        )
-                        cleaned.append(recovered)
+                    cleaned.extend(
+                        _complete_side_effecting_tool_batch(msg, tool_results)
+                    )
                     i = j
                     continue
                 logger.debug(
-                    "Stripping interrupted read-only assistant→tool replay block "
+                    "Stripping interrupted or incomplete read-only assistant→tool replay block "
                     "(indices %d–%d, tool_results=%d)",
-                    i, j - 1, len(tool_results),
+                    i,
+                    j - 1,
+                    len(tool_results),
                 )
                 i = j
                 continue
-        if msg.get("role") == "tool" and is_interrupted_tool_result(msg.get("content", "")):
+        if msg.get("role") == "tool" and is_interrupted_tool_result(
+            msg.get("content", "")
+        ):
             logger.debug("Stripping orphan interrupted tool result from replay history")
             i += 1
             continue
@@ -154,26 +206,11 @@ def strip_dangling_tool_call_tail(
 
     tool_calls = last.get("tool_calls") or []
     if any(
-        tool_may_have_side_effect(
-            str((call.get("function") or {}).get("name") or "")
-        )
+        tool_may_have_side_effect(str((call.get("function") or {}).get("name") or ""))
         for call in tool_calls
     ):
-        recovered = list(agent_history)
-        for call in tool_calls:
-            function = call.get("function") or {}
-            name = str(function.get("name") or "unknown")
-            call_id = str(call.get("id") or call.get("call_id") or "")
-            disposition = "unknown" if tool_may_have_side_effect(name) else "none"
-            content = (
-                "[Orphan recovery: this tool may have executed before Hermes stopped; "
-                "its effect is UNKNOWN. Inspect current state before retrying.]"
-                if disposition == "unknown"
-                else "[Orphan recovery: this read-only tool did not complete and had no effect.]"
-            )
-            recovered.append(make_tool_result_message(
-                name, content, call_id, effect_disposition=disposition,
-            ))
+        recovered = list(agent_history[:-1])
+        recovered.extend(_complete_side_effecting_tool_batch(last, []))
         logger.warning(
             "Recovered dangling side-effecting tool call(s) as UNKNOWN instead of erasing them"
         )

--- a/agent/replay_cleanup.py
+++ b/agent/replay_cleanup.py
@@ -133,6 +133,7 @@ def strip_interrupted_tool_tails(
             incomplete = any(
                 result_counts[call_id] < count for call_id, count in call_counts.items()
             )
+            malformed = result_counts != call_counts
             interrupted = any(
                 is_interrupted_tool_result(m.get("content", "")) for m in tool_results
             )
@@ -155,6 +156,14 @@ def strip_interrupted_tool_tails(
                     j - 1,
                     len(tool_results),
                 )
+                i = j
+                continue
+            if malformed:
+                # Every declared call is answered, but surplus, duplicate, or
+                # unknown-ID rows still make the provider payload invalid.
+                # Rebuild from the declaration to retain exactly the first
+                # persisted result for each call in declared-call order.
+                cleaned.extend(_complete_side_effecting_tool_batch(msg, tool_results))
                 i = j
                 continue
         if msg.get("role") == "tool" and is_interrupted_tool_result(

--- a/tests/agent/test_replay_cleanup.py
+++ b/tests/agent/test_replay_cleanup.py
@@ -18,26 +18,22 @@ def _user(text):
     return {"role": "user", "content": text}
 
 
-def _assistant_tc(name):
+def _assistant_tc(name, *, call_id="c1"):
     return {
         "role": "assistant",
         "content": "",
         "tool_calls": [
-            {"id": "c1", "type": "function", "function": {"name": name, "arguments": "{}"}}
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
         ],
     }
 
 
-def _tool(content):
-    return {"role": "tool", "tool_call_id": "c1", "content": content}
-
-
-
-
-
-
-
-
+def _tool(content, *, call_id="c1"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
 
 
 def test_mixed_dangling_batch_uses_truthful_per_call_wording():
@@ -59,21 +55,62 @@ def test_mixed_dangling_batch_uses_truthful_per_call_wording():
     assert "unknown" in write_result["content"].lower()
 
 
+def test_partial_side_effecting_batch_is_completed_without_retrying_missing_call():
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "read", "function": {"name": "read_file", "arguments": "{}"}},
+            {"id": "write", "function": {"name": "write_file", "arguments": "{}"}},
+        ],
+    }
+    interrupted_read = _tool("[Command interrupted]", call_id="read")
+    following_user = _user("continue")
+
+    out = sanitize_replay_history([assistant, interrupted_read, following_user])
+
+    assert out[0] is assistant
+    assert [result["tool_call_id"] for result in out[1:3]] == ["read", "write"]
+    assert out[1]["effect_disposition"] == "none"
+    assert out[2]["effect_disposition"] == "unknown"
+    assert "inspect current state before retrying" in out[2]["content"].lower()
+    assert out[3] is following_user
 
 
+def test_partial_read_only_batch_is_removed_so_it_can_be_retried_safely():
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "a", "function": {"name": "read_file", "arguments": "{}"}},
+            {"id": "b", "function": {"name": "web_search", "arguments": "{}"}},
+        ],
+    }
+    history = [_user("inspect"), assistant, _tool("done", call_id="a"), _user("next")]
+
+    assert sanitize_replay_history(history) == [_user("inspect"), _user("next")]
 
 
+def test_completed_multi_call_batch_is_unchanged():
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "a", "function": {"name": "read_file", "arguments": "{}"}},
+            {"id": "b", "function": {"name": "write_file", "arguments": "{}"}},
+        ],
+    }
+    history = [assistant, _tool("read", call_id="a"), _tool("wrote", call_id="b")]
 
-
-
-
+    assert sanitize_replay_history(history) == history
 
 
 def test_sanitize_replay_history_combines_both():
     # interrupted block is removed; a dangling read-only call is safe to erase
     history = [
         _user("first"),
-        _assistant_tc("terminal"), _tool("[Command interrupted]"),
+        _assistant_tc("terminal"),
+        _tool("[Command interrupted]"),
         _user("second"),
         _assistant_tc("read_file"),  # dangling
     ]

--- a/tests/agent/test_replay_cleanup.py
+++ b/tests/agent/test_replay_cleanup.py
@@ -105,6 +105,43 @@ def test_completed_multi_call_batch_is_unchanged():
     assert sanitize_replay_history(history) == history
 
 
+def test_surplus_malformed_result_is_dropped_from_completed_batch():
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "a", "function": {"name": "read_file", "arguments": "{}"}},
+            {"id": "b", "function": {"name": "write_file", "arguments": "{}"}},
+        ],
+    }
+    read_result = _tool("read", call_id="a")
+    write_result = _tool("wrote", call_id="b")
+    malformed_result = {"role": "tool", "content": "missing id"}
+    following_user = _user("next")
+
+    assert sanitize_replay_history(
+        [assistant, read_result, write_result, malformed_result, following_user]
+    ) == [assistant, read_result, write_result, following_user]
+
+
+def test_surplus_duplicate_result_is_dropped_from_completed_batch():
+    assistant = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "a", "function": {"name": "read_file", "arguments": "{}"}},
+            {"id": "b", "function": {"name": "write_file", "arguments": "{}"}},
+        ],
+    }
+    first_a = _tool("first", call_id="a")
+    duplicate_a = _tool("duplicate", call_id="a")
+    result_b = _tool("wrote", call_id="b")
+
+    assert sanitize_replay_history(
+        [assistant, first_a, duplicate_a, result_b]
+    ) == [assistant, first_a, result_b]
+
+
 def test_sanitize_replay_history_combines_both():
     # interrupted block is removed; a dangling read-only call is safe to erase
     history = [


### PR DESCRIPTION
## What does this PR do?

This fixes sessions that cannot resume after only part of a concurrent tool-result batch reaches durable history. Replay recovery now preserves uncertain side effects without retrying them while ensuring every retained tool-call declaration has exactly one provider-valid result.

### Symptom

After a process stops between per-result flushes, a resumed session can send an assistant multi-call declaration with only some matching tool results. Strict providers reject the continuation because one or more declared call IDs remain unanswered.

### Impact

Affected sessions cannot continue without manual transcript repair. The failure applies to partially persisted concurrent batches that contain a potentially side-effecting call; its frequency and provider-specific blast radius have not been measured.

### Bug Cause

**Trigger:** `agent/replay_cleanup.py` in `strip_interrupted_tool_tails()` when a multi-call assistant block has only a prefix of its results.

**Causal chain:**
1. Concurrent results are appended and flushed individually.
2. Process termination between flushes leaves a partial tool-call transaction.
3. Side-effect-aware cleanup preserves the block to avoid an unsafe retry but only retains persisted result rows.
4. The zero-answer dangling-tail pass does not repair a partially answered block.
5. Strict providers reject the resumed history because declared and answered call IDs do not pair exactly.

**Why it is wrong:** Preserved replay history violates the provider invariant that every declared tool call has exactly one matching result.

**Working sibling / contrast:** Completed batches are already valid and remain unchanged. Fully unanswered side-effecting tails already recover calls as non-executing results with unknown effect disposition.

**Ruled out:** Provider serialization is not responsible because direct sanitizer output already contains the unmatched declaration.

### Fix

- Rebuild incomplete or interrupted side-effecting batches in declared-call order.
- Preserve the first valid persisted result for each call.
- Add non-executing recovery results for missing calls, using `unknown` effect disposition for potentially side-effecting tools and `none` for read-only siblings.
- Drop duplicate, surplus, and unknown-ID result rows that would still violate provider pairing.
- Preserve the existing behavior that removes incomplete all-read-only batches so they can be retried safely.

## Related Issue

Fixes #83015

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/replay_cleanup.py` - complete preserved partial batches and normalize malformed result sets without executing tools.
- `tests/agent/test_replay_cleanup.py` - cover mixed partial batches, uncertain effect disposition, completed-batch stability, queued rows, duplicate results, and malformed IDs.

## How to Test

1. Build a replay history with declared calls `a` and `b` but only a persisted result for `a`.
2. Run `sanitize_replay_history()` and verify the output contains exactly one result for each declared ID without executing either call.
3. Verify missing side-effecting calls are marked `unknown`, read-only siblings are marked `none`, completed batches are unchanged, and malformed surplus rows are removed.
4. Run the focused test file:

```bash
scripts/run_tests.sh tests/agent/test_replay_cleanup.py
```

The final reviewed tip passed 26 focused tests and REAL_ENV verification.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - replay behavior is internal and covered by docstrings and tests
- [x] `cli-config.yaml.example`: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: replay cleanup is platform-independent pure history transformation
- [x] Tool descriptions/schemas: N/A - no tool schema changed

## Screenshots / Logs

N/A - the regression and recovery invariant are covered by automated tests and REAL_ENV verification.
