### PR TITLE
fix(gateway): isolate optional platform auth failures from exit 78

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -10,10 +10,48 @@ from hermes_cli.config import DEFAULT_CONFIG
 GATEWAY_SERVICE_RESTART_EXIT_CODE = 75
 
 # EX_CONFIG from sysexits.h — fatal configuration error (e.g. token
-# collision, no messaging platforms).  The s6 finish script translates
-# this into exit 125 (permanent failure) so the supervisor stops
-# restarting the gateway.  See #51228.
+# collision / single-writer lock conflict).  The s6 finish script
+# translates this into exit 125 (permanent failure) so the supervisor
+# stops restarting the gateway.  See #51228.
+#
+# Platform-local auth/config failures (missing membership, unpaired
+# bridge, missing adapter credentials) are NOT EX_CONFIG: they park the
+# affected adapter and leave cron/Kanban/other platforms running.
 GATEWAY_FATAL_CONFIG_EXIT_CODE = 78
+
+
+def is_global_startup_conflict(
+    error_code: str | None = None,
+    message: str | None = None,
+) -> bool:
+    """Return True when a platform failure is a gateway-global single-writer conflict.
+
+    Only these failures may force ``GATEWAY_FATAL_CONFIG_EXIT_CODE`` when
+    nothing else connected. Platform-local auth/config errors must be
+    isolated so optional adapters cannot take down unrelated gateway duties.
+    """
+    code = (error_code or "").strip().lower()
+    if code:
+        if code == "lock_conflict":
+            return True
+        if code.endswith("_lock"):
+            return True
+        if "polling_conflict" in code:
+            return True
+        return False
+
+    msg = (message or "").lower()
+    if "already in use" not in msg:
+        return False
+    return any(
+        marker in msg
+        for marker in (
+            "stop the other gateway",
+            "another local hermes",
+            "another profile",
+            "pid ",
+        )
+    )
 
 # Set by ``hermes gateway run --external-supervisor``. Unlike systemd's
 # INVOCATION_ID and launchd's XPC_SERVICE_NAME, this survives wrappers that

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2460,6 +2460,7 @@ from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
+    is_global_startup_conflict,
     parse_restart_after_turn_timeout,
     parse_restart_drain_timeout,
 )
@@ -11295,7 +11296,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         connected_count = 0
         enabled_platform_count = 0
-        startup_nonretryable_errors: list[str] = []
+        # Each entry: (platform_value, error_code|None, human message)
+        startup_nonretryable_errors: list[tuple[str, str | None, str]] = []
         startup_retryable_errors: list[str] = []
         
         # Initialize and connect each configured platform
@@ -11401,14 +11403,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             error_code=adapter.fatal_error_code,
                             error_message=adapter.fatal_error_message,
                         )
-                        target = (
-                            startup_retryable_errors
-                            if adapter.fatal_error_retryable
-                            else startup_nonretryable_errors
-                        )
-                        target.append(
-                            f"{platform.value}: {adapter.fatal_error_message}"
-                        )
+                        detail = f"{platform.value}: {adapter.fatal_error_message}"
+                        if adapter.fatal_error_retryable:
+                            startup_retryable_errors.append(detail)
+                        else:
+                            startup_nonretryable_errors.append(
+                                (
+                                    platform.value,
+                                    adapter.fatal_error_code,
+                                    adapter.fatal_error_message or detail,
+                                )
+                            )
                         # Queue for reconnection if the error is retryable
                         if adapter.fatal_error_retryable:
                             self._failed_platforms[platform] = {
@@ -11519,9 +11524,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _skipped.value,
                 )
 
+        # When no platform connected, decide between fatal exit-78 (true
+        # single-writer conflicts only) and degraded continue (platform-local
+        # auth/config). Track local-only degrade so we do not clobber the
+        # diagnostic gateway_state with a later "running" write.
+        startup_local_degraded = False
         if connected_count == 0:
-            if startup_nonretryable_errors and not startup_retryable_errors:
-                reason = "; ".join(startup_nonretryable_errors)
+            def _format_nonretryable(entries: list[tuple[str, str | None, str]]) -> str:
+                return "; ".join(f"{plat}: {msg}" for plat, _code, msg in entries)
+
+            global_conflicts = [
+                entry
+                for entry in startup_nonretryable_errors
+                if is_global_startup_conflict(entry[1], entry[2])
+            ]
+            local_nonretryable = [
+                entry
+                for entry in startup_nonretryable_errors
+                if not is_global_startup_conflict(entry[1], entry[2])
+            ]
+
+            # True single-writer / exclusive-ownership conflicts remain fatal
+            # whenever nothing is connected and nothing is merely retryable.
+            # Platform-local auth/config failures alone must not kill
+            # cron/Kanban/other gateway duties (production: optional Buzz
+            # relay_membership_required previously exited 78).
+            if global_conflicts and not startup_retryable_errors:
+                reason = _format_nonretryable(global_conflicts)
+                if local_nonretryable:
+                    reason = (
+                        f"{reason}; also parked: "
+                        f"{_format_nonretryable(local_nonretryable)}"
+                    )
                 logger.error("Gateway hit a non-retryable startup conflict: %s", reason)
                 try:
                     from gateway.status import write_runtime_status
@@ -11533,26 +11567,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._startup_restore_in_progress = False
                 return True
             if startup_nonretryable_errors:
-                # Mixed failure mode (NS-609): some platforms are fatally
-                # misconfigured (e.g. WhatsApp enabled but never paired) while
-                # others hit merely transient errors (e.g. Telegram TimedOut
-                # during polling startup).  Exiting with
+                # Platform-local-only and/or mixed-with-retryable failure mode
+                # (NS-609 + optional-platform isolation). Exiting with
                 # GATEWAY_FATAL_CONFIG_EXIT_CODE here is wrong in both
                 # supervision worlds: under supervisors that honor the
                 # exit-78 contract (systemd RestartPreventExitStatus, s6
                 # finish→125 since #51228) the gateway goes PERMANENTLY down
-                # over a network blip; under anything else it crash-loops.
-                # Either way the retryable platforms never get their retry.
-                # Log the fatal side loudly, then fall through to the
-                # degraded/retry path below: the reconnect watcher recovers
-                # the retryable platforms; the non-retryable ones remain
-                # fatal-parked and visible in runtime status.
+                # over an optional adapter; under anything else it crash-loops.
+                # Log the fatal side loudly, then fall through so cron/Kanban
+                # and any retryable platforms keep running; non-retryable
+                # adapters remain fatal-parked in runtime status.
                 logger.error(
                     "%d platform(s) fatally misconfigured and parked: %s. "
-                    "Staying alive so retryable platforms can recover.",
+                    "Staying alive so gateway duties and any recoverable "
+                    "platforms can continue.",
                     len(startup_nonretryable_errors),
-                    "; ".join(startup_nonretryable_errors),
+                    _format_nonretryable(startup_nonretryable_errors),
                 )
+                if local_nonretryable and not startup_retryable_errors:
+                    startup_local_degraded = True
+                    try:
+                        from gateway.status import write_runtime_status
+                        write_runtime_status(
+                            gateway_state="degraded",
+                            exit_reason=None,
+                        )
+                    except Exception:
+                        pass
             if enabled_platform_count > 0:
                 if startup_retryable_errors:
                     # All enabled platforms hit retryable failures (network
@@ -11581,16 +11622,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         pass
                     # Fall through to the normal "running" state — reconnect
                     # watcher takes it from here.
-                # All enabled platforms had no adapter (missing library or credentials).
-                # In fleet deployments the same config.yaml is shared across nodes that
-                # may only have credentials for a subset of platforms.  Rather than
-                # failing hard, degrade gracefully and allow cron jobs to run (#5196).
-                logger.warning(
-                    "No adapter could be created for any of the %d configured platform(s). "
-                    "Check that required dependencies are installed and credentials are set. "
-                    "Gateway will continue for cron job execution.",
-                    enabled_platform_count,
-                )
+                elif not startup_nonretryable_errors:
+                    # All enabled platforms had no adapter (missing library or credentials).
+                    # In fleet deployments the same config.yaml is shared across nodes that
+                    # may only have credentials for a subset of platforms.  Rather than
+                    # failing hard, degrade gracefully and allow cron jobs to run (#5196).
+                    logger.warning(
+                        "No adapter could be created for any of the %d configured platform(s). "
+                        "Check that required dependencies are installed and credentials are set. "
+                        "Gateway will continue for cron job execution.",
+                        enabled_platform_count,
+                    )
             else:
                 logger.warning("No messaging platforms enabled.")
                 logger.info("Gateway will continue running for cron job execution.")
@@ -11602,7 +11644,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._wire_teams_pipeline_runtime()
 
         self._running = True
-        self._update_runtime_status("running")
+        # Preserve degraded diagnostics when optional platforms are parked and
+        # nothing connected; platform fatal state already holds the detail.
+        if not startup_local_degraded:
+            self._update_runtime_status("running")
 
         # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
         # stops refreshing ``state/gateway.heartbeat``. Cancelled with the

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -48,8 +48,8 @@ class _DisabledAdapter(BasePlatformAdapter):
 
 
 class _SuccessfulAdapter(BasePlatformAdapter):
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.DISCORD)
+    def __init__(self, platform: Platform = Platform.DISCORD):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         return True
@@ -348,16 +348,28 @@ class _NonRetryableFailureAdapter(BasePlatformAdapter):
         return {"id": chat_id}
 
 
+def _optional_platform() -> Platform:
+    try:
+        return Platform("buzz")
+    except Exception:
+        return Platform.TELEGRAM
+
+
 class _PlatformLocalAuthFailureAdapter(BasePlatformAdapter):
     """Optional adapter auth/config failure (e.g. Buzz membership rejected)."""
 
-    def __init__(self, platform: Platform = Platform.TELEGRAM):
-        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+    def __init__(self, platform: Platform | None = None):
+        super().__init__(
+            PlatformConfig(enabled=True, token="***"),
+            platform or _optional_platform(),
+        )
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
+        # Production shape: Buzz CLI exit 3 auth_error, non-retryable,
+        # not a single-writer lock conflict.
         self._set_fatal_error(
             "connect_failed",
-            "relay_membership_required: identity is not a member of this community (exit 1)",
+            "auth_error: relay error 403: relay_membership_required (exit 3)",
             retryable=False,
         )
         return False
@@ -374,9 +386,9 @@ class _PlatformLocalAuthFailureAdapter(BasePlatformAdapter):
 
 @pytest.mark.asyncio
 async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeypatch, tmp_path):
-    """Non-retryable startup errors (token collision, no platforms) must
-    set exit_code to 78 (EX_CONFIG) so the s6 finish script can translate
-    it to exit 125 (permanent failure).  See #51228."""
+    """Non-retryable startup errors (token collision) must set exit_code to 78
+    (EX_CONFIG) so the s6 finish script can translate it to exit 125
+    (permanent failure).  See #51228."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     config = GatewayConfig(
         platforms={
@@ -407,9 +419,10 @@ async def test_runner_stays_alive_on_platform_local_auth_failure(monkeypatch, tm
     and leave the process running for cron/Kanban and other platforms.
     """
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    local_platform = _optional_platform()
     config = GatewayConfig(
         platforms={
-            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+            local_platform: PlatformConfig(enabled=True, token="***"),
         },
         sessions_dir=tmp_path / "sessions",
     )
@@ -435,11 +448,16 @@ async def test_runner_stays_alive_on_platform_local_auth_failure(monkeypatch, tm
 
     assert ok is True
     assert runner.should_exit_cleanly is False
-    assert getattr(runner, "exit_code", None) in (None, 0)
+    assert runner.exit_code in (None, 0)
     assert runner.adapters == {}
+    # Non-retryable local auth must be parked, not queued for retry storms.
+    assert local_platform not in runner._failed_platforms
     state = read_runtime_status()
-    assert state is not None
-    assert state.get("gateway_state") in {"running", "degraded"}
+    assert state["gateway_state"] == "degraded"
+    plat_state = state.get("platforms", {}).get(local_platform.value, {})
+    assert plat_state.get("state") == "fatal"
+    assert plat_state.get("error_code") == "connect_failed"
+    assert "relay_membership_required" in (plat_state.get("error_message") or "")
     assert any(
         "fatally misconfigured and parked" in record.message
         for record in caplog.records
@@ -448,9 +466,6 @@ async def test_runner_stays_alive_on_platform_local_auth_failure(monkeypatch, tm
     assert "kanban_dispatcher_watcher" in spawned
     assert "kanban_notifier_watcher" in spawned
     assert "session_expiry_watcher" in spawned
-    # Clean stop so status writers / tasks do not leak into later tests.
-    runner._running = False
-    await runner.stop()
 
 
 @pytest.mark.asyncio
@@ -459,10 +474,12 @@ async def test_runner_keeps_healthy_platform_when_optional_adapter_fails(
 ):
     """One failed optional platform must not prevent other platforms or duties."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    local_platform = _optional_platform()
+    healthy = Platform.DISCORD if local_platform != Platform.DISCORD else Platform.TELEGRAM
     config = GatewayConfig(
         platforms={
-            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
-            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+            local_platform: PlatformConfig(enabled=True, token="***"),
+            healthy: PlatformConfig(enabled=True, token="***"),
         },
         sessions_dir=tmp_path / "sessions",
     )
@@ -470,9 +487,9 @@ async def test_runner_keeps_healthy_platform_when_optional_adapter_fails(
     spawned: list[str] = []
 
     def _create(platform, platform_config):
-        if platform == Platform.TELEGRAM:
-            return _PlatformLocalAuthFailureAdapter(Platform.TELEGRAM)
-        return _SuccessfulAdapter()
+        if platform == local_platform:
+            return _PlatformLocalAuthFailureAdapter(local_platform)
+        return _SuccessfulAdapter(healthy)
 
     monkeypatch.setattr(runner, "_create_adapter", _create)
     monkeypatch.setattr(
@@ -485,12 +502,61 @@ async def test_runner_keeps_healthy_platform_when_optional_adapter_fails(
 
     assert ok is True
     assert runner.should_exit_cleanly is False
-    assert getattr(runner, "exit_code", None) in (None, 0)
-    assert Platform.DISCORD in runner.adapters
-    assert Platform.TELEGRAM not in runner.adapters
+    assert runner.exit_code in (None, 0)
+    assert healthy in runner.adapters
+    assert local_platform not in runner.adapters
+    assert local_platform not in runner._failed_platforms
+    state = read_runtime_status()
+    assert state["gateway_state"] == "running"
+    assert state["platforms"][local_platform.value]["state"] == "fatal"
+    assert state["platforms"][healthy.value]["state"] == "connected"
     assert "kanban_dispatcher_watcher" in spawned
-    runner._running = False
-    await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_runner_stays_alive_on_mixed_retryable_and_nonretryable_errors(
+    monkeypatch, tmp_path, caplog
+):
+    """Mixed startup failures must NOT exit with EX_CONFIG (NS-609)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    def _make_adapter(platform, platform_config):
+        if platform == Platform.DISCORD:
+            # Platform-local non-retryable (not a global lock conflict).
+            return _PlatformLocalAuthFailureAdapter(Platform.DISCORD)
+        return _RetryableFailureAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+    monkeypatch.setattr(
+        runner,
+        "_spawn_supervised",
+        lambda coro_factory, name, **kwargs: None,
+    )
+
+    import logging
+    with caplog.at_level(logging.ERROR):
+        ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert runner.exit_code in (None, 0)
+    state = read_runtime_status()
+    assert state["gateway_state"] in {"degraded", "running"}
+    assert Platform.TELEGRAM in runner._failed_platforms
+    assert state["platforms"]["telegram"]["state"] == "retrying"
+    assert Platform.DISCORD not in runner._failed_platforms
+    assert state["platforms"]["discord"]["state"] == "fatal"
+    assert any(
+        "fatally misconfigured" in record.message for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio
@@ -541,7 +607,7 @@ def test_is_global_startup_conflict_contract():
     assert is_global_startup_conflict("telegram_polling_conflict", "getUpdates conflict")
     assert not is_global_startup_conflict(
         "connect_failed",
-        "relay_membership_required: identity is not a member",
+        "auth_error: relay error 403: relay_membership_required (exit 3)",
     )
     assert not is_global_startup_conflict("config_missing", "BUZZ_PRIVATE_KEY must be set")
     assert not is_global_startup_conflict("missing_credentials", "No bot token configured")
@@ -550,4 +616,3 @@ def test_is_global_startup_conflict_contract():
         None,
         "Telegram bot token already in use (PID 42). Stop the other gateway first.",
     )
-

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -348,6 +348,30 @@ class _NonRetryableFailureAdapter(BasePlatformAdapter):
         return {"id": chat_id}
 
 
+class _PlatformLocalAuthFailureAdapter(BasePlatformAdapter):
+    """Optional adapter auth/config failure (e.g. Buzz membership rejected)."""
+
+    def __init__(self, platform: Platform = Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        self._set_fatal_error(
+            "connect_failed",
+            "relay_membership_required: identity is not a member of this community (exit 1)",
+            retryable=False,
+        )
+        return False
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
 @pytest.mark.asyncio
 async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeypatch, tmp_path):
     """Non-retryable startup errors (token collision, no platforms) must
@@ -371,6 +395,102 @@ async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeyp
     assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
     state = read_runtime_status()
     assert state["gateway_state"] == "startup_failed"
+
+
+@pytest.mark.asyncio
+async def test_runner_stays_alive_on_platform_local_auth_failure(monkeypatch, tmp_path, caplog):
+    """Optional adapter auth/config failure must not kill gateway duties.
+
+    Production outage: Buzz returned relay_membership_required (non-retryable)
+    and the gateway exited 78, stopping scheduler/Kanban ownership until the
+    platform was manually disabled. Platform-local failures park the adapter
+    and leave the process running for cron/Kanban and other platforms.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    spawned: list[str] = []
+
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda platform, platform_config: _PlatformLocalAuthFailureAdapter(platform),
+    )
+
+    def _capture_spawn(coro_factory, name, **kwargs):
+        spawned.append(name)
+        # Do not schedule real background loops in the unit test.
+        return None
+
+    monkeypatch.setattr(runner, "_spawn_supervised", _capture_spawn)
+
+    import logging
+    with caplog.at_level(logging.ERROR):
+        ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert getattr(runner, "exit_code", None) in (None, 0)
+    assert runner.adapters == {}
+    state = read_runtime_status()
+    assert state is not None
+    assert state.get("gateway_state") in {"running", "degraded"}
+    assert any(
+        "fatally misconfigured and parked" in record.message
+        for record in caplog.records
+    ), "expected platform-local failure to be parked, not exit-78"
+    # Unrelated gateway duties still wire up.
+    assert "kanban_dispatcher_watcher" in spawned
+    assert "kanban_notifier_watcher" in spawned
+    assert "session_expiry_watcher" in spawned
+    # Clean stop so status writers / tasks do not leak into later tests.
+    runner._running = False
+    await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_runner_keeps_healthy_platform_when_optional_adapter_fails(
+    monkeypatch, tmp_path
+):
+    """One failed optional platform must not prevent other platforms or duties."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    spawned: list[str] = []
+
+    def _create(platform, platform_config):
+        if platform == Platform.TELEGRAM:
+            return _PlatformLocalAuthFailureAdapter(Platform.TELEGRAM)
+        return _SuccessfulAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", _create)
+    monkeypatch.setattr(
+        runner,
+        "_spawn_supervised",
+        lambda coro_factory, name, **kwargs: spawned.append(name) or None,
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert getattr(runner, "exit_code", None) in (None, 0)
+    assert Platform.DISCORD in runner.adapters
+    assert Platform.TELEGRAM not in runner.adapters
+    assert "kanban_dispatcher_watcher" in spawned
+    runner._running = False
+    await runner.stop()
 
 
 @pytest.mark.asyncio
@@ -412,4 +532,22 @@ async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_
 
     assert exc_info.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
+
+def test_is_global_startup_conflict_contract():
+    from gateway.restart import is_global_startup_conflict
+
+    assert is_global_startup_conflict("discord-bot-token_lock", "token already in use")
+    assert is_global_startup_conflict("lock_conflict", "Buzz identity in use by another profile")
+    assert is_global_startup_conflict("telegram_polling_conflict", "getUpdates conflict")
+    assert not is_global_startup_conflict(
+        "connect_failed",
+        "relay_membership_required: identity is not a member",
+    )
+    assert not is_global_startup_conflict("config_missing", "BUZZ_PRIVATE_KEY must be set")
+    assert not is_global_startup_conflict("missing_credentials", "No bot token configured")
+    # Message fallback when adapters omit a structured code.
+    assert is_global_startup_conflict(
+        None,
+        "Telegram bot token already in use (PID 42). Stop the other gateway first.",
+    )
 


### PR DESCRIPTION
## Bug Description

When an optional messaging adapter failed startup auth/config with a non-retryable error (production: Buzz `relay_membership_required`), the gateway treated it as a global EX_CONFIG and exited 78. That stopped unrelated duties (scheduler / Kanban ownership) until the platform was manually disabled.

## Root Cause

`GatewayRunner.start()` exited with `GATEWAY_FATAL_CONFIG_EXIT_CODE` whenever **every** connect failure was non-retryable and nothing connected — without distinguishing platform-local auth/config failures from true single-writer conflicts (token/identity locks, polling ownership).

## Fix

- Add `is_global_startup_conflict()` to classify lock / polling-conflict failures vs platform-local errors.
- Exit 78 only when the failure set is pure global single-writer conflicts.
- Park optional platform-local failures, keep the gateway alive for cron/Kanban and any healthy/retryable platforms.
- Preserve multiplex config errors and pure lock conflicts as fatal.

## How to Verify

1. Run focused tests (below).
2. Enable an optional adapter that fails membership/auth only: gateway should stay up, adapter marked fatal, Kanban dispatcher still starts.
3. Force a pure token/identity lock conflict with nothing else connected: gateway still exits 78.

## Test Plan

- [x] Added regression tests for platform-local isolation + healthy peer platform + classifier contract
- [x] Existing startup failure / fatal adapter / reconnect tests still pass
- [x] No live services/config/credentials mutated

```
uv run --extra dev pytest tests/gateway/test_runner_startup_failures.py \
  tests/gateway/test_runner_fatal_adapter.py \
  tests/gateway/test_platform_reconnect.py \
  tests/gateway/test_stale_platform_lock_retryable.py -q
# 10 + 27 passed
```

## Risk Assessment

Low — narrow classification on the zero-connected startup path; pure lock conflicts and multiplex config errors keep the previous fatal exit contract.