### PR TITLE
fix(tools): special-file guard follow-ups: error key on refusal, POSIX-marked tests, unicode-FIFO regression test

### DIFF
--- a/tests/tools/test_read_special_file_guard.py
+++ b/tests/tools/test_read_special_file_guard.py
@@ -26,11 +26,13 @@ class TestSpecialFileKind:
     def test_missing_path(self, tmp_path):
         assert _special_file_kind(tmp_path / "nope") is None
 
+    @pytest.mark.linux_only  # os.mkfifo is POSIX-only
     def test_fifo(self, tmp_path):
         fifo = tmp_path / "p.pipe"
         os.mkfifo(fifo)
         assert "FIFO" in (_special_file_kind(fifo) or "")
 
+    @pytest.mark.linux_only  # socket.AF_UNIX is POSIX-only
     def test_socket(self, tmp_path):
         sock_path = tmp_path / "s.sock"
         s = socket.socket(socket.AF_UNIX)
@@ -40,6 +42,7 @@ class TestSpecialFileKind:
         finally:
             s.close()
 
+    @pytest.mark.linux_only  # os.mkfifo is POSIX-only
     def test_symlink_to_fifo_followed(self, tmp_path):
         fifo = tmp_path / "p.pipe"
         os.mkfifo(fifo)
@@ -54,6 +57,7 @@ class TestSpecialFileKind:
 
 
 class TestReadFileToolFifoGuard:
+    @pytest.mark.linux_only  # os.mkfifo is POSIX-only
     def test_fifo_read_returns_note_instantly(self, tmp_path, monkeypatch):
         import time
 

--- a/tests/tools/test_read_unicode_filename_retry.py
+++ b/tests/tools/test_read_unicode_filename_retry.py
@@ -7,6 +7,7 @@ only). Visible differences stay with did-you-mean suggestions.
 """
 
 import json
+import os
 import unicodedata
 
 import pytest
@@ -59,6 +60,18 @@ class TestUnicodeVariantRepair:
     def test_plain_missing_file_unchanged(self, ws):
         result = json.loads(read_file_tool(str(ws / "missing.txt")))
         assert "not found" in result.get("error", "").lower()
+
+    @pytest.mark.linux_only  # os.mkfifo is POSIX-only
+    def test_variant_special_file_refused_instead_of_hanging(self, tmp_path, monkeypatch):
+        # The repair re-enters read_file below the tool layer, so the
+        # tool-level stat guard never sees the variant. A not-found path
+        # whose unicode-equivalent entry is a FIFO must hit the shell-side
+        # regular-file probe and come back with an error. Without that
+        # probe the variant read opens the FIFO and blocks.
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        os.mkfifo(tmp_path / "it’s.pipe")
+        result = json.loads(read_file_tool(str(tmp_path / "it's.pipe")))
+        assert "not a regular file" in (result.get("error") or "")
 
 
 class TestNearMissSuggestion:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1571,15 +1571,16 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         if _file_ops_uses_host_paths(_get_file_ops(task_id)):
             kind = _special_file_kind(_resolved)
             if kind is not None:
-                return json.dumps({
-                    "success": False,
-                    "note": (
-                        f"'{path}' is {kind}, not a regular file — reading "
-                        "it would block indefinitely, so no read was "
-                        "attempted. Use terminal utilities if you need to "
-                        "interact with it."
-                    ),
-                })
+                _msg = (
+                    f"'{path}' is {kind}, not a regular file — reading "
+                    "it would block indefinitely, so no read was "
+                    "attempted. Use terminal utilities if you need to "
+                    "interact with it."
+                )
+                # Carry the message under "error" as well: every other
+                # refusal in this function goes through tool_error(), and
+                # consumers detect failures by that key.
+                return json.dumps({"success": False, "error": _msg, "note": _msg})
 
         # ── Structured-document extraction ────────────────────────────
         # Try before the binary-extension guard so .docx/.xlsx can render as text.


### PR DESCRIPTION
Return the existing special-file refusal under both error and note so callers reliably recognize failed reads. Cover Unicode-equivalent paths resolving to a FIFO through the existing lower-level regular-file guard, and mark FIFO/device/socket tests for Linux CI.

Fixes #83032

Validation: 12 tests passed through scripts/run_tests.sh; six Linux-only tests were skipped on this Windows host and remain assigned to Linux CI.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
