### PR TITLE
fix(config): clear stale key_env on provider switch

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1046,10 +1046,12 @@ def clear_model_endpoint_credentials(
     clear_api_key: bool = True,
     clear_api_mode: bool = True,
     clear_base_url: bool = False,
+    clear_key_env: bool = True,
 ) -> Dict[str, Any]:
     """Remove stale inline endpoint credentials from a model config.
 
     ``model.api_key`` is valid only for explicit custom endpoint assignments.
+    ``model.key_env`` names an environment variable for those assignments.
     Built-in providers resolve credentials from env vars, auth.json, or the
     credential pool. When switching away from a custom endpoint, leaving these
     fields behind keeps secrets in config.yaml and can contaminate later custom
@@ -1064,6 +1066,8 @@ def clear_model_endpoint_credentials(
         model_cfg.pop("api_mode", None)
     if clear_base_url:
         model_cfg.pop("base_url", None)
+    if clear_key_env:
+        model_cfg.pop("key_env", None)
     return model_cfg
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -15,6 +15,7 @@ from hermes_cli.config import (
     get_compatible_custom_providers,
     _explicit_config_paths,
     _normalize_max_turns_config,
+    clear_model_endpoint_credentials,
     is_provider_enabled,
     load_config,
     load_env,
@@ -244,6 +245,36 @@ class TestSaveAndLoadRoundtrip:
 
 
 
+
+
+class TestClearModelEndpointCredentials:
+    def test_clears_key_env_with_endpoint_credentials_by_default(self):
+        model_cfg = {
+            "provider": "custom-provider",
+            "api_key": "sk-old",
+            "api": "legacy-old",
+            "api_mode": "chat_completions",
+            "base_url": "https://old.example.test/v1",
+            "key_env": "HERMES_CUSTOM_OLD_API_KEY",
+        }
+
+        clear_model_endpoint_credentials(model_cfg, clear_base_url=True)
+
+        assert "api_key" not in model_cfg
+        assert "api" not in model_cfg
+        assert "api_mode" not in model_cfg
+        assert "base_url" not in model_cfg
+        assert "key_env" not in model_cfg
+
+    def test_can_preserve_key_env_when_caller_needs_it(self):
+        model_cfg = {
+            "provider": "custom-provider",
+            "key_env": "HERMES_CUSTOM_PROVIDER_API_KEY",
+        }
+
+        clear_model_endpoint_credentials(model_cfg, clear_key_env=False)
+
+        assert model_cfg["key_env"] == "HERMES_CUSTOM_PROVIDER_API_KEY"
 
 
 class TestSaveEnvValueSecure:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2006,6 +2006,51 @@ class TestBuildSchemaFromConfig:
 # ---------------------------------------------------------------------------
 
 
+class TestMainModelAssignment:
+    def test_provider_switch_clears_stale_key_env(self):
+        from hermes_cli.web_server import _apply_main_model_assignment
+
+        model_cfg = {
+            "provider": "huawei-modelarts",
+            "default": "glm-5.2",
+            "base_url": "https://api.modelarts-maas.com/v2",
+            "key_env": "HERMES_CUSTOM_HUAWEI_MODELARTS_API_KEY",
+            "api_mode": "chat_completions",
+        }
+
+        result = _apply_main_model_assignment(
+            model_cfg,
+            provider="openai-api",
+            model="gpt-5.6-sol",
+        )
+
+        assert result["provider"] == "openai-api"
+        assert result["default"] == "gpt-5.6-sol"
+        assert result["base_url"] == ""
+        assert "key_env" not in result
+        assert "api_mode" not in result
+
+    def test_same_provider_repick_preserves_key_env(self):
+        from hermes_cli.web_server import _apply_main_model_assignment
+
+        model_cfg = {
+            "provider": "custom-provider",
+            "default": "old-model",
+            "base_url": "https://custom.example.test/v1",
+            "key_env": "HERMES_CUSTOM_PROVIDER_API_KEY",
+        }
+
+        result = _apply_main_model_assignment(
+            model_cfg,
+            provider="custom-provider",
+            model="new-model",
+        )
+
+        assert result["default"] == "new-model"
+        assert result["base_url"] == "https://custom.example.test/v1"
+        assert result["key_env"] == "HERMES_CUSTOM_PROVIDER_API_KEY"
+
+
 class TestConfigRoundTrip:
     """Verify config survives GET → edit → PUT without data loss."""
 


### PR DESCRIPTION
## Summary
- clear `model.key_env` as part of stale endpoint credential cleanup
- preserve `key_env` when callers explicitly opt out or when re-picking a model under the same provider
- add regression coverage for Desktop main-model assignment and the shared config helper

Fixes #82963.

## Tests
- `.venv/bin/python -m pytest tests/hermes_cli/test_config.py::TestClearModelEndpointCredentials tests/hermes_cli/test_web_server.py::TestMainModelAssignment -q`
- `.venv/bin/python -m pytest tests/hermes_cli/test_custom_provider_model_switch.py::TestCustomProviderModelSwitch::test_key_env_custom_provider_persists_reference_not_secret tests/hermes_cli/test_custom_provider_model_switch.py::TestCustomProviderModelSwitch::test_key_env_providers_dict_entry_does_not_add_api_key -q`
- `.venv/bin/python -m pytest tests/hermes_cli/test_config.py::TestClearModelEndpointCredentials tests/hermes_cli/test_web_server.py::TestMainModelAssignment tests/hermes_cli/test_custom_provider_model_switch.py -q`
- `.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestConfigRoundTrip::test_round_trip_preserves_schema_invisible_nested_keys -q`
- `.venv/bin/python -m ruff check hermes_cli/config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_web_server.py`
- `git diff --check -- hermes_cli/config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_web_server.py`