### PR TITLE
fix(web): gate tools by provider capability

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -531,20 +531,36 @@ def _compute_tool_definitions(
                         filtered_tools[i] = {"type": "function", "function": dynamic}
                         break
 
-    # Strip web tool cross-references from browser_navigate description when
-    # web_search / web_extract are not available.  The static schema says
-    # "prefer web_search or web_extract" which causes the model to hallucinate
-    # those tools when they're missing.
+    # Keep browser_navigate's web-tool references aligned with the tools that
+    # actually passed their capability checks. Search-only providers such as
+    # DDGS must not leave a tempting but guaranteed-to-fail web_extract hint.
     if "browser_navigate" in available_tool_names:
         web_tools_available = {"web_search", "web_extract"} & available_tool_names
-        if not web_tools_available:
+        if web_tools_available != {"web_search", "web_extract"}:
             for i, td in enumerate(filtered_tools):
                 if td.get("function", {}).get("name") == "browser_navigate":
                     desc = td["function"].get("description", "")
-                    desc = desc.replace(
-                        " For simple information retrieval, prefer web_search or web_extract (faster, cheaper).",
-                        "",
-                    )
+                    if web_tools_available == {"web_search"}:
+                        desc = desc.replace(
+                            "prefer web_search or web_extract (faster, cheaper)",
+                            "prefer web_search (faster, cheaper)",
+                        ).replace(
+                            "curl via the terminal tool or web_extract",
+                            "curl via the terminal tool",
+                        )
+                    elif web_tools_available == {"web_extract"}:
+                        desc = desc.replace(
+                            "prefer web_search or web_extract (faster, cheaper)",
+                            "prefer web_extract (faster, cheaper)",
+                        )
+                    else:
+                        desc = desc.replace(
+                            " For simple information retrieval, prefer web_search or web_extract (faster, cheaper).",
+                            "",
+                        ).replace(
+                            "curl via the terminal tool or web_extract",
+                            "curl via the terminal tool",
+                        )
                     filtered_tools[i] = {
                         "type": "function",
                         "function": {**td["function"], "description": desc},

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -362,6 +362,42 @@ class TestLegacyToolsetMap:
             assert name in _LEGACY_TOOLSET_MAP, f"Missing legacy toolset: {name}"
 
 
+class TestBrowserWebCapabilityDescription:
+    def test_search_only_toolset_removes_web_extract_references(self, monkeypatch):
+        from model_tools import _compute_tool_definitions
+
+        browser_schema = {
+            "type": "function",
+            "function": {
+                "name": "browser_navigate",
+                "description": (
+                    "Navigate. For simple information retrieval, prefer web_search or "
+                    "web_extract (faster, cheaper). For plain text prefer curl via the "
+                    "terminal tool or web_extract."
+                ),
+            },
+        }
+        search_schema = {
+            "type": "function",
+            "function": {"name": "web_search", "description": "Search."},
+        }
+        monkeypatch.setattr(
+            "model_tools.registry.get_definitions",
+            lambda names, quiet=False: [browser_schema, search_schema],
+        )
+
+        definitions = _compute_tool_definitions(
+            enabled_toolsets=["browser_tools", "web_tools"], quiet_mode=True
+        )
+        browser = next(
+            item["function"]
+            for item in definitions
+            if item["function"]["name"] == "browser_navigate"
+        )
+        assert "prefer web_search (faster, cheaper)" in browser["description"]
+        assert "web_extract" not in browser["description"]
+
+
 
 # =========================================================================
 # Backward-compat wrappers

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -255,6 +255,24 @@ class TestDDGSBackendWiring:
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         assert web_tools.check_web_api_key() is True
 
+    def test_ddgs_advertises_search_but_not_extract(self, monkeypatch):
+        from tools import web_tools
+        from tools.registry import invalidate_check_fn_cache
+
+        monkeypatch.setattr(
+            web_tools, "_load_web_config", lambda: {"search_backend": "ddgs"}
+        )
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
+        assert web_tools.check_web_search_available() is True
+        assert web_tools.check_web_extract_available() is False
+
+        invalidate_check_fn_cache()
+        definitions = web_tools.registry.get_definitions(
+            {"web_search", "web_extract"}, quiet=True
+        )
+        names = {item["function"]["name"] for item in definitions}
+        assert names == {"web_search"}
+
 
 # ---------------------------------------------------------------------------
 # ddgs is search-only: web_extract returns a clear error

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -550,17 +550,23 @@ class TestNonBuiltinProviderAvailability:
             assert _get_extract_backend() == "fake-plugin-prov"
 
     def test_tool_registry_entries_not_filtered_out(self):
-        """web_search and web_extract tool entries must remain in the
-        registry when only a custom provider is available."""
+        """A custom provider exposes every capability it implements."""
         with patch("tools.web_tools._ddgs_package_importable", return_value=False), \
              patch("tools.web_tools._peek_nous_access_token", return_value=None):
             import tools.web_tools
-            web_search_entry = tools.web_tools.registry.get_entry("web_search")
-            web_extract_entry = tools.web_tools.registry.get_entry("web_extract")
-            assert web_search_entry is not None, \
-                "web_search tool was filtered out despite custom provider being available"
-            assert web_extract_entry is not None, \
-                "web_extract tool was filtered out despite custom provider being available"
+            assert tools.web_tools.check_web_search_available() is True
+            assert tools.web_tools.check_web_extract_available() is True
+
+    def test_custom_search_only_provider_does_not_expose_extract(self):
+        from agent.web_search_registry import _reset_for_tests, register_provider
+        from tools import web_tools
+
+        _reset_for_tests()
+        register_provider(self._create_fake_provider(search=True, extract=False))
+        with patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch("tools.web_tools._peek_nous_access_token", return_value=None):
+            assert web_tools.check_web_search_available() is True
+            assert web_tools.check_web_extract_available() is False
 
 
 class TestFirecrawlEnvResolution:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1045,43 +1045,79 @@ async def web_extract_tool(
         return tool_error(error_msg)
 
 
-# Convenience function to check Firecrawl credentials
-def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available.
+# Built-in capability map used only as a fallback when plugin discovery is
+# unavailable. The registered provider remains authoritative in normal runs.
+_LEGACY_SEARCH_BACKENDS = _LEGACY_WEB_BACKENDS
+_LEGACY_EXTRACT_BACKENDS = frozenset({"parallel", "firecrawl", "tavily", "exa"})
 
-    Used as the ``check_fn`` gate for the ``web_search`` and ``web_extract``
-    tool registry entries — so a plugin-registered provider that reports
-    ``is_available()`` must light the tools up even when no built-in backend
-    has credentials (issues #28651, #31873). Resolution funnels through
-    :func:`_is_backend_available`, which delegates non-legacy names to the
-    registry.
+
+def _check_web_capability(capability: str) -> bool:
+    """Return whether the selected backend can service *capability* now.
+
+    Availability and capability are separate facts: DDGS, Brave, SearXNG,
+    and xAI can search but cannot extract arbitrary URLs. A shared boolean
+    gate used to advertise both tools whenever either fact was true, so a
+    DDGS-only install exposed a guaranteed-to-fail ``web_extract`` tool.
     """
-    # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
-    # ``None.lower()`` would raise. Mirrors ``_get_backend``.
-    configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured and _is_backend_available(configured):
-        return True
-    # Any built-in backend with credentials present. This is a boolean OR, so
-    # unlike _get_backend() the probe order is irrelevant.
-    if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS):
-        return True
-    # Any plugin-registered provider the registry considers active for either
-    # capability. Delegating to the registry's own availability-filtered
-    # resolvers keeps a single authority for "is a custom provider usable"
-    # rather than re-implementing the walk here.
-    try:
-        from agent.web_search_registry import (
-            get_active_search_provider,
-            get_active_extract_provider,
-        )
-
-        return (
-            get_active_search_provider() is not None
-            or get_active_extract_provider() is not None
-        )
-    except Exception as exc:  # noqa: BLE001 — registry optional; never fatal
-        logger.debug("web provider registry availability check failed: %s", exc)
+    if capability not in {"search", "extract"}:
         return False
+
+    _ensure_web_plugins_loaded()
+    backend = (
+        _get_search_backend() if capability == "search" else _get_extract_backend()
+    )
+    provider = _registered_web_provider(backend)
+    if provider is not None:
+        try:
+            supports = (
+                provider.supports_search()
+                if capability == "search"
+                else provider.supports_extract()
+            )
+            # Legacy providers share the established config-aware probes in
+            # this module (including test seams and OAuth-aware xAI checks).
+            # Custom providers own their availability contract directly.
+            available = (
+                _is_backend_available(backend)
+                if backend in _LEGACY_WEB_BACKENDS
+                else provider.is_available()
+            )
+            return bool(supports and available)
+        except Exception as exc:  # noqa: BLE001 — a broken provider is unavailable
+            logger.debug(
+                "web provider %r %s capability check failed: %s",
+                backend,
+                capability,
+                exc,
+            )
+            return False
+
+    capable_backends = (
+        _LEGACY_SEARCH_BACKENDS
+        if capability == "search"
+        else _LEGACY_EXTRACT_BACKENDS
+    )
+    return backend in capable_backends and _is_backend_available(backend)
+
+
+def check_web_search_available() -> bool:
+    """Check whether ``web_search`` has an available search provider."""
+    return _check_web_capability("search")
+
+
+def check_web_extract_available() -> bool:
+    """Check whether ``web_extract`` has an available extract provider."""
+    return _check_web_capability("extract")
+
+
+def check_web_api_key() -> bool:
+    """Backward-compatible aggregate web availability check.
+
+    New tool registry entries use the capability-specific checks above.
+    Existing callers that only need to know whether *any* web API is usable
+    retain the historical boolean-OR behavior.
+    """
+    return check_web_search_available() or check_web_extract_available()
 
 
 if __name__ == "__main__":
@@ -1215,7 +1251,7 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
-    check_fn=check_web_api_key,
+    check_fn=check_web_search_available,
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,
@@ -1229,7 +1265,7 @@ registry.register(
         "markdown",
         char_limit=args.get("char_limit"),
     ),
-    check_fn=check_web_api_key,
+    check_fn=check_web_extract_available,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",


### PR DESCRIPTION
## Summary

- separate web-search availability from URL-extraction availability
- keep DDGS and other search-only providers from exposing unsupported extraction tools
- filter browser tool descriptions so unavailable cross-tool references are not advertised

## Testing

- Python 3.11 focused web suites — 78 passed
- `ruff check model_tools.py tools/web_tools.py tests/test_model_tools.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_tools_config.py` — passed
- Full Python 3.11 official runner: 17 failure files / 74 failed tests
- Exact clean base `a1da384c6d968000773ba0d1617d6931dfe25748` under the same runner: the same 17 failure files / 74 failed tests
- All changed web test files passed; merge-tree against upstream `92dd230c8c3bdbc900f29a3d6cedca1ce1450b50` is clean

The full-suite failures are existing baseline/environment failures, including unavailable opt-in provider extras and platform-specific macOS/systemd/WSL assertions.