### PR TITLE
fix(cli): drain stdin on every curses picker exit, and stop raw arrow keys clearing the search query

### DIFF
--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -574,11 +574,23 @@ def _run_curses_menu(
                     key = stdscr.getch()
 
                     if search.active:
-                        # Active search consumes query-editing keys; nav keys
-                        # fall through to be decoded below.
-                        handled, confirm, changed = _handle_active_search_key(
-                            curses, key, search
+                        # A raw 27 is ambiguous: it is either a lone ESC or the
+                        # introducer of a CSI/SS3 cursor sequence, which is how
+                        # many terminals still deliver arrow keys (see
+                        # _decode_menu_key). Run the continuation probe FIRST so
+                        # an arrow press moves the cursor instead of being read
+                        # as "stop searching and wipe the query".
+                        esc_action = (
+                            _decode_menu_key(stdscr, key) if key == 27 else None
                         )
+                        if esc_action is not None and esc_action != NAV_CANCEL:
+                            handled = confirm = changed = False
+                        else:
+                            # Active search consumes query-editing keys; nav keys
+                            # fall through to be decoded below.
+                            handled, confirm, changed = _handle_active_search_key(
+                                curses, key, search
+                            )
                         if changed:
                             scroll_offset = 0
                             cursor, cursor_pos = _reconcile_cursor(
@@ -593,7 +605,13 @@ def _run_curses_menu(
                             continue
                         if handled:
                             continue
-                        action = _decode_menu_key(stdscr, key)
+                        # An already-decoded ESC sequence must not be decoded a
+                        # second time — its bytes are gone from the queue.
+                        action = (
+                            esc_action
+                            if esc_action is not None
+                            else _decode_menu_key(stdscr, key)
+                        )
                     elif key == ord("/"):
                         search.active = True
                         continue

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -614,8 +614,16 @@ def _run_curses_menu(
                         result_holder[0] = outcome
                         return
 
-        curses.wrapper(_draw)
-        flush_stdin()
+        # Drain on EVERY exit path, not just the normal return. A
+        # KeyboardInterrupt or a curses error leaves exactly the same stray
+        # escape bytes in the OS input buffer, and the numbered fallback below
+        # calls input() as its very next statement. flush_stdin() no-ops on
+        # non-TTY stdin and swallows its own errors, so it cannot mask the
+        # exception that is unwinding.
+        try:
+            curses.wrapper(_draw)
+        finally:
+            flush_stdin()
         return result_holder[0] if result_holder[0] is not _KEEP else cancel_value
 
     except KeyboardInterrupt:

--- a/tests/hermes_cli/test_curses_ui_teardown.py
+++ b/tests/hermes_cli/test_curses_ui_teardown.py
@@ -1,0 +1,177 @@
+"""Regression tests for the shared curses picker's escape-byte handling.
+
+Two invariants are guarded here, both about raw escape bytes:
+
+1. ``flush_stdin()`` must run on EVERY exit path out of ``curses.wrapper()``.
+   ``curses.endwin()`` restores terminal modes but does not drain the OS input
+   buffer, so leftover CSI bytes from arrow keys survive into the next
+   ``input()``.  Every numbered fallback calls ``input()`` as its next
+   statement, so the curses-error path is exactly where the leak hurts most.
+2. While the type-to-filter prompt is open, a raw ``27`` must be decoded with
+   the escape-sequence continuation probe before it is treated as a lone ESC.
+   Terminals that deliver cursor keys as raw CSI otherwise wipe the query on
+   every arrow press.
+"""
+import sys
+
+import pytest
+
+# curses (and its _curses C extension) is Unix-only; skip the whole module on Windows.
+if sys.platform == "win32":
+    pytest.skip("curses is not available on Windows", allow_module_level=True)
+import curses
+
+from hermes_cli import curses_ui
+from hermes_cli.curses_ui import _KEEP, NAV_SELECT
+
+
+class FakeStdscr:
+    """Minimal stdscr stand-in that replays a queue of getch() byte returns.
+
+    ``getch`` pops from ``keys``; an empty queue yields ``-1`` (matching curses
+    non-blocking behavior). Drawing calls are recorded but otherwise inert.
+    """
+
+    def __init__(self, keys=()):
+        self.keys = list(keys)
+        self.timeouts = []
+
+    def getch(self):
+        return self.keys.pop(0) if self.keys else -1
+
+    def timeout(self, ms):
+        self.timeouts.append(ms)
+
+    def getmaxyx(self):
+        return 24, 80
+
+    def clear(self):
+        pass
+
+    def refresh(self):
+        pass
+
+    def addnstr(self, *args, **kwargs):
+        pass
+
+
+class _TtyStdin:
+    """stdin stand-in that reports a real TTY so the non-TTY guard is skipped."""
+
+    def isatty(self):
+        return True
+
+
+@pytest.fixture
+def flushes(monkeypatch):
+    """Record every ``flush_stdin()`` call made by the picker driver."""
+    calls = []
+    monkeypatch.setattr("sys.stdin", _TtyStdin())
+    monkeypatch.setattr(curses_ui, "flush_stdin", lambda: calls.append("flush"))
+    monkeypatch.setattr(curses, "curs_set", lambda _visibility: None)
+    monkeypatch.setattr(curses, "has_colors", lambda: False)
+    return calls
+
+
+def _menu_kwargs(**overrides):
+    """Minimal ``_run_curses_menu`` wiring: two rows, select resolves to index."""
+    kwargs = dict(
+        initial_cursor=0,
+        item_count=2,
+        draw_header=lambda stdscr, max_y, max_x: 2,
+        draw_row=lambda stdscr, y, idx, is_cursor, max_x: None,
+        on_action=lambda action, cursor: cursor if action == NAV_SELECT else _KEEP,
+        fallback=lambda: "fallback",
+        cancel_value="cancelled",
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_flush_stdin_runs_when_picker_is_interrupted(monkeypatch, flushes):
+    """Ctrl+C out of the picker must still drain the buffered escape bytes."""
+
+    def _interrupt(_draw):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(curses, "wrapper", _interrupt)
+
+    result = curses_ui._run_curses_menu(**_menu_kwargs())
+
+    assert result == "cancelled"
+    assert flushes == ["flush"]
+
+
+def test_flush_stdin_runs_before_the_numbered_fallback(monkeypatch, flushes):
+    """The fallback's first act is ``input()`` — the drain must precede it."""
+    flushes_at_fallback = []
+
+    def _explode(_draw):
+        raise curses.error("curses unavailable")
+
+    def _fallback():
+        flushes_at_fallback.append(len(flushes))
+        return "fallback"
+
+    monkeypatch.setattr(curses, "wrapper", _explode)
+
+    result = curses_ui._run_curses_menu(**_menu_kwargs(fallback=_fallback))
+
+    assert result == "fallback"
+    # Ordering, not just count: the fallback must observe the drain as done.
+    assert flushes_at_fallback == [1]
+
+
+def test_flush_stdin_still_runs_on_the_normal_path(monkeypatch, flushes):
+    """Guards against a regression that MOVES the flush instead of widening it."""
+
+    def _run(draw):
+        draw(FakeStdscr([10]))  # ENTER resolves the menu
+
+    monkeypatch.setattr(curses, "wrapper", _run)
+
+    result = curses_ui.curses_single_select("Pick one", ["alpha", "beta"])
+
+    assert result == 0
+    assert flushes == ["flush"]
+
+
+def test_raw_arrow_escape_does_not_wipe_the_active_search_query(monkeypatch, flushes):
+    """A raw CSI arrow-down while searching must move the cursor, not clear the query.
+
+    Keys: ``/`` opens search, ``b`` filters to ``beta``/``banana``, then the raw
+    three-byte arrow-down ``ESC [ B``, then ENTER. With the query intact the
+    cursor lands on ``banana`` (original index 2); if the leading ``27`` is
+    mistaken for a lone ESC the query is wiped and ENTER confirms ``beta`` (1).
+    """
+
+    def _run(draw):
+        draw(FakeStdscr([ord("/"), ord("b"), 27, ord("["), ord("B"), 10]))
+
+    monkeypatch.setattr(curses, "wrapper", _run)
+
+    result = curses_ui.curses_single_select(
+        "Pick one", ["alpha", "beta", "banana"], searchable=True
+    )
+
+    assert result == 2
+
+
+def test_lone_escape_still_stops_the_search_and_restores_the_full_list(
+    monkeypatch, flushes
+):
+    """A genuine lone ESC (no continuation byte) keeps its clear-the-query meaning."""
+
+    def _run(draw):
+        # The explicit -1 is the continuation probe timing out, i.e. no byte
+        # followed the ESC: a real lone ESC. ENTER then confirms the row the
+        # cursor was left on, proving the full list came back.
+        draw(FakeStdscr([ord("/"), ord("b"), 27, -1, 10]))
+
+    monkeypatch.setattr(curses, "wrapper", _run)
+
+    result = curses_ui.curses_single_select(
+        "Pick one", ["alpha", "beta", "banana"], searchable=True
+    )
+
+    assert result == 1  # "beta" — its index in the restored, unfiltered list


### PR DESCRIPTION
## This is a sibling follow-up to #7167 (merged 2026-04-10)

- **What #7167 covered:** it introduced `flush_stdin()` and wired it into
  `hermes_cli/curses_ui.py` so stray escape bytes left in the OS input buffer
  by a curses menu can't leak into the next `input()`.
- **What #7167 did NOT touch:** the call it added sits on the *normal return*
  path only. `_run_curses_menu`'s two abnormal exits — `except
  KeyboardInterrupt` and the `except Exception` branch that hands off to the
  numbered fallback — still return without draining.
- **What this adds:** the drain moves into a `finally`, so all three exits
  drain. Plus a second escape-byte defect in the same driver: a raw `27` during
  an active search is now decoded before it is treated as a lone ESC.

## What does this PR do?

Two bugs in `hermes_cli/curses_ui.py`'s shared picker driver, `_run_curses_menu`,
both about raw escape bytes.

**1. `flush_stdin()` only ran on the normal return path.**

```python
        curses.wrapper(_draw)
        flush_stdin()
        return result_holder[0] if result_holder[0] is not _KEEP else cancel_value

    except KeyboardInterrupt:
        return cancel_value
    except Exception:
        return fallback()
```

The invariant is stated in this file, by `flush_stdin`'s own docstring: it
*"must be called after `curses.wrapper()` … **before** the next `input()` /
`getpass.getpass()` call"*, because `curses.endwin()` restores the terminal but
does **not** drain the OS input buffer, so leftover escape-sequence bytes
"silently get consumed by the next `input()` call, corrupting user data".

To be precise about the blast radius: `curses.wrapper`'s teardown is
`keypad(0); echo(); nocbreak(); endwin()`, so terminal **modes** are restored
correctly. This is **not** a "terminal left unusable" bug. The claim is
narrower and concrete: buffered bytes leak into the next prompt.

The fallback path is where that bites hardest. All three numbered fallbacks
call `input()` as their next real statement — `_radio_numbered_fallback`,
`_numbered_single_fallback`, `_numbered_fallback` — so the one code path whose
entire job is *"curses died, let the user type a number instead"* goes from
curses teardown straight to `input()` with the buffer undrained. Stray bytes
are read as the answer, `int(val)` raises `ValueError`, and the picker silently
resolves to its cancel value without the user having answered. On the
Ctrl+C path the bytes survive into whatever the caller prompts for next.

Fixed by wrapping the wrapper call in `try/finally`. `import curses` stays
*outside* the inner `try` so an ImportError on Windows never triggers a
pointless flush, and `flush_stdin` already no-ops on non-TTY stdin and swallows
its own exceptions, so it cannot mask the error that is unwinding.

**2. A raw arrow key during an active search was read as "cancel the search".**

The driver reads `key = stdscr.getch()` and, when the type-to-filter prompt is
open, hands that raw byte to `_handle_active_search_key`, which treats any `27`
as a lone ESC and wipes `search.query`.

`_decode_menu_key` exists in this same module precisely because some
terminals/terminfo entries deliver cursor keys as raw CSI/SS3 sequences even
with `keypad(True)` — `getch()` returns `27`, then `[`, then `A`/`B` — and it
disambiguates with a 60 ms continuation probe. The search branch ran no such
probe. Repro on an affected terminal: `hermes model` → `/` → type `sonnet` →
press ↓. The query vanishes, the full list snaps back, and the cursor does not
move (the `[` and `B` tail bytes decode to `NAV_NONE` and are swallowed).

Now the driver decodes a `27` first and only routes a genuine `NAV_CANCEL`
(probe timed out ⇒ real lone ESC) to `_handle_active_search_key`. A decoded
arrow becomes the loop's action, so the cursor moves through the filtered list
with the query intact. `_handle_active_search_key` keeps its signature and its
lone-ESC semantics, which are still covered.

## Related Issue

No filed issue. Direct sibling completion of merged #7167; the interrupt-path
variant of the same drain already merged in #54058 (`flush_stdin()` on the
turn-interrupt path in `cli.py`). The raw-CSI terminal population is
repo-acknowledged — merged #35806 ("ESC + Ghostty") and the dedicated
`tests/hermes_cli/test_curses_arrow_keys.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/curses_ui.py` — `_run_curses_menu`: `curses.wrapper(_draw)` now
  runs under `try/finally` with `flush_stdin()` in the `finally`, so the
  KeyboardInterrupt and curses-error paths drain too.
- `hermes_cli/curses_ui.py` — `_run_curses_menu`: while search is active, a raw
  `27` is decoded via `_decode_menu_key` before `_handle_active_search_key` is
  allowed to treat it as a lone ESC; the already-consumed sequence is never
  decoded twice.
- `tests/hermes_cli/test_curses_ui_teardown.py` (new) — five regression tests,
  three of which fail on `main` today.

### Sibling sweep — deliberately not changed

There are three production `curses.wrapper(...)` sites. This PR fixes the
shared driver only; the other two are **left alone on purpose because I already
have open PRs holding those files**, and stacking an unrelated change into them
would make both harder to review:

| site | disposition |
|---|---|
| `hermes_cli/curses_ui.py` `_run_curses_menu` | **fixed here** |
| `hermes_cli/plugins_cmd.py` (`curses.wrapper` + `flush_stdin` on the normal path only) | not touched — file held by my open #80162 |
| `hermes_cli/main.py` `_session_browse_picker` (never calls `flush_stdin` on any path) | not touched — file held by my open #58336 |

Both have the same defect and are worth a follow-up; I did not want to bundle
them.

## Related / Positioning

- #40458 (@liuhao1024) also edits `_handle_active_search_key` and the
  `key = stdscr.getch()` line, but for a different bug — accepting `get_wch()`
  wide characters for CJK input. It adds no `finally` and no ESC continuation
  probe. Neither PR is a subset of the other; if both land the textual overlap
  is small and mechanical.
- #54711 (@hzhaoy) applies the same "route ESC through `_decode_menu_key`" idea,
  but in `hermes_cli/main.py`'s `_session_browse_picker` — a different function
  in a different file. It does not touch `curses_ui.py`.
- Searched `flush_stdin` across open PRs: no results.

## How to Test

Automated:

```
pytest tests/hermes_cli/test_curses_ui_teardown.py -v
```

Before/after on clean `main` (`56dc01d904d`), three of the five are red:

| test | on `main` | with this PR |
|---|---|---|
| `test_flush_stdin_runs_when_picker_is_interrupted` | FAIL — `assert [] == ['flush']` | PASS |
| `test_flush_stdin_runs_before_the_numbered_fallback` | FAIL — `assert [0] == [1]` (fallback sees zero drains) | PASS |
| `test_raw_arrow_escape_does_not_wipe_the_active_search_query` | FAIL — `assert 1 == 2` (query wiped, cursor never moved) | PASS |
| `test_flush_stdin_still_runs_on_the_normal_path` | PASS (guard) | PASS |
| `test_lone_escape_still_stops_the_search_and_restores_the_full_list` | PASS (guard) | PASS |

The two guards are deliberately green in both directions: one catches a
regression that *moves* the drain into the exception handlers instead of
widening it to every path, the other pins that a genuine lone ESC still stops
the search and restores the full list.

Manual (bug 2), on a terminal that emits raw CSI cursor keys (Ghostty, some
tmux/SSH terminfo combinations):

1. `hermes model`
2. Press `/`, type `sonnet`.
3. Press ↓.
4. Before: the filter is cleared and the whole list returns. After: the cursor
   moves to the next match and `Search: sonnet` stays on the hint line.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

I ran the curses/picker-adjacent suites rather than the full tree:
`test_curses_ui_teardown.py`, `test_curses_ui_search.py`, `test_curses_arrow_keys.py`,
`test_curses_ui_fuzzy_rank.py`, `test_curses_color_compat.py`,
`test_setup_menu_curses_migration.py`, `test_reasoning_effort_menu.py`,
`test_custom_provider_model_switch.py`, `test_model_switch_custom_providers.py`,
`test_plugins_cmd.py`, `test_session_browse.py` — 126 passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Windows: `import curses` stays outside the new inner `try`, so the ImportError
path is unchanged and no flush is attempted; `flush_stdin` is already a no-op
there. The new test module carries the same module-level `sys.platform ==
"win32"` skip as `test_curses_arrow_keys.py`.
