### PR TITLE
feat(discord): per-channel user allowlists

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -21,6 +21,7 @@ import os
 from typing import Optional
 
 from gateway.config import Platform
+from gateway.discord_scoped_auth import is_channel_scoped_user_allowed
 from gateway.session import SessionSource
 from gateway.whatsapp_identity import (
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
@@ -503,6 +504,32 @@ class GatewayAuthorizationMixin:
 
         if not user_id:
             return False
+
+        # Discord channel-scoped users are admitted only in the configured
+        # channel or a thread whose trusted adapter metadata names that channel
+        # as its parent. DMs deliberately receive no channel candidates.
+        if source.platform == Platform.DISCORD and source.chat_type in {
+            "group", "forum", "channel", "thread"
+        }:
+            channel_ids = {
+                str(channel_id)
+                for channel_id in (source.chat_id, source.parent_chat_id)
+                if channel_id
+            }
+            try:
+                adapter = self._authorization_adapter(
+                    source.platform,
+                    profile=adapter_profile,
+                )
+                if adapter is not None:
+                    getter = getattr(adapter, "_get_channel_allowed_users_raw", None)
+                    raw = getter() if callable(getter) else None
+                    if raw and is_channel_scoped_user_allowed(
+                        user_id, channel_ids, raw
+                    ):
+                        return True
+            except Exception:
+                pass
 
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",

--- a/gateway/discord_scoped_auth.py
+++ b/gateway/discord_scoped_auth.py
@@ -1,0 +1,85 @@
+"""Channel-scoped Discord user authorization.
+
+``channel_allowed_users`` in ``config.yaml`` maps Discord channel snowflake IDs
+to lists of user snowflake IDs. A listed user is authorized only in that channel
+or a thread whose adapter-resolved parent ID is that channel. Global Discord
+authorization continues to use ``allow_from`` / ``DISCORD_ALLOWED_USERS``.
+
+Authorization is a **union of grants** across pairing, channel-scoped entries,
+global user/role allowlists, allow-all flags, and ``DISCORD_ALLOWED_CHANNELS``
+(when no user/role allowlists are configured). The adapter and gateway layers
+evaluate different subsets of that union; outcomes match because any single
+grant is sufficient. When no scoped mapping is configured, behavior is unchanged.
+
+Enforcement matches **immutable numeric snowflake IDs only** — never channel
+names, ``#name`` forms, or display names. Slash authorization passes mixed
+name/ID key sets into ``_is_allowed_user``; the scoped grant filters to
+digit-only IDs before matching so a renamed channel cannot collide with another
+channel's snowflake.
+
+Scoped lists treat ``"*"`` as a **literal** user-ID string, not an allow-all
+wildcard (unlike global ``allow_from`` / ``DISCORD_ALLOWED_USERS``).
+
+Scoped entries require bare numeric snowflakes. Unlike global ``allow_from``,
+``<@id>`` / ``user:`` prefixes are **not** stripped — malformed paste forms
+fail closed rather than accidentally matching.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+
+def _clean_ids(values: object) -> frozenset[str]:
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, list):
+        return frozenset()
+    return frozenset(str(value).strip() for value in values if str(value).strip())
+
+
+def channel_user_allowlists(raw: object = None) -> dict[str, frozenset[str]]:
+    """Parse the scoped allowlist, returning an empty policy on malformed input."""
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        decoded = raw
+    elif isinstance(raw, str):
+        if not raw.strip():
+            return {}
+        try:
+            decoded = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return {}
+        if not isinstance(decoded, dict):
+            return {}
+    else:
+        return {}
+
+    result: dict[str, frozenset[str]] = {}
+    for channel_id, users in decoded.items():
+        clean_channel = str(channel_id).strip()
+        clean_users = _clean_ids(users)
+        if clean_channel and clean_users:
+            result[clean_channel] = clean_users
+    return result
+
+
+def is_channel_scoped_user_allowed(
+    user_id: str,
+    channel_ids: Iterable[str] | None,
+    raw: object = None,
+) -> bool:
+    """Return True only when user and current/parent channel match one entry."""
+    clean_user = str(user_id or "").strip()
+    if not clean_user or channel_ids is None:
+        return False
+    policy = channel_user_allowlists(raw)
+    if not policy:
+        return False
+    for channel_id in channel_ids:
+        allowed_users = policy.get(str(channel_id).strip())
+        if allowed_users and clean_user in allowed_users:
+            return True
+    return False

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -29,6 +29,8 @@ from contextlib import suppress
 from typing import Callable, Dict, List, Optional, Any, Tuple
 from urllib.parse import quote, urljoin
 
+from gateway.discord_scoped_auth import is_channel_scoped_user_allowed
+
 from agent.async_utils import (
     consume_detached_task_result as _consume_background_task_result,
 )
@@ -4606,10 +4608,17 @@ class DiscordAdapter(BasePlatformAdapter):
         guild=None,
         is_dm: bool = False,
         channel_ids: Optional[set[str]] = None,
+        channel_keys: Optional[set[str]] = None,
     ) -> bool:
         """Check if user is allowed via DISCORD_ALLOWED_USERS or DISCORD_ALLOWED_ROLES.
 
-        Uses OR semantics: if the user matches EITHER allowlist, they're allowed.
+        Authorization is a union of grants: pairing, channel-scoped entries
+        (``channel_allowed_users``), allow-all flags (when no user/role
+        allowlists), ``DISCORD_ALLOWED_CHANNELS`` bypass (when no user/role
+        allowlists), user-ID allowlist, and role allowlist. Any one grant
+        suffices; scoped entries union with global lists.
+
+        Uses OR semantics for user/role allowlists: matching either allowlist allows.
         With no user/role allowlists configured, guild traffic may still pass when
         ``channel_ids`` matches ``DISCORD_ALLOWED_CHANNELS`` — but only when the
         caller supplies the validated channel context (on_message, slash). Calls
@@ -4628,8 +4637,10 @@ class DiscordAdapter(BasePlatformAdapter):
             author: Optional Member/User object for in-guild role lookup.
             guild: The guild the message arrived in (None for DMs).
             is_dm: True if the message came from a DM channel.
-            channel_ids: Resolved text-channel ids for guild traffic when an
-                upstream gate has already scoped the message to a channel.
+            channel_ids: Resolved channel snowflake IDs (current + thread parent).
+            channel_keys: Optional superset including bare names and ``#name``
+                forms for ``DISCORD_ALLOWED_CHANNELS`` matching. Slash callers
+                pass snowflakes in ``channel_ids`` and the full key set here.
         """
         # ``getattr`` fallbacks here guard against test fixtures that build
         # an adapter via ``object.__new__(DiscordAdapter)`` and skip __init__
@@ -4646,6 +4657,26 @@ class DiscordAdapter(BasePlatformAdapter):
         if self._is_pairing_approved_user(user_id):
             return True
 
+        # A scoped entry authorizes this user only in the configured channel or
+        # one of its threads. ``channel_ids`` must be immutable snowflakes only
+        # (on_message passes them directly; slash passes its snowflake set
+        # separately from ``channel_keys`` name forms).
+        scoped_channel_ids = (
+            {cid for cid in channel_ids if cid.isdigit()} if channel_ids else None
+        )
+        if (
+            not is_dm
+            and scoped_channel_ids
+            and is_channel_scoped_user_allowed(
+                user_id,
+                scoped_channel_ids,
+                self._get_channel_allowed_users_raw(),
+            )
+        ):
+            return True
+
+        channel_gate_keys = channel_keys if channel_keys is not None else channel_ids
+
         if not has_users and not has_roles:
             if self._discord_allow_all_users():
                 return True
@@ -4656,8 +4687,8 @@ class DiscordAdapter(BasePlatformAdapter):
             # (voice loops and other guild-scoped callers may lack channel ids).
             if (
                 not is_dm
-                and channel_ids is not None
-                and self._discord_channel_ids_allowed(channel_ids)
+                and channel_gate_keys is not None
+                and self._discord_channel_ids_allowed(channel_gate_keys)
             ):
                 return True
             return False
@@ -4723,6 +4754,8 @@ class DiscordAdapter(BasePlatformAdapter):
         if allowed_users or allowed_roles:
             return
         if self._get_allowed_channels():
+            return
+        if self._get_channel_allowed_users():
             return
         if self._discord_allow_all_users():
             return
@@ -4848,7 +4881,8 @@ class DiscordAdapter(BasePlatformAdapter):
             author=user,
             guild=interaction_guild,
             is_dm=in_dm,
-            channel_ids=channel_keys if not in_dm else None,
+            channel_ids=channel_ids if not in_dm else None,
+            channel_keys=channel_keys if not in_dm else None,
         ):
             return (
                 False,
@@ -6276,6 +6310,22 @@ class DiscordAdapter(BasePlatformAdapter):
             for entry in self._gate_csv_set(raw)
             if _clean_discord_id(str(entry))
         }
+
+    def _get_channel_allowed_users_raw(self) -> object:
+        """Raw ``channel_allowed_users`` mapping from this adapter's config extra."""
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        if isinstance(extra, dict):
+            return extra.get("channel_allowed_users")
+        return None
+
+    def _get_channel_allowed_users(self) -> dict[str, frozenset[str]]:
+        """Parse this adapter's per-channel user allowlists (per-profile)."""
+        from gateway.discord_scoped_auth import channel_user_allowlists
+
+        raw = self._get_channel_allowed_users_raw()
+        if raw is None:
+            return {}
+        return channel_user_allowlists(raw)
 
     def _get_allowed_roles(self) -> set:
         """This adapter's DISCORD_ALLOWED_ROLES role IDs (per-profile)."""
@@ -9962,6 +10012,13 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         seeded_extra["allow_from"] = str(allowed_users_cfg)
         if not _skip_env_bridge and not os.getenv("DISCORD_ALLOWED_USERS"):
             os.environ["DISCORD_ALLOWED_USERS"] = str(allowed_users_cfg)
+    channel_allowed_users_cfg = (
+        discord_cfg["channel_allowed_users"]
+        if "channel_allowed_users" in discord_cfg
+        else platform_extra_cfg.get("channel_allowed_users")
+    )
+    if channel_allowed_users_cfg is not None:
+        seeded_extra["channel_allowed_users"] = channel_allowed_users_cfg
     allowed_roles_cfg = (
         discord_cfg["allowed_roles"] if "allowed_roles" in discord_cfg
         else platform_extra_cfg.get("allowed_roles")

--- a/tests/gateway/test_discord_scoped_auth.py
+++ b/tests/gateway/test_discord_scoped_auth.py
@@ -1,0 +1,354 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.config import Platform
+from gateway.discord_scoped_auth import (
+    channel_user_allowlists,
+    is_channel_scoped_user_allowed,
+)
+from gateway.session import SessionSource
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+POLICY_JSON = '{"888000000000000001":["scoped-a","scoped-b"]}'
+POLICY_DICT = {"888000000000000001": ["scoped-a", "scoped-b"]}
+SNOW = "888000000000000001"
+REAL_USER_ID = "123456789012345678"
+DISPLAY_NAME = "Alice#1234"
+
+
+class _Runner(GatewayAuthorizationMixin):
+    adapters = {}
+    pairing_store = None
+    pairing_stores = {}
+
+
+def _adapter(global_users=(), channel_allowed_users=None):
+    adapter = object.__new__(DiscordAdapter)
+    adapter._allowed_user_ids = set(global_users)
+    adapter._allowed_role_ids = set()
+    adapter._client = MagicMock(guilds=[])
+    extra = {}
+    if channel_allowed_users is not None:
+        extra["channel_allowed_users"] = channel_allowed_users
+    adapter.config = SimpleNamespace(extra=extra)
+    return adapter
+
+
+def _source(user_id, chat_id, chat_type="group", parent_chat_id=None):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        parent_chat_id=parent_chat_id,
+    )
+
+
+def _guild():
+    return SimpleNamespace(id=1, get_member=lambda _uid: None)
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parser_accepts_json_mapping_and_rejects_malformed_values():
+    assert channel_user_allowlists(POLICY_JSON) == {
+        SNOW: frozenset({"scoped-a", "scoped-b"})
+    }
+    assert channel_user_allowlists("not-json") == {}
+    assert channel_user_allowlists('["not", "a", "mapping"]') == {}
+    assert channel_user_allowlists('{"target": 42}') == {}
+    assert channel_user_allowlists('{"target": []}') == {}
+
+
+def test_parser_accepts_native_yaml_mapping():
+    assert channel_user_allowlists(POLICY_DICT) == {
+        SNOW: frozenset({"scoped-a", "scoped-b"})
+    }
+
+
+def test_parser_cleans_whitespace_and_coerces_scalars():
+    assert channel_user_allowlists({"  target  ": ["  scoped-a  ", "", 42]}) == {
+        "target": frozenset({"scoped-a", "42"})
+    }
+
+
+# ---------------------------------------------------------------------------
+# Predicate matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("user_id", "channels", "expected"),
+    [
+        ("scoped-a", {SNOW}, True),
+        ("scoped-a", {"thread", SNOW}, True),
+        ("scoped-a", {"elsewhere"}, False),
+        ("scoped-a", None, False),
+        ("unknown", {SNOW}, False),
+        ("", {SNOW}, False),
+        (None, {SNOW}, False),
+    ],
+)
+def test_scoped_predicate_matrix(user_id, channels, expected):
+    assert is_channel_scoped_user_allowed(user_id, channels, POLICY_JSON) is expected
+
+
+def test_scoped_predicate_empty_policy():
+    assert is_channel_scoped_user_allowed("scoped-a", {"target"}, {}) is False
+
+
+def test_display_names_never_authorize_numeric_user_id():
+    display_only = {"target": [DISPLAY_NAME, "Bob"]}
+    assert (
+        is_channel_scoped_user_allowed(REAL_USER_ID, {"target"}, display_only)
+        is False
+    )
+    id_policy = {"target": [REAL_USER_ID]}
+    assert (
+        is_channel_scoped_user_allowed(REAL_USER_ID, {"target"}, id_policy)
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter _is_allowed_user
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_enforces_global_owner_plus_scoped_users():
+    adapter = _adapter(global_users={"owner"}, channel_allowed_users=POLICY_DICT)
+    guild = _guild()
+
+    assert adapter._is_allowed_user(
+        "owner", guild=guild, channel_ids={"elsewhere"}
+    )
+    assert adapter._is_allowed_user("owner", is_dm=True)
+    assert adapter._is_allowed_user(
+        "scoped-a", guild=guild, channel_ids={"888000000000000001"}
+    )
+    assert adapter._is_allowed_user(
+        "scoped-a", guild=guild, channel_ids={"thread", "888000000000000001"}
+    )
+    assert not adapter._is_allowed_user(
+        "scoped-a", guild=guild, channel_ids={"elsewhere"}
+    )
+    assert not adapter._is_allowed_user("scoped-a", is_dm=True)
+    assert not adapter._is_allowed_user(
+        "unknown", guild=guild, channel_ids={"target"}
+    )
+
+
+def test_adapter_scoped_mapping_absent_preserves_global_allowlist():
+    adapter = _adapter(global_users={"owner"})
+    guild = _guild()
+    assert adapter._is_allowed_user(
+        "owner", guild=guild, channel_ids={"elsewhere"}
+    )
+
+
+def test_adapter_scoped_mapping_absent_preserves_allowed_channels_bypass(
+    monkeypatch,
+):
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "999")
+    adapter = _adapter()
+    guild = _guild()
+    assert adapter._is_allowed_user(
+        "42",
+        guild=guild,
+        is_dm=False,
+        channel_ids={"999"},
+    )
+
+
+def test_adapter_malformed_scoped_config_denies_scoped_user():
+    adapter = _adapter(channel_allowed_users='{"888000000000000001": 42}')
+    guild = _guild()
+    assert not adapter._is_allowed_user(
+        "scoped-a", guild=guild, channel_ids={"888000000000000001"}
+    )
+
+
+def test_adapter_display_name_in_config_does_not_authorize_user_id():
+    adapter = _adapter(
+        channel_allowed_users={"888000000000000001": [DISPLAY_NAME]},
+    )
+    guild = _guild()
+    assert not adapter._is_allowed_user(
+        REAL_USER_ID, guild=guild, channel_ids={"888000000000000001"}
+    )
+
+
+def test_per_profile_scoped_mapping_isolation():
+    adapter_a = _adapter(channel_allowed_users={"777000000000000001": ["user-a"]})
+    adapter_b = _adapter(channel_allowed_users={"777000000000000002": ["user-b"]})
+    guild = _guild()
+
+    assert adapter_a._is_allowed_user(
+        "user-a", guild=guild, channel_ids={"777000000000000001"}
+    )
+    assert not adapter_a._is_allowed_user(
+        "user-a", guild=guild, channel_ids={"777000000000000002"}
+    )
+    assert adapter_b._is_allowed_user(
+        "user-b", guild=guild, channel_ids={"777000000000000002"}
+    )
+    assert not adapter_b._is_allowed_user(
+        "user-b", guild=guild, channel_ids={"777000000000000001"}
+    )
+
+
+VICTIM_CHANNEL_SNOWFLAKE = "111111111111111111"
+CURRENT_CHANNEL_SNOWFLAKE = "999999999999999999"
+
+
+def test_scoped_grant_rejects_slash_name_collision_with_foreign_snowflake():
+    """A channel renamed to another channel's snowflake must not inherit its grant."""
+    adapter = _adapter(
+        channel_allowed_users={VICTIM_CHANNEL_SNOWFLAKE: ["scoped-a"]},
+    )
+    guild = _guild()
+    slash_style_keys = {
+        CURRENT_CHANNEL_SNOWFLAKE,
+        VICTIM_CHANNEL_SNOWFLAKE,
+        f"#{VICTIM_CHANNEL_SNOWFLAKE}",
+    }
+    assert not adapter._is_allowed_user(
+        "scoped-a",
+        guild=guild,
+        channel_ids={CURRENT_CHANNEL_SNOWFLAKE},
+        channel_keys=slash_style_keys,
+    )
+
+
+def test_scoped_grant_allows_when_real_snowflake_in_mapping():
+    adapter = _adapter(
+        channel_allowed_users={VICTIM_CHANNEL_SNOWFLAKE: ["scoped-a"]},
+    )
+    guild = _guild()
+    slash_style_keys = {
+        VICTIM_CHANNEL_SNOWFLAKE,
+        "general",
+        "#general",
+    }
+    assert adapter._is_allowed_user(
+        "scoped-a",
+        guild=guild,
+        channel_ids={VICTIM_CHANNEL_SNOWFLAKE},
+        channel_keys=slash_style_keys,
+    )
+
+
+def test_allowed_channels_bypass_still_honors_name_forms(monkeypatch):
+    """DISCORD_ALLOWED_CHANNELS name matching is unchanged by scoped filtering."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "general")
+    adapter = _adapter(
+        channel_allowed_users={VICTIM_CHANNEL_SNOWFLAKE: ["scoped-a"]},
+    )
+    guild = _guild()
+    slash_style_keys = {
+        CURRENT_CHANNEL_SNOWFLAKE,
+        "general",
+        "#general",
+    }
+    assert adapter._is_allowed_user(
+        "42",
+        guild=guild,
+        is_dm=False,
+        channel_ids={CURRENT_CHANNEL_SNOWFLAKE},
+        channel_keys=slash_style_keys,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gateway second layer
+# ---------------------------------------------------------------------------
+
+
+def _runner_with_adapter(adapter):
+    runner = _Runner()
+    runner.adapters = {Platform.DISCORD: adapter}
+    return runner
+
+
+def test_gateway_second_layer_enforces_same_matrix(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "owner")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_ALLOWED_ROLES", raising=False)
+    adapter = _adapter(channel_allowed_users=POLICY_DICT)
+    runner = _runner_with_adapter(adapter)
+
+    assert runner._is_user_authorized(_source("owner", "elsewhere"))
+    assert runner._is_user_authorized(_source("owner", "dm", "dm"))
+    assert runner._is_user_authorized(_source("scoped-a", SNOW))
+    assert runner._is_user_authorized(
+        _source("scoped-a", "thread", "thread", parent_chat_id=SNOW)
+    )
+    assert not runner._is_user_authorized(_source("scoped-a", "elsewhere"))
+    assert not runner._is_user_authorized(_source("scoped-a", "dm", "dm"))
+    assert not runner._is_user_authorized(_source("unknown", SNOW))
+    assert not runner._is_user_authorized(
+        _source("scoped-a", "thread", "thread", parent_chat_id=None)
+    )
+
+
+def test_gateway_no_scoped_mapping_preserves_env_allowlist(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "owner")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    adapter = _adapter()
+    runner = _runner_with_adapter(adapter)
+
+    assert runner._is_user_authorized(_source("owner", "elsewhere"))
+    assert not runner._is_user_authorized(_source("stranger", "target"))
+
+
+def test_gateway_malformed_scoped_config_denies_scoped_user(monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+    adapter = _adapter(channel_allowed_users='{"888000000000000001": 42}')
+    runner = _runner_with_adapter(adapter)
+
+    assert not runner._is_user_authorized(_source("scoped-a", "target"))
+
+
+def test_gateway_per_profile_adapter_isolation(monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOWED_USERS", raising=False)
+    adapter_default = _adapter(channel_allowed_users={"chan-a": ["user-a"]})
+    adapter_secondary = _adapter(channel_allowed_users={"chan-b": ["user-b"]})
+    runner = _Runner()
+    runner.adapters = {Platform.DISCORD: adapter_default}
+    runner._profile_adapters = {"coder": {Platform.DISCORD: adapter_secondary}}
+
+    source_default = _source("user-a", "chan-a")
+    source_secondary = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chan-b",
+        chat_type="group",
+        user_id="user-b",
+        profile="coder",
+    )
+
+    assert runner._is_user_authorized(source_default)
+    assert not runner._is_user_authorized(
+        SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chan-b",
+            chat_type="group",
+            user_id="user-b",
+        )
+    )
+    assert runner._is_user_authorized(source_secondary)
+    assert not runner._is_user_authorized(
+        SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chan-a",
+            chat_type="group",
+            user_id="user-a",
+            profile="coder",
+        )
+    )

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -632,6 +632,32 @@ gateway:
 
 Use `/whoami` to see the active scope, your tier (admin / user / unrestricted), and which slash commands you can run.
 
+## Per-Channel User Allowlists
+
+Grant specific users access to individual channels without adding them to the global `allow_from` list. Scoped grants are a **union** with global allowlists — a user in `allow_from` remains authorized everywhere, including DMs. Pairing, scoped entries, global allowlists, and allow-all flags are independent grants; any one is sufficient.
+
+```yaml
+discord:
+  channel_allowed_users:
+    "111111111111111111":   # channel ID
+      - "222222222222222222"  # user ID allowed only in this channel
+      - "333333333333333333"
+    "444444444444444444":
+      - "555555555555555555"
+```
+
+The same key under `gateway.platforms.discord.extra` works; the top-level `discord:` key wins when both are set.
+
+**Behavior:**
+
+- A listed user is authorized **only** in the configured channel, or in a thread whose parent channel ID matches an entry.
+- DMs never inherit a channel grant — scoped users cannot DM the bot unless they are also in `allow_from` or otherwise globally authorized.
+- Only numeric Discord **user IDs** and **channel IDs** (snowflakes) match. Channel names, ``#name`` forms, and display names (e.g. `Alice#1234`) are never accepted.
+- The literal string `"*"` in a scoped user list is treated as a user ID, **not** an allow-all wildcard (unlike global `allow_from`).
+- Scoped entries require bare numeric snowflakes — ``<@id>`` / ``user:`` prefixes are not normalized (unlike global `allow_from`).
+- Malformed config (invalid JSON, non-list values, empty user lists) is dropped fail-closed — it does not broaden access.
+- An empty user list for a channel denies everyone for that channel entry; it does not mean allow-all.
+
 ## Interactive Model Picker
 
 Send `/model` with no arguments in a Discord channel to open a dropdown-based model picker:


### PR DESCRIPTION
## Summary

Channel allowlists scope which user IDs may command Hermes per channel, expressed as a channel -> user-ID mapping in config (`gateway.discord.channel_allowed_users`, JSON mapping or native YAML).

- enforcement matches immutable numeric snowflake IDs only; name-form channel keys from slash-command paths cannot inherit a foreign channel's grant
- malformed mappings and empty allowlists deny rather than broaden; `"*"` is a literal member, not a wildcard
- scoped grants union with existing pairing/global-allowlist behavior; absent mapping preserves current semantics; per-profile adapters get isolated mappings

## Test Plan

- `scripts/run_tests.sh` over 9 Discord authz suites (scoped auth, allowed channels, slash auth/commands, bot auth bypass, roles DM scope, multiplex profile authz, unauthorized DM behavior, channel controls) -> 91 passed, 0 failed
- regression: slash-style mixed key sets containing a name equal to a victim channel's snowflake do NOT authorize

Restored from stranded local work, adapted to the current per-profile Discord gate; fresh-context adversarial review PASS after one fix round.
