### PR TITLE
feat(gateway): sender-based profile routes

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -950,9 +950,10 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
-    # Profile-based routing: route specific guilds/channels/threads to
+    # Profile-based routing: route specific users/guilds/channels/threads to
     # different profiles. See gateway/profile_routing.py. Each entry is a
-    # dict with: name, platform, profile, and optional guild_id/chat_id/thread_id.
+    # dict with: name, platform, profile, and optional
+    # user_id/guild_id/chat_id/thread_id.
     profile_routes: list = field(default_factory=list)
 
     def __post_init__(self) -> None:

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -148,6 +148,54 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
         except (ValueError, ImportError):
             logger.warning("Skipping profile route %s: invalid profile name %r", name, profile)
             continue
+        user_id = None
+        if entry.get("user_id") is not None:
+            raw_user_id = entry["user_id"]
+            if isinstance(raw_user_id, bool):
+                logger.warning(
+                    "Skipping profile route %s: invalid user_id %r",
+                    name,
+                    raw_user_id,
+                )
+                continue
+            if isinstance(raw_user_id, (list, dict, set, tuple)):
+                logger.warning(
+                    "Skipping profile route %s: invalid user_id %r",
+                    name,
+                    raw_user_id,
+                )
+                continue
+            if isinstance(raw_user_id, float):
+                logger.warning(
+                    "Skipping profile route %s: invalid user_id %r",
+                    name,
+                    raw_user_id,
+                )
+                continue
+            if isinstance(raw_user_id, int):
+                if raw_user_id <= 0:
+                    logger.warning(
+                        "Skipping profile route %s: user_id must be a positive integer, got %r",
+                        name,
+                        raw_user_id,
+                    )
+                    continue
+                user_id = str(raw_user_id)
+            elif isinstance(raw_user_id, str):
+                user_id = raw_user_id.strip()
+                if not user_id:
+                    logger.warning(
+                        "Skipping profile route %s: empty user_id",
+                        name,
+                    )
+                    continue
+            else:
+                logger.warning(
+                    "Skipping profile route %s: invalid user_id %r",
+                    name,
+                    raw_user_id,
+                )
+                continue
         routes.append(
             ProfileRoute(
                 name=name,
@@ -156,11 +204,7 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
                 guild_id=entry.get("guild_id"),
                 chat_id=entry.get("chat_id"),
                 thread_id=entry.get("thread_id"),
-                user_id=(
-                    str(entry["user_id"]).strip()
-                    if entry.get("user_id") is not None
-                    else None
-                ),
+                user_id=user_id,
                 enabled=entry.get("enabled", True),
             )
         )

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -1,13 +1,16 @@
 """Profile-based routing for the gateway with hierarchical matching.
 
-Allows a single Hermes instance to route specific Discord guilds/channels/threads
-to different profiles — each with their own model, tools, memory, and persona.
+Allows a single Hermes instance to route specific senders or Discord
+guilds/channels/threads to different profiles — each with their own model,
+tools, memory, and persona.
 
 Matching priority (most specific first):
-  1. platform + chat_id + thread_id (exact thread)  — specificity 14
-  2. platform + chat_id (channel route)             — specificity 6
-  3. platform + guild_id (guild/server route)       — specificity 2
-  4. No match                                       → default profile
+  1. sender + location constraints                  — specificity 18-30
+  2. platform + user_id (sender route)              — specificity 16
+  3. platform + chat_id + thread_id (exact thread)  — specificity 14
+  4. platform + chat_id (channel route)             — specificity 6
+  5. platform + guild_id (guild/server route)       — specificity 2
+  6. No match                                       → default profile
 
 Parent-chain matching:
 For Discord threads and forum posts, ``parent_chat_id`` carries the
@@ -35,6 +38,11 @@ Configuration (config.yaml):
           chat_id: "YOUR_CHANNEL_ID"
           thread_id: "YOUR_THREAD_ID"
           profile: thread-profile
+
+        - name: sender-route
+          platform: discord
+          user_id: "YOUR_USER_ID"
+          profile: sender-profile
 """
 
 from __future__ import annotations
@@ -57,6 +65,7 @@ class ProfileRoute:
     guild_id: Optional[str] = None
     chat_id: Optional[str] = None
     thread_id: Optional[str] = None
+    user_id: Optional[str] = None
     enabled: bool = True
 
     @property
@@ -69,6 +78,8 @@ class ProfileRoute:
             s += 4
         if self.thread_id:
             s += 8
+        if self.user_id:
+            s += 16
         return s
 
     def matches(
@@ -78,6 +89,7 @@ class ProfileRoute:
         chat_id: Optional[str] = None,
         thread_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> bool:
         """Return True if this route matches the given source fields.
 
@@ -98,6 +110,8 @@ class ProfileRoute:
         if self.chat_id and self.chat_id != chat_id and self.chat_id != parent_chat_id:
             return False
         if self.guild_id and self.guild_id != guild_id:
+            return False
+        if self.user_id and self.user_id != user_id:
             return False
         return True
 
@@ -142,6 +156,11 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
                 guild_id=entry.get("guild_id"),
                 chat_id=entry.get("chat_id"),
                 thread_id=entry.get("thread_id"),
+                user_id=(
+                    str(entry["user_id"]).strip()
+                    if entry.get("user_id") is not None
+                    else None
+                ),
                 enabled=entry.get("enabled", True),
             )
         )
@@ -158,9 +177,17 @@ def match_profile_route(
     chat_id: Optional[str] = None,
     thread_id: Optional[str] = None,
     parent_chat_id: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> Optional[ProfileRoute]:
     """Return the best-matching route, or None for no match."""
     for route in routes:
-        if route.matches(platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id, parent_chat_id=parent_chat_id):
+        if route.matches(
+            platform,
+            guild_id=guild_id,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            parent_chat_id=parent_chat_id,
+            user_id=user_id,
+        ):
             return route
     return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24947,7 +24947,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         no route matches. Callers (``build_source``,
         ``_resolve_profile_home_for_source``) treat ``None`` as "use the
         default/active profile". When ``gateway.profile_routes`` is configured,
-        the most specific matching route wins (guild < channel < thread). See
+        the most specific matching route wins
+        (guild < channel < thread < sender). See
         :mod:`gateway.profile_routing` for matching rules.
 
         Gated on ``gateway.multiplex_profiles``: routing stamps
@@ -24972,6 +24973,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_id=source.chat_id,
                 thread_id=getattr(source, "thread_id", None),
                 parent_chat_id=getattr(source, "parent_chat_id", None),
+                user_id=getattr(source, "user_id", None),
             )
         except Exception:
             logger.warning(

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -8,7 +8,7 @@ import pytest
 
 from gateway.session import SessionSource, build_session_key
 from gateway.run import GatewayRunner
-from gateway.profile_routing import ProfileRoute
+from gateway.profile_routing import ProfileRoute, parse_profile_routes
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import BasePlatformAdapter
 
@@ -243,6 +243,7 @@ class TestAdapterToSessionKeyIntegration:
         ]
 
     def test_discord_adapter_stamps_profile_and_scopes_key(self, mock_runner):
+        mock_runner.config.multiplex_profiles = True
         mock_runner.config.profile_routes = self._routes()
         adapter = _stub_adapter(Platform.DISCORD, mock_runner)
 
@@ -255,6 +256,84 @@ class TestAdapterToSessionKeyIntegration:
         assert key.startswith("agent:coder:"), key
         # A default-profile key would land in agent:main — must differ.
         assert key != build_session_key(source, profile=None)
+
+    def test_discord_sender_route_via_parse_stamps_profile_and_scopes_key(
+        self, mock_runner,
+    ):
+        mock_runner.config.multiplex_profiles = True
+        mock_runner.config.profile_routes = parse_profile_routes([
+            {"name": "builder", "platform": "discord", "profile": "product-builder",
+             "user_id": 392686399226380294},
+        ])
+        adapter = _stub_adapter(Platform.DISCORD, mock_runner)
+
+        source = adapter.build_source(
+            chat_id="222",
+            chat_type="group",
+            guild_id="111",
+            user_id="392686399226380294",
+        )
+        assert source.profile == "product-builder"
+
+        key = build_session_key(source, profile=source.profile)
+        assert key.startswith("agent:product-builder:"), key
+        assert key != build_session_key(source, profile=None)
+
+    def test_telegram_sender_route_via_parse_matching_user(self, mock_runner):
+        mock_runner.config.multiplex_profiles = True
+        mock_runner.config.profile_routes = parse_profile_routes([
+            {"name": "vip", "platform": "telegram", "profile": "vip-profile",
+             "user_id": 123456789},
+        ])
+        adapter = _stub_adapter(Platform.TELEGRAM, mock_runner)
+
+        source = adapter.build_source(
+            chat_id="-1001234567890",
+            chat_type="group",
+            user_id="123456789",
+        )
+        assert source.profile == "vip-profile"
+
+        key = build_session_key(source, profile=source.profile)
+        assert key.startswith("agent:vip-profile:"), key
+
+    def test_telegram_sender_route_via_parse_nonmatching_user(self, mock_runner):
+        mock_runner.config.multiplex_profiles = True
+        mock_runner.config.profile_routes = parse_profile_routes([
+            {"name": "vip", "platform": "telegram", "profile": "vip-profile",
+             "user_id": 123456789},
+        ])
+        adapter = _stub_adapter(Platform.TELEGRAM, mock_runner)
+
+        source = adapter.build_source(
+            chat_id="-1001234567890",
+            chat_type="group",
+            user_id="999999999",
+        )
+        assert source.profile is None
+
+        key = build_session_key(source, profile=source.profile)
+        assert key.startswith("agent:main:"), key
+
+    def test_empty_user_id_route_does_not_stamp_profile(self, mock_runner):
+        mock_runner.config.multiplex_profiles = True
+        mock_runner.config.profile_routes = parse_profile_routes([
+            {"name": "bad-sender", "platform": "discord", "profile": "leaked",
+             "user_id": ""},
+        ])
+        assert mock_runner.config.profile_routes == []
+        adapter = _stub_adapter(Platform.DISCORD, mock_runner)
+
+        source = adapter.build_source(
+            chat_id="222",
+            chat_type="group",
+            guild_id="111",
+            user_id="392686399226380294",
+        )
+        assert source.profile is None
+
+        key = build_session_key(source, profile=source.profile)
+        assert key.startswith("agent:main:"), key
 
 
 class TestMultiplexGate:

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -168,6 +168,26 @@ class TestNonDiscordProfileRouting:
         assert mock_runner._profile_name_for_source(telegram_source) == "tg-profile"
 
 
+class TestSenderProfileRouting:
+    def test_discord_sender_route_reaches_gateway_resolution(self, mock_runner, discord_source):
+        mock_runner.config.profile_routes = [
+            ProfileRoute(name="builder", platform="discord", profile="product-builder",
+                         user_id="392686399226380294"),
+        ]
+        discord_source.user_id = "392686399226380294"
+
+        assert mock_runner._profile_name_for_source(discord_source) == "product-builder"
+
+    def test_discord_sender_route_rejects_other_user(self, mock_runner, discord_source):
+        mock_runner.config.profile_routes = [
+            ProfileRoute(name="builder", platform="discord", profile="product-builder",
+                         user_id="392686399226380294"),
+        ]
+        discord_source.user_id = "someone-else"
+
+        assert mock_runner._profile_name_for_source(discord_source) is None
+
+
 class TestGatewayRunnerInjection:
     """``BasePlatformAdapter`` declares ``gateway_runner`` so the gateway's
     unconditional injection reaches every platform adapter — the foundation

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -14,6 +14,16 @@ class TestProfileRoute:
                          guild_id="g", chat_id="c", thread_id="t")
         assert r.specificity == 14  # 2 + 4 + 8
 
+    def test_specificity_sender(self):
+        r = ProfileRoute(name="u", platform="discord", profile="p",
+                         user_id="42")
+        assert r.specificity == 16
+
+    def test_specificity_sender_thread(self):
+        r = ProfileRoute(name="ut", platform="discord", profile="p",
+                         guild_id="g", chat_id="c", thread_id="t", user_id="42")
+        assert r.specificity == 30  # 2 + 4 + 8 + 16
+
 
     def test_frozen(self):
         r = ProfileRoute(name="x", platform="discord", profile="p")
@@ -44,11 +54,36 @@ class TestProfileRouteMatching:
         # guild matches but chat differs -> NO match
         assert not r.matches("discord", guild_id="111", chat_id="333")
 
+    def test_sender_match(self):
+        r = ProfileRoute(name="u", platform="discord", profile="builder",
+                         user_id="42")
+        assert r.matches("discord", user_id="42")
+        assert not r.matches("discord", user_id="43")
+        assert not r.matches("discord")
+
+    def test_sender_and_chat_are_conjunctive(self):
+        r = ProfileRoute(name="uc", platform="discord", profile="builder",
+                         user_id="42", chat_id="222")
+        assert r.matches("discord", user_id="42", chat_id="222")
+        assert not r.matches("discord", user_id="42", chat_id="333")
+        assert not r.matches("discord", user_id="43", chat_id="222")
+
 
 class TestParseProfileRoutes:
     def test_empty(self):
         assert parse_profile_routes(None) == []
         assert parse_profile_routes([]) == []
+
+    def test_sender_route_parsed_and_coerced(self):
+        raw = [
+            {"name": "thread", "platform": "discord", "profile": "p",
+             "guild_id": "1", "chat_id": "2", "thread_id": "3"},
+            {"name": "sender", "platform": "discord", "profile": "p",
+             "user_id": 42},
+        ]
+        routes = parse_profile_routes(raw)
+        by_name = {r.name: r for r in routes}
+        assert by_name["sender"].user_id == "42"
 
 
 class TestMatchProfileRoute:
@@ -59,6 +94,24 @@ class TestMatchProfileRoute:
             ProfileRoute(name="r", platform="telegram", profile="p"),
         ]
         assert match_profile_route(routes, "discord") is None
+
+    def test_sender_route_outranks_location_only_route(self):
+        routes = parse_profile_routes([
+            {"name": "thread", "platform": "discord", "profile": "thread-profile",
+             "guild_id": "1", "chat_id": "2", "thread_id": "3"},
+            {"name": "sender", "platform": "discord", "profile": "builder",
+             "user_id": "42"},
+        ])
+        matched = match_profile_route(
+            routes,
+            "discord",
+            guild_id="1",
+            chat_id="2",
+            thread_id="3",
+            user_id="42",
+        )
+        assert matched is not None
+        assert matched.profile == "builder"
 
 
 class TestSessionKeyIntegration:

--- a/tests/gateway/test_profile_routing.py
+++ b/tests/gateway/test_profile_routing.py
@@ -1,5 +1,7 @@
 """Tests for gateway/profile_routing.py — profile-based routing."""
 
+import logging
+
 import pytest
 from gateway.profile_routing import (
     ProfileRoute,
@@ -68,6 +70,29 @@ class TestProfileRouteMatching:
         assert not r.matches("discord", user_id="42", chat_id="333")
         assert not r.matches("discord", user_id="43", chat_id="222")
 
+    def test_sender_guild_chat_thread_conjunctive(self):
+        r = ProfileRoute(
+            name="full",
+            platform="discord",
+            profile="scoped",
+            user_id="42",
+            guild_id="111",
+            chat_id="222",
+            thread_id="333",
+        )
+        base = dict(
+            platform="discord",
+            user_id="42",
+            guild_id="111",
+            chat_id="222",
+            thread_id="333",
+        )
+        assert r.matches(**base)
+        assert not r.matches(**{**base, "user_id": "99"})
+        assert not r.matches(**{**base, "guild_id": "999"})
+        assert not r.matches(**{**base, "chat_id": "888"})
+        assert not r.matches(**{**base, "thread_id": "444"})
+
 
 class TestParseProfileRoutes:
     def test_empty(self):
@@ -84,6 +109,71 @@ class TestParseProfileRoutes:
         routes = parse_profile_routes(raw)
         by_name = {r.name: r for r in routes}
         assert by_name["sender"].user_id == "42"
+
+    @pytest.mark.parametrize("user_id", ["", "   "])
+    def test_empty_user_id_route_skipped(self, user_id, caplog):
+        raw = [
+            {"name": "bad-sender", "platform": "discord", "profile": "p",
+             "user_id": user_id},
+        ]
+        with caplog.at_level(logging.WARNING):
+            routes = parse_profile_routes(raw)
+        assert routes == []
+        assert any("bad-sender" in r.message and "empty user_id" in r.message
+                   for r in caplog.records)
+
+    @pytest.mark.parametrize(
+        "user_id",
+        [True, 1.5, [123], {"id": 1}],
+    )
+    def test_malformed_user_id_route_skipped(self, user_id, caplog):
+        raw = [
+            {"name": "bad-sender", "platform": "discord", "profile": "p",
+             "user_id": user_id},
+        ]
+        with caplog.at_level(logging.WARNING):
+            routes = parse_profile_routes(raw)
+        assert routes == []
+        assert any("bad-sender" in r.message and "invalid user_id" in r.message
+                   for r in caplog.records)
+
+    @pytest.mark.parametrize("user_id", [0, -7])
+    def test_nonpositive_int_user_id_route_skipped(self, user_id, caplog):
+        raw = [
+            {"name": "bad-sender", "platform": "discord", "profile": "p",
+             "user_id": user_id},
+        ]
+        with caplog.at_level(logging.WARNING):
+            routes = parse_profile_routes(raw)
+        assert routes == []
+        assert any(
+            "bad-sender" in r.message and "positive integer" in r.message
+            for r in caplog.records
+        )
+
+    def test_valid_user_id_normalization(self):
+        snowflake = 392686399226380294
+        raw = [
+            {"name": "int-sender", "platform": "discord", "profile": "p",
+             "user_id": 42},
+            {"name": "snowflake-sender", "platform": "discord", "profile": "p",
+             "user_id": snowflake},
+            {"name": "str-sender", "platform": "discord", "profile": "p",
+             "user_id": " 42 "},
+        ]
+        routes = parse_profile_routes(raw)
+        by_name = {r.name: r for r in routes}
+        assert by_name["int-sender"].user_id == "42"
+        assert by_name["snowflake-sender"].user_id == str(snowflake)
+        assert by_name["str-sender"].user_id == "42"
+
+    def test_absent_user_id_stays_none(self):
+        routes = parse_profile_routes([
+            {"name": "loc", "platform": "discord", "profile": "p",
+             "guild_id": "1", "chat_id": "2"},
+        ])
+        assert len(routes) == 1
+        assert routes[0].user_id is None
 
 
 class TestMatchProfileRoute:


### PR DESCRIPTION
## Summary

Profile routes could only match on location (guild/channel/thread). This adds an optional `user_id` constraint so a specific sender is routed to a profile regardless of where they post.

- sender-only routes at specificity 16; sender+location combos up to 30 (`guild < channel < thread < sender`)
- matching is conjunctive with any location constraints
- fail-closed parsing: an explicitly configured `user_id` that normalizes empty, whitespace-only, non-positive, or malformed (bool/float/container) skips the route with a warning rather than silently broadening it; real Discord snowflakes (int or nonempty string) normalize correctly
- existing routes without `user_id` are unaffected

## Test Plan

- `scripts/run_tests.sh tests/gateway/test_profile_routing.py tests/gateway/test_profile_resolution.py tests/gateway/test_config.py` -> 96 passed, 0 failed
- parse -> `build_source` -> `_profile_name_for_source` -> `build_session_key` integration covered for Discord and Telegram, including proof that `user_id: ""` produces no route and never stamps a profile

Restored and hardened from stranded local work; fresh-context adversarial review PASS.
