### PR TITLE
fix(desktop): read the Linux HUD cursor via XQueryPointer, not Chromium's frozen cache

### DIFF
--- a/apps/desktop/electron/hud-cursor-x11.test.ts
+++ b/apps/desktop/electron/hud-cursor-x11.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for the X11-backed HUD cursor reader.
+ *
+ * The reader exists because `screen.getCursorScreenPoint()` freezes on X11 the
+ * instant the HUD window ignores the mouse (Chromium's cursor cache stops being
+ * fed by motion events), which is the one-way door behind the Linux HUD bug.
+ * XQueryPointer asks the X server directly, so it always knows the real
+ * pointer position. These tests pin down the reader's contract: it never
+ * throws, it degrades to null when the X connection is unavailable, and it
+ * stops polling after close().
+ */
+
+import assert from 'node:assert/strict'
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createX11CursorReader } from './hud-cursor-x11'
+
+// --- mock the x11 module -----------------------------------------------------
+// The tests run in a headless environment with no X server; the module under
+// test is the only consumer, so a hand-rolled fake is exact.
+
+type QueryPointerCb = (err: Error | null, reply: { rootX: number; rootY: number } | null) => void
+
+const mocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  queryPointer: vi.fn(),
+  terminate: vi.fn()
+}))
+
+vi.mock('x11', () => ({
+  default: {
+    createClient: mocks.createClient
+  }
+}))
+
+describe('createX11CursorReader', () => {
+  let captureCreateCallback: (err: Error | null, display?: any) => void
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createClient.mockImplementation((cb: (err: Error | null, display?: any) => void) => {
+      captureCreateCallback = cb
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function connectDisplay() {
+    captureCreateCallback(null, {
+      client: { QueryPointer: mocks.queryPointer, terminate: mocks.terminate },
+      screen: [{ root: 0x1234 }]
+    })
+  }
+
+  test('read() returns null before the X connection is established', () => {
+    const reader = createX11CursorReader()
+    assert.equal(reader.read(), null)
+  })
+
+  test('read() returns the latest XQueryPointer result', () => {
+    mocks.queryPointer.mockImplementation((_root: number, cb: QueryPointerCb) => {
+      cb(null, { rootX: 100, rootY: 200 })
+    })
+
+    const reader = createX11CursorReader()
+    connectDisplay()
+    reader.read()
+    reader.read()
+
+    assert.deepEqual(reader.read(), { x: 100, y: 200 })
+    expect(mocks.queryPointer).toHaveBeenCalled()
+  })
+
+  test('a failed X connection degrades to null instead of throwing', () => {
+    const reader = createX11CursorReader()
+    captureCreateCallback(new Error('cannot open display'))
+    assert.equal(reader.read(), null)
+  })
+
+  test('close() terminates the X connection and stops polling', () => {
+    mocks.queryPointer.mockImplementation((_root: number, cb: QueryPointerCb) => {
+      cb(null, { rootX: 1, rootY: 2 })
+    })
+
+    const reader = createX11CursorReader()
+    connectDisplay()
+    reader.read()
+    reader.close()
+    expect(mocks.terminate).toHaveBeenCalled()
+    // After close, no further polling happens.
+    const callsBefore = mocks.queryPointer.mock.calls.length
+    reader.read()
+    assert.equal(mocks.queryPointer.mock.calls.length, callsBefore)
+  })
+})

--- a/apps/desktop/electron/hud-cursor-x11.ts
+++ b/apps/desktop/electron/hud-cursor-x11.ts
@@ -1,0 +1,104 @@
+import x11 from 'x11'
+
+/**
+ * Reliable cursor position on X11, bypassing Electron's frozen cache.
+ *
+ * `screen.getCursorScreenPoint()` is a Chromium-side cache updated by X11
+ * motion events the browser process receives. The moment the HUD window is
+ * `setIgnoreMouseEvents(true)` — click-through — the window stops receiving
+ * those events, the cache freezes on the last point, and the Linux cursor
+ * feed (startHudCursorFeed) keeps computing the same point forever, so the
+ * dedup guard `key === last` never fires and the renderer never hears that the
+ * pointer came back to the bar. One-way door on X11.
+ *
+ * XQueryPointer asks the X server itself, which always knows where the pointer
+ * is, regardless of any window's input shape. That is exactly what `xdotool
+ * getmouselocation` does. This module wraps a minimal x11 client around that
+ * single request, with a cache so the 60ms feed never piles up round-trips.
+ *
+ * The x11 package is a pure-JS X client (no native build). If it cannot
+ * connect (no DISPLAY, Wayland-native without XWayland, ...), `create()` still
+ * succeeds but `read()` returns null and the caller falls back to Electron's
+ * API — same behaviour as today.
+ */
+
+interface Point {
+  x: number
+  y: number
+}
+
+export interface X11CursorReader {
+  /** Latest known pointer position in screen pixels, or null if unavailable. */
+  read(): Point | null
+  /** Terminate the X connection. Safe to call multiple times. */
+  close(): void
+}
+
+/**
+ * Create an X11-backed cursor reader. Never throws; a failed connection
+ * degrades to `read() → null`.
+ */
+export function createX11CursorReader(): X11CursorReader {
+  // The x11 package ships no TypeScript types; `client` is the opaque X client
+  // returned by createClient, used only through its runtime methods below.
+  let client: any = null
+  let root: number | null = null
+  let cached: Point | null = null
+  let pending = false
+  let failed = false
+  let closed = false
+
+  x11.createClient((err, display) => {
+    if (err || !display) {
+      failed = true
+      return
+    }
+
+    try {
+      client = display.client
+      root = display.screen?.[0]?.root ?? null
+      if (!root) {
+        failed = true
+      }
+    } catch {
+      failed = true
+    }
+  })
+
+  function poll(): void {
+    if (failed || closed || pending || !client || root === null) {
+      return
+    }
+
+    pending = true
+
+    try {
+      client.QueryPointer(root, (qerr: Error | null, reply: { rootX: number; rootY: number } | null) => {
+        pending = false
+
+        if (!qerr && reply) {
+          cached = { x: reply.rootX, y: reply.rootY }
+        }
+      })
+    } catch {
+      pending = false
+    }
+  }
+
+  return {
+    read() {
+      poll()
+      return cached
+    },
+
+    close() {
+      closed = true
+
+      try {
+        client?.terminate?.()
+      } catch {
+        // best effort
+      }
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -139,6 +139,7 @@ import {
 import { cursorPointInWindow } from './hud-cursor'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
+import { createX11CursorReader, type X11CursorReader } from './hud-cursor-x11'
 import { buildHudWindowUrl } from './hud-url'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
@@ -9353,6 +9354,14 @@ function startHudCursorFeed(win: BrowserWindow) {
     return
   }
 
+  // XQueryPointer is the only cursor source that survives click-through on X11:
+  // `screen.getCursorScreenPoint()` is a Chromium-side cache updated by motion
+  // events, and those stop arriving the instant the window ignores the mouse —
+  // the cached point freezes, the feed computes the same point forever, and the
+  // renderer never learns the pointer came back. Ask the X server instead;
+  // fall back to Electron's API if the X connection is unavailable.
+  const x11Reader = createX11CursorReader()
+
   let last: string | null = null
 
   const timer = setInterval(() => {
@@ -9360,7 +9369,15 @@ function startHudCursorFeed(win: BrowserWindow) {
       return
     }
 
-    const point = cursorPointInWindow(screen.getCursorScreenPoint(), win.getBounds(), win.webContents.getZoomFactor())
+    const x11Point = x11Reader.read()
+    // X11 reports physical pixels; bounds and the renderer speak DIP. On the
+    // HUD's own display scale is what reconciles them (1 on most desktops).
+    const scale = screen.getDisplayMatching(win.getBounds()).scaleFactor || 1
+    const cursor =
+      x11Point !== null
+        ? { x: x11Point.x / scale, y: x11Point.y / scale }
+        : screen.getCursorScreenPoint()
+    const point = cursorPointInWindow(cursor, win.getBounds(), win.webContents.getZoomFactor())
 
     // Off-window is a real answer (it is what hands the mouse back), so it is
     // sent — once. Only an unchanged answer is dropped, to keep an idle cursor
@@ -9375,7 +9392,10 @@ function startHudCursorFeed(win: BrowserWindow) {
     win.webContents.send('hermes:hud:cursor', point)
   }, HUD_CURSOR_POLL_MS)
 
-  win.on('closed', () => clearInterval(timer))
+  win.on('closed', () => {
+    clearInterval(timer)
+    x11Reader.close()
+  })
 }
 
 function hudBounds() {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -133,7 +133,8 @@
     "unist-util-visit-parents": "6.0.2",
     "use-stick-to-bottom": "1.1.6",
     "vfile": "6.0.3",
-    "web-haptics": "0.0.6"
+    "web-haptics": "0.0.6",
+    "x11": "^3.1.1"
   },
   "devDependencies": {
     "@electron/rebuild": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,8 @@
         "unist-util-visit-parents": "6.0.2",
         "use-stick-to-bottom": "1.1.6",
         "vfile": "6.0.3",
-        "web-haptics": "0.0.6"
+        "web-haptics": "0.0.6",
+        "x11": "^3.1.1"
       },
       "devDependencies": {
         "@electron/rebuild": "4.2.0",
@@ -18860,6 +18861,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/x11": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.1.1.tgz",
+      "integrity": "sha512-FeTpXbOVBogU8ndjZCM5YQvjIDDRkoGqLiTA7eJJFz9xXRfBzyTcPxIDaSQfgRDNMnpIK8M9GmknfjQ+tLc4lQ==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/xml-name-validator": {


### PR DESCRIPTION
## Symptom

On Linux/X11, the HUD (Ctrl+Shift+H) becomes permanently click-through after the first click outside the composer: the window turns semi-transparent, subsequent clicks pass through to the app behind, and the composer never becomes clickable again. Dragging the HUD dies the same way (a long-press triggers the same one-way door).

Reproduced on Kubuntu 24.04 / KDE Plasma / X11 / x86_64.

## Root cause

`startHudCursorFeed` polls `screen.getCursorScreenPoint()` to tell the renderer where the pointer is once the window is click-through (`forward: true` is macOS/Windows only). But on X11, `setIgnoreMouseEvents(true)` stops the window from receiving motion events — and Chromium's cursor position is a cache fed by those events. The cache freezes on the last point seen, the feed computes the same point every 60ms tick, the `key === last` dedup guard never fires, and the renderer never learns the pointer came back to the bar. One-way door: the window stays click-through forever.

This is a Chromium/Electron limitation, not a wiring bug: the IPC channel, the preload bridge (`hermes:hud:cursor`) and the renderer hit-test are all correct (verified with CDP counters + xdotool).

## Fix

Query the X server directly with **XQueryPointer** (the same call `xdotool getmouselocation` makes) instead of relying on Chromium's frozen cache. The X server always knows where the pointer is, regardless of any window's input shape.

- New `apps/desktop/electron/hud-cursor-x11.ts`: minimal wrapper around the pure-JS `x11` client (MIT, no native build), caching the latest `XQueryPointer` reply so the 60ms feed never piles up round-trips.
- `startHudCursorFeed` reads from it, with DIP conversion via the display scale factor, and falls back to Electron's API when the X connection is unavailable (e.g. pure Wayland) — same behaviour as before in that case.
- The renderer is untouched: the `hermes:hud:cursor` contract is identical.

## Validation

- Unit: `hud-cursor-x11.test.ts` (4 tests, mocked x11) — green; full desktop electron suite 1007 tests green; typecheck green.
- E2E on X11 with xdotool: click in the faded band still passes through to the app behind (feature preserved), and moving the pointer back over the composer re-arms the window — the click lands on the HUD again. 3 back-and-forth cycles, plus HUD dragging, all pass.
- Also verified live on the packaged release binary.

## Notes

- PR #82632 explored an alternative (a permanently solid HUD); our approach preserves click-through while re-arming the window.
- `x11` pinned to 3.1.1 to satisfy the repo's `min-release-age` npm gate.