### PR TITLE
fix: raise manual /compress RPC timeout to 600s

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -629,7 +629,7 @@ describe('usePromptActions /compress', () => {
     expect(requestGateway).toHaveBeenCalledWith(
       'session.compress',
       expect.objectContaining({ session_id: RUNTIME_SESSION_ID }),
-      120_000
+      600_000
     )
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
     expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
@@ -763,7 +763,7 @@ describe('usePromptActions /compress', () => {
     expect(requestGateway).toHaveBeenCalledWith(
       'session.compress',
       expect.objectContaining({ focus_topic: 'the auth refactor' }),
-      120_000
+      600_000
     )
   })
 
@@ -870,7 +870,7 @@ describe('usePromptActions /compress', () => {
     act(() => {
       submitted = handle!.submitTextRaw('/compress')
     })
-    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.compress', expect.anything(), 120_000))
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.compress', expect.anything(), 600_000))
 
     // Switch to session B before compression resolves.
     activeSessionIdRef.current = RUNTIME_SESSION_B
@@ -929,7 +929,7 @@ describe('usePromptActions /compress', () => {
     act(() => {
       submitted = handle!.submitTextRaw('/compress')
     })
-    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.compress', expect.anything(), 120_000))
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.compress', expect.anything(), 600_000))
     activeSessionIdRef.current = RUNTIME_SESSION_B
     storedSessionIdRef.current = 'stored-b'
     rejectCompress(new Error('compression failed'))

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -67,10 +67,14 @@ import {
   withSessionNotFoundResume
 } from './utils'
 
-// Manual compression is LLM-bound and routinely outlives the desktop's 30s
-// default WS request timeout on large sessions — give it the TUI client's
-// 120s RPC budget (HERMES_TUI_RPC_TIMEOUT_MS default) instead.
-const SESSION_COMPRESS_TIMEOUT_MS = 120_000
+// Manual compression is LLM-bound: one summarisation call over the whole
+// session, routinely outliving the desktop's 30s default WS request timeout
+// on large histories or slow providers. The server-side auxiliary compression
+// timeout is floored at 300s, so a 120s client budget abandons the RPC while
+// the server keeps working — the user sees an error while the compression
+// actually lands. Give it 10 minutes, matching the server-side compute-host
+// wait (600s) and the auxiliary.compression.timeout default (600s).
+const SESSION_COMPRESS_TIMEOUT_MS = 600_000
 const WAKE_START_TIMEOUT_MS = 180_000
 
 const wakeDeviceLabel = (device?: WakeInputDeviceStatus): string => {

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -925,7 +925,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "timeout": 600,        # seconds — compression summarises large contexts; increase for local models
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
         },

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2517,7 +2517,7 @@ def _(rid, params: dict) -> dict:
                 route_name="session.compress",
                 command=command,
                 wait=True,
-                timeout=120.0,
+                timeout=600.0,
             )
         except Exception as exc:
             return _err(rid, 5019, f"compute-host compress failed: {exc}")


### PR DESCRIPTION
## Summary

The desktop client hardcoded a **120s budget** for the `session.compress` RPC (`SESSION_COMPRESS_TIMEOUT_MS`). Manual `/compress` is one LLM summarisation call over the **whole session**, and routinely exceeds 2 minutes on large histories or slow providers — the server-side auxiliary compression timeout is already floored at **300s** (`_COMPRESSION_TIMEOUT_FLOOR_SECONDS`), so the client was abandoning the RPC *while the server kept working*.

**Observed symptom:** `/compress` shows `request timed out after 120s: session.compress`, while the compression actually lands server-side a little later (the chat bar drops, but the transcript never gets replaced and no summary notice appears).

## Changes

Align all three timeout walls at **600s** (10 min):

| Location | Before | After |
|---|---|---|
| `apps/desktop/.../slash.ts` — `SESSION_COMPRESS_TIMEOUT_MS` | 120_000 | 600_000 |
| `tui_gateway/methods_session.py` — compute-host `session.compress` wait | 120.0 | 600.0 |
| `hermes_cli/config_defaults.py` — `auxiliary.compression.timeout` default | 120 | 600 |

Desktop tests asserting the RPC timeout value updated to match (4 assertions).

## Why 600s

- The server-side LLM call is floored at 300s today, so a 120s client budget can never cover a legitimate long summary.
- The compute-host control wait mirrored the old client budget; both move together.
- 600s is the same figure already used for gateway agent timeouts (`gateway_timeout`) — a bounded, consistent ceiling.

## Test Plan

- `python3 -m py_compile hermes_cli/config_defaults.py tui_gateway/methods_session.py` ✅
- TS assertion counts verified (4× `600_000`, zero `120_000` left in the compress path) ✅
- No other tests pin the old values (swept `tests/` for `compress…120` / `timeout=120.0`) ✅