### PR TITLE
fix(agent): drop empty assistant messages after tool_call_id dedup

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3476,6 +3476,36 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # 4. Drop assistant messages left with nothing to send.  Step 3 empties an
+    # assistant message's tool_calls when every call it carried was a duplicate,
+    # which happens with models that reuse the same tool_call_id across turns
+    # (observed: kimi-k2.7-code re-emitting "terminal_121").  Strict providers
+    # reject the resulting content-less message with HTTP 400 "the message at
+    # position N with role 'assistant' must not be empty", and that error is
+    # non-retryable, so the whole turn dies.  Reasoning-bearing messages are kept
+    # so codex-style continuity is untouched.
+    pruned: List[Dict[str, Any]] = []
+    removed_empty = 0
+    for msg in messages:
+        if (
+            msg.get("role") == "assistant"
+            and not str(msg.get("content") or "").strip()
+            and not msg.get("tool_calls")
+            and not msg.get("function_call")
+            and not msg.get("reasoning")
+            and not msg.get("reasoning_content")
+            and not msg.get("reasoning_details")
+        ):
+            removed_empty += 1
+            continue
+        pruned.append(msg)
+    if removed_empty:
+        messages = pruned
+        _ra().logger.warning(
+            "Pre-call sanitizer: dropped %d empty assistant message(s)",
+            removed_empty,
+        )
     return messages
 
 


### PR DESCRIPTION
## Summary

Step 3 in `sanitize_api_messages()` deduplicates `tool_call_id`s across assistant messages. When every call in an assistant message's `tool_calls` list is a duplicate, the list becomes empty. If the same message also has empty `content` (normal for tool-only turns), the sanitizer produces an assistant message with no content and no tool calls.

Strict providers reject that with HTTP 400 "the message at position N with role 'assistant' must not be empty". The error is non-retryable, killing the turn. Worse, once persisted in session history, every subsequent request fails until the row is manually deactivated in `state.db`.

## Changes

Add a step 4 to `sanitize_api_messages()` that prunes assistant messages left with nothing to send after dedup. Messages carrying reasoning payloads (`reasoning`, `reasoning_content`, `reasoning_details`) or `function_call` are preserved so codex-style continuity is unaffected.

## Test Plan

- [x] All existing sanitize tests pass (14/14 in `test_message_sequence_repair.py`)
- [x] All guardrails + session meta filtering tests pass (29/29)
- [x] Syntax check passes

Fixes #82924