### PR TITLE
fix(aux): carry top-level reasoning_effort through Codex/Anthropic adapters

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1402,11 +1402,28 @@ class _CodexCompletionsAdapter:
         # that configure reasoning via auxiliary.<task>.extra_body get the
         # same behavior as the main agent's Codex transport.
         extra_body = kwargs.get("extra_body") or {}
-        if isinstance(extra_body, dict):
-            reasoning_cfg = extra_body.get("reasoning")
-            if isinstance(reasoning_cfg, dict):
+        reasoning_cfg = extra_body.get("reasoning") if isinstance(extra_body, dict) else None
+        if not isinstance(reasoning_cfg, dict):
+            # Fall back to a top-level reasoning_effort string — the wire
+            # shape the custom-provider profile emits — and then to the
+            # private normalized config dict, so MoA per-slot reasoning
+            # survives the codex_responses translation exactly like it does
+            # on the chat-completions path (custom profile → top-level
+            # reasoning_effort, which the Codex adapter previously dropped).
+            _top_effort = kwargs.get("reasoning_effort")
+            if _top_effort:
+                _eff = str(_top_effort).strip().lower()
+                if _eff in ("none", "false", "disabled"):
+                    reasoning_cfg = {"enabled": False}
+                else:
+                    reasoning_cfg = {"enabled": True, "effort": _eff}
+            else:
+                _rc = kwargs.get("_reasoning_config")
+                if isinstance(_rc, dict):
+                    reasoning_cfg = _rc
+        if isinstance(reasoning_cfg, dict):
                 if reasoning_cfg.get("enabled") is False:
-                    # Reasoning explicitly disabled — do not set reasoning
+                # Reasoning explicitly disabled — do not set reasoning
                     # or include.  The Codex backend still thinks by
                     # default, but we honor the caller's intent where the
                     # API allows it.
@@ -1890,6 +1907,21 @@ class _AnthropicCompletionsAdapter:
                 _rc = _eb.get("reasoning")
                 if isinstance(_rc, dict):
                     _reasoning_cfg = _rc
+        if _reasoning_cfg is None:
+            # Fall back to the top-level reasoning_effort string the
+            # custom-provider profile emits. A custom provider with
+            # api_mode=anthropic_messages but a base_url without an
+            # /anthropic marker (e.g. a relay's plain /v1) misses the
+            # _reasoning_config injection in _build_call_kwargs, and the
+            # profile's top-level reasoning_effort would otherwise be
+            # dropped here. Mirrors the _CodexCompletionsAdapter fallback.
+            _top_effort = kwargs.get("reasoning_effort")
+            if _top_effort:
+                _eff = str(_top_effort).strip().lower()
+                if _eff in ("none", "false", "disabled"):
+                    _reasoning_cfg = {"enabled": False}
+                else:
+                    _reasoning_cfg = {"enabled": True, "effort": _eff}
 
         anthropic_kwargs = build_anthropic_kwargs(
             model=model,


### PR DESCRIPTION
## Problem

The custom-provider profile (`plugins/model-providers/custom`) emits reasoning config as a **top-level `reasoning_effort` string** — the correct wire shape for OpenAI-compatible chat.completions endpoints (GLM/ARK, vLLM, etc.). But the two auxiliary adapters for non-chat transports only consulted `extra_body.reasoning` / `_reasoning_config`:

- **`_CodexCompletionsAdapter`** (api_mode=`codex_responses`): translated only `extra_body.reasoning` → Responses-API `reasoning`. A custom provider with `reasoning_effort: max` sent **no reasoning field at all** on the Responses wire.
- **`_AnthropicCompletionsAdapter`** (api_mode=`anthropic_messages`): `_build_call_kwargs` injects `_reasoning_config` only when the base_url *looks* Anthropic (`/anthropic` marker, `api.anthropic.com`, Kimi coding). A custom relay serving Anthropic Messages on a plain `/v1` base_url misses the injection, and the profile's top-level `reasoning_effort` was dropped there too.

**Observed impact (MoA):** with a MOA preset whose aggregator is a custom provider in `codex_responses` mode, the per-slot `reasoning_effort: max` never reached the upstream — the aggregator silently ran at the backend default. Same for an `anthropic_messages` custom relay on `/v1`.

## Fix

In both adapters, when no `extra_body.reasoning` dict is present, fall back to `kwargs["reasoning_effort"]` (the custom-profile wire shape) and then to `_reasoning_config`. Semantics mirror the chat-completions path and the main-agent Codex transport (`agent/transports/codex.py`):

- `"none"` / `"false"` / `"disabled"` → reasoning disabled (no `reasoning` key on Codex; `thinking` disabled on Anthropic via the normalized config)
- `"minimal"` → clamped to `"low"` on the Codex side (backend rejects `minimal`)
- priority: `extra_body.reasoning` > top-level `reasoning_effort` > `_reasoning_config`

## Verification

- `python -m py_compile` passes on the modified file.
- Adapter-level behavior matrix (6 cases): top-level `max` → `{effort: max, summary: auto}`; `extra_body.reasoning` still wins when both present; `_reasoning_config` used as last fallback; `none` → disabled; `minimal` → `low`; no config → no reasoning key.
- End-to-end (Hermes 0.19.0 runtime, MOA preset, aggregator on custom provider with `api_mode=codex_responses`): outbound Responses request now carries `reasoning: {"effort": "max", "summary": "auto"}`.

## Notes

- Related: #78382 (MoA facade dropped on client rebuild — different layer, same user-visible MOA failure family).
- No config or docs changes; pure transport-layer fallback.
