### PR TITLE
fix invalid chat tool transactions before API calls

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -33,7 +33,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.timeouts import get_provider_request_timeout
-from agent.message_sanitization import _FULL_ARGS_LOG_BOUND
+from agent.message_sanitization import (
+    _FULL_ARGS_LOG_BOUND,
+    normalize_tool_transaction_adjacency,
+)
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -3503,6 +3506,23 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: dropped %d empty/invalid tool_calls field(s) "
             "created during de-duplication",
             dropped_post_dedup_tool_calls,
+        )
+
+    # Global id membership is not enough for Chat Completions: every tool
+    # result must be in the contiguous block immediately following the
+    # assistant that issued it.  De-duplication can keep an early call while
+    # leaving its only result much later in the transcript, which strict
+    # providers reject as "insufficient tool messages".  Canonicalize each
+    # local transaction after all global filtering/dedup passes.
+    messages, inserted_stubs, dropped_local_results = (
+        normalize_tool_transaction_adjacency(messages)
+    )
+    if inserted_stubs or dropped_local_results:
+        _ra().logger.debug(
+            "Pre-call sanitizer: repaired tool transaction adjacency "
+            "(added %d stub result(s), dropped %d misplaced/duplicate result(s))",
+            inserted_stubs,
+            dropped_local_results,
         )
     return messages
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3476,6 +3476,34 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # De-duplication above can itself create ``tool_calls: []`` when every
+    # call on a later assistant message reuses an id seen earlier in the
+    # transcript.  The initial empty-array pass cannot catch a value created
+    # after it runs, and strict OpenAI-compatible providers reject the result.
+    # Normalize again at the final sanitizer boundary, then heal any
+    # tool-call-only assistant turn that became payload-empty after the key
+    # was removed.  This operates on the per-call copy only; durable history
+    # and its prompt-cache prefix remain untouched.
+    final_normalized: List[Dict[str, Any]] = []
+    dropped_post_dedup_tool_calls = 0
+    for msg in messages:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and "tool_calls" in msg
+            and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
+        ):
+            msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+            dropped_post_dedup_tool_calls += 1
+        final_normalized.append(msg)
+    if dropped_post_dedup_tool_calls:
+        messages = repair_empty_non_final_messages(final_normalized)
+        _ra().logger.debug(
+            "Pre-call sanitizer: dropped %d empty/invalid tool_calls field(s) "
+            "created during de-duplication",
+            dropped_post_dedup_tool_calls,
+        )
     return messages
 
 

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -492,7 +492,7 @@ def normalize_tool_transaction_adjacency(
     This copy-on-write pass treats each assistant plus its immediately
     following run of tool messages as one transaction.  It:
 
-    * preserves one matching result per call, in tool-call order;
+    * preserves one matching result per call in its existing order;
     * inserts a deterministic placeholder for each locally missing result;
     * drops duplicate, mismatched, and standalone tool results.
 
@@ -543,7 +543,7 @@ def normalize_tool_transaction_adjacency(
             expected.append((call_id, name if isinstance(name, str) else ""))
 
         result_by_id: dict[str, dict[str, Any]] = {}
-        encountered_result_ids: list[str] = []
+        encountered_results: list[dict[str, Any]] = []
         cursor = index + 1
         while cursor < len(messages):
             candidate = messages[cursor]
@@ -555,20 +555,19 @@ def normalize_tool_transaction_adjacency(
             result_id = (candidate.get("tool_call_id") or "").strip()
             if result_id in expected_ids and result_id not in result_by_id:
                 result_by_id[result_id] = candidate
-                encountered_result_ids.append(result_id)
+                encountered_results.append(candidate)
             else:
                 dropped_results += 1
                 changed = True
             cursor += 1
 
-        expected_order = [call_id for call_id, _ in expected]
-        if encountered_result_ids != expected_order:
-            changed = True
+        # Existing result order is semantically valid because each message
+        # carries its pairing id.  Preserve it to avoid needless prompt-prefix
+        # churn; only append placeholders for ids absent from this local block.
+        repaired.extend(encountered_results)
 
         for call_id, name in expected:
-            result = result_by_id.get(call_id)
-            if result is not None:
-                repaired.append(result)
+            if call_id in result_by_id:
                 continue
             repaired.append({
                 "role": "tool",

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -475,6 +475,117 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
     return found
 
 
+_MISSING_TOOL_RESULT_CONTENT = "[Result unavailable — see context summary above]"
+
+
+def normalize_tool_transaction_adjacency(
+    messages: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Make every Chat Completions tool transaction locally complete.
+
+    Strict OpenAI-compatible providers require the ``tool`` messages for an
+    assistant's ``tool_calls`` to appear immediately after that assistant
+    message, before any other role.  A global call-id/result-id set is not
+    sufficient: a result hundreds of messages later cannot satisfy an earlier
+    assistant turn.
+
+    This copy-on-write pass treats each assistant plus its immediately
+    following run of tool messages as one transaction.  It:
+
+    * preserves one matching result per call, in tool-call order;
+    * inserts a deterministic placeholder for each locally missing result;
+    * drops duplicate, mismatched, and standalone tool results.
+
+    The original list and message dictionaries are returned untouched when
+    the transaction layout is already valid.  The counters are
+    ``(inserted_stubs, dropped_results)``.
+    """
+    repaired: list[dict[str, Any]] = []
+    inserted_stubs = 0
+    dropped_results = 0
+    changed = False
+    index = 0
+
+    while index < len(messages):
+        message = messages[index]
+        role = message.get("role") if isinstance(message, dict) else None
+        tool_calls = (
+            message.get("tool_calls")
+            if isinstance(message, dict) and role == "assistant"
+            else None
+        )
+
+        if not (isinstance(tool_calls, list) and tool_calls):
+            if role == "tool":
+                # A tool result outside the immediately preceding assistant
+                # transaction can never be accepted by strict providers.
+                dropped_results += 1
+                changed = True
+            else:
+                repaired.append(message)
+            index += 1
+            continue
+
+        repaired.append(message)
+        expected: list[tuple[str, str]] = []
+        expected_ids: set[str] = set()
+        for tool_call in tool_calls:
+            call_id = coalesce_tool_call_id(tool_call)
+            if not call_id or call_id in expected_ids:
+                continue
+            expected_ids.add(call_id)
+            if isinstance(tool_call, dict):
+                function = tool_call.get("function")
+                name = function.get("name", "") if isinstance(function, dict) else ""
+            else:
+                function = getattr(tool_call, "function", None)
+                name = getattr(function, "name", "") if function is not None else ""
+            expected.append((call_id, name if isinstance(name, str) else ""))
+
+        result_by_id: dict[str, dict[str, Any]] = {}
+        encountered_result_ids: list[str] = []
+        cursor = index + 1
+        while cursor < len(messages):
+            candidate = messages[cursor]
+            candidate_role = (
+                candidate.get("role") if isinstance(candidate, dict) else None
+            )
+            if candidate_role != "tool":
+                break
+            result_id = (candidate.get("tool_call_id") or "").strip()
+            if result_id in expected_ids and result_id not in result_by_id:
+                result_by_id[result_id] = candidate
+                encountered_result_ids.append(result_id)
+            else:
+                dropped_results += 1
+                changed = True
+            cursor += 1
+
+        expected_order = [call_id for call_id, _ in expected]
+        if encountered_result_ids != expected_order:
+            changed = True
+
+        for call_id, name in expected:
+            result = result_by_id.get(call_id)
+            if result is not None:
+                repaired.append(result)
+                continue
+            repaired.append({
+                "role": "tool",
+                "name": name,
+                "content": _MISSING_TOOL_RESULT_CONTENT,
+                "tool_call_id": call_id,
+            })
+            inserted_stubs += 1
+            changed = True
+
+        index = cursor
+
+    if not changed:
+        return messages, 0, 0
+    return repaired, inserted_stubs, dropped_results
+
+
 __all__ = [
     "_SURROGATE_RE",
     "close_interrupted_tool_sequence",
@@ -488,6 +599,7 @@ __all__ = [
     "_sanitize_tools_non_ascii",
     "_strip_images_from_messages",
     "_sanitize_structure_non_ascii",
+    "normalize_tool_transaction_adjacency",
     # call_id policy owners (F4 consolidation)
     "deterministic_call_id",
     "coalesce_tool_call_id",

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -295,7 +295,9 @@ class ChatCompletionsTransport(ProviderTransport):
                     break
 
         if not needs_sanitize:
-            return messages
+            from agent.message_sanitization import normalize_tool_transaction_adjacency
+
+            return normalize_tool_transaction_adjacency(messages)[0]
 
         sanitized = list(messages)
         for msg_idx, msg in enumerate(messages):
@@ -365,7 +367,12 @@ class ChatCompletionsTransport(ProviderTransport):
                             copied_tool_calls[tc_idx] = copied_tc
                 if copied_tool_calls is not None:
                     mutable_msg()["tool_calls"] = copied_tool_calls
-        return sanitized
+        # Final wire invariant: even if an upstream sanitizer is bypassed or
+        # later middleware reorders history, never emit an assistant tool call
+        # without its complete, immediately adjacent tool-result block.
+        from agent.message_sanitization import normalize_tool_transaction_adjacency
+
+        return normalize_tool_transaction_adjacency(sanitized)[0]
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Tools are already in OpenAI format — identity."""

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -249,6 +249,10 @@ class ChatCompletionsTransport(ProviderTransport):
           gateways (e.g. opencode-go, codex.nekos.me) reject with
           ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
           which then poisons every subsequent request in the session.
+        - Empty or malformed ``tool_calls`` fields on assistant messages.
+          This is the last chat-completions wire boundary, so it defends
+          against any upstream history repair or middleware pass that creates
+          ``tool_calls: []`` after the main sanitizer has already run.
         """
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
@@ -271,6 +275,13 @@ class ChatCompletionsTransport(ProviderTransport):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
+            if (
+                msg.get("role") == "assistant"
+                and "tool_calls" in msg
+                and not (isinstance(tool_calls, list) and tool_calls)
+            ):
+                needs_sanitize = True
+                break
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
                     if isinstance(tc, dict) and (
@@ -327,6 +338,13 @@ class ChatCompletionsTransport(ProviderTransport):
                     out_msg.pop(key, None)
 
             tool_calls = msg.get("tool_calls")
+            if (
+                msg.get("role") == "assistant"
+                and "tool_calls" in msg
+                and not (isinstance(tool_calls, list) and tool_calls)
+            ):
+                mutable_msg().pop("tool_calls", None)
+                tool_calls = None
             if isinstance(tool_calls, list):
                 copied_tool_calls: list[Any] | None = None
                 for tc_idx, tc in enumerate(tool_calls):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -129,11 +129,11 @@ class TestChatCompletionsBasic:
         result = transport.convert_messages(msgs)
 
         assert [msg["tool_call_id"] for msg in result[1:3]] == [
-            "call_a",
             "call_b",
+            "call_a",
         ]
-        assert result[1]["content"] == "[Result unavailable — see context summary above]"
-        assert result[2]["content"] == "B"
+        assert result[1]["content"] == "B"
+        assert result[2]["content"] == "[Result unavailable — see context summary above]"
         assert not any(msg.get("content") == "late A" for msg in result)
         assert msgs[1]["tool_call_id"] == "call_b"
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -100,6 +100,43 @@ class TestChatCompletionsBasic:
         assert result[0]["content"] == "answer"
         assert "tool_calls" in msgs[0]
 
+    def test_convert_messages_repairs_incomplete_tool_transaction_at_wire_boundary(
+        self, transport
+    ):
+        """The final transport guard enforces local call/result adjacency."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_b", "content": "B"},
+            {"role": "user", "content": "next"},
+            {"role": "tool", "tool_call_id": "call_a", "content": "late A"},
+        ]
+
+        result = transport.convert_messages(msgs)
+
+        assert [msg["tool_call_id"] for msg in result[1:3]] == [
+            "call_a",
+            "call_b",
+        ]
+        assert result[1]["content"] == "[Result unavailable — see context summary above]"
+        assert result[2]["content"] == "B"
+        assert not any(msg.get("content") == "late A" for msg in result)
+        assert msgs[1]["tool_call_id"] == "call_b"
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -84,6 +84,22 @@ class TestChatCompletionsBasic:
         msgs = [{"role": "user", "content": "hi"}]
         assert transport.convert_messages(msgs) is msgs
 
+    @pytest.mark.parametrize("tool_calls", [[], None, "invalid"])
+    def test_convert_messages_strips_empty_or_malformed_tool_calls(
+        self, transport, tool_calls
+    ):
+        """The final chat-completions boundary never emits a tool_calls field
+        unless it is a non-empty list, even if an upstream pass regresses."""
+        msgs = [
+            {"role": "assistant", "content": "answer", "tool_calls": tool_calls},
+        ]
+
+        result = transport.convert_messages(msgs)
+
+        assert "tool_calls" not in result[0]
+        assert result[0]["content"] == "answer"
+        assert "tool_calls" in msgs[0]
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -388,6 +388,80 @@ def test_sanitize_dedup_does_not_create_empty_tool_calls_array():
     assert all(m.get("tool_calls") != [] for m in out)
 
 
+def test_sanitize_repairs_results_that_exist_only_later_in_history():
+    """A global result-id match cannot satisfy a tool call locally.
+
+    Reproduces the long-session DeepSeek failure where de-duplication retained
+    an early call, while its only matching result remained hundreds of turns
+    later.  The outgoing transaction must receive an immediate stub and the
+    late standalone result must be removed.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_late",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                },
+                {
+                    "id": "call_here",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_here", "content": "local"},
+        {"role": "assistant", "content": "intervening answer"},
+        {"role": "tool", "tool_call_id": "call_late", "content": "too late"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    first_assistant = next(i for i, msg in enumerate(out) if msg.get("tool_calls"))
+    adjacent = out[first_assistant + 1:first_assistant + 3]
+    assert [msg["tool_call_id"] for msg in adjacent] == ["call_late", "call_here"]
+    assert adjacent[0]["content"] == "[Result unavailable — see context summary above]"
+    assert adjacent[1]["content"] == "local"
+    assert not any(msg.get("content") == "too late" for msg in out)
+
+
+def test_sanitize_preserves_complete_adjacent_tool_transaction_by_identity():
+    """Healthy transactions remain byte- and object-identical."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_a",
+                    "type": "function",
+                    "function": {"name": "a", "arguments": "{}"},
+                },
+                {
+                    "id": "call_b",
+                    "type": "function",
+                    "function": {"name": "b", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_a", "content": "A"},
+        {"role": "tool", "tool_call_id": "call_b", "content": "B"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    assert len(out) == len(messages)
+    assert all(actual is original for actual, original in zip(out, messages))
+
+
 
 
 
@@ -400,7 +474,6 @@ def test_sanitize_dedup_does_not_create_empty_tool_calls_array():
 # "all messages must have non-empty content except for the optional final
 # assistant message" (INVALID_REQUEST_BODY). sanitize_api_messages now heals
 # such turns on the per-call copy so the session recovers itself in memory.
-
 
 
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -425,9 +425,9 @@ def test_sanitize_repairs_results_that_exist_only_later_in_history():
 
     first_assistant = next(i for i, msg in enumerate(out) if msg.get("tool_calls"))
     adjacent = out[first_assistant + 1:first_assistant + 3]
-    assert [msg["tool_call_id"] for msg in adjacent] == ["call_late", "call_here"]
-    assert adjacent[0]["content"] == "[Result unavailable — see context summary above]"
-    assert adjacent[1]["content"] == "local"
+    assert [msg["tool_call_id"] for msg in adjacent] == ["call_here", "call_late"]
+    assert adjacent[0]["content"] == "local"
+    assert adjacent[1]["content"] == "[Result unavailable — see context summary above]"
     assert not any(msg.get("content") == "too late" for msg in out)
 
 
@@ -452,8 +452,8 @@ def test_sanitize_preserves_complete_adjacent_tool_transaction_by_identity():
                 },
             ],
         },
-        {"role": "tool", "tool_call_id": "call_a", "content": "A"},
         {"role": "tool", "tool_call_id": "call_b", "content": "B"},
+        {"role": "tool", "tool_call_id": "call_a", "content": "A"},
     ]
 
     out = sanitize_api_messages(messages)
@@ -474,7 +474,6 @@ def test_sanitize_preserves_complete_adjacent_tool_transaction_by_identity():
 # "all messages must have non-empty content except for the optional final
 # assistant message" (INVALID_REQUEST_BODY). sanitize_api_messages now heals
 # such turns on the per-call copy so the session recovers itself in memory.
-
 
 
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -356,6 +356,38 @@ def test_sanitize_drops_empty_tool_calls_array():
     assert assistant["content"] == "answer"
 
 
+def test_sanitize_dedup_does_not_create_empty_tool_calls_array():
+    """A later assistant call whose id is entirely duplicate must not leave
+    ``tool_calls: []`` after the de-duplication pass.
+
+    DeepSeek validates the final serialized request, so an empty array created
+    inside the sanitizer is just as invalid as one loaded from history.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    duplicate_call = {
+        "id": "call_duplicate",
+        "type": "function",
+        "function": {"name": "terminal", "arguments": "{}"},
+    }
+    messages = [
+        {"role": "assistant", "content": None, "tool_calls": [duplicate_call]},
+        {"role": "tool", "tool_call_id": "call_duplicate", "content": "ok"},
+        {
+            "role": "assistant",
+            "content": "final answer",
+            "tool_calls": [duplicate_call],
+        },
+        {"role": "user", "content": "next"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    final_answer = next(m for m in out if m.get("content") == "final answer")
+    assert "tool_calls" not in final_answer
+    assert all(m.get("tool_calls") != [] for m in out)
+
+
 
 
 
@@ -368,7 +400,6 @@ def test_sanitize_drops_empty_tool_calls_array():
 # "all messages must have non-empty content except for the optional final
 # assistant message" (INVALID_REQUEST_BODY). sanitize_api_messages now heals
 # such turns on the per-call copy so the session recovers itself in memory.
-
 
 
 


### PR DESCRIPTION
## Summary

- normalize empty or malformed assistant `tool_calls` fields after tool-call ID de-duplication
- rebuild every Chat Completions tool transaction so each call has one immediately adjacent result
- insert deterministic placeholder results for locally missing outputs and remove late, duplicate, or orphaned outputs
- enforce both invariants again at the final Chat Completions wire boundary
- add regression coverage for the de-duplication and long-session adjacency failures

## Root cause

The sanitizer compared assistant call IDs and tool-result IDs across the entire transcript. That can report a call as satisfied even when its matching result occurs hundreds of messages later. After global de-duplication kept the earlier call and removed a later duplicate call, the later result remained separated from the surviving assistant message. Strict providers such as DeepSeek require each assistant `tool_calls` message to be followed immediately by tool results for every call, and rejected the payload with HTTP 400 (`insufficient tool messages following tool_calls message`).

A related edge case allowed de-duplication to create `tool_calls: []` after the initial empty-array cleanup pass.

The primary fix now canonicalizes each assistant plus its contiguous tool-result block after global filtering and de-duplication. The final transport guard applies the same invariant if an upstream sanitizer is bypassed or later middleware changes the history. Both are copy-on-write and do not rewrite durable session history.

## User impact

Long-running or resumed sessions containing duplicated, reordered, or separated tool calls/results recover automatically without deleting the session or editing its database. Strict OpenAI-compatible providers no longer receive empty tool-call arrays or incomplete tool transactions.

## Validation

- `scripts/run_tests.sh tests/agent/test_message_sanitization_policy.py tests/run_agent/test_message_sequence_repair.py tests/agent/transports/` — 308 passed
- replayed the captured 635-message failing DeepSeek session through sequence repair, request sanitization, and Chat Completions conversion — 0 transaction violations, 0 stray tool results, 0 empty `tool_calls`
- `ruff check` passed for all changed files
- `git diff --check` passed
