### PR TITLE
fix(pty): track and drain detached keep-alive session closes

### DIFF
--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -119,7 +119,7 @@ class PtySession:
             pass
 
 
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict, Set, Tuple
 
 
 class RegistryFull(Exception):
@@ -144,6 +144,12 @@ class PtySessionRegistry:
         self._buffer_cap = buffer_cap
         self._read_timeout = read_timeout
         self._sessions: Dict[str, PtySession] = {}
+        # Strong references to detached ``close()`` tasks for sessions that
+        # have already been removed from ``_sessions``. asyncio keeps only a
+        # weak reference in the event loop's task table, so without this the
+        # loop can garbage-collect a capacity eviction's close mid-flight and
+        # the PTY child is never joined.
+        self._closing: Set[asyncio.Task] = set()
 
     async def attach_or_spawn(self, key: str, *, spawn: Callable[[], object]
                               ) -> Tuple[PtySession, bool]:
@@ -188,7 +194,14 @@ class PtySessionRegistry:
             raise RegistryFull()
         oldest = min(idle, key=lambda s: s.last_detached_at or 0.0)
         self._sessions.pop(oldest.key, None)
-        asyncio.create_task(oldest.close())
+        # This is a sync method (``attach_or_spawn`` calls it from a
+        # non-awaitable position), so the close cannot be awaited here. Keep
+        # the task in ``_closing`` instead: that holds the strong reference
+        # the event loop does not, and it is what lets ``close_all()`` still
+        # reach an eviction that is in flight at shutdown.
+        task = asyncio.create_task(oldest.close())
+        self._closing.add(task)
+        task.add_done_callback(self._closing.discard)
 
     async def close_all(self) -> None:
         for key in list(self._sessions):

--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -206,3 +206,11 @@ class PtySessionRegistry:
     async def close_all(self) -> None:
         for key in list(self._sessions):
             await self._sessions.pop(key).close()
+        # Capacity evictions are removed from ``_sessions`` before their
+        # close is scheduled, so the loop above cannot reach one that is
+        # still in flight. Drain them here too, or shutdown returns while a
+        # PTY child is still unjoined. ``return_exceptions=True`` keeps one
+        # failing bridge from aborting the rest of the drain, matching the
+        # swallow-and-continue posture ``PtySession.close()`` already takes.
+        if self._closing:
+            await asyncio.gather(*list(self._closing), return_exceptions=True)

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -161,6 +161,23 @@ async def _spawn_then_detach(reg, key, bridge):
     return session
 
 
+async def _wait_until(predicate, what, timeout=5.0):
+    """Poll until ``predicate()`` holds.
+
+    Used instead of a fixed sleep to synchronise on the non-evicted session's
+    close actually completing. That close goes through ``asyncio.to_thread``,
+    so its duration depends on thread-pool scheduling; a wall-clock guess
+    would let a loaded runner leave ``close_all()`` still inside its
+    ``_sessions`` loop and make the assertions below pass for the wrong
+    reason.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise AssertionError(f"timed out waiting for {what}")
+        await asyncio.sleep(0.001)
+
+
 @pytest.mark.asyncio
 async def test_close_all_awaits_an_in_flight_capacity_eviction():
     # A capacity eviction is popped from _sessions before its close is
@@ -178,7 +195,13 @@ async def test_close_all_awaits_an_in_flight_capacity_eviction():
         assert a_bridge.closed is False          # eviction close parked on the gate
 
         drain = asyncio.create_task(reg.close_all())
-        await asyncio.sleep(0.05)                # ample time to return if unaware
+        # Synchronise on the non-evicted session's close finishing. Until
+        # then close_all() is legitimately still busy and being unfinished
+        # would say nothing about the eviction. Once "b" is closed the only
+        # work left is the eviction drain, so the slack below is generous:
+        # a close_all() that ignores evictions returns immediately here.
+        await _wait_until(lambda: b_bridge.closed, "the non-evicted session to close")
+        await asyncio.sleep(0.05)
         awaited_the_eviction = not drain.done()
     finally:
         # Release unconditionally: a failed assertion above must not strand
@@ -252,7 +275,13 @@ async def test_close_all_drains_even_when_an_eviction_close_raises():
     try:
         await reg.attach_or_spawn("b", spawn=lambda: b_bridge)   # evicts "a"
         drain = asyncio.create_task(reg.close_all())
-        await asyncio.sleep(0.05)                # close_all reaches the gather
+        # Release the gate only once close_all() has finished its _sessions
+        # loop and can be parked on the eviction drain. Releasing earlier
+        # would let the raising close finish — and be discarded from
+        # _closing — before the gather ever snapshots it, so the drain would
+        # have nothing to re-raise and the test would pass vacuously.
+        await _wait_until(lambda: b_bridge.closed, "the non-evicted session to close")
+        await asyncio.sleep(0.05)
     finally:
         gate.set()
         if drain is not None:

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import time
 
 import pytest
@@ -26,11 +27,15 @@ def test_ringbuffer_drops_oldest_over_capacity():
 class FakeBridge:
     """Implements the bridge contract PtySession depends on."""
 
-    def __init__(self, chunks):
+    def __init__(self, chunks, close_gate=None):
         self._chunks = list(chunks)   # bytes; b"" = idle tick; None = EOF
         self.written = bytearray()
         self.closed = False
         self.resized = None
+        # Optional threading.Event held by close() so a test can keep a
+        # close in flight. close() runs via asyncio.to_thread, so the gate
+        # has to be a thread primitive rather than an asyncio one.
+        self._close_gate = close_gate
 
     def read(self, timeout):
         if not self._chunks:
@@ -44,6 +49,8 @@ class FakeBridge:
         self.resized = (cols, rows)
 
     def close(self):
+        if self._close_gate is not None:
+            self._close_gate.wait()
         self.closed = True
 
 
@@ -143,3 +150,113 @@ async def test_reaper_loop_invokes_reap(monkeypatch):
     except asyncio.CancelledError:
         pass
     assert calls["n"] >= 2
+
+
+async def _spawn_then_detach(reg, key, bridge):
+    """Spawn a session and leave it idle-but-reapable (detached + timestamped)."""
+    session, _ = await reg.attach_or_spawn(key, spawn=lambda: bridge)
+    ws = FakeWS()
+    await session.attach(ws)
+    session.detach(ws)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_close_all_awaits_an_in_flight_capacity_eviction():
+    # A capacity eviction is popped from _sessions before its close is
+    # scheduled, so close_all()'s loop over _sessions cannot reach it. If the
+    # drain does not also await the eviction, shutdown returns while the PTY
+    # child is still unjoined.
+    gate = threading.Event()
+    reg = make_registry(max_sessions=1)
+    a_bridge = FakeBridge([], close_gate=gate)
+    b_bridge = FakeBridge([])
+    drain = None
+    try:
+        await _spawn_then_detach(reg, "a", a_bridge)
+        await reg.attach_or_spawn("b", spawn=lambda: b_bridge)   # evicts "a"
+        assert a_bridge.closed is False          # eviction close parked on the gate
+
+        drain = asyncio.create_task(reg.close_all())
+        await asyncio.sleep(0.05)                # ample time to return if unaware
+        awaited_the_eviction = not drain.done()
+    finally:
+        # Release unconditionally: a failed assertion above must not strand
+        # the gated bridge thread and hang the run instead of failing it.
+        gate.set()
+        if drain is not None:
+            await drain
+
+    assert awaited_the_eviction, "close_all() returned without draining the eviction"
+    assert a_bridge.closed is True
+    assert b_bridge.closed is True
+
+
+@pytest.mark.asyncio
+async def test_capacity_eviction_close_task_is_strongly_referenced():
+    reg = make_registry(max_sessions=1)
+    a_bridge = FakeBridge([])
+    await _spawn_then_detach(reg, "a", a_bridge)
+
+    await reg.attach_or_spawn("b", spawn=lambda: FakeBridge([]))
+    # The loop's task table holds only a weak reference; the registry must
+    # hold its own or the close can be collected mid-flight.
+    assert len(reg._closing) == 1
+    task = next(iter(reg._closing))
+
+    await task
+    await asyncio.sleep(0)                       # let the done callback run
+    assert reg._closing == set()                 # ...and the set stays bounded
+    await reg.close_all()
+
+
+@pytest.mark.asyncio
+async def test_capacity_eviction_closes_the_evicted_bridge():
+    # Positive control: pins that the successful-eviction branch actually
+    # runs, so the assertions above cannot pass against a registry that
+    # never evicts anything.
+    reg = make_registry(max_sessions=1)
+    a_bridge = FakeBridge([])
+    await _spawn_then_detach(reg, "a", a_bridge)
+
+    b_bridge = FakeBridge([])
+    _, created = await reg.attach_or_spawn("b", spawn=lambda: b_bridge)
+    assert created is True                       # reapable idle → no RegistryFull
+
+    await reg.close_all()
+    assert a_bridge.closed is True
+    assert b_bridge.closed is True
+
+
+@pytest.mark.asyncio
+async def test_close_all_drains_even_when_an_eviction_close_raises():
+    # One failing eviction close must not abort the rest of the drain. The
+    # gate keeps the raising close in flight until close_all() is parked in
+    # the gather — otherwise it would finish (and be discarded) beforehand
+    # and the drain would have nothing to re-raise.
+    gate = threading.Event()
+    reg = make_registry(max_sessions=1)
+    a_bridge = FakeBridge([], close_gate=gate)
+    session_a = await _spawn_then_detach(reg, "a", a_bridge)
+
+    real_close = session_a.close
+
+    async def close_then_raise():
+        await real_close()
+        raise RuntimeError("bridge join failed")
+
+    session_a.close = close_then_raise
+
+    b_bridge = FakeBridge([])
+    drain = None
+    try:
+        await reg.attach_or_spawn("b", spawn=lambda: b_bridge)   # evicts "a"
+        drain = asyncio.create_task(reg.close_all())
+        await asyncio.sleep(0.05)                # close_all reaches the gather
+    finally:
+        gate.set()
+        if drain is not None:
+            await drain                          # must not propagate RuntimeError
+
+    assert a_bridge.closed is True
+    assert b_bridge.closed is True


### PR DESCRIPTION
## What does this PR do?

`PtySessionRegistry` evicts the oldest idle keep-alive session when the registry is at `max_sessions`. The eviction is the only teardown path in the module that neither retains its close task nor is reachable by the shutdown drain, so an evicted PTY child can be left un-joined:

```python
oldest = min(idle, key=lambda s: s.last_detached_at or 0.0)
self._sessions.pop(oldest.key, None)      # registry drops its only reference
asyncio.create_task(oldest.close())       # task discarded
```

Two distinct defects meet at that one call:

1. **No strong reference to the task.** The event loop's task table holds only a weak reference, so once the registry pops the session nothing owns the coroutine and the close can be garbage-collected mid-flight — `PtySession.close()` never reaches `bridge.close()`, which is what joins the child.
2. **The close is invisible to the shutdown drain.** `close_all()` is the registry's drain and the only teardown the dashboard's FastAPI lifespan awaits in its `finally`. It iterates `_sessions`, from which the evicted key has *already* been popped, so an eviction still in flight at shutdown is never awaited. This one is deterministic — it needs no GC hypothesis.

Visible symptom: with the dashboard terminal at its session cap, opening a new terminal evicts the oldest idle one and orphans its shell holding the PTY fd. Stopping the dashboard does not reap it, because `close_all()` cannot see it. Repeated evictions accumulate orphaned shells and leak `/dev/pts` slots.

Every other teardown path in the file already awaits its close — `reap_idle()`, `close_all()`'s own loop, and the dead-remnant branch of `attach_or_spawn()`. `_reap_one_idle_or_raise` is the odd one out because it is a **sync** `def` called from a non-awaitable position in `attach_or_spawn`, so it cannot `await` in place. That is why the fix tracks the task rather than awaiting it there.

### Coverage of the root cause

`asyncio.create_task` appears twice in `hermes_cli/pty_session.py`. The other site, `PtySession.start()`, already stores its task in `self._drain_task` and `close()` cancels and awaits it — it is not affected and is deliberately left alone. The eviction is the only unreferenced site, and `close_all()` is the module's only drain (sole caller: the lifespan `finally` in `hermes_cli/web_server.py`). The fix is therefore complete within this one file.

## Related Issue

No filed issue — found by inspecting the keep-alive registry's teardown paths against each other.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/pty_session.py` — `PtySessionRegistry.__init__`: add a `_closing: Set[asyncio.Task]` set holding strong references to detached close tasks for sessions already removed from `_sessions`.
- `hermes_cli/pty_session.py` — `_reap_one_idle_or_raise`: retain the eviction's close task in `_closing` and discard it from a done callback, so the set cannot grow without bound.
- `hermes_cli/pty_session.py` — `close_all`: after draining `_sessions`, `await asyncio.gather(*self._closing, return_exceptions=True)`. `return_exceptions=True` keeps one failing bridge from aborting the rest of the drain, matching the swallow-and-continue posture `PtySession.close()` already takes.
- `tests/test_pty_session.py` — four regression tests plus an optional `close_gate` on `FakeBridge`.

## How to Test

The successful-eviction branch of `_reap_one_idle_or_raise` had **no coverage at all** before this PR — `test_new_key_at_capacity_raises_when_none_reapable` exercises only the `RegistryFull` branch, which is why both defects survived.

```
pytest tests/test_pty_session.py -q     # 11 passed
pytest tests/test_pty_keepalive_ws.py -q  # 4 passed (adjacent, unaffected)
```

Verified red-before / green-after in three separate configurations:

| Production state | Failing tests |
| --- | --- |
| `origin/main` (neither fix) | `..._close_all_awaits_an_in_flight_capacity_eviction`, `..._close_task_is_strongly_referenced` |
| strong ref only, no drain in `close_all` | `..._close_all_awaits_an_in_flight_capacity_eviction`, `..._drains_even_when_an_eviction_close_raises` |
| both fixes, `return_exceptions=True` removed | `..._drains_even_when_an_eviction_close_raises` |
| both fixes (this PR) | none — 11 passed |

The middle two rows are why this ships as separate commits: each fix is independently load-bearing and independently covered.

`test_capacity_eviction_closes_the_evicted_bridge` is a deliberate positive control — it asserts the eviction branch actually runs, so the other three cannot pass vacuously against a registry that never evicts.

`FakeBridge.close_gate` is a `threading.Event` rather than an `asyncio.Event` because `close()` runs through `asyncio.to_thread`. It is always released from a `finally` so a failed assertion fails the run instead of stranding the bridge thread and hanging it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused + adjacent files listed above, not the full suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4.0), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- inline comments at both sites explain the invariant -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure asyncio task bookkeeping, no platform-specific paths -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
