### PR TITLE
fix(agent): resolve MiniMax OAuth credentials for auxiliary clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6430,6 +6430,59 @@ def resolve_provider_client(
             logger.debug("resolve_provider_client: unknown provider %r", provider)
         return None, None
 
+    if pconfig.auth_type == "oauth_minimax":
+        # MiniMax OAuth uses an Anthropic Messages-compatible endpoint with
+        # Bearer auth.  The main runtime resolver already knows how to refresh
+        # and resolve these credentials, but auxiliary calls historically fell
+        # through the generic provider switch and returned (None, None), which
+        # broke MoA reference slots and every other auxiliary MiniMax OAuth use.
+        api_key = str(explicit_api_key or "").strip()
+        base_url = str(explicit_base_url or "").strip().rstrip("/")
+        if not api_key or not base_url:
+            try:
+                from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+
+                creds = resolve_minimax_oauth_runtime_credentials()
+                api_key = api_key or str(creds.get("api_key") or "").strip()
+                base_url = base_url or str(creds.get("base_url") or "").strip().rstrip("/")
+            except Exception as exc:
+                logger.debug(
+                    "resolve_provider_client: minimax-oauth credential resolution failed: %s",
+                    exc,
+                )
+                return None, None
+        if not api_key or not base_url:
+            return None, None
+
+        default_model = _get_aux_model_for_provider(provider)
+        final_model = _normalize_resolved_model(model or default_model, provider)
+        try:
+            from agent.anthropic_adapter import build_anthropic_client
+
+            real_client = build_anthropic_client(api_key, base_url)
+        except ImportError:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requires the anthropic SDK"
+            )
+            return None, None
+        client = AnthropicAuxiliaryClient(
+            real_client,
+            final_model,
+            api_key,
+            base_url,
+            # MiniMax accepts bearer auth on an Anthropic-compatible endpoint,
+            # but it is not native Anthropic OAuth.  Enabling this flag would
+            # inject Claude Code identity prompts, tool transforms, and beta
+            # headers into third-party requests.
+            is_oauth=False,
+        )
+        logger.debug("resolve_provider_client: minimax-oauth (%s)", final_model)
+        return (
+            _to_async_client(client, final_model, is_vision=is_vision)
+            if async_mode
+            else (client, final_model)
+        )
+
     if pconfig.auth_type == "api_key":
         if provider == "anthropic":
             client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)

--- a/tests/agent/test_minimax_oauth_auxiliary.py
+++ b/tests/agent/test_minimax_oauth_auxiliary.py
@@ -1,0 +1,124 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_minimax_oauth_resolves_anthropic_auxiliary_client(monkeypatch):
+    from agent import auxiliary_client
+
+    real_client = MagicMock()
+    build_client = MagicMock(return_value=real_client)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.build_anthropic_client",
+        build_client,
+    )
+
+    client, model = auxiliary_client.resolve_provider_client(
+        "minimax-oauth",
+        "minimax-m3",
+        explicit_base_url="https://api.minimax.io/anthropic",
+        explicit_api_key="oauth-access-token",
+        api_mode="anthropic_messages",
+    )
+
+    assert client is not None
+    assert isinstance(client, auxiliary_client.AnthropicAuxiliaryClient)
+    assert model == "minimax-m3"
+    build_client.assert_called_once_with(
+        "oauth-access-token",
+        "https://api.minimax.io/anthropic",
+    )
+    # Bearer transport does not imply native Anthropic OAuth.  MiniMax must not
+    # receive Claude Code identity prompts, tool transforms, or OAuth betas.
+    assert client.chat.completions._is_oauth is False
+
+
+def test_minimax_oauth_resolver_used_when_explicit_credentials_absent(monkeypatch):
+    from agent import auxiliary_client
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        lambda: {
+            "provider": "minimax-oauth",
+            "api_key": "stored-oauth-token",
+            "base_url": "https://api.minimax.io/anthropic",
+            "source": "oauth",
+        },
+    )
+    build_client = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.build_anthropic_client",
+        build_client,
+    )
+
+    client, model = auxiliary_client.resolve_provider_client(
+        "minimax-oauth",
+        "minimax-m3",
+    )
+
+    assert client is not None
+    assert model == "minimax-m3"
+    build_client.assert_called_once_with(
+        "stored-oauth-token",
+        "https://api.minimax.io/anthropic",
+    )
+
+
+def test_minimax_oauth_credential_resolution_failure_returns_none(monkeypatch):
+    from agent import auxiliary_client
+
+    def _raise():
+        raise RuntimeError("not logged in")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        _raise,
+    )
+
+    client, model = auxiliary_client.resolve_provider_client("minimax-oauth")
+
+    assert client is None
+    assert model is None
+
+
+@pytest.mark.parametrize(
+    "creds",
+    [
+        {"provider": "minimax-oauth", "api_key": "", "base_url": "https://api.minimax.io/anthropic"},
+        {"provider": "minimax-oauth", "api_key": "token", "base_url": ""},
+        {"provider": "minimax-oauth", "api_key": "token"},
+    ],
+)
+def test_minimax_oauth_empty_resolver_credentials_returns_none(monkeypatch, creds):
+    from agent import auxiliary_client
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        lambda: creds,
+    )
+
+    client, model = auxiliary_client.resolve_provider_client("minimax-oauth")
+
+    assert client is None
+    assert model is None
+
+
+def test_minimax_oauth_partial_explicit_with_unavailable_resolver_returns_none(monkeypatch):
+    from agent import auxiliary_client
+
+    def _raise():
+        raise RuntimeError("not logged in")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        _raise,
+    )
+
+    client, model = auxiliary_client.resolve_provider_client(
+        "minimax-oauth",
+        explicit_api_key="oauth-access-token",
+        explicit_base_url="",
+    )
+
+    assert client is None
+    assert model is None


### PR DESCRIPTION
## Summary

`resolve_provider_client()` treated the MiniMax OAuth type as unsupported, so auxiliary clients (MoA advisors, etc.) could not use configured MiniMax OAuth credentials even though the runtime already supports MiniMax OAuth.

- dedicated `oauth_minimax` branch placed after registry lookup and before the `api_key` branch
- resolves explicit credentials first, falls back to `hermes_cli.auth.resolve_minimax_oauth_runtime_credentials()`; clean `(None, None)` on resolver failure, empty credentials, or missing anthropic SDK
- wraps the result in `AnthropicAuxiliaryClient(..., is_oauth=False)` so MiniMax never receives Claude-identity prompts, tool transforms, or OAuth betas
- default model comes from `_get_aux_model_for_provider` instead of a hardcoded value

No tokens are logged or persisted; failure paths return `None` rather than raising.

## Test Plan

- `scripts/run_tests.sh tests/agent/test_minimax_oauth_auxiliary.py tests/agent/test_auxiliary_client.py tests/agent/test_minimax_auxiliary_url.py tests/agent/test_minimax_provider.py` -> 210 passed, 0 failed
- covers resolver-failure, empty api_key/base_url, and no-credentials negative paths

Restored from stranded local work (newest of three historical variants); fresh-context adversarial review PASS.
