### PR TITLE
fix(vision): describe images via aux vision on text-only model failover

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -16,6 +16,7 @@ resolved through :func:`_ra` so those patches keep working.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -1149,6 +1150,160 @@ def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool
     return False
 
 
+def _run_aux_vision_sync(image_ref: str, timeout: float = 90.0) -> str:
+    """Describe an image via the auxiliary vision model from a sync context.
+
+    ``run_conversation`` (and therefore failover recovery) is synchronous,
+    while the vision tool is async.  This bridges the two with the same
+    pattern as ``context_references.preprocess_context_references_async``:
+    a running loop gets the coroutine executed in a worker thread, otherwise
+    ``asyncio.run`` is used directly.
+
+    Returns the analysis text, or "" when the aux vision call fails or
+    returns nothing usable (the caller falls back to a placeholder).
+    """
+    async def _describe() -> str:
+        try:
+            from tools.vision_tools import vision_analyze_tool
+
+            result = await vision_analyze_tool(
+                image_ref,
+                "Describe this image in detail. Include all visible text, "
+                "numbers, objects, UI elements and layout.",
+            )
+            import json as _json
+
+            try:
+                parsed = _json.loads(result)
+                if isinstance(parsed, dict):
+                    text = parsed.get("analysis") or parsed.get("error") or ""
+                    return str(text).strip()
+            except Exception:
+                pass
+            return str(result).strip()
+        except Exception:
+            return ""
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is not None and loop.is_running():
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, _describe()).result(timeout=timeout)
+    return asyncio.run(_describe())
+
+
+def _extract_image_ref(part: Dict[str, Any]) -> str:
+    """Extract a usable image reference (data: or http(s): URL) from a
+    multimodal content part, or \"\" when the part carries none."""
+    ptype = part.get("type")
+    if ptype == "image_url":
+        nested = part.get("image_url")
+        if isinstance(nested, dict):
+            return str(nested.get("url") or "").strip()
+        return str(nested or "").strip()
+    if ptype == "input_image":
+        nested = part.get("image_url")
+        return str(nested or "").strip()
+    if ptype == "image":
+        # Anthropic-style base64 source — not a URL we can re-send;
+        # leave it to the placeholder path.
+        return ""
+    return ""
+
+
+def _sync_failover_vision_support(agent, api_messages) -> bool:
+    """After a provider failover, verify the new model accepts image input.
+
+    The image-input mode (native vs text) is decided once per turn against
+    the PRIMARY model. If the primary dies and the fallback chain lands on
+    a text-only model, image_url parts already embedded in api_messages are
+    rejected with HTTP 400 (e.g. DeepSeek's "unknown variant `image_url`").
+    Instead of dropping the pixels outright, each image is described through
+    the auxiliary vision model and the part is replaced with a text
+    description in place — the failover model still learns what the image
+    contained, without ever shipping image bytes it rejects.
+
+    Returns True if any image part was replaced.
+    """
+    if not getattr(agent, "_vision_supported", True):
+        return False
+    try:
+        from agent.image_routing import _lookup_supports_vision
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        supports = _lookup_supports_vision(
+            getattr(agent, "provider", "") or "",
+            getattr(agent, "model", "") or "",
+            cfg,
+            requested_provider=getattr(agent, "requested_provider", "") or "",
+        )
+    except Exception:
+        logger.debug("failover vision sync: capability lookup failed", exc_info=True)
+        return False
+    if supports is not False:
+        # Vision-capable or unknown — leave images alone.  Unknown falls
+        # through to the existing reactive 4xx image-rejection recovery.
+        return False
+    if not isinstance(api_messages, list) or not api_messages:
+        return False
+
+    # Collect every multimodal part that carries an image reference.
+    image_sites = []  # (message, part)
+    for msg in api_messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if (
+                isinstance(part, dict)
+                and part.get("type") in ("image_url", "image", "input_image")
+            ):
+                image_sites.append((msg, part))
+    if not image_sites:
+        return False
+
+    replaced = 0
+    for _msg, part in image_sites:
+        ref = _extract_image_ref(part)
+        description = _run_aux_vision_sync(ref) if ref else ""
+        # Replace the image part with a text part in place, preserving the
+        # containing message (tool_call_id linkage etc.).
+        part.clear()
+        part["type"] = "text"
+        if description:
+            part["text"] = (
+                "[Image content — described by vision model: " + description + "]"
+            )
+        else:
+            part["text"] = (
+                "[image content removed — server does not support images]"
+            )
+        replaced += 1
+
+    agent._vision_supported = False
+    # Also set the module-level flag in vision_tools so that
+    # _should_use_native_vision_fast_path() returns False for the rest of
+    # this turn — the runtime-main globals still point at the (vision-capable)
+    # primary, so without this the fast path would deliver image bytes to the
+    # text-only fallback model on every vision_analyze tool call.
+    try:
+        import tools.vision_tools as _vt
+        _vt._failover_vision_disabled = True
+    except Exception:
+        pass
+    logger.info(
+        "Failover vision sync: fallback model %s (%s) does not support "
+        "images — replaced %d image part(s) with vision descriptions",
+        agent.model, agent.provider, replaced,
+    )
+    return replaced > 0
+
+
 def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     """Refresh the in-flight system message after a provider failover.
 
@@ -1161,9 +1316,14 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     whole turn (and every gateway turn, since fallback re-activates per
     message while the primary is down) ships the stale identity.
 
+    Also verifies the failover model accepts image input (see
+    ``_sync_failover_vision_support``) so a text-only fallback strips
+    embedded image parts before the retry instead of 400-ing on them.
+
     Mutates ``api_messages[0]`` in place and returns the prompt to use as
     ``active_system_prompt`` for subsequent call-block rebuilds.
     """
+    _sync_failover_vision_support(agent, api_messages)
     sp = getattr(agent, "_cached_system_prompt", None)
     if not isinstance(sp, str) or not sp:
         return active_system_prompt

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -572,6 +572,13 @@ def build_turn_context(
     if callable(_reset_consol):
         _reset_consol()
     agent._vision_supported = True
+    # Clear the failover-vision-disabled flag so vision_analyze's native fast
+    # path is re-enabled when the primary (vision-capable) model is restored.
+    try:
+        import tools.vision_tools as _vt
+        _vt._failover_vision_disabled = False
+    except Exception:
+        pass
 
     # Pre-turn connection health check: clean up dead TCP connections.
     if agent.api_mode != "anthropic_messages":

--- a/tests/agent/test_failover_identity.py
+++ b/tests/agent/test_failover_identity.py
@@ -352,3 +352,191 @@ class TestPeelReferenceGuidanceRoundTrip:
         ]
         peeled = peel_reference_guidance(messages, self._GUIDANCE)
         assert peeled == messages[:-1]
+
+
+# =============================================================================
+# Failover vision support sync
+# =============================================================================
+
+
+class TestFailoverVisionSupport:
+    """``_sync_failover_vision_support`` replaces image parts with auxiliary
+    vision descriptions when the failover model is text-only, so a retry
+    doesn't 400 on embedded image_url parts and the model still learns what
+    the image contained."""
+
+    def _agent(self, *, provider="deepseek", model="deepseek-v4-flash"):
+        return SimpleNamespace(
+            provider=provider,
+            model=model,
+            requested_provider=provider,
+            _vision_supported=True,
+        )
+
+    def _image_messages(self):
+        return [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this"},
+                    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+                ],
+            },
+        ]
+
+    def _patch_lookup(self, monkeypatch, result):
+        def _fake_lookup(provider, model, cfg, requested_provider=""):
+            return result
+
+        monkeypatch.setattr(
+            "agent.image_routing._lookup_supports_vision", _fake_lookup
+        )
+
+    def _patch_aux_vision(self, monkeypatch, description="a screenshot of a dashboard"):
+        def _fake_aux_vision(image_ref, timeout=90.0):
+            return description
+
+        monkeypatch.setattr(
+            "agent.conversation_loop._run_aux_vision_sync", _fake_aux_vision
+        )
+
+    def test_text_only_fallback_replaces_with_description(self, monkeypatch):
+        agent = self._agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = self._image_messages()
+        self._patch_lookup(monkeypatch, False)
+        self._patch_aux_vision(monkeypatch, "deepseek dashboard with balance $0.98")
+
+        from agent.conversation_loop import _sync_failover_vision_support
+
+        replaced = _sync_failover_vision_support(agent, messages)
+        assert replaced is True
+        assert agent._vision_supported is False
+        user_content = messages[1]["content"]
+        # Image part replaced with a text description, original text kept.
+        assert all(p.get("type") != "image_url" for p in user_content)
+        texts = [p.get("text", "") for p in user_content if p.get("type") == "text"]
+        assert any("look at this" in t for t in texts)
+        assert any("dashboard with balance" in t for t in texts)
+
+    def test_aux_vision_failure_falls_back_to_placeholder(self, monkeypatch):
+        agent = self._agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = self._image_messages()
+        self._patch_lookup(monkeypatch, False)
+        self._patch_aux_vision(monkeypatch, "")  # aux vision failed
+
+        from agent.conversation_loop import _sync_failover_vision_support
+
+        replaced = _sync_failover_vision_support(agent, messages)
+        assert replaced is True
+        assert agent._vision_supported is False
+        user_content = messages[1]["content"]
+        texts = [p.get("text", "") for p in user_content if p.get("type") == "text"]
+        assert any("image content removed" in t for t in texts)
+
+    def test_vision_fallback_keeps_images(self, monkeypatch):
+        agent = self._agent(provider="litellm", model="kimi-router")
+        messages = self._image_messages()
+        self._patch_lookup(monkeypatch, True)
+        self._patch_aux_vision(monkeypatch)
+
+        from agent.conversation_loop import _sync_failover_vision_support
+
+        replaced = _sync_failover_vision_support(agent, messages)
+        assert replaced is False
+        assert agent._vision_supported is True
+        user_content = messages[1]["content"]
+        assert any(p.get("type") == "image_url" for p in user_content)
+
+    def test_already_vision_unsupported_skips(self, monkeypatch):
+        agent = self._agent()
+        agent._vision_supported = False
+        messages = self._image_messages()
+        self._patch_lookup(monkeypatch, True)
+        self._patch_aux_vision(monkeypatch)
+
+        from agent.conversation_loop import _sync_failover_vision_support
+
+        replaced = _sync_failover_vision_support(agent, messages)
+        assert replaced is False
+        # Images untouched.
+        user_content = messages[1]["content"]
+        assert any(p.get("type") == "image_url" for p in user_content)
+
+    def test_tool_message_placeholder_preserves_linkage(self, monkeypatch):
+        """A tool message whose content was entirely images keeps its
+        message (and tool_call_id linkage); only the part is replaced."""
+        agent = self._agent()
+        self._patch_lookup(monkeypatch, False)
+        self._patch_aux_vision(monkeypatch, "")
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]},
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,BBBB"}}],
+            },
+        ]
+        from agent.conversation_loop import _sync_failover_vision_support
+
+        replaced = _sync_failover_vision_support(agent, messages)
+        assert replaced is True
+        assert len(messages) == 3  # tool message NOT deleted
+        assert messages[2]["role"] == "tool"
+        assert messages[2]["tool_call_id"] == "call_1"
+        content = messages[2]["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "text"
+        assert "image content removed" in content[0]["text"]
+
+
+class TestFailoverVisionDisablesFastPath:
+    """When _sync_failover_vision_support fires, it must also set the
+    module-level ``_failover_vision_disabled`` flag in vision_tools so that
+    ``_should_use_native_vision_fast_path`` returns False for the rest of the
+    turn.  Otherwise the fast path (which reads stale runtime-main globals
+    still pointing at the vision-capable primary) would deliver image bytes
+    to the text-only fallback model on every vision_analyze tool call."""
+
+    def test_text_only_failover_sets_vision_tools_flag(self, monkeypatch):
+        import tools.vision_tools as vt
+
+        vt._failover_vision_disabled = False  # reset
+        agent = SimpleNamespace(
+            provider="deepseek",
+            model="deepseek-v4-flash",
+            requested_provider="deepseek",
+            _vision_supported=True,
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+                ],
+            },
+        ]
+
+        def _fake_lookup(provider, model, cfg, requested_provider=""):
+            return False
+
+        def _fake_aux(image_ref, timeout=90.0):
+            return "a red car"
+
+        monkeypatch.setattr("agent.image_routing._lookup_supports_vision", _fake_lookup)
+        monkeypatch.setattr("agent.conversation_loop._run_aux_vision_sync", _fake_aux)
+
+        from agent.conversation_loop import _sync_failover_vision_support
+
+        _sync_failover_vision_support(agent, messages)
+        assert vt._failover_vision_disabled is True
+
+    def test_fast_path_returns_false_after_failover(self, monkeypatch):
+        import tools.vision_tools as vt
+
+        vt._failover_vision_disabled = True
+        assert vt._should_use_native_vision_fast_path() is False
+        vt._failover_vision_disabled = False  # cleanup

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -71,6 +71,15 @@ logger = logging.getLogger(__name__)
 
 _debug = DebugSession("vision_tools", env_var="VISION_TOOLS_DEBUG")
 
+# Module-level flag set by _sync_failover_vision_support when a provider
+# failover lands on a text-only model.  Checked by
+# _should_use_native_vision_fast_path to avoid returning pixels to a model
+# that already had its inline images stripped/described — the runtime-main
+# globals still reflect the (vision-capable) primary, so without this flag
+# the fast path would short-circuit and deliver image bytes to a text-only
+# fallback model.  Cleared on primary restore (turn_context).
+_failover_vision_disabled: bool = False
+
 # Configurable HTTP download timeout for _download_image().
 # Separate from auxiliary.vision.timeout which governs the LLM API call.
 # Resolution: config.yaml auxiliary.vision.download_timeout → env var → 30s default.
@@ -1046,7 +1055,17 @@ def _should_use_native_vision_fast_path() -> bool:
     The override is the escape hatch for custom/local providers that aren't in
     the static allowlist. Best-effort: any resolution failure returns False so
     the caller falls back to the legacy aux-LLM path.
+
+    Returns False (forcing the aux-LLM text path) when a provider failover has
+    landed on a text-only model mid-turn — detected via
+    ``_failover_vision_disabled``, set by ``_sync_failover_vision_support``.
+    The runtime-main globals still reflect the (vision-capable) primary, so
+    without this check the fast path would deliver image bytes to a model
+    that already had its inline images stripped.
     """
+    if _failover_vision_disabled:
+        logger.debug("Native vision fast-path disabled: failover to text-only model")
+        return False
     try:
         from agent.auxiliary_client import _read_main_provider, _read_main_model
         from agent.image_routing import decide_image_input_mode, _lookup_supports_vision


### PR DESCRIPTION
## Problem

When the primary model (vision-capable) dies mid-turn and the fallback chain lands on a text-only model (e.g. DeepSeek), two bugs occur:

1. **Inline image parts in api_messages cause 400 errors** — the text-only model rejects `image_url` parts it cannot process.

2. **`vision_analyze` tool still uses the native fast path** — `_should_use_native_vision_fast_path()` reads stale runtime-main globals (still pointing at the vision-capable primary), so every `vision_analyze` call returns image bytes that the text-only fallback model cannot process.

## Fix

`_sync_failover_vision_support` (called after every provider failover):
- Looks up the failover model's vision capability via `_lookup_supports_vision`
- If text-only and image parts present — describes each image via the **auxiliary vision LLM** and replaces the part in place with a text description
- Falls back to a plaintext placeholder if aux vision fails
- Sets `agent._vision_supported = False`
- Sets module-level `_failover_vision_disabled` flag in `vision_tools`

`_should_use_native_vision_fast_path` (vision_tools.py):
- Checks `_failover_vision_disabled` at the top — returns `False` when set, forcing `vision_analyze` through the auxiliary vision text path

`turn_context.build_turn_context`:
- Clears `_failover_vision_disabled` on primary restore, re-enabling the native fast path when the vision-capable primary is back

## Tests

`TestFailoverVisionSupport` (5 cases): text-only replacement, aux-vision failure placeholder, vision-capable pass-through, already-unsupported skip, tool-message linkage.

`TestFailoverVisionDisablesFastPath` (2 cases): text-only failover sets the vision_tools flag, fast path returns False when flag is set.

```
18 passed in 0.64s
```