### PR TITLE
fix(file_tools): refuse destination-symlink writes by default

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -16,6 +16,7 @@ from tools.file_operations import (
     SearchMatch,
     LintResult,
     ShellFileOperations,
+    ExecuteResult,
     MAX_LINE_LENGTH,
     normalize_read_pagination,
     normalize_search_pagination,
@@ -656,6 +657,259 @@ class TestAtomicWriteThroughSymlink:
         assert result.error is None, f"write failed: {result.error}"
         assert target.exists()
         assert target.read_text() == "data\n"
+
+
+class TestDestinationSymlinkRefusal:
+    """Destination symlinks are refused by default before any write primitive."""
+
+    def test_refuses_symlink_before_write_command(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        real = tmp_path / "real.txt"
+        link = tmp_path / "link.txt"
+        real.write_text("original\n")
+        link.symlink_to(real)
+
+        exec_calls = []
+        original_exec = ops._exec
+
+        def tracking_exec(cmd, **kwargs):
+            exec_calls.append(cmd)
+            return original_exec(cmd, **kwargs)
+
+        ops._exec = tracking_exec
+
+        result = ops.write_file(str(link), "new\n", follow_symlink=False)
+
+        assert result.code == "symlink_destination_refused"
+        assert result.resolved_target == str(real.resolve())
+        assert real.read_text() == "original\n"
+        assert link.is_symlink()
+        assert any("[ -L " in c and "__HERMES_SYMLINK__" in c for c in exec_calls)
+        assert "[ -L " in exec_calls[0]
+        assert not any("mktemp" in c for c in exec_calls)
+
+    def test_follow_symlink_true_writes_through_allowed_symlink(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        real = tmp_path / "real.txt"
+        link = tmp_path / "link.txt"
+        real.write_text("original\n")
+        link.symlink_to(real)
+
+        exec_calls = []
+        original_exec = ops._exec
+
+        def tracking_exec(cmd, **kwargs):
+            exec_calls.append(cmd)
+            return original_exec(cmd, **kwargs)
+
+        ops._exec = tracking_exec
+
+        result = ops.write_file(str(link), "new\n", follow_symlink=True)
+
+        assert result.error is None, result.error
+        assert real.read_text() == "new\n"
+        probe_idxs = [i for i, c in enumerate(exec_calls) if "[ -L " in c and "__HERMES_SYMLINK__" in c]
+        write_idxs = [i for i, c in enumerate(exec_calls) if "mktemp" in c]
+        assert probe_idxs, "symlink probe must run before write"
+        assert write_idxs, "write must proceed when target is allowed"
+        assert min(probe_idxs) < min(write_idxs)
+
+    def test_symlink_probe_runs_before_write_on_regular_file(self, tmp_path):
+        """Every write probes destination; regular files proceed to atomic write."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        dest = tmp_path / "plain.txt"
+        dest.write_text("old\n")
+
+        exec_calls = []
+        original_exec = ops._exec
+
+        def tracking_exec(cmd, **kwargs):
+            exec_calls.append(cmd)
+            return original_exec(cmd, **kwargs)
+
+        ops._exec = tracking_exec
+
+        result = ops.write_file(str(dest), "new\n", follow_symlink=True)
+
+        assert result.error is None, result.error
+        probe_idxs = [i for i, c in enumerate(exec_calls) if "[ -L " in c and "__HERMES_SYMLINK__" in c]
+        write_idxs = [i for i, c in enumerate(exec_calls) if "mktemp" in c]
+        assert probe_idxs, "destination probe must run first"
+        assert write_idxs, "expected atomic write command"
+        assert min(probe_idxs) < min(write_idxs)
+
+    def test_refusal_probe_precedes_write_when_both_would_run(self, tmp_path):
+        """Deterministic ordering: symlink probe index < write index (if any)."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        real = tmp_path / "real.txt"
+        link = tmp_path / "link.txt"
+        real.write_text("x\n")
+        link.symlink_to(real)
+
+        exec_calls = []
+        original_exec = ops._exec
+
+        def tracking_exec(cmd, **kwargs):
+            exec_calls.append(cmd)
+            return original_exec(cmd, **kwargs)
+
+        ops._exec = tracking_exec
+
+        ops.write_file(str(link), "y\n", follow_symlink=False)
+
+        probe_idxs = [i for i, c in enumerate(exec_calls) if "[ -L " in c and "__HERMES_SYMLINK__" in c]
+        write_idxs = [i for i, c in enumerate(exec_calls) if "mktemp" in c]
+        assert probe_idxs, "symlink probe must run"
+        assert not write_idxs, "write must not run after refusal"
+        assert max(probe_idxs) < (min(write_idxs) if write_idxs else len(exec_calls))
+
+    def test_multi_hop_symlink_resolved_target_is_canonical(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        real = tmp_path / "real.txt"
+        mid = tmp_path / "mid.lnk"
+        link = tmp_path / "link.txt"
+        real.write_text("x\n")
+        mid.symlink_to(real)
+        link.symlink_to(mid)
+
+        result = ops.write_file(str(link), "y\n", follow_symlink=False)
+
+        assert result.code == "symlink_destination_refused"
+        assert result.resolved_target == str(real.resolve())
+
+    def test_follow_symlink_true_denies_guest_resolved_sensitive_target(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        link = tmp_path / "link_to_etc"
+        link.symlink_to("/etc/passwd")
+
+        exec_calls = []
+        original_exec = ops._exec
+
+        def tracking_exec(cmd, **kwargs):
+            exec_calls.append(cmd)
+            return original_exec(cmd, **kwargs)
+
+        ops._exec = tracking_exec
+
+        result = ops.write_file(str(link), "evil\n", follow_symlink=True)
+
+        assert result.error is not None
+        assert "denied" in result.error.lower()
+        assert not any("mktemp" in c for c in exec_calls)
+
+    def test_probe_transport_failure_returns_error(self, mock_env):
+        mock_env.execute.return_value = {"output": "", "returncode": 1}
+        ops = ShellFileOperations(mock_env)
+
+        result = ops.write_file("/tmp/link.txt", "data\n", follow_symlink=False)
+
+        assert result.error is not None
+        assert "probe" in result.error.lower()
+        mock_env.execute.assert_called_once()
+
+    def test_probe_malformed_output_returns_error(self, mock_env):
+        mock_env.execute.return_value = {
+            "output": "__HERMES_SYMLINK__\n",
+            "returncode": 0,
+        }
+        ops = ShellFileOperations(mock_env)
+
+        result = ops.write_file("/tmp/link.txt", "data\n", follow_symlink=False)
+
+        assert result.error is not None
+        assert "no resolved target" in result.error.lower()
+        assert mock_env.execute.call_count == 1
+
+
+class TestRemoteBackendSymlinkProbeContract:
+    """Stubbed _exec contract: probe ordering, refusal, and guest deny checks."""
+
+    def _stub_ops(self, side_effect):
+        env = MagicMock()
+        env.cwd = "/workspace"
+        ops = ShellFileOperations(env)
+        ops._exec = MagicMock(side_effect=side_effect)
+        return ops, ops._exec
+
+    def test_probe_command_is_first_exec(self):
+        calls = []
+
+        def side_effect(cmd, **kwargs):
+            calls.append(cmd)
+            if "[ -L " in cmd:
+                return ExecuteResult(stdout="", exit_code=0)
+            return ExecuteResult(stdout="", exit_code=0)
+
+        ops, mock_exec = self._stub_ops(side_effect)
+        ops.write_file("/workspace/out.txt", "data\n", follow_symlink=False)
+
+        assert mock_exec.call_count >= 1
+        assert "[ -L " in calls[0]
+        assert "__HERMES_SYMLINK__" in calls[0]
+        assert "readlink -f" in calls[0]
+
+    def test_symlink_refusal_issues_no_write_commands(self):
+        write_markers = ("mktemp", "trap ", "cat >")
+
+        def side_effect(cmd, **kwargs):
+            if "[ -L " in cmd:
+                return ExecuteResult(
+                    stdout="__HERMES_SYMLINK__\n/workspace/secret.txt\n",
+                    exit_code=0,
+                )
+            raise AssertionError(f"unexpected write command: {cmd!r}")
+
+        ops, mock_exec = self._stub_ops(side_effect)
+        result = ops.write_file("/workspace/link.txt", "evil\n", follow_symlink=False)
+
+        assert result.code == "symlink_destination_refused"
+        assert result.resolved_target == "/workspace/secret.txt"
+        assert mock_exec.call_count == 1
+        assert not any(m in mock_exec.call_args.args[0] for m in write_markers)
+
+    def test_resolved_target_parses_absolute_readlink_output(self):
+        def side_effect(cmd, **kwargs):
+            if "[ -L " in cmd:
+                return ExecuteResult(
+                    stdout="__HERMES_SYMLINK__\n/etc/passwd\n",
+                    exit_code=0,
+                )
+            raise AssertionError(f"unexpected command: {cmd!r}")
+
+        ops, _ = self._stub_ops(side_effect)
+        result = ops.write_file("/workspace/link", "x\n", follow_symlink=False)
+
+        assert result.resolved_target == "/etc/passwd"
+
+    def test_resolved_target_parses_relative_readlink_output(self):
+        def side_effect(cmd, **kwargs):
+            if "[ -L " in cmd:
+                return ExecuteResult(
+                    stdout="__HERMES_SYMLINK__\n../real.txt\n",
+                    exit_code=0,
+                )
+            raise AssertionError(f"unexpected command: {cmd!r}")
+
+        ops, _ = self._stub_ops(side_effect)
+        result = ops.write_file("/workspace/sub/link.txt", "x\n", follow_symlink=False)
+
+        assert result.resolved_target == "/workspace/real.txt"
+
+    def test_follow_symlink_denies_guest_resolved_etc_target(self):
+        def side_effect(cmd, **kwargs):
+            if "[ -L " in cmd:
+                return ExecuteResult(
+                    stdout="__HERMES_SYMLINK__\n/etc/passwd\n",
+                    exit_code=0,
+                )
+            raise AssertionError(f"write must not run after deny: {cmd!r}")
+
+        ops, mock_exec = self._stub_ops(side_effect)
+        result = ops.write_file("/workspace/link", "evil\n", follow_symlink=True)
+
+        assert result.error is not None
+        assert "denied" in result.error.lower()
+        assert mock_exec.call_count == 1
 
 
 class TestReadNonUtf8IsBinary:

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -12,6 +12,7 @@ import pytest
 
 from tools.file_tools import (
     PATCH_SCHEMA,
+    WRITE_FILE_SCHEMA,
 )
 
 
@@ -54,7 +55,137 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            "/tmp/out.txt", "hello world!\n", follow_symlink=False,
+        )
+
+    def test_schema_exposes_safe_symlink_override(self):
+        follow = WRITE_FILE_SCHEMA["parameters"]["properties"]["follow_symlink"]
+        assert follow["type"] == "boolean"
+        assert follow["default"] is False
+
+    def test_destination_symlink_refused_without_mutating_target(self, tmp_path):
+        from tools.file_tools import write_file_tool
+
+        target = tmp_path / "canonical.txt"
+        target.write_bytes(b"ORIGINAL\n")
+        link = tmp_path / "alias.txt"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        result = json.loads(write_file_tool(
+            str(link), "REPLACEMENT\n", task_id="symlink_refusal",
+        ))
+
+        assert result["code"] == "symlink_destination_refused"
+        assert result["resolved_target"] == str(target)
+        assert target.read_bytes() == b"ORIGINAL\n"
+        assert link.is_symlink()
+
+    def test_explicit_follow_symlink_preserves_previous_behavior(self, tmp_path):
+        from tools.file_tools import write_file_tool
+
+        target = tmp_path / "canonical.txt"
+        target.write_text("old\n")
+        link = tmp_path / "alias.txt"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        result = json.loads(write_file_tool(
+            str(link), "new\n", task_id="symlink_override", follow_symlink=True,
+        ))
+
+        assert "error" not in result
+        assert target.read_text() == "new\n"
+        assert link.is_symlink()
+
+    def test_parent_directory_symlink_remains_allowed(self, tmp_path):
+        from tools.file_tools import write_file_tool
+
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        linked_dir = tmp_path / "linked"
+        try:
+            linked_dir.symlink_to(real_dir, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        result = json.loads(write_file_tool(
+            str(linked_dir / "new.txt"), "content\n",
+            task_id="symlink_parent",
+        ))
+
+        assert "error" not in result
+        assert (real_dir / "new.txt").read_text() == "content\n"
+
+    def test_dangling_symlink_destination_refused(self, tmp_path):
+        from tools.file_tools import write_file_tool
+
+        target = tmp_path / "nonexistent.txt"
+        link = tmp_path / "dangling.lnk"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        result = json.loads(write_file_tool(
+            str(link), "data\n", task_id="dangling_symlink",
+        ))
+
+        assert result["code"] == "symlink_destination_refused"
+        assert not target.exists()
+        assert link.is_symlink()
+
+    def test_symlink_to_sensitive_target_blocked_when_following(self, tmp_path, monkeypatch):
+        from tools.file_tools import write_file_tool
+
+        fake_config = tmp_path / "config.yaml"
+        fake_config.write_text("original\n")
+        link = tmp_path / "link.yaml"
+        try:
+            link.symlink_to(fake_config)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved", str(fake_config))
+        monkeypatch.setattr("tools.file_tools._hermes_config_resolved_loaded", True)
+
+        result = json.loads(write_file_tool(
+            str(link), "evil\n", follow_symlink=True,
+        ))
+
+        assert "error" in result
+        assert "Hermes config" in result["error"]
+        assert fake_config.read_text() == "original\n"
+
+    def test_write_regular_existing_and_new_paths(self, tmp_path):
+        from tools.file_tools import write_file_tool
+
+        existing = tmp_path / "existing.txt"
+        existing.write_text("old\n")
+        new_file = tmp_path / "new.txt"
+
+        r1 = json.loads(write_file_tool(str(existing), "new content\n", task_id="happy_path"))
+        assert "error" not in r1
+        assert existing.read_text() == "new content\n"
+
+        r2 = json.loads(write_file_tool(str(new_file), "created\n", task_id="happy_path"))
+        assert "error" not in r2
+        assert new_file.read_text() == "created\n"
+
+    def test_overwrite_replaces_entire_file(self, tmp_path):
+        from tools.file_tools import write_file_tool
+
+        existing = tmp_path / "multi.txt"
+        existing.write_text("line1\nline2\nline3\n")
+
+        result = json.loads(write_file_tool(str(existing), "only\n", task_id="overwrite"))
+        assert "error" not in result
+        assert existing.read_text() == "only\n"
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,6 +28,7 @@ Usage:
 import base64
 import binascii
 import os
+import posixpath
 import re
 import difflib
 import hashlib
@@ -58,6 +59,7 @@ WRITE_DENIED_PREFIXES = build_write_denied_prefixes(_HOME)
 
 _OSC_SEQUENCE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 _FENCE_MARKER_RE = re.compile(r"'?\x07?__HERMES_FENCE_[A-Za-z0-9]+__\x07?'?")
+_SYMLINK_PROBE_MARKER = "__HERMES_SYMLINK__\n"
 
 
 def _strip_terminal_fence_leaks(text: str) -> str:
@@ -196,6 +198,8 @@ class WriteResult:
     lsp_diagnostics: Optional[str] = None
     error: Optional[str] = None
     warning: Optional[str] = None
+    resolved_target: Optional[str] = None
+    code: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {k: v for k, v in self.__dict__.items() if v is not None}
@@ -472,8 +476,15 @@ class FileOperations(ABC):
 
     @abstractmethod
     def write_file(self, path: str, content: str,
-                   pre_content: Optional[str] = None) -> WriteResult:
-        """Write content to a file, creating directories as needed."""
+                   pre_content: Optional[str] = None,
+                   *, follow_symlink: bool = True) -> WriteResult:
+        """Write content to a file, creating directories as needed.
+
+        Destination-symlink refusal (``follow_symlink=False``) is scoped to
+        ``write_file`` only; ``patch``/``move_file`` keep the default
+        write-through semantics, and ``terminal``/``execute_code`` ``open()``
+        are out-of-band.
+        """
         ...
 
     @abstractmethod
@@ -1533,8 +1544,50 @@ class ShellFileOperations(FileOperations):
     # WRITE Implementation
     # =========================================================================
 
+    def _probe_destination_symlink(
+        self, path: str,
+    ) -> tuple[str, Optional[str], Optional[str]]:
+        """Return ``(status, resolved_target, error)`` for a guest-side probe.
+
+        ``status`` is one of ``"none"`` (not a symlink), ``"symlink"``, or
+        ``"error"`` (transport failure or malformed probe output).
+        """
+        link_result = self._exec(
+            f"if [ -L {self._escape_shell_arg(path)} ]; then "
+            f"printf '__HERMES_SYMLINK__\\n'; "
+            f"readlink -f {self._escape_shell_arg(path)} 2>/dev/null "
+            f"|| realpath {self._escape_shell_arg(path)} 2>/dev/null; "
+            f"fi"
+        )
+        if link_result.exit_code != 0:
+            return (
+                "error",
+                None,
+                (
+                    f"Could not probe symlink status for '{path}': "
+                    f"probe command failed (exit {link_result.exit_code})."
+                ),
+            )
+        if not link_result.stdout.startswith(_SYMLINK_PROBE_MARKER):
+            return "none", None, None
+        raw_target = link_result.stdout[len(_SYMLINK_PROBE_MARKER):].rstrip("\r\n")
+        if not raw_target:
+            return (
+                "error",
+                None,
+                f"Symlink probe for '{path}' returned no resolved target.",
+            )
+        if posixpath.isabs(raw_target):
+            resolved_target = posixpath.normpath(raw_target)
+        else:
+            resolved_target = posixpath.normpath(
+                posixpath.join(posixpath.dirname(path), raw_target)
+            )
+        return "symlink", resolved_target, None
+
     def write_file(self, path: str, content: str,
-                   pre_content: Optional[str] = None) -> WriteResult:
+                   pre_content: Optional[str] = None,
+                   *, follow_symlink: bool = True) -> WriteResult:
         """
         Write content to a file, creating parent directories as needed.
 
@@ -1576,6 +1629,25 @@ class ShellFileOperations(FileOperations):
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
+
+        probe_status, resolved_target, probe_error = self._probe_destination_symlink(path)
+        if probe_status == "error":
+            return WriteResult(error=probe_error)
+
+        if probe_status == "symlink":
+            if not follow_symlink:
+                return WriteResult(
+                    error=(
+                        f"Refusing to write through destination symlink '{path}' "
+                        f"(resolved target: '{resolved_target}'). The target was NOT "
+                        "modified. Set follow_symlink=true only if this is intentional."
+                    ),
+                    resolved_target=resolved_target,
+                    code="symlink_destination_refused",
+                )
+            denied = get_write_denied_error(resolved_target)
+            if denied:
+                return WriteResult(error=denied)
 
         # Block writes to sensitive paths
         denied = get_write_denied_error(path)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -399,6 +399,45 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     return resolved.resolve()
 
 
+def _resolve_write_path_for_task(
+    filepath: str,
+    task_id: str = "default",
+    *,
+    follow_symlink: bool = False,
+) -> Path | PurePosixPath:
+    """Resolve a write path without dereferencing its final component by default."""
+    if follow_symlink:
+        return _resolve_path_for_task(filepath, task_id)
+
+    container_paths = _uses_container_paths(task_id)
+    if container_paths:
+        expanded = _expand_tilde(filepath)
+        if posixpath.isabs(expanded):
+            return _normalize_without_host_deref(expanded)
+        return _normalize_without_host_deref(
+            _resolve_base_dir(task_id, container_paths=True) / expanded
+        )
+
+    from tools.environments.local import _msys_to_windows_path
+
+    expanded = _expand_tilde(_msys_to_windows_path(filepath))
+    if sys.platform == "win32":
+        import ntpath
+
+        if ntpath.isabs(expanded):
+            candidate = Path(expanded)
+        else:
+            candidate = Path(
+                ntpath.join(str(_resolve_base_dir(task_id, container_paths=False)), expanded)
+            )
+        return candidate.parent.resolve() / candidate.name
+
+    candidate = Path(expanded)
+    if not candidate.is_absolute():
+        candidate = Path(_resolve_base_dir(task_id, container_paths=False)) / candidate
+    return candidate.parent.resolve() / candidate.name
+
+
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
@@ -2049,7 +2088,7 @@ def _mark_verification_stale(
 
 
 def write_file_tool(path: str, content: str, task_id: str = "default",
-                    cross_profile: bool = False,
+                    cross_profile: bool = False, follow_symlink: bool = False,
                     session_id: str | None = None) -> str:
     """Write content to a file.
 
@@ -2080,14 +2119,18 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         # fall back to the legacy path — write proceeds, per-task staleness
         # check below still runs.
         try:
-            _resolved = str(_resolve_path_for_task(path, task_id))
+            _resolved = str(_resolve_write_path_for_task(
+                path, task_id, follow_symlink=follow_symlink,
+            ))
         except Exception:
             _resolved = None
 
         if _resolved is None:
             stale_warning = _check_file_staleness(path, task_id)
             file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(path, content)
+            result = file_ops.write_file(
+                path, content, follow_symlink=follow_symlink,
+            )
             result_dict = result.to_dict()
             if stale_warning:
                 result_dict["_warning"] = stale_warning
@@ -2108,7 +2151,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
             cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
             file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(_resolved, content)
+            result = file_ops.write_file(
+                _resolved, content, follow_symlink=follow_symlink,
+            )
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
@@ -2474,12 +2519,17 @@ READ_FILE_SCHEMA = {
 
 WRITE_FILE_SCHEMA = {
     "name": "write_file",
-    "description": "Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out). The result's verified:true means the on-disk content hash was confirmed — do NOT re-read the file to check the write landed.",
+    "description": "Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. Refuses destination symlinks by default; set follow_symlink=true only for an intentional write through a symlink. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out). The result's verified:true means the on-disk content hash was confirmed — do NOT re-read the file to check the write landed.",
     "parameters": {
         "type": "object",
         "properties": {
             "path": {"type": "string", "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does)"},
             "content": {"type": "string", "description": "Complete content to write to the file"},
+            "follow_symlink": {
+                "type": "boolean",
+                "description": "Allow writing through a destination symlink. Defaults to false; when false, the write is rejected before mutation and the resolved target is reported.",
+                "default": False,
+            },
             "cross_profile": {
                 "type": "boolean",
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories — by default these writes are blocked with a warning because they affect a different profile than the one this session is running under.",
@@ -2589,6 +2639,7 @@ def _handle_write_file(args, **kw):
     return write_file_tool(
         path=args["path"], content=args["content"], task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
+        follow_symlink=bool(args.get("follow_symlink", False)),
         session_id=kw.get("session_id"),
     )
 


### PR DESCRIPTION
## Summary

`write_file` now probes whether the destination's final component is a symlink before any write and refuses by default with a clear error. The target is never truncated or mutated through the link.

- probe resolves via `readlink -f` with a `realpath` fallback, exactly matching the atomic-write resolution path (no divergent canonical targets); fail-closed when resolution is ambiguous
- existing sensitive-path, profile-boundary, traversal, backend, and approval checks apply to the resolved target
- local and remote backends covered; non-symlink destinations and new-file creation unchanged; parent-directory symlinks keep existing documented semantics

## Test Plan

- `scripts/run_tests.sh tests/tools/test_file_operations.py tests/tools/test_file_tools.py` -> 126 passed, 0 failed, 4 skipped
- covers symlink-to-regular, dangling link, sensitive target via link, multi-hop canonical resolution, remote-backend probe contract, refusal error paths

Restored from stranded local work; fresh-context adversarial review (round 1 FAIL -> probe/writer resolution alignment -> round 2 PASS).
