### PR TITLE
fix: close two more sibling display_kind drops in /branch history copy

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4851,6 +4851,16 @@ class GatewaySlashCommandsMixin:
                         "reasoning_details": msg.get("reasoning_details"),
                         "codex_reasoning_items": msg.get("codex_reasoning_items"),
                         "codex_message_items": msg.get("codex_message_items"),
+                        # Timeline markers (model_switch, personality_switch,
+                        # auto_continue, …) ride as role=user; dropping the tag
+                        # here re-plants them as bare user turns after a
+                        # restart, corrupting the truncate ordinal address
+                        # space the same way #82756 did (see 327f7efab8, which
+                        # closed this same gap in session.branch and
+                        # _persist_branch_seed but missed this third,
+                        # structurally identical history-copy site).
+                        "display_kind": msg.get("display_kind"),
+                        "display_metadata": msg.get("display_metadata"),
                         # Keep the api_content sidecar so the branch's first turn
                         # replays the parent's exact wire bytes (warm provider
                         # prompt cache) instead of a full cold prefill.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1266,6 +1266,16 @@ class CLICommandsMixin:
                         "reasoning_details": msg.get("reasoning_details"),
                         "codex_reasoning_items": msg.get("codex_reasoning_items"),
                         "codex_message_items": msg.get("codex_message_items"),
+                        # Timeline markers (model_switch, personality_switch,
+                        # auto_continue, …) ride as role=user; dropping the tag
+                        # here re-plants them as bare user turns after a
+                        # restart/resume. is_user_originated_turn() (#80622,
+                        # agent/context_compressor.py) treats a missing
+                        # display_kind as a genuine human ask — /retry, /undo,
+                        # active-turn selection and this CLI's own resumed-
+                        # history message count all rely on that distinction.
+                        "display_kind": msg.get("display_kind"),
+                        "display_metadata": msg.get("display_metadata"),
                         # Keep the api_content sidecar so the branch's first turn
                         # replays the parent's exact wire bytes (warm provider
                         # prompt cache) instead of a full cold prefill.

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -232,3 +232,44 @@ class TestBranchPreservesReasoningFields:
         assert assistant["reasoning_details"] == REASONING_DETAILS
         assert assistant["codex_reasoning_items"] == CODEX_REASONING_ITEMS
         assert assistant["codex_message_items"] == CODEX_MESSAGE_ITEMS
+
+
+class TestBranchPreservesDisplayKind:
+    """The copy loop must carry display_kind/display_metadata across.
+
+    Timeline markers (model_switch, personality_switch, auto_continue, ...)
+    ride as role=user rows. Dropping display_kind during the branch copy
+    re-plants them as bare user turns: is_user_originated_turn() (#80622,
+    agent/context_compressor.py) treats a missing display_kind as a genuine
+    human ask, so /retry, /undo, active-turn selection, and this CLI's own
+    resumed-history message count would all misclassify the marker after a
+    branch. Same bug class 327f7efab8 closed for session.branch and
+    _persist_branch_seed; this is the CLI's independent third copy site.
+    """
+
+    def test_display_kind_survives_branch(self, cli_instance, session_db):
+        from cli import HermesCLI
+
+        cli_instance.conversation_history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there."},
+            {
+                "role": "user",
+                "content": "[System: personality changed]",
+                "display_kind": "personality_switch",
+                "display_metadata": {"personality": "sage"},
+            },
+        ]
+
+        HermesCLI._handle_branch_command(cli_instance, "/branch")
+
+        messages = session_db.get_messages_as_conversation(cli_instance.session_id)
+        marker = next(
+            (m for m in messages if m.get("display_kind") == "personality_switch"),
+            None,
+        )
+        assert marker is not None, (
+            "branch dropped display_kind: the marker re-entered the "
+            "conversation as a phantom user turn"
+        )
+        assert marker["display_metadata"] == {"personality": "sage"}

--- a/tests/gateway/test_branch_routing_columns.py
+++ b/tests/gateway/test_branch_routing_columns.py
@@ -153,3 +153,54 @@ class TestBranchRoutingColumns:
 
         _ = real_switch_session  # silence unused
 
+
+class TestBranchPreservesDisplayKind:
+    """The history-copy loop must carry display_kind/display_metadata across.
+
+    Timeline markers (model_switch, personality_switch, auto_continue, ...)
+    ride as role=user rows. Dropping display_kind during the branch copy
+    re-plants them as bare user turns after a restart, corrupting the
+    truncate ordinal address space the same way #82756 did (327f7efab8
+    closed this exact gap for tui_gateway's session.branch and
+    _persist_branch_seed, but never touched gateway/slash_commands.py's own
+    independent, structurally identical history-copy site).
+    """
+
+    @pytest.mark.asyncio
+    async def test_display_kind_survives_gateway_branch(self, store):
+        # Realistic alternation: the marker follows an assistant turn, not
+        # another bare user row. Two adjacent role=user rows would hit
+        # load_transcript's repair_alternation=True wedge-merge, which is an
+        # unrelated pre-existing repair path (not what this test targets) —
+        # avoid it so the test isolates the display_kind-drop this PR fixes.
+        source = _make_source()
+        parent_entry = store.get_or_create_session(source)
+        store._db.append_message(parent_entry.session_id, role="user", content="hello")
+        store._db.append_message(parent_entry.session_id, role="assistant", content="world")
+        store._db.append_message(
+            parent_entry.session_id,
+            role="user",
+            content="[System: personality changed]",
+            display_kind="personality_switch",
+            display_metadata={"personality": "sage"},
+        )
+
+        runner = _make_branch_runner(store)
+
+        result = await runner._handle_branch_command(_make_event("/branch"))
+        assert "Failed" not in result and "failed" not in result
+
+        new_session_id = store.get_or_create_session(source).session_id
+        assert new_session_id != parent_entry.session_id
+
+        messages = store._db.get_messages_as_conversation(new_session_id)
+        marker = next(
+            (m for m in messages if m.get("display_kind") == "personality_switch"),
+            None,
+        )
+        assert marker is not None, (
+            "gateway /branch dropped display_kind: the marker re-entered the "
+            "truncate ordinal address space as a phantom user turn (#82756)"
+        )
+        assert marker["display_metadata"] == {"personality": "sage"}
+


### PR DESCRIPTION
## Summary

`327f7efab8` (merged earlier today) fixed `session.branch` and `_persist_branch_seed` dropping `display_kind`/`display_metadata` during branch history copy, which re-plants timeline markers (personality pivot, model switch, auto-continue) as bare `role=user` rows and corrupts the truncate-ordinal address space (#82756). Its own commit message names exactly those two sites.

It missed two more, structurally identical, independent history-copy sites:

- `gateway/slash_commands.py::_handle_branch_command` — the gateway's own `/branch` slash command (a third copy implementation, never touched by `327f7efab8`).
- `hermes_cli/cli_commands_mixin.py`'s `/branch` handler — a fourth, CLI-only copy implementation.

For the CLI site specifically: `is_user_originated_turn()` (#80622, `agent/context_compressor.py`) explicitly treats a missing `display_kind` as a genuine human ask — so `/retry`, `/undo`, active-turn selection, and the CLI's own resumed-history message count would all misclassify the marker after a branch.

Both projection dicts now carry `display_kind`/`display_metadata`, matching `append_messages_batch`'s documented row shape (its own docstring already lists these fields as part of the standard shape it consumes).

## Test plan

- [x] Added `TestBranchPreservesDisplayKind::test_display_kind_survives_gateway_branch` to `tests/gateway/test_branch_routing_columns.py`, driving the real `_handle_branch_command` against a real `SessionStore`/`SessionDB`.
- [x] Added `TestBranchPreservesDisplayKind::test_display_kind_survives_branch` to `tests/cli/test_branch_command.py`, mirroring the existing `TestBranchPreservesReasoningFields` pattern.
- [x] Mutation-verified: reverted both production changes and confirmed both new tests fail without the fix.
- [x] Full `tests/cli/` suite (947 tests) passes; the one unrelated failure (`test_resume_quiet_stderr.py`) is a pre-existing test-order-pollution flake, confirmed identical with the fix stashed out.
- [x] `ruff check` clean on all changed files.
- [x] Fresh rival-PR search (`branch display_kind`, `slash_commands branch history`, `cli_commands_mixin branch`, `82756`) found no overlapping open PR.