### PR TITLE
fix(tools): close session_search owned db handles

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -108,6 +108,49 @@ class TestBrowseShape:
         assert "s_newest" not in sids
 
 
+class TestSessionDbOwnership:
+    class FakeSessionDB:
+        def __init__(self):
+            self.closed = False
+
+        def list_sessions_rich(self, **_kwargs):
+            return []
+
+        def close(self):
+            self.closed = True
+
+    def test_lazy_opened_default_db_is_closed(self, monkeypatch):
+        owned = self.FakeSessionDB()
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: owned)
+
+        result = json.loads(session_search())
+
+        assert result["success"] is True
+        assert owned.closed is True
+
+    def test_caller_supplied_db_is_not_closed(self):
+        supplied = self.FakeSessionDB()
+
+        result = json.loads(session_search(db=supplied))
+
+        assert result["success"] is True
+        assert supplied.closed is False
+
+    def test_profile_db_owned_by_call_is_closed_but_supplied_db_is_not(self, monkeypatch):
+        supplied = self.FakeSessionDB()
+        profile_db = self.FakeSessionDB()
+        monkeypatch.setattr(
+            "tools.session_search_tool._resolve_profile_db",
+            lambda _profile: profile_db,
+        )
+
+        result = json.loads(session_search(db=supplied, profile="work"))
+
+        assert result["success"] is True
+        assert supplied.closed is False
+        assert profile_db.closed is True
+
+
 # =========================================================================
 # Discovery shape (with query)
 # =========================================================================

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -845,6 +845,20 @@ def _discover(
     return json.dumps(_final_payload, ensure_ascii=False)
 
 
+def _close_owned_session_dbs(owned_dbs: List[Any]) -> None:
+    """Close SessionDB handles opened by this tool invocation."""
+    seen: set[int] = set()
+    for owned_db in reversed(owned_dbs):
+        marker = id(owned_db)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        try:
+            owned_db.close()
+        except Exception:
+            logging.debug("session_search: closing owned SessionDB failed", exc_info=True)
+
+
 def session_search(
     query: str = "",
     role_filter: str = None,
@@ -871,15 +885,51 @@ def session_search(
     ``@session:<profile>/<id>`` link). Scroll wins over read/discovery when an
     anchor is set — the agent has asked for a specific slice.
     """
+    owned_dbs: List[Any] = []
     if db is None:
         try:
             from hermes_state import SessionDB
             db = SessionDB()
+            owned_dbs.append(db)
         except Exception:
             logging.debug("SessionDB unavailable for session_search", exc_info=True)
             from hermes_state import format_session_db_unavailable
             return tool_error(format_session_db_unavailable(), success=False)
 
+    try:
+        return _session_search_impl(
+            query=query,
+            role_filter=role_filter,
+            limit=limit,
+            db=db,
+            current_session_id=current_session_id,
+            session_id=session_id,
+            around_message_id=around_message_id,
+            window=window,
+            sort=sort,
+            profile=profile,
+            _owned_dbs=owned_dbs,
+        )
+    finally:
+        _close_owned_session_dbs(owned_dbs)
+
+
+def _session_search_impl(
+    query: str = "",
+    role_filter: str = None,
+    limit: int = 3,
+    db=None,
+    current_session_id: str = None,
+    # Scroll shape
+    session_id: str = None,
+    around_message_id: int = None,
+    window: int = 5,
+    # Discovery shape
+    sort: str = None,
+    # Cross-profile (any shape)
+    profile: str = None,
+    _owned_dbs: Optional[List[Any]] = None,
+) -> str:
     # Normalise a raw `@session:<profile>/<id>` link value passed as session_id.
     # Session ids never contain "/", so a slash unambiguously means profile/id —
     # always strip the prefix off the id, and adopt the embedded profile only
@@ -901,6 +951,8 @@ def session_search(
         except Exception as e:
             return tool_error(f"profile '{profile}': {e}", success=False)
         if profile_db is not None:
+            if _owned_dbs is not None:
+                _owned_dbs.append(profile_db)
             db = profile_db
             current_session_id = None
 


### PR DESCRIPTION
## Summary
- wrap `session_search()` with owned-SessionDB cleanup so lazy-opened handles close on every return path
- close cross-profile read-only DB handles opened by `profile=` while preserving caller-owned `db` handles
- add ownership regression tests for lazy default DBs, supplied DBs, and profile DBs

Fixes #83027.

## Tests
- `.venv/bin/python -m pytest tests/tools/test_session_search.py::TestSessionDbOwnership -q`
- `.venv/bin/python -m pytest tests/tools/test_session_search.py -q`
- `.venv/bin/python -m ruff check tools/session_search_tool.py tests/tools/test_session_search.py`
- `git diff --check -- tools/session_search_tool.py tests/tools/test_session_search.py`