### PR TITLE
fix(desktop): no-op branch switch on non-repo project lanes

### DIFF
--- a/apps/desktop/electron/git-worktree-ops.test.ts
+++ b/apps/desktop/electron/git-worktree-ops.test.ts
@@ -435,3 +435,38 @@ test('addWorktree: a remote default branch gets its own worktree, not a home swi
     fs.rmSync(cloneDir, { recursive: true, force: true })
   }
 })
+
+test('switchBranch: non-repo dir short-circuits instead of throwing', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-sw-'))
+
+  try {
+    // A plain folder pinned as a project (no .git): its lane label is the
+    // folder basename, not a branch — switching must no-op, not error, so
+    // callers like "+" new session can proceed with a plain session.
+    const result = await switchBranch(dir, '国创大赛', 'git')
+
+    assert.deepEqual(result, { branch: null })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('switchBranch: repo dir still validates the branch name and switches', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-sw-'))
+
+  try {
+    execFileSync('git', ['init', '-b', 'main'], { cwd: dir })
+    execFileSync('git', ['config', 'user.email', 't@example.com'], { cwd: dir })
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir })
+    execFileSync('git', ['commit', '--allow-empty', '-m', 'root'], { cwd: dir })
+
+    // Existing behaviour preserved: an illegal branch name still errors.
+    await assert.rejects(() => switchBranch(dir, '///', 'git'), /Branch name is required/)
+
+    // And switching to a real branch still works.
+    const result = await switchBranch(dir, 'main', 'git')
+    assert.deepEqual(result, { branch: 'main' })
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -437,6 +437,25 @@ async function listBranches(repoPath, gitBin) {
 
 async function switchBranch(repoPath, branch, gitBin) {
   const resolved = resolveRequestedPathForIpc(repoPath, { purpose: 'Branch switch' })
+
+  // Sidebar lanes exist for plain folders too (non-repo explicit projects),
+  // and their lane label is the folder basename — not a branch. `git switch`
+  // there is meaningless, and sanitizing that label would throw a misleading
+  // "Branch name is required." — so short-circuit for non-repo roots and let
+  // callers (e.g. "+" new session on the project lane) proceed with a plain
+  // session instead of aborting.
+  let inside = 'false'
+
+  try {
+    inside = (await runGit(gitBin, ['rev-parse', '--is-inside-work-tree'], resolved)).trim()
+  } catch {
+    // Not a git repo (or git unavailable): fall through to the short-circuit.
+  }
+
+  if (inside !== 'true') {
+    return { branch: null }
+  }
+
   const target = sanitizeBranch(branch)
 
   if (!target) {


### PR DESCRIPTION
## Problem

In Hermes Desktop, clicking the **"+" (new session)** button on a project lane whose root directory is **not a Git repository** (an explicit project pinned to a plain folder) fails with `无法切换到 <project>` / **"Branch name is required."** and the new session is **never created**.

The bug is intermittent: it only appears after the backend's first probe assigns a lane label (the folder basename) to the non-repo project — before that the label is `null` and the git step is skipped entirely (see #83028 for the full trigger-condition analysis).

## Root cause

`apps/desktop/electron/git-worktree-ops.ts` — `switchBranch` sanitizes the requested branch before verifying the path is even a repo:

```ts
async function switchBranch(repoPath, branch, gitBin) {
  const resolved = resolveRequestedPathForIpc(repoPath, { purpose: 'Branch switch' })
  const target = sanitizeBranch(branch)   // folder basename "国创大赛" → "" (non-ASCII dropped)
  if (!target) {
    throw new Error('Branch name is required.')   // ← aborts the whole "+ new session" flow
  }
  ...
}
```

A non-repo project's lane label is the folder **basename** (`_place_by_heuristic` in `tui_gateway/project_tree.py`), not a branch. `sanitizeBranch` drops non-ASCII characters, so a Chinese basename sanitizes to `""` → `throw new Error('Branch name is required.')`. The renderer's `handleNewSession` (`workspace-group.tsx`) catches this, shows the error toast, and `return`s — `onNewSession(group.path)` never runs.

## Fix

`switchBranch` now probes `git rev-parse --is-inside-work-tree` **before** sanitizing and short-circuits with `{ branch: null }` for roots that are not git work trees (or where git is unavailable), so callers like the project lane's "+" proceed with a plain session. Behavior for real repos is unchanged: an illegal/empty branch name still throws `Branch name is required.`, and switching to a valid branch still works.

## Tests

Two regression tests added to `electron/git-worktree-ops.test.ts`:

- `switchBranch: non-repo dir short-circuits instead of throwing` — a plain folder with a Chinese label no-ops with `{ branch: null }` instead of throwing.
- `switchBranch: repo dir still validates the branch name and switches` — in a real repo, an illegal branch name still rejects with `Branch name is required.`, and switching to `main` works.

Verified locally: `git-worktree-ops.test.ts` 18/18 pass; `npm run check:lint` 0 errors; full electron suite shows only pre-existing environment failures (ssh/packaging tests, identical with and without this change).

Fixes #83028
