### PR TITLE
fix(pricing): add Claude Opus 5 to the official-docs snapshot

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -151,6 +151,26 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
         pricing_version="openai-gpt-5.6-2026-07",
     ),
+    # ── Anthropic Claude Opus 5 ──────────────────────────────────────────
+    # Launched 2026-07-25. Same sticker as Opus 4.5/4.6/4.7/4.8: $5/$25 per
+    # MTok, cache read at the standard 90% discount ($0.50), 5-minute cache
+    # write at 1.25x input ($6.25). The 1-hour cache write ($10.00/MTok, 2x
+    # input) has no field in PricingEntry — cache_write_cost_per_million is
+    # the 5-minute rate, matching every other Anthropic entry in this table —
+    # so a 1h-TTL session is under-costed by the same margin as its siblings.
+    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    (
+        "anthropic",
+        "claude-opus-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-07",
+    ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
     # model ID with 2x premium (vs the 6x premium on older Opus generations).


### PR DESCRIPTION
## Problem

The sealed official-docs pricing table has entries for Claude Opus 4.8 and Claude Sonnet 5, but none for `claude-opus-5`. A direct Anthropic session on that model therefore falls through as unknown and reports no estimated cost.

That is more than a display gap. Any budget check or spend report that deliberately relies on the sealed snapshot sees the lane as free even while it is consuming paid tokens.

Current main still has no `("anthropic", "claude-opus-5")` entry or alias. The existing Anthropic name-normalization path already handles the `anthropic/` prefix, so the missing data row is the only gap.

## Fix

Add an official-docs snapshot row for `claude-opus-5` using the published rates:

- input: $5.00 per million tokens;
- output: $25.00 per million tokens;
- cache read: $0.50 per million tokens;
- five-minute cache write: $6.25 per million tokens.

`PricingEntry` has one cache-write field. As with the other Anthropic entries, the row records the five-minute rate there and documents the one-hour $10.00 rate rather than changing the pricing schema in a one-model update.

The row retains the existing `official_docs_snapshot` provenance and links to Anthropic's pricing documentation. No lookup or normalization behavior changes.

## Testing

I would add table-driven coverage that verifies:

- direct lookup of `claude-opus-5` returns the four expected Decimal rates and official-docs provenance;
- the `anthropic/claude-opus-5` form resolves to the same row;
- cost calculation includes uncached input, output, cache reads, and cache writes at those rates;
- a genuinely unknown future model still reports unknown rather than inheriting this entry.

The carried patch is a data-only change and does not yet include that regression test; I would add it on the upstream branch before opening the PR.

## Test run

Rebased on current `main` and re-verified:
`scripts/run_tests.sh tests/agent/test_usage_pricing.py — 11 passed`, 0 failed.
