### PR TITLE
fix(update-check): recover shallow behind counts safely

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -127,6 +127,19 @@ _UPDATE_CHECK_CACHE_SECONDS = 6 * 3600
 # (e.g. nix-built hermes — no local git history to count against).
 UPDATE_AVAILABLE_NO_COUNT = -1
 
+# How many extra commits to pull when recovering a countable merge-base on a
+# shallow installer checkout. Bounded so passive checks never unshallow the
+# whole history; enough that typical candidate lag becomes countable.
+_SHALLOW_DEEPEN_COMMITS = 200
+
+# ``shallow.lock`` is only held for the duration of a fetch that rewrites the
+# shallow boundary. Anything older than this is treated as abandoned debris
+# from a crashed/interrupted fetch. We deliberately do NOT sweep
+# index.lock / HEAD.lock / packed-refs.lock — those can be held by a live
+# concurrent git process (status, commit, rebase) and unlinking them races
+# that process.
+_STALE_SHALLOW_LOCK_MIN_AGE_SECONDS = 120
+
 _UPSTREAM_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 _OFFICIAL_REPO_CANONICAL = "github.com/nousresearch/hermes-agent"
 
@@ -182,6 +195,94 @@ def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str
     return (result.stdout or "").strip()
 
 
+def _resolve_git_dirs(repo_dir: Path) -> list[Path]:
+    """Return unique absolute git-dir paths for ``repo_dir``.
+
+    Linked worktrees / candidate installs share objects via the *common*
+    git dir (``git rev-parse --git-common-dir``). Lock files written by a
+    fetch live there, not in the per-worktree git dir — so callers that
+    only look at ``repo_dir / ".git"`` miss the debris that actually
+    wedges subsequent fetches.
+    """
+    dirs: list[Path] = []
+    for flag in ("--git-common-dir", "--git-dir"):
+        raw = _git_stdout(["rev-parse", flag], cwd=repo_dir)
+        if not raw:
+            continue
+        root = Path(raw)
+        if not root.is_absolute():
+            root = (repo_dir / root).resolve()
+        else:
+            root = root.resolve()
+        if root not in dirs:
+            dirs.append(root)
+    return dirs
+
+
+def _clear_stale_shallow_locks(
+    repo_dir: Path,
+    *,
+    min_age_seconds: Optional[int] = None,
+    now: Optional[float] = None,
+) -> list[str]:
+    """Remove abandoned ``shallow.lock`` files that block deepen/fetch.
+
+    Scope is intentionally narrow:
+
+    * only ``shallow.lock`` (never index/HEAD/packed-refs locks — those can
+      be held by a live concurrent git process);
+    * only when the lock's mtime is older than
+      :data:`_STALE_SHALLOW_LOCK_MIN_AGE_SECONDS` (live fetches finish well
+      under that window; younger locks are presumed in use);
+    * both ``--git-common-dir`` and ``--git-dir`` so shared-git candidate
+      worktrees are covered.
+
+    Returns the list of removed paths. Never raises.
+    """
+    removed: list[str] = []
+    age = (
+        _STALE_SHALLOW_LOCK_MIN_AGE_SECONDS
+        if min_age_seconds is None
+        else min_age_seconds
+    )
+    cutoff = (time.time() if now is None else now) - age
+    try:
+        for root in _resolve_git_dirs(repo_dir):
+            lock = root / "shallow.lock"
+            try:
+                if lock.is_file() and lock.stat().st_mtime < cutoff:
+                    lock.unlink()
+                    removed.append(str(lock))
+                    logger.info("Removed stale git shallow.lock at %s", lock)
+            except OSError:
+                logger.debug("Could not clear %s (skipping)", lock, exc_info=True)
+    except Exception:
+        logger.debug("stale shallow.lock sweep failed", exc_info=True)
+    return removed
+
+
+def _count_commits_behind(repo_dir: Path, target_ref: str) -> Optional[int]:
+    """Return ``rev-list --count HEAD..<target_ref>`` when countable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", f"HEAD..{target_ref}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    text = (result.stdout or "").strip()
+    if not text.isdigit():
+        return None
+    return int(text)
+
+
 def _check_via_rev(local_rev: str) -> Optional[int]:
     """Compare an embedded git revision to upstream main via ls-remote.
 
@@ -214,16 +315,22 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
             return 1
         return checked
 
-    # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
-    # clone the history stops at a single commit, so a plain `git fetch` would
-    # unshallow the repo (dragging in the whole history) and
-    # `rev-list --count HEAD..origin/main` would report a huge bogus "behind"
-    # number (e.g. "12492 commits behind"). Detect shallow up front: fetch with
-    # --depth 1 to preserve the boundary and compare tip SHAs instead of
-    # counting. Full clones (developers, Docker dev images) keep the exact
-    # count path unchanged. Mirrors the desktop fix in apps/desktop/electron/main.cjs.
+    # Installer / candidate checkouts are often shallow (`git clone --depth 1`
+    # or a linked worktree sharing a shallow common dir). A plain unscoped
+    # fetch would unshallow the whole history, and ``rev-list --count`` without
+    # a merge-base walks remote ancestry into a huge bogus "behind" number
+    # (see #51922). Strategy:
+    #   1. Clear abandoned shallow.lock debris (common-dir aware).
+    #   2. Refresh with ``--deepen N`` — never ``--depth 1``, which re-shallows
+    #      and destroys any previously recovered merge-base.
+    #   3. Tip-equal → 0. Tip-differs → deepen again, count only when
+    #      merge-base exists; otherwise fall back to UPDATE_AVAILABLE_NO_COUNT
+    #      (Desktop maps -1 → "(update)", >0 → "(+N)").
+    # Full clones keep the exact ``HEAD..origin/main`` count path.
     shallow = _git_stdout(["rev-parse", "--is-shallow-repository"], cwd=repo_dir)
     is_shallow = shallow == "true"
+
+    _clear_stale_shallow_locks(repo_dir)
 
     try:
         # Scope the fetch to the one branch the behind-count compares against.
@@ -236,7 +343,7 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         # scoped fetch also updates.
         fetch_args = ["git", "fetch", "origin", "main"]
         if is_shallow:
-            fetch_args += ["--depth", "1"]
+            fetch_args += ["--deepen", str(_SHALLOW_DEEPEN_COMMITS)]
         fetch_args.append("--quiet")
         subprocess.run(
             fetch_args,
@@ -247,9 +354,10 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         pass  # Offline or timeout — use stale refs, that's fine
 
     if is_shallow:
-        # No history to count across the shallow boundary. `origin/main` may not
-        # be a tracking ref in a `clone --depth 1`, so prefer FETCH_HEAD (just
-        # updated by the fetch above) and fall back to origin/main.
+        # Depth-1 clones can compare tips, but tip inequality alone cannot
+        # produce a commit count. Prefer FETCH_HEAD (just updated above), then
+        # origin/main. When tips differ, deepen enough to connect history and
+        # return a real rev-list count when merge-base exists.
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
         target_rev = (
             _git_stdout(["rev-parse", "FETCH_HEAD"], cwd=repo_dir)
@@ -257,19 +365,47 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         )
         if not head_rev or not target_rev:
             return None
-        return 0 if head_rev == target_rev else UPDATE_AVAILABLE_NO_COUNT
+        if head_rev == target_rev:
+            return 0
 
-    try:
-        result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=5,
-            cwd=str(repo_dir),
+        # Best-effort second deepen so HEAD..upstream is countable. Ignore
+        # failures (offline / immutable). Scoped to main to match the fetch
+        # above. Clear abandoned shallow.lock again first — a crashed first
+        # deepen is exactly how the lock gets left behind.
+        _clear_stale_shallow_locks(repo_dir)
+        try:
+            subprocess.run(
+                [
+                    "git",
+                    "fetch",
+                    "--deepen",
+                    str(_SHALLOW_DEEPEN_COMMITS),
+                    "origin",
+                    "main",
+                    "--quiet",
+                ],
+                capture_output=True,
+                timeout=30,
+                cwd=str(repo_dir),
+            )
+        except Exception:
+            pass
+
+        target_ref = (
+            "FETCH_HEAD"
+            if _git_stdout(["rev-parse", "FETCH_HEAD"], cwd=repo_dir)
+            else "origin/main"
         )
-        if result.returncode == 0:
-            return int(result.stdout.strip())
-    except Exception:
-        pass
+        merge_base = _git_stdout(["merge-base", "HEAD", target_ref], cwd=repo_dir)
+        if merge_base:
+            counted = _count_commits_behind(repo_dir, target_ref)
+            if counted is not None:
+                return counted
+        return UPDATE_AVAILABLE_NO_COUNT
+
+    counted = _count_commits_behind(repo_dir, "origin/main")
+    if counted is not None:
+        return counted
     return None
 
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -2,14 +2,13 @@
 
 import json
 import os
+import subprocess
 import threading
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-
-
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
@@ -33,10 +32,6 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     mock_run.assert_not_called()
 
 
-
-
-
-
 def test_prefetch_non_blocking():
     """prefetch_update_check() should return immediately without blocking."""
     import hermes_cli.banner as banner
@@ -58,5 +53,281 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    )
+    return (result.stdout or "").strip()
 
 
+def _init_repo(path: Path) -> Path:
+    path.mkdir(parents=True)
+    _git(path, "init")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "test")
+    (path / "README").write_text("one\n", encoding="utf-8")
+    _git(path, "add", "README")
+    _git(path, "commit", "-m", "init")
+    return path
+
+
+def test_clear_stale_shallow_locks_removes_old_only(tmp_path):
+    """Only aged shallow.lock is removed; young locks and other lock names stay."""
+    import hermes_cli.banner as banner
+
+    repo = _init_repo(tmp_path / "repo")
+    git_dir = Path(_git(repo, "rev-parse", "--git-dir"))
+    if not git_dir.is_absolute():
+        git_dir = (repo / git_dir).resolve()
+
+    stale = git_dir / "shallow.lock"
+    fresh = git_dir / "shallow.lock.fresh-marker"  # not used; we toggle mtime
+    index_lock = git_dir / "index.lock"
+    head_lock = git_dir / "HEAD.lock"
+    packed_lock = git_dir / "packed-refs.lock"
+
+    stale.write_text("stale\n", encoding="utf-8")
+    index_lock.write_text("live-index\n", encoding="utf-8")
+    head_lock.write_text("live-head\n", encoding="utf-8")
+    packed_lock.write_text("live-packed\n", encoding="utf-8")
+
+    old = time.time() - (banner._STALE_SHALLOW_LOCK_MIN_AGE_SECONDS + 30)
+    os.utime(stale, (old, old))
+
+    # Fresh shallow.lock should survive
+    # (recreate after first sweep with recent mtime)
+    removed = banner._clear_stale_shallow_locks(repo)
+    assert str(stale) in removed
+    assert not stale.exists()
+    assert index_lock.exists()
+    assert head_lock.exists()
+    assert packed_lock.exists()
+
+    fresh_lock = git_dir / "shallow.lock"
+    fresh_lock.write_text("fresh\n", encoding="utf-8")
+    removed_fresh = banner._clear_stale_shallow_locks(repo)
+    assert removed_fresh == []
+    assert fresh_lock.exists()
+
+
+def test_clear_stale_shallow_locks_uses_common_dir_for_worktree(tmp_path):
+    """Candidate/worktree installs store shallow.lock in the common git dir."""
+    import hermes_cli.banner as banner
+
+    main = _init_repo(tmp_path / "main")
+    # Need a second commit so worktree can detach cleanly on older git.
+    (main / "README").write_text("two\n", encoding="utf-8")
+    _git(main, "add", "README")
+    _git(main, "commit", "-m", "two")
+
+    wt = tmp_path / "worktree"
+    _git(main, "worktree", "add", "--detach", str(wt), "HEAD~0")
+
+    common = Path(_git(wt, "rev-parse", "--git-common-dir"))
+    if not common.is_absolute():
+        common = (wt / common).resolve()
+
+    lock = common / "shallow.lock"
+    lock.write_text("stale-common\n", encoding="utf-8")
+    old = time.time() - (banner._STALE_SHALLOW_LOCK_MIN_AGE_SECONDS + 5)
+    os.utime(lock, (old, old))
+
+    # Also plant a non-shallow lock in common dir — must survive.
+    other = common / "index.lock"
+    other.write_text("nope\n", encoding="utf-8")
+    os.utime(other, (old, old))
+
+    removed = banner._clear_stale_shallow_locks(wt)
+    assert any(Path(p).name == "shallow.lock" for p in removed)
+    assert not lock.exists()
+    assert other.exists()
+
+
+def test_shallow_clone_returns_real_count_when_history_connects(tmp_path, monkeypatch):
+    """Shallow installs must not force behind=-1 when rev-list can count.
+
+    Desktop maps -1 → "(update)" and >0 → "(+N)". Candidate/worktree deploys
+    are shallow; without a real count the status bar never shows (+N).
+    """
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    calls = {"deepen": 0, "depth1": 0, "cleared": 0}
+
+    def fake_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "true"
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return "aaa111"
+        if args[:2] == ["rev-parse", "FETCH_HEAD"]:
+            return "bbb222"
+        if args[:2] == ["rev-parse", "origin/main"]:
+            return "bbb222"
+        if args[:3] == ["remote", "get-url", "origin"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:1] == ["merge-base"]:
+            return "aaa111"
+        if args[:1] == ["rev-parse"] and args[1] in ("--git-common-dir", "--git-dir"):
+            return str(repo / ".git")
+        return None
+
+    real_run = subprocess.run
+
+    def fake_run(args, **kwargs):
+        argv = list(args)
+        if argv and argv[0] == "git":
+            argv = argv[1:]
+        if argv[:1] == ["fetch"]:
+            if "--deepen" in argv:
+                calls["deepen"] += 1
+            if "--depth" in argv:
+                calls["depth1"] += 1
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        if argv[:1] == ["rev-list"]:
+            return type("R", (), {"returncode": 0, "stdout": "7\n", "stderr": ""})()
+        return real_run(args, **kwargs)
+
+    def fake_clear(repo_dir, **kwargs):
+        calls["cleared"] += 1
+        return []
+
+    monkeypatch.setattr(banner, "_git_stdout", fake_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    monkeypatch.setattr(banner, "_clear_stale_shallow_locks", fake_clear)
+
+    behind = banner._check_via_local_git(repo)
+    assert behind == 7
+    assert calls["deepen"] >= 1
+    assert calls["depth1"] == 0
+    assert calls["cleared"] >= 1
+
+
+def test_shallow_tip_equal_returns_zero_without_count(tmp_path, monkeypatch):
+    """Matching tips on a shallow clone are up-to-date — no deepen/count needed."""
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    def fake_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "true"
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return "same"
+        if args[:2] == ["rev-parse", "FETCH_HEAD"]:
+            return "same"
+        if args[:3] == ["remote", "get-url", "origin"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:1] == ["rev-parse"] and args[1] in ("--git-common-dir", "--git-dir"):
+            return str(repo / ".git")
+        return None
+
+    def fake_run(args, **kwargs):
+        argv = list(args)
+        if argv and argv[0] == "git":
+            argv = argv[1:]
+        if argv[:1] == ["fetch"]:
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        if argv[:1] == ["rev-list"]:
+            raise AssertionError("rev-list must not run when tips match")
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": "nope"})()
+
+    monkeypatch.setattr(banner, "_git_stdout", fake_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    monkeypatch.setattr(banner, "_clear_stale_shallow_locks", lambda *a, **k: [])
+
+    assert banner._check_via_local_git(repo) == 0
+
+
+def test_shallow_without_merge_base_falls_back_to_no_count(tmp_path, monkeypatch):
+    """When deepen cannot connect history, keep the presence-only sentinel."""
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    def fake_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "true"
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return "aaa"
+        if args[:2] == ["rev-parse", "FETCH_HEAD"]:
+            return "bbb"
+        if args[:3] == ["remote", "get-url", "origin"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:1] == ["merge-base"]:
+            return None
+        if args[:1] == ["rev-parse"] and args[1] in ("--git-common-dir", "--git-dir"):
+            return str(repo / ".git")
+        return None
+
+    def fake_run(args, **kwargs):
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(banner, "_git_stdout", fake_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    monkeypatch.setattr(banner, "_clear_stale_shallow_locks", lambda *a, **k: [])
+
+    assert banner._check_via_local_git(repo) == banner.UPDATE_AVAILABLE_NO_COUNT
+
+
+def test_shallow_fetch_never_uses_depth_one(tmp_path, monkeypatch):
+    """Re-fetching with --depth 1 destroys merge-base; deepen is required."""
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    seen = []
+
+    def fake_stdout(args, *, cwd, timeout=5):
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "true"
+        if args[:2] == ["rev-parse", "HEAD"]:
+            return "h1"
+        if args[:2] == ["rev-parse", "FETCH_HEAD"]:
+            return "h2"
+        if args[:3] == ["remote", "get-url", "origin"]:
+            return "https://github.com/NousResearch/hermes-agent.git"
+        if args[:1] == ["merge-base"]:
+            return "h1"
+        if args[:1] == ["rev-parse"] and args[1] in ("--git-common-dir", "--git-dir"):
+            return str(repo / ".git")
+        return None
+
+    def fake_run(args, **kwargs):
+        argv = list(args)
+        if argv and argv[0] == "git":
+            argv = argv[1:]
+        if argv[:1] == ["fetch"]:
+            seen.append(argv)
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        if argv[:1] == ["rev-list"]:
+            return type("R", (), {"returncode": 0, "stdout": "3\n", "stderr": ""})()
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(banner, "_git_stdout", fake_stdout)
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    monkeypatch.setattr(banner, "_clear_stale_shallow_locks", lambda *a, **k: [])
+
+    assert banner._check_via_local_git(repo) == 3
+    assert seen, "expected at least one fetch"
+    for argv in seen:
+        assert "--depth" not in argv
+        assert "--deepen" in argv


### PR DESCRIPTION
## Summary

Shallow candidate/worktree installs were stuck at `behind=-1` (Desktop badge `(update)` instead of `(+N)`) because:

1. `git fetch --depth 1` re-shallowed the checkout and destroyed any recovered merge-base
2. abandoned `shallow.lock` from a crashed deepen/fetch blocked later fetches (especially on shared-`.git` candidate worktrees, where the lock lives in the *common* git dir)

### Fix

- Clear **only** age-stale `shallow.lock` (≥120s), consulting both `--git-common-dir` and `--git-dir`
- **Never** unlink `index.lock` / `HEAD.lock` / `packed-refs.lock` (live concurrent git can hold those)
- Refresh shallow repos with bounded `--deepen 200` instead of `--depth 1`
- When tips differ: deepen again, count via `rev-list` only if `merge-base` exists; otherwise keep `UPDATE_AVAILABLE_NO_COUNT` (`-1`)

## Overlap / supersession analysis

| PR | Scope | Overlap with this change |
|---|---|---|
| **#82608** desktop separate client/backend update states | Desktop TS/TSX only | **None** — no `banner.py` |
| **#82658** backend update failure visibility | `banner.py` structured `(behind, error_code, revision)` + ownership/writable | **Adjacent, does not supersede** — still uses `--depth 1` on shallow and has no lock cleanup / deepen / countable recovery |

This PR is intentionally **not** folded into #82658: that PR is a large return-type/ownership refactor; this is a focused shallow-recovery fix that applies cleanly on current `main` and can be rebased into #82658 later if desired.

Preserved local patch (`.active-banner.patch` from the active candidate) was more aggressive (unlinked index/HEAD/packed-refs locks unconditionally). This implementation is the **conservative** subset required by acceptance: age-gated `shallow.lock` only.

## Test plan

- [x] `uv run pytest tests/hermes_cli/test_update_check.py tests/hermes_cli/test_banner_git_state.py tests/hermes_cli/test_banner.py -q` → 13 passed
- [x] Real-git: stale `shallow.lock` removed; fresh lock kept; common-dir worktree covered; other lock names untouched
- [x] Mocked shallow path: `--deepen` used, never `--depth 1`; real count when merge-base exists; `-1` without merge-base; tip-equal → 0
- [x] `ruff check` on touched files
- [x] Does **not** edit the active installed checkout

## Active-install note

Project owner should clean active-install dirt only after this PR (or equivalent) is durable. This worktree never touched the live install.