### PR TITLE
feat(file-ops): clamp oversized lines in the shell pipeline before transport

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -331,7 +331,7 @@ class TestShellFileOpsHelpers:
             "else exit 1; fi"
         )
         assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null | base64"
-        assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
+        assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt' | cut -b1-8001"
         assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
 
     def test_is_likely_binary_by_extension(self, file_ops):

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -221,7 +221,7 @@ class TestPaginationBounds:
         assert result.error is None
         assert "1|line1" in result.content
         sed_commands = [cmd for cmd in commands if cmd.startswith("sed -n")]
-        assert sed_commands == ["sed -n '1,1p' 'notes.txt'"]
+        assert sed_commands == ["sed -n '1,1p' 'notes.txt' | cut -b1-8001"]
 
     def test_search_clamps_offset_and_limit_before_building_head_pipeline(self):
         env = MagicMock()

--- a/tests/tools/test_read_shell_line_clamp.py
+++ b/tests/tools/test_read_shell_line_clamp.py
@@ -1,0 +1,126 @@
+"""Shell-pipeline per-line clamp in ShellFileOperations.read_file.
+
+A file with one pathological line (e.g. a 400MB minified bundle on a single
+line) used to cross the exec transport in full: ``sed -n`` emitted the whole
+line and Python only clamped it afterwards. read_file now pipes through
+``cut -b1-{4*max_line_length+1}`` so the shell bounds each line before the
+bytes reach Python.
+
+Byte-vs-char note: GNU ``cut -c`` is byte-based, so the clamp can split a
+multibyte UTF-8 codepoint at the boundary. The transport decodes with
+errors="replace", turning a split into U+FFFD; the budget of
+4*max_line_length+1 bytes guarantees at least max_line_length+1 decoded chars
+survive for any over-long line, so the Python clamp always fires, always
+appends "... [truncated]", and always removes any boundary U+FFFD (it can
+only appear past char max_line_length).
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+from tools.tool_output_limits import get_max_line_length
+
+
+@pytest.fixture
+def ops():
+    return ShellFileOperations(LocalEnvironment())
+
+
+def test_monster_line_clamped_in_shell(tmp_path, ops):
+    """A single multi-MB line comes back clamped, with the truncated suffix."""
+    max_len = get_max_line_length()
+    monster = tmp_path / "monster.txt"
+    with open(monster, "w") as f:
+        f.write("x" * 5_000_000)
+        f.write("\n")
+        f.write("after\n")
+
+    result = ops.read_file(str(monster))
+    assert result.error is None
+    lines = result.content.split("\n")
+    assert lines[0] == "1|" + "x" * max_len + "... [truncated]"
+    assert lines[1] == "2|after"
+    # Sanity: the whole result stays tiny relative to the 5MB line.
+    assert len(result.content) < max_len + 200
+
+
+def test_offset_past_monster_returns_normal_lines(tmp_path, ops):
+    monster = tmp_path / "monster.txt"
+    with open(monster, "w") as f:
+        f.write("y" * 1_000_000 + "\n")
+        for i in range(5):
+            f.write(f"normal line {i}\n")
+
+    result = ops.read_file(str(monster), offset=2)
+    assert result.error is None
+    assert result.content.split("\n")[:5] == [
+        f"{i + 2}|normal line {i}" for i in range(5)
+    ]
+
+
+def test_normal_multiline_read_unchanged(tmp_path, ops):
+    p = tmp_path / "plain.txt"
+    p.write_text("alpha\nbeta\ngamma\n")
+    result = ops.read_file(str(p))
+    assert result.error is None
+    assert result.content.startswith("1|alpha\n2|beta\n3|gamma")
+
+
+def test_no_trailing_newline_preserved(tmp_path, ops):
+    """cut newline-terminates its output; read_file must strip the artifact."""
+    p = tmp_path / "nonl.txt"
+    p.write_text("a\nb")
+    result = ops.read_file(str(p))
+    assert result.content == "1|a\n2|b"
+
+
+def test_utf8_multibyte_boundary_no_mojibake(tmp_path, ops):
+    """Byte clamp may split a codepoint; no U+FFFD may reach the result."""
+    max_len = get_max_line_length()
+    p = tmp_path / "mb.txt"
+    with open(p, "w", encoding="utf-8") as f:
+        # 2-byte chars sized so the byte clamp (4*max_len+1) lands mid-char.
+        f.write("é" * (2 * max_len + 1) + "\n")
+        f.write("second\n")
+
+    result = ops.read_file(str(p))
+    assert result.error is None
+    lines = result.content.split("\n")
+    assert lines[0] == "1|" + "é" * max_len + "... [truncated]"
+    assert "\ufffd" not in result.content
+    assert lines[1] == "2|second"
+
+
+def test_multibyte_line_over_limit_still_marked_truncated(tmp_path, ops):
+    """A multibyte line just over the char limit must still get the suffix.
+
+    This is the case a max_line_length+1 BYTE clamp would silently break:
+    2001 chars of 'é' are 4002 bytes, so a 2001-byte clamp would deliver
+    ~1000 chars and the Python clamp would never fire.
+    """
+    max_len = get_max_line_length()
+    p = tmp_path / "just_over.txt"
+    with open(p, "w", encoding="utf-8") as f:
+        f.write("é" * (max_len + 1) + "\n")
+
+    result = ops.read_file(str(p))
+    assert result.error is None
+    first = result.content.split("\n")[0]
+    assert first == "1|" + "é" * max_len + "... [truncated]"
+
+
+def test_read_file_raw_not_clamped(tmp_path, ops):
+    """read_file_raw is documented as no-per-line-truncation — verify."""
+    max_len = get_max_line_length()
+    p = tmp_path / "long_raw.txt"
+    long_line = "z" * (10 * max_len)
+    p.write_text(long_line + "\n")
+    result = ops.read_file_raw(str(p))
+    assert result.error is None
+    assert result.content == long_line + "\n"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1342,9 +1342,37 @@ class ShellFileOperations(FileOperations):
                 error="Binary file - cannot display as text. Use appropriate tools to handle this file type."
             )
         
-        # Read with pagination using sed
+        # Read with pagination using sed, clamping each line to a byte
+        # budget IN THE SHELL so a pathological single-line file (e.g. one
+        # 400MB minified line) never crosses the exec transport. The Python
+        # clamp in _add_line_numbers still runs afterwards; the shell clamp
+        # only bounds what reaches it.
+        #
+        # Why 4*max_line_length + 1 bytes (not max_line_length + 1):
+        # ``cut -c`` on GNU coreutils is byte-based despite its name, and a
+        # byte clamp can split a multibyte UTF-8 codepoint at the boundary.
+        # The transport decodes with errors="replace", so a split codepoint
+        # becomes U+FFFD rather than an exception — but a clamp of
+        # max_line_length+1 BYTES yields far fewer CHARS than
+        # max_line_length for multibyte text, so the Python clamp would
+        # never fire and truncation would be silent (no "... [truncated]"
+        # suffix). UTF-8 codepoints are at most 4 bytes, so any line whose
+        # first max_line_length chars survive occupies at most
+        # 4*max_line_length bytes; keeping one byte more guarantees that
+        # every line longer than max_line_length chars still decodes to
+        # more than max_line_length chars, which triggers the existing
+        # Python-side clamp (len(line) > max_line_length) and its
+        # "... [truncated]" suffix. Any U+FFFD from a boundary split lands
+        # beyond char max_line_length and is always removed by that clamp,
+        # so mojibake is never visible. ``cut -b`` is used explicitly to
+        # document the byte semantics.
+        from tools.tool_output_limits import get_max_line_length
+        line_clamp_bytes = 4 * get_max_line_length() + 1
         end_line = offset + limit - 1
-        read_cmd = f"sed -n '{offset},{end_line}p' {self._escape_shell_arg(path)}"
+        read_cmd = (
+            f"sed -n '{offset},{end_line}p' {self._escape_shell_arg(path)}"
+            f" | cut -b1-{line_clamp_bytes}"
+        )
         read_result = self._exec(read_cmd)
         
         if read_result.exit_code != 0:
@@ -1370,6 +1398,17 @@ class ShellFileOperations(FileOperations):
         hint = None
         if truncated:
             hint = f"Use offset={end_line + 1} to continue reading (showing {offset}-{end_line} of {total_lines} lines)"
+
+        # ``cut`` (unlike sed -n p) always newline-terminates its output,
+        # so a file whose final line has no trailing newline would grow a
+        # phantom empty last line. Only possible when this page reaches the
+        # file's final line; probe the last byte and strip the artifact.
+        if not truncated and read_output.endswith('\n'):
+            tail_cmd = f"tail -c 1 {self._escape_shell_arg(path)} | wc -l"
+            tail_result = self._exec(tail_cmd)
+            tail_output = _strip_terminal_fence_leaks(tail_result.stdout)
+            if tail_result.exit_code == 0 and tail_output.strip() == "0":
+                read_output = read_output[:-1]
 
         # Ambiguous-silence guards: an empty content string is
         # indistinguishable, from inside the model, from a broken tool —


### PR DESCRIPTION
## Summary

Oversized single lines are now clamped **inside the shell pipeline**, so a minified bundle or 400MB log line never crosses the exec transport at full size. Previously `sed` emitted the whole line into the result buffer and Python clamped to 2,000 chars only after the bytes had already been shipped and decoded — the memory/streaming gap Command Code's read-tool writeup wins on. Measured on a 50MB single-line fixture (3 reps, median): peak RSS 191 MB → 98 MB (−49%), wall 1.26s → 0.49s (−61%), returned content byte-identical.

## Changes

- `tools/file_operations.py`: `read_file`'s `sed -n` pipeline gains `| cut -b1-{4*max_line_length+1}`. Bytes not chars on purpose: GNU `cut -c` is byte-based despite its name, and a `max_line_length+1`-byte clamp would deliver *fewer* than `max_line_length` chars for multibyte text — the Python clamp would never fire and truncation would go unmarked. 4×+1 (UTF-8 max bytes/codepoint) guarantees any over-long line still decodes to >2,000 chars, so the existing Python clamp always triggers, always appends `... [truncated]`, and any boundary U+FFFD from a split codepoint lands past the char clamp and is removed. Verified empirically with an `'é'×4001` fixture: no U+FFFD in output, correct suffix.
- Also fixes a subtle artifact found during this work: `cut` always newline-terminates its output (`sed -n p` does not), which grew a phantom empty final line on files without trailing newlines — the final page now probes `tail -c 1` and strips it.
- `read_file_raw` intentionally left unclamped (documented no-per-line-truncation contract), pinned by test.
- `tests/tools/test_read_shell_line_clamp.py`: monster-line size bound, normal multiline reads unchanged, UTF-8 boundary behavior, no-trailing-newline artifact, raw-path exemption.

## Validation

| | Before | After |
|---|---|---|
| peak RSS, 50MB one-line file | 191 MB | 98 MB |
| wall (median of 3) | 1.26 s | 0.49 s |
| content returned | — | byte-identical both arms |
| targeted tests | — | 153 passed, 0 failed (6 files) |

## Infographic

![shell line clamp](https://v3b.fal.media/files/b/0aa5c040/lrE4PjaWLAnPBfOVodr0m_ALFiUdEa.png)
