### PR TITLE
feat(web): opt-in RSS/Atom specialization for web_extract

### DIFF
--- a/tests/tools/test_web_rss_specialization.py
+++ b/tests/tools/test_web_rss_specialization.py
@@ -61,6 +61,41 @@ XXE_PAYLOAD = b"""<?xml version="1.0"?>
 <rss version="2.0"><channel><title>&xxe;</title></channel></rss>
 """
 
+RDF_ONTOLOGY = b"""<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Class rdf:about="http://example.com/Foo"/>
+</rdf:RDF>
+"""
+
+EMPTY_RSS = (
+    b'<?xml version="1.0"?><rss version="2.0"><channel>'
+    b"<title>Empty</title></channel></rss>"
+)
+
+
+def _use_stdlib_xml(monkeypatch):
+    import xml.etree.ElementTree as stdlib_et
+
+    monkeypatch.setattr(rss, "_HAS_DEFUSEDXML", False)
+    monkeypatch.setattr(rss, "ET", stdlib_et)
+    monkeypatch.setattr(rss, "_PARSE_ERRORS", (stdlib_et.ParseError,))
+
+
+def _padded_doctype_payload() -> bytes:
+    padding = b"x" * 9000
+    return padding + BILLION_LAUGHS
+
+
+def _utf16_doctype_payload() -> bytes:
+    text = (
+        '<?xml version="1.0"?>\n'
+        "<!DOCTYPE foo [\n  <!ENTITY xxe \"test\">\n]>\n"
+        '<rss version="2.0"><channel><title>T</title>'
+        "<item><title>One</title></item></channel></rss>"
+    )
+    return b"\xff\xfe" + text.encode("utf-16-le")
+
 
 def test_parse_rss_normalizes_and_deduplicates():
     result = rss.parse_feed(RSS_XML, "https://example.com/feed")
@@ -103,14 +138,101 @@ def test_xxe_doctype_rejected():
 
 
 def test_billion_laughs_rejected_when_defusedxml_absent(monkeypatch):
-    monkeypatch.setattr(rss, "_HAS_DEFUSEDXML", False)
+    _use_stdlib_xml(monkeypatch)
     assert rss.parse_feed(BILLION_LAUGHS, "https://example.com/feed") is None
 
 
 def test_xxe_rejected_when_defusedxml_absent(monkeypatch):
-    monkeypatch.setattr(rss, "_HAS_DEFUSEDXML", False)
+    _use_stdlib_xml(monkeypatch)
     assert rss.parse_feed(XXE_PAYLOAD, "https://example.com/feed") is None
 
+
+def test_padded_doctype_rejected_on_stdlib_path_without_expansion(monkeypatch):
+    _use_stdlib_xml(monkeypatch)
+    payload = _padded_doctype_payload()
+    assert len(payload) > 8192
+    assert rss.parse_feed(payload, "https://example.com/feed") is None
+
+
+def test_utf16_doctype_rejected_on_stdlib_path(monkeypatch):
+    _use_stdlib_xml(monkeypatch)
+    assert rss.parse_feed(_utf16_doctype_payload(), "https://example.com/feed") is None
+
+
+def test_malformed_xml_returns_none_on_stdlib_path(monkeypatch):
+    _use_stdlib_xml(monkeypatch)
+    assert rss.parse_feed(b"<rss><channel>", "https://example.com/feed") is None
+
+
+def test_rdf_ontology_falls_back_without_overwriting():
+    assert rss.parse_feed(RDF_ONTOLOGY, "https://example.com/ontology.rdf") is None
+
+
+def test_empty_rss_feed_falls_back():
+    assert rss.parse_feed(EMPTY_RSS, "https://example.com/empty") is None
+
+
+def test_empty_rss_feed_apply_leaves_content_unchanged():
+    original = {
+        "url": "https://example.com/empty",
+        "title": "Provider",
+        "content": EMPTY_RSS.decode(),
+        "raw_content": EMPTY_RSS.decode(),
+    }
+    before = dict(original)
+    rss.apply_rss_specialization(original)
+    assert original["content"] == before["content"]
+
+
+def test_oversized_content_is_never_parsed():
+    sniff_prefix = b"<?xml version='1.0'?><rss><channel><title>x</title>"
+    oversized = sniff_prefix + (b" " * (rss._MAX_FEED_BYTES + 1))
+    assert len(oversized) > rss._MAX_FEED_BYTES
+    assert rss.parse_feed(oversized, "https://example.com/huge") is None
+
+
+def test_oversized_apply_specialization_leaves_content_unchanged(monkeypatch):
+    sniff_prefix = b"<?xml version='1.0'?><rss><channel><title>x</title>"
+    oversized = sniff_prefix + (b" " * (rss._MAX_FEED_BYTES + 1))
+    original = {
+        "url": "https://example.com/huge",
+        "title": "Provider",
+        "content": oversized.decode("latin-1"),
+        "raw_content": oversized,
+    }
+    before = dict(original)
+    called = []
+
+    def forbidden_parse(*args, **kwargs):
+        called.append(1)
+        raise AssertionError("parse_feed must not run for oversized content")
+
+    monkeypatch.setattr(rss, "parse_feed", forbidden_parse)
+    rss.apply_rss_specialization(original)
+    assert not called
+    assert original["content"] == before["content"]
+
+
+def test_rss_specialization_disabled_when_extract_specializations_not_dict(monkeypatch):
+    from tools import web_tools
+
+    monkeypatch.setattr(
+        web_tools,
+        "_load_web_config",
+        lambda: {"extract_specializations": "yes"},
+    )
+    assert web_tools._rss_specialization_enabled() is False
+
+
+def test_rss_specialization_disabled_when_web_section_null(monkeypatch):
+    from tools import web_tools
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"web": None},
+    )
+    assert web_tools._load_web_config() == {}
+    assert web_tools._rss_specialization_enabled() is False
 
 def test_apply_specialization_leaves_plain_html_unchanged():
     original = {

--- a/tests/tools/test_web_rss_specialization.py
+++ b/tests/tools/test_web_rss_specialization.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.web_specializations import rss
+
+
+RSS_XML = b"""<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Example News</title>
+    <description>Useful &amp; current</description>
+    <lastBuildDate>Tue, 14 Jul 2026 06:00:00 GMT</lastBuildDate>
+    <item>
+      <guid>one</guid>
+      <title>First item</title>
+      <link>https://example.com/one</link>
+      <pubDate>Tue, 14 Jul 2026 05:00:00 GMT</pubDate>
+      <description><![CDATA[<p>Hello <b>world</b>.</p>]]></description>
+    </item>
+    <item>
+      <guid>one</guid>
+      <title>Duplicate</title>
+      <link>https://example.com/duplicate</link>
+    </item>
+  </channel>
+</rss>
+"""
+
+ATOM_XML = b"""<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Atom</title>
+  <updated>2026-07-14T06:00:00Z</updated>
+  <entry>
+    <id>tag:example.com,2026:1</id>
+    <title>Atom item</title>
+    <link rel="alternate" href="https://example.com/atom-one" />
+    <author><name>Ada</name></author>
+    <published>2026-07-14T05:00:00Z</published>
+    <summary>Atom summary</summary>
+  </entry>
+</feed>
+"""
+
+BILLION_LAUGHS = b"""<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+]>
+<rss version="2.0"><channel><title>x</title><item><title>y</title></item></channel></rss>
+"""
+
+XXE_PAYLOAD = b"""<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<rss version="2.0"><channel><title>&xxe;</title></channel></rss>
+"""
+
+
+def test_parse_rss_normalizes_and_deduplicates():
+    result = rss.parse_feed(RSS_XML, "https://example.com/feed")
+    assert result is not None
+    assert result["title"] == "Example News"
+    assert result["metadata"]["entryCount"] == 1
+    assert "# Example News" in result["content"]
+    assert "[First item](https://example.com/one)" in result["content"]
+    assert "Hello world." in result["content"]
+    assert "Duplicate" not in result["content"]
+
+
+def test_parse_atom_normalizes_author_and_link():
+    result = rss.parse_feed(ATOM_XML, "https://example.com/atom.xml")
+    assert result is not None
+    assert result["title"] == "Example Atom"
+    assert result["metadata"]["entryCount"] == 1
+    assert "[Atom item](https://example.com/atom-one)" in result["content"]
+    assert "- Author: Ada" in result["content"]
+    assert "Atom summary" in result["content"]
+
+
+def test_parse_non_feed_xml_returns_none():
+    assert (
+        rss.parse_feed(b"<document><title>Nope</title></document>", "https://example.com/x.xml")
+        is None
+    )
+
+
+def test_parse_malformed_xml_returns_none():
+    assert rss.parse_feed(b"<rss><channel>", "https://example.com/feed") is None
+
+
+def test_billion_laughs_rejected_without_expansion():
+    assert rss.parse_feed(BILLION_LAUGHS, "https://example.com/feed") is None
+
+
+def test_xxe_doctype_rejected():
+    assert rss.parse_feed(XXE_PAYLOAD, "https://example.com/feed") is None
+
+
+def test_billion_laughs_rejected_when_defusedxml_absent(monkeypatch):
+    monkeypatch.setattr(rss, "_HAS_DEFUSEDXML", False)
+    assert rss.parse_feed(BILLION_LAUGHS, "https://example.com/feed") is None
+
+
+def test_xxe_rejected_when_defusedxml_absent(monkeypatch):
+    monkeypatch.setattr(rss, "_HAS_DEFUSEDXML", False)
+    assert rss.parse_feed(XXE_PAYLOAD, "https://example.com/feed") is None
+
+
+def test_apply_specialization_leaves_plain_html_unchanged():
+    original = {
+        "url": "https://example.com/page",
+        "title": "Page",
+        "content": "<html><body>Hello</body></html>",
+        "raw_content": "<html><body>Hello</body></html>",
+    }
+    before = dict(original)
+    rss.apply_rss_specialization(original)
+    assert original["content"] == before["content"]
+
+
+def test_many_entries_are_bounded():
+    items = []
+    for i in range(500):
+        items.append(
+            f"<item><guid>{i}</guid><title>Item {i}</title>"
+            f"<description>summary {i}</description></item>"
+        )
+    xml = (
+        b'<?xml version="1.0"?><rss version="2.0"><channel><title>Big</title>'
+        + "".join(items).encode()
+        + b"</channel></rss>"
+    )
+    assert len(xml) <= rss._MAX_FEED_BYTES
+    result = rss.parse_feed(xml, "https://example.com/big")
+    assert result is not None
+    assert result["metadata"]["entryCount"] == rss._MAX_ENTRIES
+
+
+@pytest.mark.asyncio
+async def test_web_extract_malformed_feed_falls_back_to_provider_content(monkeypatch):
+    from agent import web_search_registry
+    from agent.web_search_provider import WebSearchProvider
+    from tools import web_tools
+
+    malformed = b"<rss><channel>"
+
+    class FakeExa(WebSearchProvider):
+        @property
+        def name(self):
+            return "exa"
+
+        def is_available(self):
+            return True
+
+        def supports_search(self):
+            return False
+
+        def supports_extract(self):
+            return True
+
+        def extract(self, urls, **kwargs):
+            return [
+                {
+                    "url": url,
+                    "title": "Provider",
+                    "content": malformed.decode(),
+                    "raw_content": malformed.decode(),
+                }
+                for url in urls
+            ]
+
+    original = dict(web_search_registry._providers)
+    try:
+        web_search_registry._providers.clear()
+        web_search_registry.register_provider(FakeExa())
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "extract_specializations": {"rss": True},
+            },
+        )
+        monkeypatch.setattr(web_tools, "async_is_safe_url", lambda url: _true())
+
+        output = json.loads(
+            await web_tools.web_extract_tool(["https://example.com/feed"])
+        )
+        assert output["results"][0]["content"] == malformed.decode()
+        assert output["results"][0].get("error") is None
+    finally:
+        web_search_registry._providers.clear()
+        web_search_registry._providers.update(original)
+
+
+@pytest.mark.asyncio
+async def test_web_extract_xxe_payload_falls_back(monkeypatch):
+    from agent import web_search_registry
+    from agent.web_search_provider import WebSearchProvider
+    from tools import web_tools
+
+    class FakeExa(WebSearchProvider):
+        @property
+        def name(self):
+            return "exa"
+
+        def is_available(self):
+            return True
+
+        def supports_search(self):
+            return False
+
+        def supports_extract(self):
+            return True
+
+        def extract(self, urls, **kwargs):
+            return [
+                {
+                    "url": url,
+                    "title": "Provider",
+                    "content": XXE_PAYLOAD.decode(),
+                    "raw_content": XXE_PAYLOAD.decode(),
+                }
+                for url in urls
+            ]
+
+    original = dict(web_search_registry._providers)
+    try:
+        web_search_registry._providers.clear()
+        web_search_registry.register_provider(FakeExa())
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "extract_specializations": {"rss": True},
+            },
+        )
+        monkeypatch.setattr(web_tools, "async_is_safe_url", lambda url: _true())
+
+        output = json.loads(
+            await web_tools.web_extract_tool(["https://example.com/feed"])
+        )
+        assert XXE_PAYLOAD.decode() in output["results"][0]["content"]
+    finally:
+        web_search_registry._providers.clear()
+        web_search_registry._providers.update(original)
+
+
+@pytest.mark.asyncio
+async def test_web_extract_many_entries_respects_char_limit(monkeypatch, tmp_path):
+    from agent import web_search_registry
+    from agent.web_search_provider import WebSearchProvider
+    from tools import web_tools
+
+    items = []
+    for i in range(500):
+        items.append(
+            f"<item><guid>{i}</guid><title>Item {i}</title>"
+            f"<description>{'word ' * 400}</description></item>"
+        )
+    big_feed = (
+        b'<?xml version="1.0"?><rss version="2.0"><channel><title>Big</title>'
+        + "".join(items).encode()
+        + b"</channel></rss>"
+    )
+
+    class FakeExa(WebSearchProvider):
+        @property
+        def name(self):
+            return "exa"
+
+        def is_available(self):
+            return True
+
+        def supports_search(self):
+            return False
+
+        def supports_extract(self):
+            return True
+
+        def extract(self, urls, **kwargs):
+            return [
+                {
+                    "url": url,
+                    "title": "Big",
+                    "content": big_feed.decode(),
+                    "raw_content": big_feed.decode(),
+                }
+                for url in urls
+            ]
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    original = dict(web_search_registry._providers)
+    try:
+        web_search_registry._providers.clear()
+        web_search_registry.register_provider(FakeExa())
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "extract_specializations": {"rss": True},
+            },
+        )
+        monkeypatch.setattr(web_tools, "async_is_safe_url", lambda url: _true())
+
+        char_limit = 5000
+        output = json.loads(
+            await web_tools.web_extract_tool(
+                ["https://example.com/big"], char_limit=char_limit
+            )
+        )
+        content = output["results"][0]["content"]
+        assert len(content) <= char_limit + 500
+        assert "[TRUNCATED]" in content
+    finally:
+        web_search_registry._providers.clear()
+        web_search_registry._providers.update(original)
+
+
+@pytest.mark.asyncio
+async def test_default_off_skips_specialization(monkeypatch):
+    from agent import web_search_registry
+    from agent.web_search_provider import WebSearchProvider
+    from tools import web_tools
+
+    class FakeExa(WebSearchProvider):
+        @property
+        def name(self):
+            return "exa"
+
+        def is_available(self):
+            return True
+
+        def supports_search(self):
+            return False
+
+        def supports_extract(self):
+            return True
+
+        def extract(self, urls, **kwargs):
+            return [
+                {
+                    "url": url,
+                    "title": "Feed",
+                    "content": RSS_XML.decode(),
+                    "raw_content": RSS_XML.decode(),
+                }
+                for url in urls
+            ]
+
+    def forbidden_parse(*args, **kwargs):
+        raise AssertionError("parse_feed must not run when specialization is off")
+
+    original = dict(web_search_registry._providers)
+    try:
+        web_search_registry._providers.clear()
+        web_search_registry.register_provider(FakeExa())
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_backend": "exa"})
+        monkeypatch.setattr(web_tools, "async_is_safe_url", lambda url: _true())
+        monkeypatch.setattr(rss, "parse_feed", forbidden_parse)
+
+        output = json.loads(
+            await web_tools.web_extract_tool(["https://example.com/feed"])
+        )
+        assert RSS_XML.decode() in output["results"][0]["content"]
+        assert "# Example News" not in output["results"][0]["content"]
+        assert "<rss" in output["results"][0]["content"]
+    finally:
+        web_search_registry._providers.clear()
+        web_search_registry._providers.update(original)
+
+
+@pytest.mark.asyncio
+async def test_web_extract_opt_in_parses_feed_from_provider(monkeypatch):
+    from agent import web_search_registry
+    from agent.web_search_provider import WebSearchProvider
+    from tools import web_tools
+
+    calls = []
+
+    class FakeExa(WebSearchProvider):
+        @property
+        def name(self):
+            return "exa"
+
+        def is_available(self):
+            return True
+
+        def supports_search(self):
+            return False
+
+        def supports_extract(self):
+            return True
+
+        def extract(self, urls, **kwargs):
+            calls.extend(urls)
+            out = []
+            for url in urls:
+                if url.endswith("/feed"):
+                    out.append(
+                        {
+                            "url": url,
+                            "title": "Raw",
+                            "content": RSS_XML.decode(),
+                            "raw_content": RSS_XML.decode(),
+                        }
+                    )
+                else:
+                    out.append(
+                        {
+                            "url": url,
+                            "title": "Generic",
+                            "content": "generic body",
+                            "raw_content": "generic body",
+                        }
+                    )
+            return out
+
+    original = dict(web_search_registry._providers)
+    try:
+        web_search_registry._providers.clear()
+        web_search_registry.register_provider(FakeExa())
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "extract_specializations": {"rss": True},
+            },
+        )
+        monkeypatch.setattr(web_tools, "async_is_safe_url", lambda url: _true())
+
+        output = json.loads(
+            await web_tools.web_extract_tool(
+                ["https://example.com/feed", "https://example.com/article"]
+            )
+        )
+        assert calls == ["https://example.com/feed", "https://example.com/article"]
+        assert [item["url"] for item in output["results"]] == [
+            "https://example.com/feed",
+            "https://example.com/article",
+        ]
+        assert "# Example News" in output["results"][0]["content"]
+        assert "[First item](https://example.com/one)" in output["results"][0]["content"]
+        assert output["results"][1]["content"] == "generic body"
+    finally:
+        web_search_registry._providers.clear()
+        web_search_registry._providers.update(original)
+
+
+@pytest.mark.asyncio
+async def test_web_extract_performs_exactly_one_provider_fetch(monkeypatch):
+    from agent import web_search_registry
+    from agent.web_search_provider import WebSearchProvider
+    from tools import web_tools
+
+    extract_calls = 0
+
+    class FakeExa(WebSearchProvider):
+        @property
+        def name(self):
+            return "exa"
+
+        def is_available(self):
+            return True
+
+        def supports_search(self):
+            return False
+
+        def supports_extract(self):
+            return True
+
+        def extract(self, urls, **kwargs):
+            nonlocal extract_calls
+            extract_calls += 1
+            return [
+                {
+                    "url": url,
+                    "title": "Feed",
+                    "content": RSS_XML.decode(),
+                    "raw_content": RSS_XML.decode(),
+                }
+                for url in urls
+            ]
+
+    async def forbidden_stream(*args, **kwargs):
+        raise AssertionError("web_extract must not open a separate httpx stream")
+
+    original = dict(web_search_registry._providers)
+    try:
+        web_search_registry._providers.clear()
+        web_search_registry.register_provider(FakeExa())
+        monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "extract_specializations": {"rss": True},
+            },
+        )
+        monkeypatch.setattr(web_tools, "async_is_safe_url", lambda url: _true())
+        monkeypatch.setattr(web_tools.httpx, "stream", forbidden_stream)
+        monkeypatch.setattr(web_tools.httpx, "AsyncClient", forbidden_stream)
+
+        output = json.loads(
+            await web_tools.web_extract_tool(["https://example.com/feed"])
+        )
+        assert extract_calls == 1
+        assert "# Example News" in output["results"][0]["content"]
+    finally:
+        web_search_registry._providers.clear()
+        web_search_registry._providers.update(original)
+
+
+async def _true():
+    return True

--- a/tools/web_specializations/__init__.py
+++ b/tools/web_specializations/__init__.py
@@ -1,0 +1,1 @@
+"""Private URL-specific helpers for the existing web extraction tool."""

--- a/tools/web_specializations/rss.py
+++ b/tools/web_specializations/rss.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import html
 import logging
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple, Type
 
 logger = logging.getLogger(__name__)
 
@@ -34,16 +34,31 @@ _FEED_SNIFF_MARKERS = (
     b"<rdf ",
 )
 
+_UNSAFE_MARKERS_ASCII = (b"<!DOCTYPE", b"<!ENTITY")
+_UTF16LE_MARKERS = (
+    b"<\x00!\x00D\x00O\x00C\x00T\x00Y\x00P\x00E\x00",
+    b"<\x00!\x00E\x00N\x00T\x00I\x00T\x00Y\x00",
+    b"<\x00!\x00d\x00o\x00c\x00t\x00y\x00p\x00e\x00",
+    b"<\x00!\x00e\x00n\x00t\x00i\x00t\x00y\x00",
+)
+_UTF16BE_MARKERS = (
+    b"\x00<\x00!\x00D\x00O\x00C\x00T\x00Y\x00P\x00E",
+    b"\x00<\x00!\x00E\x00N\x00T\x00I\x00T\x00Y",
+    b"\x00<\x00!\x00d\x00o\x00c\x00t\x00y\x00p\x00e",
+    b"\x00<\x00!\x00e\x00n\x00t\x00i\x00t\x00y",
+)
+
 try:
     from defusedxml import ElementTree as ET  # type: ignore[import-untyped]
     from defusedxml.common import EntitiesForbidden  # type: ignore[import-untyped]
 
     _HAS_DEFUSEDXML = True
+    _PARSE_ERRORS: Tuple[Type[BaseException], ...] = (ET.ParseError, EntitiesForbidden)
 except ImportError:
     import xml.etree.ElementTree as ET
 
     _HAS_DEFUSEDXML = False
-    EntitiesForbidden = ()  # type: ignore[misc,assignment]
+    _PARSE_ERRORS = (ET.ParseError,)
 
 
 def _local_name(tag: Any) -> str:
@@ -92,15 +107,67 @@ def _entry_link(entry: Any) -> str:
     return fallback
 
 
+def _scan_utf16_for_unsafe_markers(buf: bytes) -> Optional[bool]:
+    """Return True/False when UTF-16 scan is decisive; None if not UTF-16."""
+    if buf.startswith(b"\xff\xfe") or buf.startswith(b"\xfe\xff"):
+        for encoding in ("utf-16", "utf-16-le", "utf-16-be"):
+            try:
+                text = buf.decode(encoding)
+                sample = text.upper()
+                return "<!DOCTYPE" in sample or "<!ENTITY" in sample
+            except UnicodeDecodeError:
+                continue
+            except Exception:
+                return True
+        return True
+
+    if b"\x00" not in buf[:512]:
+        return None
+
+    if buf.lstrip().startswith(b"<?") or buf.lstrip().startswith(b"<r"):
+        return None
+
+    decoded_any = False
+    for encoding in ("utf-16-le", "utf-16-be", "utf-16"):
+        try:
+            text = buf.decode(encoding)
+            decoded_any = True
+            sample = text.upper()
+            if "<!DOCTYPE" in sample or "<!ENTITY" in sample:
+                return True
+        except UnicodeDecodeError:
+            continue
+        except Exception:
+            return True
+
+    if decoded_any:
+        return False
+    return True
+
+
 def _reject_unsafe_xml_text(xml_bytes: bytes) -> bool:
     """Return True when stdlib parsing must be rejected (XXE / entity expansion)."""
     if _HAS_DEFUSEDXML:
         return False
-    try:
-        sample = xml_bytes[:8192].decode("utf-8", errors="ignore").upper()
-    except Exception:
+    if not xml_bytes:
+        return False
+
+    buf = xml_bytes[:_MAX_FEED_BYTES]
+
+    upper = buf.upper()
+    if any(marker in upper for marker in _UNSAFE_MARKERS_ASCII):
         return True
-    return "<!DOCTYPE" in sample or "<!ENTITY" in sample
+
+    if any(marker in buf for marker in _UTF16LE_MARKERS + _UTF16BE_MARKERS):
+        return True
+
+    utf16_result = _scan_utf16_for_unsafe_markers(buf)
+    if utf16_result is True:
+        return True
+    if utf16_result is False:
+        return False
+
+    return False
 
 
 def _safe_fromstring(xml_bytes: bytes) -> Optional[Any]:
@@ -108,7 +175,9 @@ def _safe_fromstring(xml_bytes: bytes) -> Optional[Any]:
         return None
     try:
         return ET.fromstring(xml_bytes)
-    except (ET.ParseError, EntitiesForbidden):
+    except _PARSE_ERRORS:
+        return None
+    except Exception:
         return None
 
 
@@ -140,31 +209,7 @@ def _looks_like_feed_content(result: Dict[str, Any], xml_bytes: bytes) -> bool:
     return any(marker in sample for marker in _FEED_SNIFF_MARKERS)
 
 
-def parse_feed(xml_bytes: bytes, source_url: str) -> Optional[Dict[str, Any]]:
-    """Parse RSS 2.0, Atom, or RDF/RSS bytes into a web-extract result.
-
-    Returns ``None`` when XML is malformed, rejected as unsafe, or valid but
-    not a recognized feed. Never raises.
-    """
-    if not xml_bytes or len(xml_bytes) > _MAX_FEED_BYTES:
-        return None
-
-    root = _safe_fromstring(xml_bytes)
-    if root is None:
-        return None
-
-    root_name = _local_name(root.tag)
-    if root_name not in {"rss", "feed", "rdf"}:
-        return None
-
-    channel = _child(root, "channel") if root_name in {"rss", "rdf"} else root
-    if channel is None:
-        channel = root
-
-    feed_title = _text(_child(channel, "title")) or "Feed"
-    feed_description = _clean_summary(_text(_child(channel, "description", "subtitle")))
-    feed_updated = _text(_child(channel, "lastbuilddate", "updated", "pubdate"))
-
+def _collect_entries(root: Any) -> list:
     entries = []
     seen = set()
     for candidate in root.iter():
@@ -196,39 +241,79 @@ def parse_feed(xml_bytes: bytes, source_url: str) -> Optional[Dict[str, Any]]:
                 "summary": summary,
             }
         )
+    return entries
 
-    lines = [f"# {feed_title}", "", f"- Source: {source_url}"]
-    if feed_updated:
-        lines.append(f"- Updated: {feed_updated}")
-    if feed_description:
-        lines.extend(["", feed_description])
-    lines.extend(["", "## Entries"])
 
-    if not entries:
-        lines.extend(["", "No entries found."])
-    for entry in entries:
-        heading = f"[{entry['title']}]({entry['link']})" if entry["link"] else entry["title"]
-        lines.extend(["", f"### {heading}"])
-        if entry["published"]:
-            lines.append(f"- Published: {entry['published']}")
-        if entry["author"]:
-            lines.append(f"- Author: {entry['author']}")
-        if entry["summary"]:
-            lines.extend(["", entry["summary"]])
+def parse_feed(xml_bytes: bytes, source_url: str) -> Optional[Dict[str, Any]]:
+    """Parse RSS 2.0, Atom, or RDF/RSS bytes into a web-extract result.
 
-    content = "\n".join(lines).strip()
-    return {
-        "url": source_url,
-        "title": feed_title,
-        "content": content,
-        "raw_content": content,
-        "metadata": {
-            "sourceURL": source_url,
+    Returns ``None`` when XML is malformed, rejected as unsafe, or valid but
+    not a recognized feed. Never raises.
+    """
+    try:
+        if not xml_bytes or len(xml_bytes) > _MAX_FEED_BYTES:
+            return None
+
+        root = _safe_fromstring(xml_bytes)
+        if root is None:
+            return None
+
+        root_name = _local_name(root.tag)
+        if root_name not in {"rss", "feed", "rdf"}:
+            return None
+
+        if root_name == "rdf":
+            channel = _child(root, "channel")
+            if channel is None:
+                return None
+        elif root_name == "rss":
+            channel = _child(root, "channel")
+            if channel is None:
+                return None
+        else:
+            channel = root
+
+        entries = _collect_entries(root)
+        if not entries:
+            return None
+
+        feed_title = _text(_child(channel, "title")) or "Feed"
+        feed_description = _clean_summary(_text(_child(channel, "description", "subtitle")))
+        feed_updated = _text(_child(channel, "lastbuilddate", "updated", "pubdate"))
+
+        lines = [f"# {feed_title}", "", f"- Source: {source_url}"]
+        if feed_updated:
+            lines.append(f"- Updated: {feed_updated}")
+        if feed_description:
+            lines.extend(["", feed_description])
+        lines.extend(["", "## Entries"])
+
+        for entry in entries:
+            heading = f"[{entry['title']}]({entry['link']})" if entry["link"] else entry["title"]
+            lines.extend(["", f"### {heading}"])
+            if entry["published"]:
+                lines.append(f"- Published: {entry['published']}")
+            if entry["author"]:
+                lines.append(f"- Author: {entry['author']}")
+            if entry["summary"]:
+                lines.extend(["", entry["summary"]])
+
+        content = "\n".join(lines).strip()
+        return {
+            "url": source_url,
             "title": feed_title,
-            "contentType": "feed",
-            "entryCount": len(entries),
-        },
-    }
+            "content": content,
+            "raw_content": content,
+            "metadata": {
+                "sourceURL": source_url,
+                "title": feed_title,
+                "contentType": "feed",
+                "entryCount": len(entries),
+            },
+        }
+    except Exception as exc:
+        logger.debug("RSS/Atom parse_feed skipped: %s", exc)
+        return None
 
 
 def apply_rss_specialization(result: Dict[str, Any]) -> None:

--- a/tools/web_specializations/rss.py
+++ b/tools/web_specializations/rss.py
@@ -1,0 +1,254 @@
+"""RSS/Atom post-processing specialization for :func:`tools.web_tools.web_extract_tool`.
+
+Pure parsing and normalization only — no network I/O. Runs after the existing
+provider fetch/validation path returns bounded content.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_MAX_FEED_BYTES = 2 * 1024 * 1024
+_MAX_ENTRIES = 200
+_MAX_SUMMARY_CHARS = 2000
+_SNIFF_SAMPLE_CHARS = 512
+_STRIP_TAGS_RE = re.compile(r"<[^>]+>")
+
+_FEED_CONTENT_TYPES = {
+    "application/atom+xml",
+    "application/rss+xml",
+    "application/rdf+xml",
+    "application/xml",
+    "text/xml",
+}
+_FEED_SNIFF_MARKERS = (
+    b"<?xml",
+    b"<rss",
+    b"<feed",
+    b"<rdf:rdf",
+    b"<rdf ",
+)
+
+try:
+    from defusedxml import ElementTree as ET  # type: ignore[import-untyped]
+    from defusedxml.common import EntitiesForbidden  # type: ignore[import-untyped]
+
+    _HAS_DEFUSEDXML = True
+except ImportError:
+    import xml.etree.ElementTree as ET
+
+    _HAS_DEFUSEDXML = False
+    EntitiesForbidden = ()  # type: ignore[misc,assignment]
+
+
+def _local_name(tag: Any) -> str:
+    value = str(tag or "")
+    return value.rsplit("}", 1)[-1].lower()
+
+
+def _text(element: Any) -> str:
+    if element is None:
+        return ""
+    value = " ".join(part.strip() for part in element.itertext() if part.strip())
+    return re.sub(r"\s+", " ", html.unescape(value)).strip()
+
+
+def _clean_summary(value: str) -> str:
+    value = html.unescape(value or "")
+    value = _STRIP_TAGS_RE.sub(" ", value)
+    value = re.sub(r"\s+", " ", value).strip()
+    value = re.sub(r"\s+([,.;:!?])", r"\1", value)
+    if len(value) > _MAX_SUMMARY_CHARS:
+        value = value[: _MAX_SUMMARY_CHARS].rstrip() + "…"
+    return value
+
+
+def _child(element: Any, *names: str) -> Any:
+    wanted = {name.lower() for name in names}
+    for candidate in list(element):
+        if _local_name(candidate.tag) in wanted:
+            return candidate
+    return None
+
+
+def _entry_link(entry: Any) -> str:
+    fallback = ""
+    for element in list(entry):
+        if _local_name(element.tag) != "link":
+            continue
+        href = (element.attrib.get("href") or _text(element)).strip()
+        if not href:
+            continue
+        rel = (element.attrib.get("rel") or "alternate").lower()
+        if rel == "alternate":
+            return href
+        if not fallback:
+            fallback = href
+    return fallback
+
+
+def _reject_unsafe_xml_text(xml_bytes: bytes) -> bool:
+    """Return True when stdlib parsing must be rejected (XXE / entity expansion)."""
+    if _HAS_DEFUSEDXML:
+        return False
+    try:
+        sample = xml_bytes[:8192].decode("utf-8", errors="ignore").upper()
+    except Exception:
+        return True
+    return "<!DOCTYPE" in sample or "<!ENTITY" in sample
+
+
+def _safe_fromstring(xml_bytes: bytes) -> Optional[Any]:
+    if _reject_unsafe_xml_text(xml_bytes):
+        return None
+    try:
+        return ET.fromstring(xml_bytes)
+    except (ET.ParseError, EntitiesForbidden):
+        return None
+
+
+def _content_bytes(result: Dict[str, Any]) -> bytes:
+    raw = result.get("raw_content")
+    if raw is None:
+        raw = result.get("content") or ""
+    if isinstance(raw, bytes):
+        return raw
+    if isinstance(raw, str):
+        return raw.encode("utf-8")
+    return b""
+
+
+def _looks_like_feed_content(result: Dict[str, Any], xml_bytes: bytes) -> bool:
+    metadata = result.get("metadata") or {}
+    content_type = (
+        metadata.get("contentType")
+        or metadata.get("content_type")
+        or metadata.get("Content-Type")
+        or ""
+    )
+    if isinstance(content_type, str) and content_type.strip():
+        media_type = content_type.split(";", 1)[0].strip().lower()
+        if media_type in _FEED_CONTENT_TYPES:
+            return True
+
+    sample = xml_bytes[:_SNIFF_SAMPLE_CHARS].lower()
+    return any(marker in sample for marker in _FEED_SNIFF_MARKERS)
+
+
+def parse_feed(xml_bytes: bytes, source_url: str) -> Optional[Dict[str, Any]]:
+    """Parse RSS 2.0, Atom, or RDF/RSS bytes into a web-extract result.
+
+    Returns ``None`` when XML is malformed, rejected as unsafe, or valid but
+    not a recognized feed. Never raises.
+    """
+    if not xml_bytes or len(xml_bytes) > _MAX_FEED_BYTES:
+        return None
+
+    root = _safe_fromstring(xml_bytes)
+    if root is None:
+        return None
+
+    root_name = _local_name(root.tag)
+    if root_name not in {"rss", "feed", "rdf"}:
+        return None
+
+    channel = _child(root, "channel") if root_name in {"rss", "rdf"} else root
+    if channel is None:
+        channel = root
+
+    feed_title = _text(_child(channel, "title")) or "Feed"
+    feed_description = _clean_summary(_text(_child(channel, "description", "subtitle")))
+    feed_updated = _text(_child(channel, "lastbuilddate", "updated", "pubdate"))
+
+    entries = []
+    seen = set()
+    for candidate in root.iter():
+        if _local_name(candidate.tag) not in {"item", "entry"}:
+            continue
+        if len(entries) >= _MAX_ENTRIES:
+            break
+
+        title = _text(_child(candidate, "title")) or "Untitled"
+        link = _entry_link(candidate)
+        identifier = _text(_child(candidate, "guid", "id")) or link or title
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+
+        author_element = _child(candidate, "author", "creator")
+        author = _text(_child(author_element, "name")) if author_element is not None else ""
+        author = author or _text(author_element)
+        published = _text(_child(candidate, "pubdate", "published", "updated", "date"))
+        summary = _clean_summary(
+            _text(_child(candidate, "description", "summary", "content", "encoded"))
+        )
+        entries.append(
+            {
+                "title": title,
+                "link": link,
+                "author": author,
+                "published": published,
+                "summary": summary,
+            }
+        )
+
+    lines = [f"# {feed_title}", "", f"- Source: {source_url}"]
+    if feed_updated:
+        lines.append(f"- Updated: {feed_updated}")
+    if feed_description:
+        lines.extend(["", feed_description])
+    lines.extend(["", "## Entries"])
+
+    if not entries:
+        lines.extend(["", "No entries found."])
+    for entry in entries:
+        heading = f"[{entry['title']}]({entry['link']})" if entry["link"] else entry["title"]
+        lines.extend(["", f"### {heading}"])
+        if entry["published"]:
+            lines.append(f"- Published: {entry['published']}")
+        if entry["author"]:
+            lines.append(f"- Author: {entry['author']}")
+        if entry["summary"]:
+            lines.extend(["", entry["summary"]])
+
+    content = "\n".join(lines).strip()
+    return {
+        "url": source_url,
+        "title": feed_title,
+        "content": content,
+        "raw_content": content,
+        "metadata": {
+            "sourceURL": source_url,
+            "title": feed_title,
+            "contentType": "feed",
+            "entryCount": len(entries),
+        },
+    }
+
+
+def apply_rss_specialization(result: Dict[str, Any]) -> None:
+    """Replace *result* content with parsed feed markdown when applicable.
+
+    Mutates *result* in place on success. On any failure or non-feed content,
+    leaves *result* unchanged. Never raises.
+    """
+    try:
+        xml_bytes = _content_bytes(result)
+        if not xml_bytes or len(xml_bytes) > _MAX_FEED_BYTES:
+            return
+        if not _looks_like_feed_content(result, xml_bytes):
+            return
+
+        source_url = result.get("url") or ""
+        parsed = parse_feed(xml_bytes, source_url)
+        if parsed is None:
+            return
+
+        result.update(parsed)
+    except Exception as exc:
+        logger.debug("RSS/Atom specialization skipped: %s", exc)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -156,6 +156,32 @@ def _load_web_config() -> dict:
         return {}
 
 
+def _config_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return bool(value)
+
+
+def _rss_specialization_enabled() -> bool:
+    """Return True when ``web.extract_specializations.rss`` is explicitly enabled."""
+    web = _load_web_config()
+    specializations = web.get("extract_specializations")
+    if not isinstance(specializations, dict):
+        return False
+    configured = specializations.get("rss")
+    if configured is None:
+        return False
+    return _config_bool(configured)
+
+
 # The built-in web backends whose availability is driven by hardcoded
 # env-var / package / OAuth probes below. Any name NOT in this set is a
 # candidate plugin-registered provider and must be resolved through the
@@ -963,7 +989,15 @@ async def web_extract_tool(
             results = [by_index[index] for index in range(len(urls))]
 
         response = {"results": results}
-        
+
+        if _rss_specialization_enabled():
+            from tools.web_specializations.rss import apply_rss_specialization
+
+            for result in response.get("results", []):
+                if result.get("error"):
+                    continue
+                apply_rss_specialization(result)
+
         pages_extracted = len(response.get('results', []))
         logger.info("Extracted content from %d pages", pages_extracted)
         


### PR DESCRIPTION
## Summary

Opt-in RSS/Atom specialization for `web_extract`, gated by `web.extract_specializations.rss` (default off).

- pure post-processing: no new fetcher, DNS resolver, redirect handling, or network path; the existing fetch, SSRF, timeout, redirect, and byte limits are untouched
- feed detection from bounded fetched content plus `metadata.contentType` after a successful fetch; feeds up to 2 MiB are parsed into bounded markdown (feed title + entries, per-entry caps) within the existing `char_limit`
- defusedxml preferred; stdlib fallback rejects DOCTYPE/ENTITY across UTF-8/UTF-16 with BOM, fail-closed; malformed or non-feed input returns the original provider content
- `parse_feed` never raises; deterministic bounded output

## Test Plan

- `scripts/run_tests.sh tests/tools/test_web_rss_specialization.py tests/tools/test_web_extract_robustness.py tests/tools/test_web_tools_config.py tests/tools/test_web_tools_truncate.py tests/tools/test_web_tools_dict_urls.py` -> 75 passed, 0 failed
- fixtures only (no live network): RSS 2.0, Atom, malformed XML, XXE/DOCTYPE/entity rejection, encoding padding, oversized entries, non-feed fallback, single-fetch proof

Not the provider fallback chains from #74410; no coupling to that branch. Restored from stranded local work; fresh-context adversarial review PASS after one fix round.
