### PR TITLE
fix(codex): keep the reasoning-only continuation contract for GPT-5.x on third-party Responses endpoints

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -52,7 +52,39 @@ def _classify_responses_issuer(
     return "other"
 
 
+def _is_codex_family_issuer(issuer_kind: Optional[str], response: Any = None) -> bool:
+    """True when this response came from a Codex-contract Responses endpoint.
+
+    The native Codex/xAI/GitHub backends are identified by ``issuer_kind``.
+    Third-party relays of the same GPT-5.x weights (AWS Bedrock Mantle's
+    ``openai.gpt-5.x``, self-hosted Responses proxies) surface as
+    ``other:<base_url>`` because they are keyed on hostname, yet they inherit
+    the Codex behaviour where a reasoning-only item with ``status="completed"``
+    means "still thinking, call me again" rather than "final answer".
+
+    Treating those as ordinary providers ends the turn on a reasoning-only
+    response, which users experience as the model announcing an action and then
+    doing nothing. Fall back to the model id so the contract follows the model
+    family rather than the hostname that happens to serve it.
+    """
+    if issuer_kind in ("codex_backend", "xai_responses", "github_responses"):
+        return True
+    model = getattr(response, "model", None)
+    if not isinstance(model, str) or not model:
+        return False
+    m = model.strip().lower()
+    # Strip a vendor prefix in slash ("openai/gpt-5.6") or Bedrock-style dot
+    # ("openai.gpt-5.6-sol") form. Only treat the dot as a vendor separator
+    # when followed by gpt-5 so the version dot in "gpt-5.6" survives.
+    if "/" in m:
+        m = m.rsplit("/", 1)[-1]
+    elif re.match(r"^[a-z0-9_-]+\.gpt-5", m):
+        m = m.split(".", 1)[-1]
+    return m.startswith("gpt-5")
+
+
 # Throttle the per-process cross-issuer skip warning so we don't flood logs
+
 # when a long history contains many stale-issuer reasoning blocks.
 _CROSS_ISSUER_WARN_EMITTED = False
 
@@ -1612,10 +1644,19 @@ def _normalize_codex_response(
         # state — forcing "incomplete" causes multi-minute stalls as the
         # continuation path re-issues calls (3 retries × up to 240s each).
         # See https://github.com/NousResearch/hermes-agent/issues/64434
-        if response_status == "completed" and issuer_kind not in (
-            "codex_backend",
-            "xai_responses",
-            "github_responses",
+        #
+        # EXCEPTION — Codex-family models served from a third-party Responses
+        # endpoint (e.g. AWS Bedrock Mantle's openai.gpt-5.x). These are the
+        # same GPT-5.x weights as the native Codex backend and share its
+        # "reasoning-only item means I am mid-thought, call me again" contract,
+        # but they arrive here as issuer_kind="other:<base_url>" because the
+        # host is not chatgpt.com. Trusting status=="completed" for them ends
+        # the turn on a reasoning-only response, which the user experiences as
+        # the model narrating an intention and then silently doing nothing.
+        # Detect the model family instead of the hostname so the correct
+        # continuation contract applies on every surface that serves it.
+        if response_status == "completed" and not _is_codex_family_issuer(
+            issuer_kind, response
         ):
             finish_reason = "stop"
         else:

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -227,6 +227,90 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
     assert assistant_message.codex_reasoning_items is None
 
 
+def test_reasoning_only_gpt5_on_third_party_endpoint_stays_incomplete():
+    """Codex-family weights keep the continuation contract off-host.
+
+    AWS Bedrock Mantle relays the same GPT-5.x weights as the native Codex
+    backend, but ``_classify_responses_issuer`` keys on hostname, so it lands
+    as ``other:<base_url>``. Before this fix the #64434 branch trusted
+    ``status="completed"`` and returned ``stop``, ending the turn on a
+    reasoning-only response — the model would announce an action and then
+    silently do nothing.
+    """
+    mantle = "other:https://bedrock-mantle.us-east-1.api.aws/openai/v1"
+    response = SimpleNamespace(
+        status="completed",
+        model="openai.gpt-5.6-sol",
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_1",
+                encrypted_content="opaque",
+                summary=[],
+            )
+        ],
+        output_text="",
+    )
+
+    _, finish_reason = _normalize_codex_response(response, issuer_kind=mantle)
+
+    assert finish_reason == "incomplete"
+
+
+def test_reasoning_only_non_codex_model_on_third_party_endpoint_still_stops():
+    """#64434 must keep holding for genuinely non-Codex models.
+
+    Mantle also serves GLM/Qwen/DeepSeek. Those do not share the Codex
+    "reasoning-only means keep going" contract, so forcing ``incomplete``
+    would reintroduce the multi-minute continuation stalls #64434 fixed.
+    """
+    mantle = "other:https://bedrock-mantle.us-east-1.api.aws/openai/v1"
+    response = SimpleNamespace(
+        status="completed",
+        model="zai.glm-5",
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_1",
+                encrypted_content="opaque",
+                summary=[],
+            )
+        ],
+        output_text="",
+    )
+
+    _, finish_reason = _normalize_codex_response(response, issuer_kind=mantle)
+
+    assert finish_reason == "stop"
+
+
+def test_final_answer_from_third_party_gpt5_still_stops():
+    """The fix must not turn real answers into continuations."""
+    mantle = "other:https://bedrock-mantle.us-east-1.api.aws/openai/v1"
+    response = SimpleNamespace(
+        status="completed",
+        model="openai.gpt-5.6-sol",
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                phase="final_answer",
+                id="msg_1",
+                content=[SimpleNamespace(type="output_text", text="Done.")],
+            )
+        ],
+        output_text="Done.",
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(
+        response, issuer_kind=mantle
+    )
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == "Done."
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Codex-family models (GPT-5.x) served from a **third-party Responses endpoint** end their turn on a reasoning-only or `phase="commentary"`-only response, instead of continuing to do the work. The user sees the model announce an action — "I'm fixing that now", "Step 3/4: checking root disk usage." — and then the turn just stops. No tool call, no error, a clean `finish_reason=stop`.

The same model on the native ChatGPT Codex backend behaves correctly.

## Root cause

`_normalize_codex_response()` in `agent/codex_responses_adapter.py` implements #64434, which fixed multi-minute continuation stalls by trusting a provider's own `response.status`:

```python
if response_status == "completed" and issuer_kind not in (
    "codex_backend", "xai_responses", "github_responses",
):
    finish_reason = "stop"
else:
    finish_reason = "incomplete"
```

That allowlist is populated by `_classify_responses_issuer()`, which keys on **hostname**:

```python
if is_codex_backend:            # provider == "openai-codex" or chatgpt.com/backend-api/codex
    return "codex_backend"
if base_url:
    return f"other:{base_url}"
```

So any relay of the *same GPT-5.x weights* that isn't literally `chatgpt.com` — AWS Bedrock Mantle (`bedrock-mantle.<region>.api.aws/openai/v1`), a self-hosted Responses proxy, an enterprise gateway — is classified `other:<base_url>` and takes the `stop` branch.

GPT-5.x routinely emits turns whose entire `output` is a `reasoning` item (plus optionally a `phase="commentary"` message) with `status="completed"`, meaning "still mid-thought, call me again." On the native backend that's correctly read as `incomplete` and the continuation path re-elicits the tool call. Off-host it's read as a finished answer and the turn dies.

Reproduced against Bedrock Mantle `openai.gpt-5.6-sol`:

```
T0: tool_calls=1  messages=[]
T1: tool_calls=1  messages=[('commentary', 'Step 2/5 — Uptime.')]
T2: tool_calls=0  messages=[('commentary', 'Step 3/5 — Disk usage.')]   <-- turn ended here
```

## Fix

Classify by **model family** in addition to hostname. `_is_codex_family_issuer()` keeps the existing issuer allowlist and adds a fallback that strips a vendor prefix (`openai/gpt-5.6`, `openai.gpt-5.6-sol`) and checks for `gpt-5`:

```python
if response_status == "completed" and not _is_codex_family_issuer(issuer_kind, response):
    finish_reason = "stop"
else:
    finish_reason = "incomplete"
```

The dot-prefix strip is guarded on `.gpt-5` so the version dot in `gpt-5.6` is never treated as a vendor separator.

This is deliberately narrow. #64434's behavior is preserved for every genuinely non-Codex model, including ones served from the *same* endpoint:

| issuer | model | reasoning-only → |
|---|---|---|
| `codex_backend` | `gpt-5.6-sol` | `incomplete` (unchanged) |
| `other:…bedrock-mantle…` | `openai.gpt-5.6-sol` | `incomplete` (**fixed**) |
| `other:…bedrock-mantle…` | `openai.gpt-5.5` | `incomplete` (**fixed**) |
| `other:…bedrock-mantle…` | `zai.glm-5` | `stop` (unchanged) |
| `other:…bedrock-mantle…` | `qwen.qwen3-32b` | `stop` (unchanged) |
| `other:…bedrock-mantle…` | *no model field* | `stop` (unchanged) |

A real `phase="final_answer"` response still returns `stop` with its content intact, so genuine answers are never converted into continuations.

## Tests

Three cases added to `tests/agent/test_codex_responses_adapter.py`:

- `test_reasoning_only_gpt5_on_third_party_endpoint_stays_incomplete` — the regression
- `test_reasoning_only_non_codex_model_on_third_party_endpoint_still_stops` — guards #64434
- `test_final_answer_from_third_party_gpt5_still_stops` — guards against answer loss

Verified on a clean `origin/main` worktree:

- tests-only, without the fix → `test_reasoning_only_gpt5_on_third_party_endpoint_stays_incomplete` FAILS (`assert 'stop' == 'incomplete'`)
- with the fix → `19 passed`

Also green locally: `tests/agent/test_bedrock_adapter.py`, `tests/agent/test_intent_ack_continuation.py`, `tests/run_agent/test_run_agent_codex_responses.py`, `tests/agent/test_codex_ttfb_watchdog.py` (134 passed, 5 skipped), and `tests/run_agent/test_streaming.py` (32 passed with the `anthropic` extra installed).

## End-to-end verification

Same prompt, Bedrock Mantle `openai.gpt-5.6-sol`, before and after.

Before — 2 tool calls, then the turn ended on commentary:

```
5. assistant  len=35  tools=[]  'Step 3/4: checking root disk usage.'
```

After — 6 tool calls and a real answer:

```
1. Hostname: Orchuss-MacBook-Pro.local
2. Uptime: 48 days, 9 hours — load averages 1.83, 2.17, 2.18
3. Root /: 460 GiB size, 17 GiB used, 271 GiB available, 6% capacity
```

The stored session shows a commentary-only assistant turn mid-conversation that now continues instead of terminating.

## Note on `phase="commentary"`

Worth stating explicitly since it looks like a second bug: the terse fragments ("Step 2/5 — Uptime.") are the model's normal commentary channel, and Hermes already routes them to reasoning/interim display and keeps them out of assistant content. That part works. The defect was only that a commentary/reasoning-only turn was accepted as *final* on non-native issuers.
