### PR TITLE
docs(kanban): document the parent-link context handoff for follow-up cards

### DIFF
--- a/website/docs/user-guide/features/kanban-tutorial.md
+++ b/website/docs/user-guide/features/kanban-tutorial.md
@@ -294,6 +294,28 @@ This replaces the "dig through comments and the work output" dance that plagues 
 
 The bulk-close guard exists because this data is per-run. `hermes kanban complete a b c --summary X` (you, from the CLI) is refused — copy-pasting the same summary to three tasks is almost always wrong. Bulk close without the handoff flags still works for the common "I finished a pile of admin tasks" case. The tool surface doesn't expose a bulk variant at all; `kanban_complete` is always single-task-at-a-time for the same reason.
 
+## Follow-up on a done card — CI remediation via the parent link
+
+Story 1's implementation card is `done`. Two hours later CI fails on the merged branch. Don't reopen the done card — completed cards are history, and their handoff flows forward. Create a remediation card with the done card as its **parent**:
+
+```bash
+hermes kanban create "Fix CI: test_backoff_jitter flakes on 3.11" \
+    --assignee backend-dev \
+    --parent t_impl \
+    --workspace worktree --branch wt/ci-fix-backoff \
+    --body "CI run #4812 failed after t_impl completed.
+FAILED tests/test_retry.py::test_backoff_jitter - TimeoutError
+Acceptance: tests/test_retry.py green on 3.11 and 3.12."
+```
+
+Three things make this work:
+
+- **Immediate dispatch.** Because the parent is already `done`, the child is created straight into `ready` — the dispatcher can claim it on the next tick. (A child of a still-open parent would wait in `todo`.)
+- **Inherited context.** The remediation worker's context includes a *Parent task results* section carrying `t_impl`'s completion summary and metadata — the changed files and decisions the original worker recorded — so it knows why the code is shaped the way it is before reading a line of it.
+- **Fresh evidence in the body.** The CI log didn't exist when `t_impl` completed, so it can't be in the parent's handoff — it goes in the new card's body, alongside explicit acceptance criteria.
+
+Prefer a fresh worktree/branch for the remediation card. Checking out the original branch gives the worker repo *state* but none of the *rationale* — the parent handoff carries that. Same assignee profile is usually right: the profile that wrote the code has the skills to fix it.
+
 ## Inspecting a task currently running
 
 For completeness — here's the drawer of a task still in flight (the API implementation from Story 1, claimed by `backend-dev` but not yet complete):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -879,6 +879,40 @@ The board supports these eight patterns without any new primitives:
 
 For worked examples of each, see `docs/hermes-kanban-v1-spec.pdf`.
 
+## Handing context to follow-up cards (the parent link)
+
+A parent link is not just a scheduling gate — it is the context handoff channel from a **completed** card to a new one. When you create a card with `--parent <done-card-id>`, two things happen:
+
+1. **It's immediately eligible.** `create_task` sets status by parent state: a child whose parents are all `done` is created directly in `ready` — no waiting, no manual promotion. (Children of still-open parents sit in `todo` until `recompute_ready` promotes them when the last parent finishes.)
+2. **The parent's handoff rides along.** The worker context assembled for the child (`build_worker_context`, what `kanban_show()` returns) contains a `## Parent task results` section with each parent's completion `summary` and `metadata`, verbatim:
+
+```
+## Parent task results
+### t_77c26979 (completed just now)
+Added exponential backoff with jitter to the retry helper.
+_metadata_: `{"changed_files": ["hermes_cli/retry.py", "tests/test_retry.py"], "decisions": ["capped backoff at 60s", "jitter = full"]}`
+```
+
+This is why the pattern for follow-up work on a finished card is **a new child card, not reopening the done card**. Completed cards are immutable history — their context flows forward through the parent link. Same-card rework (retry loops on a failing card) is a different mechanism: prior attempts on the *same* card surface as "prior attempts" in that card's own context.
+
+A worktree or branch alone is not a substitute: repo state tells the follow-up worker *what* the code looks like, but not *why* — the decisions, tests run, and files touched live in the parent's structured handoff, not in git. Evidence that didn't exist when the parent completed (e.g. a CI log that failed later) belongs in the new card's **body**.
+
+```bash
+# Implementation card t_impl is done. CI fails two hours later.
+hermes kanban create "Fix CI failure from t_impl: test_retry flakes on 3.11" \
+    --assignee coder \
+    --parent t_impl \
+    --body "$(cat <<'EOF'
+CI run #4812 failed after t_impl merged.
+Log excerpt: FAILED tests/test_retry.py::test_backoff_jitter - TimeoutError
+Acceptance: tests/test_retry.py green on 3.11 and 3.12 in CI.
+Use a fresh worktree/branch; do not force-push the original branch.
+EOF
+)"
+```
+
+The remediation worker spawns with the original card's summary and metadata (changed files, decisions) already in context, plus the fresh evidence you put in the body.
+
 ## Multi-tenant usage
 
 When one specialist fleet serves multiple businesses, tag each task with a tenant:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban-tutorial.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban-tutorial.md
@@ -293,6 +293,28 @@ Run 1 — `crashed`，错误为 `OOM kill at row 2.3M (process 99999 gone)`。Ru
 
 批量关闭保护的存在正是因为这些数据是按 run 存储的。`hermes kanban complete a b c --summary X`（你，从 CLI 执行）会被拒绝——将相同的 summary 复制粘贴到三个任务几乎总是错误的。不带交接标志的批量关闭仍然适用于常见的"我完成了一堆行政任务"场景。工具界面根本不提供批量变体；`kanban_complete` 始终是单任务操作，原因相同。
 
+## 已完成卡片的后续工作 — 通过父任务链接进行 CI 修复
+
+场景一的实现卡片已经 `done`。两小时后，合并分支上的 CI 失败了。不要重开已完成的卡片——已完成的卡片是历史，它的交接内容会向前流动。创建一张以该卡片为**父任务**的修复卡片：
+
+```bash
+hermes kanban create "Fix CI: test_backoff_jitter flakes on 3.11" \
+    --assignee backend-dev \
+    --parent t_impl \
+    --workspace worktree --branch wt/ci-fix-backoff \
+    --body "CI run #4812 failed after t_impl completed.
+FAILED tests/test_retry.py::test_backoff_jitter - TimeoutError
+Acceptance: tests/test_retry.py green on 3.11 and 3.12."
+```
+
+三个要点让这个模式生效：
+
+- **立即调度。** 由于父任务已经 `done`，子任务直接以 `ready` 状态创建——调度器在下一个 tick 就能认领它。（父任务尚未完成的子任务会停在 `todo` 等待。）
+- **继承的上下文。** 修复 worker 的上下文包含 *Parent task results* 部分，携带 `t_impl` 的完成 summary 和 metadata——原 worker 记录的改动文件与决策——因此它在读任何一行代码之前就知道代码为什么是现在这个样子。
+- **正文中的新证据。** CI 日志在 `t_impl` 完成时尚不存在，不可能出现在父任务的交接中——所以它写在新卡片的正文里，连同明确的验收标准。
+
+修复卡片优先使用全新的 worktree/分支。检出原分支只能给 worker 仓库*状态*，但没有*缘由*——缘由由父任务交接携带。assignee 通常沿用同一 profile：写这段代码的 profile 也具备修复它的技能。
+
 ## 检查当前正在运行的任务
 
 作为补充——以下是一个仍在执行中的任务的抽屉视图（场景一中的 API 实现，已被 `backend-dev` 认领但尚未完成）：

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -635,6 +635,40 @@ Gateway 平台有实际的消息长度限制。如果 `/kanban list`、`/kanban 
 
 每种模式的详细示例，请参阅 `docs/hermes-kanban-v1-spec.pdf`。
 
+## 向后续卡片传递上下文（父任务链接）
+
+父任务链接不只是调度门槛——它是从**已完成**卡片向新卡片传递上下文的通道。当你用 `--parent <已完成卡片id>` 创建卡片时，会发生两件事：
+
+1. **立即可调度。** `create_task` 根据父任务状态设置新卡片的状态：所有父任务均为 `done` 的子任务直接以 `ready` 状态创建——无需等待，无需手动提升。（父任务尚未完成的子任务停在 `todo`，直到最后一个父任务完成后由 `recompute_ready` 提升。）
+2. **父任务的交接内容随之而来。** 为子任务组装的 worker 上下文（`build_worker_context`，即 `kanban_show()` 返回的内容）包含 `## Parent task results` 部分，逐字呈现每个父任务的完成 `summary` 和 `metadata`：
+
+```
+## Parent task results
+### t_77c26979 (completed just now)
+Added exponential backoff with jitter to the retry helper.
+_metadata_: `{"changed_files": ["hermes_cli/retry.py", "tests/test_retry.py"], "decisions": ["capped backoff at 60s", "jitter = full"]}`
+```
+
+这就是为什么对已完成卡片的后续工作应当**创建新的子卡片，而不是重开已完成的卡片**。已完成的卡片是不可变的历史——它的上下文通过父任务链接向前流动。同卡片返工（失败卡片上的重试循环）是另一种机制：*同一张*卡片的先前尝试会作为"prior attempts"出现在该卡片自己的上下文中。
+
+单靠 worktree 或分支无法替代这一点：仓库状态告诉后续 worker 代码*是什么样*，但不告诉它*为什么*——决策、运行过的测试、改动的文件都在父任务的结构化交接中，而不在 git 里。父任务完成时尚不存在的证据（例如后来才失败的 CI 日志）应写入新卡片的**正文**。
+
+```bash
+# 实现卡片 t_impl 已完成。两小时后 CI 失败。
+hermes kanban create "Fix CI failure from t_impl: test_retry flakes on 3.11" \
+    --assignee coder \
+    --parent t_impl \
+    --body "$(cat <<'EOF'
+CI run #4812 failed after t_impl merged.
+Log excerpt: FAILED tests/test_retry.py::test_backoff_jitter - TimeoutError
+Acceptance: tests/test_retry.py green on 3.11 and 3.12 in CI.
+Use a fresh worktree/branch; do not force-push the original branch.
+EOF
+)"
+```
+
+修复 worker 启动时，原卡片的 summary 和 metadata（改动的文件、决策）已在其上下文中，再加上你写入正文的新证据。
+
 ## 多租户使用
 
 当一个专家团队为多个业务提供服务时，为每个任务添加租户标签：


### PR DESCRIPTION
## Summary

Documents the kanban parent-link context handoff: creating a follow-up card with a **completed** card as its parent gives the new worker the parent's completion summary and metadata automatically — the pattern for CI-remediation and other post-completion follow-ups, instead of trying to reopen done cards.

Community-driven: a user modeling a coder→reviewer→CI-remediation pipeline couldn't discover this (it took three rounds of Discord back-and-forth); it works today but was documented nowhere.

## Changes

- `website/docs/user-guide/features/kanban.md`: new "Handing context to follow-up cards (the parent link)" section — immediate eligibility of children of done parents, the `## Parent task results` context block, why branch state alone is insufficient, new-child-vs-reopen contrast
- `website/docs/user-guide/features/kanban-tutorial.md`: worked CI-remediation example (`--parent` flag, fresh evidence in the card body)
- zh-Hans mirrors for both pages

## Validation

Every claim live-verified against real `kanban_db` on an isolated board (`HERMES_KANBAN_DB=/tmp/...`), real venv imports:

| Claim | Result |
|---|---|
| complete_task(summary, metadata) on card A | done ✓ |
| create_task B, parents=[A] after A done | created directly in `ready` ✓ |
| build_worker_context(B) contains A's summary + metadata | verbatim `## Parent task results` block ✓ |
| Negative control: child of not-done parent | stays `todo` ✓ |

Docs build: `docusaurus build` green (en + zh-Hans).

## Infographic

![The parent link is the context handoff](https://v3b.fal.media/files/b/0aa5c11b/Q_gb7b0TK_vSYD6HoBT61_RT03Amwj.png)
