### PR TITLE
fix(bedrock): claude-opus-5 missing from BEDROCK_CONTEXT_LENGTHS

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1413,6 +1413,7 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     "anthropic.claude-fable-5":      1_000_000,
     "anthropic.claude-fable":        1_000_000,
     "anthropic.claude-sonnet-5":     1_000_000,
+    "anthropic.claude-opus-5":       1_000_000,
     "anthropic.claude-opus-4-8":     1_000_000,
     "anthropic.claude-opus-4-7":     1_000_000,
     "anthropic.claude-opus-4-6":     1_000_000,

--- a/tests/agent/test_bedrock_1m_context.py
+++ b/tests/agent/test_bedrock_1m_context.py
@@ -61,3 +61,65 @@ class TestBedrockContext1MBeta:
         # Other common betas still present — no regression.
         assert "interleaved-thinking-2025-05-14" in beta_header
         assert "fine-grained-tool-streaming-2025-05-14" in beta_header
+
+
+class TestBedrockContextTableParity:
+    """``BEDROCK_CONTEXT_LENGTHS`` must agree with ``DEFAULT_CONTEXT_LENGTHS``.
+
+    The two tables are maintained by hand and the Bedrock one carries a
+    comment requiring the 1M entries to match. Nothing enforced it, so
+    ``claude-opus-5`` was added to ``DEFAULT_CONTEXT_LENGTHS`` while the
+    Bedrock table kept falling through to the generic
+    ``anthropic.claude-opus-4`` (200K) entry — the agent then compressed
+    at 200K on a model that serves 1M.
+
+    This is a parity invariant, not a snapshot: it derives the expected
+    value from the source table, so a future model only has to be added
+    in one place for the mismatch to be caught rather than hardcoded here.
+    """
+
+    def _bedrock_lookup(self, bedrock_table, model_id):
+        """Resolve a Bedrock model id the way the adapter does: longest key."""
+        matches = [(len(k), v) for k, v in bedrock_table.items() if k in model_id]
+        return max(matches)[1] if matches else None
+
+    def test_1m_claude_models_match_across_tables(self):
+        from agent.bedrock_adapter import BEDROCK_CONTEXT_LENGTHS
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+
+        mismatches = []
+        for model, expected in DEFAULT_CONTEXT_LENGTHS.items():
+            # Only bare Claude ids with a 1M window; skip dotted aliases,
+            # which are spelling variants of an entry already covered.
+            if not model.startswith("claude-") or "." in model:
+                continue
+            if expected != 1_000_000:
+                continue
+            actual = self._bedrock_lookup(
+                BEDROCK_CONTEXT_LENGTHS, f"anthropic.{model}"
+            )
+            if actual != expected:
+                mismatches.append(
+                    f"anthropic.{model}: bedrock={actual} metadata={expected}"
+                )
+
+        assert not mismatches, (
+            "BEDROCK_CONTEXT_LENGTHS is out of sync with "
+            "DEFAULT_CONTEXT_LENGTHS for 1M-context Claude models. The "
+            "agent will compress prematurely on Bedrock for:\n  "
+            + "\n  ".join(mismatches)
+        )
+
+    def test_non_1m_claude_models_not_widened(self):
+        """Guard the other direction: 200K models must stay 200K."""
+        from agent.bedrock_adapter import BEDROCK_CONTEXT_LENGTHS
+
+        for model_id in (
+            "anthropic.claude-haiku-4-5",
+            "anthropic.claude-sonnet-4-5",
+            "anthropic.claude-opus-4",
+        ):
+            assert self._bedrock_lookup(BEDROCK_CONTEXT_LENGTHS, model_id) == 200_000, (
+                f"{model_id} must remain 200K — a longest-key regression here "
+                "would over-advertise context and cause hard API errors"
+            )


### PR DESCRIPTION
claude-opus-5 was added to `DEFAULT_CONTEXT_LENGTHS` in 306c9f7661, but `BEDROCK_CONTEXT_LENGTHS` was not updated — even though its own comment requires the 1M entries to match:

```
# These 1M entries must match agent/model_metadata.py
# DEFAULT_CONTEXT_LENGTHS or the agent compresses context prematurely.
```

Bedrock ids are resolved by longest-substring match, so `anthropic.claude-opus-5` had no entry, fell through to the generic `anthropic.claude-opus-4`, and resolved to **200K**.

### Effect

On Bedrock the agent compresses at 200K for a model that serves 1M, silently discarding context the user already paid to load. No error surfaces — it just quietly truncates.

### Verification

The 1M window is real; a live Anthropic endpoint rejects an oversized prompt with its actual ceiling:

```
prompt is too long: 8460056 tokens > 1000000 maximum
```

### Tests

Rather than hardcode another model list that can drift the same way, the added test derives the expected value from `DEFAULT_CONTEXT_LENGTHS`, so a future 1M model only has to be added in one place for a mismatch to fail CI. Confirmed it fails without the one-line fix:

```
anthropic.claude-opus-5: bedrock=None metadata=1000000
```

A second test guards the opposite direction — `haiku-4-5`, `sonnet-4-5`, and `opus-4` must stay 200K, so a longest-key regression that over-advertises context (which would cause hard API errors rather than silent truncation) also fails.

`tests/agent/test_bedrock_1m_context.py` — 4 passed.