### PR TITLE
fix(terminal): strip heredoc bodies before blocked-command regex checks

### DIFF
--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -3,7 +3,7 @@
 import pytest
 
 from tools.approval import _hardline_block_result, _PARSER_LIMIT_DESCRIPTION, _MALFORMED_EXEC_DESCRIPTION
-from tools.terminal_tool import _foreground_background_guidance
+from tools.terminal_tool import _foreground_background_guidance, _strip_heredoc_bodies
 
 
 class TestParserLimitRecovery:
@@ -79,3 +79,395 @@ class TestBackgroundGuidanceRecipes:
 
     def test_quoted_ampersand_not_flagged(self):
         assert _foreground_background_guidance('git commit -m "a & b"') is None
+
+
+class TestHeredocBackgroundGuidance:
+    """Heredoc bodies are inline data — '&', 'nohup', etc. inside them must not
+    trigger backgrounding guidance, while real backgrounding after the heredoc
+    still must."""
+
+    def test_quoted_heredoc_python_bitwise_and_not_flagged(self):
+        cmd = (
+            "python3 - <<'EOF'\n"
+            "import os\n"
+            "st = os.stat('/tmp/x')\n"
+            "print(oct(st.st_mode & 0o777))\n"
+            "EOF"
+        )
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_unquoted_heredoc_ampersand_text_not_flagged(self):
+        cmd = "python3 <<EOF\nprint('up & own')\nEOF"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_heredoc_nohup_text_not_flagged(self):
+        cmd = "cat <<'EOF'\nrun it with nohup or setsid if you like\nEOF"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_dash_heredoc_tab_indented_body_not_flagged(self):
+        cmd = "cat <<-EOF\n\tbody & stuff\n\tEOF"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_unterminated_heredoc_body_not_flagged(self):
+        # An unterminated heredoc consumes the rest of the command as data.
+        cmd = "python3 <<EOF\na & b"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_real_background_ampersand_after_heredoc_still_blocked(self):
+        cmd = "python3 - <<'EOF'\nprint(1)\nEOF\nsleep 30 &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the '&'" in msg
+
+    def test_real_nohup_after_heredoc_still_blocked(self):
+        cmd = "cat <<EOF\nhi\nEOF\nnohup ./worker.sh > /dev/null 2>&1"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    # --- Adversarial regressions for review findings ---
+
+    def test_punctuation_bare_delimiter_does_not_swallow_trailing_nohup(self):
+        cmd = "cat <<EOF-X\nline1\nEOF-X\nnohup ./worker.sh > /dev/null 2>&1"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_comment_containing_heredoc_opener_does_not_strip_nohup(self):
+        cmd = "echo ok # <<EOF\nnohup bad &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_foo_hash_bar_is_not_a_comment(self):
+        # Inline `#` without preceding whitespace/operator is not a comment.
+        cmd = "foo#bar <<EOF\nnohup inside\nEOF"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_multiple_heredocs_consumed_in_shell_order(self):
+        cmd = (
+            "cat <<A <<B\n"
+            "body of A\n"
+            "A\n"
+            "body of B & stuff\n"
+            "B\n"
+            "nohup real &"
+        )
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_multiple_heredoc_bodies_ignore_background_operators(self):
+        cmd = "cat <<A <<B\nnohup in A\nA\nsetsid in B &\nB"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_composite_single_quoted_delimiter_terminates_body(self):
+        cmd = "cat <<'EO'F\nhi\nEOF\nnohup x &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_composite_backslash_delimiter_terminates_body(self):
+        cmd = "cat <<EO\\F\nhi\nEOF\nnohup x &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_composite_double_quoted_delimiter_terminates_body(self):
+        cmd = 'cat <<"EO"F\nhi\nEOF\nnohup x &'
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_composite_mixed_quote_delimiter_terminates_body(self):
+        cmd = "cat <<'E'\"O\"F\nhi\nEOF\nnohup x &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_unterminated_quote_delimiter_fail_closed(self):
+        cmd = "cat <<'EOF\nnohup x &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_empty_delimiter_fail_closed(self):
+        cmd = "cat << \nnohup x &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    @pytest.mark.parametrize(
+        "body_cmd",
+        [
+            "cat <<EOF-X\nnohup & setsid\nEOF-X",
+            "cat <<'EOF'\nnohup & setsid\nEOF",
+            'cat <<"EOF"\nnohup & setsid\nEOF',
+            "cat <<\\EOF\nnohup & setsid\nEOF",
+            "cat <<'EO'F\nnohup & setsid\nEOF",
+            "cat <<-EOF\n\tnohup & setsid\n\tEOF",
+        ],
+    )
+    def test_background_text_inside_each_delimiter_style_ignored(self, body_cmd):
+        assert _foreground_background_guidance(body_cmd) is None
+
+    @pytest.mark.parametrize(
+        "cmd,expect_amp,expect_wrapper",
+        [
+            ("cat <<EOF-X\nx\nEOF-X\nsleep 30 &", True, False),
+            ("cat <<'EOF'\nx\nEOF\nsleep 30 &", True, False),
+            ('cat <<"EOF"\nx\nEOF\nsleep 30 &', True, False),
+            ("cat <<'EO'F\nx\nEOF\nsleep 30 &", True, False),
+            (
+                "cat <<A <<B\na\nA\nb\nB\nnohup ./w.sh > /dev/null 2>&1",
+                False,
+                True,
+            ),
+        ],
+    )
+    def test_real_background_after_final_delimiter_detected(
+        self, cmd, expect_amp, expect_wrapper
+    ):
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        if expect_amp:
+            assert "WITHOUT the '&'" in msg
+        if expect_wrapper:
+            assert "WITHOUT the wrapper" in msg
+
+    @pytest.mark.parametrize(
+        "prefix",
+        [
+            'echo "<<EOF"',
+            "echo '<<EOF'",
+            "echo ok # <<EOF",
+        ],
+    )
+    def test_quoted_or_commented_heredoc_opener_ignored(self, prefix):
+        cmd = f"{prefix}\nnohup ./worker.sh > /dev/null 2>&1"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    # --- Expandable / ANSI-C delimiter words: fail closed ---
+
+    @pytest.mark.parametrize(
+        "opener,suffix,expect_wrapper,expect_amp",
+        [
+            ("cat <<$'EOF'", "nohup ./worker.sh > /dev/null 2>&1", True, False),
+            ('cat <<$"EOF"', "nohup ./worker.sh > /dev/null 2>&1", True, False),
+            ("cat <<$DELIM", "sleep 30 &", False, True),
+            ("cat <<EOF$X", "nohup x &", True, False),
+            ("cat <<$(cmd)EOF", "nohup x &", True, False),
+            ("cat <<`EOF`", "nohup x &", True, False),
+        ],
+    )
+    def test_expandable_delimiter_fail_closed_preserves_trailing_command(
+        self, opener, suffix, expect_wrapper, expect_amp
+    ):
+        cmd = f"{opener}\nhi\nEOF\n{suffix}"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        if expect_wrapper:
+            assert "WITHOUT the wrapper" in msg
+        if expect_amp:
+            assert "WITHOUT the '&'" in msg
+
+    def test_literal_dollar_in_single_quoted_delimiter_strips_body(self):
+        cmd = "cat <<'E$F'\nnohup inside\nE$F"
+        assert _foreground_background_guidance(cmd) is None
+
+    def test_backslash_escaped_dollar_delimiter_strips_body(self):
+        cmd = "cat <<E\\$F\nnohup inside\nE$F"
+        assert _foreground_background_guidance(cmd) is None
+
+
+class TestStripHeredocArithmetic:
+    """``<<`` inside shell arithmetic must not swallow trailing executable lines."""
+
+    def test_arithmetic_shift_does_not_strip_trailing_nohup(self):
+        cmd = "echo $((1 << 2))\nnohup ./worker &\n2"
+        assert _strip_heredoc_bodies(cmd) == cmd
+
+    def test_arithmetic_shift_does_not_strip_trailing_sleep_amp(self):
+        cmd = "echo $((1 << 2))\nsleep 30 &\n2"
+        assert _strip_heredoc_bodies(cmd) == cmd
+
+    def test_nested_arithmetic_shifts_ignored(self):
+        cmd = "echo $(( (1 << 2) << (2 + 1) ))"
+        assert _strip_heredoc_bodies(cmd) == cmd
+
+    def test_multiple_arithmetic_shifts_on_one_line(self):
+        cmd = "echo $((1 << 2)) $((3 << 4))"
+        assert _strip_heredoc_bodies(cmd) == cmd
+
+    def test_arithmetic_command_form_retains_trailing_executable(self):
+        cmd = "(( x = 1 << 2 ))\nnohup ./worker &"
+        assert _strip_heredoc_bodies(cmd) == cmd
+
+    def test_unmatched_dollar_arith_fail_closed(self):
+        cmd = "echo $((1 << 2\nnohup ./worker &"
+        assert _strip_heredoc_bodies(cmd) == cmd
+
+    def test_cmd_sub_with_heredoc_fail_closed(self):
+        cmd = "echo $(cat <<EOF\nx\nEOF)"
+        assert _strip_heredoc_bodies(cmd) == cmd
+
+    def test_real_heredoc_still_strips_body(self):
+        cmd = "cat <<EOF\n<nohup-looking data>\nEOF"
+        assert _strip_heredoc_bodies(cmd) == "cat <<EOF\nEOF"
+
+    def test_arithmetic_then_real_heredoc_on_same_line(self):
+        cmd = "echo $((1 << 2)); cat <<EOF\nbody\nEOF\nnohup x &"
+        assert _strip_heredoc_bodies(cmd) == "echo $((1 << 2)); cat <<EOF\nEOF\nnohup x &"
+
+    def test_real_heredoc_then_arithmetic_on_opener_line(self):
+        cmd = "cat <<EOF; echo $((1 << 2))\nbody\nEOF\nnohup x &"
+        assert _strip_heredoc_bodies(cmd) == "cat <<EOF; echo $((1 << 2))\nEOF\nnohup x &"
+
+    def test_nested_dollar_arith_shift_does_not_strip_trailing_nohup(self):
+        cmd = "echo $((1 + $((2 << 1)) << 3))\nnohup ./worker &\n3"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert stripped == cmd
+        assert "nohup ./worker &" in stripped
+
+    def test_nested_dollar_arith_shift_does_not_strip_trailing_sleep_amp(self):
+        cmd = "echo $((1 + $((2 << 1)) << 3))\nsleep 30 &\n3"
+        assert _strip_heredoc_bodies(cmd) == cmd
+        assert "sleep 30 &" in _strip_heredoc_bodies(cmd)
+
+    def test_triple_nested_dollar_arith_retains_trailing_nohup(self):
+        cmd = "echo $(( $(( $((1 << 2)) + 3 )) << 1 ))\nnohup ./worker &"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert stripped == cmd
+        assert "nohup ./worker &" in stripped
+
+    def test_sibling_nested_dollar_arith_retains_trailing_nohup(self):
+        cmd = "echo $(( $((1 << 2)) + $((3 << 4)) ))\nnohup ./worker &"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert stripped == cmd
+        assert "nohup ./worker &" in stripped
+
+    def test_unmatched_inner_dollar_arith_fail_closed(self):
+        cmd = "echo $((1 + $((2 << 1) << 3))\nnohup ./worker &\n3"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert stripped == cmd
+        assert "nohup ./worker &" in stripped
+
+    def test_unmatched_outer_dollar_arith_extra_closer_fail_closed(self):
+        cmd = "echo $((1 + $((2 << 1)) << 3)))\nnohup ./worker &"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert stripped == cmd
+        assert "nohup ./worker &" in stripped
+
+    def test_unmatched_outer_dollar_arith_missing_closer_fail_closed(self):
+        cmd = "echo $((1 + $((2 << 1)) << 3)\nnohup ./worker &"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert stripped == cmd
+        assert "nohup ./worker &" in stripped
+
+    def test_nested_arith_then_real_heredoc_strips_fake_retains_real_nohup(self):
+        cmd = (
+            "echo $((1 + $((2 << 1)) << 3))\n"
+            "cat <<EOF\n"
+            "nohup fake\n"
+            "EOF\n"
+            "nohup ./worker &"
+        )
+        stripped = _strip_heredoc_bodies(cmd)
+        assert stripped == (
+            "echo $((1 + $((2 << 1)) << 3))\n"
+            "cat <<EOF\n"
+            "EOF\n"
+            "nohup ./worker &"
+        )
+        assert "nohup fake" not in stripped
+        assert "nohup ./worker &" in stripped
+
+    def test_nested_arith_cmd_shift_retains_trailing_nohup(self):
+        cmd = "(( x = 1 + (( y = 2 << 1 )) << 3 ))\nnohup ./worker &"
+        stripped = _strip_heredoc_bodies(cmd)
+        assert stripped == cmd
+        assert "nohup ./worker &" in stripped
+
+
+class TestHeredocArithmeticBackgroundGuidance:
+    """End-to-end: arithmetic ``<<`` false positives must not hide background commands."""
+
+    def test_nohup_after_arithmetic_shift_still_blocked(self):
+        cmd = "echo $((1 << 2))\nnohup ./worker &\n2"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_sleep_amp_after_arithmetic_shift_still_blocked(self):
+        cmd = "echo $((1 << 2))\nsleep 30 &\n2"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the '&'" in msg
+
+    def test_nohup_after_arithmetic_command_still_blocked(self):
+        cmd = "(( x = 1 << 2 ))\nnohup ./worker &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_real_heredoc_after_arithmetic_on_same_line_still_strips(self):
+        cmd = "echo $((1 << 2)); cat <<EOF\nbody\nEOF\nnohup x &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_nohup_after_nested_dollar_arith_shift_still_blocked(self):
+        cmd = "echo $((1 + $((2 << 1)) << 3))\nnohup ./worker &\n3"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_sleep_amp_after_nested_dollar_arith_shift_still_blocked(self):
+        cmd = "echo $((1 + $((2 << 1)) << 3))\nsleep 30 &\n3"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the '&'" in msg
+
+    def test_nohup_after_triple_nested_dollar_arith_still_blocked(self):
+        cmd = "echo $(( $(( $((1 << 2)) + 3 )) << 1 ))\nnohup ./worker &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_nohup_after_sibling_nested_dollar_arith_still_blocked(self):
+        cmd = "echo $(( $((1 << 2)) + $((3 << 4)) ))\nnohup ./worker &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_nohup_after_unmatched_inner_dollar_arith_still_blocked(self):
+        cmd = "echo $((1 + $((2 << 1) << 3))\nnohup ./worker &\n3"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_nohup_after_unmatched_outer_extra_closer_still_blocked(self):
+        cmd = "echo $((1 + $((2 << 1)) << 3)))\nnohup ./worker &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_nohup_after_nested_arith_then_real_heredoc_still_blocked(self):
+        cmd = (
+            "echo $((1 + $((2 << 1)) << 3))\n"
+            "cat <<EOF\n"
+            "nohup fake\n"
+            "EOF\n"
+            "nohup ./worker &"
+        )
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg
+
+    def test_nohup_after_nested_arith_cmd_shift_still_blocked(self):
+        cmd = "(( x = 1 + (( y = 2 << 1 )) << 3 ))\nnohup ./worker &"
+        msg = _foreground_background_guidance(cmd)
+        assert msg is not None
+        assert "WITHOUT the wrapper" in msg

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2375,15 +2375,326 @@ _INLINE_BACKGROUND_AMP_RE = re.compile(r"\s&\s")
 _TRAILING_BACKGROUND_AMP_RE = re.compile(r"\s&\s*(?:#.*)?$")
 
 
+# Characters that terminate a bare (unquoted) heredoc delimiter word.
+_HEREDOC_BARE_STOP = set(" \t|&;()<>'\"\\$`")
+
+
+def _shell_comment_index(line: str) -> int | None:
+    """Return index of ``#`` starting a shell comment, or None."""
+    i = 0
+    n = len(line)
+    in_single = in_double = False
+    while i < n:
+        ch = line[i]
+        if ch == "\\" and not in_single and i + 1 < n:
+            i += 2
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            i += 1
+            continue
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            i += 1
+            continue
+        if in_single or in_double:
+            i += 1
+            continue
+        if ch == "#" and (i == 0 or line[i - 1] in " \t;|&"):
+            return i
+        i += 1
+    return None
+
+
+def _parse_shell_word(line: str, start: int, limit: int) -> tuple[str | None, int]:
+    """Parse one composite shell word from ``line[start:limit]``.
+
+    Returns ``(word, end_index)`` or ``(None, -1)`` when the word is empty,
+    contains an unterminated quote, or uses expandable ``$`` / backtick syntax
+    (``$'…'``, ``$"…"``, ``$VAR``, command substitution) — fail-closed.
+    """
+    parts: list[str] = []
+    i = start
+    while i < limit:
+        ch = line[i]
+        if ch in " \t":
+            break
+        if ch == "'":
+            j = i + 1
+            while j < limit and line[j] != "'":
+                j += 1
+            if j >= limit:
+                return None, -1
+            parts.append(line[i + 1 : j])
+            i = j + 1
+        elif ch == '"':
+            j = i + 1
+            buf: list[str] = []
+            while j < limit:
+                if line[j] == "\\" and j + 1 < limit:
+                    buf.append(line[j + 1])
+                    j += 2
+                elif line[j] == '"':
+                    break
+                elif line[j] in "$`":
+                    return None, -1
+                else:
+                    buf.append(line[j])
+                    j += 1
+            if j >= limit:
+                return None, -1
+            parts.append("".join(buf))
+            i = j + 1
+        elif ch == "\\":
+            if i + 1 >= limit:
+                return None, -1
+            parts.append(line[i + 1])
+            i += 2
+        elif ch in "$`":
+            return None, -1
+        elif ch in "|&;()<>":
+            break
+        else:
+            j = i
+            while j < limit and line[j] not in _HEREDOC_BARE_STOP:
+                j += 1
+            parts.append(line[i:j])
+            i = j
+    word = "".join(parts)
+    if not word:
+        return None, -1
+    return word, i
+
+
+def _heredoc_scan_unterminated(stack: list) -> bool:
+    """True when compound shell context on the line did not close (fail-closed)."""
+    return len(stack) > 0
+
+
+def _heredoc_scan_suppresses_shift(stack: list) -> bool:
+    """True when ``<<`` is arithmetic/test syntax, not a heredoc opener."""
+    return any(
+        entry["kind"] in ("dollar_arith", "arith_cmd", "test_bracket")
+        for entry in stack
+    )
+
+
+def _heredoc_scan_in_cmd_sub(stack: list) -> bool:
+    return any(entry["kind"] == "cmd_sub" for entry in stack)
+
+
+def _heredoc_stack_in_dollar_arith(stack: list) -> bool:
+    return any(entry["kind"] == "dollar_arith" for entry in stack)
+
+
+def _heredoc_stack_top_arith(stack: list) -> dict | None:
+    if not stack:
+        return None
+    top = stack[-1]
+    if top["kind"] in ("dollar_arith", "arith_cmd"):
+        return top
+    return None
+
+
+def _heredoc_close_arith_paren(stack: list) -> bool:
+    """Pop innermost arithmetic on ``)``; return False when unmatched (fail-closed)."""
+    top = _heredoc_stack_top_arith(stack)
+    if top is None:
+        return False
+    if top["paren_depth"] > 0:
+        top["paren_depth"] -= 1
+    elif top["close_remaining"] > 1:
+        top["close_remaining"] -= 1
+    else:
+        stack.pop()
+    return True
+
+
+def _find_heredoc_markers_on_line(line: str) -> list[tuple[str, bool]] | None:
+    """Return all heredoc openers on *line* in left-to-right order.
+
+    Returns ``None`` when any opener has an ambiguous delimiter (fail-closed),
+    when compound shell context is unterminated on the line (``$((``,
+    ``((``, ``[[``, ``$(``), or when command substitution contains heredoc
+    syntax (``<<`` inside ``$(...)`` — not soundly supported across lines).
+    """
+    comment_idx = _shell_comment_index(line)
+    limit = comment_idx if comment_idx is not None else len(line)
+    markers: list[tuple[str, bool]] = []
+    i = 0
+    in_single = False
+    in_double = False
+    stack: list[dict] = []
+    malformed = False
+    while i < limit:
+        ch = line[i]
+        if ch == "\\" and not in_single and i + 1 < limit:
+            i += 2
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            i += 1
+            continue
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            i += 1
+            continue
+        if in_single or in_double:
+            i += 1
+            continue
+
+        if ch == "$" and i + 2 < limit and line[i + 1 : i + 3] == "((":
+            stack.append(
+                {"kind": "dollar_arith", "close_remaining": 2, "paren_depth": 0}
+            )
+            i += 3
+            continue
+        if ch == "$" and i + 1 < limit and line[i + 1] == "(":
+            stack.append({"kind": "cmd_sub"})
+            i += 2
+            continue
+
+        if (
+            ch == "("
+            and i + 1 < limit
+            and line[i + 1] == "("
+            and not _heredoc_stack_in_dollar_arith(stack)
+        ):
+            stack.append(
+                {"kind": "arith_cmd", "close_remaining": 2, "paren_depth": 0}
+            )
+            i += 2
+            continue
+
+        if ch == "[" and i + 1 < limit and line[i + 1] == "[":
+            stack.append({"kind": "test_bracket"})
+            i += 2
+            continue
+
+        if ch == "(" and _heredoc_stack_top_arith(stack) is not None:
+            _heredoc_stack_top_arith(stack)["paren_depth"] += 1
+            i += 1
+            continue
+
+        if ch == ")":
+            if stack and stack[-1]["kind"] == "cmd_sub":
+                stack.pop()
+            elif _heredoc_stack_top_arith(stack) is not None:
+                if not _heredoc_close_arith_paren(stack):
+                    malformed = True
+            else:
+                malformed = True
+            i += 1
+            continue
+
+        if (
+            stack
+            and stack[-1]["kind"] == "test_bracket"
+            and ch == "]"
+            and i + 1 < limit
+            and line[i + 1] == "]"
+        ):
+            stack.pop()
+            i += 2
+            continue
+
+        if ch == "<" and i + 1 < limit and line[i + 1] == "<":
+            if _heredoc_scan_in_cmd_sub(stack):
+                return None
+            if _heredoc_scan_suppresses_shift(stack):
+                i += 2
+                continue
+            if i + 2 < limit and line[i + 2] == "<":
+                i += 3
+                while i < limit and line[i] in " \t":
+                    i += 1
+                _word, next_i = _parse_shell_word(line, i, limit)
+                if next_i == -1:
+                    return None
+                i = next_i if next_i >= i else i
+                continue
+            j = i + 2
+            strip_dash = False
+            if j < limit and line[j] == "-":
+                strip_dash = True
+                j += 1
+            while j < limit and line[j] in " \t":
+                j += 1
+            word, next_i = _parse_shell_word(line, j, limit)
+            if word is None:
+                return None
+            markers.append((word, strip_dash))
+            i = next_i
+            continue
+        i += 1
+    if malformed or _heredoc_scan_unterminated(stack):
+        return None
+    return markers
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Remove heredoc bodies so regex checks don't match inside inline data.
+
+    Keeps every heredoc's opening line and delimiter line, drops the body
+    lines between them. Runs before quote stripping because heredoc bodies
+    routinely contain unbalanced quotes that would derail quote-pair regexes.
+    An unterminated heredoc consumes the rest of the command (all data).
+
+    When any heredoc delimiter cannot be parsed unambiguously, returns
+    *command* unchanged so dangerous operators after it remain detectable.
+
+    Left-shift ``<<`` inside shell arithmetic (``$(( ... ))``, ``(( ... ))``)
+    or lexical tests (``[[ ... ]]``) is never treated as a heredoc opener.
+    Unterminated compound context on a line, or heredoc syntax inside
+    ``$(...)`` command substitution, also returns *command* unchanged
+    (fail-closed) rather than mis-stripping executable trailing commands.
+    """
+    lines = command.split("\n")
+    out_lines: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        markers = _find_heredoc_markers_on_line(line)
+        if markers is None:
+            return command
+        out_lines.append(line)
+        if not markers:
+            i += 1
+            continue
+        queue = list(markers)
+        i += 1
+        while queue and i < n:
+            word, strip_dash = queue.pop(0)
+            while i < n:
+                body = lines[i]
+                if strip_dash:
+                    terminated = body.lstrip("\t") == word
+                else:
+                    terminated = body == word
+                if terminated:
+                    out_lines.append(body)
+                    i += 1
+                    break
+                i += 1
+        if queue:
+            break
+    return "\n".join(out_lines)
+
+
 def _strip_quotes(command: str) -> str:
     """Remove single- and double-quoted content so regex checks don't match inside strings.
 
     This prevents false positives when keywords like 'nohup' or 'setsid' appear
     in commit messages, Python -c code, echo arguments, or PR body text.
-    Also strips backtick-quoted content and heredoc-style inline text.
+    Also strips backtick-quoted content and heredoc bodies (inline script/data
+    payloads, e.g. ``python3 - <<'EOF' ... EOF``).
     """
+    # Remove heredoc bodies first — they can hold unbalanced quotes and shell
+    # operators that are data, not commands.
+    result = _strip_heredoc_bodies(command)
     # Remove single-quoted strings (no escaping inside single quotes in shell)
-    result = re.sub(r"'[^']*'", "''", command)
+    result = re.sub(r"'[^']*'", "''", result)
     # Remove double-quoted strings (handle escaped quotes)
     result = re.sub(r'"(?:[^"\\]|\\.)*"', '""', result)
     # Remove backtick-quoted strings


### PR DESCRIPTION
## Summary

`_strip_quotes` in the terminal tool's blocked-command checks misread heredoc bodies (`python3 - <<'EOF' ... EOF`) as shell syntax: unbalanced quotes and shell operators inside inline data produced false positives for backgrounding/`nohup` detection.

This strips heredoc bodies before quote stripping, using a bounded shell-aware scanner:

- comment-aware line scan (`<<` inside `#` comments ignored)
- FIFO queue for multiple heredocs per command line
- composite delimiter words: `<<'EO'F`, `<<EO\F`, `<<"EO"F` -> `EOF`
- punctuation-inclusive bare delimiters (`EOF-X`) and the `<<-` tab form
- here-strings (`<<<`) and arithmetic shifts (`$((1 << 2))`, nested) ignored
- fail-closed: ambiguous or expandable delimiter words (`$VAR`, backtick, `<<$'EOF'`) leave the command unchanged so trailing commands stay visible to the filter

Security invariant: the scanner may over-retain text (false positive) but never deletes real executable commands from filter inspection.

## Test Plan

- `scripts/run_tests.sh tests/tools/test_blocked_command_guidance.py tests/tools/test_terminal_compound_background.py tests/tools/test_terminal_tool.py` -> 106 passed, 0 failed
- adversarial coverage: nested arithmetic, multiple heredocs, composite/escaped/quoted delimiters, comment-embedded `<<`, body false-positive suppression, trailing `nohup`/`&` detection after final delimiter

Restored and hardened from stranded local work; independent fresh-context adversarial review PASS after three fix rounds.
