### PR TITLE
fix(plugins): scope hindsight config-drift check to plugin-managed keys (#82943)

### DIFF
--- a/contributors/emails/chinmayrawat15@gmail.com
+++ b/contributors/emails/chinmayrawat15@gmail.com
@@ -1,0 +1,1 @@
+Chinmayrawat15

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -566,6 +566,29 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
+# Every env key this plugin owns in the hindsight-embed profile `.env`.
+#
+# The file is shared: `hindsight_embed.ProfileManager.create_profile` re-renders
+# it from its own bundled template on every `ensure_running` — including the
+# "daemon already healthy, reuse it" path — and writes keys the plugin never
+# emits, notably `HINDSIGHT_API_PORT`. Scoping the config-drift check to these
+# keys keeps a foreign key from reading as a local config change. (#82943)
+#
+# Deliberately a fixed set rather than `expected.keys()`: two of these are
+# emitted conditionally, so *removing* `llm_base_url` (or `idle_timeout`) from
+# the config must still count as a change — a subset-of-expected compare would
+# silently miss that and leave the stale value live in the daemon.
+# `test_managed_keys_cover_every_built_key` pins this set to the builder below.
+_MANAGED_PROFILE_ENV_KEYS = frozenset({
+    "HINDSIGHT_API_LLM_PROVIDER",
+    "HINDSIGHT_API_LLM_API_KEY",
+    "HINDSIGHT_API_LLM_MODEL",
+    "HINDSIGHT_API_LOG_LEVEL",
+    "HINDSIGHT_API_LLM_BASE_URL",
+    "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT",
+})
+
+
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
@@ -602,6 +625,26 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
     return env_values
+
+
+def _embedded_profile_env_changed(saved: dict[str, str], expected: dict[str, str]) -> bool:
+    """Has a plugin-managed key in the saved profile env drifted from *expected*?
+
+    Only `_MANAGED_PROFILE_ENV_KEYS` are compared, so keys owned by
+    `hindsight_embed` itself (`HINDSIGHT_API_PORT`, and anything else its
+    template grows) never read as a local config change. Reading both sides
+    with `.get()` means an edited, added *or removed* managed key all register.
+
+    Missing and empty are treated as the same state: `_build_embedded_profile_env`
+    renders an unset value as `""` for the keys it always emits and omits the
+    conditional ones entirely, so `KEY=` and "no KEY" mean the same thing here.
+    Without that, a template that seeds a managed key as empty would reintroduce
+    exactly the permanent-restart loop this check exists to avoid. (#82943)
+    """
+    return any(
+        (saved.get(key) or "") != (expected.get(key) or "")
+        for key in _MANAGED_PROFILE_ENV_KEYS
+    )
 
 
 def _embedded_profile_env_path(config: dict[str, Any]):
@@ -1797,7 +1840,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     profile_env = _embedded_profile_env_path(self._config)
                     expected_env = _build_embedded_profile_env(self._config)
                     saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                    config_changed = _embedded_profile_env_changed(saved, expected_env)
 
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)

--- a/tests/plugins/memory/test_hindsight_config_drift.py
+++ b/tests/plugins/memory/test_hindsight_config_drift.py
@@ -1,0 +1,216 @@
+"""Regression tests for the embedded Hindsight config-drift check (#82943).
+
+The hindsight-embed profile ``.env`` has two writers. The plugin owns the LLM
+settings; ``hindsight_embed.ProfileManager.create_profile`` re-renders the same
+file from its own bundled template on every ``ensure_running`` — including the
+"daemon already healthy, reuse it" path — and writes ``HINDSIGHT_API_PORT``,
+which the plugin never emits.
+
+A whole-dict ``saved != expected`` compare therefore never matched, so the
+"config changed" branch fired on every single session start and stopped a
+daemon that was already healthy (SIGTERM reads as a clean exit, so an
+externally supervised unit never restarts). These tests pin the comparison to
+the keys the plugin actually manages, in both directions: foreign keys must be
+ignored, and real drift — including *removal* of a conditionally-emitted key —
+must still be caught.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from plugins.memory.hindsight import (
+    _MANAGED_PROFILE_ENV_KEYS,
+    _build_embedded_profile_env,
+    _embedded_profile_env_changed,
+    _embedded_profile_env_path,
+    _load_simple_env,
+    _materialize_embedded_profile_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Keep every profile-env write inside the temp dir, never ``~/.hindsight``."""
+    isolated_home = tmp_path / "user-home"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: isolated_home))
+    return isolated_home
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_env(monkeypatch):
+    """``_build_embedded_profile_env`` falls back to these when config omits them."""
+    monkeypatch.delenv("HINDSIGHT_API_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("HINDSIGHT_IDLE_TIMEOUT", raising=False)
+
+
+_CONFIG = {
+    "profile": "hermes",
+    "llm_provider": "openai",
+    "llm_model": "gpt-4o-mini",
+}
+
+# Exercises both conditionally-emitted keys.
+_CONFIG_FULL = {
+    **_CONFIG,
+    "llm_base_url": "https://example.invalid/v1",
+    "idle_timeout": 900,
+}
+
+
+def _expected(config=_CONFIG):
+    return _build_embedded_profile_env(config, llm_api_key="sk-test")
+
+
+# ---------------------------------------------------------------------------
+# The bug: a key owned by hindsight_embed must not read as local config drift
+# ---------------------------------------------------------------------------
+
+
+def test_foreign_daemon_key_does_not_trigger_restart():
+    """#82943: ``HINDSIGHT_API_PORT`` is written by hindsight_embed, not by the
+    plugin. Its presence alone must not restart a healthy daemon."""
+    expected = _expected()
+    saved = {**expected, "HINDSIGHT_API_PORT": "9177"}
+
+    assert _embedded_profile_env_changed(saved, expected) is False
+
+
+def test_unknown_future_daemon_keys_are_also_ignored():
+    """The guarantee is "keys we don't manage", not a HINDSIGHT_API_PORT
+    special case — the template is free to grow new keys."""
+    expected = _expected()
+    saved = {
+        **expected,
+        "HINDSIGHT_API_PORT": "9177",
+        "HINDSIGHT_API_HOST": "127.0.0.1",
+        "HINDSIGHT_DB_PATH": "/var/lib/hindsight/db",
+    }
+
+    assert _embedded_profile_env_changed(saved, expected) is False
+
+
+def test_identical_managed_env_is_not_a_change():
+    expected = _expected()
+
+    assert _embedded_profile_env_changed(dict(expected), expected) is False
+
+
+# ---------------------------------------------------------------------------
+# Real drift must still be caught — the check has to stay useful
+# ---------------------------------------------------------------------------
+
+
+def test_changed_managed_value_is_detected():
+    expected = _expected()
+    saved = {**expected, "HINDSIGHT_API_LLM_MODEL": "some-older-model"}
+
+    assert _embedded_profile_env_changed(saved, expected) is True
+
+
+def test_rotated_api_key_is_detected():
+    expected = _expected()
+    saved = {**expected, "HINDSIGHT_API_LLM_API_KEY": "sk-previous"}
+
+    assert _embedded_profile_env_changed(saved, expected) is True
+
+
+def test_missing_managed_key_is_detected():
+    expected = _expected()
+    saved = {k: v for k, v in expected.items() if k != "HINDSIGHT_API_LLM_PROVIDER"}
+    saved["HINDSIGHT_API_LLM_PROVIDER"] = ""
+
+    assert _embedded_profile_env_changed(saved, expected) is True
+
+
+def test_removed_conditional_key_is_detected():
+    """Dropping ``llm_base_url`` from the config removes the key from *expected*
+    while the stale value lives on in the saved file. A subset-of-expected
+    compare would miss this; the fixed managed-key set catches it."""
+    saved = _expected(_CONFIG_FULL)
+    expected = _expected(_CONFIG)  # no llm_base_url, no idle_timeout
+
+    assert "HINDSIGHT_API_LLM_BASE_URL" in saved
+    assert "HINDSIGHT_API_LLM_BASE_URL" not in expected
+    assert _embedded_profile_env_changed(saved, expected) is True
+
+
+def test_added_conditional_key_is_detected():
+    saved = _expected(_CONFIG)
+    expected = _expected(_CONFIG_FULL)
+
+    assert _embedded_profile_env_changed(saved, expected) is True
+
+
+def test_missing_and_empty_managed_value_are_equivalent():
+    """``_build_embedded_profile_env`` renders an unset value as ``""`` for the
+    keys it always emits and omits the conditional ones, so ``KEY=`` and a
+    missing KEY describe the same state. Treating them as different would
+    reintroduce the permanent-restart loop via an empty template placeholder."""
+    expected = _expected()
+    saved = {**expected, "HINDSIGHT_API_LLM_BASE_URL": ""}
+
+    assert "HINDSIGHT_API_LLM_BASE_URL" not in expected
+    assert _embedded_profile_env_changed(saved, expected) is False
+
+
+# ---------------------------------------------------------------------------
+# The managed-key set must stay pinned to the builder
+# ---------------------------------------------------------------------------
+
+
+def test_managed_keys_cover_every_built_key():
+    """Invariant: every key ``_build_embedded_profile_env`` can emit is declared
+    managed. Without this, a new key added to the builder would be compared
+    against nothing and silently stop triggering a restart."""
+    for config in (_CONFIG, _CONFIG_FULL):
+        built = set(_build_embedded_profile_env(config, llm_api_key="sk-test"))
+        assert built <= _MANAGED_PROFILE_ENV_KEYS, (
+            f"builder emits keys not declared in _MANAGED_PROFILE_ENV_KEYS: "
+            f"{sorted(built - _MANAGED_PROFILE_ENV_KEYS)}"
+        )
+
+    # Guard against the assertion above passing vacuously: the maximal config
+    # must actually exercise the conditionally-emitted keys.
+    full = set(_build_embedded_profile_env(_CONFIG_FULL, llm_api_key="sk-test"))
+    assert {"HINDSIGHT_API_LLM_BASE_URL", "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"} <= full
+
+
+# ---------------------------------------------------------------------------
+# End-to-end over the real file, the way the daemon path actually runs
+# ---------------------------------------------------------------------------
+
+
+def test_materialized_env_plus_daemon_port_key_is_stable_on_reload():
+    """The real loop: the plugin writes the profile env, hindsight_embed appends
+    its port key, and the next session start re-reads the file. That second read
+    must not report a config change."""
+    profile_env = _materialize_embedded_profile_env(_CONFIG, llm_api_key="sk-test")
+
+    # hindsight_embed re-renders the file and adds the key the plugin never emits.
+    with profile_env.open("a", encoding="utf-8") as fh:
+        fh.write("HINDSIGHT_API_PORT=9177\n")
+
+    saved = _load_simple_env(profile_env)
+    expected = _build_embedded_profile_env(_CONFIG, llm_api_key="sk-test")
+
+    assert saved["HINDSIGHT_API_PORT"] == "9177"
+    assert _embedded_profile_env_changed(saved, expected) is False, (
+        "a healthy daemon would be SIGTERMed on every session start"
+    )
+
+
+def test_real_config_edit_still_restarts_after_daemon_wrote_its_port_key():
+    """The complement: a genuine config change is still caught even once the
+    foreign port key is present in the file."""
+    profile_env = _materialize_embedded_profile_env(_CONFIG, llm_api_key="sk-test")
+    with profile_env.open("a", encoding="utf-8") as fh:
+        fh.write("HINDSIGHT_API_PORT=9177\n")
+
+    saved = _load_simple_env(profile_env)
+    expected = _build_embedded_profile_env(
+        {**_CONFIG, "llm_model": "gpt-4o"}, llm_api_key="sk-test"
+    )
+
+    assert _embedded_profile_env_changed(saved, expected) is True
+    assert _embedded_profile_env_path(_CONFIG) == profile_env


### PR DESCRIPTION
## What does this PR do?

The embedded-hindsight profile `.env` has **two writers**. This plugin owns the LLM settings; `hindsight_embed.ProfileManager.create_profile` re-renders the same file from its own bundled template on every `ensure_running` — including the "daemon already healthy, reuse it" early return — and writes `HINDSIGHT_API_PORT`, a key `_build_embedded_profile_env` never emits.

`_start_daemon` compared the two dicts whole:

```python
expected_env = _build_embedded_profile_env(self._config)
saved = _load_simple_env(profile_env)
config_changed = saved != expected_env      # foreign key ⇒ never equal
```

So the foreign key alone guaranteed a mismatch. The "config changed" branch fired on **every session start** and called `client._manager.stop(profile)` on a daemon that was already healthy. A clean SIGTERM looks like a normal exit, so an externally supervised unit's `Restart=on-failure` never fires and supervision is silently lost (real failure chain documented in the issue).

Verified against `main` before writing anything: `HINDSIGHT_API_PORT` appears **nowhere** in the plugin, while `_load_simple_env` returns every key in the file — so the two sides can never be equal once the daemon has run once. `hindsight_embed` is an external dependency (`hindsight-client==0.6.1`), so Hermes can't change the writer; the plugin-side comparison is the only place this can be fixed.

**Why a fixed key set rather than the obvious `expected.keys()` subset compare.** `HINDSIGHT_API_LLM_BASE_URL` and `HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT` are emitted *conditionally*. Comparing only the keys present in `expected` would stop detecting their **removal** — drop `llm_base_url` from your config and the stale value silently stays live in the daemon. I implemented that simpler variant first and confirmed it fails `test_removed_conditional_key_is_detected`, which is why the set is fixed and pinned to the builder by `test_managed_keys_cover_every_built_key`.

Missing and empty compare equal, matching how the builder renders an unset value (`str(current_key or "")`, conditional keys omitted). Without that, a template that seeds a managed key as empty would reintroduce the exact same permanent-restart loop.

## Related Issue

Fixes #82943

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - Added `_MANAGED_PROFILE_ENV_KEYS` — the six env keys the plugin owns in the profile `.env`.
  - Added `_embedded_profile_env_changed(saved, expected)` — drift check scoped to those keys, reading both sides with `.get()` so an edited, added *or removed* managed key all register.
  - `_start_daemon` now calls it instead of `saved != expected_env`. One-line behavior change; the surrounding restart logic is untouched.
- `tests/plugins/memory/test_hindsight_config_drift.py` — new, 12 tests.
- `contributors/emails/chinmayrawat15@gmail.com` — required by the Contributor Attribution Check workflow. (Also added by my open #82979; identical content, so the two should not conflict. Happy to drop it here if that one lands first.)

Scope check: `saved != expected` at `__init__.py:1674` was the only instance of this pattern in the tree — I grepped `plugins/` and `hermes_cli/` for sibling config-drift compares, and the other `!= expected` hits are unrelated (auth tokens, mem0 vector dims, and the metrics contract's deliberate exact-set semantics). No other call path needed the same fix.

## How to Test

```bash
scripts/run_tests.sh tests/plugins/memory/test_hindsight_config_drift.py
```

**Proof the tests capture the bug** — reverting just the comparison to `saved != expected` fails exactly the 4 regression tests while the 8 "real drift is still caught" tests keep passing, so the fix demonstrably doesn't weaken the check:

```
FAILED ...::test_foreign_daemon_key_does_not_trigger_restart
FAILED ...::test_unknown_future_daemon_keys_are_also_ignored
FAILED ...::test_missing_and_empty_managed_value_are_equivalent
FAILED ...::test_materialized_env_plus_daemon_port_key_is_stable_on_reload
4 failed, 8 passed
```

Coverage: foreign key ignored · unknown future daemon keys ignored · identical env is no-change · changed value detected · rotated API key detected · missing managed key detected · **removed** conditional key detected · added conditional key detected · missing≡empty · managed-set pinned to the builder (non-vacuously) · plus two end-to-end tests that materialize the real file, append `HINDSIGHT_API_PORT` the way the daemon does, reload it through `_load_simple_env`, and assert both stability *and* that a genuine config edit still restarts.

Manual repro of the original symptom needs a live embedded daemon; the two E2E tests reproduce the exact file state that caused it (`Path.home()` redirected to `tmp_path`, so nothing touches `~/.hindsight`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.13

> Test note: `scripts/run_tests.sh tests/plugins/` is green for every hindsight file (25 tests across 5 files). `tests/plugins/memory/test_hindsight_provider.py` has 6 failures locally, but they reproduce **identically on unmodified `origin/main`** and are purely environmental — the optional `hindsight-client` extra isn't installed (`FeatureUnavailable: lazy installs disabled`). Nothing in this PR touches those paths, and the new tests deliberately need no optional extra.

### Documentation & Housekeeping

- [x] Documentation — N/A (internal helper; rationale captured in the constant/function docstrings)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact — pure dict comparison, no platform-specific paths; `scripts/check-windows-footguns.py` clean on both changed files
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Notes for the reviewer

- **Relationship to #83003** (for #82944): complementary, not overlapping. That PR adds an opt-in `externally_managed` flag so the plugin skips `.stop()` for supervised daemons; this removes the *spurious* restart for everyone, including Hermes-owned daemons that were being cycled needlessly on every session. They touch adjacent lines in `_start_daemon` — mine changes the condition, theirs the body — so whichever lands second may need a trivial rebase. I'm happy to do that.
- **Deliberately not changed:** `_materialize_embedded_profile_env` still rewrites the file with only the plugin's keys, dropping `HINDSIGHT_API_PORT`. That path now runs only on a *real* config change, where the daemon is being restarted anyway and `hindsight_embed` re-renders its own keys — and preserving a foreign port value across a restart seemed more likely to be wrong than right. Easy to add if you'd prefer it.
- Lint: `ruff` clean; `ty` reports the same 17 pre-existing diagnostics before and after this change (0 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQJi5t651AYwdi4Jd9mSuT
