### PR TITLE
fix(tools): close the SessionDB handles session_search opens itself (fd leak → EMFILE)

### DIFF
--- a/tests/tools/test_session_search_fd_leak.py
+++ b/tests/tools/test_session_search_fd_leak.py
@@ -1,0 +1,116 @@
+"""Regression tests for the session_search SessionDB fd leak (#83027).
+
+``session_search`` opens two kinds of handle for itself: the default
+``SessionDB()`` when the caller passes no ``db``, and the read-only profile DB
+from ``_resolve_profile_db`` on a cross-profile read. Before the fix neither
+was closed on any of the function's eight return paths.
+
+Neither handle is reclaimed by GC either: once its token-writer thread starts,
+a ``SessionDB`` pins itself through ``atexit.register(_drain_token_queue_at_exit)``
+and only ``close()`` unregisters it (see the note in ``run_agent.py``). So each
+call leaked ~2 fds (``state.db`` + its WAL sidecar) for the life of the process.
+Measured on a launchd-managed gateway with the macOS default 256-fd soft limit:
+122 of 283 fds were these handles after 3.5h, at which point cron scripts,
+SQLite writes and DNS lookups all began failing with ``[Errno 24]`` while the
+process still reported healthy.
+
+These tests assert ownership rather than raw fd counts, so they are
+deterministic and platform-independent: whoever opened a handle closes it, and
+a caller-supplied handle is never touched.
+"""
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_state import SessionDB
+from tools.session_search_tool import session_search
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _seed(db, session_id="s1"):
+    """One session with a searchable message, so discovery has a hit."""
+    db.create_session(session_id, source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (int(time.time()) - 60, "Fd leak fixture", session_id),
+    )
+    db.append_message(session_id, role="user", content="searchable modpack content")
+
+
+def _tracked(instance):
+    """Wrap ``close`` so the test can assert on it without disabling it."""
+    instance.close = MagicMock(wraps=instance.close)
+    return instance
+
+
+def test_lazily_opened_db_is_closed(tmp_path, monkeypatch):
+    """No caller ``db`` → session_search opens one and must close it."""
+    opened = []
+
+    def _factory(*args, **kwargs):
+        opened.append(_tracked(SessionDB(tmp_path / "state.db")))
+        return opened[-1]
+
+    monkeypatch.setattr("hermes_state.SessionDB", _factory)
+
+    session_search(query="modpack", limit=1)
+
+    assert len(opened) == 1, "expected exactly one self-opened SessionDB"
+    opened[0].close.assert_called_once()
+
+
+def test_caller_supplied_db_is_not_closed(db):
+    """A caller-owned handle outlives the call — closing it would break the caller."""
+    _seed(db)
+    _tracked(db)
+
+    session_search(query="modpack", limit=1, db=db)
+
+    db.close.assert_not_called()
+
+
+def test_profile_db_is_closed_and_caller_db_untouched(tmp_path, db, monkeypatch):
+    """Cross-profile read swaps in a second handle — it must be closed too."""
+    _seed(db)
+    profile_db = _tracked(SessionDB(tmp_path / "other_state.db"))
+    _seed(profile_db, "s_other")
+    _tracked(db)
+
+    monkeypatch.setattr(
+        "tools.session_search_tool._resolve_profile_db", lambda profile: profile_db
+    )
+
+    session_search(query="modpack", limit=1, db=db, profile="other")
+
+    profile_db.close.assert_called_once()
+    db.close.assert_not_called()
+
+
+def test_self_opened_db_is_closed_on_early_return(tmp_path, monkeypatch):
+    """Every return path releases the handle, including the error shapes.
+
+    ``_resolve_profile_db`` raising returns a tool_error long before the normal
+    exit — the pre-fix code leaked the default handle on exactly these paths.
+    """
+    opened = []
+
+    def _factory(*args, **kwargs):
+        opened.append(_tracked(SessionDB(tmp_path / "state.db")))
+        return opened[-1]
+
+    def _boom(profile):
+        raise ValueError(f"profile '{profile}' does not exist")
+
+    monkeypatch.setattr("hermes_state.SessionDB", _factory)
+    monkeypatch.setattr("tools.session_search_tool._resolve_profile_db", _boom)
+
+    result = session_search(query="modpack", limit=1, profile="nope")
+
+    assert "does not exist" in result
+    assert len(opened) == 1
+    opened[0].close.assert_called_once()

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -871,103 +871,123 @@ def session_search(
     ``@session:<profile>/<id>`` link). Scroll wins over read/discovery when an
     anchor is set — the agent has asked for a specific slice.
     """
+    # Handles this call opened itself, closed on every exit path below. A
+    # caller-supplied ``db`` is never closed — it belongs to the caller (the
+    # ``_owns_session_db`` rule in agent/agent_init.py: whoever hands over a
+    # dedicated handle owns closing it). Left unclosed these keep their
+    # state.db/-wal fds *and* pin themselves through the token-writer's
+    # atexit hook, so GC never reclaims them: ~2 fds leaked per call for the
+    # life of the process (#83027).
+    _opened: List[Any] = []
     if db is None:
         try:
             from hermes_state import SessionDB
             db = SessionDB()
+            _opened.append(db)
         except Exception:
             logging.debug("SessionDB unavailable for session_search", exc_info=True)
             from hermes_state import format_session_db_unavailable
             return tool_error(format_session_db_unavailable(), success=False)
 
-    # Normalise a raw `@session:<profile>/<id>` link value passed as session_id.
-    # Session ids never contain "/", so a slash unambiguously means profile/id —
-    # always strip the prefix off the id, and adopt the embedded profile only
-    # when one wasn't passed explicitly. Handles every permutation the model
-    # might send (full value as id, with or without a separate profile=).
-    if isinstance(session_id, str) and "/" in session_id:
-        emb_profile, _, emb_id = session_id.partition("/")
-        if emb_id:
-            session_id = emb_id
-            if emb_profile and (profile is None or not str(profile).strip()):
-                profile = emb_profile
+    try:
+        # Normalise a raw `@session:<profile>/<id>` link value passed as session_id.
+        # Session ids never contain "/", so a slash unambiguously means profile/id —
+        # always strip the prefix off the id, and adopt the embedded profile only
+        # when one wasn't passed explicitly. Handles every permutation the model
+        # might send (full value as id, with or without a separate profile=).
+        if isinstance(session_id, str) and "/" in session_id:
+            emb_profile, _, emb_id = session_id.partition("/")
+            if emb_id:
+                session_id = emb_id
+                if emb_profile and (profile is None or not str(profile).strip()):
+                    profile = emb_profile
 
-    # Cross-profile read: swap in the named profile's DB (read-only) for every
-    # shape below. The current-session-lineage guards no longer apply across
-    # profiles, but they key off ids that won't collide, so they stay inert.
-    if profile is not None and str(profile).strip():
-        try:
-            profile_db = _resolve_profile_db(profile)
-        except Exception as e:
-            return tool_error(f"profile '{profile}': {e}", success=False)
-        if profile_db is not None:
-            db = profile_db
-            current_session_id = None
+        # Cross-profile read: swap in the named profile's DB (read-only) for every
+        # shape below. The current-session-lineage guards no longer apply across
+        # profiles, but they key off ids that won't collide, so they stay inert.
+        if profile is not None and str(profile).strip():
+            try:
+                profile_db = _resolve_profile_db(profile)
+            except Exception as e:
+                return tool_error(f"profile '{profile}': {e}", success=False)
+            if profile_db is not None:
+                db = profile_db
+                _opened.append(profile_db)
+                current_session_id = None
 
-    # Scroll shape takes precedence — explicit anchor beats any query.
-    if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
-        return _scroll(
-            db=db,
-            session_id=session_id,
-            around_message_id=around_message_id,
-            window=window,
-            current_session_id=current_session_id,
-        )
+        # Scroll shape takes precedence — explicit anchor beats any query.
+        if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:
+            return _scroll(
+                db=db,
+                session_id=session_id,
+                around_message_id=around_message_id,
+                window=window,
+                current_session_id=current_session_id,
+            )
 
-    # Read shape: a session_id with no anchor → dump the whole session.
-    if isinstance(session_id, str) and session_id.strip():
-        sid = session_id.strip()
-        result = _read_session(db, sid, link_profile=profile)
-        if json.loads(result).get("success"):
+        # Read shape: a session_id with no anchor → dump the whole session.
+        if isinstance(session_id, str) and session_id.strip():
+            sid = session_id.strip()
+            result = _read_session(db, sid, link_profile=profile)
+            if json.loads(result).get("success"):
+                return result
+
+            # Miss in the target profile — the model may have dropped the owning
+            # profile from the link. Scan every profile and read it from wherever
+            # it lives, tagging the profile it was found in.
+            located, owner = _locate_session_db(sid)
+            if located is not None:
+                try:
+                    found = json.loads(_read_session(located, sid, link_profile=owner))
+                finally:
+                    located.close()
+                if found.get("success"):
+                    found["profile"] = owner
+                    return json.dumps(found, ensure_ascii=False)
             return result
 
-        # Miss in the target profile — the model may have dropped the owning
-        # profile from the link. Scan every profile and read it from wherever
-        # it lives, tagging the profile it was found in.
-        located, owner = _locate_session_db(sid)
-        if located is not None:
+        # Limit clamp [1, 10]
+        if not isinstance(limit, int):
             try:
-                found = json.loads(_read_session(located, sid, link_profile=owner))
-            finally:
-                located.close()
-            if found.get("success"):
-                found["profile"] = owner
-                return json.dumps(found, ensure_ascii=False)
-        return result
+                limit = int(limit)
+            except (TypeError, ValueError):
+                limit = 3
+        limit = max(1, min(limit, 10))
 
-    # Limit clamp [1, 10]
-    if not isinstance(limit, int):
-        try:
-            limit = int(limit)
-        except (TypeError, ValueError):
-            limit = 3
-    limit = max(1, min(limit, 10))
+        # Browse shape: no query → recent sessions.
+        if not query or not isinstance(query, str) or not query.strip():
+            return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
 
-    # Browse shape: no query → recent sessions.
-    if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
+        # Parse role_filter
+        role_list: Optional[List[str]] = None
+        if isinstance(role_filter, str) and role_filter.strip():
+            role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 
-    # Parse role_filter
-    role_list: Optional[List[str]] = None
-    if isinstance(role_filter, str) and role_filter.strip():
-        role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
+        # Normalise sort
+        sort_norm: Optional[str] = None
+        if isinstance(sort, str):
+            candidate = sort.strip().lower()
+            if candidate in ("newest", "oldest"):
+                sort_norm = candidate
 
-    # Normalise sort
-    sort_norm: Optional[str] = None
-    if isinstance(sort, str):
-        candidate = sort.strip().lower()
-        if candidate in ("newest", "oldest"):
-            sort_norm = candidate
-
-    return _discover(
-        db=db,
-        query=query.strip(),
-        role_filter=role_list,
-        limit=limit,
-        sort=sort_norm,
-        current_session_id=current_session_id,
-        link_profile=profile,
-    )
+        return _discover(
+            db=db,
+            query=query.strip(),
+            role_filter=role_list,
+            limit=limit,
+            sort=sort_norm,
+            current_session_id=current_session_id,
+            link_profile=profile,
+        )
+    finally:
+        for _handle in _opened:
+            try:
+                _handle.close()
+            except Exception:
+                logging.debug(
+                    "session_search: closing an owned SessionDB failed",
+                    exc_info=True,
+                )
 
 
 def check_session_search_requirements() -> bool:


### PR DESCRIPTION
## What does this PR do?

`session_search()` opens two handles for its own use and closed neither:

1. the default `SessionDB()` when the caller passes no `db`
2. the read-only profile DB from `_resolve_profile_db()` on a cross-profile read

Neither is reclaimed by GC — once its token-writer thread starts a `SessionDB` pins itself through `atexit.register(_drain_token_queue_at_exit)`, and only `close()` unregisters it (`run_agent.py` documents exactly this for dedicated handles). So each call leaked ~2 fds (`state.db` + its WAL sidecar) for the life of the process.

This restores the rule `agent/agent_init.py` already states for `_owns_session_db`: **whoever hands over a dedicated handle owns closing it.** A caller-supplied `db` is never touched.

Both handles are tracked in a list rather than closing `db` directly, because the cross-profile path rebinds `db` to the profile DB — a `finally: db.close()` would close the wrong handle and still leak the original.

> **Reviewing tip:** the diff is mostly the re-indent for the `try` block. `git diff -w` shows the actual change (~20 lines).

## Related Issue

Fixes #83027

Also one of the fd sources behind #30230 (that issue attributes the growth to MCP subprocess pipes/sockets; this is separate and additive). Same bug class as #60859, different call site.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/session_search_tool.py` — track handles opened by the call in `_opened`, close them in a `finally`. Caller-supplied `db` untouched.
- `tests/tools/test_session_search_fd_leak.py` — 4 regression tests.

## How to Test

Reproduce the leak on `main` (macOS/Linux):

```python
import os, sys
sys.path.insert(0, ".")
from tools.session_search_tool import session_search

def fds(): return len(os.listdir("/dev/fd"))

base = fds()
for i in range(10):
    session_search(query=f"probe-{i}", limit=1)
print(base, "->", fds())     # main: 4 -> 24    this branch: 4 -> 4
```

The committed tests assert ownership rather than raw fd counts, so they are deterministic and platform-independent:

```
pytest tests/tools/test_session_search_fd_leak.py -q
```

- On this branch: **4 passed**
- With the fix reverted and only the tests applied: **3 failed, 1 passed** — the one that passes either way is `test_caller_supplied_db_is_not_closed`, which pins the half of the contract the old code got right by doing nothing.

Existing suite unaffected: `pytest tests/tools/test_session_search.py -q` → **39 passed**. `ruff check` on both files → clean.

## Field measurement

From a launchd-managed gateway running with the macOS default 256-fd soft limit:

- 3.5 h uptime → 283 fds total, of which **65 `state.db` + 57 `state.db-wal` = 122** were these handles
- `agent.log` showed **35** `session_search` calls over that window
- At the limit, three unrelated-looking failures appear at once while `hermes cron status` still reports ✓:
  - `Script execution failed: [Errno 24] Too many open files`
  - `cron.scheduler: unable to open database file` — execution records never finish, so jobs stick in `running`
  - `aiohttp ... ClientConnectorDNSError: Cannot connect to host ...:443 [nodename nor servname provided]`

That last one is the expensive part: fd exhaustion presents as a DNS outage, so the first hour goes into the network instead of into `lsof`.

## Note

`tools/react_to_message_tool.py` has the same shape — `_open_session_db()` returns a `SessionDB()` and the file contains no `close()` at all. It is gated to GUI surfaces so it may be unreachable in a headless gateway; left it out of this PR to keep the change reviewable, happy to add it here or in a follow-up.
