### PR TITLE
fix(kimi): send Hermes attribution headers instead of claude-code/0.1.0

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -26,6 +26,13 @@ from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
 from agent.secret_scope import get_secret as _get_secret
 
+try:
+    import hermes_cli as _hermes_cli
+
+    _HERMES_VERSION = str(_hermes_cli.__version__)
+except Exception:
+    _HERMES_VERSION = "0.0.0"
+
 
 def _getenv(name: str, default: str = "") -> str:
     """Profile-scoped replacement for os.getenv on credential reads.
@@ -857,12 +864,18 @@ def build_anthropic_client(
     )
 
     if _is_kimi_coding_endpoint(base_url):
-        # Kimi's /coding endpoint requires User-Agent: claude-code/0.1.0
-        # to be recognized as a valid Coding Agent. Without it, returns 403.
-        # Check this BEFORE _requires_bearer_auth since both match api.kimi.com/coding.
+        # Kimi's /coding endpoint requires a non-empty User-Agent to be
+        # recognized as a valid Coding Agent. Originally we sent
+        # ``claude-code/0.1.0`` (the minimum that avoided a 403), but the Kimi
+        # team asked us to identify ourselves properly so they can attribute
+        # traffic correctly. Send the same attribution header set we send to
+        # OpenRouter, Vercel AI Gateway, and Fireworks:
+        # HTTP-Referer + X-Title + HermesAgent User-Agent.
         kwargs["api_key"] = api_key
         kwargs["default_headers"] = {
-            "User-Agent": "claude-code/0.1.0",
+            "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+            "X-Title": "Hermes Agent",
+            "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
             **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
         }
     elif _requires_bearer_auth(normalized_base_url):

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -10,6 +10,7 @@ This module covers the chat_completions path (/v1 endpoint).
 from typing import Any
 from urllib.parse import urlparse
 
+from hermes_cli import __version__ as _HERMES_VERSION
 from providers import register_provider
 from providers.base import OMIT_TEMPERATURE, ProviderProfile
 
@@ -102,7 +103,11 @@ kimi = KimiProfile(
     base_url="https://api.moonshot.ai/v1",
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
-    default_headers={"User-Agent": "hermes-agent/1.0"},
+    default_headers={
+        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+        "X-Title": "Hermes Agent",
+        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+    },
     default_aux_model="kimi-k2-turbo-preview",
 )
 
@@ -113,7 +118,11 @@ kimi_cn = KimiProfile(
     base_url="https://api.moonshot.cn/v1",
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
-    default_headers={"User-Agent": "hermes-agent/1.0"},
+    default_headers={
+        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+        "X-Title": "Hermes Agent",
+        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+    },
     default_aux_model="kimi-k2-turbo-preview",
 )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5936,7 +5936,8 @@ class AIAgent:
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
-            self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            from agent.auxiliary_client import _AI_GATEWAY_HEADERS
+            self._client_kwargs["default_headers"] = dict(_AI_GATEWAY_HEADERS)
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):


### PR DESCRIPTION
## Summary

The Kimi team noticed that traffic from Hermes Coding Plan users identifies itself as Claude (`User-Agent: claude-code/0.1.0`) rather than the actual client. They asked us to update the UA so they can properly attribute traffic and understand how their services are accessed — especially important as they open up to more third-party agents.

Three code paths were sending wrong or attribution-less headers to Kimi. All now send the **same canonical attribution header set** we use for OpenRouter, Vercel AI Gateway, and Fireworks:

```python
{
    "HTTP-Referer": "https://hermes-agent.nousresearch.com",
    "X-Title": "Hermes Agent",
    "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
}
```

### 1. `run_agent.py` — `_apply_client_headers_for_base_url`

The host-gated `api.kimi.com` branch sent `{"User-Agent": "claude-code/0.1.0"}`. Now sends `_AI_GATEWAY_HEADERS` — the same constant already used for the Vercel AI Gateway branch.

**Before:**
```python
elif base_url_host_matches(base_url, "api.kimi.com"):
    self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
```

**After:**
```python
elif base_url_host_matches(base_url, "api.kimi.com"):
    from agent.auxiliary_client import _AI_GATEWAY_HEADERS
    self._client_kwargs["default_headers"] = dict(_AI_GATEWAY_HEADERS)
```

### 2. `agent/anthropic_adapter.py` — Anthropic Messages path

The `/coding` endpoint branch sent `claude-code/0.1.0` (added in `de181dfd2` to avoid a 403). Now sends the full three-header attribution set.

### 3. `plugins/model-providers/kimi-coding/__init__.py` — provider profiles

Both `kimi` and `kimi_cn` profiles sent a static `hermes-agent/1.0` with no `HTTP-Referer` or `X-Title`. Now sends the full three-header set with a dynamic version, matching the pattern used by the `gmi`, `fireworks`, `xai`, and `ai-gateway` provider profiles.

## Test Plan

- [x] `tests/plugins/model_providers/test_kimi_profile.py` — 17 passed
- [x] `tests/run_agent/test_provider_attribution_headers.py` — 9 passed
- [x] `tests/agent/test_auxiliary_transport_autodetect.py` — 16 passed
- [x] `tests/run_agent/test_run_agent.py` (kimi tests) — 3 passed
- [x] Runtime verification: all four code paths (provider profile, anthropic adapter, run_agent host-gated branch, kimi_cn profile) now emit the full `HTTP-Referer` + `X-Title` + `HermesAgent/{version}` set
