### PR TITLE
fix(mcp): reap owner task on failed/cancelled start

### DIFF
--- a/tests/tools/test_mcp_start_cleanup.py
+++ b/tests/tools/test_mcp_start_cleanup.py
@@ -1,0 +1,126 @@
+"""MCP startup cleanup regressions for failed and cancelled connections."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask
+
+
+@pytest.mark.asyncio
+async def test_failed_start_awaits_parked_owner_task_cleanup():
+    server = MCPServerTask("broken")
+    cleanup_finished = asyncio.Event()
+    failure = RuntimeError("connect failed")
+
+    async def failed_run(self, _config):
+        try:
+            self._error = failure
+            self._ready.set()
+            await self._wait_for_reconnect_or_shutdown()
+        finally:
+            await asyncio.sleep(0)
+            cleanup_finished.set()
+
+    with patch.object(MCPServerTask, "run", failed_run):
+        with pytest.raises(RuntimeError, match="connect failed"):
+            await server.start({})
+
+    assert cleanup_finished.is_set()
+    assert server._task is not None
+    assert server._task.done()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_start_awaits_owner_task_cleanup():
+    server = MCPServerTask("slow")
+    owner_started = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    async def parked_run(self, _config):
+        owner_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(0)
+            cleanup_finished.set()
+
+    with patch.object(MCPServerTask, "run", parked_run):
+        start_task = asyncio.create_task(server.start({}))
+        await owner_started.wait()
+        start_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await start_task
+
+    assert cleanup_finished.is_set()
+    assert server._task is not None
+    assert server._task.done()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_start_preserves_cancellation_when_owner_cleanup_raises():
+    server = MCPServerTask("broken-cleanup")
+    owner_started = asyncio.Event()
+
+    async def cleanup_raises(self, _config):
+        owner_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            raise RuntimeError("owner cleanup failed")
+
+    with patch.object(MCPServerTask, "run", cleanup_raises):
+        start_task = asyncio.create_task(server.start({}))
+        await owner_started.wait()
+        start_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await start_task
+
+    assert server._task is not None
+    assert server._task.done()
+
+
+@pytest.mark.asyncio
+async def test_failed_start_preserves_connection_error_when_shutdown_raises():
+    server = MCPServerTask("broken-shutdown")
+    failure = RuntimeError("original connection failure")
+
+    async def failed_run(self, _config):
+        self._error = failure
+        self._ready.set()
+
+    with (
+        patch.object(MCPServerTask, "run", failed_run),
+        patch.object(
+            MCPServerTask,
+            "shutdown",
+            AsyncMock(side_effect=RuntimeError("secondary shutdown failure")),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="original connection failure") as exc:
+            await server.start({})
+
+    assert exc.value is failure
+
+
+@pytest.mark.asyncio
+async def test_claimed_failed_start_preserves_parked_owner_for_adoption():
+    server = MCPServerTask("claimed-park")
+    failure = RuntimeError("connect failed")
+
+    async def failed_run(self, _config):
+        self._error = failure
+        self._ready.set()
+        await self._wait_for_reconnect_or_shutdown()
+
+    with patch.object(MCPServerTask, "run", failed_run):
+        with pytest.raises(RuntimeError, match="connect failed"):
+            await server.start({}, shutdown_on_error=False)
+
+    assert server._task is not None
+    assert not server._task.done()
+    try:
+        await server.shutdown()
+    finally:
+        assert server._task.done()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3635,7 +3635,7 @@ class MCPServerTask:
             finally:
                 self.session = None
 
-    async def start(self, config: dict):
+    async def start(self, config: dict, *, shutdown_on_error: bool = True):
         """Create the background Task and wait until ready (or failed)."""
         self._task = asyncio.ensure_future(self.run(config))
         try:
@@ -3645,14 +3645,52 @@ class MCPServerTask:
             # in asyncio.wait_for) cancels *this* coroutine, but the
             # ensure_future'd run() task is independent and would otherwise
             # keep running detached — parked on a hung transport with no
-            # owner to reap it (#59349). Propagate the cancellation so the
+            # owner to reap it (#59349). Cancel and await the owner task so
             # transport context managers unwind and their finally blocks
-            # release the child process / FDs.
+            # release the child process / FDs before propagating cancellation.
             if self._task and not self._task.done():
                 self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+                except BaseException:
+                    # Cleanup failures must not replace the caller's original
+                    # cancellation. Preserve the cancellation and retain the
+                    # cleanup traceback in debug logs for diagnosis.
+                    logger.debug(
+                        "MCP server '%s' owner cleanup failed after start cancellation",
+                        self.name,
+                        exc_info=True,
+                    )
             raise
         if self._error:
-            raise self._error
+            if not shutdown_on_error:
+                raise self._error
+            # Initial connection failures park run() for a later self-probe.
+            # The server is not registered until start() succeeds, so returning
+            # the error without reaping that parked owner task leaves it
+            # unreachable. At process exit the MCP loop then closes underneath
+            # the task and its cancellation cleanup raises "Event loop is
+            # closed". Shut the unregistered owner down while its loop is alive.
+            error = self._error
+            error_traceback = error.__traceback__
+            try:
+                await self.shutdown()
+            except asyncio.CancelledError:
+                # A caller cancellation during cleanup supersedes the stored
+                # connection failure and must retain normal cancellation flow.
+                raise
+            except BaseException:
+                # Preserve the original connection error. Shutdown is
+                # best-effort here and must not turn a useful startup failure
+                # into an unrelated cleanup exception.
+                logger.debug(
+                    "MCP server '%s' cleanup failed after startup error",
+                    self.name,
+                    exc_info=True,
+                )
+            raise error.with_traceback(error_traceback)
 
     async def shutdown(self):
         """Signal the Task to exit and wait for clean resource teardown."""
@@ -5061,7 +5099,7 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
         # retain its discovery closure for the server's lifetime.
         claim_token = _connect_server_claim.set(None)
     try:
-        await server.start(config)
+        await server.start(config, shutdown_on_error=claim is None)
     except asyncio.CancelledError:
         # start() already cancels/reaps server._task on external cancellation
         # (see the comment there) -- awaiting a redundant shutdown() inside a


### PR DESCRIPTION
## Summary

MCP server startup cancellation cancelled the owner task but never awaited it, leaking the task; failed starts raised stored errors without shutting down the owner.

- cancelled start: after `self._task.cancel()`, the owner task is awaited and reaped (`CancelledError` swallowed, other cleanup exceptions debug-logged), original cancellation re-raised
- failed start: reap gated behind `shutdown_on_error` (default `True`) so claimed discovery starts keep the adoptable park for self-probe revival (#65673 auth-park); original error object identity and traceback preserved
- `shutdown()` unchanged (already bounded and idempotent); caller cancellation during cleanup supersedes the stored error

## Test Plan

- `scripts/run_tests.sh tests/tools/test_mcp_start_cleanup.py tests/tools/test_mcp_initial_connect_shutdown.py tests/tools/test_mcp_parked_self_probe.py tests/tools/test_mcp_cancelled_error_propagation.py tests/tools/test_mcp_tool.py` -> 109 passed, 0 failed
- new regression test locks the claimed-park adoption constraint

Restored from stranded local work, adapted to current park-adoption APIs; fresh-context adversarial review PASS.
