### PR TITLE
fix(terminal): inline CI-poller hint instead of dead skill_view pointer

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -406,13 +406,73 @@ def test_foreground_command_does_not_emit_hint(monkeypatch, tmp_path):
 #
 # Background processes whose command looks like a hand-rolled CI poller
 # (`gh pr view` / `gh pr checks` combined with jq/awk on stdout) get an
-# additional hint pointing at the canonical green-ci-policy snippet. The
-# homebrew shape has burned us repeatedly (May 2026 PRs #31329, #31448,
-# #31695, #31709, #31745, #32264, #33131) with stdout buffering, jq null
-# keys, conclusion-vs-status confusion, and TTY-only banner grepping —
-# none of which the canonical snippets suffer from. Fire on every detection;
-# false positives are cheap (~one read).
+# additional hint naming the green-ci-policy and inlining the canonical
+# alternatives directly in the hint text. The homebrew shape has burned
+# us repeatedly (May 2026 PRs #31329, #31448, #31695, #31709, #31745,
+# #32264, #33131) with stdout buffering, jq null keys, conclusion-vs-status
+# confusion, and TTY-only banner grepping, none of which the canonical
+# snippets suffer from. Fire on every detection; false positives are
+# cheap (~one read).
 # ---------------------------------------------------------------------------
+
+
+def test_homebrew_ci_poller_via_statusCheckRollup_emits_hint(monkeypatch, tmp_path):
+    """The canonical anti-pattern: jq pipeline parsing statusCheckRollup
+    JSON. Tool must name the green-ci-policy and inline the fix."""
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command=(
+                    "PR=12345; while true; do "
+                    "status=$(gh pr view $PR --json statusCheckRollup "
+                    "--jq '[.statusCheckRollup[] | .conclusion] "
+                    "| group_by(.) | map({k:.[0],v:length}) | from_entries'); "
+                    "echo \"$status\"; sleep 30; done"
+                ),
+                background=True,
+                notify_on_complete=True,
+            )
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    hint = result.get("hint", "")
+    assert hint, "Homebrew CI poller must emit a hint naming green-ci-policy"
+    assert "green-ci-policy" in hint, (
+        "Hint must name the green-ci-policy so the agent recognizes the fix"
+    )
+    # Naming exit-code-driven OR column-2 in the hint is what makes it actionable.
+    assert "exit" in hint.lower() or "column-2" in hint.lower() or "tab" in hint.lower(), (
+        "Hint must point at the canonical alternatives (exit-code or column-2)"
+    )
+
+
+def test_homebrew_ci_poller_via_gh_pr_checks_piped_to_jq_emits_hint(monkeypatch, tmp_path):
+    """`gh pr checks` doesn't emit JSON, so piping it to jq is a confused-
+    intent anti-pattern that produces silent failures (jq fails, loop
+    keeps spinning with empty data)."""
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command=(
+                    "PR=99; while true; do "
+                    "gh pr checks $PR | jq -R 'split(\"\\t\")[1]'; "
+                    "sleep 30; done"
+                ),
+                background=True,
+                notify_on_complete=True,
+            )
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    hint = result.get("hint", "")
+    assert hint, "Homebrew `gh pr checks | jq` poller must emit a hint"
+    assert "green-ci-policy" in hint
 
 
 def test_non_ci_background_command_does_not_emit_homebrew_hint(monkeypatch, tmp_path):
@@ -434,4 +494,65 @@ def test_non_ci_background_command_does_not_emit_homebrew_hint(monkeypatch, tmp_
 
     assert "hint" not in result, (
         f"Non-CI command using awk must not be flagged as homebrew CI poller, got: {result.get('hint')!r}"
+    )
+
+
+def test_canonical_column2_awk_poller_does_not_emit_homebrew_hint(monkeypatch, tmp_path):
+    """The blessed column-2 awk-on-tabs poller from green-ci-policy is the
+    PREFERRED pattern for sharded matrices. Must not be flagged as
+    homebrew: the gating signal is statusCheckRollup or `gh pr checks
+    | jq`, NOT awk on tabs."""
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command=(
+                    "PR=1; while :; do "
+                    "out=$(gh pr checks $PR 2>&1); "
+                    "pending=$(echo \"$out\" | awk -F\"\\t\" \"\\$2==\\\"pending\\\"\" | wc -l); "
+                    "failed=$(echo \"$out\" | awk -F\"\\t\" \"\\$2==\\\"fail\\\"\" | wc -l); "
+                    "if [ \"$pending\" -eq 0 ]; then "
+                    "[ \"$failed\" -gt 0 ] && exit 1 || exit 0; "
+                    "fi; sleep 30; "
+                    "done"
+                ),
+                background=True,
+                notify_on_complete=True,
+            )
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert "hint" not in result, (
+        f"Canonical column-2 awk poller must not be flagged as homebrew, got: {result.get('hint')!r}"
+    )
+
+
+def test_canonical_gh_pr_checks_exit_code_loop_does_not_emit_hint(monkeypatch, tmp_path):
+    """The blessed exit-code-driven snippet from green-ci-policy is exactly
+    what we want: no jq, no awk-on-stdout, gates the loop on exit code.
+    Must not be flagged as a homebrew anti-pattern."""
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command=(
+                    "PR=1; while :; do "
+                    "gh pr checks $PR >/dev/null 2>&1; rc=$?; "
+                    "case $rc in 0) exit 0;; 8) sleep 30;; *) exit 1;; esac; "
+                    "done"
+                ),
+                background=True,
+                notify_on_complete=True,
+            )
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    # No silent-process hint (we have notify_on_complete) AND no
+    # homebrew-poller hint (no jq / awk pipeline parsing stdout).
+    assert "hint" not in result, (
+        f"Canonical exit-code-driven poller must not be flagged as homebrew, got: {result.get('hint')!r}"
     )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2868,9 +2868,9 @@ def terminal_tool(
                 #     checks still IN_PROGRESS.
                 #   * grepping for TTY-only banners ("All checks were
                 #     successful") that never appear when stdout is piped.
-                # The canonical patterns in the green-ci-policy skill avoid
-                # every one of these — drive the loop off exit codes or on
-                # tab-separated `awk -F"\t" "$2==\"pending\""` (column 2).
+                # These canonical patterns avoid every one of these. Drive
+                # the loop off exit codes, or use the tab-separated
+                # `awk -F"\t" "$2==\"pending\""` pattern (column 2).
                 # The detector here is deliberately narrow: it flags the
                 # statusCheckRollup JSON-API path and the `gh pr checks` +
                 # jq combination, but NOT the canonical column-2 awk
@@ -2896,32 +2896,30 @@ def terminal_tool(
                     )
                     if _bad_shape:
                         existing = result_data.get("hint", "")
+                        awk_snippet = 'awk -F"\\t" "$2==\\"pending\\""'
                         canonical_hint = (
                             "This looks like a homebrewed CI poller built from "
                             "`gh pr view --json statusCheckRollup` and/or "
                             "`gh pr checks | jq`. That shape has burned us "
                             "repeatedly in hermes-agent dev work (PRs #31329, "
-                            "#31448, #31695, #31709, #31745, #32264, #33131) — "
-                            "stdout buffering kills output capture, jq null-key "
+                            "#31448, #31695, #31709, #31745, #32264, #33131). "
+                            "Stdout buffering kills output capture, jq null-key "
                             "edge cases silently exit the loop, conclusion-vs-"
                             "status field confusion exits early with bogus "
-                            "all-green verdicts, TTY-only summary banners "
-                            "never appear when piped. Use the canonical "
-                            "snippets in the green-ci-policy skill instead: "
-                            "the exit-code-driven `gh pr checks $PR >/dev/null` "
-                            "(rc 0 = green, 8 = pending, else fail) for "
-                            "exit-on-first-fail behavior, or the column-2 "
-                            "awk-on-tabs poller "
-                            "(`awk -F\"\\t\" \"$2==\\\"pending\\\"\"`) for "
-                            "sharded matrices. Load skill_view("
-                            "name='github/hermes-agent-dev', "
-                            "file_path='references/green-ci-policy.md') for "
-                            "the verbatim snippets. If you must roll a custom "
-                            "loop with rich structured output, write each tick "
-                            "to a known file (`tee -a /tmp/ci.log`) and rely "
-                            "on `process(action='log')` to read THAT file — "
-                            "do not rely on background-process stdout capture "
-                            "for line-buffered shell loops."
+                            "all-green verdicts, and TTY-only summary banners "
+                            "never appear when piped. green-ci-policy: use "
+                            "one of these instead. (1) Exit-code-driven: "
+                            "`gh pr checks $PR >/dev/null; rc=$?` then branch "
+                            "on rc (0 = green, 8 = pending, anything else = "
+                            "failed). (2) Column-2 awk-on-tabs for sharded "
+                            f"matrices: `{awk_snippet}` counts pending rows by "
+                            "reading the actual tab-separated status column "
+                            "instead of a TTY-only banner. For a custom loop "
+                            "with richer output, write each tick to a known "
+                            "file (`tee -a /tmp/ci.log`) and read THAT file "
+                            "with `process(action='log')` rather than trusting "
+                            "background-process stdout capture for a "
+                            "line-buffered shell loop."
                         )
                         result_data["hint"] = (
                             existing + "\n\n" + canonical_hint if existing


### PR DESCRIPTION
> ## ⚠️ Reviewer action required before submission
> - **branch/commit-type mismatch**: branch `feat/ci-poller-hint-dead-skill-ref` uses `fix:` commit type — either squash into a `fix:`-prefixed title or rename the branch to `fix/…` before merge.
> - **uncommitted verifier test**: `tests/tools/test_ci_poller_hint_verifier.py` was created by the verifier but not committed. Fold it into this PR or note whether it should live on a separate branch.

## What this does

The CI-poller hint in `terminal_tool.py` told agents to load `skill_view(name='github/hermes-agent-dev', file_path='references/green-ci-policy.md')`. That file never existed, so every agent who followed the hint got a dead pointer. I inlined the exit-code and column-2 awk snippets directly into the hint string and updated the docstrings and assertions to match.

## Why

The homebrew CI-poller shape (`gh pr view --json statusCheckRollup` / `gh pr checks | jq`) has burned us repeatedly in May 2026 dev work: stdout buffering kills output capture, jq null-key edge cases silently exit the loop, conclusion-vs-status field confusion exits early with bogus all-green verdicts, and TTY-only summary banners never appear when piped. Refs #31329, #31448, #31695, #31709, #31745, #32264, and #33131, which all landed fixes for one or more of these. The hint in #33142 was supposed to point at the canonical snippets but referenced a nonexistent file. Agents who hit it had to guess the right pattern.

This fix also restores the three tests removed by the pruning commit 39975613b1, so test coverage for the homebrew-poller detection stays at three cases: statusCheckRollup shape, `gh pr checks | jq` shape, and the two canonical patterns that must NOT false-positive.

## Changes

- **`tools/terminal_tool.py`** — Replaced the dead `skill_view` call with the canonical exit-code-driven and column-2 awk snippets inline. Shortened the hint text (removed em-dash, tightened prose). Updated the comment block to name the convention by its label (`green-ci-policy`) rather than a file path.
- **`tests/tools/test_notify_on_complete.py`** — Restored the three tests removed by 39975613b1: `test_homebrew_ci_poller_via_statusCheckRollup_emits_hint`, `test_homebrew_ci_poller_via_gh_pr_checks_piped_to_jq_emits_hint`, and `test_canonical_column2_awk_poller_does_not_emit_homebrew_hint` (plus the existing `test_canonical_gh_pr_checks_exit_code_loop_does_not_emit_hint`). Updated assertions and docstrings to describe `green-ci-policy` as the named convention.

## Verification

```bash
# Run the homebrew-poller tests in isolation
python -m pytest tests/tools/test_notify_on_complete.py::test_homebrew_ci_poller_via_statusCheckRollup_emits_hint tests/tools/test_notify_on_complete.py::test_homebrew_ci_poller_via_gh_pr_checks_piped_to_jq_emits_hint tests/tools/test_notify_on_complete.py::test_canonical_column2_awk_poller_does_not_emit_homebrew_hint tests/tools/test_notify_on_complete.py::test_canonical_gh_pr_checks_exit_code_loop_does_not_emit_hint tests/tools/test_notify_on_complete.py::test_non_ci_background_command_does_not_emit_homebrew_hint -v

# Run the full test suite for the file (policy-auditor confirmed all 30 tests green)
python -m pytest tests/tools/test_notify_on_complete.py -v
```

## Related

- Dead pointer introduced by: #33142 (merged 2026-05-27)
- Homebrew CI-poller incidents: Refs #31329, #31448, #31695, #31709, #31745, #32264, #33131 (all merged May 2026)
- Pruning commit that dropped the tests: 39975613b1
