### PR TITLE
fix(mcp): suppress RuntimeError: Event loop is closed during shutdown

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2294,11 +2294,11 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                    except (asyncio.CancelledError, RuntimeError, Exception):
+                        pass  # RuntimeError: Event loop is closed — benign shutdown race
 
         if self._shutdown_event.is_set():
             return "shutdown"
@@ -2338,11 +2338,11 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                    except (asyncio.CancelledError, RuntimeError, Exception):
+                        pass  # RuntimeError: Event loop is closed — benign shutdown race
         if self._shutdown_event.is_set():
             return "shutdown"
         self._reconnect_event.clear()


### PR DESCRIPTION
## Problem

On every Hermes exit, two `Exception ignored in: <coroutine object MCPServerTask.run ...>` tracebacks are printed to stderr:

```
Traceback (most recent call last):
  File ".../tools/mcp_tool.py", line 3274, in run
    parked = await self._wait_for_reconnect_or_shutdown(
  File ".../tools/mcp_tool.py", line 2341, in _wait_for_reconnect_or_shutdown
    t.cancel()
  ...
RuntimeError: Event loop is closed
```

## Root cause

In `_wait_for_reconnect_or_shutdown`, the `finally` block calls `t.cancel()` before entering the `try/except`. When Hermes shuts down, the asyncio event loop is already closed by the time GC finalizes pending `MCPServerTask.run` coroutines — so `t.cancel()` raises `RuntimeError('Event loop is closed')` before reaching the `except` clause.

The existing `_mcp_loop_exception_handler` only catches exceptions routed through asyncio's internal exception handler; GC-triggered coroutine teardown bypasses it entirely.

## Fix

Move `t.cancel()` inside the `try` block so `RuntimeError` is caught alongside `CancelledError`. Both call sites in the method are patched identically.

## Testing

Reproduced locally by exiting Hermes with active MCP servers configured. After the patch, no tracebacks are printed on exit.