### PR TITLE
feat(skills): add opt-in SkillHub provider

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -655,6 +655,7 @@ def _run_review_in_thread(
     agent: Any,
     messages_snapshot: List[Dict],
     prompt: str,
+    review_skills: bool = False,
 ) -> None:
     """Worker function executed in the background-review daemon thread.
 
@@ -684,6 +685,7 @@ def _run_review_in_thread(
 
     review_agent = None
     review_messages: List[Dict] = []
+    skillhub_refresh_changed = False
 
     def _unregister_review_agent(agent_ref) -> None:
         """Idempotent: clears the review fork from both tracking slots.
@@ -720,6 +722,29 @@ def _run_review_in_thread(
         # thread's writes to devnull and leaves all other threads on the real
         # streams.
         with thread_scoped_silence():
+            # SkillHub is an opt-in source. Refresh only when this review has
+            # the skills curator enabled, and use the same quarantine/scanner
+            # path as `hermes skills update`. The current live turn is never
+            # rebuilt mid-turn; after a successful refresh the parent's cache
+            # is invalidated so its next turn sees the new skill content.
+            if review_skills:
+                try:
+                    from tools.skills_hub import refresh_skillhub_installed_skills
+
+                    refresh_results = refresh_skillhub_installed_skills()
+                    skillhub_refresh_changed = any(
+                        item.get("status") == "updated"
+                        for item in refresh_results
+                        if isinstance(item, dict)
+                    )
+                    if skillhub_refresh_changed:
+                        # Do not rebuild the parent prompt from this worker.
+                        # Mark it stale for the next foreground turn instead.
+                        setattr(agent, "_cached_system_prompt", None)
+                        logger.info("Background review refreshed installed SkillHub skills")
+                except Exception as exc:
+                    logger.warning("Background SkillHub refresh failed: %s", exc)
+
             # Inherit the parent agent's live runtime (provider, model,
             # base_url, api_key, api_mode) so the fork uses the exact
             # same credentials the main turn is using.  Without this,
@@ -876,7 +901,7 @@ def _run_review_in_thread(
             # runs on the SAME model (not routed). When routed to a different
             # model the parent's cached prompt is for the wrong model/cache key
             # and would miss anyway, so let the routed fork build its own.
-            if not _routed:
+            if not _routed and not skillhub_refresh_changed:
                 review_agent._cached_system_prompt = agent._cached_system_prompt
                 # Defensive: pin session_start + session_id to the
                 # parent's so any code path that re-renders parts of
@@ -886,6 +911,11 @@ def _run_review_in_thread(
                 # rebuild path, but these pins guarantee parity even
                 # if a future code path bypasses the cache.
                 review_agent.session_start = agent.session_start
+            else:
+                # A provider refresh changed the skill documents that belong
+                # in the fork prompt. Rebuild this fork's prompt rather than
+                # copying the parent's stale cached prefix.
+                setattr(review_agent, "_cached_system_prompt", None)
             review_agent.session_id = agent.session_id
             # The fork shares the parent's live session_id (pinned above for
             # prefix-cache parity). It is single-lifecycle and calls close()
@@ -1129,7 +1159,7 @@ def spawn_background_review_thread(
         )
 
     def _target() -> None:
-        _run_review_in_thread(agent, messages_snapshot, prompt)
+        _run_review_in_thread(agent, messages_snapshot, prompt, review_skills)
 
     return _target, prompt
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -824,6 +824,16 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Optional self-hosted SkillHub registry. When configured, SkillHub appears
+  # as a first-class source for `hermes skills search/inspect/install/check/update`.
+  # The token must remain in the profile secret environment (`SKILLHUB_TOKEN`);
+  # do not put credentials in config.yaml. Background skill reviews refresh
+  # already-installed SkillHub skills through the normal scanner by default.
+  # skillhub:
+  #   registry: "https://skillhub.example.internal"
+  #   namespace: "company-common"   # optional; filters search and bare names
+  #   auto_update: true              # default true when registry is configured
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/tests/agent/test_background_review_skillhub_refresh.py
+++ b/tests/agent/test_background_review_skillhub_refresh.py
@@ -1,0 +1,39 @@
+"""Background-review wiring for SkillHub refresh support."""
+
+from unittest.mock import MagicMock, patch
+
+from agent.background_review import spawn_background_review_thread
+
+
+def test_background_review_target_forwards_skill_review_flag():
+    agent = MagicMock()
+    agent._SKILL_REVIEW_PROMPT = "review skills"
+    snapshot = [{"role": "user", "content": "hello"}]
+
+    with patch("agent.background_review._run_review_in_thread") as run_review:
+        target, prompt = spawn_background_review_thread(
+            agent,
+            snapshot,
+            review_memory=False,
+            review_skills=True,
+        )
+        target()
+
+    assert prompt == "review skills"
+    run_review.assert_called_once_with(agent, snapshot, "review skills", True)
+
+
+def test_memory_only_review_does_not_request_skill_refresh():
+    agent = MagicMock()
+    agent._MEMORY_REVIEW_PROMPT = "review memory"
+
+    with patch("agent.background_review._run_review_in_thread") as run_review:
+        target, _ = spawn_background_review_thread(
+            agent,
+            [],
+            review_memory=True,
+            review_skills=False,
+        )
+        target()
+
+    assert run_review.call_args.args[-1] is False

--- a/tests/tools/test_skillhub_source.py
+++ b/tests/tools/test_skillhub_source.py
@@ -1,0 +1,226 @@
+"""Tests for the opt-in native SkillHub source adapter."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from unittest.mock import MagicMock, patch
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tools import skills_hub as hub
+from tools.skills_hub import (
+    HubLockFile,
+    SkillHubSource,
+    SkillMeta,
+    SkillBundle,
+    SkillSource,
+    bundle_content_hash,
+    content_hash,
+    create_source_router,
+    ensure_hub_dirs,
+    refresh_skillhub_installed_skills,
+)
+
+
+def _json_response(data, *, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = {"code": 0, "msg": "ok", "data": data}
+    return response
+
+
+def _skill_zip() -> bytes:
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w") as archive:
+        archive.writestr(
+            "SKILL.md",
+            "---\nname: deploy-k8s\ndescription: deploy\n---\n\n# Deploy\n",
+        )
+        archive.writestr("references/runbook.md", "runbook")
+        archive.writestr("../escape.txt", "must not extract")
+    return out.getvalue()
+
+
+class TestSkillHubSource:
+    def test_search_maps_cli_api_items_and_filters_namespace(self):
+        source = SkillHubSource(
+            "https://skillhub.example.internal",
+            namespace="company-common",
+            token="secret",
+        )
+        response = _json_response({
+            "items": [
+                {
+                    "namespace": "company-common",
+                    "slug": "deploy-k8s",
+                    "latestVersion": "1.2.0",
+                    "summary": "Deploy Kubernetes services",
+                },
+                {
+                    "namespace": "other-team",
+                    "slug": "same-name",
+                    "latestVersion": "1.0.0",
+                    "summary": "Other team",
+                },
+            ],
+            "total": 2,
+            "limit": 20,
+        })
+
+        with patch("tools.skills_hub.httpx.get", return_value=response) as mock_get:
+            result = source.search("deploy", limit=20)
+
+        assert len(result) == 1
+        assert result[0].source == "skillhub"
+        assert result[0].identifier == "skillhub://company-common/deploy-k8s"
+        assert result[0].extra["latest_version"] == "1.2.0"
+        assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer secret"
+
+    def test_inspect_uses_resolve_fingerprint_without_following_download_url(self):
+        source = SkillHubSource("https://skillhub.example.internal")
+        response = _json_response({
+            "namespace": "company-common",
+            "slug": "deploy-k8s",
+            "version": "1.2.0",
+            "versionId": 4,
+            "fingerprint": "sha256:abc",
+            "downloadUrl": "https://untrusted.example/download",
+        })
+
+        with patch("tools.skills_hub.httpx.get", return_value=response):
+            result = source.inspect("skillhub://company-common/deploy-k8s")
+
+        assert isinstance(result, SkillMeta)
+        assert result.extra["fingerprint"] == "sha256:abc"
+        assert result.extra["source_url"].endswith(
+            "/api/cli/v1/skills/company-common/deploy-k8s/resolve"
+        )
+
+    def test_fetch_resolves_latest_and_extracts_only_safe_text_files(self):
+        source = SkillHubSource("https://skillhub.example.internal")
+        with patch.object(
+            source,
+            "_request_json",
+            return_value={"version": "1.2.0", "fingerprint": "sha256:abc"},
+        ), patch.object(source, "_download", return_value=_skill_zip()):
+            bundle = source.fetch("skillhub://company-common/deploy-k8s")
+
+        assert isinstance(bundle, SkillBundle)
+        assert bundle.name == "deploy-k8s"
+        assert bundle.source == "skillhub"
+        assert bundle.identifier == "skillhub://company-common/deploy-k8s"
+        assert set(bundle.files) == {"SKILL.md", "references/runbook.md"}
+        assert bundle.metadata["version"] == "1.2.0"
+
+    def test_fetch_rejects_bundle_without_root_skill_md(self):
+        source = SkillHubSource("https://skillhub.example.internal")
+        content = io.BytesIO()
+        with zipfile.ZipFile(content, "w") as archive:
+            archive.writestr("README.md", "not a skill")
+
+        with patch.object(source, "_request_json", return_value={"version": "1.0.0"}), \
+             patch.object(source, "_download", return_value=content.getvalue()):
+            assert source.fetch("company-common/not-a-skill") is None
+
+    def test_invalid_registry_and_identifier_are_rejected(self):
+        try:
+            SkillHubSource("not-a-url")
+        except ValueError as exc:
+            assert "absolute HTTP(S)" in str(exc)
+        else:
+            raise AssertionError("invalid registry was accepted")
+
+        source = SkillHubSource("https://skillhub.example.internal")
+        assert source.inspect("skillhub://company-common/../escape") is None
+
+
+def test_router_adds_skillhub_only_when_configured():
+    with patch(
+        "tools.skills_hub._skillhub_settings",
+        return_value={
+            "registry": "https://skillhub.example.internal",
+            "namespace": "company-common",
+            "token": None,
+            "auto_update": True,
+        },
+    ):
+        sources = create_source_router()
+
+    assert sum(1 for source in sources if source.source_id() == "skillhub") == 1
+
+
+def test_router_does_not_add_skillhub_without_registry():
+    with patch("tools.skills_hub._skillhub_settings", return_value=None):
+        sources = create_source_router()
+
+    assert all(source.source_id() != "skillhub" for source in sources)
+
+
+def test_background_refresh_updates_real_temp_profile_and_lockfile(tmp_path):
+    class FakeSkillHub(SkillSource):
+        def source_id(self):
+            return "skillhub"
+
+        def fetch(self, identifier):
+            return SkillBundle(
+                "deploy-k8s",
+                {"SKILL.md": "---\nname: deploy-k8s\nversion: 1.1.0\n---\n\n# new\n"},
+                "skillhub",
+                identifier,
+                "community",
+                {"registry": "https://skillhub.example.internal", "version": "1.1.0"},
+            )
+
+        def search(self, query, limit=10):
+            return []
+
+        def inspect(self, identifier):
+            return None
+
+    token = set_hermes_home_override(tmp_path)
+    try:
+        skill_dir = tmp_path / "skills" / "team" / "deploy-k8s"
+        skill_dir.mkdir(parents=True)
+        old_content = "---\nname: deploy-k8s\nversion: 1.0.0\n---\n\n# old\n"
+        (skill_dir / "SKILL.md").write_text(old_content)
+        ensure_hub_dirs()
+
+        identifier = "skillhub://company-common/deploy-k8s"
+        old_bundle = SkillBundle(
+            "deploy-k8s", {"SKILL.md": old_content}, "skillhub", identifier, "community"
+        )
+        lock = HubLockFile()
+        lock.record_install(
+            "deploy-k8s",
+            "skillhub",
+            identifier,
+            "community",
+            "clean",
+            bundle_content_hash(old_bundle),
+            "team/deploy-k8s",
+            ["SKILL.md"],
+        )
+
+        with patch.object(
+            hub,
+            "_skillhub_settings",
+            return_value={
+                "registry": "https://skillhub.example.internal",
+                "namespace": "company-common",
+                "token": None,
+                "auto_update": True,
+            },
+        ):
+            result = refresh_skillhub_installed_skills(
+                lock=lock,
+                sources=[FakeSkillHub()],
+            )
+
+        assert result[0]["status"] == "updated"
+        assert "1.1.0" in (skill_dir / "SKILL.md").read_text()
+        installed = lock.get_installed("deploy-k8s")
+        assert installed is not None
+        assert installed["source"] == "skillhub"
+        assert installed["content_hash"] == content_hash(skill_dir)
+    finally:
+        reset_hermes_home_override(token)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -132,7 +132,7 @@ class SkillMeta:
     """Minimal metadata returned by search results."""
     name: str
     description: str
-    source: str           # "official", "github", "clawhub", "lobehub"
+    source: str           # "official", "github", "clawhub", "lobehub", "skillhub"
     identifier: str       # source-specific ID (e.g. "openai/skills/skill-creator")
     trust_level: str      # "builtin" | "trusted" | "community"
     repo: Optional[str] = None
@@ -505,6 +505,373 @@ class SkillSource(ABC):
     def trust_level_for(self, identifier: str) -> str:
         """Determine trust level for a skill from this source."""
         return "community"
+
+
+# ---------------------------------------------------------------------------
+# SkillHub source adapter
+# ---------------------------------------------------------------------------
+
+_SKILLHUB_PART_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _skillhub_settings() -> Optional[Dict[str, Any]]:
+    """Return configured SkillHub connection settings, or ``None``.
+
+    The registry URL and namespace are ordinary profile configuration. The
+    bearer token is deliberately secret-only: it is never read from the YAML
+    config or included in logs. Environment variables are supported for
+    headless deployments and take precedence over the YAML URL/namespace.
+    """
+    config: Dict[str, Any] = {}
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        loaded = load_config_readonly()
+        if isinstance(loaded, dict):
+            config = loaded
+    except Exception:
+        logger.debug("Unable to load SkillHub config", exc_info=True)
+
+    skills_config = config.get("skills", {})
+    skillhub_config = (
+        skills_config.get("skillhub", {})
+        if isinstance(skills_config, dict)
+        else {}
+    )
+    if not isinstance(skillhub_config, dict):
+        skillhub_config = {}
+
+    registry = (
+        os.environ.get("HERMES_SKILLHUB_REGISTRY")
+        or os.environ.get("SKILLHUB_REGISTRY")
+        or skillhub_config.get("registry")
+    )
+    if not isinstance(registry, str) or not registry.strip():
+        return None
+
+    namespace = (
+        os.environ.get("HERMES_SKILLHUB_NAMESPACE")
+        or os.environ.get("SKILLHUB_NAMESPACE")
+        or skillhub_config.get("namespace")
+        or ""
+    )
+    if not isinstance(namespace, str):
+        namespace = ""
+
+    auto_update = skillhub_config.get("auto_update", True)
+    if isinstance(auto_update, str):
+        auto_update = auto_update.strip().lower() in {"1", "true", "yes", "on"}
+
+    try:
+        from agent.secret_scope import get_secret
+
+        token = get_secret("HERMES_SKILLHUB_TOKEN") or get_secret("SKILLHUB_TOKEN")
+    except Exception:
+        token = os.environ.get("HERMES_SKILLHUB_TOKEN") or os.environ.get("SKILLHUB_TOKEN")
+
+    return {
+        "registry": registry.strip().rstrip("/"),
+        "namespace": namespace.strip(),
+        "token": token,
+        "auto_update": bool(auto_update),
+    }
+
+
+class SkillHubSource(SkillSource):
+    """Read-only SkillHub REST adapter.
+
+    SkillHub's CLI API is used directly so Hermes does not need the SkillHub
+    CLI installed. Identifiers are explicit and provenance-safe:
+    ``skillhub://<namespace>/<slug>``. The registry URL is configuration, not
+    skill metadata, so a fetched bundle cannot redirect Hermes to another
+    registry during resolution.
+    """
+
+    API_PREFIX = "/api/cli/v1"
+
+    def __init__(
+        self,
+        registry: str,
+        *,
+        namespace: str = "",
+        token: Optional[str] = None,
+    ):
+        parsed = urlparse(registry.strip())
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("SkillHub registry must be an absolute HTTP(S) URL")
+        if parsed.username or parsed.password:
+            raise ValueError("SkillHub registry must not contain credentials")
+        self.registry = registry.strip().rstrip("/")
+        self.namespace = self._validate_part(namespace, "namespace") if namespace else ""
+        self.token = token
+
+    @classmethod
+    def from_config(cls) -> Optional["SkillHubSource"]:
+        settings = _skillhub_settings()
+        if not settings:
+            return None
+        try:
+            return cls(
+                settings["registry"],
+                namespace=settings.get("namespace", ""),
+                token=settings.get("token"),
+            )
+        except ValueError as exc:
+            logger.warning("Ignoring invalid SkillHub configuration: %s", exc)
+            return None
+
+    @staticmethod
+    def _validate_part(value: str, label: str) -> str:
+        if not isinstance(value, str) or not _SKILLHUB_PART_RE.fullmatch(value):
+            raise ValueError(f"SkillHub {label} is invalid")
+        return value
+
+    def source_id(self) -> str:
+        return "skillhub"
+
+    def trust_level_for(self, identifier: str) -> str:
+        # Registry provenance is useful, but all remote content still goes
+        # through the normal Hermes scanner and install policy.
+        return "community"
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def _url(self, path: str) -> str:
+        return f"{self.registry}{self.API_PREFIX}{path}"
+
+    def _request_json(self, path: str, params: Optional[Dict[str, str]] = None) -> Optional[Any]:
+        url = self._url(path)
+        try:
+            response = httpx.get(
+                url,
+                params=params or {},
+                headers=self._headers(),
+                timeout=20,
+                follow_redirects=True,
+            )
+        except httpx.HTTPError as exc:
+            logger.debug("SkillHub request failed for %s: %s", url, exc)
+            return None
+        if response.status_code != 200:
+            logger.debug("SkillHub request for %s returned %s", url, response.status_code)
+            return None
+        try:
+            envelope = response.json()
+        except (ValueError, json.JSONDecodeError):
+            logger.debug("SkillHub returned invalid JSON for %s", url)
+            return None
+        if not isinstance(envelope, dict):
+            return None
+        code = envelope.get("code")
+        if code not in (None, 0, "0"):
+            logger.debug("SkillHub rejected %s: %s", url, envelope.get("msg", code))
+            return None
+        return envelope.get("data")
+
+    def _parse_identifier(self, identifier: str) -> Optional[Tuple[str, str]]:
+        raw = identifier.strip()
+        if raw.startswith("skillhub://"):
+            parsed = urlsplit(raw)
+            namespace, slug = parsed.netloc, parsed.path.strip("/")
+        else:
+            if raw.startswith("skillhub/"):
+                raw = raw[len("skillhub/"):]
+            parts = raw.strip("/").split("/", 1)
+            if len(parts) == 2:
+                namespace, slug = parts
+            elif len(parts) == 1 and self.namespace:
+                namespace, slug = self.namespace, parts[0]
+            else:
+                return None
+        if not namespace or not slug or "/" in slug:
+            return None
+        try:
+            return self._validate_part(namespace, "namespace"), self._validate_part(slug, "slug")
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _identifier(namespace: str, slug: str) -> str:
+        return f"skillhub://{namespace}/{slug}"
+
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        data = self._request_json(
+            "/skills/search",
+            params={
+                "q": query or "",
+                "limit": str(100 if limit <= 0 else min(limit, 100)),
+            },
+        )
+        if not isinstance(data, dict):
+            return []
+        items = data.get("items")
+        if not isinstance(items, list):
+            return []
+        results: List[SkillMeta] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            namespace = item.get("namespace")
+            slug = item.get("slug")
+            if not isinstance(namespace, str) or not isinstance(slug, str):
+                continue
+            if self.namespace and namespace != self.namespace:
+                continue
+            try:
+                namespace = self._validate_part(namespace, "namespace")
+                slug = self._validate_part(slug, "slug")
+            except ValueError:
+                continue
+            results.append(SkillMeta(
+                name=slug,
+                description=str(item.get("summary") or "SkillHub skill"),
+                source=self.source_id(),
+                identifier=self._identifier(namespace, slug),
+                trust_level=self.trust_level_for(slug),
+                path=slug,
+                extra={
+                    "registry": self.registry,
+                    "namespace": namespace,
+                    "latest_version": item.get("latestVersion"),
+                },
+            ))
+        return results[:limit] if limit > 0 else results
+
+    def _resolve(self, identifier: str) -> Optional[Dict[str, Any]]:
+        parsed = self._parse_identifier(identifier)
+        if not parsed:
+            return None
+        namespace, slug = parsed
+        data = self._request_json(f"/skills/{namespace}/{slug}/resolve")
+        return data if isinstance(data, dict) else None
+
+    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+        data = self._resolve(identifier)
+        parsed = self._parse_identifier(identifier)
+        if not data or not parsed:
+            return None
+        namespace, slug = parsed
+        version = data.get("version")
+        return SkillMeta(
+            name=slug,
+            description=f"SkillHub skill in namespace {namespace}",
+            source=self.source_id(),
+            identifier=self._identifier(namespace, slug),
+            trust_level=self.trust_level_for(identifier),
+            path=slug,
+            extra={
+                "registry": self.registry,
+                "namespace": namespace,
+                "version": version,
+                "fingerprint": data.get("fingerprint"),
+                "source_url": self._url(f"/skills/{namespace}/{slug}/resolve"),
+            },
+        )
+
+    def _download(self, namespace: str, slug: str, version: Optional[str]) -> Optional[bytes]:
+        self._validate_part(namespace, "namespace")
+        self._validate_part(slug, "slug")
+        if version:
+            self._validate_part(str(version), "version")
+            path = f"/skills/{namespace}/{slug}/versions/{version}/download"
+        else:
+            path = f"/skills/{namespace}/{slug}/download"
+        current_url = self._url(path)
+        from tools.url_safety import SSRFConnectionBlocked, create_ssrf_safe_client
+
+        for _ in range(_MAX_SKILL_FETCH_REDIRECTS + 1):
+            if not is_safe_url(current_url) or check_website_access(current_url):
+                logger.warning("Blocked unsafe SkillHub download URL: %s", current_url)
+                return None
+            headers = self._headers() if urlparse(current_url).netloc == urlparse(self.registry).netloc else {}
+            try:
+                with create_ssrf_safe_client(timeout=30, follow_redirects=False) as client:
+                    response = client.get(current_url, headers=headers)
+            except (SSRFConnectionBlocked, httpx.HTTPError) as exc:
+                logger.debug("SkillHub download failed for %s: %s", current_url, exc)
+                return None
+            if response.status_code in _REDIRECT_STATUS_CODES:
+                location = response.headers.get("location")
+                if not location:
+                    return None
+                current_url = urljoin(current_url, location)
+                continue
+            if response.status_code != 200:
+                logger.debug("SkillHub download returned %s for %s", response.status_code, current_url)
+                return None
+            return response.content
+        logger.warning("SkillHub download exceeded redirect limit for %s", current_url)
+        return None
+
+    @staticmethod
+    def _extract_zip(content: bytes) -> Dict[str, Union[str, bytes]]:
+        import io
+        import zipfile
+
+        files: Dict[str, Union[str, bytes]] = {}
+        try:
+            with zipfile.ZipFile(io.BytesIO(content)) as archive:
+                for info in archive.infolist():
+                    if info.is_dir() or info.file_size > 500_000:
+                        continue
+                    try:
+                        name = _validate_bundle_rel_path(info.filename)
+                    except ValueError:
+                        logger.debug("Skipping unsafe SkillHub ZIP member: %s", info.filename)
+                        continue
+                    try:
+                        raw = archive.read(info.filename)
+                        files[name] = raw.decode("utf-8")
+                    except (UnicodeDecodeError, KeyError):
+                        logger.debug("Skipping non-text SkillHub ZIP member: %s", name)
+        except zipfile.BadZipFile:
+            logger.warning("SkillHub returned an invalid ZIP bundle")
+            return {}
+        return files
+
+    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+        parsed = self._parse_identifier(identifier)
+        resolved = self._resolve(identifier)
+        if not parsed or not resolved:
+            return None
+        namespace, slug = parsed
+        version = resolved.get("version")
+        content = self._download(namespace, slug, str(version) if version else None)
+        if content is None:
+            return None
+        files = self._extract_zip(content)
+        if "SKILL.md" not in files:
+            logger.warning("SkillHub bundle %s/%s has no root SKILL.md", namespace, slug)
+            return None
+        name = slug
+        skill_md = files.get("SKILL.md")
+        if isinstance(skill_md, str) and skill_md.startswith("---"):
+            try:
+                frontmatter = yaml.safe_load(skill_md.split("---", 2)[1]) or {}
+                candidate = frontmatter.get("name") if isinstance(frontmatter, dict) else None
+                if isinstance(candidate, str) and _SKILLHUB_PART_RE.fullmatch(candidate):
+                    name = candidate
+            except yaml.YAMLError:
+                pass
+        return SkillBundle(
+            name=name,
+            files=files,
+            source=self.source_id(),
+            identifier=self._identifier(namespace, slug),
+            trust_level=self.trust_level_for(identifier),
+            metadata={
+                "registry": self.registry,
+                "namespace": namespace,
+                "slug": slug,
+                "version": version,
+                "fingerprint": resolved.get("fingerprint"),
+                "source_url": self._url(f"/skills/{namespace}/{slug}/resolve"),
+            },
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -3998,7 +4365,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(_skills_dir())),
+        install_path=str(install_dir.relative_to(_skills_dir().resolve())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
         scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),
@@ -4147,6 +4514,121 @@ def check_for_skill_updates(
         })
 
     return results
+
+
+def refresh_skillhub_installed_skills(
+    *,
+    lock: Optional[HubLockFile] = None,
+    sources: Optional[List[SkillSource]] = None,
+) -> List[dict]:
+    """Refresh configured SkillHub installs through the normal install gate.
+
+    This is intentionally a non-UI helper for background review and other
+    autonomous callers. It only considers lock entries whose source is exactly
+    ``skillhub`` and only runs when a SkillHub registry is configured with
+    ``skills.skillhub.auto_update`` enabled. Every update is fetched,
+    quarantined, scanned, and installed using the same path as the interactive
+    ``hermes skills update`` command.
+
+    Returns compact per-skill results. A failed or blocked update is reported
+    in the result and never aborts the remaining refreshes.
+    """
+    settings = _skillhub_settings()
+    if not settings or not settings.get("auto_update", True):
+        return []
+
+    lock = lock or HubLockFile()
+    if sources is None:
+        source = SkillHubSource.from_config()
+        sources = [source] if source is not None else []
+    skillhub_sources = [src for src in sources if _source_matches(src, "skillhub")]
+    if not skillhub_sources:
+        return []
+
+    installed = [
+        entry for entry in lock.list_installed()
+        if entry.get("source") == "skillhub"
+    ]
+    refreshed: List[dict] = []
+
+    for entry in installed:
+        name = str(entry.get("name", ""))
+        try:
+            results = check_for_skill_updates(
+                name=name,
+                lock=lock,
+                sources=skillhub_sources,
+            )
+            result = results[0] if results else {"status": "unavailable"}
+            if result.get("status") != "update_available":
+                refreshed.append({"name": name, "status": result.get("status", "unavailable")})
+                continue
+
+            bundle = result.get("bundle")
+            if not isinstance(bundle, SkillBundle):
+                refreshed.append({"name": name, "status": "unavailable"})
+                continue
+            # The installed name is the lockfile identity. Preserve it even
+            # if a remote frontmatter edit changes its display name.
+            bundle.name = name
+            install_path = str(entry.get("install_path", ""))
+            path_parts = PurePosixPath(install_path).parts
+            if not path_parts or path_parts[-1] != name:
+                refreshed.append({"name": name, "status": "blocked", "reason": "invalid install path"})
+                continue
+            category = "/".join(path_parts[:-1])
+
+            q_path = quarantine_bundle(bundle)
+            try:
+                from tools.skills_guard import scan_skill_cached, should_allow_install
+
+                scan_result, scan_provenance = scan_skill_cached(
+                    q_path,
+                    source=bundle.identifier,
+                    source_url=source_url_for_bundle(bundle),
+                    cache_dir=_hub_dir() / "scan-cache",
+                )
+                allowed, reason = should_allow_install(scan_result, force=True)
+                if not allowed:
+                    shutil.rmtree(q_path, ignore_errors=True)
+                    append_audit_log(
+                        "BLOCKED", name, bundle.source, bundle.trust_level,
+                        scan_result.verdict, str(reason),
+                    )
+                    refreshed.append({"name": name, "status": "blocked", "reason": reason})
+                    continue
+                install_from_quarantine(
+                    q_path,
+                    name,
+                    category,
+                    bundle,
+                    scan_result,
+                    scan_provenance,
+                )
+                refreshed.append({
+                    "name": name,
+                    "status": "updated",
+                    "latest_hash": result.get("latest_hash", ""),
+                })
+            except Exception as exc:
+                shutil.rmtree(q_path, ignore_errors=True)
+                logger.warning("SkillHub background refresh failed for %s: %s", name, exc)
+                refreshed.append({"name": name, "status": "failed", "reason": str(exc)})
+        except Exception as exc:
+            logger.warning("SkillHub background refresh failed for %s: %s", name, exc)
+            refreshed.append({"name": name, "status": "failed", "reason": str(exc)})
+
+    if any(item.get("status") == "updated" for item in refreshed):
+        # The current turn's prompt is not rebuilt here. Clear the shared
+        # skills snapshot so the next turn sees the newly installed content.
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            logger.debug("Unable to clear the skills prompt cache after SkillHub refresh", exc_info=True)
+
+    return refreshed
 
 
 # ---------------------------------------------------------------------------
@@ -4451,12 +4933,23 @@ def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]
         HermesIndexSource(auth=auth), # Centralized index (search + resolved install paths)
         SkillsShSource(auth=auth),
         WellKnownSkillSource(),
+    ]
+
+    # SkillHub is deliberately opt-in. A normal Hermes installation must not
+    # add a new network source unless a registry is configured for the active
+    # profile. The provider is still a first-class source once enabled, so
+    # search, inspect, install, check, and update all use the same router.
+    skillhub = SkillHubSource.from_config()
+    if skillhub is not None:
+        sources.append(skillhub)
+
+    sources.extend([
         UrlSource(),                  # Direct HTTP(S) URL to a SKILL.md file
         GitHubSource(auth=auth, extra_taps=extra_taps),
         ClawHubSource(),
         LobeHubSource(),
         BrowseShSource(),   # browse.sh: 169+ site-specific browser automation skills
-    ]
+    ])
 
     return sources
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -373,6 +373,57 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 
 All four skills appear in your skill index. If you create a new skill called `my-custom-workflow` locally, it shadows the external version.
 
+## SkillHub Registry
+
+Hermes can use a self-hosted [SkillHub](https://github.com/iflytek/skillhub)
+instance as a first-class Skills Hub source. This is useful when a team needs
+namespaces, a web registry, and one versioned package source shared by Hermes,
+Codex, and Claude Code. It is different from `external_dirs`: the registry is
+queried for search/resolve, packages are downloaded through the SkillHub REST
+API, and Hermes still materializes them locally after quarantine and scanning.
+
+Configure the registry in the active profile's `config.yaml`:
+
+```yaml
+skills:
+  skillhub:
+    registry: "https://skillhub.example.internal"
+    namespace: "company-common"  # optional search filter and bare-name scope
+    auto_update: true             # default true when registry is configured
+```
+
+Keep the optional bearer token in the profile secret environment, not YAML:
+
+```bash
+export SKILLHUB_TOKEN="..."
+```
+
+The provider is opt-in: without `skills.skillhub.registry`, the normal source
+router and network behavior are unchanged. Once enabled, these commands use
+the same provider selection and provenance lock as other sources:
+
+```bash
+hermes skills search deployment
+hermes skills inspect skillhub://company-common/deploy-k8s
+hermes skills install skillhub://company-common/deploy-k8s
+hermes skills check
+hermes skills update
+```
+
+SkillHub identifiers are recorded in `skills/.hub/lock.json` as
+`skillhub://<namespace>/<slug>`. Updates remain pinned to the configured
+SkillHub source; Hermes never falls back to a same-named GitHub or public-hub
+skill. The SkillHub bundle is still validated for safe paths, scanned, and
+installed through the existing quarantine gate.
+
+When background skill review is enabled, Hermes refreshes already-installed
+SkillHub entries before creating the review fork when `auto_update` is true.
+The current turn is not rebuilt: if a refresh changes a skill, the review fork
+builds a fresh skill prompt and the parent prompt cache is invalidated for its
+next turn. Background review does not publish arbitrary local edits back to
+SkillHub in this path; SkillHub publishing has namespace membership, version,
+and review-state semantics and must be an explicit publication workflow.
+
 ## Skill Bundles
 
 Skill bundles are tiny YAML files that group several skills under a single slash command. When you run `/<bundle-name>`, every skill listed in the bundle loads at once — useful when a particular task always benefits from the same set of skills together.


### PR DESCRIPTION
## Summary

- add an opt-in native SkillHub REST source to the Skills Hub router
- resolve and fetch immutable SkillHub versions with registry provenance
- refresh installed SkillHub skills before background skill reviews
- keep downloaded content on the existing scanner, quarantine, and lockfile paths
- document configuration and add focused provider/background-review tests

## Design

SkillHub is enabled only when `skills.skillhub.registry` is configured. Skills use explicit
`skillhub://<namespace>/<slug>` identifiers. `latest` is resolved at the update boundary,
then the resolved version and fingerprint are stored in the existing Skills Hub provenance
and lockfile metadata.

Background review refreshes only installed SkillHub entries and invalidates the parent skill
prompt cache for the next turn. It does not rebuild the current turn's prompt while the
review is running.

## Safety

- SkillHub remains an untrusted remote source and uses the existing Hermes scanner and
  installation policy.
- ZIP members are validated before extraction.
- Download redirects are bounded and checked through the existing SSRF-safe client.
- Registry credentials are accepted only through the configured secret environment variables;
  credentials in registry URLs are rejected.
- SkillHub publishing is intentionally not implicit in background review. Publishing has
  namespace, visibility, version, and review-state semantics and should be an explicit
  publication workflow.

## Verification

- focused canonical test runner: 87 passed
- temporary `HERMES_HOME` end-to-end refresh/install/lockfile path: passed
- `uvx ruff check`: passed
- Python compilation and `git diff --check`: passed
- full-suite attempt reached 7,822/25,559 tests before two failures in existing test areas;
  one failure reproduced independently as an existing `agent.moa_loop._preset_cache` /
  `tests/conftest.py` mismatch. Full-suite green is not claimed.

## Scope

This is the native provider and background-refresh increment. SkillHub-side automatic
publication is deliberately left to a separate explicit publication workflow.
