### PR TITLE
fix(buzz): isolate owner auth credentials per profile

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -245,52 +245,62 @@ def _resolve_cli_path(configured: str = "") -> str:
     return str(fallback) if fallback.is_file() else ""
 
 
-def _resolve_private_key(extra: Optional[dict] = None) -> str:
-    """Resolve the Nostr private key: env first, then a credentials JSON.
-
-    NEVER log the return value.
-    """
-    key = _get_scoped_secret("BUZZ_PRIVATE_KEY", "").strip()
-    if key:
-        return key
-    configured = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get("credentials_file", "")
+def _credentials_candidates(extra: Optional[dict] = None) -> List[Path]:
+    configured = str(_get_scoped_secret("BUZZ_CREDENTIALS_FILE", "") or "").strip() or str(
+        (extra or {}).get("credentials_file", "") or ""
+    ).strip()
     if configured:
-        candidates = [Path(configured).expanduser()]
-    else:
-        try:
-            candidates = sorted(_DEFAULT_CREDENTIALS_DIR.glob("*credentials*.json"))
-        except OSError:
-            candidates = []
-    for path in candidates:
+        return [Path(configured).expanduser()]
+    try:
+        return sorted(_DEFAULT_CREDENTIALS_DIR.glob("*credentials*.json"))
+    except OSError:
+        return []
+
+
+def _resolve_credentials_data(extra: Optional[dict] = None) -> dict:
+    """Load the first credential record containing a private key."""
+    for path in _credentials_candidates(extra):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             continue
         if not isinstance(data, dict):
             continue
-        for field in ("nsec", "private_key_hex", "private_key"):
-            value = data.get(field)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+        if any(isinstance(data.get(field), str) and data[field].strip() for field in ("nsec", "private_key_hex", "private_key")):
+            return data
+    return {}
+
+
+def _resolve_private_key(extra: Optional[dict] = None) -> str:
+    """Resolve the Nostr private key: scoped secret first, then credentials JSON.
+
+    NEVER log the return value.
+    """
+    key = str(_get_scoped_secret("BUZZ_PRIVATE_KEY", "") or "").strip()
+    if key:
+        return key
+    data = _resolve_credentials_data(extra)
+    for field in ("nsec", "private_key_hex", "private_key"):
+        value = data.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
     return ""
 
 
 def _resolve_auth_tag(extra: Optional[dict] = None) -> str:
     """Resolve and validate the optional NIP-OA owner-attestation tag."""
-    configured = os.getenv("BUZZ_AUTH_TAG", "").strip()
+    configured = str(_get_scoped_secret("BUZZ_AUTH_TAG", "") or "").strip()
     if configured:
         raw: Any = configured
     else:
-        credentials_file = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get(
-            "credentials_file", ""
-        )
-        if not credentials_file:
+        credentials_file = str(_get_scoped_secret("BUZZ_CREDENTIALS_FILE", "") or "").strip() or str(
+            (extra or {}).get("credentials_file", "") or ""
+        ).strip()
+        direct_key = str(_get_scoped_secret("BUZZ_PRIVATE_KEY", "") or "").strip()
+        if direct_key and not credentials_file:
             return ""
-        try:
-            data = json.loads(Path(credentials_file).expanduser().read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            return ""
-        if not isinstance(data, dict) or "auth_tag" not in data:
+        data = _resolve_credentials_data(extra)
+        if "auth_tag" not in data:
             return ""
         raw = data["auth_tag"]
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -51,6 +51,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
+from agent.secret_scope import is_multiplex_active as _is_multiplex_active
 
 
 def _get_scoped_secret(name, default=None):
@@ -251,6 +252,8 @@ def _credentials_candidates(extra: Optional[dict] = None) -> List[Path]:
     ).strip()
     if configured:
         return [Path(configured).expanduser()]
+    if _is_multiplex_active():
+        return []
     try:
         return sorted(_DEFAULT_CREDENTIALS_DIR.glob("*credentials*.json"))
     except OSError:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -275,12 +275,47 @@ def _resolve_private_key(extra: Optional[dict] = None) -> str:
     return ""
 
 
+def _resolve_auth_tag(extra: Optional[dict] = None) -> str:
+    """Resolve and validate the optional NIP-OA owner-attestation tag."""
+    configured = os.getenv("BUZZ_AUTH_TAG", "").strip()
+    if configured:
+        raw: Any = configured
+    else:
+        credentials_file = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get(
+            "credentials_file", ""
+        )
+        if not credentials_file:
+            return ""
+        try:
+            data = json.loads(Path(credentials_file).expanduser().read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return ""
+        if not isinstance(data, dict) or "auth_tag" not in data:
+            return ""
+        raw = data["auth_tag"]
+
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Buzz auth tag is not valid JSON") from exc
+    if (
+        not isinstance(raw, list)
+        or len(raw) != 4
+        or raw[0] != "auth"
+        or not all(isinstance(part, str) for part in raw)
+    ):
+        raise ValueError("Buzz auth tag must be a four-string auth tag")
+    return json.dumps(raw, separators=(",", ":"))
+
+
 async def _exec_buzz(
     cli_path: str,
     args: List[str],
     *,
     relay_url: str,
     private_key: str,
+    auth_tag: str = "",
     input_text: Optional[str] = None,
     timeout: float = _CLI_TIMEOUT,
 ) -> Tuple[int, str, str]:
@@ -293,6 +328,9 @@ async def _exec_buzz(
     env = os.environ.copy()
     env["BUZZ_RELAY_URL"] = relay_url
     env["BUZZ_PRIVATE_KEY"] = private_key
+    env.pop("BUZZ_AUTH_TAG", None)
+    if auth_tag:
+        env["BUZZ_AUTH_TAG"] = auth_tag
     proc = await asyncio.create_subprocess_exec(
         cli_path,
         *args,
@@ -415,6 +453,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # never logged).  connect() re-resolves it to fail fast with a clear
         # error when it is missing.
         self._private_key: str = ""
+        self._auth_tag: str = ""
 
         # Identity — filled in by connect() from ``buzz users get``
         self._self_pubkey: str = ""
@@ -446,11 +485,13 @@ class BuzzAdapter(BasePlatformAdapter):
     async def _run_cli(self, args: List[str], *, input_text: Optional[str] = None) -> Tuple[int, str, str]:
         if not self._private_key:
             self._private_key = _resolve_private_key(self._extra)
+            self._auth_tag = _resolve_auth_tag(self._extra)
         return await _exec_buzz(
             self.cli_path,
             args,
             relay_url=self.relay_url,
             private_key=self._private_key,
+            auth_tag=self._auth_tag,
             input_text=input_text,
         )
 
@@ -466,7 +507,13 @@ class BuzzAdapter(BasePlatformAdapter):
             logger.error("Buzz: buzz CLI binary not found (set BUZZ_CLI_PATH or put 'buzz' on PATH)")
             self._set_fatal_error("cli_missing", "buzz CLI binary not found", retryable=False)
             return False
-        self._private_key = _resolve_private_key(self._extra)
+        try:
+            self._private_key = _resolve_private_key(self._extra)
+            self._auth_tag = _resolve_auth_tag(self._extra)
+        except ValueError as exc:
+            logger.error("Buzz: invalid owner-auth configuration — %s", exc)
+            self._set_fatal_error("config_invalid", str(exc), retryable=False)
+            return False
         if not self._private_key:
             logger.error("Buzz: no private key (set BUZZ_PRIVATE_KEY or a credentials file)")
             self._set_fatal_error("config_missing", "BUZZ_PRIVATE_KEY must be set", retryable=False)
@@ -774,7 +821,7 @@ class BuzzAdapter(BasePlatformAdapter):
             private_key=self._private_key,
             challenge=str(message[1]),
             relay_url=self._websocket_url(),
-            auth_tag_json=os.getenv("BUZZ_AUTH_TAG", ""),
+            auth_tag_json=self._auth_tag,
         )
         await websocket.send(json.dumps(["AUTH", event], separators=(",", ":")))
         while True:
@@ -1374,6 +1421,10 @@ async def _standalone_send(
     extra = getattr(pconfig, "extra", {}) or {}
     relay = (os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")).strip()
     private_key = _resolve_private_key(extra)
+    try:
+        auth_tag = _resolve_auth_tag(extra)
+    except ValueError as exc:
+        return {"error": f"Buzz standalone send: {exc}"}
     cli_path = _resolve_cli_path(
         os.getenv("BUZZ_CLI_PATH", "").strip() or str(extra.get("cli_path", "") or "")
     )
@@ -1392,7 +1443,12 @@ async def _standalone_send(
         args += ["--file", str(path)]
     try:
         code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+            cli_path,
+            args,
+            relay_url=relay,
+            private_key=private_key,
+            auth_tag=auth_tag,
+            input_text=message,
         )
     except asyncio.CancelledError:
         raise

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -525,6 +525,23 @@ class TestCredentialResolution:
         assert _resolve_private_key() == "nsec1fromfile"
         assert json.loads(_resolve_auth_tag()) == tag
 
+    def test_empty_multiplex_scope_never_autodiscovers_ambient_credentials(self, monkeypatch, tmp_path):
+        from agent import secret_scope as ss
+
+        tag = ["auth", "a" * 64, "", "d" * 128]
+        (tmp_path / "general_credentials.json").write_text(
+            json.dumps({"nsec": "nsec1ambient", "auth_tag": tag}), encoding="utf-8"
+        )
+        monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path)
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({})
+        try:
+            assert _resolve_private_key() == ""
+            assert _resolve_auth_tag() == ""
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
 
 # ── Env enablement / registration / standalone send ──────────────────────
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -598,4 +598,95 @@ class TestStandaloneSend:
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_injects_owner_auth_tag_from_credentials_file(
+        self, monkeypatch, tmp_path
+    ):
+        """Cron/standalone path must load NIP-OA auth_tag from credentials JSON.
+
+        Main-line regression: when only BUZZ_PRIVATE_KEY is ambient and the
+        credentials file holds auth_tag, omitting injection causes relay 403
+        membership failures on owner-gated relays.
+        """
+        from gateway.config import PlatformConfig
+
+        tag = ["auth", "b" * 64, "", "c" * 128]
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "auth_tag": tag}),
+            encoding="utf-8",
+        )
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        monkeypatch.delenv("BUZZ_PRIVATE_KEY", raising=False)
+        monkeypatch.delenv("BUZZ_AUTH_TAG", raising=False)
+
+        captured = {}
+
+        async def fake_exec(
+            cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=30.0
+        ):
+            captured.update(
+                private_key=private_key,
+                auth_tag=auth_tag,
+                args=args,
+                input_text=input_text,
+            )
+            return 0, json.dumps({"accepted": True, "event_id": "evt-auth", "message": ""}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}), CHANNEL, "cron needs owner auth"
+        )
+        assert result == {"success": True, "message_id": "evt-auth"}
+        assert captured["private_key"] == "nsec1fromfile"
+        assert json.loads(captured["auth_tag"]) == tag
+        # Secrets stay out of argv (auth_tag is env-injected by _exec_buzz).
+        joined_args = " ".join(str(a) for a in captured["args"])
+        assert "nsec1fromfile" not in joined_args
+        assert tag[1] not in joined_args
+        assert tag[3] not in joined_args
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_key_only_does_not_invent_auth_tag(
+        self, monkeypatch, tmp_path
+    ):
+        """Direct private key without credentials_file must not invent an auth tag."""
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.delenv("BUZZ_AUTH_TAG", raising=False)
+        monkeypatch.delenv("BUZZ_CREDENTIALS_FILE", raising=False)
+        # Ambient credentials dir must not be borrowed when a direct key is set.
+        ambient = tmp_path / "ambient_credentials.json"
+        ambient.write_text(
+            json.dumps({"nsec": "nsec1ambient", "auth_tag": ["auth", "a" * 64, "", "d" * 128]}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path)
+
+        captured = {}
+
+        async def fake_exec(
+            cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=30.0
+        ):
+            captured.update(private_key=private_key, auth_tag=auth_tag)
+            return 0, json.dumps({"accepted": True, "event_id": "evt-key", "message": ""}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}), CHANNEL, "key only"
+        )
+        assert result == {"success": True, "message_id": "evt-key"}
+        assert captured["private_key"] == "nsec1x"
+        assert captured["auth_tag"] == ""
+
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -497,6 +497,34 @@ class TestCredentialResolution:
         with pytest.raises(ValueError, match="auth tag"):
             _resolve_auth_tag()
 
+    def test_scoped_credentials_and_tag_do_not_borrow_ambient_profile(self, monkeypatch, tmp_path):
+        from agent import secret_scope as ss
+
+        ambient_tag = ["auth", "a" * 64, "", "d" * 128]
+        scoped_tag = ["auth", "b" * 64, "", "c" * 128]
+        ambient = tmp_path / "ambient.json"
+        scoped = tmp_path / "scoped.json"
+        ambient.write_text(json.dumps({"nsec": "nsec1ambient", "auth_tag": ambient_tag}))
+        scoped.write_text(json.dumps({"nsec": "nsec1scoped", "auth_tag": scoped_tag}))
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(ambient))
+        monkeypatch.setenv("BUZZ_AUTH_TAG", json.dumps(ambient_tag))
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"BUZZ_CREDENTIALS_FILE": str(scoped)})
+        try:
+            assert _resolve_private_key() == "nsec1scoped"
+            assert json.loads(_resolve_auth_tag()) == scoped_tag
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
+    def test_owner_auth_tag_uses_credentials_autodiscovery(self, monkeypatch, tmp_path):
+        tag = ["auth", "b" * 64, "", "c" * 128]
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(json.dumps({"nsec": "nsec1fromfile", "auth_tag": tag}), encoding="utf-8")
+        monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path)
+        assert _resolve_private_key() == "nsec1fromfile"
+        assert json.loads(_resolve_auth_tag()) == tag
+
 
 # ── Env enablement / registration / standalone send ──────────────────────
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -19,6 +19,7 @@ npub_to_hex = _buzz_mod.npub_to_hex
 _normalize_user_ref = _buzz_mod._normalize_user_ref
 _cli_error_message = _buzz_mod._cli_error_message
 _resolve_private_key = _buzz_mod._resolve_private_key
+_resolve_auth_tag = _buzz_mod._resolve_auth_tag
 check_requirements = _buzz_mod.check_requirements
 validate_config = _buzz_mod.validate_config
 register = _buzz_mod.register
@@ -45,6 +46,7 @@ _ENV_VARS = (
     "BUZZ_POLL_INTERVAL",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
+    "BUZZ_AUTH_TAG",
 )
 
 
@@ -481,6 +483,20 @@ class TestCredentialResolution:
         monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
         assert _resolve_private_key() == "nsec1fromfile"
 
+    def test_owner_auth_tag_from_credentials_file(self, monkeypatch, tmp_path):
+        tag = ["auth", "b" * 64, "", "c" * 128]
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(json.dumps({"nsec": "nsec1fromfile", "auth_tag": tag}), encoding="utf-8")
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        assert json.loads(_resolve_auth_tag()) == tag
+
+    def test_invalid_owner_auth_tag_fails_closed(self, monkeypatch, tmp_path):
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(json.dumps({"nsec": "nsec1fromfile", "auth_tag": ["bad"]}), encoding="utf-8")
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        with pytest.raises(ValueError, match="auth tag"):
+            _resolve_auth_tag()
+
 
 # ── Env enablement / registration / standalone send ──────────────────────
 
@@ -524,8 +540,8 @@ class TestStandaloneSend:
 
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
-            captured.update(cli_path=cli_path, args=args, relay_url=relay_url, input_text=input_text)
+        async def fake_exec(cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=30.0):
+            captured.update(cli_path=cli_path, args=args, relay_url=relay_url, auth_tag=auth_tag, input_text=input_text)
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron", "message": ""}), ""
 
         monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -119,3 +119,12 @@ async def test_websocket_auth_raises_on_rejection():
         await adapter._authenticate_websocket(RejectingWs())
 
 
+@pytest.mark.asyncio
+async def test_websocket_auth_uses_credentials_owner_tag():
+    adapter = _make_adapter()
+    adapter._auth_tag = json.dumps(["auth", "b" * 64, "", "c" * 128])
+    websocket = _FakeWebSocket()
+    await adapter._authenticate_websocket(websocket)
+    assert ["auth", "b" * 64, "", "c" * 128] in websocket.sent[0][1]["tags"]
+
+


### PR DESCRIPTION
## Summary
Reconciles three previously reviewed Buzz credential-isolation fixes onto current `main`:

1. Load the optional NIP-OA owner-attestation auth tag from the profile credentials path (not only ambient `BUZZ_AUTH_TAG`) and propagate it through CLI subprocess env and WebSocket AUTH.
2. Resolve private key + auth tag via scoped secrets / the profile's configured credentials path so multiplexed secondary profiles cannot borrow ambient process-global credentials.
3. Fail closed on multiplex filesystem credential autodiscovery (empty scope → no ambient `~/.config/buzz/*credentials*.json` borrow). Non-multiplex/default-profile autodiscovery remains supported.

Original authorship preserved via cherry-pick (Alex P. Günsberg). Unrelated skills-sweep commit excluded.

## Test plan
- [x] `HERMES_PYTHON=... scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -v` → 33 passed
- [x] Broader affected: `test_secret_scope.py`, `test_multiplex_credential_isolation.py`, `test_adapter_startup_secret_scope.py` (+ buzz) → 134 passed total
- [x] Diff limited to Buzz adapter + its tests (no skill sweep, no secret values)

## Notes
- Cherry-picks applied cleanly on `origin/main` @ `03fa32c92dd445eb64c7f67434dd91b32c40701d` with no conflict repair commits.
- Source commits: `b9431a63c4`, `307855e056`, `ca352060fa` (excluded `1c9433897c`).