### PR TITLE
fix(plugins): prevent duplicate correlated subagent launches

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -153,7 +153,10 @@ class _Registry:
     def __init__(self) -> None:
         self.lock = threading.RLock()
         self.records: dict[str, _Record] = {}
-        self.correlations: dict[tuple[Optional[str], str], str] = {}
+        # ``None`` reserves a correlation ID while its child is being built.
+        # Construction stays outside the lock so existing lifecycle operations
+        # are not blocked by slow child setup.
+        self.correlations: dict[tuple[Optional[str], str], Optional[str]] = {}
 
 
 _REGISTRY = _Registry()
@@ -208,55 +211,76 @@ class SubagentLifecycleService:
                 "parent_session_id does not match the active session."
             )
         correlation_key = (parent_session_id, request.correlation_id or "")
+        correlation_reserved = bool(request.correlation_id)
         with _REGISTRY.lock:
             self._cleanup_locked()
             if request.correlation_id and correlation_key in _REGISTRY.correlations:
                 raise SubagentLifecycleError(
                     "Duplicate correlation_id for this parent session."
                 )
+            if correlation_reserved:
+                _REGISTRY.correlations[correlation_key] = None
 
-        # Delegate construction remains internal so plugin code never imports
-        # private delegation helpers or manipulates the active-child registry.
-        from tools.delegate_tool import (
-            _build_child_preserving_parent_tools,
-            DEFAULT_MAX_ITERATIONS,
-        )
+        try:
+            # Delegate construction remains internal so plugin code never imports
+            # private delegation helpers or manipulates the active-child registry.
+            from tools.delegate_tool import (
+                _build_child_preserving_parent_tools,
+                DEFAULT_MAX_ITERATIONS,
+            )
 
-        child = _build_child_preserving_parent_tools(
-            task_index=0,
-            goal=request.goal,
-            context=request.context,
-            toolsets=list(request.allowed_toolsets)
-            if request.allowed_toolsets
-            else None,
-            model=request.model,
-            max_iterations=DEFAULT_MAX_ITERATIONS,
-            task_count=1,
-            parent_agent=parent,
-            role=request.role,
-        )
-        subagent_id = str(getattr(child, "_subagent_id", "") or "")
-        if not subagent_id:
-            raise SubagentLifecycleError("Hermes failed to assign a child identity.")
-        created = time.time()
-        handle = SubagentHandle(
-            PUBLIC_CONTRACT_VERSION,
-            subagent_id,
-            parent_session_id,
-            request.correlation_id,
-            created,
-            getattr(child, "provider", None),
-            getattr(child, "model", None),
-            getattr(child, "_delegate_role", request.role),
-            int(getattr(child, "_delegate_depth", 1) or 1),
-            self._capability(subagent_id, parent_session_id, created),
-        )
-        record = _Record(handle, SubagentState.PENDING, created, agent=child)
+            child = _build_child_preserving_parent_tools(
+                task_index=0,
+                goal=request.goal,
+                context=request.context,
+                toolsets=list(request.allowed_toolsets)
+                if request.allowed_toolsets
+                else None,
+                model=request.model,
+                max_iterations=DEFAULT_MAX_ITERATIONS,
+                task_count=1,
+                parent_agent=parent,
+                role=request.role,
+            )
+            subagent_id = str(getattr(child, "_subagent_id", "") or "")
+            if not subagent_id:
+                raise SubagentLifecycleError("Hermes failed to assign a child identity.")
+            created = time.time()
+            handle = SubagentHandle(
+                PUBLIC_CONTRACT_VERSION,
+                subagent_id,
+                parent_session_id,
+                request.correlation_id,
+                created,
+                getattr(child, "provider", None),
+                getattr(child, "model", None),
+                getattr(child, "_delegate_role", request.role),
+                int(getattr(child, "_delegate_depth", 1) or 1),
+                self._capability(subagent_id, parent_session_id, created),
+            )
+            record = _Record(handle, SubagentState.PENDING, created, agent=child)
+        except BaseException:
+            if correlation_reserved:
+                with _REGISTRY.lock:
+                    if _REGISTRY.correlations.get(correlation_key) is None:
+                        _REGISTRY.correlations.pop(correlation_key, None)
+            raise
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
-            if request.correlation_id:
+            if correlation_reserved:
                 _REGISTRY.correlations[correlation_key] = subagent_id
-        record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        try:
+            record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        except BaseException:
+            with _REGISTRY.lock:
+                if _REGISTRY.records.get(subagent_id) is record:
+                    _REGISTRY.records.pop(subagent_id, None)
+                if (
+                    correlation_reserved
+                    and _REGISTRY.correlations.get(correlation_key) == subagent_id
+                ):
+                    _REGISTRY.correlations.pop(correlation_key, None)
+            raise
         return handle
 
     def status(self, handle: SubagentHandle) -> SubagentStatus:

--- a/contributors/emails/bkashjee@gmail.com
+++ b/contributors/emails/bkashjee@gmail.com
@@ -1,0 +1,1 @@
+BkashJEE

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -1,6 +1,8 @@
 """Contract tests for the public plugin subagent lifecycle API."""
 
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -65,8 +67,88 @@ def lifecycle(monkeypatch):
     return SubagentLifecycleService(lambda: parent)
 
 
+def test_duplicate_correlation_is_reserved_during_child_construction(
+    lifecycle, monkeypatch
+):
+    first_build_started = threading.Event()
+    release_first_build = threading.Event()
+    build_count = iter(range(2))
+
+    def slow_build(**_kwargs):
+        ident = next(build_count)
+        if ident == 0:
+            first_build_started.set()
+            assert release_first_build.wait(timeout=1)
+        return FakeChild(f"sa-race-{ident}")
+
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_preserving_parent_tools", slow_build
+    )
+    request = SubagentLaunchRequest(goal="x", correlation_id="same-concurrent")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(lifecycle.launch, request)
+        assert first_build_started.wait(timeout=1)
+        second = executor.submit(lifecycle.launch, request)
+        try:
+            with pytest.raises(SubagentLifecycleError, match="Duplicate"):
+                second.result(timeout=1)
+        finally:
+            release_first_build.set()
+        handle = first.result(timeout=1)
+
+    assert handle.correlation_id == "same-concurrent"
+    lifecycle.wait(handle, timeout_seconds=1)
 
 
+@pytest.mark.parametrize("failure", ["build", "identity"])
+def test_failed_child_construction_releases_correlation_reservation(
+    lifecycle, monkeypatch, failure
+):
+    attempts = iter(range(2))
+
+    def build(**_kwargs):
+        if next(attempts) == 0:
+            if failure == "build":
+                raise RuntimeError("build failed")
+            return SimpleNamespace(_subagent_id="")
+        return FakeChild(f"sa-retry-{failure}")
+
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_preserving_parent_tools", build
+    )
+    request = SubagentLaunchRequest(goal="x", correlation_id=f"retry-{failure}")
+
+    expected = RuntimeError if failure == "build" else SubagentLifecycleError
+    with pytest.raises(expected):
+        lifecycle.launch(request)
+    handle = lifecycle.launch(request)
+
+    assert handle.subagent_id == f"sa-retry-{failure}"
+    lifecycle.wait(handle, timeout_seconds=1)
+
+
+def test_failed_executor_submission_rolls_back_record_and_correlation(
+    lifecycle, monkeypatch
+):
+    import agent.subagent_lifecycle as lifecycle_module
+
+    executor = lifecycle_module._EXECUTOR
+    real_submit = executor.submit
+
+    def reject_submission(*_args, **_kwargs):
+        raise RuntimeError("executor rejected")
+
+    monkeypatch.setattr(executor, "submit", reject_submission)
+    request = SubagentLaunchRequest(goal="x", correlation_id="retry-after-reject")
+
+    with pytest.raises(RuntimeError, match="executor rejected"):
+        lifecycle.launch(request)
+    monkeypatch.setattr(executor, "submit", real_submit)
+    handle = lifecycle.launch(request)
+
+    assert handle.correlation_id == "retry-after-reject"
+    lifecycle.wait(handle, timeout_seconds=1)
 
 
 def test_cancel_is_cooperative_and_forged_handle_is_unknown(lifecycle):

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -78,7 +78,7 @@ def test_duplicate_correlation_is_reserved_during_child_construction(
         ident = next(build_count)
         if ident == 0:
             first_build_started.set()
-            assert release_first_build.wait(timeout=1)
+            assert release_first_build.wait(timeout=5)
         return FakeChild(f"sa-race-{ident}")
 
     monkeypatch.setattr(
@@ -88,17 +88,17 @@ def test_duplicate_correlation_is_reserved_during_child_construction(
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         first = executor.submit(lifecycle.launch, request)
-        assert first_build_started.wait(timeout=1)
+        assert first_build_started.wait(timeout=5)
         second = executor.submit(lifecycle.launch, request)
         try:
             with pytest.raises(SubagentLifecycleError, match="Duplicate"):
-                second.result(timeout=1)
+                second.result(timeout=5)
         finally:
             release_first_build.set()
-        handle = first.result(timeout=1)
+        handle = first.result(timeout=5)
 
     assert handle.correlation_id == "same-concurrent"
-    lifecycle.wait(handle, timeout_seconds=1)
+    lifecycle.wait(handle, timeout_seconds=5)
 
 
 @pytest.mark.parametrize("failure", ["build", "identity"])
@@ -125,7 +125,7 @@ def test_failed_child_construction_releases_correlation_reservation(
     handle = lifecycle.launch(request)
 
     assert handle.subagent_id == f"sa-retry-{failure}"
-    lifecycle.wait(handle, timeout_seconds=1)
+    lifecycle.wait(handle, timeout_seconds=5)
 
 
 def test_failed_executor_submission_rolls_back_record_and_correlation(
@@ -148,7 +148,7 @@ def test_failed_executor_submission_rolls_back_record_and_correlation(
     handle = lifecycle.launch(request)
 
     assert handle.correlation_id == "retry-after-reject"
-    lifecycle.wait(handle, timeout_seconds=1)
+    lifecycle.wait(handle, timeout_seconds=5)
 
 
 def test_cancel_is_cooperative_and_forged_handle_is_unknown(lifecycle):


### PR DESCRIPTION
## What does this PR do?

Concurrent plugin callbacks can currently launch the same correlated subagent job twice, duplicating delegated work and side effects while leaving only one child reachable through the correlation map. This change atomically reserves each non-empty parent-scoped correlation ID before child construction and precisely rolls the reservation back when launch setup fails.

### Symptom

Two synchronized `SubagentLifecycleService.launch()` calls with the same parent and non-empty `correlation_id` can both return valid handles and execute distinct children. The shared correlation map retains only the later child ID.

### Impact

Plugins can run delegated work and its side effects twice even though the public lifecycle contract treats correlation IDs as unique per parent. Correlation-based status tracking then loses the association to one of the running children. The unmeasured production frequency depends on plugins issuing concurrent duplicate launches.

### Bug Cause

**Trigger:** `agent/subagent_lifecycle.py` / `SubagentLifecycleService.launch()` when concurrent calls share one parent-scoped non-empty correlation ID.

**Causal chain:**
1. One launch checks the correlation map and releases the registry lock before building its child.
2. A concurrent launch checks during that gap, also sees no mapping, and builds another child.
3. Both children are submitted, and the later correlation write overwrites the earlier association while both execute.

**Why it is wrong:** The duplicate check and claim were separated by unlocked child construction, so checking uniqueness did not reserve the key.

**Working sibling / contrast:** Sequential duplicates are already rejected after the first registration. Empty correlation IDs remain intentionally unrestricted, and equal values under distinct parents remain isolated by the parent-scoped key.

**Ruled out:** This is not caused by terminal cleanup or retention. The race occurs before either child reaches a terminal state and was reproduced with synchronized construction on the default-branch tip.

### Fix

- Reserve non-empty parent-scoped correlation IDs inside the initial registry critical section while keeping child construction outside the lock.
- Replace the reservation with the assigned child ID when construction succeeds.
- Remove only the exact reservation or record on import, construction, identity, or executor-submission failure so retries and unrelated keys remain valid.
- Add deterministic concurrency and rollback tests for duplicate launch, build failure, missing identity, and rejected executor submission.

## Related Issue

Fixes #83018

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/subagent_lifecycle.py` - reserve correlation keys before child construction and make launch rollback transactional.
- `tests/agent/test_subagent_lifecycle.py` - cover concurrent duplicate rejection and retry after each setup failure class.

## How to Test

1. Start two synchronized launches with one parent and one non-empty correlation ID; verify one succeeds, one raises the duplicate-correlation error, and only one child builds and executes.
2. Force child build, identity assignment, and executor submission failures; retry each correlation and verify the retry succeeds.
3. Automated (already run locally, 8 passed):

```bash
HERMES_PYTHON=C:/workspace/hermes-agent/.venv/Scripts/python.exe scripts/run_tests.sh tests/agent/test_subagent_lifecycle.py
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for this bug fix
- [x] I've tested the synchronized lifecycle path on Windows 10
