### PR TITLE
fix(desktop): skip titlebar Y nudge on Tahoe and macOS fullscreen

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5251,12 +5251,18 @@ async function waitForHermes(baseUrl, token, signal?, authMode?) {
   })
 }
 
-function getWindowButtonPosition() {
+function getWindowButtonPosition(win = mainWindow) {
   if (!IS_MAC) {
     return null
   }
 
-  return mainWindow?.getWindowButtonPosition?.() || WINDOW_BUTTON_POSITION
+  // Fullscreen hides the traffic lights — treat as no left-side controls so the
+  // renderer drops the traffic-light dodge inset and Y nudge.
+  if (Boolean(win?.isFullScreen?.())) {
+    return null
+  }
+
+  return win?.getWindowButtonPosition?.() || WINDOW_BUTTON_POSITION
 }
 
 function getNativeOverlayWidth() {
@@ -5269,7 +5275,8 @@ function getWindowState(win = mainWindow) {
     isMinimized: Boolean(win?.isMinimized?.()),
     isVisible: Boolean(win?.isVisible?.()),
     nativeOverlayWidth: getNativeOverlayWidth(),
-    windowButtonPosition: getWindowButtonPosition()
+    windowButtonPosition: getWindowButtonPosition(win),
+    darwinMajor: IS_MAC ? DARWIN_MAJOR : 0
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5258,7 +5258,7 @@ function getWindowButtonPosition(win = mainWindow) {
 
   // Fullscreen hides the traffic lights — treat as no left-side controls so the
   // renderer drops the traffic-light dodge inset and Y nudge.
-  if (Boolean(win?.isFullScreen?.())) {
+  if (win?.isFullScreen?.()) {
     return null
   }
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -112,7 +112,7 @@ import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
 import { startWorkspaceSession } from '../session/workspace-session-target'
 import { useOverlayRouting } from '../shell/hooks/use-overlay-routing'
 import { useWindowControlsOverlayWidth } from '../shell/hooks/use-window-controls-overlay-width'
-import { titlebarControlsPosition, titlebarControlsYNudge, titlebarToolsWidthCss } from '../shell/titlebar'
+import { titlebarControlsPosition, titlebarControlsYNudge, titlebarToolsRightCss, titlebarToolsWidthCss } from '../shell/titlebar'
 import { TitlebarControls } from '../shell/titlebar-controls'
 import { UpdatesOverlay } from '../updates-overlay'
 
@@ -971,7 +971,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // prefer the live WCO measurement, fall back to the static reservation).
   const measuredOverlayWidth = useWindowControlsOverlayWidth()
   const nativeOverlayWidth = measuredOverlayWidth ?? connection?.nativeOverlayWidth ?? 0
-  const titlebarToolsRight = nativeOverlayWidth > 0 ? `${nativeOverlayWidth}px` : '0.75rem'
+  const titlebarChrome = {
+    darwinMajor: connection?.darwinMajor ?? 0,
+    isFullscreen: Boolean(connection?.isFullscreen),
+    windowButtonPosition: connection?.windowButtonPosition
+  }
+  const titlebarToolsRight = titlebarToolsRightCss(nativeOverlayWidth, titlebarChrome)
   // Pane-registered tools (preview's monitor/devtools cluster) anchor flush
   // against the static system cluster — in the tree layout the titlebar band
   // sits ABOVE the grid, so AppShell's pane-width anchoring doesn't apply.
@@ -990,7 +995,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           {
             '--titlebar-controls-left': `${controlsPos.left}px`,
             '--titlebar-controls-top': `${controlsPos.top}px`,
-            '--titlebar-controls-y-nudge': titlebarControlsYNudge(connection?.windowButtonPosition),
+            '--titlebar-controls-y-nudge': titlebarControlsYNudge(titlebarChrome),
             '--titlebar-tools-right': titlebarToolsRight,
             '--titlebar-tools-width': titlebarToolsWidth,
             '--shell-preview-toolbar-gap': systemToolsWidth

--- a/apps/desktop/src/app/shell/titlebar.test.ts
+++ b/apps/desktop/src/app/shell/titlebar.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  MACOS_TAHOE_DARWIN_MAJOR,
   TITLEBAR_CONTROL_OFFSET_X,
   TITLEBAR_CONTROL_SIZE,
   TITLEBAR_EDGE_INSET,
@@ -10,6 +11,7 @@ import {
   titlebarControlsPosition,
   titlebarControlsYNudge,
   titlebarIconSizeCss,
+  titlebarToolsRightCss,
   titlebarToolsWidthCss
 } from './titlebar'
 
@@ -44,15 +46,35 @@ describe('titlebarControlsPosition', () => {
 })
 
 describe('titlebarControlsYNudge', () => {
-  it('nudges the left cluster on macOS when traffic lights are visible', () => {
-    expect(titlebarControlsYNudge({ x: 24, y: 10 })).toBe(TITLEBAR_MAC_TRAFFIC_LIGHTS_Y_NUDGE)
+  it('nudges pre-Tahoe macOS when traffic lights are visible', () => {
+    expect(titlebarControlsYNudge({ windowButtonPosition: { x: 24, y: 10 }, darwinMajor: 24 })).toBe(
+      TITLEBAR_MAC_TRAFFIC_LIGHTS_Y_NUDGE
+    )
   })
 
-  it('stays flat on Windows/Linux and macOS fullscreen', () => {
-    expect(titlebarControlsYNudge(null)).toBe('0px')
+  it('stays flat on Tahoe, Windows/Linux, and macOS fullscreen', () => {
+    expect(titlebarControlsYNudge({ windowButtonPosition: { x: 24, y: 10 }, darwinMajor: MACOS_TAHOE_DARWIN_MAJOR })).toBe(
+      '0px'
+    )
+    expect(titlebarControlsYNudge({ windowButtonPosition: null })).toBe('0px')
+    expect(titlebarControlsYNudge({ windowButtonPosition: { x: 24, y: 10 }, isFullscreen: true })).toBe('0px')
   })
 
-  it('nudges while macOS window-button position is still unknown', () => {
-    expect(titlebarControlsYNudge(undefined)).toBe(TITLEBAR_MAC_TRAFFIC_LIGHTS_Y_NUDGE)
+  it('nudges while macOS window-button position is still unknown on pre-Tahoe', () => {
+    expect(titlebarControlsYNudge({ darwinMajor: 24 })).toBe(TITLEBAR_MAC_TRAFFIC_LIGHTS_Y_NUDGE)
+  })
+})
+
+describe('titlebarToolsRightCss', () => {
+  it('reserves the native overlay width when present', () => {
+    expect(titlebarToolsRightCss(144)).toBe('144px')
+  })
+
+  it('matches the left edge inset on macOS fullscreen', () => {
+    expect(titlebarToolsRightCss(0, { darwinMajor: 25, isFullscreen: true })).toBe(`${TITLEBAR_EDGE_INSET}px`)
+  })
+
+  it('keeps the default chrome inset otherwise', () => {
+    expect(titlebarToolsRightCss(0)).toBe('0.75rem')
   })
 })

--- a/apps/desktop/src/app/shell/titlebar.ts
+++ b/apps/desktop/src/app/shell/titlebar.ts
@@ -22,15 +22,46 @@ export const TITLEBAR_FALLBACK_WINDOW_BUTTON_X = 24
 // (traffic lights are hidden). Matches the right-cluster's 0.75rem padding.
 export const TITLEBAR_EDGE_INSET = 14
 
+// macOS Tahoe = Darwin 25+. Keep in sync with electron/titlebar-overlay-width.ts.
+export const MACOS_TAHOE_DARWIN_MAJOR = 25
+
 // macOS traffic-light row only: nudge the left toolbar cluster down to sit on
-// the same optical center as the native buttons. null windowButtonPosition means
-// Windows/Linux (controls on the right) or macOS fullscreen (lights hidden).
+// the same optical center as the native buttons on pre-Tahoe macOS. null
+// windowButtonPosition means Windows/Linux, macOS fullscreen, or Tahoe.
 export const TITLEBAR_MAC_TRAFFIC_LIGHTS_Y_NUDGE = 'calc(var(--spacing) * 0.9)'
 
-export function titlebarControlsYNudge(
-  windowButtonPosition: HermesConnection['windowButtonPosition'] | undefined
+export interface TitlebarChromeContext {
+  darwinMajor?: number
+  isFullscreen?: boolean
+  windowButtonPosition?: HermesConnection['windowButtonPosition']
+}
+
+export function titlebarControlsYNudge({
+  darwinMajor = 0,
+  isFullscreen = false,
+  windowButtonPosition
+}: TitlebarChromeContext = {}): string {
+  if (isFullscreen || windowButtonPosition === null || darwinMajor >= MACOS_TAHOE_DARWIN_MAJOR) {
+    return '0px'
+  }
+
+  return TITLEBAR_MAC_TRAFFIC_LIGHTS_Y_NUDGE
+}
+
+/** Right-cluster inset — WCO width when present; macOS fullscreen matches left edge inset. */
+export function titlebarToolsRightCss(
+  nativeOverlayWidth: number,
+  { darwinMajor = 0, isFullscreen = false }: Pick<TitlebarChromeContext, 'darwinMajor' | 'isFullscreen'> = {}
 ): string {
-  return windowButtonPosition !== null ? TITLEBAR_MAC_TRAFFIC_LIGHTS_Y_NUDGE : '0px'
+  if (nativeOverlayWidth > 0) {
+    return `${nativeOverlayWidth}px`
+  }
+
+  if (isFullscreen && darwinMajor > 0) {
+    return `${TITLEBAR_EDGE_INSET}px`
+  }
+
+  return '0.75rem'
 }
 
 // Titlebar palette only. All sizing/radius/cursor/centering come from the

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -499,6 +499,7 @@ export interface DesktopUpdateProgress {
 
 export interface HermesConnection {
   baseUrl: string
+  darwinMajor?: number
   isFullscreen: boolean
   // The live, RESOLVED connection mode. Only ever 'local' or 'remote' — a
   // 'cloud' saved-config entry resolves to a 'remote' connection under the hood
@@ -532,6 +533,7 @@ export interface HermesActiveWork {
 }
 
 export interface HermesWindowState {
+  darwinMajor?: number
   isFullscreen: boolean
   isMinimized?: boolean
   isVisible?: boolean


### PR DESCRIPTION
## Summary

- Skip the left-cluster Y nudge on macOS Tahoe (Darwin 25+), where traffic lights already sit correctly without the optical translate.
- In macOS fullscreen, clear `windowButtonPosition` in the main process so the renderer drops traffic-light dodge chrome; also skip the Y nudge and pin the right cluster with the same edge inset as the left.

## Test plan

- [ ] Tahoe: left titlebar cluster has no Y nudge; icons still 24×24 / 13.9px
- [ ] Pre-Tahoe macOS: Y nudge still applies beside visible traffic lights
- [ ] macOS fullscreen: no traffic-light offset or Y nudge; left/right clusters use edge inset