### PR TITLE
fix(terminal): preserve opted-in jobs on abandoned turns

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -11,9 +11,12 @@ Covers:
 import json
 import os
 import time
-import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from tools import process_registry as process_registry_module
 from tools.process_registry import (
     ProcessRegistry,
     ProcessSession,
@@ -368,6 +371,33 @@ def test_background_with_notify_does_not_emit_hint(monkeypatch, tmp_path):
         f"Correct usage must not emit a hint, got: {result.get('hint')!r}"
     )
     assert result.get("notify_on_complete") is True
+
+
+def test_background_persistence_is_forwarded_to_the_process_registry(monkeypatch, tmp_path):
+    tt = _silent_bg_harness(monkeypatch, tmp_path)
+    captured = {}
+
+    def fake_spawn_local(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id="proc_persistent_test", pid=4242)
+
+    monkeypatch.setattr(
+        process_registry_module.process_registry, "spawn_local", fake_spawn_local
+    )
+    try:
+        result = json.loads(
+            tt.terminal_tool(
+                command="python long_job.py",
+                background=True,
+                persist_on_turn_abandon=True,
+            )
+        )
+    finally:
+        tt._active_environments.pop("default", None)
+        tt._last_activity.pop("default", None)
+
+    assert captured["persist_on_turn_abandon"] is True
+    assert result["persist_on_turn_abandon"] is True
 
 
 def test_foreground_command_does_not_emit_hint(monkeypatch, tmp_path):

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -80,8 +80,11 @@ def test_kill_started_since_preserves_preexisting_and_foreign_processes(registry
     baseline = registry.snapshot_running_ids("session-a")
 
     new = _make_session(sid="proc_new", task_id="session-a")
+    persistent = _make_session(sid="proc_persistent", task_id="session-a")
+    persistent.persist_on_turn_abandon = True
     foreign = _make_session(sid="proc_foreign", task_id="session-b")
     registry._running[new.id] = new
+    registry._running[persistent.id] = persistent
     registry._running[foreign.id] = foreign
 
     calls = []
@@ -109,10 +112,12 @@ def test_kill_started_since_preserves_preexisting_and_foreign_processes(registry
 
 def test_kill_all_backward_compat_and_exclude_ids(registry):
     """kill_all keeps its historical default behavior (kill everything for
-    the task, consume_output=False, source='kill_all') and honors the new
-    exclude_ids kwarg that kill_started_since delegates through (#76188)."""
+    the task, including turn-persistence opt-ins, consume_output=False,
+    source='kill_all') and honors the new exclude_ids kwarg that
+    kill_started_since delegates through (#76188)."""
     a = _make_session(sid="proc_a", task_id="session-a")
     b = _make_session(sid="proc_b", task_id="session-a")
+    b.persist_on_turn_abandon = True
     registry._running[a.id] = a
     registry._running[b.id] = b
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -383,6 +383,7 @@ class ProcessSession:
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # True if recovered from crash (no pipe)
+    persist_on_turn_abandon: bool = False       # Explicitly survive gateway abandoned-turn reaping
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
     systemd_unit: str = ""                      # transient scope unit name when spawned under systemd-run (#70716)
     # Watcher/notification metadata (persisted for crash recovery)
@@ -971,6 +972,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        persist_on_turn_abandon: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -998,6 +1000,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            persist_on_turn_abandon=persist_on_turn_abandon,
         )
 
         pty_scope_attempted = False
@@ -1209,6 +1212,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        persist_on_turn_abandon: bool = False,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -1230,6 +1234,7 @@ class ProcessRegistry:
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            persist_on_turn_abandon=persist_on_turn_abandon,
         )
 
         # Run the command in the sandbox with output capture
@@ -2392,6 +2397,7 @@ class ProcessRegistry:
             exclude_ids=frozenset(baseline_ids or ()),
             source=source,
             consume_output=True,
+            skip_persist_on_turn_abandon=True,
         )
 
     def kill_all(
@@ -2401,6 +2407,7 @@ class ProcessRegistry:
         exclude_ids: frozenset = frozenset(),
         source: str = "kill_all",
         consume_output: bool = False,
+        skip_persist_on_turn_abandon: bool = False,
     ) -> int:
         """Kill all running processes, optionally filtered by task_id. Returns count killed."""
         with self._lock:
@@ -2409,6 +2416,10 @@ class ProcessRegistry:
                 if (task_id is None or s.task_id == task_id)
                 and s.id not in exclude_ids
                 and not s.exited
+                and (
+                    not skip_persist_on_turn_abandon
+                    or not s.persist_on_turn_abandon
+                )
             ]
 
         killed = 0

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1080,7 +1080,7 @@ Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), se
 Environment state persists: activate a virtualenv or export variables once per session, not before every command.
 
 Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.
-Background: set background=true (returns a session_id). Pair with notify_on_complete=true for bounded tasks; leave silent only for servers/daemons that never exit. Never use nohup/setsid/trailing '&' — use background=true so Hermes tracks the process. After starting a server, verify readiness with a health check, then act in a separate call; no blind sleep loops. Manage with process(action="poll"/"wait").
+Background: set background=true (returns a session_id). Pair with notify_on_complete=true for bounded tasks; leave silent only for servers/daemons that never exit. Use persist_on_turn_abandon=true only when a background task must survive an abandoned gateway turn; it still stops on gateway shutdown or explicit process cleanup. Never use nohup/setsid/trailing '&' — use background=true so Hermes tracks the process. After starting a server, verify readiness with a health check, then act in a separate call; no blind sleep loops. Manage with process(action="poll"/"wait").
 Working directory: use 'workdir' for per-command cwd. When a command changes the session cwd (cd, pushd), the result includes a "cwd" field — trust it instead of prefixing every command with 'cd'.
 PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output to cat if it might page.
 """
@@ -2531,6 +2531,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    persist_on_turn_abandon: bool = False,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2546,6 +2547,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        persist_on_turn_abandon: If True with background=True, keep the process when its gateway turn is abandoned. It does not bypass explicit process cleanup or gateway shutdown.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2994,6 +2996,7 @@ def terminal_tool(
                         session_key=session_key,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        persist_on_turn_abandon=persist_on_turn_abandon,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -3002,6 +3005,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        persist_on_turn_abandon=persist_on_turn_abandon,
                     )
 
                 result_data = {
@@ -3011,6 +3015,8 @@ def terminal_tool(
                     "exit_code": 0,
                     "error": None,
                 }
+                if persist_on_turn_abandon:
+                    result_data["persist_on_turn_abandon"] = True
                 # Background spawns detached and returns exit_code 0 immediately;
                 # it never inline-polls is_interrupted(), so the stale-bit kill
                 # cannot occur here and this note never co-occurs with rc=130.
@@ -3745,6 +3751,11 @@ TERMINAL_SCHEMA = {
                 "description": "Run in the background, returning a session_id. Pair with notify_on_complete=true for anything with a defined end (tests, builds, deploys) — without it the process runs silently. Only servers/watchers/daemons that never exit should stay silent. Short commands: prefer foreground with a generous timeout.",
                 "default": False
             },
+            "persist_on_turn_abandon": {
+                "type": "boolean",
+                "description": "With background=true: keep this explicitly durable process when its gateway turn is abandoned by timeout, stop, reset, or disconnect. It remains manageable with process(action=...) but does not bypass explicit process cleanup or gateway shutdown.",
+                "default": False
+            },
             "timeout": {
                 "type": "integer",
                 "description": f"Max seconds to wait (default: 180, foreground max: {FOREGROUND_MAX_TIMEOUT}). Returns INSTANTLY when command finishes — set high for long tasks, you won't wait unnecessarily. Foreground timeout above {FOREGROUND_MAX_TIMEOUT}s is rejected; use background=true for longer commands.",
@@ -3786,6 +3797,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        persist_on_turn_abandon=args.get("persist_on_turn_abandon", False),
     )
 
 


### PR DESCRIPTION
## What changed and why

Per the reporter's 2026-08-10 current-main gateway reproduction, add `persist_on_turn_abandon=true` for explicitly durable `terminal(background=true)` jobs. The process registry excludes only opted-in jobs from abandoned-turn reaping; regular background jobs retain the existing leak-prevention behavior, and `kill_all()` continues to stop opted-in jobs during gateway shutdown or explicit cleanup.

The name deliberately describes the verified boundary. It does not promise that a process survives gateway shutdown or a direct process kill.

## How to test

- Start `terminal(command="sleep 600", background=true, persist_on_turn_abandon=true)` from a gateway turn.
- Abandon the turn through inactivity timeout, stop, reset, or disconnect; verify the returned process session remains visible and running through `process(action="poll")`.
- Start the same command without the opt-in and verify the abandoned-turn reaper still stops it.
- Verify gateway shutdown or explicit process cleanup still stops the opted-in process.
- Automated: `pytest -q -x --timeout=60 tests/tools/test_process_registry.py::test_kill_started_since_preserves_preexisting_and_foreign_processes tests/tools/test_process_registry.py::test_kill_all_backward_compat_and_exclude_ids tests/tools/test_notify_on_complete.py::test_background_persistence_is_forwarded_to_the_process_registry tests/gateway/test_abandoned_turn_process_cleanup.py` (11 passed); `pytest -q -x --timeout=60 tests/tools/test_notify_on_complete.py tests/gateway/test_abandoned_turn_process_cleanup.py` (28 passed).

The required broader `pytest tests/ -q -x --timeout=60` run was attempted but the sandbox interpreter lacks `psutil`, causing an unrelated existing `tests/tools/test_process_registry.py` test to fail at import.

## What platforms tested on

- macOS 26.6 (Darwin 25.6.0), automated unit coverage.
- Linux gateway/systemd integration was not available in this sandbox.

Fixes #41225

<!-- autocontrib:worker-id=issue-followup-40c54525 kind=pr-open -->