### PR TITLE
fix(gateway): raise macOS launchd file limit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4143,6 +4143,20 @@ def generate_launchd_plist() -> str:
     <key>ExitTimeOut</key>
     <integer>25</integer>
 
+    <!-- The gateway maintains Discord sockets and several SQLite-backed subsystems.
+         The macOS per-job default of 256 FDs is too small for long-lived gateway
+         workloads and can prevent new database or network connections. -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>8192</integer>
+    </dict>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1649,6 +1649,21 @@ class TestServiceWorkingDirIsStable:
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
 
+    def test_launchd_plist_reserves_fd_headroom_for_long_lived_gateway(
+        self, tmp_path, monkeypatch
+    ):
+        """macOS's 256-FD launchd default is insufficient for gateway SQLite/socket use."""
+        import plistlib
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["SoftResourceLimits"]["NumberOfFiles"] == 4096
+        assert plist["HardResourceLimits"]["NumberOfFiles"] == 8192
+
 
 class TestLaunchctlBootstrapEioRetry:
     """`_launchctl_bootstrap` must recover from a stale already-loaded label.


### PR DESCRIPTION
## Summary
- Set macOS launchd gateway soft/hard `NumberOfFiles` limits to 4096/8192.
- Prevents the default 256-FD cap from exhausting SQLite/socket capacity in long-lived Discord gateways.
- Add a plist regression test for both limits.

## Verification
- `.venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q` → 71 passed.
- Live macOS launchd gateway confirmed with the same 4096/8192 limits and Discord connected.