### PR TITLE
fix(desktop): keyless plugin rows render read-only + backend contract v6

### DIFF
--- a/apps/desktop/src/app/settings/plugins-settings.test.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { requestGateway } = vi.hoisted(() => ({ requestGateway: vi.fn() }))
+
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway })
+}))
+
+import { $pluginRecords } from '@/contrib/plugins-store'
+import {
+  $agentPluginBusy,
+  $agentPlugins,
+  $agentPluginsError,
+  $agentPluginsStatus,
+  type AgentPluginRow
+} from '@/store/agent-plugins'
+import { $connection, $gatewayState } from '@/store/session'
+
+import { PluginsSettings } from './plugins-settings'
+
+const legacyRow = {
+  name: 'Legacy plugin',
+  version: '0.20.0',
+  description: 'Returned by a pre-key backend',
+  source: 'user',
+  status: 'disabled'
+} satisfies AgentPluginRow
+
+beforeEach(() => {
+  requestGateway.mockReset()
+  $pluginRecords.set({})
+  $agentPlugins.set([legacyRow])
+  $agentPluginsStatus.set('ready')
+  $agentPluginsError.set(null)
+  $agentPluginBusy.set(null)
+  $gatewayState.set('idle')
+  $connection.set(null)
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('PluginsSettings', () => {
+  it('renders and searches plugin rows returned without a canonical key', () => {
+    render(<PluginsSettings />)
+
+    expect(screen.getByText('Legacy plugin')).toBeTruthy()
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'pre-key' } })
+
+    expect(screen.getByText('Legacy plugin')).toBeTruthy()
+  })
+
+  it('uses the legacy name address when toggling a row without a key', async () => {
+    requestGateway.mockResolvedValue({ ok: true, plugin: { ...legacyRow, status: 'enabled' } })
+
+    render(<PluginsSettings />)
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable Legacy plugin' }))
+
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('plugins.manage', {
+        action: 'toggle',
+        name: 'Legacy plugin',
+        enable: true
+      })
+    )
+  })
+
+  it('keeps using the canonical key when the backend provides one', async () => {
+    const keyedRow = { ...legacyRow, key: 'image_gen/legacy' }
+
+    $agentPlugins.set([keyedRow])
+    requestGateway.mockResolvedValue({ ok: true, plugin: { ...keyedRow, status: 'enabled' } })
+
+    render(<PluginsSettings />)
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable Legacy plugin' }))
+
+    await waitFor(() =>
+      expect(requestGateway).toHaveBeenCalledWith('plugins.manage', {
+        action: 'toggle',
+        key: 'image_gen/legacy',
+        enable: true
+      })
+    )
+  })
+})

--- a/apps/desktop/src/app/settings/plugins-settings.test.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.test.tsx
@@ -40,6 +40,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
 })
 
 describe('PluginsSettings', () => {
@@ -66,6 +67,27 @@ describe('PluginsSettings', () => {
         enable: true
       })
     )
+  })
+
+  it('keeps duplicate-named legacy rows distinct after a name-addressed toggle', async () => {
+    const sibling = {
+      ...legacyRow,
+      description: 'A second plugin category with the same legacy name'
+    }
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    $agentPlugins.set([legacyRow, sibling])
+    requestGateway.mockResolvedValue({ ok: true, plugin: { ...legacyRow, status: 'enabled' } })
+
+    render(<PluginsSettings />)
+    fireEvent.click(screen.getAllByRole('switch', { name: 'Enable Legacy plugin' })[0])
+
+    await waitFor(() =>
+      expect(screen.getAllByRole('switch', { name: 'Disable Legacy plugin' })).toHaveLength(2)
+    )
+
+    expect(screen.getByText(sibling.description)).toBeTruthy()
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('same key')
   })
 
   it('keeps using the canonical key when the backend provides one', async () => {

--- a/apps/desktop/src/app/settings/plugins-settings.test.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.test.tsx
@@ -54,22 +54,22 @@ describe('PluginsSettings', () => {
     expect(screen.getByText('Legacy plugin')).toBeTruthy()
   })
 
-  it('uses the legacy name address when toggling a row without a key', async () => {
-    requestGateway.mockResolvedValue({ ok: true, plugin: { ...legacyRow, status: 'enabled' } })
-
+  it('renders keyless rows read-only instead of falling back to name-addressed toggles', () => {
+    // Name-addressed toggles flip every same-named plugin across category
+    // dirs (image_gen/fal vs video_gen/fal) — the reason toggles moved to
+    // canonical keys. A pre-contract-v6 row must never reach the RPC.
     render(<PluginsSettings />)
-    fireEvent.click(screen.getByRole('switch', { name: 'Enable Legacy plugin' }))
 
-    await waitFor(() =>
-      expect(requestGateway).toHaveBeenCalledWith('plugins.manage', {
-        action: 'toggle',
-        name: 'Legacy plugin',
-        enable: true
-      })
-    )
+    const toggle = screen.getByRole('switch', { name: 'Enable Legacy plugin' })
+
+    expect(toggle.hasAttribute('disabled') || toggle.getAttribute('aria-disabled') === 'true').toBe(true)
+
+    fireEvent.click(toggle)
+
+    expect(requestGateway).not.toHaveBeenCalledWith('plugins.manage', expect.objectContaining({ action: 'toggle' }))
   })
 
-  it('keeps duplicate-named legacy rows distinct after a name-addressed toggle', async () => {
+  it('keeps duplicate-named keyless rows distinct (no React key collision)', () => {
     const sibling = {
       ...legacyRow,
       description: 'A second plugin category with the same legacy name'
@@ -77,15 +77,10 @@ describe('PluginsSettings', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     $agentPlugins.set([legacyRow, sibling])
-    requestGateway.mockResolvedValue({ ok: true, plugin: { ...legacyRow, status: 'enabled' } })
 
     render(<PluginsSettings />)
-    fireEvent.click(screen.getAllByRole('switch', { name: 'Enable Legacy plugin' })[0])
 
-    await waitFor(() =>
-      expect(screen.getAllByRole('switch', { name: 'Disable Legacy plugin' })).toHaveLength(2)
-    )
-
+    expect(screen.getAllByRole('switch', { name: 'Enable Legacy plugin' })).toHaveLength(2)
     expect(screen.getByText(sibling.description)).toBeTruthy()
     expect(consoleError.mock.calls.flat().join(' ')).not.toContain('same key')
   })

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -45,6 +45,9 @@ const isDesktopRelevant = (row: AgentPluginRow) => {
   return !key || !HIDDEN_KEY_PREFIXES.some(prefix => key.startsWith(prefix))
 }
 
+const agentPluginRowKey = (row: AgentPluginRow) =>
+  row.key ?? [row.name, row.source, row.version, row.description].join('\0')
+
 function reveal(file: string) {
   void window.hermesDesktop?.revealPath?.(file)?.catch(() => undefined)
 }
@@ -240,7 +243,7 @@ function AgentPluginsSection() {
       ) : (
         <div>
           {sorted.map(row => (
-            <AgentPluginRowView key={row.key || row.name} row={row} />
+            <AgentPluginRowView key={agentPluginRowKey(row)} row={row} />
           ))}
         </div>
       )}

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -134,20 +134,31 @@ function AgentPluginRowView({ row }: { row: AgentPluginRow }) {
   const p = t.settings.plugins
   const { requestGateway } = useGatewayRequest()
   const busy = useStore($agentPluginBusy)
+  const key = row.key
+
+  // Pre-contract-v6 backends return rows without a canonical key. Name-addressed
+  // toggles silently flip every same-named plugin across category dirs
+  // (image_gen/fal vs video_gen/fal), so keyless rows are read-only — the
+  // backend-contract skew toast tells the user to update.
+  const toggle = (
+    <Switch
+      aria-label={`${row.status === 'enabled' ? p.disable : p.enable} ${row.name}`}
+      checked={row.status === 'enabled'}
+      disabled={!key || busy === key}
+      onCheckedChange={on => {
+        if (!key) {
+          return
+        }
+
+        triggerHaptic('selection')
+        void toggleAgentPlugin(requestGateway, key, on, p.agent.toggleFailed(row.name))
+      }}
+    />
+  )
 
   return (
     <PluginLine
-      controls={
-        <Switch
-          aria-label={`${row.status === 'enabled' ? p.disable : p.enable} ${row.name}`}
-          checked={row.status === 'enabled'}
-          disabled={busy === (row.key ?? row.name)}
-          onCheckedChange={on => {
-            triggerHaptic('selection')
-            void toggleAgentPlugin(requestGateway, row, on, p.agent.toggleFailed(row.name))
-          }}
-        />
-      }
+      controls={key ? toggle : <Tip label={p.agent.updateBackendToManage}>{toggle}</Tip>}
       description={row.description || (row.version ? `v${row.version}` : undefined)}
       title={
         <>

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -39,7 +39,11 @@ const SOURCE_ORDER: Record<string, number> = { user: 0, git: 0, project: 1, entr
 // the user-facing control for any of them, so listing them here is noise.
 const HIDDEN_KEY_PREFIXES = ['dashboard_auth/', 'model-providers/', 'platforms/']
 
-const isDesktopRelevant = (row: AgentPluginRow) => !HIDDEN_KEY_PREFIXES.some(prefix => row.key.startsWith(prefix))
+const isDesktopRelevant = (row: AgentPluginRow) => {
+  const key = row.key
+
+  return !key || !HIDDEN_KEY_PREFIXES.some(prefix => key.startsWith(prefix))
+}
 
 function reveal(file: string) {
   void window.hermesDesktop?.revealPath?.(file)?.catch(() => undefined)
@@ -134,10 +138,10 @@ function AgentPluginRowView({ row }: { row: AgentPluginRow }) {
         <Switch
           aria-label={`${row.status === 'enabled' ? p.disable : p.enable} ${row.name}`}
           checked={row.status === 'enabled'}
-          disabled={busy === row.key}
+          disabled={busy === (row.key ?? row.name)}
           onCheckedChange={on => {
             triggerHaptic('selection')
-            void toggleAgentPlugin(requestGateway, row.key, on, p.agent.toggleFailed(row.name))
+            void toggleAgentPlugin(requestGateway, row, on, p.agent.toggleFailed(row.name))
           }}
         />
       }
@@ -180,7 +184,7 @@ function AgentPluginsSection() {
       row =>
         !needle ||
         row.name.toLowerCase().includes(needle) ||
-        row.key.toLowerCase().includes(needle) ||
+        (row.key ?? '').toLowerCase().includes(needle) ||
         row.description.toLowerCase().includes(needle)
     )
     .sort((a, b) => (SOURCE_ORDER[a.source] ?? 9) - (SOURCE_ORDER[b.source] ?? 9) || a.name.localeCompare(b.name))

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -376,6 +376,7 @@ export const en: Translations = {
         search: 'Search plugins…',
         noMatches: 'No plugins match your search.',
         toggleFailed: (name: string) => `Could not toggle ${name}`,
+        updateBackendToManage: 'Update the Hermes backend to manage this plugin from Desktop.',
         sources: { bundled: 'bundled', user: 'user', git: 'git', project: 'project', entrypoint: 'pip' }
       }
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -326,6 +326,7 @@ export interface Translations {
         search: string
         noMatches: string
         toggleFailed: (name: string) => string
+        updateBackendToManage: string
         sources: Record<string, string>
       }
     }

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -367,6 +367,7 @@ export const zh: Translations = {
         search: '搜索插件…',
         noMatches: '没有匹配的插件。',
         toggleFailed: (name: string) => `无法切换 ${name}`,
+        updateBackendToManage: '请更新 Hermes 后端以便在桌面端管理此插件。',
         sources: { bundled: '内置', user: '用户', git: 'git', project: '项目', entrypoint: 'pip' }
       }
     },

--- a/apps/desktop/src/store/agent-plugins.ts
+++ b/apps/desktop/src/store/agent-plugins.ts
@@ -70,22 +70,24 @@ export function loadAgentPlugins(request: GatewayRequest): Promise<void> {
 }
 
 /** Flip a backend plugin on/off and patch the row from the RPC's refreshed
- *  copy. Current backends use canonical keys; legacy keyless rows fall back
- *  to the name-addressed protocol they were returned by. */
+ *  copy. Addressed by canonical key ONLY — bare names collide across category
+ *  dirs (image_gen/fal vs video_gen/fal), which is exactly why the backend
+ *  moved to key-addressed toggles. Rows without a key (pre-contract-v6
+ *  backends) render read-only instead of falling back to the collision-prone
+ *  name protocol; the backend-contract skew toast points the user at the
+ *  update. Returns whether the toggle stuck. */
 export async function toggleAgentPlugin(
   request: GatewayRequest,
-  row: Pick<AgentPluginRow, 'key' | 'name'>,
+  key: string,
   enable: boolean,
   failMessage: string
 ): Promise<boolean> {
-  const address = row.key ?? row.name
-
-  $agentPluginBusy.set(address)
+  $agentPluginBusy.set(key)
 
   try {
     const result = await request<{ ok?: boolean; plugin?: AgentPluginRow | null }>('plugins.manage', {
       action: 'toggle',
-      ...(row.key ? { key: row.key } : { name: row.name }),
+      key,
       enable
     })
 
@@ -96,15 +98,7 @@ export async function toggleAgentPlugin(
     const refreshed = result.plugin
 
     if (refreshed) {
-      const currentRows = $agentPlugins.get()
-
-      $agentPlugins.set(
-        row.key
-          ? currentRows.map(current => (current.key === row.key ? { ...current, ...refreshed } : current))
-          : currentRows.map(current =>
-              current.name === row.name ? { ...current, status: refreshed.status } : current
-            )
-      )
+      $agentPlugins.set($agentPlugins.get().map(row => (row.key === key ? { ...row, ...refreshed } : row)))
     } else {
       await loadAgentPlugins(request)
     }

--- a/apps/desktop/src/store/agent-plugins.ts
+++ b/apps/desktop/src/store/agent-plugins.ts
@@ -96,10 +96,14 @@ export async function toggleAgentPlugin(
     const refreshed = result.plugin
 
     if (refreshed) {
+      const currentRows = $agentPlugins.get()
+
       $agentPlugins.set(
-        $agentPlugins
-          .get()
-          .map(current => ((current.key ?? current.name) === address ? { ...current, ...refreshed } : current))
+        row.key
+          ? currentRows.map(current => (current.key === row.key ? { ...current, ...refreshed } : current))
+          : currentRows.map(current =>
+              current.name === row.name ? { ...current, status: refreshed.status } : current
+            )
       )
     } else {
       await loadAgentPlugins(request)

--- a/apps/desktop/src/store/agent-plugins.ts
+++ b/apps/desktop/src/store/agent-plugins.ts
@@ -17,8 +17,8 @@ import { notifyError } from '@/store/notifications'
 
 export interface AgentPluginRow {
   name: string
-  /** Canonical registry key (e.g. `image_gen/fal`) — names can collide. */
-  key: string
+  /** Canonical registry key (e.g. `image_gen/fal`) — absent on legacy backends. */
+  key?: string
   version: string
   description: string
   /** 'bundled' | 'user' | 'git' | 'project' | 'entrypoint' */
@@ -36,7 +36,7 @@ export type GatewayRequest = <T>(method: string, params?: Record<string, unknown
 export const $agentPlugins = atom<AgentPluginRow[]>([])
 export const $agentPluginsStatus = atom<AgentPluginsStatus>('idle')
 export const $agentPluginsError = atom<string | null>(null)
-/** Key of the row whose toggle RPC is in flight (disables its switch). */
+/** Best available address of the row whose toggle RPC is in flight. */
 export const $agentPluginBusy = atom<string | null>(null)
 
 let inflight: Promise<void> | null = null
@@ -70,20 +70,22 @@ export function loadAgentPlugins(request: GatewayRequest): Promise<void> {
 }
 
 /** Flip a backend plugin on/off and patch the row from the RPC's refreshed
- *  copy. Addressed by canonical key — bare names collide (image_gen/fal vs
- *  video_gen/fal). Returns whether the toggle stuck. */
+ *  copy. Current backends use canonical keys; legacy keyless rows fall back
+ *  to the name-addressed protocol they were returned by. */
 export async function toggleAgentPlugin(
   request: GatewayRequest,
-  key: string,
+  row: Pick<AgentPluginRow, 'key' | 'name'>,
   enable: boolean,
   failMessage: string
 ): Promise<boolean> {
-  $agentPluginBusy.set(key)
+  const address = row.key ?? row.name
+
+  $agentPluginBusy.set(address)
 
   try {
     const result = await request<{ ok?: boolean; plugin?: AgentPluginRow | null }>('plugins.manage', {
       action: 'toggle',
-      key,
+      ...(row.key ? { key: row.key } : { name: row.name }),
       enable
     })
 
@@ -94,7 +96,11 @@ export async function toggleAgentPlugin(
     const refreshed = result.plugin
 
     if (refreshed) {
-      $agentPlugins.set($agentPlugins.get().map(row => (row.key === key ? { ...row, ...refreshed } : row)))
+      $agentPlugins.set(
+        $agentPlugins
+          .get()
+          .map(current => ((current.key ?? current.name) === address ? { ...current, ...refreshed } : current))
+      )
     } else {
       await loadAgentPlugins(request)
     }

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -134,7 +134,7 @@ describe('reportBackendContract', () => {
   })
 
   it('dismisses the toast when the backend meets the contract', () => {
-    reportBackendContract(5)
+    reportBackendContract(6)
     expect(dismissSpy).toHaveBeenCalledWith('backend-contract-skew')
     expect(notifySpy).not.toHaveBeenCalled()
   })
@@ -174,8 +174,8 @@ describe('reportBackendContract', () => {
     lastToast().onDismiss()
     notifySpy.mockClear()
 
-    reportBackendContract(5) // backend updated → satisfied, snooze cleared
-    reportBackendContract(4) // a later regression must warn immediately
+    reportBackendContract(6) // backend updated → satisfied, snooze cleared
+    reportBackendContract(5) // a later regression must warn immediately
     expect(notifySpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -94,7 +94,9 @@ function isUpdateToastSnoozed(): boolean {
 // v3: requires approvals.mode config RPCs and session.info reconciliation.
 // v4: requires explicit Fast-off session creation and session-scoped Fast edits.
 // v5: requires raised WebSocket frame size for large one-shot file.attach.
-const REQUIRED_BACKEND_CONTRACT = 5
+// v6: requires key-addressed plugins.manage rows (keyless rows render
+//     read-only in Settings → Plugins).
+const REQUIRED_BACKEND_CONTRACT = 6
 const SKEW_TOAST_ID = 'backend-contract-skew'
 // The contract check runs on every session.resume (applyRuntimeInfo), so
 // without a snooze the warning re-popped on every thread the user opened, even

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5134,7 +5134,9 @@ def _current_profile_name() -> str:
 # v3: adds approvals.mode config RPCs and session.info reconciliation.
 # v4: session.create fast=false is an explicit per-session normal-tier override.
 # v5: uvicorn ws_max_size raised for one-shot base64 file.attach frames (>16 MiB).
-DESKTOP_BACKEND_CONTRACT = 5
+# v6: plugins.manage list rows carry the canonical registry key; toggles are
+#     key-addressed (keyless rows render read-only in Desktop Settings).
+DESKTOP_BACKEND_CONTRACT = 6
 
 
 def _session_usage_snapshot(session: dict | None) -> dict:


### PR DESCRIPTION
# Summary

Settings → Plugins no longer crashes ("Something broke the interface") when the Desktop app talks to a backend that predates key-addressed plugin rows — keyless rows render read-only with an "update your backend" hint, and the backend contract bumps to v6 so the existing skew toast points users at the one-click update.

Root cause: the Plugins page (c86da8397b) and the backend's key-addressed `plugins.manage` rows (a60b492e07) both landed Aug 8. A newer Desktop against an older backend receives rows without `key`, and `isDesktopRelevant` called `key.startsWith(...)` → unhandled TypeError → root error boundary tears down the whole Settings view. Reported in #82697 / Discord (Windows Desktop).

Salvages the crash guards from #82828 by @fangliquanflq (both commits cherry-picked with authorship preserved), reworked per review: the PR's legacy name-addressed toggle fallback is dropped because name toggles silently flip every same-named plugin across category dirs (image_gen/fal vs video_gen/fal) — the very bug key-addressing was introduced to fix.

## Changes

- `apps/desktop/src/app/settings/plugins-settings.tsx`: guard key-based filter/search, synthetic React row identity for keyless rows, disabled switch + tooltip for keyless rows
- `apps/desktop/src/store/agent-plugins.ts`: `key` optional in `AgentPluginRow`; `toggleAgentPlugin` stays key-addressed only
- `apps/desktop/src/store/updates.ts` + `tui_gateway/server.py`: `REQUIRED_BACKEND_CONTRACT` / `DESKTOP_BACKEND_CONTRACT` → 6
- `apps/desktop/src/i18n/{types,en,zh}.ts`: `updateBackendToManage` tooltip copy
- Tests: keyless rows render/search without crashing, keyless toggle never reaches the RPC, duplicate-named keyless rows keep distinct identities, keyed toggles unchanged; contract tests updated

## Validation

| | Before | After |
|---|---|---|
| Plugins page vs pre-v6 backend | root error boundary, Settings unusable | renders; keyless rows read-only + hint |
| Keyless toggle | name-addressed RPC (flips colliding names) | never sent |
| Skew messaging | none | contract toast with one-click backend update |
| `vitest` plugins-settings + updates | — | 47/47 pass |
| `npm run typecheck` | — | pass |
| `run_tests.sh tests/test_tui_gateway_server.py -k contract` | — | 2/2 pass |

Closes #82697

## Infographic

![Plugins Settings version-skew fix](https://v3b.fal.media/files/b/0aa5c01e/1WGVdmDTKm_0E2EIcxFmG_5aB6Ug9P.png)
