### PR TITLE
test(timezone): cover invalid-timezone fallback, drop redundant except

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -85,7 +85,7 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
     try:
         return ZoneInfo(name)
-    except (KeyError, Exception) as exc:
+    except Exception as exc:
         logger.warning(
             "Invalid timezone '%s': %s. Falling back to server local time.",
             name, exc,

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -86,6 +86,26 @@ class TestGetTimezone:
         assert isinstance(tz, ZoneInfo)
         assert str(tz) == "Europe/London"
 
+    def test_invalid_timezone_falls_back_to_none(self, caplog):
+        """An invalid IANA name must not crash: get_timezone() returns None."""
+        os.environ["HERMES_TIMEZONE"] = "Not/AZone"
+        tz = hermes_time.get_timezone()
+        assert tz is None
+
+    def test_now_falls_back_to_server_local_time_on_invalid_tz(self, caplog):
+        """now() must stay tz-aware and not raise for an invalid timezone."""
+        os.environ["HERMES_TIMEZONE"] = "Not/AZone"
+        result = hermes_time.now()
+        assert result.tzinfo is not None
+        assert result.utcoffset() is not None
+
+    def test_invalid_timezone_logs_a_warning(self, caplog):
+        """The fallback is observable: a warning names the bad timezone."""
+        os.environ["HERMES_TIMEZONE"] = "Not/AZone"
+        with caplog.at_level(logging.WARNING, logger="hermes_time"):
+            hermes_time.get_timezone()
+        assert any("Not/AZone" in r.message for r in caplog.records)
+
 
 
 


### PR DESCRIPTION
**Problem:** `hermes_time` promises in its module docstring that Hermes *never crashes due to a bad timezone string*, and `tests/test_timezone.py` even lists "Invalid timezone falls back safely" as covered behavior — but **no test exercises the fallback path**. A regression here (e.g. an exception escaping `_get_zoneinfo`) would crash every `now()` call silently.

**Fix:**
- Add tests: invalid IANA name (`Not/AZone`) → `get_timezone()` returns `None`, `now()` stays tz-aware, and a warning names the offending value.
- Drop the redundant `except (KeyError, Exception)` — `ZoneInfoNotFoundError` is a `KeyError` subclass, and `Exception` already covers it.

**Verified:** `python3 -m pytest tests/test_timezone.py -k "not TestCodeExecutionTZ"` → 12 passed. (The two excluded tests need a sandbox/UDS environment and fail identically on unmodified main here.)