### PR TITLE
fix(web): let paste fall through to xterm when Clipboard API is unavailable

### DIFF
--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -17,6 +17,7 @@ class FakeWebglAddon {
 }
 
 class FakeTerminal {
+  static instances: FakeTerminal[] = [];
   options: Record<string, unknown>;
   rows = 24;
   cols = 80;
@@ -24,12 +25,15 @@ class FakeTerminal {
     registerOscHandler: vi.fn(),
   };
   unicode = { activeVersion: "" };
+  keyHandler: ((ev: KeyboardEvent) => boolean) | null = null;
 
   constructor(options: Record<string, unknown>) {
     this.options = options;
+    FakeTerminal.instances.push(this);
   }
 
-  attachCustomKeyEventHandler() {
+  attachCustomKeyEventHandler(handler: (ev: KeyboardEvent) => boolean) {
+    this.keyHandler = handler;
     return true;
   }
 
@@ -146,6 +150,25 @@ type CloseEventLike = {
 let container: HTMLDivElement;
 let root: Root;
 
+// jsdom runs without an origin here (per-file @vitest-environment jsdom on a
+// node-default config), so localStorage is undefined. Stub it so components
+// that persist UI state (side panel collapse) can be exercised.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
 async function render(ui: ReactNode) {
   container = document.createElement("div");
   document.body.append(container);
@@ -155,6 +178,7 @@ async function render(ui: ReactNode) {
 
 beforeEach(() => {
   FakeWebSocket.instances = [];
+  FakeTerminal.instances = [];
   maybeReloadForLoopbackWsAuthFailure.mockClear();
   apiMocks.buildWsUrl.mockReset();
   apiMocks.buildWsUrl.mockResolvedValue("ws://localhost/api/pty?channel=chat-1");
@@ -208,6 +232,8 @@ beforeEach(() => {
     },
   });
   sessionStorage.clear();
+  vi.stubGlobal("localStorage", localStorageMock);
+  localStorageMock.clear();
 });
 
 afterEach(async () => {
@@ -322,5 +348,62 @@ describe("ChatPage PTY ticket connect deadline", () => {
     // force-close a wedged handshake — the two must not both fire.
     await advance(PTY_TICKET_TIMEOUT_MS);
     expect(apiMocks.buildWsUrl).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Paste shortcut handling: the dashboard is often opened over plain http
+// from a remote host (non-secure context), where the async Clipboard API is
+// undefined. In that case Cmd/Ctrl+Shift+V must NOT be intercepted — the
+// keydown handler returns true so the DOM paste event reaches xterm, whose
+// hidden textarea pastes without the Clipboard API (same path as
+// context-menu paste). When the API exists, the shortcut stays intercepted.
+describe("ChatPage paste shortcut", () => {
+  async function renderChat() {
+    const { default: ChatPage } = await import("./ChatPage");
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+  }
+
+  function pasteKeydown() {
+    return {
+      type: "keydown",
+      key: "v",
+      ctrlKey: true,
+      shiftKey: true,
+      metaKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent;
+  }
+
+  it("falls through to the DOM paste path when the Clipboard API is unavailable", async () => {
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    await renderChat();
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const term = FakeTerminal.instances[0];
+    expect(term.keyHandler).toBeDefined();
+
+    // Non-mac test runner: the paste modifier is Ctrl+Shift (see hotkeys).
+    const ev = pasteKeydown();
+    expect(term.keyHandler!(ev)).toBe(true);
+    expect(ev.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("still intercepts the paste shortcut when the Clipboard API exists", async () => {
+    // beforeEach defines navigator.clipboard.readText/writeText.
+    await renderChat();
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const term = FakeTerminal.instances[0];
+    const ev = pasteKeydown();
+    expect(term.keyHandler!(ev)).toBe(false);
+    expect(ev.preventDefault).toHaveBeenCalled();
   });
 });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -672,6 +672,18 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
 
       if (pasteModifier && ev.key.toLowerCase() === "v") {
+        // Non-secure context (dashboard opened over plain http from a
+        // remote host): the async Clipboard API is undefined, so the
+        // read()/readText() path below can never succeed. Don't
+        // preventDefault — let the DOM paste event reach xterm, whose
+        // hidden textarea pastes without the Clipboard API (the same
+        // path context-menu paste uses).
+        if (
+          typeof navigator.clipboard?.read !== "function" &&
+          typeof navigator.clipboard?.readText !== "function"
+        ) {
+          return true;
+        }
         // preventDefault suppresses the DOM paste event, so image paste must
         // be handled here via clipboard.read() — readText() alone misses
         // image-only clipboards (the Discord / #24860 failure mode).


### PR DESCRIPTION
## Summary

The dashboard chat tab is often opened over plain http from a remote host, which is a **non-secure context**: `navigator.clipboard` is undefined there, so the Cmd/Ctrl+Shift+V keydown handler could never read the clipboard — yet it still called `preventDefault()`, which also suppressed the DOM paste event that would have reached xterm's hidden textarea (the same path context-menu paste uses). Result: no working paste shortcut at all, only right-click paste.

When the Clipboard API is unavailable, return `true` from the keydown handler instead of intercepting, so the browser's native paste event reaches xterm and pastes without the API.

## Test Plan

- New unit tests in `web/src/pages/ChatPage.test.tsx`: paste falls through to the DOM path when the Clipboard API is unavailable; the shortcut is still intercepted when the API exists
- `npx vitest run src/pages/ChatPage.test.tsx` → 6 passing
- `npx tsc -p tsconfig.app.json --noEmit` → clean
- `npx eslint src/pages/ChatPage.tsx src/pages/ChatPage.test.tsx` → 0 errors
- Manually verified in a real deployment opened over plain http from a remote macOS host: Cmd+V now pastes text into the chat (right-click paste already worked).