### PR TITLE
fix(tools): only trust read_file empty/past-EOF notes when the read came back empty

### DIFF
--- a/tests/tools/test_read_past_eof_note.py
+++ b/tests/tools/test_read_past_eof_note.py
@@ -42,3 +42,37 @@ class TestPastEofNote:
         p.write_text("\n".join(f"l{i}" for i in range(1, 300)) + "\n")
         result = json.loads(read_file_tool(str(p), offset=1, limit=100))
         assert "offset=101" in (result.get("hint") or "")
+
+    def test_no_trailing_newline_last_line_still_reads(self, tmp_path, monkeypatch):
+        # wc -l counts newlines, so "a\nb\nc" reports 2 lines. Asking for
+        # line 3 looks past EOF to that count, but the line exists and the
+        # read must return it instead of claiming the file ends at line 2.
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "r.txt"
+        p.write_text("a\nb\nc")
+        result = json.loads(read_file_tool(str(p), offset=3, limit=10))
+        assert "c" in result.get("content", "")
+        assert "beyond" not in (result.get("hint") or "")
+
+    def test_unparseable_size_probe_not_reported_empty(self, tmp_path, monkeypatch):
+        # file_size falls back to 0 when the wc probe output is unparseable
+        # (transport junk with exit 0). A non-empty file must not be
+        # reported as "File is empty" in that case: the read already
+        # produced its content.
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        p = tmp_path / "r.txt"
+        p.write_text("real content\n")
+        from tools import file_tools
+        ops = file_tools._get_file_ops("default")
+        real_exec = ops._exec
+
+        def noisy_exec(command, **kwargs):
+            res = real_exec(command, **kwargs)
+            if "wc -c <" in command:
+                res.stdout = "shell profile junk\r\n" + res.stdout
+            return res
+
+        monkeypatch.setattr(ops, "_exec", noisy_exec)
+        result = json.loads(read_file_tool(str(p)))
+        assert "real content" in result.get("content", "")
+        assert "empty" not in (result.get("hint") or "").lower()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1375,14 +1375,19 @@ class ShellFileOperations(FileOperations):
         # indistinguishable, from inside the model, from a broken tool —
         # it re-reads, widens the window, tries another path. Name the
         # dead end and its recovery instead.
-        if file_size == 0:
+        # Both guards require an empty page from the real read. The wc
+        # figures are advisory: file_size falls back to 0 when the probe
+        # output is unparseable, and wc -l undercounts a file whose last
+        # line has no trailing newline. Trusting them alone would refuse
+        # content the read already produced and state a false fact.
+        if file_size == 0 and not read_output:
             return ReadResult(
                 content="",
                 total_lines=0,
                 file_size=0,
                 hint="File is empty (0 bytes).",
             )
-        if offset > total_lines > 0:
+        if offset > total_lines > 0 and not read_output:
             return ReadResult(
                 content="",
                 total_lines=total_lines,


### PR DESCRIPTION
Keep content returned by read_file when size or last-byte probes fail. Empty-file and past-EOF hints now require an empty read result. Preserve main's existing final-line count correction.

Fixes #83022

Validation: Both regressions failed on main and passed after the fix. 13 related tests passed through scripts/run_tests.sh, including real sequential reads with failing metadata probes.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
