### PR TITLE
fix(env): fail open when managed .env is inaccessible

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -579,21 +579,34 @@ def _apply_managed_env() -> None:
     v2 item (design §8.1). v1 relies on filesystem permissions only.
 
     Fail-open: a missing managed dir or .env is the common case and a no-op; any
-    error here is swallowed so managed scope can never block startup.
+    error here (including PermissionError/OSError on exists/stat/read of an
+    inaccessible managed path) is swallowed so managed scope can never block
+    startup. User/project dotenv errors are intentionally out of scope here.
     """
+    managed_env = None
     try:
         from hermes_cli import managed_scope
 
         managed_dir = managed_scope.get_managed_dir()
-    except Exception:  # noqa: BLE001 — managed scope must never block startup
-        return
-    if managed_dir is None:
-        return
-    managed_env = managed_dir / ".env"
-    if not managed_env.exists():
-        return
-    _sanitize_env_file_if_needed(managed_env)
-    _load_dotenv_with_fallback(managed_env, override=True)
+        if managed_dir is None:
+            return
+        managed_env = managed_dir / ".env"
+        # exists()/sanitize/load can raise when the managed dir is present but
+        # not traversable/readable to this uid (e.g. root-only /etc/hermes/.env).
+        if not managed_env.exists():
+            return
+        _sanitize_env_file_if_needed(managed_env)
+        _load_dotenv_with_fallback(managed_env, override=True)
+    except Exception as exc:  # noqa: BLE001 — managed scope must never block startup
+        import logging
+
+        # Path + exception only — never log managed file contents/secret values.
+        logging.getLogger(__name__).warning(
+            "managed scope: failed to apply managed .env (%s): %s — "
+            "IGNORING managed env. Admin policy from this file is NOT being applied.",
+            managed_env if managed_env is not None else "unresolved",
+            exc,
+        )
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:

--- a/tests/hermes_cli/test_managed_scope_env.py
+++ b/tests/hermes_cli/test_managed_scope_env.py
@@ -1,5 +1,9 @@
 """Env integration tests — managed .env applied last with override."""
+
+import logging
 import os
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,8 +25,12 @@ def test_managed_env_beats_user_env(env_homes, monkeypatch):
     from hermes_cli.env_loader import load_hermes_dotenv
 
     home, managed = env_homes
-    (home / ".env").write_text("OPENAI_API_BASE=https://user.example/v1\n", encoding="utf-8")
-    (managed / ".env").write_text("OPENAI_API_BASE=https://org.example/v1\n", encoding="utf-8")
+    (home / ".env").write_text(
+        "OPENAI_API_BASE=https://user.example/v1\n", encoding="utf-8"
+    )
+    (managed / ".env").write_text(
+        "OPENAI_API_BASE=https://org.example/v1\n", encoding="utf-8"
+    )
     load_hermes_dotenv(hermes_home=str(home))
     assert os.environ["OPENAI_API_BASE"] == "https://org.example/v1"
 
@@ -34,4 +42,129 @@ def test_no_managed_env_is_noop(env_homes, monkeypatch):
     monkeypatch.setenv("SOME_VALUE", "from_shell")
     (home / ".env").write_text("SOME_VALUE=from_user\n", encoding="utf-8")
     load_hermes_dotenv(hermes_home=str(home))
+    assert os.environ["SOME_VALUE"] == "from_user"
+
+
+def test_unreadable_managed_env_exists_fail_open(env_homes, monkeypatch, caplog):
+    """PermissionError on managed .env.exists() must not brick dotenv load.
+
+    Mirrors /etc/hermes present but .env not stat-readable to the process user.
+    Uses a fake Path so tests never touch real /etc/hermes.
+    """
+    from hermes_cli import managed_scope
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    home, _managed = env_homes
+    (home / ".env").write_text(
+        "OPENAI_API_BASE=https://user.example/v1\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("OPENAI_API_BASE", "https://shell.example/v1")
+
+    fake_env = MagicMock(spec=Path)
+    fake_env.__str__.return_value = "/etc/hermes/.env"
+    fake_env.exists.side_effect = PermissionError(
+        13, "Permission denied", "/etc/hermes/.env"
+    )
+
+    fake_dir = MagicMock(spec=Path)
+    fake_dir.__truediv__.return_value = fake_env
+    monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: fake_dir)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.env_loader"):
+        loaded = load_hermes_dotenv(hermes_home=str(home))
+
+    assert loaded == [home / ".env"]
+    # User env still applied; managed must not raise or partially apply.
+    assert os.environ["OPENAI_API_BASE"] == "https://user.example/v1"
+    assert any("managed" in r.getMessage().lower() for r in caplog.records)
+    # Never log secret values from a managed file body.
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "sk-" not in joined
+    assert "secret" not in joined.lower()
+
+
+def test_unreadable_managed_env_load_oserror_fail_open(env_homes, monkeypatch):
+    """OSError while loading a present managed .env must fail open."""
+    from hermes_cli import env_loader, managed_scope
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    home, _managed = env_homes
+    (home / ".env").write_text("SOME_VALUE=from_user\n", encoding="utf-8")
+
+    fake_env = MagicMock(spec=Path)
+    fake_env.__str__.return_value = str(_managed / ".env")
+    fake_env.exists.return_value = True
+
+    fake_dir = MagicMock(spec=Path)
+    fake_dir.__truediv__.return_value = fake_env
+    monkeypatch.setattr(managed_scope, "get_managed_dir", lambda: fake_dir)
+
+    real_sanitize = env_loader._sanitize_env_file_if_needed
+    real_load = env_loader._load_dotenv_with_fallback
+
+    def _is_managed(path) -> bool:
+        return path is fake_env or str(path) == str(fake_env)
+
+    def _sanitize(path):
+        if _is_managed(path):
+            return None
+        return real_sanitize(path)
+
+    def _load(path, override=False):
+        # Only the managed path should fail; user/project dotenv stays normal.
+        if _is_managed(path):
+            raise OSError(13, "Permission denied", str(fake_env))
+        return real_load(path, override=override)
+
+    monkeypatch.setattr(env_loader, "_sanitize_env_file_if_needed", _sanitize)
+    monkeypatch.setattr(env_loader, "_load_dotenv_with_fallback", _load)
+
+    load_hermes_dotenv(hermes_home=str(home))
+    assert os.environ["SOME_VALUE"] == "from_user"
+
+
+def test_managed_env_still_overrides_after_fail_open_path(env_homes, monkeypatch):
+    """Valid managed .env must still apply last with override (precedence intact)."""
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    home, managed = env_homes
+    monkeypatch.setenv("OPENAI_API_BASE", "https://shell.example/v1")
+    (home / ".env").write_text(
+        "OPENAI_API_BASE=https://user.example/v1\nOTHER=user-only\n",
+        encoding="utf-8",
+    )
+    (managed / ".env").write_text(
+        "OPENAI_API_BASE=https://org.example/v1\n",
+        encoding="utf-8",
+    )
+    load_hermes_dotenv(hermes_home=str(home))
+    assert os.environ["OPENAI_API_BASE"] == "https://org.example/v1"
+    assert os.environ["OTHER"] == "user-only"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory execute bits")
+def test_untraversable_managed_dir_fail_open_real_fs(env_homes, monkeypatch):
+    """Real FS: managed dir without +x makes .env.exists() raise PermissionError.
+
+    get_managed_dir() still resolves the directory (is_dir on the dir itself
+    succeeds), then Path.exists() on the child raises — the original production
+    failure mode when /etc/hermes is present but not fully traversable.
+    """
+    from hermes_cli import managed_scope
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    home, managed = env_homes
+    (home / ".env").write_text("SOME_VALUE=from_user\n", encoding="utf-8")
+    (managed / ".env").write_text("SOME_VALUE=from_managed\n", encoding="utf-8")
+    managed_scope.invalidate_managed_cache()
+
+    managed.chmod(0o600)  # rw, no execute → children not stat-able
+    try:
+        # Sanity: this is the exact raise the production bug hit.
+        with pytest.raises(PermissionError):
+            (managed / ".env").exists()
+        load_hermes_dotenv(hermes_home=str(home))
+    finally:
+        managed.chmod(0o700)
+
     assert os.environ["SOME_VALUE"] == "from_user"


### PR DESCRIPTION
## Summary
- `_apply_managed_env()` only guarded `get_managed_dir()`; `Path.exists()` / sanitize / load could still raise `PermissionError` when a managed directory exists but is not traversable/stat-readable (e.g. root-owned `/etc/hermes` without full access for the process user).
- Python's `Path.exists()` re-raises `PermissionError` (EACCES is not in the ignored-errno set), so managed scope could brick CLI/gateway import and test collection despite its documented fail-open contract.
- Move the full managed `.env` apply path into the fail-open boundary and emit a bounded warning (path + exception only; never managed file contents/secret values). Valid managed `.env` still applies last with `override=True`.

## Test plan
- [x] `uv run pytest tests/hermes_cli/test_managed_scope_env.py tests/hermes_cli/test_managed_scope.py tests/hermes_cli/test_managed_scope_loaders.py -q` → 10 passed
- [x] `uv run ruff check hermes_cli/env_loader.py tests/hermes_cli/test_managed_scope_env.py` → clean
- [x] Deterministic mock: `PermissionError` on managed `.env.exists()` does not raise; user `.env` still loads; warning emitted without secret values
- [x] OSError during managed load fails open
- [x] Valid managed `.env` still beats user/shell
- [x] Real FS: managed dir without `+x` raises on bare `.exists()` but `load_hermes_dotenv` fails open

Tested SHA: `8fb0a59bec4d76d0f2c3db0f041db487a023aa3c`