### PR TITLE
fix(agent): return failed turns when Codex app-server exits during RPC writes

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -44,6 +44,10 @@ class CodexAppServerError(RuntimeError):
         return f"codex app-server error {self.code}: {self.message}"
 
 
+class CodexAppServerTransportError(RuntimeError):
+    """Raised when a JSON-RPC message cannot be written to the child."""
+
+
 @dataclass
 class _Pending:
     queue: queue.Queue
@@ -222,7 +226,12 @@ class CodexAppServerClient:
         q: queue.Queue = queue.Queue(maxsize=1)
         with self._pending_lock:
             self._pending[rid] = _Pending(queue=q, method=method)
-        self._send({"id": rid, "method": method, "params": params or {}})
+        try:
+            self._send({"id": rid, "method": method, "params": params or {}})
+        except CodexAppServerTransportError:
+            with self._pending_lock:
+                self._pending.pop(rid, None)
+            raise
         try:
             msg = q.get(timeout=timeout)
         except queue.Empty:
@@ -300,14 +309,16 @@ class CodexAppServerClient:
 
     def _send(self, obj: dict) -> None:
         if self._closed:
-            raise RuntimeError("codex app-server client is closed")
+            raise CodexAppServerTransportError("codex app-server client is closed")
         if self._proc.stdin is None:
-            raise RuntimeError("codex app-server stdin not available")
+            raise CodexAppServerTransportError(
+                "codex app-server stdin not available"
+            )
         try:
             self._proc.stdin.write((json.dumps(obj) + "\n").encode("utf-8"))
             self._proc.stdin.flush()
         except (BrokenPipeError, ValueError) as exc:
-            raise RuntimeError(
+            raise CodexAppServerTransportError(
                 f"codex app-server stdin closed unexpectedly: {exc}"
             ) from exc
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -36,6 +36,7 @@ from agent.redact import redact_sensitive_text
 from agent.transports.codex_app_server import (
     CodexAppServerClient,
     CodexAppServerError,
+    CodexAppServerTransportError,
 )
 from agent.transports.codex_event_projector import CodexEventProjector
 
@@ -420,7 +421,11 @@ class CodexAppServerSession:
                 },
                 timeout=10,
             )
-        except (CodexAppServerError, TimeoutError):
+        except (
+            CodexAppServerError,
+            CodexAppServerTransportError,
+            TimeoutError,
+        ):
             logger.debug("turn/steer rejected for active Codex turn", exc_info=True)
             return False
         accepted_turn_id = response.get("turnId") if isinstance(response, dict) else None
@@ -493,7 +498,11 @@ class CodexAppServerSession:
         result = TurnResult()
         try:
             self.ensure_started()
-        except (CodexAppServerError, TimeoutError) as exc:
+        except (
+            CodexAppServerError,
+            CodexAppServerTransportError,
+            TimeoutError,
+        ) as exc:
             result.error = self._format_error_with_stderr(
                 "codex app-server startup failed", exc
             )
@@ -551,6 +560,13 @@ class CodexAppServerSession:
             hint = _classify_oauth_failure(stderr_blob)
             result.error = hint or self._format_error_with_stderr(
                 "turn/start timed out", exc
+            )
+            result.should_retire = True
+            self._interrupt_event.clear()
+            return result
+        except CodexAppServerTransportError as exc:
+            result.error = self._format_error_with_stderr(
+                "turn/start transport failed", exc
             )
             result.should_retire = True
             self._interrupt_event.clear()
@@ -804,7 +820,11 @@ class CodexAppServerSession:
         result = TurnResult()
         try:
             self.ensure_started()
-        except (CodexAppServerError, TimeoutError) as exc:
+        except (
+            CodexAppServerError,
+            CodexAppServerTransportError,
+            TimeoutError,
+        ) as exc:
             result.error = self._format_error_with_stderr(
                 "codex app-server startup failed", exc
             )
@@ -838,6 +858,12 @@ class CodexAppServerSession:
             hint = _classify_oauth_failure(stderr_blob)
             result.error = hint or self._format_error_with_stderr(
                 "thread/compact/start timed out", exc
+            )
+            result.should_retire = True
+            return result
+        except CodexAppServerTransportError as exc:
+            result.error = self._format_error_with_stderr(
+                "thread/compact/start transport failed", exc
             )
             result.should_retire = True
             return result
@@ -994,6 +1020,8 @@ class CodexAppServerSession:
             logger.debug("turn/interrupt non-fatal: %s", exc)
         except TimeoutError:
             logger.warning("turn/interrupt timed out")
+        except CodexAppServerTransportError:
+            logger.debug("turn/interrupt transport unavailable", exc_info=True)
 
     def _handle_server_request(self, req: dict) -> None:
         """Translate a codex server request (approval) into Hermes' approval

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -679,7 +679,14 @@ class CodexAppServerSession:
                                 result.error
                                 or "codex reported turn_aborted"
                             )
-                self._handle_server_request(sreq)
+                try:
+                    self._handle_server_request(sreq)
+                except CodexAppServerTransportError as exc:
+                    result.error = self._format_error_with_stderr(
+                        "server request response transport failed", exc
+                    )
+                    result.should_retire = True
+                    break
                 # Activity counts as live signal — reset the post-tool
                 # quiet timer so an approval round-trip doesn't trip it.
                 last_tool_completion_at = None
@@ -892,7 +899,14 @@ class CodexAppServerSession:
 
             sreq = self._client.take_server_request(timeout=0)
             if sreq is not None:
-                self._handle_server_request(sreq)
+                try:
+                    self._handle_server_request(sreq)
+                except CodexAppServerTransportError as exc:
+                    result.error = self._format_error_with_stderr(
+                        "server request response transport failed", exc
+                    )
+                    result.should_retire = True
+                    break
                 continue
 
             note = self._client.take_notification(

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -7,6 +7,8 @@ covered by a separate live test gated on `codex --version`.
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from hermes_cli.runtime_provider import (
@@ -109,6 +111,28 @@ class TestCodexAppServerModule:
         assert isinstance(err, RuntimeError)
         assert "boom" in str(err)
         assert "-32600" in str(err)
+
+    def test_request_write_failure_is_typed_and_clears_pending(self) -> None:
+        from agent.transports.codex_app_server import (
+            CodexAppServerClient,
+            CodexAppServerTransportError,
+        )
+
+        client = object.__new__(CodexAppServerClient)
+        client._next_id = 1
+        client._pending = {}
+        client._pending_lock = threading.Lock()
+
+        def fail_send(_payload: dict) -> None:
+            raise CodexAppServerTransportError("stdin closed")
+
+        client._send = fail_send
+
+        with pytest.raises(CodexAppServerTransportError, match="stdin closed") as exc:
+            client.request("turn/start", {})
+
+        assert isinstance(exc.value, RuntimeError)
+        assert client._pending == {}
 
 
 class TestSpawnEnvIsolation:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -406,6 +406,27 @@ class TestRunTurn:
         with pytest.raises(RuntimeError, match="unexpected adapter defect"):
             make_session(client).run_turn("hi", turn_timeout=2.0)
 
+    def test_approval_response_transport_failure_returns_retiring_result(self):
+        from agent.transports.codex_app_server import CodexAppServerTransportError
+
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            command="pwd",
+            cwd="/tmp",
+        )
+
+        def fail_write(_request_id, _result):
+            raise CodexAppServerTransportError("stdin closed")
+
+        client.respond = fail_write
+
+        result = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert result.error and "response transport failed" in result.error
+        assert "stdin closed" in result.error
+        assert result.should_retire is True
+
 
 
 
@@ -513,6 +534,27 @@ class TestCompactThread:
 
         assert result.thread_id == "thread-fake-001"
         assert result.error and "thread/compact/start transport failed" in result.error
+        assert result.should_retire is True
+
+    def test_compact_approval_response_transport_failure_retires(self):
+        from agent.transports.codex_app_server import CodexAppServerTransportError
+
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            command="pwd",
+            cwd="/tmp",
+        )
+
+        def fail_write(_request_id, _result):
+            raise CodexAppServerTransportError("stdin closed")
+
+        client.respond = fail_write
+
+        result = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert result.error and "response transport failed" in result.error
+        assert "stdin closed" in result.error
         assert result.should_retire is True
 
     def test_compact_thread_ignores_foreign_child_completion(self):

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -366,6 +366,46 @@ class TestRunTurn:
         assert "sk-stalled-secret-abc123" not in r.error
         assert r.should_retire is True
 
+    def test_turn_start_transport_failure_returns_retiring_result(self):
+        from agent.transports.codex_app_server import CodexAppServerTransportError
+
+        client = FakeClient()
+        client.set_stderr_tail(["provider token sk-transport-secret"])
+
+        def fail_write(method, params):
+            if method == "turn/start":
+                raise CodexAppServerTransportError("stdin closed unexpectedly")
+            return {
+                "thread": {"id": "thread-fake-001"},
+                "activePermissionProfile": {"id": "x"},
+            }
+
+        client._request_handler = fail_write
+
+        result = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert result.thread_id == "thread-fake-001"
+        assert result.error and "turn/start transport failed" in result.error
+        assert "stdin closed unexpectedly" in result.error
+        assert "sk-transport-secret" not in result.error
+        assert result.should_retire is True
+
+    def test_turn_start_unrelated_runtime_error_still_escapes(self):
+        client = FakeClient()
+
+        def programming_error(method, params):
+            if method == "turn/start":
+                raise RuntimeError("unexpected adapter defect")
+            return {
+                "thread": {"id": "thread-fake-001"},
+                "activePermissionProfile": {"id": "x"},
+            }
+
+        client._request_handler = programming_error
+
+        with pytest.raises(RuntimeError, match="unexpected adapter defect"):
+            make_session(client).run_turn("hi", turn_timeout=2.0)
+
 
 
 
@@ -384,6 +424,22 @@ class TestRunTurn:
             "input": [{"type": "text", "text": "Use Postgres instead"}],
             "expectedTurnId": "turn-live-123",
         }
+
+    def test_steer_transport_failure_is_non_fatal(self):
+        from agent.transports.codex_app_server import CodexAppServerTransportError
+
+        client = FakeClient()
+        session = make_session(client)
+        session.ensure_started()
+        with session._active_turn_lock:
+            session._active_turn_id = "turn-live-123"
+
+        def fail_write(method, params):
+            raise CodexAppServerTransportError("stdin closed")
+
+        client._request_handler = fail_write
+
+        assert session.request_steer("Use Postgres instead") is False
 
 
 
@@ -437,6 +493,27 @@ class TestCompactThread:
         assert r.final_text == "compacted"
         assert r.token_usage_last["totalTokens"] == 12
         assert r.model_context_window == 200000
+
+    def test_compact_start_transport_failure_returns_retiring_result(self):
+        from agent.transports.codex_app_server import CodexAppServerTransportError
+
+        client = FakeClient()
+
+        def fail_write(method, params):
+            if method == "thread/compact/start":
+                raise CodexAppServerTransportError("stdin closed unexpectedly")
+            return {
+                "thread": {"id": "thread-fake-001"},
+                "activePermissionProfile": {"id": "x"},
+            }
+
+        client._request_handler = fail_write
+
+        result = make_session(client).compact_thread(turn_timeout=2.0)
+
+        assert result.thread_id == "thread-fake-001"
+        assert result.error and "thread/compact/start transport failed" in result.error
+        assert result.should_retire is True
 
     def test_compact_thread_ignores_foreign_child_completion(self):
         client = FakeClient()
@@ -822,6 +899,20 @@ class TestSessionRetirement:
         assert r.should_retire is True
         # Stderr-derived auth hint takes precedence over generic message
         assert r.error and "codex login" in r.error
+
+    def test_interrupt_transport_failure_is_non_fatal(self):
+        from agent.transports.codex_app_server import CodexAppServerTransportError
+
+        client = FakeClient()
+        session = make_session(client)
+        session.ensure_started()
+
+        def fail_write(method, params):
+            raise CodexAppServerTransportError("stdin closed")
+
+        client._request_handler = fail_write
+
+        session._issue_interrupt("turn-fake-001")
 
 
 # ---- thread/start cross-fill ----


### PR DESCRIPTION
## What does this PR do?

Codex turns and native compaction now return structured failures when the app-server exits during an RPC write instead of aborting the enclosing conversation with a runtime exception. The failed session is marked for retirement, allowing a later turn to start a clean child, while unrelated runtime errors remain visible.

### Symptom

If the Codex child exits after startup succeeds but before `turn/start`, `thread/compact/start`, or an approval response reaches stdin, the write exception can escape `run_turn()` or `compact_thread()` instead of returning a failed `TurnResult`.

### Impact

Affected Codex users can lose the current conversation or compaction call outside the normal structured error path. A dead session may also remain eligible for reuse instead of being retired. Frequency and broader blast radius were not measured.

### Bug Cause

**Trigger:** `agent/transports/codex_app_server.py` in `CodexAppServerClient._send()` when stdin is closed or a write raises `BrokenPipeError` or `ValueError`.

**Causal chain:**
1. The Codex child passes the session startup or liveness check.
2. The child exits before the following JSON-RPC write completes.
3. The client raises a plain runtime exception, but the session catches only RPC-domain errors and timeouts, so no structured retiring result is produced.

**Why it is wrong:** A process can exit between any liveness check and the next write. Transport loss is an expected lifecycle race, but plain `RuntimeError` cannot be handled narrowly without also hiding unrelated programming failures.

**Working sibling / contrast:** RPC-domain errors and timeouts already become structured session results. Steering and interruption already treat expected control-path failures as non-fatal.

**Ruled out:** An extra `is_alive()` check cannot remove the check-to-write race. Catching all runtime exceptions would mask unrelated defects.

### Fix

- Add `CodexAppServerTransportError` for closed or broken child stdin writes.
- Remove pending JSON-RPC requests when their initial send fails.
- Convert initial turn, compaction, and approval-response transport loss into redacted failed results with `should_retire=True`.
- Treat the same transport loss during steering and interruption as non-fatal without suppressing unrelated runtime exceptions.

## Related Issue

Fixes #83127

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/transports/codex_app_server.py` - define the transport write exception and clean pending request state after failed sends.
- `agent/transports/codex_app_server_session.py` - handle transport loss at turn, compaction, approval-response, steering, and interrupt boundaries.
- `tests/agent/transports/test_codex_app_server_runtime.py` - cover typed closed-stdin and pending cleanup behavior.
- `tests/agent/transports/test_codex_app_server_session.py` - cover structured retirement, redaction, sibling control paths, and unrelated runtime errors.

## How to Test

1. Reproduce a child exit after startup but before the initial turn or compaction request write, then confirm a failed retiring result is returned.
2. Exercise approval-response, steering, interrupt, pending cleanup, redaction, and unrelated runtime error contracts.
3. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/agent/transports/test_codex_app_server_runtime.py tests/agent/transports/test_codex_app_server_session.py
```

Result: 65 passed.

## Checklist

- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I ran the repository test entry point on the relevant tests and all tests pass.
- [x] I added behavior tests for the bug fix.
- [x] I verified the transport contracts on Windows 10.
