### PR TITLE
fix(mcp): route untrusted CLI approval through callback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14274,7 +14274,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # finishes; reset on the next turn.
             self._prompt_start_time = time.time()
             self._prompt_duration = 0.0
-            agent_thread = threading.Thread(target=run_agent, daemon=True)
+            # Carry the interactive CLI's callback/context ownership across
+            # the foreground turn boundary. The direct setters in ``run_agent``
+            # remain a compatibility fallback for direct ``chat()`` callers,
+            # while the shared wrapper provides the audited install/clear
+            # lifecycle used by other Hermes worker threads.
+            from tools.thread_context import propagate_context_to_thread
+
+            agent_thread = threading.Thread(
+                target=propagate_context_to_thread(
+                    run_agent,
+                    approval_callback=self._approval_callback,
+                    sudo_password_callback=self._sudo_password_callback,
+                ),
+                daemon=True,
+            )
             agent_thread.start()
 
             # Ambient "thinking" sound: calm bubble blips while the agent
@@ -17735,7 +17749,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     logger.warning("process_loop unhandled error (msg may be lost): %s", e)
         
         # Start processing thread
-        process_thread = threading.Thread(target=process_loop, daemon=True)
+        # ``run()`` owns the live prompt callbacks on this thread. Preserve
+        # them when handing foreground messages to the long-lived processing
+        # worker so nested agent/tool workers can inherit the same UI surface.
+        from tools.thread_context import propagate_context_to_thread
+
+        process_thread = threading.Thread(
+            target=propagate_context_to_thread(
+                process_loop,
+                approval_callback=self._approval_callback,
+                sudo_password_callback=self._sudo_password_callback,
+            ),
+            daemon=True,
+        )
         process_thread.start()
 
         # Wake word ("Hey Hermes") — start the always-on hotword listener if

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -6,6 +6,10 @@ from unittest.mock import MagicMock, patch
 
 import cli as cli_module
 from cli import HermesCLI
+from gateway.session_context import clear_session_vars, set_session_vars
+from tools import approval as approval_module
+from tools.terminal_tool import set_approval_callback
+from tools.thread_context import propagate_context_to_thread
 
 
 class _FakeBuffer:
@@ -67,6 +71,49 @@ def _make_background_cli_stub():
 
 
 class TestCliApprovalUi:
+    def test_mcp_consent_renders_registered_cli_panel(self):
+        """The shared MCP consent seam drives the real CLI modal callback."""
+        cli = _make_cli_stub()
+        result = {}
+
+        def request_consent():
+            result["value"] = approval_module.request_elicitation_consent(
+                "MCP tool 'save_knowledge' wants to run",
+                "Untrusted server requests one write-capable operation",
+                timeout_seconds=5,
+            )
+
+        set_approval_callback(cli._approval_callback)
+        session_tokens = set_session_vars(
+            platform="cli", session_key="mcp-cli-panel-test"
+        )
+        try:
+            thread = threading.Thread(
+                target=propagate_context_to_thread(request_consent),
+                daemon=True,
+            )
+            thread.start()
+
+            deadline = time.time() + 2
+            while cli._approval_state is None and time.time() < deadline:
+                time.sleep(0.01)
+
+            assert cli._approval_state is not None
+            assert cli._approval_state["command"] == (
+                "MCP tool 'save_knowledge' wants to run"
+            )
+            assert cli._approval_state["choices"] == [
+                "once", "session", "deny"
+            ]
+            cli._approval_state["response_queue"].put("once")
+            thread.join(timeout=2)
+        finally:
+            clear_session_vars(session_tokens)
+            set_approval_callback(None)
+
+        assert not thread.is_alive()
+        assert result["value"] == "accept"
+
     def test_smart_denied_callback_offers_only_once_and_deny(self):
         cli = _make_cli_stub()
         result = {}

--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -18,13 +18,25 @@ Adversarial notes encoded in these tests:
 """
 
 import asyncio
+import concurrent.futures
 import json
+import threading
+import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import cli as cli_module
+from cli import HermesCLI
+from run_agent import AIAgent
+from tools import approval as approval_module
 from tools import mcp_tool
+from tools.registry import registry
+from gateway.session_context import clear_session_vars, set_session_vars
+from tools.terminal_tool import set_approval_callback
+from tools.thread_context import propagate_context_to_thread
 
 
 class _FakeContentBlock:
@@ -83,6 +95,324 @@ def _set_trust(server: str, trust: str):
 
 def _set_read_only(server: str, tool: str, value: bool):
     mcp_tool._tool_read_only_hints.setdefault(server, {})[tool] = value
+
+
+@contextmanager
+def _session_platform(platform: str, session_key: str = "mcp-cli-test"):
+    tokens = set_session_vars(platform=platform, session_key=session_key)
+    try:
+        yield
+    finally:
+        clear_session_vars(tokens)
+
+
+def _make_cli_approval_stub():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._approval_state = None
+    cli._approval_deadline = 0
+    cli._approval_lock = threading.Lock()
+    cli._sudo_state = None
+    cli._sudo_deadline = 0
+    cli._modal_input_snapshot = None
+    cli._invalidate = MagicMock()
+    cli._paint_now = MagicMock()
+    cli._persist_prompt_summary = MagicMock()
+    return cli
+
+
+class TestCliApprovalSurface:
+    """Untrusted MCP confirmation reaches the registered CLI callback."""
+
+    @pytest.mark.parametrize(
+        ("choice", "expected"),
+        [("once", "accept"), ("session", "accept"),
+         ("deny", "decline"), ("timeout", "cancel")],
+    )
+    def test_registered_callback_choice_is_normalized_without_persistence(
+        self, choice, expected
+    ):
+        calls = []
+        session_before = {
+            key: values.copy()
+            for key, values in approval_module._session_approved.items()
+        }
+        permanent_before = approval_module._permanent_approved.copy()
+        fake_secret = "ghp_" + "FAKEGITHUBTOKEN123456789012345678"
+
+        def callback(command, description, **kwargs):
+            calls.append((command, description, kwargs))
+            return choice
+
+        set_approval_callback(callback)
+        try:
+            with _session_platform("cli"), patch(
+                "prompt_toolkit.application.current.get_app_or_none",
+                return_value=object(),
+            ):
+                result = approval_module.request_elicitation_consent(
+                    f"run write with token {fake_secret}",
+                    f"approve external mutation using {fake_secret}",
+                    timeout_seconds=1,
+                )
+        finally:
+            set_approval_callback(None)
+
+        assert result == expected
+        assert len(calls) == 1
+        command, description, kwargs = calls[0]
+        assert fake_secret not in command
+        assert fake_secret not in description
+        assert kwargs == {"allow_permanent": False}
+        assert approval_module._session_approved == session_before
+        assert approval_module._permanent_approved == permanent_before
+
+    def test_callback_absence_under_prompt_toolkit_fails_closed(self):
+        set_approval_callback(None)
+        with _session_platform("cli"), patch(
+            "prompt_toolkit.application.current.get_app_or_none",
+            return_value=object(),
+        ), patch(
+            "builtins.input",
+            side_effect=AssertionError("must not read stdin under prompt_toolkit"),
+        ):
+            result = approval_module.request_elicitation_consent(
+                "write external state", "untrusted MCP server", timeout_seconds=1
+            )
+
+        assert result == "decline"
+
+    def test_gateway_routing_remains_on_pending_approval_queue(self):
+        session_key = "mcp-gateway-routing-test"
+        captured = []
+
+        def notify(data):
+            captured.append(dict(data))
+            approval_module.resolve_gateway_approval(session_key, "once")
+
+        token = approval_module.set_current_session_key(session_key)
+        approval_module.register_gateway_notify(session_key, notify)
+        try:
+            with _session_platform("telegram", session_key):
+                result = approval_module.request_elicitation_consent(
+                    "gateway MCP write", "confirm one operation",
+                    surface="mcp-trust/srv",
+                )
+        finally:
+            approval_module.unregister_gateway_notify(session_key)
+            approval_module.reset_current_session_key(token)
+
+        assert result == "accept"
+        assert len(captured) == 1
+        assert captured[0]["command"] == "gateway MCP write"
+        assert captured[0]["pattern_key"] == "mcp_elicitation"
+
+    def test_real_cli_panel_once_invokes_untrusted_transport_once(
+        self, fake_session
+    ):
+        _set_trust("srv", "untrusted")
+        handler = mcp_tool._make_tool_handler("srv", "save_knowledge", 30.0)
+        cli = _make_cli_approval_stub()
+        result = {}
+
+        set_approval_callback(cli._approval_callback)
+        try:
+            with _session_platform("cli"):
+                thread = threading.Thread(
+                    target=propagate_context_to_thread(
+                        lambda: result.setdefault("raw", handler({"note": "x"}))
+                    ),
+                    daemon=True,
+                )
+                thread.start()
+
+                deadline = time.time() + 2
+                while cli._approval_state is None and time.time() < deadline:
+                    time.sleep(0.01)
+
+                assert cli._approval_state is not None
+                assert "save_knowledge" in cli._approval_state["command"]
+                assert cli._approval_state["choices"][:3] == [
+                    "once", "session", "deny"
+                ]
+                assert "always" not in cli._approval_state["choices"]
+                cli._approval_state["response_queue"].put("once")
+                thread.join(timeout=3)
+        finally:
+            set_approval_callback(None)
+
+        assert not thread.is_alive()
+        assert json.loads(result["raw"]) == {"result": "ok"}
+        assert fake_session.call_tool.await_count == 1
+
+    @pytest.mark.parametrize(("choice", "rpc_count"), [("once", 1), ("deny", 0)])
+    def test_foreground_cli_turn_routes_untrusted_mcp_to_real_modal(
+        self, fake_session, tmp_path, choice, rpc_count
+    ):
+        """The production CLI turn owns approval without test-side callback wiring.
+
+        This traverses ``HermesCLI.chat``'s real foreground worker closure, a
+        deterministic two-response ``AIAgent.run_conversation`` turn, executor
+        selection, registry dispatch, and the MCP trust gate.  The test never
+        calls ``set_approval_callback`` or ``propagate_context_to_thread``:
+        callback installation is exclusively the production CLI's job.
+        """
+        server_name = "foreground-cli"
+        registered_name = mcp_tool.mcp_prefixed_tool_name(server_name, "save_knowledge")
+        schema = {
+            "name": registered_name,
+            "description": "Save one knowledge note",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+        }
+        tool_def = {"type": "function", "function": schema}
+        mcp_tool._servers[server_name] = mcp_tool._servers["srv"]
+        registry.register(
+            name=registered_name,
+            toolset=f"mcp-{server_name}",
+            schema=schema,
+            handler=mcp_tool._make_tool_handler(
+                server_name, "save_knowledge", 5.0
+            ),
+            is_async=False,
+            description=schema["description"],
+        )
+        _set_trust(server_name, "untrusted")
+
+        tool_call = SimpleNamespace(
+            id="call-save",
+            type="function",
+            function=SimpleNamespace(
+                name=registered_name,
+                arguments=json.dumps({"text": "foreground approval proof"}),
+            ),
+        )
+        tool_response = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="", tool_calls=[tool_call]),
+                finish_reason="tool_calls",
+            )],
+            model="test/model",
+            usage=None,
+        )
+        final_response = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="done", tool_calls=None),
+                finish_reason="stop",
+            )],
+            model="test/model",
+            usage=None,
+        )
+
+        try:
+            with patch("run_agent.get_tool_definitions", return_value=[tool_def]), \
+                 patch("run_agent.check_toolset_requirements", return_value={}), \
+                 patch("run_agent.OpenAI"), \
+                 patch("run_agent._hermes_home", tmp_path), \
+                 patch("agent.model_metadata.fetch_model_metadata", return_value={}):
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://example.test/v1",
+                    provider="test",
+                    model="test/model",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                    platform="cli",
+                )
+            agent.client = MagicMock()
+            agent.client.chat.completions.create.side_effect = [
+                tool_response,
+                final_response,
+            ]
+            agent._cached_system_prompt = "You are helpful."
+            agent._use_prompt_caching = False
+            agent.compression_enabled = False
+            agent.save_trajectories = False
+
+            with patch.object(cli_module, "get_tool_definitions", return_value=[]):
+                cli = HermesCLI(compact=True)
+            cli.agent = agent
+            agent.session_id = cli.session_id
+            setattr(agent, "tools", [tool_def])
+            setattr(agent, "valid_tool_names", {registered_name})
+            # Keep the deterministic single-tool snapshot byte-stable; this
+            # regression targets foreground dispatch rather than MCP discovery.
+            setattr(agent, "_skip_mcp_refresh", True)
+
+            modal = {}
+
+            def answer_modal():
+                deadline = time.time() + 5
+                while cli._approval_state is None and time.time() < deadline:
+                    time.sleep(0.01)
+                state = cli._approval_state
+                if state is not None:
+                    modal["choices"] = list(state["choices"])
+                    state["response_queue"].put(choice)
+
+            responder = threading.Thread(target=answer_modal, daemon=True)
+            responder.start()
+            with patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+                 patch.object(cli, "_resolve_turn_agent_config", return_value={
+                     "signature": cli._active_agent_route_signature,
+                     "model": agent.model,
+                     "runtime": None,
+                     "request_overrides": None,
+                 }), \
+                 patch.object(cli, "_init_agent", return_value=True), \
+                 patch.object(cli_module, "_cprint"), \
+                 patch.object(cli_module, "set_approval_callback"):
+                # Disable the legacy duplicate setter inside ``run_agent`` so
+                # this regression proves the production thread handoff carries
+                # the owning CLI instance's callback explicitly.
+                result = cli.chat("save one knowledge note")
+            responder.join(timeout=5)
+        finally:
+            registry.deregister(registered_name)
+            mcp_tool._servers.pop(server_name, None)
+
+        assert not responder.is_alive()
+        assert modal["choices"][:3] == ["once", "session", "deny"]
+        assert "always" not in modal["choices"]
+        assert fake_session.call_tool.await_count == rpc_count
+        assert result == "done"
+
+    @pytest.mark.parametrize(
+        ("choice", "rpc_count"), [("once", 1), ("deny", 0)]
+    )
+    def test_untrusted_handler_uses_propagated_cli_callback(
+        self, fake_session, choice, rpc_count
+    ):
+        _set_trust("srv", "untrusted")
+        handler = mcp_tool._make_tool_handler("srv", "delete_repo", 30.0)
+        calls = []
+
+        def callback(command, description, **kwargs):
+            calls.append((command, description, kwargs))
+            return choice
+
+        set_approval_callback(callback)
+        try:
+            with _session_platform("cli"), patch(
+                "prompt_toolkit.application.current.get_app_or_none",
+                return_value=object(),
+            ), concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                raw = executor.submit(
+                    propagate_context_to_thread(handler), {"repo": "x"}
+                ).result(timeout=5)
+        finally:
+            set_approval_callback(None)
+
+        assert len(calls) == 1
+        assert calls[0][2] == {"allow_permanent": False}
+        assert fake_session.call_tool.await_count == rpc_count
+        if choice == "once":
+            assert json.loads(raw) == {"result": "ok"}
+        else:
+            assert "did not approve" in json.loads(raw)["error"]
 
 
 class TestTrustGateAtCallTime:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4489,7 +4489,19 @@ def request_elicitation_consent(
         logger.warning("Elicitation consent: session lookup failed: %s", exc)
         return "decline"
 
-    if _is_gateway_approval_context():
+    # An installed thread-local callback is the authoritative interactive
+    # surface for CLI and ACP workers.  Those workers can also carry a nonempty
+    # session platform (for example ``cli``), which by itself is not proof that
+    # a gateway notify queue owns approval routing.
+    approval_callback = None
+    try:
+        from tools.terminal_tool import _get_approval_callback
+        approval_callback = _get_approval_callback()
+    except Exception:
+        # Missing terminal tooling or callback stays fail-closed below.
+        pass
+
+    if approval_callback is None and _is_gateway_approval_context():
         with _lock:
             notify_cb = _gateway_notify_cbs.get(session_key)
         if notify_cb is None:
@@ -4525,14 +4537,19 @@ def request_elicitation_consent(
             return "accept"
         return "decline"
 
-    # CLI / TUI path. allow_permanent=False because elicitation is a
-    # per-call confirmation — there is no pattern to remember.
+    # CLI / TUI path. Tool dispatch runs on a worker thread, where the CLI's
+    # thread-local callback is installed by propagate_context_to_thread(). Pass
+    # that callback explicitly so prompt_toolkit renders its approval panel;
+    # without it, the stdin-deadlock guard correctly but invisibly denies.
+    # allow_permanent=False because elicitation is a per-call confirmation —
+    # there is no pattern to remember.
     try:
         choice = prompt_dangerous_approval(
             message,
             description,
             timeout_seconds=timeout_seconds,
             allow_permanent=False,
+            approval_callback=approval_callback,
         )
     except Exception as exc:
         logger.error(

--- a/tools/thread_context.py
+++ b/tools/thread_context.py
@@ -38,6 +38,7 @@ import logging
 from typing import Callable
 
 logger = logging.getLogger(__name__)
+_UNSET = object()
 
 
 def _callback_api():
@@ -61,13 +62,24 @@ def _callback_api():
     )
 
 
-def propagate_context_to_thread(target: Callable) -> Callable:
+def propagate_context_to_thread(
+    target: Callable,
+    *,
+    approval_callback=_UNSET,
+    sudo_password_callback=_UNSET,
+) -> Callable:
     """Wrap *target* for execution on a worker thread with the *current*
     thread's ContextVars and approval/sudo callbacks propagated.
 
     Call this on the parent thread; pass the returned callable as the
     thread/executor target.  The returned callable forwards its positional
     and keyword arguments to *target* and returns its result.
+
+    ``approval_callback`` and ``sudo_password_callback`` normally default to
+    the callback registered on the calling thread. Interactive owners may pass
+    their bound callbacks explicitly when the parent is itself an intermediate
+    worker with no callback slot (for example CLI UI -> process loop -> agent
+    turn). This keeps ownership per instance while avoiding a global callback.
 
     Fail-closed: if callback installation raises, the callbacks are left
     unset (``None``).  That is the safe outcome — ``prompt_dangerous_approval``
@@ -80,8 +92,16 @@ def propagate_context_to_thread(target: Callable) -> Callable:
     setters = None
     try:
         get_approval, get_sudo, set_approval, set_sudo = _callback_api()
-        parent_approval_cb = get_approval()
-        parent_sudo_cb = get_sudo()
+        parent_approval_cb = (
+            get_approval()
+            if approval_callback is _UNSET
+            else approval_callback
+        )
+        parent_sudo_cb = (
+            get_sudo()
+            if sudo_password_callback is _UNSET
+            else sudo_password_callback
+        )
         setters = (set_approval, set_sudo)
     except Exception:
         logger.debug("Could not capture parent approval/sudo callbacks", exc_info=True)


### PR DESCRIPTION
## Summary

Untrusted MCP elicitation could be routed as a gateway approval whenever a CLI session carried a nonempty platform value, even though no gateway notify queue owned the request. The fallback CLI/TUI prompt then ran on worker threads without the interactive approval callback, so the stdin deadlock guard denied the request without displaying a usable approval surface.

This repair:
- treats an installed thread-local approval callback as the authoritative CLI/ACP interactive surface before considering gateway routing;
- propagates explicit per-instance approval and sudo callbacks across the CLI process-loop and agent-thread boundaries;
- passes the recovered callback into the per-call MCP confirmation prompt so prompt_toolkit can render the approval panel;
- remains fail-closed when no usable callback or gateway notify surface exists;
- keeps `allow_permanent=False`, because MCP elicitation is a per-call confirmation and must not create a remembered approval.

## Verification

- `uv run --extra dev pytest -q tests/tools/test_mcp*.py` — 465 passed
- `uv run --extra dev pytest -q tests/cli/test_cli_approval_ui.py tests/tools/test_mcp_trust_gating.py` — 38 passed
- `uv run --extra dev --extra messaging --extra acp pytest -q tests/acp/test_edit_approval.py tests/acp/test_approval_isolation.py tests/gateway/*approval*.py` — 72 passed
- `uv run --extra dev ruff check cli.py tools/approval.py tools/thread_context.py tests/tools/test_mcp_trust_gating.py tests/cli/test_cli_approval_ui.py` — clean
- `uv run python -m py_compile cli.py tools/approval.py tools/thread_context.py tests/tools/test_mcp_trust_gating.py tests/cli/test_cli_approval_ui.py` — clean
- The bounded approval/file/execute-code/terminal command reports 3 known macOS `/tmp` → `/private/tmp` path-alias failures, reproduced identically on the exact base: 170 passed, 2 skipped. The failing test files are byte-unchanged by this PR.

## Scope

One commit changing only `cli.py`, `tools/approval.py`, `tools/thread_context.py`, `tests/tools/test_mcp_trust_gating.py`, and `tests/cli/test_cli_approval_ui.py`.
