### PR TITLE
feat(slack): add send_choice_picker with Block Kit buttons

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -966,6 +966,7 @@ class SlackAdapter(BasePlatformAdapter):
         # buttons); mirrors _approval_resolved.
         self._clarify_resolved: Dict[Any, bool] = {}
         self._CLARIFY_RESOLVED_MAX = 1000
+        self._choice_picker_state: Dict[str, Any] = {}
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set[str] = set()
@@ -2110,6 +2111,12 @@ class SlackAdapter(BasePlatformAdapter):
                 _re.compile(r"^hermes_clarify_choice_\d+$")
             )(self._handle_clarify_action)
             self._app.action("hermes_clarify_other")(self._handle_clarify_action)
+
+            # Register Block Kit action handlers for choice picker buttons
+            # (flat single-level pickers; see gateway/slash_commands.py).
+            self._app.action(
+                _re.compile(r"^hermes_cp_\d+$")
+            )(self._handle_choice_picker_action)
 
             # Register plugin-provided Block Kit action handlers.
             #
@@ -6648,6 +6655,78 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error("[Slack] send_clarify failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+
+    async def send_choice_picker(
+        self,
+        chat_id: str,
+        title: str,
+        choices: list,
+        session_key: str,
+        on_choice_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a flat choice picker as Block Kit buttons.
+
+        Each choice dict: ``{"value": str, "label": str, "is_current": bool}``.
+        Current selection is marked with a "✓ " prefix. Button taps are
+        dispatched via ``hermes_cp_<idx>`` action_id and resolved through
+        ``on_choice_selected``.  Follows the same Block Kit pattern as
+        ``send_clarify`` in this adapter.
+        """
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        chat_id = await self._ensure_dm_conversation(
+            chat_id, team_id=self._metadata_team_id(metadata)
+        )
+        try:
+            thread_ts = self._resolve_thread_ts(None, metadata)
+
+            t = (title or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+            body = t[:3000] if t else "Choose an option"
+
+            elements = []
+            for idx, choice in enumerate(choices):
+                label = str(choice.get("label") or choice.get("value") or f"Option {idx + 1}").strip()
+                if choice.get("is_current"):
+                    label = "✓ " + label
+                elements.append({
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": label[:75], "emoji": True},
+                    "action_id": f"hermes_cp_{idx}",
+                    "value": f"cp:{idx}",
+                })
+
+            if not elements:
+                return SendResult(success=False, error="No choices provided")
+
+            blocks: list = [
+                {"type": "section", "text": {"type": "mrkdwn", "text": body}},
+            ]
+            for start in range(0, len(elements), 5):
+                blocks.append({"type": "actions", "elements": elements[start:start + 5]})
+
+            kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": body,
+                "blocks": blocks,
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+
+            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            msg_ts = result.get("ts", "")
+            if msg_ts:
+                self._choice_picker_state[msg_ts] = {
+                    "choices": choices,
+                    "session_key": session_key,
+                    "on_choice_selected": on_choice_selected,
+                }
+            return SendResult(success=True, message_id=msg_ts, raw_response=result)
+        except Exception as e:
+            logger.error("[Slack] send_choice_picker failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
     def _is_interactive_user_authorized(
         self,
         user_id: str,
@@ -7016,6 +7095,71 @@ class SlackAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             logger.warning("[Slack] Failed to update clarify message: %s", e)
+
+    async def _handle_choice_picker_action(self, ack, body, action) -> None:
+        """Handle a choice picker button click (hermes_cp_<idx>) from Block Kit."""
+        await ack()
+
+        action_id = action.get("action_id", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized choice picker click by %s (%s) - ignoring",
+                user_name, user_id,
+            )
+            return
+
+        # Parse index from action_id: hermes_cp_<idx>
+        try:
+            idx = int(action_id.split("_")[-1])
+        except (ValueError, TypeError):
+            logger.warning("[Slack] Malformed choice picker action_id: %s", action_id)
+            return
+
+        state = self._choice_picker_state.pop(msg_ts, None)
+        if state is None:
+            logger.warning("[Slack] Choice picker state not found for ts=%s", msg_ts)
+            return
+
+        choices = state.get("choices", [])
+        on_choice_selected = state.get("on_choice_selected")
+
+        if idx < 0 or idx >= len(choices):
+            logger.warning("[Slack] Choice picker index %d out of range (%d choices)", idx, len(choices))
+            return
+
+        chosen = choices[idx]
+        label = str(chosen.get("label") or chosen.get("value") or f"Option {idx + 1}")
+
+        # Update the message to show the selection.
+        try:
+            client = self._get_client(channel_id)
+            await client.chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text=f"✓ {label} (selected by {user_name})",
+                blocks=[
+                    {"type": "section", "text": {"type": "mrkdwn", "text": f"✓ *{label}* — selected by {user_name}"}},
+                ],
+            )
+        except Exception as e:
+            logger.warning("[Slack] Could not update choice picker message: %s", e)
+
+        # Fire the callback.
+        if callable(on_choice_selected):
+            try:
+                await on_choice_selected(chosen.get("value", label))
+            except Exception as e:
+                logger.error("[Slack] on_choice_selected callback failed: %s", e, exc_info=True)
 
     async def _handle_clarify_action(self, ack, body, action) -> None:
         """Handle a clarify button click (a choice or "Other") from Block Kit."""

--- a/tests/gateway/test_slack_choice_picker.py
+++ b/tests/gateway/test_slack_choice_picker.py
@@ -1,0 +1,408 @@
+"""Tests for Slack Block Kit interactive choice picker.
+
+Mirrors test_slack_clarify_buttons.py (harness) for the
+``send_choice_picker`` override and the ``hermes_cp_<idx>``
+action dispatch via ``_handle_choice_picker_action``.
+
+Coverage:
+- send_choice_picker: renders Block Kit buttons, stores state, returns msg_ts
+- send_choice_picker: empty choices → early failure
+- send_choice_picker: not connected → early failure
+- send_choice_picker: marks current choice with ✓
+- _handle_choice_picker_action: valid tap fires on_choice_selected callback
+- _handle_choice_picker_action: unauthorized user → ignored (auth bypass guard)
+- _handle_choice_picker_action: double-tap → state already popped, no callback
+- _handle_choice_picker_action: malformed action_id → no crash
+- _handle_choice_picker_action: out-of-range index → no crash
+- _handle_choice_picker_action: expired state (msg_ts not in dict) → no crash
+- _handle_choice_picker_action: callback exception → logged, no crash
+- _handle_choice_picker_action: chat_update failure → logged, callback still fires
+- State isolation: separate pickers don't interfere
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, call
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+# ---------------------------------------------------------------------------
+# Minimal Slack SDK mock (mirrors test_slack_clarify_buttons.py)
+# ---------------------------------------------------------------------------
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules:
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    sys.modules["slack_bolt"] = slack_bolt
+    sys.modules["slack_bolt.async_app"] = slack_bolt.async_app
+    handler_mod = MagicMock()
+    handler_mod.AsyncSocketModeHandler = MagicMock
+    sys.modules["slack_bolt.adapter"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode"] = MagicMock()
+    sys.modules["slack_bolt.adapter.socket_mode.async_handler"] = handler_mod
+    sdk_mod = MagicMock()
+    sdk_mod.web = MagicMock()
+    sdk_mod.web.async_client = MagicMock()
+    sdk_mod.web.async_client.AsyncWebClient = MagicMock
+    sys.modules["slack_sdk"] = sdk_mod
+    sys.modules["slack_sdk.web"] = sdk_mod.web
+    sys.modules["slack_sdk.web.async_client"] = sdk_mod.web.async_client
+
+_ensure_slack_mock()
+
+from plugins.platforms.slack.adapter import SlackAdapter
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-test-token")
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_clients = {"T1": AsyncMock()}
+    adapter._team_bot_user_ids = {"T1": "U_BOT"}
+    adapter._channel_team = {"C1": "T1"}
+    return adapter
+
+
+def _make_choices():
+    return [
+        {"value": "fast", "label": "Fast", "is_current": False},
+        {"value": "auto", "label": "Auto", "is_current": True},
+        {"value": "slow", "label": "Slow", "is_current": False},
+    ]
+
+
+def _make_action_body(action_id="hermes_cp_0", msg_ts="111.222", channel_id="C1",
+                      user_id="U1", user_name="alice"):
+    return {
+        "message": {"ts": msg_ts, "blocks": []},
+        "channel": {"id": channel_id},
+        "user": {"id": user_id, "name": user_name},
+    }
+
+
+def _make_action(action_id="hermes_cp_0"):
+    return {"action_id": action_id, "value": ""}
+
+
+# ---------------------------------------------------------------------------
+# send_choice_picker tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_choice_picker_not_connected():
+    adapter = _make_adapter()
+    adapter._app = None
+    result = await adapter.send_choice_picker(
+        chat_id="C1", title="Pick one", choices=_make_choices(),
+        session_key="sk", on_choice_selected=AsyncMock(),
+    )
+    assert not result.success
+    assert "Not connected" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_send_choice_picker_empty_choices():
+    adapter = _make_adapter()
+    adapter._ensure_dm_conversation = AsyncMock(return_value="C1")
+    adapter._resolve_thread_ts = MagicMock(return_value=None)
+    adapter._get_client = MagicMock(return_value=AsyncMock())
+    result = await adapter.send_choice_picker(
+        chat_id="C1", title="Pick one", choices=[],
+        session_key="sk", on_choice_selected=AsyncMock(),
+    )
+    assert not result.success
+    assert "No choices" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_send_choice_picker_renders_buttons_and_stores_state():
+    adapter = _make_adapter()
+    adapter._ensure_dm_conversation = AsyncMock(return_value="C1")
+    adapter._resolve_thread_ts = MagicMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.chat_postMessage = AsyncMock(return_value={"ts": "111.001"})
+    adapter._get_client = MagicMock(return_value=mock_client)
+
+    on_selected = AsyncMock()
+    choices = _make_choices()
+    result = await adapter.send_choice_picker(
+        chat_id="C1", title="Choose mode", choices=choices,
+        session_key="sk1", on_choice_selected=on_selected,
+    )
+
+    assert result.success
+    assert result.message_id == "111.001"
+    assert "111.001" in adapter._choice_picker_state
+    state = adapter._choice_picker_state["111.001"]
+    assert state["session_key"] == "sk1"
+    assert state["on_choice_selected"] is on_selected
+    assert state["choices"] is choices
+
+    # Verify Block Kit structure
+    call_kwargs = mock_client.chat_postMessage.call_args.kwargs
+    blocks = call_kwargs["blocks"]
+    assert blocks[0]["type"] == "section"
+    action_blocks = [b for b in blocks if b["type"] == "actions"]
+    assert len(action_blocks) >= 1
+    all_elements = [e for b in action_blocks for e in b["elements"]]
+    assert len(all_elements) == 3
+    assert all_elements[0]["action_id"] == "hermes_cp_0"
+    assert all_elements[0]["value"] == "cp:0"
+
+
+@pytest.mark.asyncio
+async def test_send_choice_picker_marks_current_choice():
+    adapter = _make_adapter()
+    adapter._ensure_dm_conversation = AsyncMock(return_value="C1")
+    adapter._resolve_thread_ts = MagicMock(return_value=None)
+
+    mock_client = AsyncMock()
+    mock_client.chat_postMessage = AsyncMock(return_value={"ts": "111.002"})
+    adapter._get_client = MagicMock(return_value=mock_client)
+
+    choices = _make_choices()  # index 1 is_current=True
+    await adapter.send_choice_picker(
+        chat_id="C1", title="Pick", choices=choices,
+        session_key="sk", on_choice_selected=AsyncMock(),
+    )
+
+    call_kwargs = mock_client.chat_postMessage.call_args.kwargs
+    action_blocks = [b for b in call_kwargs["blocks"] if b["type"] == "actions"]
+    all_elements = [e for b in action_blocks for e in b["elements"]]
+    current_label = all_elements[1]["text"]["text"]
+    assert current_label.startswith("✓ ")
+
+
+@pytest.mark.asyncio
+async def test_send_choice_picker_with_thread_ts():
+    adapter = _make_adapter()
+    adapter._ensure_dm_conversation = AsyncMock(return_value="C1")
+    adapter._resolve_thread_ts = MagicMock(return_value="100.000")
+
+    mock_client = AsyncMock()
+    mock_client.chat_postMessage = AsyncMock(return_value={"ts": "111.003"})
+    adapter._get_client = MagicMock(return_value=mock_client)
+
+    await adapter.send_choice_picker(
+        chat_id="C1", title="Pick", choices=_make_choices(),
+        session_key="sk", on_choice_selected=AsyncMock(),
+    )
+
+    call_kwargs = mock_client.chat_postMessage.call_args.kwargs
+    assert call_kwargs.get("thread_ts") == "100.000"
+
+
+# ---------------------------------------------------------------------------
+# _handle_choice_picker_action tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_handle_choice_picker_valid_tap_fires_callback():
+    adapter = _make_adapter()
+    on_selected = AsyncMock()
+    adapter._choice_picker_state["111.222"] = {
+        "choices": _make_choices(),
+        "session_key": "sk",
+        "on_choice_selected": on_selected,
+    }
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    mock_client = AsyncMock()
+    adapter._get_client = MagicMock(return_value=mock_client)
+
+    ack = AsyncMock()
+    await adapter._handle_choice_picker_action(
+        ack=ack,
+        body=_make_action_body(action_id="hermes_cp_0", msg_ts="111.222"),
+        action=_make_action("hermes_cp_0"),
+    )
+
+    ack.assert_awaited_once()
+    on_selected.assert_awaited_once_with("fast")
+    assert "111.222" not in adapter._choice_picker_state
+
+
+@pytest.mark.asyncio
+async def test_handle_choice_picker_unauthorized_user_ignored():
+    adapter = _make_adapter()
+    on_selected = AsyncMock()
+    adapter._choice_picker_state["111.333"] = {
+        "choices": _make_choices(),
+        "session_key": "sk",
+        "on_choice_selected": on_selected,
+    }
+    adapter._is_interactive_user_authorized = MagicMock(return_value=False)
+
+    ack = AsyncMock()
+    await adapter._handle_choice_picker_action(
+        ack=ack,
+        body=_make_action_body(action_id="hermes_cp_0", msg_ts="111.333"),
+        action=_make_action("hermes_cp_0"),
+    )
+
+    ack.assert_awaited_once()
+    on_selected.assert_not_called()
+    # State must NOT be consumed — authorized user should still be able to pick
+    assert "111.333" in adapter._choice_picker_state
+
+
+@pytest.mark.asyncio
+async def test_handle_choice_picker_double_tap_no_second_callback():
+    adapter = _make_adapter()
+    on_selected = AsyncMock()
+    adapter._choice_picker_state["111.444"] = {
+        "choices": _make_choices(),
+        "session_key": "sk",
+        "on_choice_selected": on_selected,
+    }
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    mock_client = AsyncMock()
+    adapter._get_client = MagicMock(return_value=mock_client)
+
+    ack = AsyncMock()
+    body = _make_action_body(action_id="hermes_cp_1", msg_ts="111.444")
+    action = _make_action("hermes_cp_1")
+
+    # First tap
+    await adapter._handle_choice_picker_action(ack=ack, body=body, action=action)
+    # Second tap — state already popped
+    await adapter._handle_choice_picker_action(ack=ack, body=body, action=action)
+
+    assert on_selected.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_choice_picker_malformed_action_id_no_crash():
+    adapter = _make_adapter()
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+
+    ack = AsyncMock()
+    await adapter._handle_choice_picker_action(
+        ack=ack,
+        body=_make_action_body(action_id="hermes_cp_notanumber"),
+        action=_make_action("hermes_cp_notanumber"),
+    )
+    ack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_choice_picker_out_of_range_index_no_crash():
+    adapter = _make_adapter()
+    on_selected = AsyncMock()
+    adapter._choice_picker_state["111.555"] = {
+        "choices": _make_choices(),
+        "session_key": "sk",
+        "on_choice_selected": on_selected,
+    }
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+
+    ack = AsyncMock()
+    await adapter._handle_choice_picker_action(
+        ack=ack,
+        body=_make_action_body(action_id="hermes_cp_99", msg_ts="111.555"),
+        action=_make_action("hermes_cp_99"),
+    )
+    on_selected.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_choice_picker_expired_state_no_crash():
+    adapter = _make_adapter()
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+
+    ack = AsyncMock()
+    # No state planted — simulates expired/evicted entry
+    await adapter._handle_choice_picker_action(
+        ack=ack,
+        body=_make_action_body(action_id="hermes_cp_0", msg_ts="999.999"),
+        action=_make_action("hermes_cp_0"),
+    )
+    ack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_choice_picker_callback_exception_logged_no_crash():
+    adapter = _make_adapter()
+    on_selected = AsyncMock(side_effect=RuntimeError("boom"))
+    adapter._choice_picker_state["111.666"] = {
+        "choices": _make_choices(),
+        "session_key": "sk",
+        "on_choice_selected": on_selected,
+    }
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    mock_client = AsyncMock()
+    adapter._get_client = MagicMock(return_value=mock_client)
+
+    ack = AsyncMock()
+    # Should not raise
+    await adapter._handle_choice_picker_action(
+        ack=ack,
+        body=_make_action_body(action_id="hermes_cp_0", msg_ts="111.666"),
+        action=_make_action("hermes_cp_0"),
+    )
+    ack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_choice_picker_chat_update_failure_callback_still_fires():
+    adapter = _make_adapter()
+    on_selected = AsyncMock()
+    adapter._choice_picker_state["111.777"] = {
+        "choices": _make_choices(),
+        "session_key": "sk",
+        "on_choice_selected": on_selected,
+    }
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    mock_client = AsyncMock()
+    mock_client.chat_update = AsyncMock(side_effect=Exception("Slack down"))
+    adapter._get_client = MagicMock(return_value=mock_client)
+
+    ack = AsyncMock()
+    await adapter._handle_choice_picker_action(
+        ack=ack,
+        body=_make_action_body(action_id="hermes_cp_2", msg_ts="111.777"),
+        action=_make_action("hermes_cp_2"),
+    )
+    # Callback must still fire even when chat_update fails
+    on_selected.assert_awaited_once_with("slow")
+
+
+@pytest.mark.asyncio
+async def test_choice_picker_state_isolation():
+    """Two concurrent pickers must not interfere with each other."""
+    adapter = _make_adapter()
+    on_selected_a = AsyncMock()
+    on_selected_b = AsyncMock()
+
+    adapter._choice_picker_state["ts_a"] = {
+        "choices": [{"value": "x", "label": "X", "is_current": False}],
+        "session_key": "sk_a",
+        "on_choice_selected": on_selected_a,
+    }
+    adapter._choice_picker_state["ts_b"] = {
+        "choices": [{"value": "y", "label": "Y", "is_current": False}],
+        "session_key": "sk_b",
+        "on_choice_selected": on_selected_b,
+    }
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    mock_client = AsyncMock()
+    adapter._get_client = MagicMock(return_value=mock_client)
+
+    ack = AsyncMock()
+    await adapter._handle_choice_picker_action(
+        ack=ack,
+        body=_make_action_body(action_id="hermes_cp_0", msg_ts="ts_a"),
+        action=_make_action("hermes_cp_0"),
+    )
+
+    on_selected_a.assert_awaited_once_with("x")
+    on_selected_b.assert_not_called()
+    assert "ts_a" not in adapter._choice_picker_state
+    assert "ts_b" in adapter._choice_picker_state


### PR DESCRIPTION
## What does this PR do?

Adds the missing `send_choice_picker` method to the Slack adapter, completing interactive-method parity with Telegram, Discord, and Matrix.

The Slack adapter already implements `send_exec_approval`, `send_clarify`, and `send_slash_confirm` using Block Kit — this PR adds the one remaining interactive method using the same pattern.

## Related Issue

Closes the interactive-method parity gap identified in the adapter coverage matrix (Slack was the only mature adapter missing `send_choice_picker`).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

`plugins/platforms/slack/adapter.py`
- Add `_choice_picker_state: Dict[str, Any] = {}` to `__init__`
- Add `send_choice_picker`: renders choices as Block Kit buttons, marks current selection with ✓, stores state keyed by `msg_ts`, follows the same `chat_postMessage` / `thread_ts` pattern as `send_clarify`
- Add `_handle_choice_picker_action`: dispatches `hermes_cp_<idx>` button taps, guards against unauthorized users, double-taps, out-of-range indices, and expired state; fires `on_choice_selected` callback; updates the message to show the confirmed selection
- Register `hermes_cp_\d+` action handler in `connect()` alongside existing clarify/approval/slash_confirm registrations

`tests/gateway/test_slack_choice_picker.py`
- 14 tests covering: not-connected, empty choices, Block Kit structure, current-choice marking, thread_ts, valid tap, auth bypass guard, double-tap dedup, malformed action_id, out-of-range index, expired state, callback exception, chat_update failure, state isolation

## How to Test

1. Configure Slack adapter with `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`
2. Run `/reasoning` or `/fast` slash command in a Slack channel
3. Verify a Block Kit message appears with choice buttons
4. Tap a button — message should update to show ✓ selection
5. Tap the same button again — callback should not fire twice (double-tap guard)
6. Run `python3 -m pytest tests/gateway/test_slack_choice_picker.py -v` → 14/14 passing

## Checklist

- [x] Single commit
- [x] 14/14 tests passing
- [x] Follows existing Block Kit pattern (send_clarify, send_exec_approval)
- [x] Auth bypass guard (unauthorized users cannot change settings)
- [x] Double-tap dedup (state popped on first tap)
- [x] Zero changes to gateway core