### PR TITLE
fix(gateway): recover persisted turns after WebSocket replacement

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -35,6 +35,7 @@ import { $billingSettingsRequest } from '@/store/billing-block'
 import { $desktopBoot } from '@/store/boot'
 import { requestVoiceConversationStart } from '@/store/composer'
 import { setCronFocusJobId } from '@/store/cron'
+import { $gatewayConnectionEpochs } from '@/store/gateway'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $previewTarget } from '@/store/preview'
 import {
@@ -164,6 +165,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const actionsRef = useRef<WiringActions | null>(null)
 
   const gatewayState = useStore($gatewayState)
+  const gatewayConnectionEpochs = useStore($gatewayConnectionEpochs)
   const activeSessionId = useStore($activeSessionId)
   const billingSettingsRequest = useStore($billingSettingsRequest)
   const currentCwd = useStore($currentCwd)
@@ -187,6 +189,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const messagingSessions = useStore($messagingSessions)
   const sessions = useStore($sessions)
   const activeGatewayProfile = useStore($activeGatewayProfile)
+  const gatewayConnectionEpoch = gatewayConnectionEpochs[normalizeProfileKey(activeGatewayProfile)] ?? 0
   const profileScope = useStore($profileScope)
   const boot = useStore($desktopBoot)
 
@@ -671,6 +674,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     creatingSessionRef,
     currentView,
     freshDraftReady,
+    gatewayConnectionEpoch,
     gatewayState,
     locationPathname: location.pathname,
     resumeSession,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
@@ -1,10 +1,11 @@
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
 import { $gateway } from '@/store/gateway'
+import { setGatewayState } from '@/store/session'
 
-import { useGatewayRequest } from './use-gateway-request'
+import { requestMayReplayAfterReconnect, useGatewayRequest } from './use-gateway-request'
 
 const fakeGateway = { connectionState: 'open' } as unknown as HermesGateway
 
@@ -35,5 +36,69 @@ describe('useGatewayRequest', () => {
     act(() => $gateway.set(fakeGateway))
 
     expect(result.current.gateway).toBe(fakeGateway)
+  })
+
+  it('never replays prompt.submit after an ambiguous reconnect', () => {
+    expect(requestMayReplayAfterReconnect('prompt.submit')).toBe(false)
+    expect(requestMayReplayAfterReconnect('session.list')).toBe(true)
+    expect(requestMayReplayAfterReconnect('session.list', { replayOnReconnect: false })).toBe(false)
+  })
+
+  it('reconnects and reports prompt delivery as unconfirmed after a submit timeout', async () => {
+    let connectionState = 'open'
+
+    const request = vi.fn(async () => {
+      throw new Error('request timed out after 30s: prompt.submit')
+    })
+
+    const invalidate = vi.fn(() => {
+      connectionState = 'closed'
+      setGatewayState('closed')
+    })
+
+    const connect = vi.fn(async () => {
+      connectionState = 'open'
+      setGatewayState('open')
+    })
+
+    const gateway = {
+      connect,
+      invalidate,
+      request,
+      get connectionState() {
+        return connectionState
+      }
+    } as unknown as HermesGateway
+
+    const desktop = window.hermesDesktop
+
+    window.hermesDesktop = {
+      ...desktop,
+      getConnection: vi.fn(async () => ({
+        authMode: 'token',
+        baseUrl: 'http://gateway.test',
+        isFullscreen: false,
+        logs: [],
+        nativeOverlayWidth: 0,
+        token: 'test-token',
+        windowButtonPosition: null,
+        wsUrl: 'ws://gateway.test/api/ws'
+      }))
+    } as typeof window.hermesDesktop
+    setGatewayState('open')
+    $gateway.set(gateway)
+
+    try {
+      const { result } = renderHook(() => useGatewayRequest())
+
+      await expect(result.current.requestGateway('prompt.submit', { text: 'one prompt' })).rejects.toThrow(
+        'delivery not confirmed after reconnect: prompt.submit'
+      )
+      expect(request).toHaveBeenCalledTimes(1)
+      expect(invalidate).toHaveBeenCalledTimes(1)
+      expect(connect).toHaveBeenCalledTimes(1)
+    } finally {
+      window.hermesDesktop = desktop
+    }
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
@@ -101,4 +101,82 @@ describe('useGatewayRequest', () => {
       window.hermesDesktop = desktop
     }
   })
+
+  it('waits for an in-flight reconnect owner before reporting an ambiguous submit', async () => {
+    let connectionState = 'open'
+    let settled = false
+    const stateHandlers = new Set<(state: string) => void>()
+
+    const request = vi.fn(async () => {
+      throw new Error('request timed out after 30s: prompt.submit')
+    })
+
+    const invalidate = vi.fn(() => {
+      // The normal boot owner reacts first and starts the replacement socket.
+      connectionState = 'connecting'
+      setGatewayState('connecting')
+    })
+
+    // JsonRpcGatewayClient.connect() returns immediately when another owner is
+    // already connecting. requestGateway must still wait for the real open.
+    const connect = vi.fn(async () => undefined)
+
+    const gateway = {
+      connect,
+      invalidate,
+      onState: vi.fn((handler: (state: string) => void) => {
+        stateHandlers.add(handler)
+
+        return () => stateHandlers.delete(handler)
+      }),
+      request,
+      get connectionState() {
+        return connectionState
+      }
+    } as unknown as HermesGateway
+
+    const desktop = window.hermesDesktop
+
+    window.hermesDesktop = {
+      ...desktop,
+      getConnection: vi.fn(async () => ({
+        authMode: 'token',
+        baseUrl: 'http://gateway.test',
+        isFullscreen: false,
+        logs: [],
+        nativeOverlayWidth: 0,
+        token: 'test-token',
+        windowButtonPosition: null,
+        wsUrl: 'ws://gateway.test/api/ws'
+      }))
+    } as typeof window.hermesDesktop
+    setGatewayState('open')
+    $gateway.set(gateway)
+
+    try {
+      const { result } = renderHook(() => useGatewayRequest())
+      const recovery = result.current.requestGateway('prompt.submit', { text: 'one prompt' })
+
+      void recovery.then(
+        () => {
+          settled = true
+        },
+        () => {
+          settled = true
+        }
+      )
+
+      await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(1))
+      expect(settled).toBe(false)
+
+      connectionState = 'open'
+      setGatewayState('open')
+      stateHandlers.forEach(handler => handler('open'))
+
+      await expect(recovery).rejects.toThrow('delivery not confirmed after reconnect: prompt.submit')
+      expect(request).toHaveBeenCalledTimes(1)
+    } finally {
+      window.hermesDesktop = desktop
+    }
+  })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -20,6 +20,49 @@ export function requestMayReplayAfterReconnect(method: string, policy: GatewayRe
   return policy.replayOnReconnect ?? method !== 'prompt.submit'
 }
 
+function waitForGatewayOpen(gateway: HermesGateway): Promise<void> {
+  if (gateway.connectionState === 'open') {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+
+    let unsubscribe = () => {}
+
+    const finish = (error?: Error) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      unsubscribe()
+
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    }
+
+    unsubscribe = gateway.onState(state => {
+      if (state === 'open') {
+        finish()
+      } else if (state === 'closed' || state === 'error') {
+        finish(new Error(`gateway reconnect ended in ${state}`))
+      }
+    })
+
+    const state = gateway.connectionState
+
+    if (state === 'open') {
+      finish()
+    } else if (state === 'closed' || state === 'error') {
+      finish(new Error(`gateway reconnect ended in ${state}`))
+    }
+  })
+}
+
 export function useGatewayRequest() {
   const gatewayState = useStore($gatewayState)
   // Reactive companion to `gatewayRef`. The ref exists so `requestGateway`
@@ -97,6 +140,7 @@ export function useGatewayRequest() {
         // actionable "sign in again" message.
         const wsUrl = await resolveGatewayWsUrl(desktop, conn)
         await existing.connect(wsUrl)
+        await waitForGatewayOpen(existing)
 
         return existing
       } catch (error) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -7,6 +7,19 @@ import { $gateway, ensureActiveGatewayOpen, isActivePrimary } from '@/store/gate
 import { $activeGatewayProfile } from '@/store/profile'
 import { $gatewayState, setConnection } from '@/store/session'
 
+export interface GatewayReconnectPolicy {
+  /**
+   * Whether a request may be sent again after reconnect. Non-idempotent calls
+   * such as prompt.submit must opt out because a closed socket cannot prove
+   * whether the backend accepted the first frame.
+   */
+  replayOnReconnect?: boolean
+}
+
+export function requestMayReplayAfterReconnect(method: string, policy: GatewayReconnectPolicy = {}): boolean {
+  return policy.replayOnReconnect ?? method !== 'prompt.submit'
+}
+
 export function useGatewayRequest() {
   const gatewayState = useStore($gatewayState)
   // Reactive companion to `gatewayRef`. The ref exists so `requestGateway`
@@ -52,7 +65,7 @@ export function useGatewayRequest() {
       return null
     }
 
-    if (gatewayStateRef.current === 'open') {
+    if (gatewayStateRef.current === 'open' && existing.connectionState === 'open') {
       return existing
     }
 
@@ -104,7 +117,13 @@ export function useGatewayRequest() {
   }, [])
 
   const requestGateway = useCallback(
-    async <T>(method: string, params: Record<string, unknown> = {}, timeoutMs?: number, signal?: AbortSignal) => {
+    async <T>(
+      method: string,
+      params: Record<string, unknown> = {},
+      timeoutMs?: number,
+      signal?: AbortSignal,
+      reconnectPolicy: GatewayReconnectPolicy = {}
+    ) => {
       const gateway = gatewayRef.current
 
       if (!gateway) {
@@ -115,9 +134,17 @@ export function useGatewayRequest() {
         return await gateway.request<T>(method, params, timeoutMs, signal)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
+        const ambiguousPromptTimeout = method === 'prompt.submit' && /request timed out/i.test(message)
 
-        if (!/not connected|connection closed/i.test(message)) {
+        if (
+          !ambiguousPromptTimeout &&
+          !/not connected|connection closed|heartbeat acknowledgement timed out/i.test(message)
+        ) {
           throw error
+        }
+
+        if (ambiguousPromptTimeout) {
+          gateway.invalidate('prompt.submit delivery timed out')
         }
 
         // Primary keeps the OAuth-aware reconnect (remote gateways re-mint a
@@ -136,6 +163,12 @@ export function useGatewayRequest() {
           }
 
           throw error
+        }
+
+        const replayOnReconnect = requestMayReplayAfterReconnect(method, reconnectPolicy)
+
+        if (!replayOnReconnect) {
+          throw new Error(`delivery not confirmed after reconnect: ${method}`)
         }
 
         return recovered.request<T>(method, params, timeoutMs, signal)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -3146,29 +3146,28 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls).not.toContain('session.resume')
   })
 
-  it('recovers via session.resume when prompt.submit TIMES OUT and a stored session is selected (#55578)', async () => {
-    // A starved gateway loop rejects with "request timed out: prompt.submit".
-    // With a stored session selected, that must recover exactly like
-    // "session not found" — resume + retry — not surface an error that leaves
-    // activeSessionId null and lets the next send mint a new session.
+  it('reconciles an ambiguously accepted prompt without resubmitting it', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
-    let submitAttempts = 0
+    let lastMessages: Array<{ role: string }> = []
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
 
       if (method === 'prompt.submit') {
-        submitAttempts += 1
-
-        if (submitAttempts === 1) {
-          throw new Error('request timed out: prompt.submit')
-        }
-
-        return {} as never
+        throw new Error('delivery not confirmed after reconnect: prompt.submit')
       }
 
-      if (method === 'session.resume') {
-        return { session_id: RECOVERED_SESSION_ID } as never
+      if (method === 'session.activate') {
+        return {
+          session_id: RUNTIME_SESSION_ID,
+          session_key: STORED_SESSION_ID,
+          messages: [
+            { content: 'message during replacement', role: 'user', row_id: 1 },
+            { content: 'persisted answer', role: 'assistant', row_id: 2 }
+          ],
+          running: false,
+          status: 'idle'
+        } as never
       }
 
       return {} as never
@@ -3178,25 +3177,19 @@ describe('usePromptActions sleep/wake session recovery', () => {
     await actRender(
       <Harness
         onReady={h => (handle = h)}
+        onSeedState={state => (lastMessages = state.messages as Array<{ role: string }>)}
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}
         storedSessionId={STORED_SESSION_ID}
       />
     )
 
-    const ok = await handle!.submitText('message during starved loop')
+    const ok = await handle!.submitText('message during replacement')
 
     expect(ok).toBe(true)
-    expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[1]?.params).toEqual({
-      session_id: STORED_SESSION_ID,
-      source: 'desktop',
-      omit_messages: true
-    })
-    expect(calls[2]?.params).toEqual({
-      session_id: RECOVERED_SESSION_ID,
-      text: 'message during starved loop'
-    })
+    expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.activate'])
+    expect(calls.filter(c => c.method === 'prompt.submit')).toHaveLength(1)
+    expect(lastMessages.map(message => message.role)).toEqual(['user', 'assistant'])
   })
 
   it('resumes the SELECTED stored session instead of minting a new one when activeSessionId is null (#55578 split)', async () => {
@@ -3649,32 +3642,27 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(true)
   })
 
-  it('aborts recovery submit when the user switches sessions during timeout resume', async () => {
+  it('never resubmits an ambiguous prompt when activation cannot prove acceptance', async () => {
     const calls: { method: string; params?: Record<string, unknown> }[] = []
-    let submitAttempts = 0
-
-    let releaseResume: () => void = () => {}
-
     const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_A }
+    let lastMessages: Array<{ role: string }> = []
+    setComposerDraft('')
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
 
       if (method === 'prompt.submit') {
-        submitAttempts += 1
-
-        if (submitAttempts === 1) {
-          throw new Error('request timed out: prompt.submit')
-        }
+        throw new Error('delivery not confirmed after reconnect: prompt.submit')
       }
 
-      if (method === 'session.resume') {
-        await new Promise<void>(resolve => {
-          releaseResume = resolve
-        })
-        selectedStoredSessionIdRef.current = STORED_SESSION_B
-
-        return { session_id: RUNTIME_SESSION_B } as never
+      if (method === 'session.activate') {
+        return {
+          session_id: RUNTIME_SESSION_ID,
+          session_key: STORED_SESSION_A,
+          messages: [],
+          running: false,
+          status: 'idle'
+        } as never
       }
 
       return {} as never
@@ -3684,6 +3672,7 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     render(
       <Harness
         onReady={h => (handle = h)}
+        onSeedState={state => (lastMessages = state.messages as Array<{ role: string }>)}
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}
         selectedStoredSessionIdRef={selectedStoredSessionIdRef}
@@ -3692,16 +3681,11 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     )
     await waitFor(() => expect(handle).not.toBeNull())
 
-    const submitting = handle!.submitText('message that must not land in session B')
-    await waitFor(() => expect(calls.some(c => c.method === 'session.resume')).toBe(true))
-    releaseResume()
-
-    expect(await submitting).toBe(false)
-    expect(submitAttempts).toBe(1)
+    expect(await handle!.submitText('message whose delivery is unknown')).toBe(false)
     expect(calls.filter(c => c.method === 'prompt.submit')).toHaveLength(1)
-    expect(calls.find(c => c.method === 'session.resume')?.params).toMatchObject({
-      session_id: STORED_SESSION_A
-    })
+    expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.activate'])
+    expect($composerDraft.get()).toBe('message whose delivery is unknown')
+    expect(lastMessages.some(message => message.role === 'user')).toBe(false)
   })
 
   it('submits the first prompt of a new chat — the create pipeline re-homing selection/route is not user drift', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -2,7 +2,7 @@ import { type MutableRefObject, useCallback } from 'react'
 
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import type { Translations } from '@/i18n'
-import { type ChatMessage, textPart } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText, textPart, toChatMessages } from '@/lib/chat-messages'
 import { optimisticAttachmentRef } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import { setMutableRef } from '@/lib/mutable-ref'
@@ -14,8 +14,11 @@ import {
 } from '@/lib/voice-playback'
 import {
   $composerAttachments,
+  $composerDraft,
+  addComposerAttachment,
   clearComposerAttachments,
   type ComposerAttachment,
+  setComposerDraft,
   terminalContextBlocksFromDraft
 } from '@/store/composer'
 import { $hudMode } from '@/store/hud'
@@ -31,6 +34,7 @@ import {
   touchSessionActivity
 } from '@/store/session'
 import { $sessionStates } from '@/store/session-states'
+import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
@@ -41,6 +45,7 @@ import {
   _submitInFlight,
   type GatewayRequest,
   inlineErrorMessage,
+  isPromptDeliveryUnconfirmedError,
   isProviderSetupError,
   isSessionBusyError,
   isTargetSessionBusy,
@@ -82,6 +87,11 @@ interface SubmitPromptDeps {
     setMessages: (updater: (current: ChatMessage[]) => ChatMessage[]) => void
   }
 }
+
+type SessionActivationRecovery = Pick<
+  SessionResumeResponse,
+  'inflight' | 'messages' | 'running' | 'session_id' | 'session_key' | 'status'
+>
 
 // Stable identity — a fresh default object per render would churn the
 // useCallback below on every render.
@@ -658,17 +668,115 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
                   setActiveSessionId(recoveredId)
                 }
               }
-            },
-            // A starved backend loop (#55578 symptom d) rejects the submit even
-            // though the stored session is fine — recover it like a dead id
-            // instead of erroring out and losing the session binding.
-            { alsoTimeout: true }
+            }
           )
         } catch (firstErr) {
           if (firstErr instanceof SessionRecoveryAborted) {
             console.warn('[submit-drift-abort]', firstErr.reason, { phase: 'post-resume-retry' })
 
             return abortForSessionSwitch(sessionId)
+          }
+
+          if (isPromptDeliveryUnconfirmedError(firstErr)) {
+            let activated: SessionActivationRecovery | null = null
+
+            try {
+              activated = await requestGateway<SessionActivationRecovery>('session.activate', {
+                session_id: sessionId
+              })
+            } catch {
+              // A replacement gateway process may have lost the volatile id.
+              // Resume the durable route once, then activate the fresh binding.
+              const recoverStoredSessionId =
+                targetStoredSessionId ?? selectedStoredSessionIdRef.current ?? startingStoredSessionId
+
+              if (recoverStoredSessionId) {
+                try {
+                  await resumeStoredSession(recoverStoredSessionId)
+                  const recoveredId = activeSessionIdRef.current
+
+                  if (recoveredId) {
+                    sessionId = recoveredId
+                    activated = await requestGateway<SessionActivationRecovery>('session.activate', {
+                      session_id: recoveredId
+                    })
+                  }
+                } catch {
+                  activated = null
+                }
+              }
+            }
+
+            const canonicalMessages = activated?.messages ? toChatMessages(activated.messages) : []
+            const expectedVisible = bubbleText.trim()
+            const expectedWire = text.trim()
+
+            const acceptedUser = canonicalMessages.some(message => {
+              if (message.role !== 'user' || message.id === optimisticId) {
+                return false
+              }
+
+              const persisted = chatMessageText(message).trim()
+
+              return (
+                persisted === expectedVisible ||
+                persisted === expectedWire ||
+                (expectedVisible.length > 0 && persisted.endsWith(expectedVisible))
+              )
+            })
+
+            const accepted = Boolean(activated?.running || activated?.inflight?.user || acceptedUser)
+
+            if (accepted && activated) {
+              sessionId = activated.session_id || sessionId
+              updateSessionState(
+                sessionId,
+                state => ({
+                  ...state,
+                  messages: canonicalMessages,
+                  busy: Boolean(activated.running),
+                  awaitingResponse: Boolean(activated.running),
+                  pendingBranchGroup: null,
+                  sawAssistantPayload: canonicalMessages.some(message => message.role === 'assistant'),
+                  streamId: null
+                }),
+                targetStoredSessionId
+              )
+
+              if (targetIsCurrentView()) {
+                scope.setBusy(Boolean(activated.running))
+                scope.setAwaitingResponse(Boolean(activated.running))
+              }
+
+              if (usingComposerAttachments) {
+                scope.clearAttachments()
+              }
+
+              releaseSubmitLock()
+
+              return true
+            }
+
+            dropOptimistic(sessionId)
+            releaseBusy()
+
+            if (targetIsCurrentView() && scope === MAIN_SUBMIT_SCOPE) {
+              if (!$composerDraft.get().trim()) {
+                setComposerDraft(rawText)
+              }
+
+              const presentAttachmentIds = new Set($composerAttachments.get().map(attachment => attachment.id))
+
+              for (const attachment of attachments) {
+                if (!presentAttachmentIds.has(attachment.id)) {
+                  addComposerAttachment(attachment)
+                }
+              }
+
+              notifyError(new Error(copy.deliveryNotConfirmed), copy.promptFailed)
+            }
+
+            return false
           }
 
           submitErr = firstErr

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -6,7 +6,13 @@ import { type CommandsCatalogLike, filterDesktopCommandsCatalog } from '@/lib/de
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import type { ComposerAttachment } from '@/store/composer'
 
-export type GatewayRequest = <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+export type GatewayRequest = <T>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal,
+  reconnectPolicy?: { replayOnReconnect?: boolean }
+) => Promise<T>
 
 export function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -223,6 +229,12 @@ export function isGatewayTimeoutError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
 
   return /request timed out/i.test(message)
+}
+
+export function isPromptDeliveryUnconfirmedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /delivery not confirmed after reconnect:\s*prompt\.submit/i.test(message)
 }
 
 // The gateway refuses prompt.submit while a turn is running (4009 "session

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -18,6 +18,7 @@ interface HarnessProps {
   creatingSessionRef: MutableRefObject<boolean>
   currentView: string
   freshDraftReady: boolean
+  gatewayConnectionEpoch?: number
   gatewayState: string
   locationPathname: string
   resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
@@ -30,8 +31,13 @@ interface HarnessProps {
   startFreshSessionDraft: (focus: boolean) => unknown
 }
 
-function RouteResumeHarness({ resumeFailedSessionId = null, resumeExhaustedSessionId = null, ...props }: HarnessProps) {
-  useRouteResume({ ...props, resumeExhaustedSessionId, resumeFailedSessionId })
+function RouteResumeHarness({
+  gatewayConnectionEpoch = 0,
+  resumeFailedSessionId = null,
+  resumeExhaustedSessionId = null,
+  ...props
+}: HarnessProps) {
+  useRouteResume({ ...props, gatewayConnectionEpoch, resumeExhaustedSessionId, resumeFailedSessionId })
 
   return null
 }
@@ -303,6 +309,37 @@ describe('useRouteResume', () => {
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('reconciles when a reconnect epoch advances even if React only renders open', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
+    const common = {
+      activeSessionId: 'runtime-1',
+      activeSessionIdRef,
+      creatingSessionRef: { current: false },
+      currentView: 'chat',
+      freshDraftReady: false,
+      gatewayState: 'open',
+      locationPathname: '/session-1',
+      resumeSession,
+      routedSessionId: 'session-1',
+      runtimeIdByStoredSessionIdRef: { current: new Map([['session-1', 'runtime-1']]) },
+      selectedStoredSessionId: 'session-1',
+      selectedStoredSessionIdRef,
+      startFreshSessionDraft: vi.fn()
+    } as const
+
+    const { rerender } = render(<RouteResumeHarness {...common} gatewayConnectionEpoch={1} />)
+
+    expect(resumeSession).not.toHaveBeenCalled()
+    rerender(<RouteResumeHarness {...common} gatewayConnectionEpoch={2} />)
+    expect(resumeSession).toHaveBeenCalledTimes(1)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+
+    rerender(<RouteResumeHarness {...common} gatewayConnectionEpoch={2} />)
+    expect(resumeSession).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -318,6 +318,7 @@ describe('useRouteResume', () => {
     const creatingSessionRef = { current: false }
     const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
     const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
+
     const common = {
       activeSessionId: 'runtime-1',
       activeSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -313,31 +313,39 @@ describe('useRouteResume', () => {
 
   it('reconciles when a reconnect epoch advances even if React only renders open', () => {
     const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
     const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
     const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
     const common = {
       activeSessionId: 'runtime-1',
       activeSessionIdRef,
-      creatingSessionRef: { current: false },
+      creatingSessionRef,
       currentView: 'chat',
       freshDraftReady: false,
       gatewayState: 'open',
       locationPathname: '/session-1',
       resumeSession,
       routedSessionId: 'session-1',
-      runtimeIdByStoredSessionIdRef: { current: new Map([['session-1', 'runtime-1']]) },
+      runtimeIdByStoredSessionIdRef,
       selectedStoredSessionId: 'session-1',
       selectedStoredSessionIdRef,
-      startFreshSessionDraft: vi.fn()
+      startFreshSessionDraft
     } as const
 
     const { rerender } = render(<RouteResumeHarness {...common} gatewayConnectionEpoch={1} />)
 
     expect(resumeSession).not.toHaveBeenCalled()
+
+    // The renderer never observed closed/connecting, but the socket listener
+    // published a new generation when the replacement connection opened.
     rerender(<RouteResumeHarness {...common} gatewayConnectionEpoch={2} />)
+
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
 
+    // Ordinary renders within the same connection generation are idempotent.
     rerender(<RouteResumeHarness {...common} gatewayConnectionEpoch={2} />)
     expect(resumeSession).toHaveBeenCalledTimes(1)
   })

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -10,6 +10,7 @@ interface RouteResumeOptions {
   creatingSessionRef: MutableRefObject<boolean>
   currentView: string
   freshDraftReady: boolean
+  gatewayConnectionEpoch: number
   gatewayState: string | undefined
   locationPathname: string
   resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
@@ -72,6 +73,7 @@ export function useRouteResume({
   creatingSessionRef,
   currentView,
   freshDraftReady,
+  gatewayConnectionEpoch,
   gatewayState,
   locationPathname,
   resumeSession,
@@ -84,6 +86,7 @@ export function useRouteResume({
   startFreshSessionDraft
 }: RouteResumeOptions) {
   const lastPathnameRef = useRef<string | null>(null)
+  const lastGatewayConnectionEpochRef = useRef<number | null>(null)
   const seenGatewayStateRef = useRef(false)
   const wasGatewayOpenRef = useRef(false)
   // True until the FIRST resume this window dispatches. That resume is the
@@ -112,7 +115,14 @@ export function useRouteResume({
     // already open is not mistaken for "became open" and does not double-resume with the
     // pathname-driven initial resume below.
     const gatewayBecameOpen = seenGatewayStateRef.current && !wasGatewayOpenRef.current && gatewayOpen
+    // React can batch a fast closed -> connecting -> open cycle and render only
+    // the final "open" state. The socket listener's monotonic epoch still
+    // exposes that real reconnect.
+    const gatewayConnectionAdvanced =
+      lastGatewayConnectionEpochRef.current !== null && gatewayConnectionEpoch > lastGatewayConnectionEpochRef.current
+    const gatewayReopened = gatewayBecameOpen || gatewayConnectionAdvanced
     lastPathnameRef.current = locationPathname
+    lastGatewayConnectionEpochRef.current = gatewayConnectionEpoch
     seenGatewayStateRef.current = true
     wasGatewayOpenRef.current = gatewayOpen
 
@@ -148,13 +158,13 @@ export function useRouteResume({
       // we're stranded on a routed session that never loaded. The first two
       // guard against a transient /:sid re-resume during "new chat" state clears
       // before the pathname updates from /:sid -> /.
-      const shouldResume = pathnameChanged || gatewayBecameOpen || stuckOnRoutedSession
+      const shouldResume = pathnameChanged || gatewayReopened || stuckOnRoutedSession
 
-      // On a reconnect (gatewayBecameOpen) re-resume even when the route looks
+      // On a reconnect re-resume even when the route looks
       // `alreadyActive`: the cached runtime id can be stale once the gateway
       // rebinds/reaps the session on its side, and trusting it strands Desktop on
       // a dead id ("session not found"). Otherwise keep skipping when already active.
-      if ((gatewayBecameOpen || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
+      if ((gatewayReopened || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
         // The window's FIRST resume re-attaches the pre-reload route rather
         // than navigating anywhere, so the selection listener must not home
         // focus/tabs to the workspace over the persisted layout (see
@@ -187,6 +197,7 @@ export function useRouteResume({
     creatingSessionRef,
     currentView,
     freshDraftReady,
+    gatewayConnectionEpoch,
     gatewayState,
     locationPathname,
     resumeSession,

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -115,11 +115,13 @@ export function useRouteResume({
     // already open is not mistaken for "became open" and does not double-resume with the
     // pathname-driven initial resume below.
     const gatewayBecameOpen = seenGatewayStateRef.current && !wasGatewayOpenRef.current && gatewayOpen
+
     // React can batch a fast closed -> connecting -> open cycle and render only
     // the final "open" state. The socket listener's monotonic epoch still
     // exposes that real reconnect.
     const gatewayConnectionAdvanced =
       lastGatewayConnectionEpochRef.current !== null && gatewayConnectionEpoch > lastGatewayConnectionEpochRef.current
+
     const gatewayReopened = gatewayBecameOpen || gatewayConnectionAdvanced
     lastPathnameRef.current = locationPathname
     lastGatewayConnectionEpochRef.current = gatewayConnectionEpoch

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2522,6 +2522,7 @@ export const ar = defineLocale({
     sessionUnavailable: 'الجلسة غير متاحة',
     createSessionFailed: 'فشل إنشاء الجلسة',
     promptFailed: 'فشل إرسال الرسالة',
+    deliveryNotConfirmed: 'تعذّر تأكيد التسليم. تمت استعادة رسالتك؛ أعد المحاولة عندما تكون مستعدًا.',
     providerCredentialRequired: 'مطلوب اعتماد المزود',
     emptySlashCommand: 'أمر slash فارغ',
     desktopCommands: 'أوامر سطح المكتب',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2911,6 +2911,7 @@ export const en: Translations = {
     sessionUnavailable: 'Session unavailable',
     createSessionFailed: 'Could not create a new session',
     promptFailed: 'Prompt failed',
+    deliveryNotConfirmed: 'Delivery not confirmed. Your message was restored; retry when ready.',
     providerCredentialRequired: 'Add a provider credential before sending your first message.',
     emptySlashCommand: 'empty slash command',
     desktopCommands: 'Desktop commands',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2734,6 +2734,7 @@ export const ja = defineLocale({
     sessionUnavailable: 'セッションが利用できません',
     createSessionFailed: '新しいセッションを作成できませんでした',
     promptFailed: 'プロンプトに失敗しました',
+    deliveryNotConfirmed: '配信を確認できませんでした。メッセージを復元しました。準備ができたら再試行してください。',
     providerCredentialRequired: '最初のメッセージを送信する前にプロバイダー認証情報を追加してください。',
     emptySlashCommand: '空のスラッシュコマンド',
     desktopCommands: 'デスクトップコマンド',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2463,6 +2463,7 @@ export interface Translations {
     sessionUnavailable: string
     createSessionFailed: string
     promptFailed: string
+    deliveryNotConfirmed: string
     providerCredentialRequired: string
     emptySlashCommand: string
     desktopCommands: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2623,6 +2623,7 @@ export const zhHant = defineLocale({
     sessionUnavailable: '工作階段不可用',
     createSessionFailed: '無法建立新工作階段',
     promptFailed: '提示詞傳送失敗',
+    deliveryNotConfirmed: '無法確認訊息是否送達。訊息已還原，請準備好後重試。',
     providerCredentialRequired: '傳送第一則訊息前請先新增提供方憑證。',
     emptySlashCommand: '空的斜線指令',
     desktopCommands: '桌面端指令',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3072,6 +3072,7 @@ export const zh: Translations = {
     sessionUnavailable: '会话不可用',
     createSessionFailed: '无法创建新会话',
     promptFailed: '提示词发送失败',
+    deliveryNotConfirmed: '无法确认消息是否送达。消息已恢复，请在准备好后重试。',
     providerCredentialRequired: '发送第一条消息前请先添加提供方凭据。',
     emptySlashCommand: '空 slash 命令',
     desktopCommands: '桌面端命令',

--- a/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { JsonRpcGatewayClient } from '@hermes/shared'
+
+interface ListenerEntry {
+  callback: (event: any) => void
+  once: boolean
+}
+
+class FakeSocket {
+  static readonly CLOSED = 3
+  static readonly OPEN = 1
+
+  readonly sent: string[] = []
+  readyState = FakeSocket.OPEN
+  private listeners = new Map<string, ListenerEntry[]>()
+
+  addEventListener(type: string, callback: (event: any) => void, options?: AddEventListenerOptions): void {
+    const entries = this.listeners.get(type) ?? []
+
+    entries.push({ callback, once: Boolean(options?.once) })
+    this.listeners.set(type, entries)
+  }
+
+  close(): void {
+    if (this.readyState === FakeSocket.CLOSED) {
+      return
+    }
+
+    this.readyState = FakeSocket.CLOSED
+    this.emit('close', { code: 1000 })
+  }
+
+  emit(type: string, event: any = {}): void {
+    const entries = [...(this.listeners.get(type) ?? [])]
+
+    for (const entry of entries) {
+      entry.callback(event)
+
+      if (entry.once) {
+        this.removeEventListener(type, entry.callback)
+      }
+    }
+  }
+
+  message(frame: unknown): void {
+    this.emit('message', { data: JSON.stringify(frame) })
+  }
+
+  removeEventListener(type: string, callback: (event: any) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter(entry => entry.callback !== callback)
+    )
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload)
+  }
+}
+
+describe('JsonRpcGatewayClient heartbeat recovery', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('invalidates a silently dead advertised socket and ignores its late frames', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: FakeSocket.OPEN })
+    const socket = new FakeSocket()
+    const states: string[] = []
+    const events: string[] = []
+    const client = new JsonRpcGatewayClient({
+      heartbeatDeadlineMs: 45,
+      heartbeatIntervalMs: 15,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    client.onState(state => states.push(state))
+    client.onAny(event => events.push(event.type))
+
+    const connected = client.connect('ws://gateway.test/api/ws')
+    socket.emit('open')
+    await connected
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'gateway.ready', payload: { heartbeat: true } }
+    })
+
+    await vi.advanceTimersByTimeAsync(61)
+
+    expect(client.connectionState).toBe('closed')
+    expect(socket.readyState).toBe(FakeSocket.CLOSED)
+    expect(states.at(-1)).toBe('closed')
+
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.complete', payload: { text: 'late duplicate' } }
+    })
+    expect(events).toEqual(['gateway.ready'])
+  })
+
+  it('keeps older backends open when gateway.ready does not advertise heartbeat', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: FakeSocket.OPEN })
+    const socket = new FakeSocket()
+    const client = new JsonRpcGatewayClient({
+      heartbeatDeadlineMs: 45,
+      heartbeatIntervalMs: 15,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connected = client.connect('ws://gateway.test/api/ws')
+    socket.emit('open')
+    await connected
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'gateway.ready', payload: {} }
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(client.connectionState).toBe('open')
+    expect(socket.readyState).toBe(FakeSocket.OPEN)
+    expect(socket.sent).toEqual([])
+  })
+})

--- a/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-
 import { JsonRpcGatewayClient } from '@hermes/shared'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 interface ListenerEntry {
   callback: (event: any) => void
@@ -71,6 +70,7 @@ describe('JsonRpcGatewayClient heartbeat recovery', () => {
     const socket = new FakeSocket()
     const states: string[] = []
     const events: string[] = []
+
     const client = new JsonRpcGatewayClient({
       heartbeatDeadlineMs: 45,
       heartbeatIntervalMs: 15,
@@ -107,6 +107,7 @@ describe('JsonRpcGatewayClient heartbeat recovery', () => {
     vi.useFakeTimers()
     vi.stubGlobal('WebSocket', { OPEN: FakeSocket.OPEN })
     const socket = new FakeSocket()
+
     const client = new JsonRpcGatewayClient({
       heartbeatDeadlineMs: 45,
       heartbeatIntervalMs: 15,

--- a/apps/desktop/src/lib/json-rpc-gateway-recovery.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-recovery.test.ts
@@ -1,0 +1,196 @@
+import { JsonRpcGatewayClient } from '@hermes/shared'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+interface ListenerEntry {
+  callback: (event: any) => void
+  once: boolean
+}
+
+class LoopbackSocket {
+  static readonly CLOSED = 3
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+
+  readyState = LoopbackSocket.CONNECTING
+  private listeners = new Map<string, ListenerEntry[]>()
+
+  constructor(
+    readonly generation: number,
+    private readonly backend: RecoveryBackend
+  ) {}
+
+  addEventListener(type: string, callback: (event: any) => void, options?: AddEventListenerOptions): void {
+    const entries = this.listeners.get(type) ?? []
+
+    entries.push({ callback, once: Boolean(options?.once) })
+    this.listeners.set(type, entries)
+  }
+
+  close(): void {
+    if (this.readyState === LoopbackSocket.CLOSED) {
+      return
+    }
+
+    this.readyState = LoopbackSocket.CLOSED
+    this.emit('close', { code: 1000 })
+  }
+
+  message(frame: unknown): void {
+    this.emit('message', { data: JSON.stringify(frame) })
+  }
+
+  open(): void {
+    this.readyState = LoopbackSocket.OPEN
+    this.emit('open', {})
+    this.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'gateway.ready', payload: { heartbeat: true } }
+    })
+  }
+
+  removeEventListener(type: string, callback: (event: any) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter(entry => entry.callback !== callback)
+    )
+  }
+
+  send(payload: string): void {
+    this.backend.receive(this, JSON.parse(payload) as Record<string, any>)
+  }
+
+  private emit(type: string, event: any): void {
+    const entries = [...(this.listeners.get(type) ?? [])]
+
+    for (const entry of entries) {
+      entry.callback(event)
+
+      if (entry.once) {
+        this.removeEventListener(type, entry.callback)
+      }
+    }
+  }
+}
+
+class RecoveryBackend {
+  readonly sockets: LoopbackSocket[] = []
+  readonly messages: Array<{ role: 'assistant' | 'user'; content: string }> = []
+  promptSubmits = 0
+
+  createSocket(): LoopbackSocket {
+    const socket = new LoopbackSocket(this.sockets.length + 1, this)
+
+    this.sockets.push(socket)
+    queueMicrotask(() => socket.open())
+
+    return socket
+  }
+
+  receive(socket: LoopbackSocket, frame: Record<string, any>): void {
+    if (socket.generation === 1 && frame.method === 'prompt.submit') {
+      this.promptSubmits += 1
+      this.messages.push(
+        { role: 'user', content: String(frame.params?.text ?? '') },
+        { role: 'assistant', content: 'persisted while transport was blackholed' }
+      )
+
+      // Accepted and persisted, but every outbound packet (including the RPC
+      // response, heartbeat acknowledgement, and message.complete) is dropped.
+      return
+    }
+
+    if (socket.generation === 1) {
+      return
+    }
+
+    if (frame.method === 'gateway.ping') {
+      socket.message({ jsonrpc: '2.0', id: frame.id, result: { ok: true } })
+
+      return
+    }
+
+    if (frame.method === 'session.activate') {
+      socket.message({
+        jsonrpc: '2.0',
+        id: frame.id,
+        result: {
+          session_id: 'runtime-1',
+          session_key: 'stored-1',
+          messages: this.messages,
+          running: false,
+          status: 'idle'
+        }
+      })
+    }
+  }
+}
+
+describe('hermes-ws-recovery-v1 silent blackhole', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('recovers the persisted final on a replacement socket without duplicating the prompt', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: LoopbackSocket.OPEN })
+    const backend = new RecoveryBackend()
+
+    const client = new JsonRpcGatewayClient({
+      heartbeatDeadlineMs: 45,
+      heartbeatIntervalMs: 15,
+      socketFactory: () => backend.createSocket() as unknown as WebSocket
+    })
+
+    let epoch = 0
+    let intentionalShutdown = false
+    let recovered: Promise<any> | null = null
+
+    client.onState(state => {
+      if (state === 'open') {
+        epoch += 1
+
+        if (epoch > 1) {
+          recovered = client.request('session.activate', { session_id: 'runtime-1' })
+        }
+      }
+
+      if (state === 'closed' && !intentionalShutdown) {
+        void client.connect('ws://gateway.test/api/ws')
+      }
+    })
+
+    await client.connect('ws://gateway.test/api/ws')
+    await Promise.resolve()
+
+    const ambiguousSubmit = client
+      .request('prompt.submit', { session_id: 'runtime-1', text: 'one prompt' })
+      .then(
+        () => null,
+        error => error as Error
+      )
+
+    await vi.advanceTimersByTimeAsync(61)
+    await vi.waitFor(() => expect(backend.sockets).toHaveLength(2))
+    await vi.waitFor(() => expect(recovered).not.toBeNull())
+
+    await expect(ambiguousSubmit).resolves.toMatchObject({
+      message: 'WebSocket heartbeat acknowledgement timed out'
+    })
+    await expect(recovered).resolves.toMatchObject({
+      messages: [
+        { role: 'user', content: 'one prompt' },
+        { role: 'assistant', content: 'persisted while transport was blackholed' }
+      ],
+      running: false,
+      status: 'idle'
+    })
+    expect(backend.promptSubmits).toBe(1)
+
+    intentionalShutdown = true
+    client.close()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(backend.sockets).toHaveLength(2)
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -58,6 +58,7 @@ interface GatewayRegistryState {
   activeKey: string
   secondaries: Map<string, Secondary>
   $gateway: ReturnType<typeof atom<HermesGateway | null>>
+  $gatewayConnectionEpochs: ReturnType<typeof atom<Record<string, number>>>
 }
 
 const STATE_KEY = Symbol.for('hermes.desktop.gatewayRegistryState')
@@ -72,7 +73,11 @@ function createRegistryState(): GatewayRegistryState {
     // The active gateway instance, exposed for inline message-stream
     // components (inline ClarifyTool, model overlays) that call gateway
     // methods without the instance threaded down through props.
-    $gateway: atom<HermesGateway | null>(null)
+    $gateway: atom<HermesGateway | null>(null),
+    // Monotonic connection generation per profile. Unlike $gatewayState, this
+    // cannot collapse a real closed -> connecting -> open cycle into the same
+    // final "open" value before React renders.
+    $gatewayConnectionEpochs: atom<Record<string, number>>({})
   }
 }
 
@@ -87,6 +92,8 @@ function gatewayState(): GatewayRegistryState {
   if (import.meta.hot) {
     const store = globalThis as unknown as { [STATE_KEY]?: GatewayRegistryState }
     store[STATE_KEY] ??= createRegistryState()
+    // Shape migration for a live dev realm created before this field existed.
+    store[STATE_KEY].$gatewayConnectionEpochs ??= atom<Record<string, number>>({})
 
     return store[STATE_KEY]
   }
@@ -100,6 +107,7 @@ const g = gatewayState()
 // reload of this module hands back the SAME atom subscribers are already wired
 // to. (A fresh `atom()` per reload would orphan existing subscriptions.)
 export const $gateway = g.$gateway
+export const $gatewayConnectionEpochs = g.$gatewayConnectionEpochs
 
 export function configureGatewayRegistry(cfg: RegistryConfig): void {
   g.config = cfg
@@ -144,7 +152,17 @@ function reportGatewayState(profile: string, state: ConnectionState): void {
     markNativeNotifyBaseline()
   }
 
-  if (normKey(profile) === g.activeKey) {
+  const key = normKey(profile)
+
+  if (state === 'open') {
+    const epochs = g.$gatewayConnectionEpochs.get()
+    g.$gatewayConnectionEpochs.set({
+      ...epochs,
+      [key]: (epochs[key] ?? 0) + 1
+    })
+  }
+
+  if (key === g.activeKey) {
     setGatewayState(state)
   }
 }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -34,7 +34,7 @@ interface Secondary {
   offState: () => void
   reconnectTimer: ReturnType<typeof setTimeout> | null
   reconnectAttempt: number
-  reconnecting: boolean
+  reconnecting: Promise<void> | null
   // While true the entry auto-reconnects on drop; pruning flips it off so a
   // deliberate close doesn't trigger the backoff loop.
   wantOpen: boolean
@@ -214,24 +214,30 @@ function scheduleReconnect(entry: Secondary): void {
 }
 
 async function reconnectSecondary(entry: Secondary): Promise<void> {
-  if (entry.reconnecting || !entry.wantOpen || isOpen(entry.gateway)) {
+  if (entry.reconnecting) {
+    return entry.reconnecting
+  }
+
+  if (!entry.wantOpen || isOpen(entry.gateway)) {
     return
   }
 
-  entry.reconnecting = true
+  entry.reconnecting = (async () => {
+    try {
+      await openSecondary(entry)
+      entry.reconnectAttempt = 0
+    } catch {
+      // Transport failure → fall through to the backoff below.
+    } finally {
+      entry.reconnecting = null
 
-  try {
-    await openSecondary(entry)
-    entry.reconnectAttempt = 0
-  } catch {
-    // Transport failure → fall through to the backoff below.
-  } finally {
-    entry.reconnecting = false
-
-    if (entry.wantOpen && !isOpen(entry.gateway)) {
-      scheduleReconnect(entry)
+      if (entry.wantOpen && !isOpen(entry.gateway)) {
+        scheduleReconnect(entry)
+      }
     }
-  }
+  })()
+
+  return entry.reconnecting
 }
 
 function createSecondary(profile: string): Secondary {
@@ -244,7 +250,7 @@ function createSecondary(profile: string): Secondary {
     offState: () => {},
     reconnectTimer: null,
     reconnectAttempt: 0,
-    reconnecting: false,
+    reconnecting: null,
     wantOpen: true
   }
 

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -54,6 +54,8 @@ export interface GatewayClientOptions {
   connectErrorMessage?: string
   connectTimeoutMs?: number
   createRequestId?: (nextId: number) => GatewayRequestId
+  heartbeatDeadlineMs?: number
+  heartbeatIntervalMs?: number
   /** Return true to intercept the default closed-state transition. */
   onSocketClose?: (event: CloseEvent) => boolean | void
   requestIdPrefix?: string
@@ -64,6 +66,8 @@ export interface GatewayClientOptions {
 
 const ANY = '*'
 const DEFAULT_REQUEST_TIMEOUT_MS = 120_000
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000
+const DEFAULT_HEARTBEAT_DEADLINE_MS = 45_000
 // A reconnect after sleep/wake must not hang forever in 'connecting' (which
 // keeps the composer disabled and stuck on "Starting Hermes..."). If the open
 // handshake doesn't land in this window, fail to 'error' so callers can retry.
@@ -74,6 +78,9 @@ export class JsonRpcGatewayClient {
   private pending = new Map<GatewayRequestId, PendingCall>()
   private socket: WebSocketLike | null = null
   private state: ConnectionState = 'idle'
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private heartbeatSequence = 0
+  private lastInboundAt = 0
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -85,6 +92,8 @@ export class JsonRpcGatewayClient {
       connectErrorMessage: options.connectErrorMessage ?? 'WebSocket connection failed',
       connectTimeoutMs: options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
       createRequestId: options.createRequestId ?? ((nextId: number) => `${options.requestIdPrefix ?? 'r'}${nextId}`),
+      heartbeatDeadlineMs: options.heartbeatDeadlineMs ?? DEFAULT_HEARTBEAT_DEADLINE_MS,
+      heartbeatIntervalMs: options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
       notConnectedErrorMessage: options.notConnectedErrorMessage ?? 'gateway not connected',
       onSocketClose: options.onSocketClose ?? (() => false),
       requestIdPrefix: options.requestIdPrefix ?? 'r',
@@ -130,12 +139,14 @@ export class JsonRpcGatewayClient {
 
     const socket = this.options.socketFactory?.(wsUrl) ?? new WebSocket(wsUrl)
     this.socket = socket
+    this.stopHeartbeat()
 
     socket.addEventListener('message', message => {
       if (this.socket !== socket) {
         return
       }
 
+      this.lastInboundAt = Date.now()
       this.handleMessage(message.data)
     })
 
@@ -149,6 +160,7 @@ export class JsonRpcGatewayClient {
       }
 
       this.socket = null
+      this.stopHeartbeat()
       this.setState('closed')
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
     })
@@ -230,9 +242,24 @@ export class JsonRpcGatewayClient {
       socket.close()
     } finally {
       this.socket = null
+      this.stopHeartbeat()
       this.setState('closed')
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
     }
+  }
+
+  /**
+   * Invalidate the current socket generation after an ambiguous transport
+   * outcome. The outer connection owner decides whether/when to reconnect.
+   */
+  invalidate(message = this.options.closedErrorMessage): void {
+    const socket = this.socket
+
+    if (!socket) {
+      return
+    }
+
+    this.invalidateSocket(socket, new Error(message))
   }
 
   on<P = unknown>(type: GatewayEventName, handler: (event: GatewayEvent<P>) => void): () => void {
@@ -380,8 +407,79 @@ export class JsonRpcGatewayClient {
     }
 
     if (frame.method === 'event' && frame.params?.type) {
+      if (frame.params.type === 'gateway.ready' && this.gatewayReadyAdvertisesHeartbeat(frame.params.payload)) {
+        const socket = this.socket
+
+        if (socket) {
+          this.startHeartbeat(socket)
+        }
+      }
+
       this.dispatchEvent(frame.params)
     }
+  }
+
+  private gatewayReadyAdvertisesHeartbeat(payload: unknown): boolean {
+    return Boolean(payload && typeof payload === 'object' && (payload as { heartbeat?: unknown }).heartbeat === true)
+  }
+
+  private startHeartbeat(socket: WebSocketLike): void {
+    this.stopHeartbeat()
+    this.lastInboundAt = Date.now()
+
+    if (this.options.heartbeatIntervalMs <= 0 || this.options.heartbeatDeadlineMs <= 0) {
+      return
+    }
+
+    this.heartbeatTimer = setInterval(() => {
+      if (this.socket !== socket || socket.readyState !== WebSocket.OPEN) {
+        return
+      }
+
+      if (Date.now() - this.lastInboundAt >= this.options.heartbeatDeadlineMs) {
+        this.invalidateSocket(socket, new Error('WebSocket heartbeat acknowledgement timed out'))
+
+        return
+      }
+
+      try {
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: `heartbeat-${++this.heartbeatSequence}`,
+            method: 'gateway.ping',
+            params: {}
+          })
+        )
+      } catch (error) {
+        this.invalidateSocket(socket, error instanceof Error ? error : new Error(String(error)))
+      }
+    }, this.options.heartbeatIntervalMs)
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  private invalidateSocket(socket: WebSocketLike, error: Error): void {
+    if (this.socket !== socket) {
+      return
+    }
+
+    this.socket = null
+    this.stopHeartbeat()
+
+    try {
+      socket.close()
+    } catch {
+      // The generation was already invalidated; the reconnect owner can redial.
+    }
+
+    this.setState('closed')
+    this.rejectAllPending(error)
   }
 
   private clearPending(id: GatewayRequestId): void {

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12772,6 +12772,67 @@ def test_session_activate_clears_stale_busy_state_after_prompt_worker_exits(monk
     assert session.get("inflight_turn") is None
 
 
+def test_session_activate_preserves_live_prompt_worker(monkeypatch):
+    class _LiveThread:
+        @staticmethod
+        def is_alive():
+            return True
+
+    session = _session(
+        agent=types.SimpleNamespace(model="model-live"),
+        running=True,
+        inflight_turn={"assistant": "still working", "user": "live prompt"},
+    )
+    session["_run_thread"] = _LiveThread()
+    server._sessions["sid-live-worker"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "model-live"})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "activate-live",
+                "method": "session.activate",
+                "params": {"session_id": "sid-live-worker"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid-live-worker", None)
+
+    assert resp["result"]["running"] is True
+    assert resp["result"]["inflight"]["user"] == "live prompt"
+    assert session["running"] is True
+
+
+def test_session_activate_preserves_running_before_worker_registration(monkeypatch):
+    session = _session(
+        agent=types.SimpleNamespace(model="model-registering"),
+        running=True,
+        inflight_turn={"user": "accepted prompt"},
+    )
+    session.pop("_run_thread", None)
+    server._sessions["sid-registering"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent: {"model": "model-registering"},
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "activate-registering",
+                "method": "session.activate",
+                "params": {"session_id": "sid-registering"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid-registering", None)
+
+    assert resp["result"]["running"] is True
+    assert resp["result"]["inflight"]["user"] == "accepted prompt"
+    assert session["running"] is True
+
+
 def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
     """A full client restart must recover an accepted next-turn prompt.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12733,6 +12733,45 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
         server._sessions.pop("sid-live", None)
 
 
+def test_session_activate_clears_stale_busy_state_after_prompt_worker_exits(monkeypatch):
+    class _DeadThread:
+        @staticmethod
+        def is_alive():
+            return False
+
+    agent = types.SimpleNamespace(model="model-stale")
+    session = _session(
+        agent=agent,
+        running=True,
+        inflight_turn={
+            "assistant": "stale partial",
+            "status": "streaming",
+            "user": "already completed",
+        },
+    )
+    session["_run_thread"] = _DeadThread()
+    server._sessions["sid-stale"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "model-stale"})
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "activate",
+                "method": "session.activate",
+                "params": {"session_id": "sid-stale"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid-stale", None)
+
+    assert resp["result"]["running"] is False
+    assert resp["result"]["status"] == "idle"
+    assert "inflight" not in resp["result"]
+    assert session["running"] is False
+    assert session.get("inflight_turn") is None
+
+
 def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
     """A full client restart must recover an accepted next-turn prompt.
 

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -250,7 +250,7 @@ def test_expired_ws_transport_can_be_rebound():
         def close(self):
             self.closed = True
 
-    owner = FakeTransport(time.monotonic() - 61)
+    owner = FakeTransport(time.monotonic() - 46)
     contender = FakeTransport(time.monotonic())
     session = {
         "history_lock": threading.Lock(),
@@ -339,4 +339,3 @@ def test_ws_transport_preserves_cross_batch_order():
         assert entered == ["A1", "A2", "B1", "B2"]
 
     asyncio.run(scenario())
-

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -153,6 +153,119 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     assert events == ["accept", "ready_after_0"]
 
 
+def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):
+    sent = []
+    inbound = iter(
+        [
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "heartbeat-1",
+                    "method": "gateway.ping",
+                    "params": {},
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            try:
+                return next(inbound)
+            except StopIteration:
+                raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    ready = sent[0]["params"]
+    assert ready["type"] == "gateway.ready"
+    assert ready["payload"]["heartbeat"] is True
+    assert sent[1] == {
+        "jsonrpc": "2.0",
+        "result": {"ok": True},
+        "id": "heartbeat-1",
+    }
+
+
+def test_session_activate_refuses_to_steal_recent_live_ws_transport():
+    class FakeTransport:
+        def __init__(self):
+            self.closed = False
+            self.last_inbound_at = time.monotonic()
+
+        def write(self, obj):
+            return True
+
+        def close(self):
+            self.closed = True
+
+    owner = FakeTransport()
+    contender = FakeTransport()
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": owner,
+    }
+    server._sessions.clear()
+    server._live_transports.clear()
+    server._sessions["sid"] = session
+    server.register_live_transport(owner)
+    try:
+        response = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": "activate-1",
+                "method": "session.activate",
+                "params": {"session_id": "sid"},
+            },
+            contender,
+        )
+
+        assert response["error"]["code"] == 4091
+        assert session["transport"] is owner
+    finally:
+        server.unregister_live_transport(owner)
+        server._sessions.clear()
+        server._live_transports.clear()
+
+
+def test_expired_ws_transport_can_be_rebound():
+    class FakeTransport:
+        def __init__(self, last_inbound_at):
+            self.closed = False
+            self.last_inbound_at = last_inbound_at
+
+        def write(self, obj):
+            return True
+
+        def close(self):
+            self.closed = True
+
+    owner = FakeTransport(time.monotonic() - 61)
+    contender = FakeTransport(time.monotonic())
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": owner,
+    }
+    server._live_transports.clear()
+    server.register_live_transport(owner)
+    try:
+        assert server._bind_session_transport(session, contender) is True
+        assert session["transport"] is contender
+    finally:
+        server.unregister_live_transport(owner)
+        server._live_transports.clear()
+
+
 def test_ws_transport_serializes_concurrent_sends():
     active_sends = 0
     max_active_sends = 0
@@ -226,5 +339,4 @@ def test_ws_transport_preserves_cross_batch_order():
         assert entered == ["A1", "A2", "B1", "B2"]
 
     asyncio.run(scenario())
-
 

--- a/tests/test_tui_gateway_ws_recovery.py
+++ b/tests/test_tui_gateway_ws_recovery.py
@@ -1,0 +1,134 @@
+"""hermes-ws-recovery-v1 loopback fault scenarios."""
+
+import threading
+import time
+import types
+
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+
+from hermes_state import SessionDB
+from tui_gateway import server
+from tui_gateway.ws import handle_ws
+
+
+class _WorkerState:
+    def __init__(self) -> None:
+        self.alive = True
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+
+def _rpc(ws, request_id: str, method: str, params: dict) -> dict:
+    ws.send_json(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+    )
+    return ws.receive_json()
+
+
+def test_disconnect_mid_turn_reconnect_recovers_one_persisted_final(
+    monkeypatch, tmp_path
+):
+    """A replacement socket recovers backend truth without another prompt."""
+    db = SessionDB(tmp_path / "state.db")
+    stored_id = "20260101_010101_a1b2c3"
+    runtime_id = "runtime1"
+    prompt = "return the persisted result"
+    final = "the persisted result"
+    worker = _WorkerState()
+
+    db.create_session(stored_id, source="desktop")
+    db.append_message(stored_id, role="user", content=prompt)
+
+    session = {
+        "agent": types.SimpleNamespace(model="loopback-model"),
+        "cols": 80,
+        "created_at": time.time(),
+        "cwd": str(tmp_path),
+        "display_history_prefix": [],
+        "history": [],
+        "history_lock": threading.Lock(),
+        "inflight_turn": {
+            "assistant": "",
+            "status": "streaming",
+            "user": prompt,
+        },
+        "last_active": time.time(),
+        "running": True,
+        "session_key": stored_id,
+        "source": "desktop",
+        "_run_thread": worker,
+    }
+
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent: {"model": "loopback-model", "desktop_contract": 1},
+    )
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+    server._sessions.clear()
+    server._live_transports.clear()
+    server._sessions[runtime_id] = session
+
+    app = FastAPI()
+
+    @app.websocket("/ws")
+    async def websocket_endpoint(ws: WebSocket):
+        await handle_ws(ws)
+
+    try:
+        with TestClient(app) as client:
+            # First renderer owns the live turn, then disconnects before the
+            # terminal message.complete frame could be displayed.
+            with client.websocket_connect("/ws") as first:
+                ready = first.receive_json()
+                assert ready["params"]["payload"]["heartbeat"] is True
+                activated = _rpc(
+                    first,
+                    "activate-first",
+                    "session.activate",
+                    {"session_id": runtime_id},
+                )
+                assert activated["result"]["running"] is True
+
+            # The worker completes and persists while no renderer transport is
+            # attached. Its old terminal event is intentionally not replayed.
+            db.append_message(
+                stored_id,
+                role="assistant",
+                content=final,
+                finish_reason="stop",
+            )
+            worker.alive = False
+
+            # A replacement socket opens without another prompt. Activation is
+            # the recovery contract: authoritative rows plus repaired idle state.
+            with client.websocket_connect("/ws") as replacement:
+                replacement.receive_json()  # gateway.ready
+                recovered = _rpc(
+                    replacement,
+                    "activate-replacement",
+                    "session.activate",
+                    {"session_id": runtime_id},
+                )["result"]
+
+        roles = [message["role"] for message in recovered["messages"]]
+        assert roles == ["user", "assistant"]
+        assert [message["text"] for message in recovered["messages"]] == [
+            prompt,
+            final,
+        ]
+        assert recovered["running"] is False
+        assert recovered["status"] == "idle"
+        assert "inflight" not in recovered
+    finally:
+        server._sessions.clear()
+        server._live_transports.clear()
+        db.close()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -132,7 +132,8 @@ def _(rid, params: dict) -> dict:
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
     if (t := current_transport()) is not None:
-        session["transport"] = t
+        if not _bind_session_transport(session, t):
+            return _err(rid, 4091, "session stream is owned by another active client")
     while True:
         busy_transport = None
         with session["history_lock"]:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -413,13 +413,20 @@ def _(rid, params: dict) -> dict:
             profile_home
         )
 
-        def _reuse_live_payload(sid: str, session: dict) -> dict:
+        def _reuse_live_response(sid: str, session: dict) -> dict:
+            transport = current_transport() or _stdio_transport
+            if not _bind_session_transport(session, transport):
+                return _err(
+                    rid,
+                    4091,
+                    "session stream is owned by another active client",
+                )
             payload = _live_session_payload(
                 sid,
                 session,
                 cols=cols,
                 touch=True,
-                transport=current_transport() or _stdio_transport,
+                transport=None,
                 omit_messages=omit_messages,
             )
             payload["resumed"] = target
@@ -429,13 +436,13 @@ def _(rid, params: dict) -> dict:
             if session.get("agent") is None and _child_run_active(target):
                 payload["running"] = True
                 payload["status"] = "streaming"
-            return payload
+            return _ok(rid, payload)
 
         # Fast path: if the session is already live, reuse it under the lock.
         with _session_resume_lock:
             live = _find_live_session_by_key(target)
             if live is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
 
         # Lazy/watch resume: register the live session WITHOUT building an agent.
         # Used by the desktop's subagent windows — the child runs inside the
@@ -474,7 +481,7 @@ def _(rid, params: dict) -> dict:
                 lazy=True,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
             # A delegated child mid-run emits no session events of its own — report
             # its liveness from the relay registry so the window shows a busy turn.
             child_running = _child_run_active(target)
@@ -572,7 +579,7 @@ def _(rid, params: dict) -> dict:
                 resume_runtime_overrides=overrides or None,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
 
             _schedule_agent_build(sid)
             _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
@@ -683,12 +690,19 @@ def _(rid, params: dict) -> dict:
                 if lease is not None:
                     lease.release()
                 other_sid, other_session = live
+                transport = current_transport() or _stdio_transport
+                if not _bind_session_transport(other_session, transport):
+                    return _err(
+                        rid,
+                        4091,
+                        "session stream is owned by another active client",
+                    )
                 payload = _live_session_payload(
                     other_sid,
                     other_session,
                     cols=cols,
                     touch=True,
-                    transport=current_transport() or _stdio_transport,
+                    transport=None,
                     omit_messages=omit_messages,
                 )
                 payload["resumed"] = target
@@ -956,6 +970,9 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     assert session is not None
+    transport = current_transport() or _stdio_transport
+    if not _bind_session_transport(session, transport):
+        return _err(rid, 4091, "session stream is owned by another active client")
 
     return _ok(
         rid,
@@ -963,7 +980,7 @@ def _(rid, params: dict) -> dict:
             sid,
             session,
             touch=True,
-            transport=current_transport() or _stdio_transport,
+            transport=None,
             omit_messages=is_truthy_value(params.get("omit_messages", False)),
         ),
     )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8163,6 +8163,35 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     return in_memory_fallback
 
 
+def _reconcile_finished_run_thread(session: dict) -> bool:
+    """Clear a stale busy projection after its prompt worker has exited.
+
+    A dropped transport must not leave ``running`` and ``inflight_turn`` pinned
+    forever after the worker is already dead.  Reconnect callers use the live
+    payload as their authority, so reconcile that impossible state before
+    returning it.  A missing thread is left untouched because other session
+    paths can briefly set ``running`` before their worker is registered.
+    """
+    if not session.get("running"):
+        return False
+
+    run_thread = session.get("_run_thread")
+    if run_thread is None:
+        return False
+
+    try:
+        alive = run_thread.is_alive()
+    except Exception:
+        return False
+
+    if alive:
+        return False
+
+    session["running"] = False
+    _clear_inflight_turn(session)
+    return True
+
+
 def _live_session_payload(
     sid: str,
     session: dict,
@@ -8173,6 +8202,7 @@ def _live_session_payload(
     omit_messages: bool = False,
 ) -> dict:
     with session["history_lock"]:
+        _reconcile_finished_run_thread(session)
         if cols is not None:
             session["cols"] = cols
         if transport is not None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1580,7 +1580,11 @@ def _emit(event: str, sid: str, payload: dict | None = None):
 # is how such events reach WS clients at all. See _broadcast_global_event.
 _live_transports: set[Transport] = set()
 _live_transports_lock = threading.Lock()
-_TRANSPORT_OWNERSHIP_LIVE_S = 60.0
+# Match the negotiated client heartbeat deadline. Once a silent transport has
+# missed 45 seconds of inbound activity, a replacement socket must be able to
+# activate immediately instead of waiting behind an owner the client already
+# declared dead.
+_TRANSPORT_OWNERSHIP_LIVE_S = 45.0
 
 
 def register_live_transport(transport: Transport | None) -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1580,6 +1580,7 @@ def _emit(event: str, sid: str, payload: dict | None = None):
 # is how such events reach WS clients at all. See _broadcast_global_event.
 _live_transports: set[Transport] = set()
 _live_transports_lock = threading.Lock()
+_TRANSPORT_OWNERSHIP_LIVE_S = 60.0
 
 
 def register_live_transport(transport: Transport | None) -> None:
@@ -1594,6 +1595,44 @@ def unregister_live_transport(transport: Transport | None) -> None:
     """Stop tracking a transport (call on disconnect). Idempotent."""
     with _live_transports_lock:
         _live_transports.discard(transport)
+
+
+def _transport_is_recently_live(transport: Transport | None) -> bool:
+    """Whether a transport still owns a session stream.
+
+    WebSocket transports publish their last inbound activity. A transport that
+    is closed, unregistered, detached, or beyond the heartbeat recovery window
+    no longer blocks a reconnecting renderer from reclaiming the stream.
+    """
+    if transport is None or transport is _detached_ws_transport:
+        return False
+    if bool(getattr(transport, "closed", False)):
+        return False
+
+    last_inbound = getattr(transport, "last_inbound_at", None)
+    if isinstance(last_inbound, (int, float)):
+        with _live_transports_lock:
+            registered = transport in _live_transports
+        return registered and (time.monotonic() - float(last_inbound)) <= _TRANSPORT_OWNERSHIP_LIVE_S
+
+    # Stdio and test transports have no application heartbeat. Preserve their
+    # historical behavior; the conflict contract is for competing WS clients.
+    return False
+
+
+def _bind_session_transport(session: dict, candidate: Transport | None) -> bool:
+    """Atomically rebind a session unless another recently-live WS owns it."""
+    if candidate is None:
+        return True
+
+    with session["history_lock"]:
+        current = session.get("transport")
+        if current is candidate:
+            return True
+        if _transport_is_recently_live(current):
+            return False
+        session["transport"] = candidate
+        return True
 
 
 def _broadcast_global_event(event: str, payload: dict | None = None) -> None:
@@ -8201,12 +8240,12 @@ def _live_session_payload(
     transport: Transport | None = None,
     omit_messages: bool = False,
 ) -> dict:
+    if transport is not None:
+        _bind_session_transport(session, transport)
     with session["history_lock"]:
         _reconcile_finished_run_thread(session)
         if cols is not None:
             session["cols"] = cols
-        if transport is not None:
-            session["transport"] = transport
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -29,6 +29,7 @@ import json
 import logging
 import socket
 import threading
+import time
 from typing import Any
 
 from tui_gateway import server
@@ -94,6 +95,7 @@ class WSTransport:
         self._loop = loop
         self._peer = peer
         self._closed = False
+        self._last_inbound_at = time.monotonic()
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
         # "armed" flag against the worker threads that call write(); the timer
@@ -106,6 +108,17 @@ class WSTransport:
         # writes need an async boundary because several batches can be queued on
         # the owning loop while it recovers from a stall.
         self._send_lock = asyncio.Lock()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def last_inbound_at(self) -> float:
+        return self._last_inbound_at
+
+    def mark_inbound(self) -> None:
+        self._last_inbound_at = time.monotonic()
 
     @staticmethod
     def _is_streaming_frame(obj: dict) -> bool:
@@ -320,7 +333,11 @@ async def handle_ws(ws: Any) -> None:
                     # change_events: this backend broadcasts pet.changed /
                     # cron.changed / sessions.changed, so clients can demote
                     # their legacy polls to slow backstops.
-                    "payload": {"skin": skin_payload, "change_events": True},
+                    "payload": {
+                        "skin": skin_payload,
+                        "change_events": True,
+                        "heartbeat": True,
+                    },
                 },
             }
         )
@@ -354,6 +371,7 @@ async def handle_ws(ws: Any) -> None:
             line = raw.strip()
             if not line:
                 continue
+            transport.mark_inbound()
             messages += 1
 
             try:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -388,6 +388,22 @@ async def handle_ws(ws: Any) -> None:
             # response dict, which we write here from the loop.
             req_id = req.get("id") if isinstance(req, dict) else None
             req_method = req.get("method") if isinstance(req, dict) else None
+
+            if req_method == "gateway.ping":
+                ok = await transport.write_async(
+                    {
+                        "jsonrpc": "2.0",
+                        "result": {"ok": True},
+                        "id": req_id,
+                    }
+                )
+                if not ok:
+                    disconnect_reason = "send_failed_after_heartbeat"
+                    send_failures += 1
+                    _log.warning("ws heartbeat reply send failed peer=%s id=%s", peer, req_id)
+                    break
+                continue
+
             try:
                 resp = await asyncio.to_thread(server.dispatch, req, transport)
             except Exception:

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -97,7 +97,7 @@ const { FakeWebSocket } = vi.hoisted(() => {
 
 vi.mock('undici', () => ({ WebSocket: FakeWebSocket }))
 
-import { GatewayClient } from '../gatewayClient.js'
+import { GatewayClient, RECONNECT_BASE_MS, RECONNECT_MAX_MS, WS_HEARTBEAT_DEAD_MS, WS_HEARTBEAT_INTERVAL_MS } from '../gatewayClient.js'
 
 describe('GatewayClient websocket attach mode', () => {
   const originalWebSocket = globalThis.WebSocket
@@ -492,5 +492,35 @@ describe('GatewayClient websocket attach mode', () => {
     expect(tail).not.toContain('token=secret')
 
     gw.kill()
+  })
+
+  it('auto-reconnects after a silent dead connection (issue #32997)', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    gw.start()
+    const first = FakeWebSocket.instances[0]!
+    first.open()
+    // Advance past one heartbeat tick (no inbound frames -> lastActivityAt stale).
+    await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
+    // Advance past the dead window -> heartbeat forces close -> handleTransportExit -> reconnect scheduled.
+    await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS)
+    // Advance past the base backoff -> start() opens a new socket.
+    await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS)
+    expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2)
+    gw.kill()
+    vi.useRealTimers()
+  })
+
+  it('does not auto-reconnect after an intentional kill() (issue #32997)', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    gw.start()
+    FakeWebSocket.instances[0]!.open()
+    gw.kill() // sets disposed
+    await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + RECONNECT_MAX_MS + 1000)
+    expect(FakeWebSocket.instances.length).toBe(1) // no reconnect attempted
+    vi.useRealTimers()
   })
 })

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -494,22 +494,75 @@ describe('GatewayClient websocket attach mode', () => {
     gw.kill()
   })
 
-  it('auto-reconnects after a silent dead connection (issue #32997)', async () => {
+  it('keeps a healthy idle websocket open when heartbeat acknowledgements arrive (issue #32997)', async () => {
     vi.useFakeTimers()
     process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
     const gw = new GatewayClient()
-    gw.start()
-    const first = FakeWebSocket.instances[0]!
-    first.open()
-    // Advance past one heartbeat tick (no inbound frames -> lastActivityAt stale).
-    await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
-    // Advance past the dead window -> heartbeat forces close -> handleTransportExit -> reconnect scheduled.
-    await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS)
-    // Advance past the base backoff -> start() opens a new socket.
-    await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS)
-    expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2)
-    gw.kill()
-    vi.useRealTimers()
+
+    try {
+      gw.start()
+      const socket = FakeWebSocket.instances[0]!
+
+      socket.open()
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
+
+      const heartbeat = JSON.parse(socket.sent.at(-1) ?? '{}') as { id: string; method: string }
+
+      expect(heartbeat.method).toBe('gateway.ping')
+      socket.message(JSON.stringify({ id: heartbeat.id, jsonrpc: '2.0', result: { ok: true } }))
+
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + WS_HEARTBEAT_INTERVAL_MS)
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN)
+      expect(FakeWebSocket.instances).toHaveLength(1)
+    } finally {
+      gw.kill()
+      vi.useRealTimers()
+    }
+  })
+
+  it('auto-reconnects after a missing heartbeat acknowledgement (issue #32997)', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+
+    try {
+      gw.start()
+      const first = FakeWebSocket.instances[0]!
+
+      first.open()
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
+      expect(JSON.parse(first.sent.at(-1) ?? '{}')).toMatchObject({ method: 'gateway.ping' })
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + WS_HEARTBEAT_INTERVAL_MS)
+      await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS)
+      expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      gw.kill()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not double-reconnect when the exit subscriber restarts immediately', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+
+    try {
+      gw.on('exit', () => gw.start())
+      gw.start()
+      const first = FakeWebSocket.instances[0]!
+
+      first.open()
+      gw.drain()
+      await Promise.resolve()
+      first.close(1011)
+
+      expect(FakeWebSocket.instances).toHaveLength(2)
+      await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS)
+      expect(FakeWebSocket.instances).toHaveLength(2)
+    } finally {
+      gw.kill()
+      vi.useRealTimers()
+    }
   })
 
   it('does not auto-reconnect after an intentional kill() (issue #32997)', async () => {

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -504,6 +504,13 @@ describe('GatewayClient websocket attach mode', () => {
       const socket = FakeWebSocket.instances[0]!
 
       socket.open()
+      socket.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { type: 'gateway.ready', payload: { heartbeat: true } }
+        })
+      )
       await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
 
       const heartbeat = JSON.parse(socket.sent.at(-1) ?? '{}') as { id: string; method: string }
@@ -530,11 +537,45 @@ describe('GatewayClient websocket attach mode', () => {
       const first = FakeWebSocket.instances[0]!
 
       first.open()
+      first.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { type: 'gateway.ready', payload: { heartbeat: true } }
+        })
+      )
       await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
       expect(JSON.parse(first.sent.at(-1) ?? '{}')).toMatchObject({ method: 'gateway.ping' })
       await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + WS_HEARTBEAT_INTERVAL_MS)
       await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS)
       expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      gw.kill()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not heartbeat an older backend that omits the capability', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+
+    try {
+      gw.start()
+      const socket = FakeWebSocket.instances[0]!
+
+      socket.open()
+      socket.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { type: 'gateway.ready', payload: {} }
+        })
+      )
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + WS_HEARTBEAT_INTERVAL_MS)
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN)
+      expect(socket.sent).toEqual([])
+      expect(FakeWebSocket.instances).toHaveLength(1)
     } finally {
       gw.kill()
       vi.useRealTimers()

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -23,9 +23,10 @@ const WS_CLOSED = 3
 
 // Keepalive + dead-connection detection. A silent drop (macOS sleep, proxy
 // idle timeout, VPN reconnect) kills the TCP socket without a `close` event,
-// so the client hangs forever (issue #32997). We send a periodic ping to stop
-// intermediaries reaping an idle socket AND watch inbound activity; if nothing
-// arrives within the dead window we force the socket closed -> reconnect.
+// so the client hangs forever (issue #32997). Browser/undici WebSocket does
+// not expose an acknowledged ping/pong API, so this uses a small JSON-RPC
+// heartbeat that the TUI gateway explicitly answers. Healthy idle sockets stay
+// open; only a missing heartbeat ack forces close -> reconnect.
 export const WS_HEARTBEAT_INTERVAL_MS = 15_000
 export const WS_HEARTBEAT_DEAD_MS = 45_000
 // Exponential backoff for reconnect attempts after a transport drop.
@@ -164,6 +165,9 @@ export class GatewayClient extends EventEmitter {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempts = 0
   private lastActivityAt = 0
+  private heartbeatSeq = 0
+  private heartbeatPendingId: string | null = null
+  private heartbeatSentAt = 0
   // Set on kill() so we never auto-reconnect after an intentional shutdown.
   private disposed = false
 
@@ -230,17 +234,41 @@ export class GatewayClient extends EventEmitter {
   private startHeartbeat(ws: WebSocket) {
     this.stopHeartbeat()
     this.lastActivityAt = Date.now()
+    this.heartbeatPendingId = null
+    this.heartbeatSentAt = 0
     this.heartbeatTimer = setInterval(() => {
-      // Keepalive: nudge the socket so proxies/OS don't reap an idle connection.
-      // Browser WebSocket has no ping(); undici (Node) does — guard either way.
-      try {
-        ;(ws as unknown as { ping?: (data?: string) => void }).ping?.()
-      } catch {
-        // best effort
+      if (this.ws !== ws || ws.readyState !== WS_OPEN) {
+        return
       }
 
-      if (Date.now() - this.lastActivityAt > WS_HEARTBEAT_DEAD_MS) {
-        this.lifecycle('[lifecycle] websocket silent drop detected (no activity); forcing reconnect')
+      const now = Date.now()
+
+      if (this.heartbeatPendingId && now - this.heartbeatSentAt > WS_HEARTBEAT_DEAD_MS) {
+        this.lifecycle('[lifecycle] websocket silent drop detected (heartbeat ack timeout); forcing reconnect')
+        this.stopHeartbeat()
+
+        try {
+          ws.close()
+        } catch {
+          // ignore
+        }
+
+        return
+      }
+
+      if (this.heartbeatPendingId) {
+        return
+      }
+
+      const id = `h${++this.heartbeatSeq}`
+
+      this.heartbeatPendingId = id
+      this.heartbeatSentAt = now
+
+      try {
+        ws.send(JSON.stringify({ id, jsonrpc: '2.0', method: 'gateway.ping', params: { last_activity_ms: this.lastActivityAt } }))
+      } catch {
+        this.lifecycle('[lifecycle] websocket heartbeat send failed; forcing reconnect')
         this.stopHeartbeat()
 
         try {
@@ -258,6 +286,9 @@ export class GatewayClient extends EventEmitter {
       clearInterval(this.heartbeatTimer)
       this.heartbeatTimer = null
     }
+
+    this.heartbeatPendingId = null
+    this.heartbeatSentAt = 0
   }
 
   private scheduleReconnect() {
@@ -338,16 +369,19 @@ export class GatewayClient extends EventEmitter {
     this.lifecycle(`[lifecycle] transport exit code=${code ?? 'null'} reason=${reason ?? 'none'}`)
     this.rejectPending(new Error(reason || `gateway exited${code === null ? '' : ` (${code})`}`))
 
+    // Self-heal: a dropped transport (real close OR silent drop caught by the
+    // heartbeat) should reconnect instead of stranding the UI on a dead socket
+    // (issue #32997). Intentional shutdown sets `disposed` and skips this.
+    // Schedule before the synchronous 'exit' emission: useMainApp's existing
+    // recovery subscriber may call start() immediately, and start() cancels this
+    // timer so there is only one recovery owner.
+    this.scheduleReconnect()
+
     if (this.subscribed) {
       this.emit('exit', code)
     } else {
       this.pendingExit = code
     }
-
-    // Self-heal: a dropped transport (real close OR silent drop caught by the
-    // heartbeat) should reconnect instead of stranding the UI on a dead socket
-    // (issue #32997). Intentional shutdown sets `disposed` and skips this.
-    this.scheduleReconnect()
   }
 
   private connectSidecarMirror() {
@@ -593,9 +627,9 @@ export class GatewayClient extends EventEmitter {
         }
 
         this.pushLog(`[lifecycle] websocket close code=${ev.code}`)
+        this.stopHeartbeat()
         this.ws = null
         this.wsConnectPromise = null
-        this.stopHeartbeat()
         this.handleTransportExit(ev.code, `gateway websocket closed${ev.code ? ` (${ev.code})` : ''}`)
       })
       ws.addEventListener('error', () => {
@@ -611,6 +645,9 @@ export class GatewayClient extends EventEmitter {
   }
 
   start() {
+    this.disposed = false
+    this.clearReconnect()
+
     const root = process.env.HERMES_PYTHON_SRC_ROOT ?? resolve(import.meta.dirname, '../../')
     const attachUrl = resolveGatewayAttachUrl()
     const sidecarUrl = resolveSidecarUrl()
@@ -641,6 +678,14 @@ export class GatewayClient extends EventEmitter {
 
   private dispatch(msg: Record<string, unknown>) {
     const id = msg.id as string | undefined
+
+    if (id && id === this.heartbeatPendingId) {
+      this.heartbeatPendingId = null
+      this.heartbeatSentAt = 0
+
+      return
+    }
+
     const p = id ? this.pending.get(id) : undefined
 
     if (p) {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -21,6 +21,17 @@ const WS_OPEN = 1
 const WS_CLOSING = 2
 const WS_CLOSED = 3
 
+// Keepalive + dead-connection detection. A silent drop (macOS sleep, proxy
+// idle timeout, VPN reconnect) kills the TCP socket without a `close` event,
+// so the client hangs forever (issue #32997). We send a periodic ping to stop
+// intermediaries reaping an idle socket AND watch inbound activity; if nothing
+// arrives within the dead window we force the socket closed -> reconnect.
+export const WS_HEARTBEAT_INTERVAL_MS = 15_000
+export const WS_HEARTBEAT_DEAD_MS = 45_000
+// Exponential backoff for reconnect attempts after a transport drop.
+export const RECONNECT_BASE_MS = 1_000
+export const RECONNECT_MAX_MS = 30_000
+
 const getWebSocketCtor = (): typeof WebSocket =>
   typeof WebSocket === 'undefined' ? (UndiciWebSocket as unknown as typeof WebSocket) : WebSocket
 
@@ -149,6 +160,12 @@ export class GatewayClient extends EventEmitter {
   private drainGeneration = 0
   private stdoutRl: ReturnType<typeof createInterface> | null = null
   private stderrRl: ReturnType<typeof createInterface> | null = null
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
+  private lastActivityAt = 0
+  // Set on kill() so we never auto-reconnect after an intentional shutdown.
+  private disposed = false
 
   constructor() {
     super()
@@ -210,6 +227,69 @@ export class GatewayClient extends EventEmitter {
     }
   }
 
+  private startHeartbeat(ws: WebSocket) {
+    this.stopHeartbeat()
+    this.lastActivityAt = Date.now()
+    this.heartbeatTimer = setInterval(() => {
+      // Keepalive: nudge the socket so proxies/OS don't reap an idle connection.
+      // Browser WebSocket has no ping(); undici (Node) does — guard either way.
+      try {
+        ;(ws as unknown as { ping?: (data?: string) => void }).ping?.()
+      } catch {
+        // best effort
+      }
+
+      if (Date.now() - this.lastActivityAt > WS_HEARTBEAT_DEAD_MS) {
+        this.lifecycle('[lifecycle] websocket silent drop detected (no activity); forcing reconnect')
+        this.stopHeartbeat()
+
+        try {
+          ws.close()
+        } catch {
+          // ignore
+        }
+      }
+    }, WS_HEARTBEAT_INTERVAL_MS)
+    this.heartbeatTimer.unref?.()
+  }
+
+  private stopHeartbeat() {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this.disposed || this.reconnectTimer !== null) {
+      return
+    }
+
+    const delay = Math.min(RECONNECT_BASE_MS * 2 ** this.reconnectAttempts, RECONNECT_MAX_MS)
+    this.reconnectAttempts += 1
+    this.lifecycle(`[lifecycle] scheduling gateway reconnect in ${delay}ms (attempt ${this.reconnectAttempts})`)
+    this.publish({ type: 'gateway.reconnecting', payload: { attempt: this.reconnectAttempts, delay_ms: delay } })
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+
+      if (this.disposed) {
+        return
+      }
+
+      this.start()
+    }, delay)
+    this.reconnectTimer.unref?.()
+  }
+
+  private clearReconnect() {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+
+    this.reconnectAttempts = 0
+  }
+
   private resetStartupState() {
     // Reject any in-flight RPCs left over from the previous transport
     // before we swap. Otherwise the old transport's stale exit/close
@@ -263,6 +343,11 @@ export class GatewayClient extends EventEmitter {
     } else {
       this.pendingExit = code
     }
+
+    // Self-heal: a dropped transport (real close OR silent drop caught by the
+    // heartbeat) should reconnect instead of stranding the UI on a dead socket
+    // (issue #32997). Intentional shutdown sets `disposed` and skips this.
+    this.scheduleReconnect()
   }
 
   private connectSidecarMirror() {
@@ -320,6 +405,7 @@ export class GatewayClient extends EventEmitter {
   }
 
   private handleWebSocketFrame(raw: unknown) {
+    this.lastActivityAt = Date.now()
     const text = asWireText(raw)
 
     if (!text) {
@@ -453,6 +539,9 @@ export class GatewayClient extends EventEmitter {
               resolve()
             }
 
+            this.lastActivityAt = Date.now()
+            this.clearReconnect()
+            this.startHeartbeat(ws)
             this.connectSidecarMirror()
           },
           { once: true }
@@ -506,6 +595,7 @@ export class GatewayClient extends EventEmitter {
         this.pushLog(`[lifecycle] websocket close code=${ev.code}`)
         this.ws = null
         this.wsConnectPromise = null
+        this.stopHeartbeat()
         this.handleTransportExit(ev.code, `gateway websocket closed${ev.code ? ` (${ev.code})` : ''}`)
       })
       ws.addEventListener('error', () => {
@@ -528,6 +618,8 @@ export class GatewayClient extends EventEmitter {
     this.attachUrl = attachUrl
     this.sidecarUrl = sidecarUrl
     this.resetStartupState()
+    this.clearReconnect()
+    this.stopHeartbeat()
 
     if (this.proc && !this.proc.killed && this.proc.exitCode === null) {
       this.lifecycle(`[lifecycle] replacing live gateway child ${describeChild(this.proc)}`)
@@ -776,6 +868,9 @@ export class GatewayClient extends EventEmitter {
   }
 
   kill(reason = 'requested') {
+    this.disposed = true
+    this.clearReconnect()
+    this.stopHeartbeat()
     const proc = this.proc
     const killed = proc?.kill()
 

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -186,6 +186,10 @@ export class GatewayClient extends EventEmitter {
         clearTimeout(this.readyTimer)
         this.readyTimer = null
       }
+
+      if (ev.payload?.heartbeat && this.ws?.readyState === WS_OPEN) {
+        this.startHeartbeat(this.ws)
+      }
     }
 
     if (this.subscribed) {
@@ -575,7 +579,6 @@ export class GatewayClient extends EventEmitter {
 
             this.lastActivityAt = Date.now()
             this.clearReconnect()
-            this.startHeartbeat(ws)
             this.connectSidecarMirror()
           },
           { once: true }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -639,6 +639,7 @@ export type GatewayEvent =
     }
   | { payload?: { reason?: string }; session_id?: string; type: 'dashboard.new_session_requested' }
   | { payload: { line: string }; session_id?: string; type: 'gateway.stderr' }
+  | { payload?: { attempt?: number; delay_ms?: number }; session_id?: string; type: 'gateway.reconnecting' }
   | {
       payload?: { level?: 'info' | 'warn' | 'error'; message?: string }
       session_id?: string

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -601,7 +601,7 @@ export interface SpawnTreeLoadResponse {
 }
 
 export type GatewayEvent =
-  | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
+  | { payload?: { heartbeat?: boolean; skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }


### PR DESCRIPTION
Closes #83147.

## What changed

- negotiate a browser-compatible 15-second application heartbeat with a 45-second acknowledgement deadline through `gateway.ready`
- invalidate only the expired socket generation, reject its pending calls, ignore late frames, and preserve existing Desktop reconnect ownership/backoff
- advance a monotonic Desktop connection epoch per profile and reactivate the routed session after every real reconnect, including React-batched reconnects
- make `prompt.submit` non-replayable after ambiguous transport outcomes; reconcile authoritative session state or restore the draft/attachments with a retryable delivery-not-confirmed error
- repair stale `running`/inflight state only when a registered prompt worker is confirmed dead
- centralize session transport rebinding so closed, detached, and heartbeat-expired owners can be replaced while another recently live WebSocket owner receives an explicit conflict
- add TUI heartbeat capability negotiation, bounded 1–30 second reconnect backoff, and intentional `kill()` suppression

Older backends remain compatible because heartbeat timers start only when the backend advertises the capability.

## Fault-injection proof

`hermes-ws-recovery-v1` passes on head `8b145ca89`:

| Scenario | Result |
| --- | --- |
| Disconnect after acceptance, before `message.complete` | Replacement-socket activation returns exactly one user row and one persisted assistant final; dead worker state returns to `idle` |
| Silent packet blackhole with no native `close` | Heartbeat invalidates the exact socket, one replacement opens, authoritative activation returns the final, and `prompt.submit` remains at exactly one call |
| Ambiguous submit accepted | No automatic replay; persisted/running state is accepted from activation |
| Ambiguous submit unproven | Optimistic row removed, composer payload restored, retryable delivery-not-confirmed error shown |
| Healthy second client | Existing recently live stream owner retains ownership; replacement receives conflict |
| Intentional shutdown | Zero reconnects |
| Older backend without capability | No heartbeat timer; connection remains compatible |

Focused local checks on the exact head:

- Desktop/shared Vitest: 5 files, 126 tests passed
- Desktop secondary-gateway reconnect test: 1 test passed
- TUI Vitest: 1 file, 18 tests passed
- Gateway Python: 3 files, 545 tests passed
- Desktop, shared, and TUI TypeScript checks passed
- changed Desktop/shared/TUI ESLint: 0 errors (one pre-existing hook dependency warning at an unchanged line)
- changed Python Ruff and `git diff --check`: passed

## Source PR credit

This combines the still-relevant behavior and tests from:

- Javier SM — #71475 (connection epochs and dead-worker activation cleanup). The obsolete readiness-auth commit is intentionally excluded.
- Tamaz Sujashvili — #40168 (Desktop heartbeat/reconnect recovery behavior), preserved through a co-author trailer on the synthesized current-architecture commit.
- Indigo Karasu — #60727 (TUI heartbeat and reconnect behavior), preserved as the original commits plus a co-author trailer where shared integration was synthesized.

The source PRs were used as behavioral specifications and test sources; obsolete code was not blindly cherry-picked.

## Scope boundary

This PR does not add a durable event outbox or delivery acknowledgement, change Relay concurrency/readiness authentication, alter proxy lifetime policy, or perform any deployment/backport. Passing proof establishes PR-head behavior only, not released or deployed customer behavior.
