### PR TITLE
feat(tool_search): pin selected deferred tools as always visible

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2445,6 +2445,11 @@ DEFAULT_CONFIG = {
             # Absolute cap on the embedded listing in tokens (chars/4
             # estimate), regardless of context size. Range 200..60000.
             "listing_max_tokens": 4000,
+            # Exact tool names (list or comma-separated string) whose full
+            # schemas stay directly visible when tool search is active.
+            # Unknown names are ignored. Use for small, high-frequency
+            # plugin/MCP tools the model should not have to discover first.
+            "always_visible": [],
         },
     },
 

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -61,6 +61,51 @@ class TestConfigParsing:
         assert cfg.max_search_limit == 50
         assert cfg.search_default_limit <= cfg.max_search_limit
 
+    def test_always_visible_accepts_list_and_csv(self):
+        from tools.tool_search import ToolSearchConfig
+        listed = ToolSearchConfig.from_raw({
+            "always_visible": ["papercuts", "mcp_ticket_create", ""],
+        })
+        assert listed.always_visible == frozenset({"papercuts", "mcp_ticket_create"})
+
+        csv = ToolSearchConfig.from_raw({
+            "always_visible": "papercuts, mcp_ticket_create",
+        })
+        assert csv.always_visible == listed.always_visible
+
+    def test_always_visible_dedupes_and_tolerates_invalid_entries(self, monkeypatch):
+        import tools.tool_search as tool_search
+        cfg = tool_search.ToolSearchConfig.from_raw({
+            "always_visible": [
+                "papercuts",
+                "papercuts",
+                "  mcp_ticket_create  ",
+                "unknown_tool_xyz",
+                42,
+            ],
+        })
+        # Parsing keeps unknown names; matching is a no-op when no tool exists.
+        assert cfg.always_visible == frozenset({
+            "papercuts", "mcp_ticket_create", "unknown_tool_xyz", "42",
+        })
+        assert tool_search.ToolSearchConfig.from_raw({"always_visible": 99}).always_visible == frozenset()
+
+        monkeypatch.setattr(
+            tool_search,
+            "is_deferrable_tool_name",
+            lambda name: name in {"papercuts", "other_deferrable"},
+        )
+        defs = [_td("papercuts", "Pinned"), _td("other_deferrable", "Deferred")]
+        visible, deferrable = tool_search.classify_tools(
+            defs,
+            always_visible=cfg.always_visible,
+        )
+        visible_names = {(td.get("function") or {}).get("name") for td in visible}
+        deferrable_names = {(td.get("function") or {}).get("name") for td in deferrable}
+        assert "papercuts" in visible_names
+        assert "unknown_tool_xyz" not in visible_names
+        assert "other_deferrable" in deferrable_names
+
 
 # ---------------------------------------------------------------------------
 # Classification — the hard invariant: core tools NEVER defer.
@@ -219,6 +264,35 @@ class TestAssembly:
         # activation happened; here it didn't).
         assert "tool_search" not in names
 
+    def test_always_visible_tool_stays_direct_when_search_activates(self, monkeypatch):
+        import tools.tool_search as tool_search
+
+        defs = [
+            _td("terminal", "Run shell"),
+            _td("papercuts", "Record reusable workflow friction"),
+            _td("other_plugin_tool", "A deferred plugin tool"),
+        ]
+        monkeypatch.setattr(
+            tool_search,
+            "is_deferrable_tool_name",
+            lambda name: name in {"papercuts", "other_plugin_tool"},
+        )
+
+        result = tool_search.assemble_tool_defs(
+            defs,
+            context_length=200_000,
+            config=tool_search.ToolSearchConfig.from_raw({
+                "enabled": "on",
+                "always_visible": ["papercuts"],
+            }),
+        )
+
+        names = {td["function"]["name"] for td in result.tool_defs}
+        assert result.activated
+        assert "papercuts" in names
+        assert "other_plugin_tool" not in names
+        assert tool_search.BRIDGE_TOOL_NAMES.issubset(names)
+
 
 # ---------------------------------------------------------------------------
 # Bridge dispatch
@@ -256,6 +330,33 @@ class TestBridgeDispatch:
         ]
         assert "remain available" in result["hint"]
         assert "before concluding" in result["hint"]
+
+    def test_pinned_tool_excluded_from_deferred_search_catalog(self, monkeypatch):
+        import tools.tool_search as tool_search
+
+        defs = [
+            _td("pinned_policy_tool", "High-frequency policy action"),
+            _td("deferred_catalog_tool", "Deferred catalog action"),
+        ]
+        monkeypatch.setattr(
+            tool_search,
+            "is_deferrable_tool_name",
+            lambda name: name in {"pinned_policy_tool", "deferred_catalog_tool"},
+        )
+        config = tool_search.ToolSearchConfig.from_raw({
+            "always_visible": ["pinned_policy_tool"],
+        })
+
+        result = json.loads(tool_search.dispatch_tool_search(
+            {"query": "tool", "limit": 10},
+            current_tool_defs=defs,
+            config=config,
+        ))
+
+        match_names = {m["name"] for m in result["matches"]}
+        assert "pinned_policy_tool" not in match_names
+        assert "deferred_catalog_tool" in match_names
+        assert result["total_available"] == 1
 
 
     def test_resolve_underlying_call_parses_object_args(self):

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -96,6 +96,10 @@ class ToolSearchConfig:
     # Absolute cap on the embedded listing, regardless of context size.
     # Effective budget = min(listing_max_tokens, threshold_pct% of context).
     listing_max_tokens: int = 4000
+    # Plugin/MCP tools whose schemas must remain directly visible. This is for
+    # small, high-frequency policy tools where requiring the model to first
+    # remember that a hidden capability exists defeats the capability itself.
+    always_visible: frozenset[str] = frozenset()
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -145,6 +149,19 @@ class ToolSearchConfig:
             listing = "auto"
         listing_max_tokens = max(200, min(60000, _safe_int(raw.get("listing_max_tokens"), 4000)))
 
+        always_visible_raw = raw.get("always_visible", [])
+        if isinstance(always_visible_raw, str):
+            always_visible_values = always_visible_raw.split(",")
+        elif isinstance(always_visible_raw, (list, tuple, set, frozenset)):
+            always_visible_values = always_visible_raw
+        else:
+            always_visible_values = []
+        always_visible = frozenset(
+            str(name).strip()
+            for name in always_visible_values
+            if str(name).strip()
+        )
+
         return cls(
             enabled=enabled,
             threshold_pct=threshold_pct,
@@ -152,6 +169,7 @@ class ToolSearchConfig:
             max_search_limit=max_search_limit,
             listing=listing,
             listing_max_tokens=listing_max_tokens,
+            always_visible=always_visible,
         )
 
 
@@ -227,13 +245,18 @@ def is_deferrable_tool_name(name: str) -> bool:
         return False
 
 
-def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def classify_tools(
+    tool_defs: List[Dict[str, Any]],
+    *,
+    always_visible: Iterable[str] = (),
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable).
 
     ``visible`` retains every tool that must stay in the model-facing array:
-    every core tool, plus any tool we can't classify. ``deferrable`` is the
-    candidate set for catalog entry.
+    every core tool, every explicitly pinned tool, plus any tool we can't
+    classify. ``deferrable`` is the candidate set for catalog entry.
     """
+    pinned = frozenset(always_visible)
     visible: List[Dict[str, Any]] = []
     deferrable: List[Dict[str, Any]] = []
     for td in tool_defs:
@@ -242,6 +265,9 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
         if name in BRIDGE_TOOL_NAMES:
             # Should never happen — bridge tools are added after classification —
             # but be defensive.
+            continue
+        if name in pinned:
+            visible.append(td)
             continue
         if is_deferrable_tool_name(name):
             deferrable.append(td)
@@ -794,7 +820,10 @@ def assemble_tool_defs(
     incoming = [td for td in tool_defs
                 if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
 
-    visible, deferrable = classify_tools(incoming)
+    visible, deferrable = classify_tools(
+        incoming,
+        always_visible=config.always_visible,
+    )
     if not deferrable:
         return AssemblyResult(tool_defs=incoming, activated=False)
 
@@ -898,7 +927,10 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(
+        current_tool_defs,
+        always_visible=config.always_visible,
+    )
     catalog = build_catalog(deferrable)
     hits = search_catalog(catalog, query, limit=limit)
     result: Dict[str, Any] = {


### PR DESCRIPTION
## Summary

Deferred plugin/MCP tools normally only appear via tool search. This adds `tools.tool_search.always_visible` (config.yaml list, default empty) to pin selected tools into the visible set while everything else stays searchable on demand.

- parsed from list/tuple/set or CSV string; stripped, empties dropped, invalid types -> empty set, never raises
- pins applied in `classify_tools` before the deferral check and threaded through `assemble_tool_defs` and `dispatch_tool_search` (pinned tools drop out of the deferred search catalog)
- existing tiered-disclosure machinery untouched; no new core tool, no env var, no config-version bump (deep-merge covers the new key)

## Test Plan

- `scripts/run_tests.sh tests/tools/test_tool_search.py tests/tools/test_plugins.py tests/tools/test_delegate.py tests/tools/test_discord_tool.py tests/tools/test_terminal_tool_requirements.py` -> 154 passed, 0 failed
- covers list/CSV parsing, duplicates/scalar coercion determinism, pinned tool stays visible, search-catalog exclusion

Restored from stranded local work; fresh-context adversarial review PASS.
