### PR TITLE
fix(vision): skip native DeepSeek chat endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -944,11 +944,16 @@ def _resolve_provider_vision_default(provider: str) -> Optional[str]:
 # it must skip straight to the aggregator chain instead of returning a client
 # that will 404 on every vision request.
 #
+# deepseek: the native DeepSeek chat endpoint is text-only. Vision models in
+# the broader DeepSeek ecosystem use separate model families/endpoints, so the
+# configured chat client cannot safely receive image content.
+#
 # kimi-coding / kimi-coding-cn: the Kimi Coding Plan routes through
 # api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
 # describe as having no image_in capability. Vision lives on the separate
 # Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
+    "deepseek",
     "kimi-coding",
     "kimi-coding-cn",
 })


### PR DESCRIPTION
## What does this PR do?

Prevents automatic vision routing from sending image content to the native DeepSeek text-chat endpoint.

Fixes #83097

## Type of change

- [x] Bug fix

## Changes

- Classify the native `deepseek` provider as unavailable for image input in the conservative auto-routing path.
- Preserve explicit provider selection for experimental/custom endpoints.
- Fall through to OpenRouter, Nous, or DeepInfra when configured; otherwise return no vision client instead of one that will fail at request time.

## How was this tested?

- Existing `test_text_only_main_skipped_when_no_aggregator` regression now passes.
- Adjacent vision suites: 85 passed across vision auto-routing, image routing, custom-provider vision, and vision tools.
- Ruff, Windows footgun scan, and `git diff --check` passed.

## Checklist

- [x] I read the contributing guide and repository instructions.
- [x] The commit uses the repository's conventional commit format.
- [x] I searched open issues and PRs for duplicate work.
- [x] The change is focused and covered by an existing behavioral regression test.
- [x] Relevant tests pass.
