### PR TITLE
fix(doctor): explain response latency risks

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -4,6 +4,7 @@ Doctor command for hermes CLI.
 Diagnoses issues with Hermes Agent setup.
 """
 
+import json
 import os
 import sys
 import subprocess
@@ -251,6 +252,93 @@ def _check_version_consistency(issues: list[str]) -> None:
             "hermes_cli/__init__.py __version__ to match pyproject.toml)",
             issues,
         )
+
+
+def _check_performance_risks(issues: list[str]) -> None:
+    """Surface settings and schedules that make ordinary replies feel stuck.
+
+    This check is deliberately read-only.  It points users at the existing
+    configuration and prompt-size surfaces instead of silently changing
+    latency/quality trade-offs under ``doctor --fix``.
+    """
+    _section("Response Performance")
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        check_warn("Performance configuration could not be inspected", str(exc))
+        return
+
+    agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+    streaming_cfg = cfg.get("streaming") if isinstance(cfg.get("streaming"), dict) else {}
+    timeout = int(agent_cfg.get("gateway_timeout") or 0)
+
+    if timeout >= 900:
+        check_warn(
+            "Gateway can appear stuck for a long time",
+            f"(idle timeout {timeout // 60}m)",
+        )
+        issues.append(
+            "Lower agent.gateway_timeout (for example, 300 seconds) so dead provider calls fail promptly"
+        )
+    elif timeout:
+        check_ok("Gateway idle timeout", f"({timeout}s)")
+    else:
+        check_warn("Gateway idle timeout is unlimited")
+        issues.append("Set agent.gateway_timeout to a finite value")
+
+    if streaming_cfg.get("enabled", True) is False:
+        check_warn("Streaming is disabled", "(answers appear only after completion)")
+        issues.append("Set streaming.enabled: true for visible response progress")
+    else:
+        check_ok("Response streaming enabled")
+
+    overlapping_jobs: list[str] = []
+    jobs_path = HERMES_HOME / "cron" / "jobs.json"
+    try:
+        raw_jobs = json.loads(jobs_path.read_text(encoding="utf-8"))
+        jobs = raw_jobs.get("jobs", []) if isinstance(raw_jobs, dict) else []
+        for job in jobs:
+            if not isinstance(job, dict) or not job.get("enabled") or job.get("no_agent"):
+                continue
+            schedule = job.get("schedule")
+            if not isinstance(schedule, dict) or schedule.get("kind") != "interval":
+                continue
+            interval_seconds = int(schedule.get("minutes") or 0) * 60
+            if timeout and interval_seconds and interval_seconds < timeout:
+                overlapping_jobs.append(str(job.get("name") or job.get("id") or "unnamed job"))
+    except (OSError, ValueError, TypeError):
+        pass
+
+    if overlapping_jobs:
+        names = ", ".join(overlapping_jobs[:3])
+        if len(overlapping_jobs) > 3:
+            names += f", +{len(overlapping_jobs) - 3} more"
+        check_warn("Agent cron jobs can overlap the gateway timeout", f"({names})")
+        issues.append(
+            "Increase the listed cron intervals or lower agent.gateway_timeout to prevent overlapping LLM runs"
+        )
+    else:
+        check_ok("No interval cron jobs can overlap the gateway timeout")
+
+    try:
+        from hermes_cli.prompt_size import compute_prompt_breakdown
+
+        breakdown = compute_prompt_breakdown("cli")
+        fixed_bytes = int(breakdown["system_prompt"]["bytes"]) + int(breakdown["tools"]["json_bytes"])
+        if fixed_bytes >= 150_000:
+            check_warn(
+                "Fresh chats start with a large fixed prompt",
+                f"({fixed_bytes / 1024:.0f} KiB before conversation history)",
+            )
+            issues.append(
+                "Run 'hermes prompt-size' and trim oversized workspace instructions or unused toolsets"
+            )
+        else:
+            check_ok("Fresh-chat fixed prompt size", f"({fixed_bytes / 1024:.0f} KiB)")
+    except Exception as exc:
+        check_warn("Fresh-chat prompt size could not be measured", str(exc))
 
 
 def _check_s6_supervision(issues: list[str]) -> None:
@@ -628,6 +716,8 @@ def run_doctor(args):
     # Detect drift between pyproject.toml and hermes_cli/__init__.py versions
     # (a git conflict resolution can silently revert one but not the other).
     _check_version_consistency(issues)
+
+    _check_performance_risks(issues)
 
     _section("SSL / CA Certificates")
     check_certificates()

--- a/tests/hermes_cli/test_doctor_performance.py
+++ b/tests/hermes_cli/test_doctor_performance.py
@@ -1,0 +1,100 @@
+"""Behavior checks for the response-performance doctor section."""
+
+import json
+
+from hermes_cli import doctor
+
+
+def _patch_config(monkeypatch, config):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr(
+        "hermes_cli.prompt_size.compute_prompt_breakdown",
+        lambda _platform: {
+            "system_prompt": {"bytes": 40_000},
+            "tools": {"json_bytes": 30_000},
+        },
+    )
+
+
+def test_performance_check_flags_long_timeout_nonstreaming_and_overlap(tmp_path, monkeypatch, capsys):
+    home = tmp_path / ".hermes"
+    cron_dir = home / "cron"
+    cron_dir.mkdir(parents=True)
+    (cron_dir / "jobs.json").write_text(
+        json.dumps({
+            "jobs": [{
+                "id": "mail",
+                "name": "Mail monitor",
+                "enabled": True,
+                "no_agent": False,
+                "schedule": {"kind": "interval", "minutes": 10},
+            }],
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(doctor, "HERMES_HOME", home)
+    _patch_config(monkeypatch, {
+        "agent": {"gateway_timeout": 1800},
+        "streaming": {"enabled": False},
+    })
+
+    issues = []
+    doctor._check_performance_risks(issues)
+
+    out = capsys.readouterr().out
+    assert "idle timeout 30m" in out
+    assert "Streaming is disabled" in out
+    assert "Mail monitor" in out
+    assert len(issues) == 3
+
+
+def test_performance_check_accepts_bounded_nonoverlapping_configuration(tmp_path, monkeypatch, capsys):
+    home = tmp_path / ".hermes"
+    cron_dir = home / "cron"
+    cron_dir.mkdir(parents=True)
+    (cron_dir / "jobs.json").write_text(
+        json.dumps({
+            "jobs": [{
+                "id": "mail",
+                "enabled": True,
+                "no_agent": False,
+                "schedule": {"kind": "interval", "minutes": 10},
+            }],
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(doctor, "HERMES_HOME", home)
+    _patch_config(monkeypatch, {
+        "agent": {"gateway_timeout": 300},
+        "streaming": {"enabled": True},
+    })
+
+    issues = []
+    doctor._check_performance_risks(issues)
+
+    out = capsys.readouterr().out
+    assert "Gateway idle timeout" in out
+    assert "Response streaming enabled" in out
+    assert "No interval cron jobs can overlap" in out
+    assert issues == []
+
+
+def test_performance_check_flags_large_fixed_prompt(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(doctor, "HERMES_HOME", tmp_path / ".hermes")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"agent": {"gateway_timeout": 300}, "streaming": {"enabled": True}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.prompt_size.compute_prompt_breakdown",
+        lambda _platform: {
+            "system_prompt": {"bytes": 100_000},
+            "tools": {"json_bytes": 60_000},
+        },
+    )
+
+    issues = []
+    doctor._check_performance_risks(issues)
+
+    assert "large fixed prompt" in capsys.readouterr().out
+    assert any("prompt-size" in issue for issue in issues)


### PR DESCRIPTION
## What changed

- add a read-only `Response Performance` section to `hermes doctor`
- flag gateway idle timeouts that make failed provider calls look frozen
- flag disabled streaming, overlapping interval cron/LLM runs, and oversized fixed prompts
- point users to existing configuration and `hermes prompt-size` controls

## Why

A healthy gateway can still appear unresponsive when a provider call stalls, retries inherit a long idle timeout, an interval job starts again before the prior run can time out, or a fresh chat carries a large fixed prompt. Today, diagnosing that combination requires manual log inspection and knowledge of several separate settings.

The new section makes those relationships visible without changing configuration or silently trading answer quality for speed.

## User impact

`hermes doctor` now explains common response-latency risks in plain language and gives concrete remediation. Healthy bounded configurations produce concise passing rows.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_doctor_performance.py -q` — 3 passed
- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_command_install.py -q` — 74 passed
- `git diff --check`
