### PR TITLE
fix(desktop): keep pane resize sash clear of scrollbars

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -626,7 +626,9 @@ function Sash({
     <div
       className={cn(
         'group absolute z-20 [-webkit-app-region:no-drag]',
-        horizontal ? 'inset-y-0 left-0 w-[9px] -translate-x-1/2' : 'inset-x-0 top-0 h-[9px] -translate-y-1/2',
+        // Keep the hit target on the incoming pane. Centering it over the
+        // boundary covers the previous pane's right/bottom scrollbar.
+        horizontal ? 'inset-y-0 left-0 w-[5px]' : 'inset-x-0 top-0 h-[5px]',
         disabled ? 'pointer-events-none' : horizontal ? 'cursor-col-resize' : 'cursor-row-resize'
       )}
       onDoubleClick={disabled ? undefined : onDoubleClick}


### PR DESCRIPTION
## Summary

- move the pane sash hit target entirely onto the incoming pane side
- reduce the hit target from 9px to 5px while retaining resize affordance
- keep the previous pane right/bottom scrollbar fully accessible

This addresses the scrollbar hit-target portion of #83026. The separate Files/Review `20rem` maximum-width behavior is intentionally unchanged.

## Test plan

- `npm run typecheck --workspace apps/desktop`
- `vitest run --project ui src/components/pane-shell/tree/renderer/track-model-absorber.test.ts src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx` (11 tests passed)

## Manual verification

- rebuilt Hermes Desktop on Windows
- confirmed scrollbars adjacent to pane boundaries remain draggable
- confirmed pane resize remains available from the incoming pane side