### PR TITLE
fix(api-server): stop Responses store history duplication from _db_persisted markers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5864,6 +5864,32 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _message_identity(message: Any) -> tuple:
+        """(role, content) projection for transcript prefix comparison.
+
+        Live ``result["messages"]`` rows accrete internal bookkeeping during
+        the turn (``_db_persisted``, ``finish_reason``, ``reasoning``), so raw
+        dict equality against the request's clean history never matches.
+        """
+        if not isinstance(message, dict):
+            return (None, message)
+        return (message.get("role"), message.get("content"))
+
+    @staticmethod
+    def _strip_response_store_markers(messages: List[Any]) -> List[Any]:
+        """Copy *messages* for the response store without ``_db_persisted``.
+
+        Copies are unconditional: the rows are live dicts that the SessionDB
+        flush stamps in place, possibly between this call and the store write.
+        """
+        return [
+            {k: v for k, v in msg.items() if k != "_db_persisted"}
+            if isinstance(msg, dict)
+            else msg
+            for msg in messages
+        ]
+
+    @staticmethod
     def _build_response_conversation_history(
         conversation_history: List[Dict[str, Any]],
         user_message: Any,
@@ -5880,6 +5906,7 @@ class APIServerAdapter(BasePlatformAdapter):
         concatenate the uncompressed history on front, bloating the stored
         context and re-triggering compression on every subsequent request.
         """
+        strip = APIServerAdapter._strip_response_store_markers
         prior = list(conversation_history)
         current_user = {"role": "user", "content": user_message}
         agent_messages = result.get("messages") if isinstance(result, dict) else None
@@ -5891,7 +5918,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 result,
             )
             if turn_start:
-                return list(agent_messages)
+                return strip(agent_messages)
 
             # turn_start == 0: agent_messages does not start with prior.
             # This can happen because compression rewrote the transcript
@@ -5901,17 +5928,17 @@ class APIServerAdapter(BasePlatformAdapter):
             # distinguishes — skip the concatenation and use the compressed
             # transcript directly.
             if result.get("_compressed"):
-                return list(agent_messages)
+                return strip(agent_messages)
 
             full_history = prior
             full_history.append(current_user)
             full_history.extend(agent_messages)
-            return full_history
+            return strip(full_history)
 
         full_history = prior
         full_history.append(current_user)
         full_history.append({"role": "assistant", "content": final_response})
-        return full_history
+        return strip(full_history)
 
     @staticmethod
     def _response_messages_turn_start_index(
@@ -5924,13 +5951,14 @@ class APIServerAdapter(BasePlatformAdapter):
         if not isinstance(agent_messages, list) or not agent_messages:
             return 0
 
-        prior = list(conversation_history)
-        current_user = {"role": "user", "content": user_message}
-        expected_prefix = prior + [current_user]
-        if agent_messages[:len(expected_prefix)] == expected_prefix:
+        identity = APIServerAdapter._message_identity
+        prior_ids = [identity(m) for m in conversation_history]
+        agent_ids = [identity(m) for m in agent_messages]
+        expected_prefix = prior_ids + [("user", user_message)]
+        if agent_ids[:len(expected_prefix)] == expected_prefix:
             return len(expected_prefix)
-        if prior and agent_messages[:len(prior)] == prior:
-            return len(prior)
+        if prior_ids and agent_ids[:len(prior_ids)] == prior_ids:
+            return len(prior_ids)
         return 0
 
     @classmethod

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1409,6 +1409,123 @@ class TestResponsesEndpoint:
 
 
     @pytest.mark.asyncio
+    async def test_stored_history_not_duplicated_by_db_persisted_marker(self, adapter):
+        """Internal markers on result["messages"] must not defeat turn-start detection."""
+        mock_result = {
+            "final_response": "Noted.",
+            "messages": [
+                {"role": "user", "content": "My favourite color is teal.", "_db_persisted": True},
+                {
+                    "role": "assistant",
+                    "content": "Noted.",
+                    "finish_reason": "stop",
+                    "_db_persisted": True,
+                },
+            ],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "My favourite color is teal.",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        stored_history = adapter._response_store.get(data["id"])["conversation_history"]
+        roles = [m.get("role") for m in stored_history]
+        assert roles == ["user", "assistant"], (
+            f"user turn duplicated in stored history: {roles}"
+        )
+        assert all("_db_persisted" not in m for m in stored_history)
+
+
+    @pytest.mark.asyncio
+    async def test_chained_turn_stored_history_not_duplicated_with_markers(self, adapter):
+        """A previous_response_id turn must not re-append the loaded prior history."""
+        prior_history = [
+            {"role": "user", "content": "My favourite color is teal."},
+            {"role": "assistant", "content": "Noted."},
+        ]
+        adapter._response_store.put(
+            "resp_prev_marker",
+            {
+                "response": {"id": "resp_prev_marker", "status": "completed"},
+                "conversation_history": list(prior_history),
+                "session_id": "api-test-session",
+            },
+        )
+
+        # The agent returns the full transcript; rows loaded from the store
+        # and this turn's rows all carry the mid-turn persistence marker.
+        mock_result = {
+            "final_response": "Teal.",
+            "messages": [
+                {**prior_history[0], "_db_persisted": True},
+                {**prior_history[1], "_db_persisted": True, "finish_reason": "stop"},
+                {"role": "user", "content": "What is my favourite color?", "_db_persisted": True},
+                {"role": "assistant", "content": "Teal.", "finish_reason": "stop"},
+            ],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "What is my favourite color?",
+                        "previous_response_id": "resp_prev_marker",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        stored_history = adapter._response_store.get(data["id"])["conversation_history"]
+        roles = [m.get("role") for m in stored_history]
+        assert roles == ["user", "assistant", "user", "assistant"], (
+            f"prior transcript re-appended in stored history: {roles}"
+        )
+        assert all("_db_persisted" not in m for m in stored_history)
+
+
+    def test_turn_start_index_ignores_internal_markers(self):
+        """Prefix detection compares (role, content), not raw dicts."""
+        prior = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+        ]
+        result = {
+            "messages": [
+                {"role": "user", "content": "a", "_db_persisted": True},
+                {"role": "assistant", "content": "b", "finish_reason": "stop"},
+                {"role": "user", "content": "c", "_db_persisted": True},
+                {"role": "assistant", "content": "d"},
+            ]
+        }
+        assert (
+            APIServerAdapter._response_messages_turn_start_index(prior, "c", result)
+            == 3
+        )
+        # Divergent content must still be treated as not-a-prefix.
+        result["messages"][0]["content"] = "different"
+        assert (
+            APIServerAdapter._response_messages_turn_start_index(prior, "c", result)
+            == 0
+        )
+
+
+    @pytest.mark.asyncio
     async def test_previous_response_id_outputs_only_current_turn_items(self, adapter):
         """Response output must not replay previous tool artifacts."""
         prior_history = [


### PR DESCRIPTION
## Problem

On the OpenAI-compatible API server, the stored Responses transcript roughly **doubles every turn** when chaining via `previous_response_id`.

Since the incremental SessionDB persistence work, the batch flush stamps `_db_persisted=True` onto the agent's live message dicts mid-turn (provider replies additionally carry `finish_reason`/`reasoning`). `_response_messages_turn_start_index` compares `result["messages"]` against the request's clean `conversation_history` with **raw dict equality**, so the stamped rows never match:

- turn-start detection returns 0,
- `_build_response_conversation_history` falls into the concatenation branch and re-appends the entire prior transcript,
- the duplicated consecutive user rows get merged on the wire (`"X\n\nX"`), the merged content leaks into the next turn's transcript, and from then on the prior-prefix fallback can't match either.

Observed growth for a simple alternating chat: **3 → 8 → ~18 → ~38** stored messages. Real tool-using conversations blow past the compression threshold within a handful of turns; after compaction the verbatim prior turns are gone and the model falls back to `session_search` on every message — i.e. multi-turn conversations behave as if history was dropped.

Stored-store evidence from a live v2026.8.3 deployment (turn 1 of a fresh chat):

```
0 user      | keys: ['content', 'role']
1 user      | keys: ['_db_persisted', 'content', 'role']          <- same message, stamped
2 assistant | keys: ['_db_persisted', 'content', 'finish_reason', 'reasoning', 'reasoning_content', 'role']
```

This is the response-store edition of the #57491 marker-strip invariant: the terminal sweep doesn't cover `result["messages"]` as consumed by the Responses store.

## Fix

- `_response_messages_turn_start_index` now compares `(role, content)` projections (`_message_identity`) instead of raw dicts, so internal bookkeeping keys can never defeat turn-start detection. Divergent content still fails the prefix check (covered by test).
- Every message copied into the response store is shallow-copied without `_db_persisted` (`_strip_response_store_markers`), so the marker cannot replay into a future request's `conversation_history`. Message contents are never mutated; `api_content` sidecars, `reasoning*`, `finish_reason`, and `tool_calls` are preserved.

The projection fix also benefits the output-items replay path, which shares `_response_messages_turn_start_index`.

## Verification

- New tests: unchained turn and `previous_response_id`-chained turn with stamped rows store clean, non-duplicated history without markers; pure unit test for marker-insensitive prefix detection incl. the divergent-content negative case.
- `tests/gateway/test_api_server.py`: 101 passed, 1 pre-existing failure (`TestHealthDetailedEndpoint::test_health_detailed_returns_ok`, fails identically on clean `main` in my environment).
- End-to-end against a stub provider: four chained turns store 2/4/6/8 messages with clean user/assistant alternation (previously 3/8/18/38 with duplicated user turns).
