### PR TITLE
feat(gateway): harden systemd event-loop watchdog

### DIFF
--- a/gateway/systemd_notify.py
+++ b/gateway/systemd_notify.py
@@ -1,176 +1,495 @@
-"""Minimal, optional systemd ``sd_notify`` support for the gateway."""
+"""systemd ``sd_notify(3)`` event-loop watchdog (opt-in, #gateway-hang).
+
+The gateway runs under systemd. The in-process Discord liveness probe and the
+reconnect watcher recover *detectable* failures, but they all run ON the asyncio
+event loop. If the loop itself wedges (a blocking call, a deadlock, a stuck
+task), nothing on the loop can recover it — the process stays alive, Discord
+goes silent, and only a manual ``systemctl restart`` recovers it. That is the
+"unresponsive until I restart the gateway" failure mode.
+
+This module closes that gap by feeding systemd's watchdog (``WatchdogSec=``) from
+an asyncio task. The ping originates ON the event loop, so a wedged loop *stops
+pinging* and systemd kills + restarts the service. As a secondary signal, each
+tick measures its own scheduling lag: if a heartbeat cycle runs late (the loop
+was blocked but not fully dead), the watchdog latches ``unhealthy``, reports a
+``STATUS=`` diagnostic, and stops sending ``WATCHDOG=1`` so systemd still acts.
+
+CRITICAL design rule: the ping MUST come from the event loop, never from a
+background thread. A thread would keep pinging happily while the loop is frozen,
+which is exactly the failure this exists to catch.
+
+Everything here is stdlib-only (no ``sdnotify`` / ``systemd`` PyPI dependency)
+and best-effort: a liveness mechanism must never be able to crash the gateway.
+The feature is gated by ``gateway.systemd_watchdog_seconds`` in config; when
+disabled (0), :class:`SystemdWatchdog` is a no-op and ``Type=simple`` is
+preserved.
+
+Lifecycle state transitions and ``STOPPING=1`` are owned exclusively by
+:meth:`SystemdWatchdog.stop`. A heartbeat that self-exits on unhealthy latch
+or error retains a completed task handle until ``stop()`` runs. When
+``stop()`` is externally cancelled while the heartbeat is still winding down,
+a done-callback clears the orphaned task reference once the coroutine exits
+and lifecycle state is already idle.
+
+:class:`SystemdWatchdog` additionally requires a valid runtime environment:
+``NOTIFY_SOCKET``, positive finite ``WATCHDOG_USEC``, ``AF_UNIX`` support, and
+(when set) a matching ``WATCHDOG_PID``. Missing or invalid watchdog env yields
+``enabled=False`` and ``start()`` returns False — there is no fallback interval.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import os
 import socket
 from typing import Optional
 
+logger = logging.getLogger(__name__)
 
-def _notify_address(raw: str) -> str:
-    """Translate systemd's ``@abstract`` notation to Python's address form."""
-    return "\0" + raw[1:] if raw.startswith("@") else raw
+_MAX_STATUS_LEN = 256
+
+# Lifecycle states for start/stop serialization.
+_STATE_IDLE = "idle"
+_STATE_RUNNING = "running"
+_STATE_STOPPING = "stopping"
+
+
+def _sanitize_status(status: str) -> str:
+    """Return a single-line STATUS payload safe for sd_notify datagrams."""
+    if not isinstance(status, str):
+        status = str(status)
+    sanitized = status.replace("\r", " ").replace("\n", " ").replace("\0", " ")
+    if len(sanitized) > _MAX_STATUS_LEN:
+        sanitized = sanitized[:_MAX_STATUS_LEN]
+    return sanitized
+
+
+# ── NOTIFY_SOCKET handling ──────────────────────────────────────────────────
+#
+# systemd provides ``$NOTIFY_SOCKET`` to the main process when ``WatchdogSec=`` /
+# ``NotifyAccess=`` are configured. Per sd_notify(3) it is an AF_UNIX path or,
+# with a leading "@", an abstract-namespace socket.
+
+
+def _resolve_notify_socket() -> Optional[str]:
+    """Return ``$NOTIFY_SOCKET`` (or None). Read fresh on every call.
+
+    systemd sets this once at process start and we read it on each ping. We
+    deliberately do NOT cache across calls: the value can differ between
+    invocations in tests, and a stale cache would silently route pings to a
+    dead socket. The cost is one ``os.environ`` lookup per ping (~every 15-45s),
+    which is negligible.
+    """
+    raw = os.environ.get("NOTIFY_SOCKET", "").strip()
+    return raw or None
 
 
 def notify(message: str) -> bool:
-    """Send one nonblocking sd_notify datagram when systemd configured it.
+    """Send a single ``sd_notify`` datagram. Best-effort; never raises.
 
-    Notification failures are deliberately non-fatal: a missing socket or an
-    older platform must never prevent the gateway from starting.
+    Returns True if a datagram was sent, False if there is no notify socket or
+    the send failed. Uses a non-blocking datagram send so a wedged systemd
+    notify socket can never block the event loop. ``message`` is the raw payload,
+    e.g. ``"WATCHDOG=1"`` or ``"READY=1\\nSTATUS=running"``.
     """
-    address = os.environ.get("NOTIFY_SOCKET", "").strip()
-    if not address:
-        return False
-    if not isinstance(message, str) or not message:
-        return False
-    if not hasattr(socket, "AF_UNIX"):
+    addr = _resolve_notify_socket()
+    if not addr:
         return False
     try:
-        payload = message.encode("utf-8")
-        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sender:
-            # A full receiver buffer must not stall the gateway event loop.
-            sender.setblocking(False)
-            sender.connect(_notify_address(address))
-            sender.send(payload)
+        if addr.startswith("@"):
+            # Abstract namespace socket: leading "@" → NUL byte.
+            sock_addr = "\0" + addr[1:]
+        else:
+            sock_addr = addr
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+            sock.setblocking(False)
+            try:
+                sock.connect(sock_addr)
+            except BlockingIOError:
+                # A non-blocking connect can report EINPROGRESS even though an
+                # AF_UNIX datagram "connection" (just a default destination) is
+                # effectively established. Proceed to send; a genuinely
+                # unreachable socket still fails at send() and is caught below.
+                pass
+            sock.send(message.encode("utf-8"))
         return True
-    except (OSError, UnicodeError, ValueError):
+    except Exception:
+        logger.debug("sd_notify(%r) failed", message, exc_info=True)
         return False
 
 
 def watchdog_interval_seconds() -> Optional[float]:
-    """Return systemd's configured watchdog interval in seconds."""
-    if not os.environ.get("NOTIFY_SOCKET", "").strip():
-        return None
-    if not hasattr(socket, "AF_UNIX"):
-        return None
+    """Return systemd's watchdog timeout (``$WATCHDOG_USEC``) in seconds.
+
+    Returns None when the variable is missing, invalid, or non-positive (i.e.
+    systemd is not watching this process). Reading it at runtime keeps the ping
+    cadence in sync with the unit file's ``WatchdogSec``.
+    """
     raw = os.environ.get("WATCHDOG_USEC", "").strip()
     if not raw:
         return None
     try:
-        interval = float(raw) / 1_000_000.0
+        usec = int(raw)
     except (TypeError, ValueError):
         return None
-    if not math.isfinite(interval) or interval <= 0:
+    if usec <= 0:
         return None
-    return interval
+    try:
+        seconds = usec / 1_000_000.0
+    except OverflowError:
+        return None
+    if not math.isfinite(seconds):
+        return None
+    return seconds
+
+
+def _watchdog_pid_matches() -> bool:
+    """Return True when ``WATCHDOG_PID`` is absent or matches this process."""
+    raw = os.environ.get("WATCHDOG_PID", "").strip()
+    if not raw:
+        return True
+    try:
+        return int(raw) == os.getpid()
+    except (TypeError, ValueError):
+        return False
+
+
+def _runtime_watchdog_available() -> bool:
+    """Return True when the process env supports an in-loop systemd watchdog."""
+    if not hasattr(socket, "AF_UNIX"):
+        return False
+    if not _resolve_notify_socket():
+        return False
+    wd = watchdog_interval_seconds()
+    if wd is None or wd <= 0:
+        return False
+    if not _watchdog_pid_matches():
+        return False
+    return True
 
 
 class SystemdWatchdog:
-    """Feed systemd while the asyncio event loop continues to make progress."""
+    """Feeds systemd's watchdog from the asyncio event loop.
+
+    A background task pings ``WATCHDOG=1`` at roughly half the systemd timeout.
+    Because the task runs on the loop, a wedged loop stops pinging and systemd
+    restarts the service. Each tick also measures its own scheduling lag; if a
+    cycle runs late (loop blocked but not fully dead) the watchdog latches
+    ``unhealthy``, emits a ``STATUS=`` diagnostic, and stops pinging.
+
+    Gated by ``config_enabled`` (from ``gateway.systemd_watchdog_seconds > 0``)
+    *and* a valid systemd watchdog runtime environment. When disabled or the env
+    is incomplete, every method is a no-op and ``Type=simple`` is preserved.
+
+    Lifecycle: ``stop()`` owns every transition to idle, every ``STOPPING=1``
+    send, and every ``_task`` clear. When the heartbeat self-exits (unhealthy
+    latch or unexpected error) it sets ``_stopped`` but leaves ``_state``
+    ``running`` and retains the completed task handle until ``stop()`` runs.
+    ``start()`` after a self-exit clears a done task and schedules a fresh
+    heartbeat; ``STOPPING=1`` is sent exactly once on the next ``stop()``. If
+    ``stop()`` itself is externally cancelled while the heartbeat is still
+    winding down, ``STOPPING=1`` is still sent; the orphaned task reference
+    clears autonomously when the coroutine finishes (a subsequent ``start()``
+    refuses only while that coroutine is still live).
+    """
 
     def __init__(
         self,
         *,
         config_enabled: bool = True,
         lag_tolerance_seconds: Optional[float] = None,
+        ping_interval_seconds: Optional[float] = None,
     ) -> None:
-        self._config_enabled = bool(config_enabled)
-        self.interval_seconds = watchdog_interval_seconds()
-        self._lag_tolerance_seconds = lag_tolerance_seconds
-        self._task: Optional[asyncio.Task[None]] = None
-        self._unhealthy = False
-        self._stopping = False
-        self._stopping_notified = False
+        self.config_enabled = bool(config_enabled)
+        self._lag_tolerance = lag_tolerance_seconds
+        self._ping_interval_override = ping_interval_seconds
+        self._resolved_ping_interval: Optional[float] = None
+        self.unhealthy = False
+        self._last_error: Optional[str] = None
+        self._task: Optional[asyncio.Task] = None
+        self._stopped = False
+        self._state = _STATE_IDLE
+        self._lock: Optional[asyncio.Lock] = None
+        self._stopping_sent = False
 
     @property
     def enabled(self) -> bool:
-        return self._config_enabled and self.interval_seconds is not None
-
-    @property
-    def unhealthy(self) -> bool:
-        return self._unhealthy
-
-    @property
-    def task(self) -> Optional[asyncio.Task[None]]:
-        return self._task
-
-    def _lag_tolerance(self) -> float:
-        interval = self.interval_seconds or 0.0
-        configured = self._lag_tolerance_seconds
-        if configured is None:
-            return max(0.1, interval * 0.25)
-        try:
-            value = float(configured)
-        except (TypeError, ValueError):
-            return max(0.1, interval * 0.25)
-        if not math.isfinite(value):
-            return max(0.1, interval * 0.25)
-        return max(0.0, value)
+        return self.config_enabled and _runtime_watchdog_available()
 
     def start(self) -> bool:
-        """Start the loop-progress sampler when systemd watchdog is enabled."""
+        """Start the heartbeat task. Returns True if enabled and started."""
         if not self.enabled:
+            return False
+        if self._state == _STATE_STOPPING:
             return False
         if self._task is not None and not self._task.done():
-            return True
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
+            if self._state == _STATE_RUNNING:
+                return True
+            # Orphaned heartbeat still finishing after a cancelled ``stop()``.
             return False
-        self._stopping = False
-        self._unhealthy = False
-        self._stopping_notified = False
-        self._task = asyncio.create_task(self._run(), name="hermes-systemd-watchdog")
+        if self._task is not None and self._task.done():
+            self._task = None
+
+        interval = self._resolve_ping_interval()
+        if interval is None:
+            return False
+
+        # Deliberate restart after unhealthy: reset latch and error state.
+        self.unhealthy = False
+        self._last_error = None
+        self._stopped = False
+        self._stopping_sent = False
+        self._resolved_ping_interval = interval
+
+        try:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+            if self._lock is None:
+                self._lock = asyncio.Lock()
+            self._state = _STATE_RUNNING
+            task = loop.create_task(self._heartbeat())
+            task.add_done_callback(self._on_heartbeat_done)
+            self._task = task
+        except Exception:
+            logger.debug("Failed to start systemd watchdog heartbeat", exc_info=True)
+            self._state = _STATE_IDLE
+            self._task = None
+            return False
         return True
 
-    def ready(self, status: str = "Gateway running") -> bool:
-        """Tell systemd that startup completed and the gateway is ready."""
+    def ready(self, status: str = "Hermes Gateway running") -> bool:
+        """Signal ``READY=1`` (harmless under Type=simple). Returns True if enabled."""
         if not self.enabled:
             return False
-        safe_status = str(status or "Gateway running").replace("\n", " ")
+        safe_status = _sanitize_status(status)
         return notify(f"READY=1\nSTATUS={safe_status}")
 
-    def record_tick(self, *, scheduled_at: float, now: float) -> bool:
-        """Feed systemd only when the event loop woke within its lag budget."""
-        if not self.enabled or self._stopping or self._unhealthy:
-            return False
-        try:
-            lag = float(now) - float(scheduled_at)
-        except (TypeError, ValueError):
-            lag = float("inf")
-        if not math.isfinite(lag) or lag > self._lag_tolerance():
-            self._unhealthy = True
-            notify("STATUS=watchdog unhealthy: event loop progress is late")
-            return False
-        notify("WATCHDOG=1")
-        return True
+    def record_tick(self, *, deadline: float, now: float) -> bool:
+        """Record one heartbeat cycle. Pings ``WATCHDOG=1`` when the loop kept up.
 
-    async def _run(self) -> None:
-        interval = self.interval_seconds
-        if interval is None:
-            return
-        cadence = max(0.01, interval / 2.0)
-        loop = asyncio.get_running_loop()
-        scheduled_at = loop.time() + cadence
+        ``deadline`` is when the cycle was due (before ``asyncio.sleep``) and
+        ``now`` is when the sleep resumed; ``max(0, now - deadline)`` is the
+        loop's scheduling lag for that cycle. If the lag exceeds the tolerance
+        the watchdog latches ``unhealthy``, reports a ``STATUS=`` diagnostic, and
+        returns False (and stops pinging, so systemd acts). Returns True when a
+        ``WATCHDOG=1`` ping was sent.
+
+        Invalid inputs (non-numeric, NaN, inf) return False without raising and
+        without latching unhealthy. No-ops (returns False, no notify) once the
+        watchdog has stopped or the heartbeat is not in the running lifecycle
+        state — including late direct calls after ``stop()`` has sent
+        ``STOPPING=1``.
+        """
+        if not self.enabled:
+            return False
+        if self._stopped or self._state != _STATE_RUNNING:
+            return False
+        if self.unhealthy:
+            return False
+
         try:
-            while not self._stopping and not self._unhealthy:
-                await asyncio.sleep(max(0.0, scheduled_at - loop.time()))
-                now = loop.time()
-                if not self.record_tick(scheduled_at=scheduled_at, now=now):
-                    return
-                scheduled_at += cadence
-                if scheduled_at < now:
-                    scheduled_at = now + cadence
-        except asyncio.CancelledError:
-            return
+            deadline_f = float(deadline)
+            now_f = float(now)
+        except (TypeError, ValueError, OverflowError):
+            return False
+        if not math.isfinite(deadline_f) or not math.isfinite(now_f):
+            return False
+
+        tolerance = self._resolve_lag_tolerance()
+        lag = max(0.0, now_f - deadline_f)
+        if lag > tolerance:
+            self.unhealthy = True
+            msg = _sanitize_status(
+                "watchdog unhealthy: event loop lag "
+                f"{lag:.3f}s exceeds tolerance {tolerance:.3f}s"
+            )
+            notify(f"STATUS={msg}")
+            return False
+        return notify("WATCHDOG=1")
 
     async def stop(self) -> None:
-        """Stop feeding systemd and emit ``STOPPING=1`` at most once."""
-        self._stopping = True
-        task = self._task
-        current = asyncio.current_task()
-        if task is not None and task is not current:
-            if not task.done():
-                task.cancel()
+        """Cancel the heartbeat and signal ``STOPPING=1`` (last notification).
+
+        Cleanup (clear task, send ``STOPPING=1`` once, return to idle) runs in
+        a ``finally`` block so an external cancellation of ``stop()`` itself
+        cannot wedge lifecycle state in ``STOPPING``.
+        """
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+
+        async with self._lock:
+            if self._state == _STATE_IDLE and (
+                self._task is None or self._task.done()
+            ):
+                if self._task is not None and self._task.done():
+                    self._task = None
+                return
+
+            self._state = _STATE_STOPPING
+            self._stopped = True
+
+            task = self._task
             try:
-                await task
+                if task is not None and not task.done():
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        current = asyncio.current_task()
+                        if current is not None and current.cancelling() > 0:
+                            raise
+                    except Exception:
+                        logger.debug(
+                            "systemd watchdog heartbeat task ended with error",
+                            exc_info=True,
+                        )
+            finally:
+                # Cleanup runs even when stop() itself is externally cancelled
+                # so lifecycle state cannot wedge in STOPPING. Only drop the
+                # task handle once the coroutine has actually finished — a
+                # cancelled stop() may exit before the heartbeat completes.
+                if task is None or task.done():
+                    self._task = None
+                if (
+                    not self._stopping_sent
+                    and self.config_enabled
+                    and _resolve_notify_socket()
+                ):
+                    notify("STOPPING=1")
+                    self._stopping_sent = True
+                self._state = _STATE_IDLE
+
+    # ── internals ───────────────────────────────────────────────────────────
+
+    def _reconcile_heartbeat_exit(self) -> None:
+        """Record heartbeat self-exit; ``stop()`` owns idle transition.
+
+        The heartbeat loop exits on unhealthy latch or unexpected error. State
+        stays ``running`` with a completed task handle so a later ``stop()``
+        still sends ``STOPPING=1`` exactly once.
+        """
+        self._stopped = True
+
+    def _on_heartbeat_done(self, task: asyncio.Task) -> None:
+        """Clear an orphaned task handle after ``stop()`` already returned idle."""
+        try:
+            if self._state != _STATE_IDLE:
+                return
+            if self._task is not task:
+                return
+            self._task = None
+        except Exception:
+            logger.debug(
+                "systemd watchdog orphan heartbeat reconciliation failed",
+                exc_info=True,
+            )
+
+    def _watchdog_budget(self) -> Optional[float]:
+        wd = watchdog_interval_seconds()
+        if wd is None or not math.isfinite(wd) or wd <= 0:
+            return None
+        return wd
+
+    def _safe_default_interval(self, wd: float) -> float:
+        return max(wd / 2.0, 0.001)
+
+    def _safe_default_tolerance(self, wd: float, interval: float) -> float:
+        """Tolerance strictly inside the remaining watchdog budget after a ping."""
+        remaining = max(wd - interval, 0.001)
+        # Use 40% of the post-ping slack, capped so interval + tolerance < wd.
+        tolerance = remaining * 0.4
+        tolerance = min(tolerance, max(wd - interval - 0.001, 0.001))
+        return max(tolerance, 0.001)
+
+    def _validate_positive_finite(self, value: object) -> Optional[float]:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if not math.isfinite(parsed) or parsed <= 0:
+            return None
+        return parsed
+
+    def _resolve_ping_interval(self) -> Optional[float]:
+        wd = self._watchdog_budget()
+        if wd is None:
+            return None
+
+        default_interval = self._safe_default_interval(wd)
+        interval = default_interval
+
+        override = self._validate_positive_finite(self._ping_interval_override)
+        if self._ping_interval_override is not None:
+            if override is None:
+                interval = default_interval
+            else:
+                tolerance = self._compute_lag_tolerance(wd, override, self._lag_tolerance)
+                if override + tolerance >= wd:
+                    interval = default_interval
+                else:
+                    interval = override
+
+        tolerance = self._compute_lag_tolerance(wd, interval, self._lag_tolerance)
+        if interval + tolerance >= wd:
+            return None
+        return interval
+
+    def _compute_lag_tolerance(
+        self,
+        wd: float,
+        interval: float,
+        override: Optional[float],
+    ) -> float:
+        safe_default = self._safe_default_tolerance(wd, interval)
+        if override is None:
+            return safe_default
+        parsed = self._validate_positive_finite(override)
+        if parsed is None:
+            return safe_default
+        if interval + parsed >= wd:
+            return safe_default
+        return parsed
+
+    def _resolve_lag_tolerance(self) -> float:
+        wd = self._watchdog_budget() or 0.0
+        interval = self._resolved_ping_interval
+        if interval is None:
+            interval = self._safe_default_interval(wd) if wd > 0 else 0.001
+        return self._compute_lag_tolerance(wd, interval, self._lag_tolerance)
+
+    async def _heartbeat(self) -> None:
+        interval = self._resolved_ping_interval
+        if interval is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.get_event_loop()
+        while not self._stopped:
+            try:
+                deadline = loop.time() + interval
+                await asyncio.sleep(interval)
+                if self._stopped:
+                    return
+                now = loop.time()
+                self.record_tick(deadline=deadline, now=now)
+                if self.unhealthy:
+                    # Latched unhealthy: stop pinging so systemd acts on timeout.
+                    self._reconcile_heartbeat_exit()
+                    return
             except asyncio.CancelledError:
-                pass
-            except Exception:
-                pass
-        self._task = None
-        if self.enabled and not self._stopping_notified:
-            notify("STOPPING=1")
-            self._stopping_notified = True
+                raise
+            except Exception as exc:
+                # Never let an unexpected per-cycle failure kill the sole task
+                # without recording why; latch unhealthy and exit the loop.
+                logger.exception("systemd watchdog heartbeat cycle failed")
+                self.unhealthy = True
+                self._last_error = str(exc)
+                msg = _sanitize_status(f"watchdog unhealthy: heartbeat error: {exc}")
+                notify(f"STATUS={msg}")
+                self._reconcile_heartbeat_exit()
+                return

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import socket
 
 import pytest
+
+
+def _install_valid_env(monkeypatch, *, usec: str = "20000000") -> None:
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", usec)
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
 
 
 @pytest.mark.skipif(
@@ -58,19 +65,26 @@ def test_notify_uses_nonblocking_datagram_send(monkeypatch):
 @pytest.mark.asyncio
 async def test_watchdog_sends_ready_heartbeat_and_stopping(monkeypatch):
     calls: list[str] = []
-    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
-    monkeypatch.setenv("WATCHDOG_USEC", "20000")
+    tick_seen = asyncio.Event()
+    _install_valid_env(monkeypatch, usec="20000")
 
     import gateway.systemd_notify as notify_mod
 
-    monkeypatch.setattr(
-        notify_mod, "notify", lambda message: calls.append(message) or True
+    def capture_notify(message: str) -> bool:
+        calls.append(message)
+        if message == "WATCHDOG=1":
+            tick_seen.set()
+        return True
+
+    monkeypatch.setattr(notify_mod, "notify", capture_notify)
+    watchdog = notify_mod.SystemdWatchdog(
+        ping_interval_seconds=0.001,
+        lag_tolerance_seconds=0.001,
     )
-    watchdog = notify_mod.SystemdWatchdog(lag_tolerance_seconds=1.0)
 
     assert watchdog.start() is True
     assert watchdog.ready("Gateway running") is True
-    await asyncio.sleep(0.04)
+    await asyncio.wait_for(tick_seen.wait(), timeout=2.0)
     await watchdog.stop()
 
     assert any(message.startswith("READY=1") for message in calls)
@@ -79,3 +93,941 @@ async def test_watchdog_sends_ready_heartbeat_and_stopping(monkeypatch):
     assert watchdog.unhealthy is False
 
 
+# ── Finding 1: STATUS newline injection ─────────────────────────────────────
+
+
+def test_sanitize_status_strips_injected_newlines(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: captured.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog()
+
+    injected = 'ok\nWATCHDOG=triggered'
+    assert watchdog.ready(injected) is True
+    payload = captured[-1]
+    lines = payload.split("\n")
+    assert len(lines) == 2
+    assert lines[0] == "READY=1"
+    assert lines[1] == "STATUS=ok WATCHDOG=triggered"
+
+
+def test_sanitize_status_replaces_cr_lf_and_nul(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: captured.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog()
+
+    injected = "ok\r\nWATCHDOG=triggered\0extra"
+    assert watchdog.ready(injected) is True
+    payload = captured[-1]
+    assert payload.count("\n") == 1
+    assert "\r" not in payload
+    assert "\0" not in payload
+    lines = payload.split("\n")
+    assert len(lines) == 2
+    assert lines[0] == "READY=1"
+    assert lines[1] == "STATUS=ok  WATCHDOG=triggered extra"
+
+
+# ── Finding 2: real enablement gating ─────────────────────────────────────────
+
+
+def test_config_disabled_is_noop_even_with_valid_env(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog(config_enabled=False)
+
+    assert watchdog.enabled is False
+    assert watchdog.start() is False
+    assert watchdog.ready("ignored") is False
+    assert watchdog.record_tick(deadline=0.0, now=0.0) is False
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "env_patch",
+    [
+        {"NOTIFY_SOCKET": ""},
+        {"WATCHDOG_USEC": ""},
+        {"WATCHDOG_USEC": "0"},
+        {"WATCHDOG_USEC": "-1000"},
+        {"WATCHDOG_USEC": "not-a-number"},
+        {"WATCHDOG_PID": "999999999"},
+    ],
+)
+def test_start_returns_false_without_full_runtime_env(monkeypatch, env_patch):
+    _install_valid_env(monkeypatch)
+    for key, value in env_patch.items():
+        monkeypatch.setenv(key, value)
+
+    import gateway.systemd_notify as notify_mod
+
+    watchdog = notify_mod.SystemdWatchdog()
+    assert watchdog.enabled is False
+    assert watchdog.start() is False
+    assert watchdog._task is None
+
+
+def test_override_does_not_bypass_missing_watchdog_usec(monkeypatch):
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.delenv("WATCHDOG_USEC", raising=False)
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=1.0)
+    assert watchdog.enabled is False
+    assert watchdog.start() is False
+
+
+def test_missing_af_unix_disables_watchdog(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    class _NoAfUnixModule:
+        SOCK_DGRAM = socket.SOCK_DGRAM
+
+        def socket(self, *args, **kwargs):
+            return socket.socket(*args, **kwargs)
+
+    monkeypatch.setattr(notify_mod, "socket", _NoAfUnixModule())
+
+    watchdog = notify_mod.SystemdWatchdog()
+    assert watchdog.enabled is False
+    assert watchdog.start() is False
+
+
+def test_watchdog_pid_match_enables_mismatch_disables(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    assert notify_mod.SystemdWatchdog().enabled is True
+
+    monkeypatch.setenv("WATCHDOG_PID", "999999999")
+    assert notify_mod.SystemdWatchdog().enabled is False
+
+
+# ── Finding 3: true lateness measurement ────────────────────────────────────
+
+
+def test_on_time_tick_has_near_zero_lag(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog()
+    watchdog.start()
+
+    deadline = 100.0
+    now = 100.0001
+    assert watchdog.record_tick(deadline=deadline, now=now) is True
+    assert "WATCHDOG=1" in calls
+    assert watchdog.unhealthy is False
+
+
+def test_lag_within_tolerance_pings(monkeypatch):
+    _install_valid_env(monkeypatch, usec="10000000")
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog()
+    watchdog.start()
+
+    tolerance = watchdog._resolve_lag_tolerance()
+    half = tolerance / 2.0
+    assert watchdog.record_tick(deadline=0.0, now=half) is True
+    assert "WATCHDOG=1" in calls
+
+
+def test_lag_at_or_over_tolerance_latches_unhealthy(monkeypatch):
+    _install_valid_env(monkeypatch, usec="10000000")
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog()
+    watchdog.start()
+
+    tolerance = watchdog._resolve_lag_tolerance()
+    assert watchdog.record_tick(deadline=0.0, now=tolerance + 0.001) is False
+    assert watchdog.unhealthy is True
+    assert "WATCHDOG=1" not in [c for c in calls if c == "WATCHDOG=1" or c.startswith("STATUS=")]
+    status_msgs = [c for c in calls if c.startswith("STATUS=")]
+    assert status_msgs
+
+
+def test_interval_plus_tolerance_stays_inside_watchdog_budget(monkeypatch):
+    _install_valid_env(monkeypatch, usec="20000000")
+    import gateway.systemd_notify as notify_mod
+
+    watchdog = notify_mod.SystemdWatchdog()
+    watchdog.start()
+    wd = notify_mod.watchdog_interval_seconds()
+    interval = watchdog._resolved_ping_interval
+    tolerance = watchdog._resolve_lag_tolerance()
+    assert interval is not None
+    assert wd is not None
+    assert interval + tolerance < wd
+
+
+# ── Finding 4: restart resets unhealthy latch ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_restart_after_unhealthy_resets_latch(monkeypatch):
+    _install_valid_env(monkeypatch, usec="10000000")
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+    watchdog = notify_mod.SystemdWatchdog()
+    watchdog.start()
+
+    tolerance = watchdog._resolve_lag_tolerance()
+    watchdog.record_tick(deadline=0.0, now=tolerance + 1.0)
+    assert watchdog.unhealthy is True
+
+    await watchdog.stop()
+    assert watchdog.start() is True
+    assert watchdog.unhealthy is False
+    assert watchdog.record_tick(deadline=0.0, now=0.0) is True
+
+
+# ── Finding 5: lifecycle race hardening ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_repeated_start_yields_one_task(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+    watchdog = notify_mod.SystemdWatchdog()
+
+    assert watchdog.start() is True
+    first_task = watchdog._task
+    assert watchdog.start() is True
+    assert watchdog._task is first_task
+
+    await watchdog.stop()
+
+
+@pytest.mark.asyncio
+async def test_repeated_stop_sends_stopping_once(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=3600.0)
+    watchdog.start()
+
+    await watchdog.stop()
+    await watchdog.stop()
+    await watchdog.stop()
+
+    stopping = [m for m in calls if m == "STOPPING=1"]
+    assert len(stopping) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_during_stop_is_refused(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+
+    cancel_started = asyncio.Event()
+    release_cancel = asyncio.Event()
+
+    async def slow_heartbeat(self) -> None:
+        try:
+            while not self._stopped:
+                await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancel_started.set()
+            await release_cancel.wait()
+            raise
+
+    monkeypatch.setattr(notify_mod.SystemdWatchdog, "_heartbeat", slow_heartbeat)
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=3600.0)
+    watchdog.start()
+
+    stop_task = asyncio.create_task(watchdog.stop())
+    await cancel_started.wait()
+    assert watchdog._state == notify_mod._STATE_STOPPING
+    assert watchdog.start() is False
+    release_cancel.set()
+    await stop_task
+
+
+# ── Finding 6: cancellation semantics ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_external_cancellation_of_stop_propagates(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog()
+
+    heartbeat_started = asyncio.Event()
+    heartbeat_exit = asyncio.Event()
+
+    async def slow_cancel_heartbeat() -> None:
+        heartbeat_started.set()
+        try:
+            await heartbeat_exit.wait()
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.05)
+            raise
+
+    watchdog._resolved_ping_interval = 3600.0
+    watchdog._state = notify_mod._STATE_RUNNING
+    watchdog._lock = asyncio.Lock()
+    watchdog._task = asyncio.create_task(slow_cancel_heartbeat())
+    await heartbeat_started.wait()
+
+    stop_task = asyncio.create_task(watchdog.stop())
+    await asyncio.sleep(0.01)
+    stop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    heartbeat_exit.set()
+
+
+def test_start_without_event_loop_returns_false(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    def _no_running_loop() -> None:
+        raise RuntimeError("no running event loop")
+
+    def _no_event_loop() -> None:
+        raise RuntimeError("no current event loop")
+
+    monkeypatch.setattr(asyncio, "get_running_loop", _no_running_loop)
+    monkeypatch.setattr(asyncio, "get_event_loop", _no_event_loop)
+
+    watchdog = notify_mod.SystemdWatchdog()
+    assert watchdog.start() is False
+    assert watchdog._state == notify_mod._STATE_IDLE
+    assert watchdog._task is None
+
+
+@pytest.mark.asyncio
+async def test_record_tick_noops_after_stop(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=3600.0)
+    watchdog.start()
+    await watchdog.stop()
+
+    calls.clear()
+    assert watchdog.record_tick(deadline=0.0, now=0.0) is False
+    assert "WATCHDOG=1" not in calls
+    assert not any(m.startswith("STATUS=") for m in calls)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_unexpected_error_latches_unhealthy(monkeypatch, caplog):
+    _install_valid_env(monkeypatch, usec="20000")
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    tick_count = {"n": 0}
+
+    def boom_record_tick(self, *, deadline, now):
+        tick_count["n"] += 1
+        if tick_count["n"] == 1:
+            raise RuntimeError("boom")
+        return True
+
+    monkeypatch.setattr(notify_mod.SystemdWatchdog, "record_tick", boom_record_tick)
+
+    async def instant_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", instant_sleep)
+
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=0.001)
+    assert watchdog.start() is True
+    task = watchdog._task
+    assert task is not None
+
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert watchdog.unhealthy is True
+    assert watchdog._last_error == "boom"
+    assert watchdog._state == notify_mod._STATE_RUNNING
+    assert watchdog._task is not None
+    assert watchdog._task.done()
+    status_msgs = [m for m in calls if m.startswith("STATUS=")]
+    assert status_msgs
+    assert "heartbeat error" in status_msgs[-1]
+
+
+# ── Round-2 finding A: self-exit must not skip STOPPING on stop() ───────────
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_self_exit_stop_still_sends_stopping_once(monkeypatch):
+    _install_valid_env(monkeypatch, usec="20000")
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+
+    async def instant_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", instant_sleep)
+
+    real_record_tick = notify_mod.SystemdWatchdog.record_tick
+    tick_count = {"n": 0}
+
+    def latch_on_first_tick(self, *, deadline, now):
+        tick_count["n"] += 1
+        if tick_count["n"] == 1:
+            tolerance = self._resolve_lag_tolerance()
+            return real_record_tick(self, deadline=0.0, now=tolerance + 1.0)
+        return real_record_tick(self, deadline=deadline, now=now)
+
+    monkeypatch.setattr(
+        notify_mod.SystemdWatchdog, "record_tick", latch_on_first_tick
+    )
+
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=0.001)
+    assert watchdog.start() is True
+    task = watchdog._task
+    assert task is not None
+
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert watchdog.unhealthy is True
+    assert watchdog._state == notify_mod._STATE_RUNNING
+    assert task.done()
+
+    await watchdog.stop()
+
+    stopping = [m for m in calls if m == "STOPPING=1"]
+    assert len(stopping) == 1
+    assert watchdog._state == notify_mod._STATE_IDLE
+    assert watchdog._task is None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_error_stop_still_sends_stopping_once(monkeypatch):
+    _install_valid_env(monkeypatch, usec="20000")
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    tick_count = {"n": 0}
+
+    def boom_record_tick(self, *, deadline, now):
+        tick_count["n"] += 1
+        if tick_count["n"] == 1:
+            raise RuntimeError("boom")
+        return True
+
+    monkeypatch.setattr(notify_mod.SystemdWatchdog, "record_tick", boom_record_tick)
+
+    async def instant_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", instant_sleep)
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=0.001)
+    assert watchdog.start() is True
+    task = watchdog._task
+    assert task is not None
+
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert watchdog.unhealthy is True
+    assert task.done()
+
+    await watchdog.stop()
+
+    stopping = [m for m in calls if m == "STOPPING=1"]
+    assert len(stopping) == 1
+    assert watchdog._state == notify_mod._STATE_IDLE
+
+
+@pytest.mark.asyncio
+async def test_start_after_self_exit_then_stop_sends_stopping_once(monkeypatch):
+    _install_valid_env(monkeypatch, usec="20000")
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+
+    async def instant_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", instant_sleep)
+
+    real_record_tick = notify_mod.SystemdWatchdog.record_tick
+    tick_count = {"n": 0}
+
+    def latch_on_first_tick(self, *, deadline, now):
+        tick_count["n"] += 1
+        if tick_count["n"] == 1:
+            tolerance = self._resolve_lag_tolerance()
+            return real_record_tick(self, deadline=0.0, now=tolerance + 1.0)
+        return real_record_tick(self, deadline=deadline, now=now)
+
+    monkeypatch.setattr(
+        notify_mod.SystemdWatchdog, "record_tick", latch_on_first_tick
+    )
+
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=0.001)
+    assert watchdog.start() is True
+    task = watchdog._task
+    assert task is not None
+
+    await asyncio.wait_for(task, timeout=2.0)
+    assert watchdog.unhealthy is True
+    assert task.done()
+
+    assert watchdog.start() is True
+    assert watchdog.unhealthy is False
+    assert watchdog._task is not None
+    assert not watchdog._task.done()
+
+    await watchdog.stop()
+
+    stopping = [m for m in calls if m == "STOPPING=1"]
+    assert len(stopping) == 1
+
+
+# ── Round-2 finding B: cancelled stop must not orphan overlapping heartbeats ──
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stop_cleans_up_and_allows_restart(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+
+    cancel_started = asyncio.Event()
+    release_cancel = asyncio.Event()
+    heartbeat_exited = asyncio.Event()
+
+    async def slow_heartbeat(self) -> None:
+        try:
+            while not self._stopped:
+                await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancel_started.set()
+            await release_cancel.wait()
+            raise
+        finally:
+            heartbeat_exited.set()
+
+    monkeypatch.setattr(notify_mod.SystemdWatchdog, "_heartbeat", slow_heartbeat)
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=3600.0)
+    old_task = None
+    assert watchdog.start() is True
+    old_task = watchdog._task
+
+    stop_task = asyncio.create_task(watchdog.stop())
+    await cancel_started.wait()
+    stop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    assert watchdog._state == notify_mod._STATE_IDLE
+    stopping = [m for m in calls if m == "STOPPING=1"]
+    assert len(stopping) == 1
+    assert old_task is not None
+
+    if not old_task.done():
+        assert watchdog._task is old_task
+        assert watchdog.start() is False
+        release_cancel.set()
+        await asyncio.wait_for(heartbeat_exited.wait(), timeout=2.0)
+    else:
+        # External cancellation can finish the heartbeat before we inspect;
+        # finally still must have cleared a completed handle.
+        assert watchdog._task is None
+        release_cancel.set()
+
+    assert old_task.done()
+    assert watchdog.start() is True
+    assert watchdog._task is not None
+    assert watchdog._task is not old_task
+    await watchdog.stop()
+    stopping_after_restart = [m for m in calls if m == "STOPPING=1"]
+    assert len(stopping_after_restart) == len(stopping) + 1
+    await watchdog.stop()
+    assert len([m for m in calls if m == "STOPPING=1"]) == len(stopping_after_restart)
+
+
+@pytest.mark.asyncio
+async def test_start_refuses_orphaned_live_heartbeat(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+    watchdog = notify_mod.SystemdWatchdog()
+    heartbeat_running = asyncio.Event()
+    release = asyncio.Event()
+
+    async def orphan_heartbeat() -> None:
+        heartbeat_running.set()
+        await release.wait()
+
+    watchdog._state = notify_mod._STATE_IDLE
+    watchdog._task = asyncio.create_task(orphan_heartbeat())
+    await heartbeat_running.wait()
+
+    assert watchdog.start() is False
+    assert not watchdog._task.done()
+
+    release.set()
+    await watchdog._task
+    watchdog._task = None
+    assert watchdog.start() is True
+    await watchdog.stop()
+
+
+# ── Finding 7: override validation ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "override",
+    [0, -1, float("nan"), float("inf"), float("-inf"), "bad"],
+)
+def test_invalid_ping_interval_override_falls_back(monkeypatch, override):
+    _install_valid_env(monkeypatch, usec="20000000")
+    import gateway.systemd_notify as notify_mod
+
+    wd = notify_mod.watchdog_interval_seconds()
+    assert wd is not None
+    expected = max(wd / 2.0, 0.001)
+
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=override)
+    resolved = watchdog._resolve_ping_interval()
+    assert resolved == expected
+
+
+@pytest.mark.parametrize(
+    "override",
+    [0, -1, float("nan"), float("inf"), float("-inf"), "bad"],
+)
+def test_invalid_lag_tolerance_override_falls_back(monkeypatch, override):
+    _install_valid_env(monkeypatch, usec="20000000")
+    import gateway.systemd_notify as notify_mod
+
+    watchdog = notify_mod.SystemdWatchdog(lag_tolerance_seconds=override)
+    watchdog.start()
+    wd = notify_mod.watchdog_interval_seconds()
+    interval = watchdog._resolved_ping_interval
+    assert wd is not None and interval is not None
+    safe = watchdog._safe_default_tolerance(wd, interval)
+    assert watchdog._resolve_lag_tolerance() == safe
+
+
+def test_budget_exceeding_overrides_rejected(monkeypatch):
+    _install_valid_env(monkeypatch, usec="1000000")
+    import gateway.systemd_notify as notify_mod
+
+    wd = notify_mod.watchdog_interval_seconds()
+    assert wd is not None
+    default_interval = max(wd / 2.0, 0.001)
+
+    too_fast = notify_mod.SystemdWatchdog(ping_interval_seconds=wd - 0.0005)
+    assert too_fast._resolve_ping_interval() == default_interval
+
+    too_lax = notify_mod.SystemdWatchdog(lag_tolerance_seconds=wd * 0.9)
+    too_lax.start()
+    safe = too_lax._safe_default_tolerance(wd, too_lax._resolved_ping_interval)
+    assert too_lax._resolve_lag_tolerance() == safe
+
+
+# ── Finding 8: best-effort robustness ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "deadline,now",
+    [
+        (float("nan"), 1.0),
+        (1.0, float("inf")),
+        (None, 1.0),
+        ("bad", 1.0),
+    ],
+)
+def test_record_tick_invalid_inputs_return_false_without_latching(
+    monkeypatch, deadline, now
+):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+    watchdog = notify_mod.SystemdWatchdog()
+    watchdog.start()
+
+    assert watchdog.record_tick(deadline=deadline, now=now) is False
+    assert watchdog.unhealthy is False
+
+
+def test_notify_failure_returns_false_without_raising(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: False)
+    watchdog = notify_mod.SystemdWatchdog()
+    watchdog.start()
+
+    assert watchdog.record_tick(deadline=0.0, now=0.0) is False
+    assert watchdog.unhealthy is False
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_survives_record_tick_notify_failure(monkeypatch):
+    _install_valid_env(monkeypatch, usec="20000")
+    import gateway.systemd_notify as notify_mod
+
+    notify_calls = {"count": 0}
+    tick_seen = asyncio.Event()
+
+    def flaky_notify(message: str) -> bool:
+        notify_calls["count"] += 1
+        if message == "WATCHDOG=1":
+            tick_seen.set()
+        return message != "WATCHDOG=1"
+
+    monkeypatch.setattr(notify_mod, "notify", flaky_notify)
+    watchdog = notify_mod.SystemdWatchdog(
+        ping_interval_seconds=0.001,
+        lag_tolerance_seconds=0.001,
+    )
+    watchdog.start()
+    await asyncio.wait_for(tick_seen.wait(), timeout=2.0)
+    await watchdog.stop()
+    assert notify_calls["count"] >= 1
+    assert watchdog.unhealthy is False
+
+
+# ── Round-3: huge-int / overflow robustness ───────────────────────────────────
+
+
+_HUGE_INT = 10**10000
+
+
+def test_record_tick_huge_int_returns_false_without_latching(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+    watchdog = notify_mod.SystemdWatchdog()
+    watchdog.start()
+
+    assert watchdog.record_tick(deadline=_HUGE_INT, now=1.0) is False
+    assert watchdog.unhealthy is False
+    assert watchdog.record_tick(deadline=0.0, now=_HUGE_INT) is False
+    assert watchdog.unhealthy is False
+
+
+def test_huge_int_overrides_fall_back_to_safe_defaults(monkeypatch):
+    _install_valid_env(monkeypatch, usec="20000000")
+    import gateway.systemd_notify as notify_mod
+
+    wd = notify_mod.watchdog_interval_seconds()
+    assert wd is not None
+    expected_interval = max(wd / 2.0, 0.001)
+
+    ping_watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=_HUGE_INT)
+    assert ping_watchdog._resolve_ping_interval() == expected_interval
+    assert ping_watchdog.start() is True
+
+    lag_watchdog = notify_mod.SystemdWatchdog(lag_tolerance_seconds=_HUGE_INT)
+    lag_watchdog.start()
+    interval = lag_watchdog._resolved_ping_interval
+    assert interval is not None
+    safe_tolerance = lag_watchdog._safe_default_tolerance(wd, interval)
+    assert lag_watchdog._resolve_lag_tolerance() == safe_tolerance
+
+
+def test_huge_watchdog_usec_disables_cleanly(monkeypatch):
+    huge_usec = "1" + "0" * 399
+    monkeypatch.setenv("NOTIFY_SOCKET", "/tmp/hermes-test-notify")
+    monkeypatch.setenv("WATCHDOG_USEC", huge_usec)
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+
+    import gateway.systemd_notify as notify_mod
+
+    assert notify_mod.watchdog_interval_seconds() is None
+
+    watchdog = notify_mod.SystemdWatchdog()
+    assert watchdog.enabled is False
+    assert watchdog.start() is False
+    assert watchdog.ready("ignored") is False
+    assert watchdog.record_tick(deadline=0.0, now=0.0) is False
+
+
+# ── Round-3: orphan heartbeat done-callback reconciliation ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orphan_heartbeat_auto_clears_after_cancelled_stop(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        notify_mod, "notify", lambda message: calls.append(message) or True
+    )
+
+    cancel_started = asyncio.Event()
+    release_cancel = asyncio.Event()
+    heartbeat_exited = asyncio.Event()
+
+    async def slow_heartbeat(self) -> None:
+        try:
+            while not self._stopped:
+                await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancel_started.set()
+            await release_cancel.wait()
+            raise
+        finally:
+            heartbeat_exited.set()
+
+    monkeypatch.setattr(notify_mod.SystemdWatchdog, "_heartbeat", slow_heartbeat)
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=3600.0)
+    assert watchdog.start() is True
+    orphan_task = watchdog._task
+    assert orphan_task is not None
+
+    stop_task = asyncio.create_task(watchdog.stop())
+    await cancel_started.wait()
+    stop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    assert watchdog._state == notify_mod._STATE_IDLE
+    stopping = [m for m in calls if m == "STOPPING=1"]
+    assert len(stopping) == 1
+
+    if not orphan_task.done():
+        assert watchdog._task is orphan_task
+        release_cancel.set()
+        await asyncio.wait_for(heartbeat_exited.wait(), timeout=2.0)
+    else:
+        release_cancel.set()
+
+    try:
+        await orphan_task
+    except asyncio.CancelledError:
+        pass
+
+    assert orphan_task.done()
+    assert watchdog._task is None
+
+    assert watchdog.start() is True
+    assert watchdog._task is not None
+    assert watchdog._task is not orphan_task
+
+    await watchdog.stop()
+    stopping_after_restart = [m for m in calls if m == "STOPPING=1"]
+    assert len(stopping_after_restart) == 2
+
+
+@pytest.mark.asyncio
+async def test_orphan_done_callback_identity_check_preserves_new_task(monkeypatch):
+    _install_valid_env(monkeypatch)
+    import gateway.systemd_notify as notify_mod
+
+    monkeypatch.setattr(notify_mod, "notify", lambda _message: True)
+
+    cancel_started = asyncio.Event()
+    release_cancel = asyncio.Event()
+
+    async def slow_heartbeat(self) -> None:
+        try:
+            while not self._stopped:
+                await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancel_started.set()
+            await release_cancel.wait()
+            raise
+
+    monkeypatch.setattr(notify_mod.SystemdWatchdog, "_heartbeat", slow_heartbeat)
+    watchdog = notify_mod.SystemdWatchdog(ping_interval_seconds=3600.0)
+    assert watchdog.start() is True
+    orphan_task = watchdog._task
+    assert orphan_task is not None
+
+    stop_task = asyncio.create_task(watchdog.stop())
+    await cancel_started.wait()
+    stop_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    release_cancel.set()
+    try:
+        await orphan_task
+    except asyncio.CancelledError:
+        pass
+    assert orphan_task.done()
+    assert watchdog._task is None
+
+    assert watchdog.start() is True
+    new_task = watchdog._task
+    assert new_task is not None
+    assert new_task is not orphan_task
+
+    watchdog._on_heartbeat_done(orphan_task)
+
+    assert watchdog._task is new_task
+    assert watchdog._state == notify_mod._STATE_RUNNING
+
+    await watchdog.stop()


### PR DESCRIPTION
## Summary

The gateway's in-process liveness probes all run on the asyncio event loop, so a wedged loop stays alive but unresponsive until a manual restart. This feeds systemd's watchdog (`WatchdogSec=`) from a task on the event loop itself: a wedged loop stops pinging and systemd restarts the service.

- each tick measures its own scheduling lateness against the expected wake deadline; a late cycle latches unhealthy, emits a sanitized `STATUS=` diagnostic, and stops sending `WATCHDOG=1`
- enablement requires `gateway.systemd_watchdog_seconds` > 0 AND a valid environment: `NOTIFY_SOCKET`, finite positive `WATCHDOG_USEC`, AF_UNIX, and matching `WATCHDOG_PID` when present; no unsafe fallback interval
- `STATUS` values sanitized against sd_notify field injection
- start/stop serialized and idempotent; `STOPPING=1` exactly once; cancelled `stop()` propagates; orphaned tasks reconcile autonomously on completion
- unhealthy resets on deliberate restart; NaN/infinity/huge-int timing overrides rejected (`math.isfinite`)
- best-effort everywhere: invalid inputs never raise or kill the heartbeat task

Stdlib-only, opt-in; disabled (0) keeps `Type=simple` behavior unchanged.

## Test Plan

- `scripts/run_tests.sh tests/gateway/test_systemd_notify.py tests/gateway/test_systemd_watchdog_lifecycle.py tests/hermes_cli/test_systemd_watchdog_unit.py tests/hermes_cli/test_systemd_optional_directives.py` -> 64 passed, 0 failed
- negative/boundary coverage: status injection, missing/invalid env and pid, T/2 vs T lateness, restart after unhealthy, concurrent start/stop, external stop cancellation, huge-int and nonfinite overrides, notify send failures

Restored and hardened from stranded local work; fresh-context adversarial review PASS after multiple fix rounds.
