### PR TITLE
feat(mcp): add read-only mode and tunnel recovery skill

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1076,7 +1076,10 @@ def mcp_command(args):
 
     if action == "serve":
         from mcp_serve import run_mcp_server
-        run_mcp_server(verbose=getattr(args, "verbose", False))
+        run_mcp_server(
+            verbose=getattr(args, "verbose", False),
+            read_only=getattr(args, "read_only", False),
+        )
         return
 
     # Catalog subcommands live in mcp_picker / mcp_catalog. Import lazily so

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -36,6 +36,11 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         action="store_true",
         help="Enable verbose logging on stderr",
     )
+    mcp_serve_p.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Expose only non-mutating tools with read-only MCP annotations",
+    )
     add_accept_hooks_flag(mcp_serve_p)
 
     mcp_add_p = mcp_sub.add_parser(

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -50,10 +50,12 @@ logger = logging.getLogger("hermes.mcp_serve")
 _MCP_SERVER_AVAILABLE = False
 try:
     from mcp.server.fastmcp import FastMCP
+    from mcp.types import ToolAnnotations
 
     _MCP_SERVER_AVAILABLE = True
 except ImportError:
     FastMCP = None  # type: ignore[assignment,misc]
+    ToolAnnotations = None  # type: ignore[assignment,misc]
 
 
 # ---------------------------------------------------------------------------
@@ -587,8 +589,11 @@ class EventBridge:
 # MCP Server
 # ---------------------------------------------------------------------------
 
-def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
-    """Create and return the Hermes MCP server with all tools registered."""
+def create_mcp_server(
+    event_bridge: Optional[EventBridge] = None,
+    read_only: bool = False,
+) -> "FastMCP":
+    """Create the Hermes MCP server, optionally omitting mutating tools."""
     if not _MCP_SERVER_AVAILABLE:
         raise ImportError(
             "MCP server requires the 'mcp' package. "
@@ -605,10 +610,22 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
     )
 
     bridge = event_bridge or EventBridge()
+    read_only_annotations = ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+
+    def register_mutating_tool(fn):
+        """Register a mutating tool unless this server is restricted."""
+        if read_only:
+            return fn
+        return mcp.tool()(fn)
 
     # -- conversations_list ------------------------------------------------
 
-    @mcp.tool()
+    @mcp.tool(annotations=read_only_annotations)
     def conversations_list(
         platform: Optional[str] = None,
         limit: int = 50,
@@ -665,7 +682,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- conversation_get --------------------------------------------------
 
-    @mcp.tool()
+    @mcp.tool(annotations=read_only_annotations)
     def conversation_get(session_key: str) -> str:
         """Get detailed info about one conversation by its session key.
 
@@ -698,7 +715,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- messages_read -----------------------------------------------------
 
-    @mcp.tool()
+    @mcp.tool(annotations=read_only_annotations)
     def messages_read(
         session_key: str,
         limit: int = 50,
@@ -755,7 +772,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- attachments_fetch -------------------------------------------------
 
-    @mcp.tool()
+    @mcp.tool(annotations=read_only_annotations)
     def attachments_fetch(
         session_key: str,
         message_id: str,
@@ -807,7 +824,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- events_poll -------------------------------------------------------
 
-    @mcp.tool()
+    @mcp.tool(annotations=read_only_annotations)
     def events_poll(
         after_cursor: int = 0,
         session_key: Optional[str] = None,
@@ -836,7 +853,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- events_wait -------------------------------------------------------
 
-    @mcp.tool()
+    @mcp.tool(annotations=read_only_annotations)
     def events_wait(
         after_cursor: int = 0,
         session_key: Optional[str] = None,
@@ -870,7 +887,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- messages_send -----------------------------------------------------
 
-    @mcp.tool()
+    @register_mutating_tool
     def messages_send(
         target: str,
         message: str,
@@ -906,7 +923,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- channels_list -----------------------------------------------------
 
-    @mcp.tool()
+    @mcp.tool(annotations=read_only_annotations)
     def channels_list(platform: Optional[str] = None) -> str:
         """List available messaging channels and targets across platforms.
 
@@ -960,7 +977,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- permissions_list_open ---------------------------------------------
 
-    @mcp.tool()
+    @mcp.tool(annotations=read_only_annotations)
     def permissions_list_open() -> str:
         """List pending approval requests observed during this bridge session.
 
@@ -976,7 +993,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     # -- permissions_respond -----------------------------------------------
 
-    @mcp.tool()
+    @register_mutating_tool
     def permissions_respond(
         id: str,
         decision: str,
@@ -1003,7 +1020,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 # Entry point
 # ---------------------------------------------------------------------------
 
-def run_mcp_server(verbose: bool = False) -> None:
+def run_mcp_server(verbose: bool = False, read_only: bool = False) -> None:
     """Start the Hermes MCP server on stdio."""
     if not _MCP_SERVER_AVAILABLE:
         print(
@@ -1021,7 +1038,7 @@ def run_mcp_server(verbose: bool = False) -> None:
     bridge = EventBridge()
     bridge.start()
 
-    server = create_mcp_server(event_bridge=bridge)
+    server = create_mcp_server(event_bridge=bridge, read_only=read_only)
 
     import asyncio
 

--- a/optional-skills/autonomous-ai-agents/recovering-mcp-tunnel-account-context/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/recovering-mcp-tunnel-account-context/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: recovering-mcp-tunnel-account-context
+description: Use when MCP tunnel setup fails before daemon traffic.
+version: 0.1.0
+author: Wade Packard (brandonwadepackard-cell), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    category: autonomous-ai-agents
+    tags: [MCP, Tunnel, OpenAI, Recovery, Read-Only]
+    related_skills: [hermes-agent]
+---
+
+# Recovering MCP Tunnel Account Context Skill
+
+Recover secure MCP tunnels that are locally healthy but fail in the ChatGPT
+control plane. This procedure preserves the working rollback path, protects
+credentials, and proves a replacement end to end.
+
+## When to Use
+
+- Connector creation fails with `424`, upstream `401`, or an active-
+  organization-context error.
+- The managed runtime is ready but a connector attempt produces zero daemon
+  traffic.
+- ChatGPT and the OpenAI Platform may use different accounts, organizations,
+  or workspaces.
+
+Do not use when the request reaches the daemon. Debug the MCP server or managed
+runtime instead.
+
+## Prerequisites
+
+- A current `tunnel-client` installation and access to its managed-runtime
+  status and logs.
+- Hermes with the restricted command `hermes mcp serve --read-only`.
+- Access to the ChatGPT workspace and OpenAI Platform organization intended to
+  own the new tunnel. The user completes login, OAuth, and 2FA privately.
+- An intact old tunnel/runtime/profile to preserve as rollback.
+
+## How to Run
+
+Use `terminal` for current CLI help, sanitized status, and log correlation. Use
+`browser_navigate` for the official ChatGPT and Platform account surfaces, and
+`web_search` or `web_extract` only for official OpenAI documentation. Do not
+show or execute syntax until every subcommand, flag, and key-source form is
+verified from those current sources.
+
+## Quick Reference
+
+| Evidence | Work next |
+|---|---|
+| Request reached daemon | Local MCP/runtime path |
+| Zero daemon traffic plus organization-context error | Identity chain |
+| Aligned identity chain plus same error | Capture once, then escalate |
+
+A Platform usage balance and a ChatGPT subscription are separate. A new
+account matters because it can split the identity chain, not because debt
+travels through the tunnel.
+
+## Procedure
+
+### 1. Freeze rollback
+
+Record the old alias, tunnel/profile paths, and sanitized runtime state. Do not
+copy or export profiles, environment files, cookies, tokens, or key material.
+Keep the old runtime running.
+
+**Done when:** the old runtime remains healthy and untouched.
+
+### 2. Classify one captured failure
+
+Record a timestamp and log offsets, submit one connector attempt, and correlate
+the sanitized connector response with daemon traffic. Zero daemon traffic plus
+the organization-context error is a control-plane signal; daemon traffic sends
+the investigation back to the local MCP/runtime path.
+
+**Done when:** evidence, not local readiness alone, identifies the failing side.
+
+### 3. Align the identity chain
+
+Side by side, compare the masked ChatGPT account and selected workspace with
+the masked Platform account and active organization. Matching displayed email
+text is insufficient: the account must be offered the intended ChatGPT
+workspace and be authorized for the Platform organization.
+
+**Done when:** one account context owns or can access every new resource.
+
+### 4. Create the replacement in parallel
+
+Create a distinct tunnel under the aligned context and use only its new IDs;
+never reuse an old workspace ID. Create the runtime key through the official
+picker and store it through an environment/provider wizard or hidden input in
+an owner-only file. Never print it or place it in chat, argv, logs, or archives.
+
+Executable syntax is allowed only after live verification with `terminal` help
+or official documentation. A handoff, memory, prior attempt, or agent answer
+is not proof. If syntax remains unverified, describe the operation without a
+code block and mark it unresolved.
+
+**Done when:** distinct tunnel, alias, profile, and key reference exist while
+the old runtime stays live.
+
+### 5. Start restricted Hermes
+
+Run the verified managed-runtime flow with `hermes mcp serve --read-only`.
+Require process running, healthy, ready, managed-runtime state ready, and no
+current error.
+
+**Done when:** the replacement runtime is ready before connector creation.
+
+### 6. Attach once
+
+From the aligned ChatGPT workspace, create and link the connector through the
+official UI. Capture only a sanitized result.
+
+**Done when:** connector creation succeeds and link status is `ACTIVE`.
+
+### 7. Prove the read-only boundary
+
+Trigger discovery and one harmless read call. Require daemon receipt,
+successful response posting, and exactly this tool set:
+
+- `attachments_fetch`
+- `channels_list`
+- `conversation_get`
+- `conversations_list`
+- `events_poll`
+- `events_wait`
+- `messages_read`
+- `permissions_list_open`
+
+Every tool must advertise `readOnlyHint=true` and `destructiveHint=false`.
+Require `messages_send` and `permissions_respond` absent from discovery. Do not
+invoke a mutating tool merely to test that it is absent.
+
+**Done when:** exact discovery and a real read round trip both pass.
+
+### 8. Cut over safely
+
+Stop only the precisely identified old runtime. Preserve its tunnel,
+connector, profile, alias, and key reference for rollback. Recheck the new
+runtime and repeat one harmless read after the old runtime stops.
+
+**Done when:** the replacement remains ready and independent after cutover.
+
+## Pitfalls
+
+- Blaming plan gating before identity proof.
+- Adding organization headers to the local daemon for a pre-daemon failure.
+- Calling remembered syntax an example. Users copy examples; omit unverified
+  commands.
+- Assuming shell variables make an unverified secret workflow safe.
+- Declaring success from HTTP `200`, visible tools, or runtime readiness alone.
+- Opening support before testing one matched identity chain.
+
+## Verification
+
+Recovery requires every gate: aligned identity chain, ready restricted runtime,
+connector success, `ACTIVE` link, correlated daemon traffic, exact read-only
+tool discovery, mutating tools absent, a harmless read round trip, post-cutover
+readiness, and rollback artifacts preserved.
+
+If a matched identity chain still fails before daemon traffic, stop rebuilding.
+Escalate one sanitized captured attempt with timestamp and request/correlation
+identifier; include no credentials or full account identifiers.

--- a/optional-skills/autonomous-ai-agents/recovering-mcp-tunnel-account-context/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/recovering-mcp-tunnel-account-context/SKILL.md
@@ -59,6 +59,23 @@ A Platform usage balance and a ChatGPT subscription are separate. A new
 account matters because it can split the identity chain, not because debt
 travels through the tunnel.
 
+## Deployment Ownership
+
+Account-context recovery and same-alias maintenance are different operations.
+During account-context recovery, keep the old runtime running and create a
+distinct replacement. Do not unload the healthy rollback runtime before the
+replacement has passed connector, discovery, harmless-read, and post-cutover
+gates.
+
+For same-alias maintenance, first identify the mechanism that owns that exact
+alias. If a service manager owns it, stop or unload only that exact service
+immediately before a verified manual launcher is used, never run both owners
+concurrently, and restore normal supervision immediately afterward.
+
+Process/state metadata is authoritative only for the mechanism that created
+it. A service-owned process plus its live health probe may disagree with stale
+manual-launcher metadata. Local runtime health is not end-to-end proof.
+
 ## Procedure
 
 ### 1. Freeze rollback
@@ -104,9 +121,11 @@ the old runtime stays live.
 
 ### 5. Start restricted Hermes
 
-Run the verified managed-runtime flow with `hermes mcp serve --read-only`.
-Require process running, healthy, ready, managed-runtime state ready, and no
-current error.
+Run the verified replacement flow with `hermes mcp serve --read-only`. If the
+managed-runtime command owns the process, require its process and state fields,
+live health/readiness, and no current error. If a service manager owns it,
+require the service-owned process plus its live health probe; do not substitute
+stale metadata from a different launcher.
 
 **Done when:** the replacement runtime is ready before connector creation.
 
@@ -141,7 +160,8 @@ invoke a mutating tool merely to test that it is absent.
 
 Stop only the precisely identified old runtime. Preserve its tunnel,
 connector, profile, alias, and key reference for rollback. Recheck the new
-runtime and repeat one harmless read after the old runtime stops.
+runtime and repeat one harmless read after the old runtime stops. This is the
+first point at which recovery may stop or unload the healthy rollback service.
 
 **Done when:** the replacement remains ready and independent after cutover.
 

--- a/tests/hermes_cli/test_mcp_read_only.py
+++ b/tests/hermes_cli/test_mcp_read_only.py
@@ -1,0 +1,17 @@
+"""CLI coverage for the restricted Hermes MCP server surface."""
+
+import argparse
+
+from hermes_cli.subcommands.mcp import build_mcp_parser
+
+
+def test_mcp_serve_read_only_flag_is_parsed():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_mcp_parser(subparsers, cmd_mcp=lambda args: None)
+
+    args = parser.parse_args(["mcp", "serve", "--read-only"])
+
+    assert args.command == "mcp"
+    assert args.mcp_action == "serve"
+    assert args.read_only is True

--- a/tests/skills/test_recovering_mcp_tunnel_account_context_skill.py
+++ b/tests/skills/test_recovering_mcp_tunnel_account_context_skill.py
@@ -97,3 +97,15 @@ def test_recovery_and_read_only_invariants_are_explicit():
     }
     for tool in expected_tools | {"messages_send", "permissions_respond"}:
         assert f"`{tool}`" in body
+
+
+def test_recovery_keeps_rollback_live_and_separates_maintenance():
+    _, body = _frontmatter_and_body()
+    assert "Account-context recovery" in body
+    assert "same-alias maintenance" in body
+    assert "Do not unload the healthy rollback runtime" in body
+    assert "distinct replacement" in body
+    assert "Local runtime health is not end-to-end proof" in body
+    assert body.index("Keep the old runtime running") < body.index(
+        "Stop only the precisely identified old runtime"
+    )

--- a/tests/skills/test_recovering_mcp_tunnel_account_context_skill.py
+++ b/tests/skills/test_recovering_mcp_tunnel_account_context_skill.py
@@ -1,0 +1,99 @@
+"""Contract tests for the MCP tunnel account-context recovery skill."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "autonomous-ai-agents"
+    / "recovering-mcp-tunnel-account-context"
+    / "SKILL.md"
+)
+
+
+def _frontmatter_and_body():
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    match = re.search(r"\n---\s*\n", content[3:])
+    assert match, "frontmatter must close with ---"
+    frontmatter = yaml.safe_load(content[3 : match.start() + 3])
+    body = content[match.end() + 3 :]
+    return frontmatter, body
+
+
+def test_frontmatter_and_portability_contract():
+    frontmatter, _ = _frontmatter_and_body()
+    assert frontmatter["name"] == "recovering-mcp-tunnel-account-context"
+    assert len(frontmatter["description"]) <= 60
+    assert frontmatter["description"].endswith(".")
+    assert frontmatter["author"].startswith(
+        "Wade Packard (brandonwadepackard-cell),"
+    )
+    assert frontmatter["platforms"] == ["linux", "macos", "windows"]
+    assert frontmatter["metadata"]["hermes"]["category"] == (
+        "autonomous-ai-agents"
+    )
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "/Users/" not in content
+    assert "/home/" not in content
+    assert not re.search(r"sk-[A-Za-z0-9_-]{10,}", content)
+
+
+def test_related_skills_resolve_in_repo():
+    frontmatter, _ = _frontmatter_and_body()
+    repo_root = SKILL_PATH.parents[3]
+    for name in frontmatter["metadata"]["hermes"]["related_skills"]:
+        matches = list(repo_root.glob(f"skills/*/{name}/SKILL.md"))
+        matches += list(repo_root.glob(f"optional-skills/*/{name}/SKILL.md"))
+        assert matches, f"related skill does not resolve: {name}"
+
+
+def test_modern_sections_are_ordered():
+    _, body = _frontmatter_and_body()
+    sections = (
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    )
+    positions = [body.index(section) for section in sections]
+    assert positions == sorted(positions)
+
+
+def test_every_procedure_step_has_a_completion_gate():
+    _, body = _frontmatter_and_body()
+    steps = re.findall(
+        r"^### \d+\..*?(?=^### \d+\.|^## )",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert len(steps) == 8
+    assert all("**Done when:**" in step for step in steps)
+
+
+def test_recovery_and_read_only_invariants_are_explicit():
+    _, body = _frontmatter_and_body()
+    assert "zero daemon traffic" in body.lower()
+    assert "hermes mcp serve --read-only" in body
+    assert "link status is `ACTIVE`" in body
+    assert re.search(r"Do not\s+invoke a mutating tool", body)
+    assert "Keep the old runtime running" in body
+    expected_tools = {
+        "attachments_fetch",
+        "channels_list",
+        "conversation_get",
+        "conversations_list",
+        "events_poll",
+        "events_wait",
+        "messages_read",
+        "permissions_list_open",
+    }
+    for tool in expected_tools | {"messages_send", "permissions_respond"}:
+        assert f"`{tool}`" in body

--- a/tests/skills/test_recovering_mcp_tunnel_account_context_skill.py
+++ b/tests/skills/test_recovering_mcp_tunnel_account_context_skill.py
@@ -74,7 +74,7 @@ def test_every_procedure_step_has_a_completion_gate():
         body,
         re.MULTILINE | re.DOTALL,
     )
-    assert len(steps) == 8
+    assert steps, "procedure must contain numbered ### steps"
     assert all("**Done when:**" in step for step in steps)
 
 

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -963,6 +963,11 @@ class TestToolRegistration:
         server, _ = mcp_server_read_only_e2e
         tool_names = {tool.name for tool in server._tool_manager.list_tools()}
 
+        # Security allowlist — intentionally an exact set, not a relation to
+        # the default surface. "default minus the two mutating tools" would
+        # silently pass a future mutating tool that was wrongly registered
+        # unconditionally; the exact set fails closed and forces every new
+        # tool to make an explicit read-only membership decision here.
         assert tool_names == {
             "conversations_list", "conversation_get", "messages_read",
             "attachments_fetch", "events_poll", "events_wait",

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -208,18 +208,19 @@ def mock_session_db(tmp_path, populated_sessions_dir):
 
 
 class _FakeTool:
-    def __init__(self, fn):
+    def __init__(self, fn, annotations=None):
         self.name = fn.__name__
         self.description = inspect.getdoc(fn) or ""
         self.fn = fn
+        self.annotations = annotations
 
 
 class _FakeToolManager:
     def __init__(self):
         self._tools = {}
 
-    def add_tool(self, fn):
-        self._tools[fn.__name__] = _FakeTool(fn)
+    def add_tool(self, fn, annotations=None):
+        self._tools[fn.__name__] = _FakeTool(fn, annotations=annotations)
 
     async def call_tool(self, name, args=None):
         return self._tools[name].fn(**(args or {}))
@@ -232,9 +233,9 @@ class _FakeFastMCP:
     def __init__(self, *args, **kwargs):
         self._tool_manager = _FakeToolManager()
 
-    def tool(self):
+    def tool(self, **kwargs):
         def decorator(fn):
-            self._tool_manager.add_tool(fn)
+            self._tool_manager.add_tool(fn, annotations=kwargs.get("annotations"))
             return fn
 
         return decorator
@@ -506,6 +507,20 @@ def mcp_server_e2e(populated_sessions_dir, mock_session_db, monkeypatch):
 
     bridge = mcp_serve.EventBridge()
     server = mcp_serve.create_mcp_server(event_bridge=bridge)
+    return server, bridge
+
+
+@pytest.fixture
+def mcp_server_read_only_e2e(populated_sessions_dir, mock_session_db, monkeypatch):
+    """Create the restricted MCP surface used by read-only connectors."""
+    pytest.importorskip("mcp", reason="MCP SDK not installed")
+    import mcp_serve
+    monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
+    monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: mock_session_db)
+    monkeypatch.setattr(mcp_serve, "_load_channel_directory", lambda: {})
+
+    bridge = mcp_serve.EventBridge()
+    server = mcp_serve.create_mcp_server(event_bridge=bridge, read_only=True)
     return server, bridge
 
 
@@ -942,6 +957,28 @@ class TestToolRegistration:
         for tool in server._tool_manager.list_tools():
             assert tool.description, f"Tool {tool.name} has no description"
 
+    def test_read_only_mode_exposes_only_non_mutating_tools(
+        self, mcp_server_read_only_e2e, _event_loop
+    ):
+        server, _ = mcp_server_read_only_e2e
+        tool_names = {tool.name for tool in server._tool_manager.list_tools()}
+
+        assert tool_names == {
+            "conversations_list", "conversation_get", "messages_read",
+            "attachments_fetch", "events_poll", "events_wait",
+            "channels_list", "permissions_list_open",
+        }
+
+    def test_read_only_mode_marks_every_tool_read_only(
+        self, mcp_server_read_only_e2e, _event_loop
+    ):
+        server, _ = mcp_server_read_only_e2e
+
+        for tool in server._tool_manager.list_tools():
+            assert tool.annotations is not None, tool.name
+            assert tool.annotations.readOnlyHint is True, tool.name
+            assert tool.annotations.destructiveHint is False, tool.name
+
 
 # ---------------------------------------------------------------------------
 # 5. SERVER LIFECYCLE / CLI INTEGRATION
@@ -1009,10 +1046,10 @@ class TestCliIntegration:
         monkeypatch.setattr("mcp_serve.run_mcp_server", mock_run)
 
         import argparse
-        args = argparse.Namespace(mcp_action="serve", verbose=True)
+        args = argparse.Namespace(mcp_action="serve", verbose=True, read_only=True)
         from hermes_cli.mcp_config import mcp_command
         mcp_command(args)
-        mock_run.assert_called_once_with(verbose=True)
+        mock_run.assert_called_once_with(verbose=True, read_only=True)
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -36,6 +36,7 @@ hermes skills uninstall <skill-name>
 | [**grok**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok) | Delegate coding to xAI Grok Build CLI (features, PRs). |
 | [**honcho**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho) | Configure and troubleshoot Honcho memory for Hermes. |
 | [**openhands**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands) | Delegate coding to OpenHands CLI (model-agnostic, LiteLLM). |
+| [**recovering-mcp-tunnel-account-context**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-recovering-mcp-tunnel-account-context) | Use when MCP tunnel setup fails before daemon traffic. |
 
 ## blockchain
 

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-recovering-mcp-tunnel-account-context.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-recovering-mcp-tunnel-account-context.md
@@ -1,0 +1,184 @@
+---
+title: "Recovering Mcp Tunnel Account Context — Use when MCP tunnel setup fails before daemon traffic"
+sidebar_label: "Recovering Mcp Tunnel Account Context"
+description: "Use when MCP tunnel setup fails before daemon traffic"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Recovering Mcp Tunnel Account Context
+
+Use when MCP tunnel setup fails before daemon traffic.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/recovering-mcp-tunnel-account-context` |
+| Path | `optional-skills/autonomous-ai-agents/recovering-mcp-tunnel-account-context` |
+| Version | `0.1.0` |
+| Author | Wade Packard (brandonwadepackard-cell), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `MCP`, `Tunnel`, `OpenAI`, `Recovery`, `Read-Only` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Recovering MCP Tunnel Account Context Skill
+
+Recover secure MCP tunnels that are locally healthy but fail in the ChatGPT
+control plane. This procedure preserves the working rollback path, protects
+credentials, and proves a replacement end to end.
+
+## When to Use
+
+- Connector creation fails with `424`, upstream `401`, or an active-
+  organization-context error.
+- The managed runtime is ready but a connector attempt produces zero daemon
+  traffic.
+- ChatGPT and the OpenAI Platform may use different accounts, organizations,
+  or workspaces.
+
+Do not use when the request reaches the daemon. Debug the MCP server or managed
+runtime instead.
+
+## Prerequisites
+
+- A current `tunnel-client` installation and access to its managed-runtime
+  status and logs.
+- Hermes with the restricted command `hermes mcp serve --read-only`.
+- Access to the ChatGPT workspace and OpenAI Platform organization intended to
+  own the new tunnel. The user completes login, OAuth, and 2FA privately.
+- An intact old tunnel/runtime/profile to preserve as rollback.
+
+## How to Run
+
+Use `terminal` for current CLI help, sanitized status, and log correlation. Use
+`browser_navigate` for the official ChatGPT and Platform account surfaces, and
+`web_search` or `web_extract` only for official OpenAI documentation. Do not
+show or execute syntax until every subcommand, flag, and key-source form is
+verified from those current sources.
+
+## Quick Reference
+
+| Evidence | Work next |
+|---|---|
+| Request reached daemon | Local MCP/runtime path |
+| Zero daemon traffic plus organization-context error | Identity chain |
+| Aligned identity chain plus same error | Capture once, then escalate |
+
+A Platform usage balance and a ChatGPT subscription are separate. A new
+account matters because it can split the identity chain, not because debt
+travels through the tunnel.
+
+## Procedure
+
+### 1. Freeze rollback
+
+Record the old alias, tunnel/profile paths, and sanitized runtime state. Do not
+copy or export profiles, environment files, cookies, tokens, or key material.
+Keep the old runtime running.
+
+**Done when:** the old runtime remains healthy and untouched.
+
+### 2. Classify one captured failure
+
+Record a timestamp and log offsets, submit one connector attempt, and correlate
+the sanitized connector response with daemon traffic. Zero daemon traffic plus
+the organization-context error is a control-plane signal; daemon traffic sends
+the investigation back to the local MCP/runtime path.
+
+**Done when:** evidence, not local readiness alone, identifies the failing side.
+
+### 3. Align the identity chain
+
+Side by side, compare the masked ChatGPT account and selected workspace with
+the masked Platform account and active organization. Matching displayed email
+text is insufficient: the account must be offered the intended ChatGPT
+workspace and be authorized for the Platform organization.
+
+**Done when:** one account context owns or can access every new resource.
+
+### 4. Create the replacement in parallel
+
+Create a distinct tunnel under the aligned context and use only its new IDs;
+never reuse an old workspace ID. Create the runtime key through the official
+picker and store it through an environment/provider wizard or hidden input in
+an owner-only file. Never print it or place it in chat, argv, logs, or archives.
+
+Executable syntax is allowed only after live verification with `terminal` help
+or official documentation. A handoff, memory, prior attempt, or agent answer
+is not proof. If syntax remains unverified, describe the operation without a
+code block and mark it unresolved.
+
+**Done when:** distinct tunnel, alias, profile, and key reference exist while
+the old runtime stays live.
+
+### 5. Start restricted Hermes
+
+Run the verified managed-runtime flow with `hermes mcp serve --read-only`.
+Require process running, healthy, ready, managed-runtime state ready, and no
+current error.
+
+**Done when:** the replacement runtime is ready before connector creation.
+
+### 6. Attach once
+
+From the aligned ChatGPT workspace, create and link the connector through the
+official UI. Capture only a sanitized result.
+
+**Done when:** connector creation succeeds and link status is `ACTIVE`.
+
+### 7. Prove the read-only boundary
+
+Trigger discovery and one harmless read call. Require daemon receipt,
+successful response posting, and exactly this tool set:
+
+- `attachments_fetch`
+- `channels_list`
+- `conversation_get`
+- `conversations_list`
+- `events_poll`
+- `events_wait`
+- `messages_read`
+- `permissions_list_open`
+
+Every tool must advertise `readOnlyHint=true` and `destructiveHint=false`.
+Require `messages_send` and `permissions_respond` absent from discovery. Do not
+invoke a mutating tool merely to test that it is absent.
+
+**Done when:** exact discovery and a real read round trip both pass.
+
+### 8. Cut over safely
+
+Stop only the precisely identified old runtime. Preserve its tunnel,
+connector, profile, alias, and key reference for rollback. Recheck the new
+runtime and repeat one harmless read after the old runtime stops.
+
+**Done when:** the replacement remains ready and independent after cutover.
+
+## Pitfalls
+
+- Blaming plan gating before identity proof.
+- Adding organization headers to the local daemon for a pre-daemon failure.
+- Calling remembered syntax an example. Users copy examples; omit unverified
+  commands.
+- Assuming shell variables make an unverified secret workflow safe.
+- Declaring success from HTTP `200`, visible tools, or runtime readiness alone.
+- Opening support before testing one matched identity chain.
+
+## Verification
+
+Recovery requires every gate: aligned identity chain, ready restricted runtime,
+connector success, `ACTIVE` link, correlated daemon traffic, exact read-only
+tool discovery, mutating tools absent, a harmless read round trip, post-cutover
+readiness, and rollback artifacts preserved.
+
+If a matched identity chain still fails before daemon traffic, stop rebuilding.
+Escalate one sanitized captured attempt with timestamp and request/correlation
+identifier; include no credentials or full account identifiers.

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-recovering-mcp-tunnel-account-context.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-recovering-mcp-tunnel-account-context.md
@@ -76,6 +76,23 @@ A Platform usage balance and a ChatGPT subscription are separate. A new
 account matters because it can split the identity chain, not because debt
 travels through the tunnel.
 
+## Deployment Ownership
+
+Account-context recovery and same-alias maintenance are different operations.
+During account-context recovery, keep the old runtime running and create a
+distinct replacement. Do not unload the healthy rollback runtime before the
+replacement has passed connector, discovery, harmless-read, and post-cutover
+gates.
+
+For same-alias maintenance, first identify the mechanism that owns that exact
+alias. If a service manager owns it, stop or unload only that exact service
+immediately before a verified manual launcher is used, never run both owners
+concurrently, and restore normal supervision immediately afterward.
+
+Process/state metadata is authoritative only for the mechanism that created
+it. A service-owned process plus its live health probe may disagree with stale
+manual-launcher metadata. Local runtime health is not end-to-end proof.
+
 ## Procedure
 
 ### 1. Freeze rollback
@@ -121,9 +138,11 @@ the old runtime stays live.
 
 ### 5. Start restricted Hermes
 
-Run the verified managed-runtime flow with `hermes mcp serve --read-only`.
-Require process running, healthy, ready, managed-runtime state ready, and no
-current error.
+Run the verified replacement flow with `hermes mcp serve --read-only`. If the
+managed-runtime command owns the process, require its process and state fields,
+live health/readiness, and no current error. If a service manager owns it,
+require the service-owned process plus its live health probe; do not substitute
+stale metadata from a different launcher.
 
 **Done when:** the replacement runtime is ready before connector creation.
 
@@ -158,7 +177,8 @@ invoke a mutating tool merely to test that it is absent.
 
 Stop only the precisely identified old runtime. Preserve its tunnel,
 connector, profile, alias, and key reference for rollback. Recheck the new
-runtime and repeat one harmless read after the old runtime stops.
+runtime and repeat one harmless read after the old runtime stops. This is the
+first point at which recovery may stop or unload the healthy rollback service.
 
 **Done when:** the replacement remains ready and independent after cutover.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -345,6 +345,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands',
+                    'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-recovering-mcp-tunnel-account-context',
                   ],
                 },
                 {


### PR DESCRIPTION
## What changed

- Add `hermes mcp serve --read-only` as an explicit restricted MCP mode.
- Expose only the eight non-mutating Hermes tools in that mode and attach MCP read-only, non-destructive annotations.
- Keep the default ten-tool MCP surface for backward compatibility; the eight non-mutating tools now advertise accurate read-only annotations in all modes (an additive `tools/list` metadata change).
- Add the optional `recovering-mcp-tunnel-account-context` skill, contract tests, generated documentation, catalog entry, and sidebar entry.

## Why

A secure MCP tunnel can be locally healthy while ChatGPT connector creation fails before any request reaches the daemon. In the reproduced failure, the control plane lacked an active organization context because ChatGPT and the OpenAI Platform were using different account/workspace contexts. The recovery skill separates runtime readiness from connector success, preserves rollback state, protects credentials, and requires end-to-end traffic plus exact read-only discovery before cutover.

## User and developer impact

- Operators can opt into a discoverably read-only Hermes MCP surface suitable for restricted connector environments.
- Mutating tools (`messages_send` and `permissions_respond`) are not registered in read-only mode.
- Existing callers that do not pass `--read-only` retain the full ten-tool surface and identical tool behavior. The only default-mode change is additive metadata: the eight non-mutating tools now carry `readOnlyHint=true` / `destructiveHint=false` annotations, which restricted clients can use for discovery.
- The optional skill documents a secret-safe, rollback-preserving recovery procedure without machine-local identifiers or credentials.

## Verification

```text
./scripts/run_tests.sh tests/test_mcp_serve.py tests/hermes_cli/test_mcp_read_only.py tests/skills/test_recovering_mcp_tunnel_account_context_skill.py -q

96 tests passed, 0 failed
```

The skill and generated documentation were also scanned for API-key, organization-ID, tunnel-ID, and private account-email patterns; no matches were found.

