### PR TITLE
fix(agent): route prompt_builder's docker probe host_cwd through the isolation resolver

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1116,7 +1116,11 @@ def _probe_remote_backend(env_type: str) -> str | None:
     try:
         # Import locally: tools/ imports are heavy and only relevant when a
         # non-local backend is actually configured.
-        from tools.terminal_tool import _create_environment, _get_env_config  # type: ignore
+        from tools.terminal_tool import (  # type: ignore
+            _create_environment,
+            _get_env_config,
+            _resolve_task_host_cwd,
+        )
     except Exception as e:
         logger.debug("Backend probe unavailable (import failed): %s", e)
         _BACKEND_PROBE_CACHE[cache_key] = ""
@@ -1168,6 +1172,15 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }
 
+        # host_cwd must route through _resolve_task_host_cwd (the single
+        # owner of the cwd-mount policy, tools/terminal_tool.py) rather than
+        # reading config["host_cwd"] directly. Under per-session docker
+        # isolation, that raw value is the process-global TERMINAL_CWD — a
+        # launch artifact that outlives the session that set it — and this
+        # probe's fixed "prompt-backend-probe" task_id has no registered
+        # session workspace, so the resolver correctly returns None (no
+        # mount) instead of leaking a stale/previous session's directory
+        # into this probe's container.
         env = _create_environment(
             env_type=env_type,
             image=image,
@@ -1176,7 +1189,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
             ssh_config=ssh_config,
             container_config=container_config,
             task_id="prompt-backend-probe",
-            host_cwd=config.get("host_cwd"),
+            host_cwd=_resolve_task_host_cwd(config, "prompt-backend-probe"),
         )
         # Single-line POSIX probe — works on any Unixy backend. Wrapped in
         # `2>/dev/null` so a missing binary doesn't pollute the output.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -850,6 +850,52 @@ class TestEnvironmentHints:
 
 
 
+    def test_probe_remote_backend_routes_host_cwd_through_resolver(self, monkeypatch, tmp_path):
+        """Regression: the probe's own host_cwd must go through
+        _resolve_task_host_cwd (tools/terminal_tool.py) — the single owner of
+        the cwd-mount policy, per its own docstring — not read
+        config["host_cwd"] directly.
+
+        Under per-session docker isolation (container_persistent: false), the
+        raw config["host_cwd"] is the process-global TERMINAL_CWD-derived
+        value — a launch artifact that outlives whatever session set it. This
+        probe always passes the fixed task_id "prompt-backend-probe", which
+        has no registered session workspace, so the resolver must return None
+        (no mount) instead of leaking a stale/previous session's directory
+        into the probe's container. e95e13783b fixed this exact leak at four
+        other _create_environment call sites but missed this one.
+        """
+        import agent.prompt_builder as _pb
+
+        stale_dir = tmp_path / "previous-session-workspace"
+        stale_dir.mkdir()
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
+        monkeypatch.setenv("TERMINAL_CWD", str(stale_dir))
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+        _pb._clear_backend_probe_cache()
+
+        class _FakeEnv:
+            def execute(self, cmd, timeout=None):
+                return {"returncode": 0, "output": "os=Linux\nhome=/root\ncwd=/workspace\nuser=root\n"}
+
+        created = {}
+
+        def _fake_create_environment(*, host_cwd=None, **kwargs):
+            created["host_cwd"] = host_cwd
+            return _FakeEnv()
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", _fake_create_environment)
+
+        line = _pb._probe_remote_backend("docker")
+        assert line is not None
+        assert created["host_cwd"] is None, (
+            "the probe leaked the process-global/stale host_cwd into its "
+            f"container mount instead of refusing it under isolation: {created['host_cwd']!r}"
+        )
+
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
         import agent.prompt_builder as _pb


### PR DESCRIPTION
## Summary

`e95e13783b` fixed a per-session docker workspace-mount leak (a new chat's container inheriting the previous session's workspace, bind-mounted rw at `/workspace`) by making `_resolve_task_host_cwd()` the single owner of the cwd-mount policy — its own docstring names it as shared across every `_create_environment()` call site, listing four: terminal tool, file tools, `execute_code`, lazy bring-up.

`agent/prompt_builder.py::_probe_remote_backend()` is a fifth `_create_environment()` call site that commit never touched. It still reads `config.get("host_cwd")` directly — the process-global `TERMINAL_CWD`-derived value that outlives whatever session set it. This probe runs on essentially every turn's system-prompt build for docker/remote backends and always passes the fixed literal `task_id="prompt-backend-probe"`, so under per-session isolation (`docker` + `container_persistent: false`) it reproduces the original leak: the probe's container mounts whatever directory a previous session (or an unrelated process invocation) last wrote to `TERMINAL_CWD`.

## Fix

Route `host_cwd` through `_resolve_task_host_cwd(config, "prompt-backend-probe")`, matching the other four sites. Since this literal task_id never has a registered session workspace override, the resolver correctly returns `None` (no mount) under isolation instead of leaking a stale directory, and falls back unchanged to the legacy behavior when isolation is off.

## Test plan

- [x] Added `test_probe_remote_backend_routes_host_cwd_through_resolver` to `tests/agent/test_prompt_builder.py`, driving the real `_probe_remote_backend()` with a fake `_create_environment` capturing the `host_cwd` kwarg under isolation mode.
- [x] Mutation-verified: reverted the production change and confirmed the new test fails, reproducing the exact leaked stale-directory value.
- [x] `tests/agent/test_prompt_builder.py` (88 tests) and `tests/tools/test_docker_session_isolation.py` (17 tests) pass.
- [x] `ruff check` clean on both changed files.

## Known textual (not semantic) conflict risk

Open PR #73280 (an unrelated 11-commit kanban-worker-safety branch) touches the same `host_cwd=config.get("host_cwd"),` line, but only wraps it as `config.get("host_cwd") or ""` for type-strictness — it does not route through the isolation resolver, so the leak this PR fixes is still present on that branch. If #73280 merges first this PR will need a trivial rebase; no semantic overlap.