### PR TITLE
fix(feishu): trust adapter's group intake decision in gateway authz

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -645,6 +645,11 @@ class GatewayAuthorizationMixin:
                         profile=adapter_profile,
                     ):
                         return True
+                    # Adapter's own group_policy check (open/allowlist/etc.)
+                    # is already a trustworthy intake decision — the adapter
+                    # gates at intake with its own policy + @mention check.
+                    if effective_policy == "open":
+                        return True
                 else:
                     effective_policy = self._adapter_dm_policy(
                         source.platform,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1484,6 +1484,7 @@ def check_feishu_requirements() -> bool:
 class FeishuAdapter(BasePlatformAdapter):
     """Feishu/Lark bot adapter."""
 
+    enforces_own_access_policy = True  # gateway authz trusts our _admit intake
     supports_code_blocks = True  # Feishu renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 


### PR DESCRIPTION
What does this PR do?
    
    FeishuAdapter already gates group messages at intake via _admit():
    - Checks group_policy (open / allowlist / disabled)
    - Enforces @mention requirement via _require_mention_for()
    
    However, the gateway's _is_user_authorized did not trust this intake decision because FeishuAdapter lacked enforces_own_access_policy = True. This meant that in a group with group_policy=open and FEISHU_DM_POLICY=pairing, messages from any unpaired user were silently dropped — even though the adapter had already checked and admitted them.
    
    This PR fixes the gap by:
    
    1. Declaring enforces_own_access_policy = True on FeishuAdapter, so the gateway knows to honour the adapter's intake decision.
    2. In authz_mixin._is_user_authorized, trusting the adapter when group_policy=open for group/forum/channel traffic (the adapter already enforces its own rules like @mention before admitting the message).
    
    Behavior after this fix
    
    | Scenario                                                   | Before                    | After                                           |
    |------------------------------------------------------------|---------------------------|-------------------------------------------------|
    | Group chat, group_policy=open, unpaired user @mentions bot | ❌ Silently ignored       | ✅ Admitted                                     |
    | Group chat, group_policy=open, user doesn't @mention bot   | ❌ Silently ignored       | ❌ Still rejected by adapter's _require_mention |
    | DM, FEISHU_DM_POLICY=pairing, unpaired user                | ✅ Pairing handshake sent | ✅ Same (unchanged)                             |
    | DM, paired user                                            | ✅ Works                  | ✅ Same (unchanged)                             |
    
    Type of Change
    
    - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
    
    Changes Made
    
    - plugins/platforms/feishu/adapter.py (+1 line): Added enforces_own_access_policy = True class attribute to FeishuAdapter.
    - gateway/authz_mixin.py (+5 lines): In _is_user_authorized, after checking _adapter_group_has_sender_allowlist, added a check: if an enforces-own-policy adapter uses group_policy=open for group traffic, the adapter's intake decision is trusted.
    
    How to Test
    
    1. Configure Hermes with Feishu platform:
       - FEISHU_GROUP_POLICY=open
       - FEISHU_DM_POLICY=pairing
       - No FEISHU_ALLOW_ALL_USERS or GATEWAY_ALLOW_ALL_USERS
       - User A (paired) can DM the bot
    2. In a group chat, have User B (unpaired) @mention the bot
       - Before fix: Bot silently ignores
       - After fix: Bot responds
    3. User B sends a DM to the bot
       - Before: Pairing handshake sent
       - After: Same (unchanged)
    
    Checklist
    
    Code
    
    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [ ] I've run pytest tests/ -q and all tests pass
    - [ ] I've added tests for my changes
    - [x] I've tested on my platform: macOS 12.7.6