### PR TITLE
fix(update-check): passive Git safety and bounded shallow counts

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -529,10 +529,10 @@ def _check_via_local_git_details(
 
 def _check_via_local_git(
     repo_dir: Path,
-) -> tuple[Optional[int], Optional[str], Optional[str]]:
-    """Compatibility wrapper returning the historical three-field result."""
-    behind, error_code, current_revision, _ = _check_via_local_git_details(repo_dir)
-    return behind, error_code, current_revision
+) -> tuple[Optional[int], Optional[str]]:
+    """Compatibility wrapper returning only count and structured error."""
+    behind, error_code, _, _ = _check_via_local_git_details(repo_dir)
+    return behind, error_code
 
 
 def check_for_updates_details() -> Dict[str, Optional[object]]:
@@ -571,6 +571,13 @@ def check_for_updates_details() -> Dict[str, Optional[object]]:
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
                 and cached.get("ver") == VERSION
+                and all(
+                    revision is None or _is_full_git_sha(revision)
+                    for revision in (
+                        cached.get("current_revision"),
+                        cached.get("upstream_revision"),
+                    )
+                )
             ):
                 return {
                     "behind": cached.get("behind"),

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -347,12 +347,14 @@ def repo_install_writable(repo_dir: Path) -> bool:
         return False
 
 
-def _check_via_local_git(
+def _check_via_local_git_details(
     repo_dir: Path,
-) -> tuple[Optional[int], Optional[str], Optional[str]]:
+) -> tuple[Optional[int], Optional[str], Optional[str], Optional[str]]:
     """Count commits behind origin/main in a local checkout.
 
-    Returns ``(behind, error_code, current_revision)``.
+    Returns ``(behind, error_code, current_revision, upstream_revision)``.
+    ``upstream_revision`` is the exact immutable object used for the result,
+    never a later probe or mutable tracking ref.
 
     Safety contract for passive update checks:
       * never unlink ``shallow.lock`` / ``index.lock`` / ``HEAD.lock`` /
@@ -375,7 +377,7 @@ def _check_via_local_git(
     head_err = _classify_git_stderr(head.stderr if head else None)
 
     if not head_rev:
-        return None, head_err or "check-failed", None
+        return None, head_err or "check-failed", None, None
 
     origin = _git_run(
         ["remote", "get-url", "origin"], cwd=repo_dir, relax_ownership=True
@@ -387,12 +389,12 @@ def _check_via_local_git(
     )
 
     if _is_official_ssh_remote(origin_url):
-        checked = _check_via_rev(head_rev)
-        if checked is None:
-            return None, "offline", head_rev
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1, None, head_rev
-        return checked, None, head_rev
+        upstream_tip = _ls_remote_main_sha(_UPSTREAM_REPO_URL)
+        if upstream_tip is None:
+            return None, "offline", head_rev, None
+        if upstream_tip == head_rev:
+            return 0, None, head_rev, upstream_tip
+        return UPDATE_AVAILABLE_NO_COUNT, None, head_rev, upstream_tip
 
     shallow_state = _git_stdout(
         ["rev-parse", "--is-shallow-repository"],
@@ -417,15 +419,15 @@ def _check_via_local_git(
     if upstream_tip is None and origin_url and origin_url != _UPSTREAM_REPO_URL:
         upstream_tip = _ls_remote_main_sha(_UPSTREAM_REPO_URL)
     if upstream_tip is not None and upstream_tip == head_rev:
-        return 0, None, head_rev
+        return 0, None, head_rev, upstream_tip
 
     if is_shallow is None:
         if upstream_tip is not None:
-            return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
+            return UPDATE_AVAILABLE_NO_COUNT, None, head_rev, upstream_tip
         checked = _check_via_rev(head_rev)
         if checked is not None:
-            return checked, None, head_rev
-        return None, "check-failed", head_rev
+            return checked, None, head_rev, None
+        return None, "check-failed", head_rev, None
 
     fetch_ok = False
     fetch_error: Optional[str] = None
@@ -462,12 +464,12 @@ def _check_via_local_git(
         # ls-remote tip probe (already computed) or a fresh official compare.
         if upstream_tip is not None:
             if upstream_tip == head_rev:
-                return 0, None, head_rev
-            return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
+                return 0, None, head_rev, upstream_tip
+            return UPDATE_AVAILABLE_NO_COUNT, None, head_rev, upstream_tip
         checked = _check_via_rev(head_rev)
         if checked is not None:
-            return checked, None, head_rev
-        return None, fetch_error or "offline", head_rev
+            return checked, None, head_rev, None
+        return None, fetch_error or "offline", head_rev, None
 
     # Capture FETCH_HEAD once, validate it against the read-only main-tip probe,
     # then use the immutable object ID for every graph operation.  FETCH_HEAD
@@ -479,10 +481,11 @@ def _check_via_local_git(
     if not target_rev or upstream_tip is None or target_rev != upstream_tip:
         # Missing or contradictory evidence must never report "latest".  The
         # earlier equal-tip path already returned 0, so unknown count is the
-        # conservative truthful result here.
-        return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
+        # conservative truthful result here. The probed SHA remains the exact
+        # provenance for that conservative result.
+        return UPDATE_AVAILABLE_NO_COUNT, None, head_rev, upstream_tip
     if head_rev == target_rev:
-        return 0, None, head_rev
+        return 0, None, head_rev, target_rev
 
     if is_shallow:
         merge_base = _git_stdout(
@@ -493,21 +496,29 @@ def _check_via_local_git(
         if merge_base:
             counted = _count_commits_behind(repo_dir, target_rev)
             if counted is not None:
-                return counted, None, head_rev
-        return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
+                return counted, None, head_rev, target_rev
+        return UPDATE_AVAILABLE_NO_COUNT, None, head_rev, target_rev
 
     counted = _count_commits_behind(repo_dir, target_rev)
     if counted is not None:
-        return counted, None, head_rev
+        return counted, None, head_rev, target_rev
 
     # Count failed (missing origin/main ref, etc.) — last-resort SHA compare.
     if upstream_tip is not None:
         behind = 0 if head_rev == upstream_tip else UPDATE_AVAILABLE_NO_COUNT
-        return behind, None, head_rev
+        return behind, None, head_rev, upstream_tip
     checked = _check_via_rev(head_rev)
     if checked is not None:
-        return checked, None, head_rev
-    return None, "check-failed", head_rev
+        return checked, None, head_rev, None
+    return None, "check-failed", head_rev, None
+
+
+def _check_via_local_git(
+    repo_dir: Path,
+) -> tuple[Optional[int], Optional[str], Optional[str]]:
+    """Compatibility wrapper returning the historical three-field result."""
+    behind, error_code, current_revision, _ = _check_via_local_git_details(repo_dir)
+    return behind, error_code, current_revision
 
 
 def check_for_updates_details() -> Dict[str, Optional[object]]:
@@ -583,21 +594,12 @@ def check_for_updates_details() -> Dict[str, Optional[object]]:
             error_code = None
         else:
             repo_writable = repo_install_writable(repo_dir)
-            behind, error_code, current_revision = _check_via_local_git(repo_dir)
-            if behind not in (None, 0):
-                origin_url = _git_stdout(
-                    ["remote", "get-url", "origin"],
-                    cwd=repo_dir,
-                    relax_ownership=True,
-                )
-                remote_for_ls = origin_url or _UPSTREAM_REPO_URL
-                upstream_revision = _ls_remote_main_sha(remote_for_ls)
-                if (
-                    upstream_revision is None
-                    and origin_url
-                    and origin_url != _UPSTREAM_REPO_URL
-                ):
-                    upstream_revision = _ls_remote_main_sha(_UPSTREAM_REPO_URL)
+            (
+                behind,
+                error_code,
+                current_revision,
+                upstream_revision,
+            ) = _check_via_local_git_details(repo_dir)
             if behind is None and error_code:
                 if error_code == "git-ownership":
                     message = (

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -517,6 +517,7 @@ def check_for_updates_details() -> Dict[str, Optional[object]]:
       - behind: int | None (null only on true failure / N/A)
       - error_code: str | None (set when behind is null due to a failed check)
       - current_revision: str | None
+      - upstream_revision: freshly probed immutable main-tip SHA when known
       - message: str | None
       - repo_writable: bool | None (git installs only)
     """
@@ -550,6 +551,7 @@ def check_for_updates_details() -> Dict[str, Optional[object]]:
                     "behind": cached.get("behind"),
                     "error_code": cached.get("error_code"),
                     "current_revision": cached.get("current_revision"),
+                    "upstream_revision": cached.get("upstream_revision"),
                     "message": cached.get("message"),
                     "repo_writable": cached.get("repo_writable"),
                 }
@@ -559,6 +561,7 @@ def check_for_updates_details() -> Dict[str, Optional[object]]:
     behind: Optional[int] = None
     error_code: Optional[str] = None
     current_revision: Optional[str] = embedded_rev
+    upstream_revision: Optional[str] = None
     message: Optional[str] = None
     repo_writable: Optional[bool] = None
 
@@ -581,6 +584,20 @@ def check_for_updates_details() -> Dict[str, Optional[object]]:
         else:
             repo_writable = repo_install_writable(repo_dir)
             behind, error_code, current_revision = _check_via_local_git(repo_dir)
+            if behind not in (None, 0):
+                origin_url = _git_stdout(
+                    ["remote", "get-url", "origin"],
+                    cwd=repo_dir,
+                    relax_ownership=True,
+                )
+                remote_for_ls = origin_url or _UPSTREAM_REPO_URL
+                upstream_revision = _ls_remote_main_sha(remote_for_ls)
+                if (
+                    upstream_revision is None
+                    and origin_url
+                    and origin_url != _UPSTREAM_REPO_URL
+                ):
+                    upstream_revision = _ls_remote_main_sha(_UPSTREAM_REPO_URL)
             if behind is None and error_code:
                 if error_code == "git-ownership":
                     message = (
@@ -610,6 +627,7 @@ def check_for_updates_details() -> Dict[str, Optional[object]]:
                     "ver": VERSION,
                     "error_code": error_code,
                     "current_revision": current_revision,
+                    "upstream_revision": upstream_revision,
                     "message": message,
                     "repo_writable": repo_writable,
                 }
@@ -623,6 +641,7 @@ def check_for_updates_details() -> Dict[str, Optional[object]]:
         "behind": behind,
         "error_code": error_code,
         "current_revision": current_revision,
+        "upstream_revision": upstream_revision,
         "message": message,
         "repo_writable": repo_writable,
     }

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -394,12 +394,20 @@ def _check_via_local_git(
             return 1, None, head_rev
         return checked, None, head_rev
 
-    shallow = _git_stdout(
+    shallow_state = _git_stdout(
         ["rev-parse", "--is-shallow-repository"],
         cwd=repo_dir,
         relax_ownership=True,
     )
-    is_shallow = shallow == "true"
+    if shallow_state == "true":
+        is_shallow: Optional[bool] = True
+    elif shallow_state == "false":
+        is_shallow = False
+    else:
+        # Unknown is not equivalent to a full clone.  A plain fetch can
+        # silently unshallow/download unbounded history, so fail closed to the
+        # read-only tip comparison below.
+        is_shallow = None
 
     # Tip probe that never writes local git state. Equal tips short-circuit
     # before any depth recovery so repeated checks cannot progressively
@@ -410,6 +418,14 @@ def _check_via_local_git(
         upstream_tip = _ls_remote_main_sha(_UPSTREAM_REPO_URL)
     if upstream_tip is not None and upstream_tip == head_rev:
         return 0, None, head_rev
+
+    if is_shallow is None:
+        if upstream_tip is not None:
+            return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
+        checked = _check_via_rev(head_rev)
+        if checked is not None:
+            return checked, None, head_rev
+        return None, "check-failed", head_rev
 
     fetch_ok = False
     fetch_error: Optional[str] = None
@@ -453,48 +469,36 @@ def _check_via_local_git(
             return checked, None, head_rev
         return None, fetch_error or "offline", head_rev
 
-    if is_shallow:
-        # FETCH_HEAD is trustworthy only because fetch_ok is True above.
-        target_rev = (
-            _git_stdout(
-                ["rev-parse", "FETCH_HEAD"], cwd=repo_dir, relax_ownership=True
-            )
-            or _git_stdout(
-                ["rev-parse", "origin/main"], cwd=repo_dir, relax_ownership=True
-            )
-        )
-        if not target_rev:
-            if upstream_tip is not None:
-                behind = (
-                    0 if head_rev == upstream_tip else UPDATE_AVAILABLE_NO_COUNT
-                )
-                return behind, None, head_rev
-            checked = _check_via_rev(head_rev)
-            if checked is not None:
-                return checked, None, head_rev
-            return None, "check-failed", head_rev
-        if head_rev == target_rev:
-            return 0, None, head_rev
+    # FETCH_HEAD is authoritative for both shallow and full clones because it
+    # is produced by the successful fetch in this call.  origin/main may stay
+    # stale under a valid narrowed remote.origin.fetch refspec.
+    target_rev = _git_stdout(
+        ["rev-parse", "FETCH_HEAD"], cwd=repo_dir, relax_ownership=True
+    )
+    if not target_rev:
+        if upstream_tip is not None:
+            behind = 0 if head_rev == upstream_tip else UPDATE_AVAILABLE_NO_COUNT
+            return behind, None, head_rev
+        checked = _check_via_rev(head_rev)
+        if checked is not None:
+            return checked, None, head_rev
+        return None, "check-failed", head_rev
+    if head_rev == target_rev:
+        return 0, None, head_rev
 
-        target_ref = (
-            "FETCH_HEAD"
-            if _git_stdout(
-                ["rev-parse", "FETCH_HEAD"], cwd=repo_dir, relax_ownership=True
-            )
-            else "origin/main"
-        )
+    if is_shallow:
         merge_base = _git_stdout(
-            ["merge-base", "HEAD", target_ref],
+            ["merge-base", "HEAD", "FETCH_HEAD"],
             cwd=repo_dir,
             relax_ownership=True,
         )
         if merge_base:
-            counted = _count_commits_behind(repo_dir, target_ref)
+            counted = _count_commits_behind(repo_dir, "FETCH_HEAD")
             if counted is not None:
                 return counted, None, head_rev
         return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
 
-    counted = _count_commits_behind(repo_dir, "origin/main")
+    counted = _count_commits_behind(repo_dir, "FETCH_HEAD")
     if counted is not None:
         return counted, None, head_rev
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -469,36 +469,34 @@ def _check_via_local_git(
             return checked, None, head_rev
         return None, fetch_error or "offline", head_rev
 
-    # FETCH_HEAD is authoritative for both shallow and full clones because it
-    # is produced by the successful fetch in this call.  origin/main may stay
-    # stale under a valid narrowed remote.origin.fetch refspec.
+    # Capture FETCH_HEAD once, validate it against the read-only main-tip probe,
+    # then use the immutable object ID for every graph operation.  FETCH_HEAD
+    # is shared mutable state: another concurrent fetch can overwrite it after
+    # our successful fetch and before these subprocesses run.
     target_rev = _git_stdout(
         ["rev-parse", "FETCH_HEAD"], cwd=repo_dir, relax_ownership=True
     )
-    if not target_rev:
-        if upstream_tip is not None:
-            behind = 0 if head_rev == upstream_tip else UPDATE_AVAILABLE_NO_COUNT
-            return behind, None, head_rev
-        checked = _check_via_rev(head_rev)
-        if checked is not None:
-            return checked, None, head_rev
-        return None, "check-failed", head_rev
+    if not target_rev or upstream_tip is None or target_rev != upstream_tip:
+        # Missing or contradictory evidence must never report "latest".  The
+        # earlier equal-tip path already returned 0, so unknown count is the
+        # conservative truthful result here.
+        return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
     if head_rev == target_rev:
         return 0, None, head_rev
 
     if is_shallow:
         merge_base = _git_stdout(
-            ["merge-base", "HEAD", "FETCH_HEAD"],
+            ["merge-base", "HEAD", target_rev],
             cwd=repo_dir,
             relax_ownership=True,
         )
         if merge_base:
-            counted = _count_commits_behind(repo_dir, "FETCH_HEAD")
+            counted = _count_commits_behind(repo_dir, target_rev)
             if counted is not None:
                 return counted, None, head_rev
         return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
 
-    counted = _count_commits_behind(repo_dir, "FETCH_HEAD")
+    counted = _count_commits_behind(repo_dir, target_rev)
     if counted is not None:
         return counted, None, head_rev
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -130,6 +130,12 @@ UPDATE_AVAILABLE_NO_COUNT = -1
 _UPSTREAM_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 _OFFICIAL_REPO_CANONICAL = "github.com/nousresearch/hermes-agent"
 
+# Absolute shallow-history target for passive update checks. Used as
+# ``git fetch --depth <N>`` (idempotent absolute depth), never relative
+# ``--deepen`` on every cache expiry. Passive at or near N once and stays
+# there; equal-tip checks avoid depth recovery entirely via ls-remote.
+_SHALLOW_HISTORY_TARGET = 200
+
 
 def _canonical_github_remote(url: str | None) -> str:
     """Return ``host/owner/repo`` for common GitHub remote URL forms."""
@@ -161,10 +167,59 @@ def _is_official_ssh_remote(url: str | None) -> bool:
     return _is_ssh_remote(url) and _canonical_github_remote(url) == _OFFICIAL_REPO_CANONICAL
 
 
-def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
+def _classify_git_stderr(stderr: str | None) -> Optional[str]:
+    """Map git stderr to a stable machine-readable error code."""
+    text = (stderr or "").lower()
+    if not text:
+        return None
+    if "dubious ownership" in text or "safe.directory" in text:
+        return "git-ownership"
+    if (
+        "permission denied" in text
+        or "read-only file system" in text
+        or "operation not permitted" in text
+    ):
+        return "git-permission"
+    # Lock contention is not offline — callers fail closed without trusting
+    # stale FETCH_HEAD, and must never unlink locks from the passive path.
+    if "could not lock" in text or ("unable to create" in text and "lock" in text):
+        return "check-failed"
+    if (
+        "could not resolve host" in text
+        or "unable to access" in text
+        or "network is unreachable" in text
+        or "connection refused" in text
+        or "timed out" in text
+        or "temporary failure in name resolution" in text
+    ):
+        return "offline"
+    return None
+
+
+def _git_cmd_prefix(cwd: Path, *, relax_ownership: bool) -> list[str]:
+    """Build a ``git`` argv prefix.
+
+    When ``relax_ownership`` is True, add a *process-local*
+    ``-c safe.directory=<abs>`` so read-only probes work on root-owned
+    checkouts (e.g. ``/opt/hermes-agent``). Never writes global git config.
+    """
+    cmd = ["git"]
+    if relax_ownership:
+        cmd.extend(["-c", f"safe.directory={cwd.resolve()}"])
+    return cmd
+
+
+def _git_run(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int = 5,
+    relax_ownership: bool = False,
+) -> Optional[subprocess.CompletedProcess]:
+    """Run a bounded argv-only git subprocess. Never shell=True."""
     try:
-        result = subprocess.run(
-            ["git", *args],
+        return subprocess.run(
+            [*_git_cmd_prefix(cwd, relax_ownership=relax_ownership), *args],
             capture_output=True,
             text=True,
             # git output is UTF-8; on Windows text=True defaults to the ANSI
@@ -177,9 +232,83 @@ def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str
         )
     except Exception:
         return None
-    if result.returncode != 0:
+
+
+def _git_stdout(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout: int = 5,
+    relax_ownership: bool = False,
+) -> Optional[str]:
+    result = _git_run(
+        args, cwd=cwd, timeout=timeout, relax_ownership=relax_ownership
+    )
+    if result is None or result.returncode != 0:
         return None
     return (result.stdout or "").strip()
+
+
+def _resolve_git_dirs(repo_dir: Path) -> list[Path]:
+    """Return unique absolute git-dir paths for ``repo_dir``.
+
+    Linked worktrees / candidate installs share objects via the *common*
+    git dir (``git rev-parse --git-common-dir``). Passiveability and shallow
+    state live there, not only in the per-worktree git dir.
+    """
+    dirs: list[Path] = []
+    for flag in ("--git-common-dir", "--git-dir"):
+        raw = _git_stdout(
+            ["rev-parse", flag], cwd=repo_dir, relax_ownership=True
+        )
+        if not raw:
+            continue
+        root = Path(raw)
+        if not root.is_absolute():
+            root = (repo_dir / root).resolve()
+        else:
+            root = root.resolve()
+        if root not in dirs:
+            dirs.append(root)
+    return dirs
+
+
+def _count_commits_behind(repo_dir: Path, target_ref: str) -> Optional[int]:
+    """Return ``rev-list --count HEAD..<target_ref>`` when countable."""
+    result = _git_run(
+        ["rev-list", "--count", f"HEAD..{target_ref}"],
+        cwd=repo_dir,
+        relax_ownership=True,
+    )
+    if result is None or result.returncode != 0:
+        return None
+    text = (result.stdout or "").strip()
+    if not text.isdigit():
+        return None
+    return int(text)
+
+
+def _ls_remote_main_sha(
+    remote: str = _UPSTREAM_REPO_URL,
+    *,
+    timeout: int = 10,
+) -> Optional[str]:
+    """Return the tip SHA of ``refs/heads/main`` at ``remote``, or None."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", remote, "refs/heads/main"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0 or not result.stdout:
+        return None
+    upstream_rev = result.stdout.split()[0]
+    return upstream_rev or None
 
 
 def _check_via_rev(local_rev: str) -> Optional[int]:
@@ -188,89 +317,313 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     Returns 0 if up-to-date, ``UPDATE_AVAILABLE_NO_COUNT`` if behind,
     or ``None`` on failure.
     """
-    try:
-        result = subprocess.run(
-            ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=10,
-        )
-    except Exception:
-        return None
-    if result.returncode != 0 or not result.stdout:
-        return None
-    upstream_rev = result.stdout.split()[0]
+    upstream_rev = _ls_remote_main_sha(_UPSTREAM_REPO_URL)
     if not upstream_rev:
         return None
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
-def _check_via_local_git(repo_dir: Path) -> Optional[int]:
-    """Count commits behind origin/main in a local checkout."""
-    origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
-    if _is_official_ssh_remote(origin_url):
-        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        checked = _check_via_rev(head_rev) if head_rev else None
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1
-        return checked
+def repo_install_writable(repo_dir: Path) -> bool:
+    """True when this process can write the install root and its git dirs.
 
-    # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
-    # clone the history stops at a single commit, so a plain `git fetch` would
-    # unshallow the repo (dragging in the whole history) and
-    # `rev-list --count HEAD..origin/main` would report a huge bogus "behind"
-    # number (e.g. "12492 commits behind"). Detect shallow up front: fetch with
-    # --depth 1 to preserve the boundary and compare tip SHAs instead of
-    # counting. Full clones (developers, Docker dev images) keep the exact
-    # count path unchanged. Mirrors the desktop fix in apps/desktop/electron/main.cjs.
-    shallow = _git_stdout(["rev-parse", "--is-shallow-repository"], cwd=repo_dir)
+    Linked worktrees point ``.git`` at a file; writability of the *common*
+    git dir is what matters for fetch/update, so both common-dir and
+    git-dir are checked when resolvable.
+    """
+    try:
+        if not os.access(repo_dir, os.W_OK):
+            return False
+        git_paths = _resolve_git_dirs(repo_dir)
+        if not git_paths:
+            git_entry = repo_dir / ".git"
+            if git_entry.exists() and not os.access(git_entry, os.W_OK):
+                return False
+            return True
+        for path in git_paths:
+            if path.exists() and not os.access(path, os.W_OK):
+                return False
+        return True
+    except OSError:
+        return False
+
+
+def _check_via_local_git(
+    repo_dir: Path,
+) -> tuple[Optional[int], Optional[str], Optional[str]]:
+    """Count commits behind origin/main in a local checkout.
+
+    Returns ``(behind, error_code, current_revision)``.
+
+    Safety contract for passive update checks:
+      * never unlink ``shallow.lock`` / ``index.lock`` / ``HEAD.lock`` /
+        ``packed-refs.lock`` (lock recovery is explicit maintenance only);
+      * never progressively ``--deepen`` on every cache expiry — shallow
+        recovery uses an absolute ``--depth`` target once tips differ;
+      * trust ``FETCH_HEAD`` only after a successful fetch in *this* call;
+        failed fetch + stale FETCH_HEAD fails closed (ls-remote / error);
+      * argv-only bounded subprocesses; linked-worktree common-dir aware
+        writable probes.
+
+    Uses process-local ``safe.directory`` for **read-only** git ops so
+    root-owned installs still report availability. Fetch writes ``.git``
+    without ownership relax; failures fall back to ``HEAD`` + ls-remote.
+    """
+    head = _git_run(
+        ["rev-parse", "HEAD"], cwd=repo_dir, relax_ownership=True
+    )
+    head_rev = (head.stdout or "").strip() if head and head.returncode == 0 else None
+    head_err = _classify_git_stderr(head.stderr if head else None)
+
+    if not head_rev:
+        return None, head_err or "check-failed", None
+
+    origin = _git_run(
+        ["remote", "get-url", "origin"], cwd=repo_dir, relax_ownership=True
+    )
+    origin_url = (
+        (origin.stdout or "").strip()
+        if origin and origin.returncode == 0
+        else None
+    )
+
+    if _is_official_ssh_remote(origin_url):
+        checked = _check_via_rev(head_rev)
+        if checked is None:
+            return None, "offline", head_rev
+        if checked == UPDATE_AVAILABLE_NO_COUNT:
+            return 1, None, head_rev
+        return checked, None, head_rev
+
+    shallow = _git_stdout(
+        ["rev-parse", "--is-shallow-repository"],
+        cwd=repo_dir,
+        relax_ownership=True,
+    )
     is_shallow = shallow == "true"
 
+    # Tip probe that never writes local git state. Equal tips short-circuit
+    # before any depth recovery so repeated checks cannot progressively
+    # deepen a shallow clone that is already current.
+    remote_for_ls = origin_url or _UPSTREAM_REPO_URL
+    upstream_tip = _ls_remote_main_sha(remote_for_ls)
+    if upstream_tip is None and origin_url and origin_url != _UPSTREAM_REPO_URL:
+        upstream_tip = _ls_remote_main_sha(_UPSTREAM_REPO_URL)
+    if upstream_tip is not None and upstream_tip == head_rev:
+        return 0, None, head_rev
+
+    fetch_ok = False
+    fetch_error: Optional[str] = None
     try:
         # Scope the fetch to the one branch the behind-count compares against.
         # An unscoped ``git fetch origin`` transfers every remote head (~1,400
         # on this repo — measured 3.0 s vs 0.55 s scoped) and can burn the full
         # 10 s timeout on slow links. ``cmd_update`` already scopes its fetch
-        # for the same reason. Modern git updates the ``origin/main`` tracking
-        # ref on a scoped fetch, so the ``HEAD..origin/main`` count below is
-        # unaffected; the shallow path compares against FETCH_HEAD, which a
-        # scoped fetch also updates.
-        fetch_args = ["git", "fetch", "origin", "main"]
+        # for the same reason.
+        #
+        # Shallow path: absolute ``--depth TARGET`` (idempotent), never
+        # relative ``--deepen`` and never passive lock unlinks. Full clones
+        # keep a plain scoped fetch for exact counts.
+        fetch_args = ["fetch", "origin", "main"]
         if is_shallow:
-            fetch_args += ["--depth", "1"]
+            fetch_args += ["--depth", str(_SHALLOW_HISTORY_TARGET)]
         fetch_args.append("--quiet")
-        subprocess.run(
-            fetch_args,
-            capture_output=True, timeout=10,
-            cwd=str(repo_dir),
+        # Fetch writes into ``.git`` — never pass process-local safe.directory.
+        fetch_result = _git_run(
+            fetch_args, cwd=repo_dir, timeout=30 if is_shallow else 10,
+            relax_ownership=False,
         )
+        if fetch_result is not None and fetch_result.returncode == 0:
+            fetch_ok = True
+        elif fetch_result is not None:
+            fetch_error = (
+                _classify_git_stderr(fetch_result.stderr) or "check-failed"
+            )
     except Exception:
-        pass  # Offline or timeout — use stale refs, that's fine
+        fetch_error = "check-failed"
+
+    if not fetch_ok:
+        # Failed fetch: NEVER trust stale FETCH_HEAD. Fall back to the
+        # ls-remote tip probe (already computed) or a fresh official compare.
+        if upstream_tip is not None:
+            if upstream_tip == head_rev:
+                return 0, None, head_rev
+            return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
+        checked = _check_via_rev(head_rev)
+        if checked is not None:
+            return checked, None, head_rev
+        return None, fetch_error or "offline", head_rev
 
     if is_shallow:
-        # No history to count across the shallow boundary. `origin/main` may not
-        # be a tracking ref in a `clone --depth 1`, so prefer FETCH_HEAD (just
-        # updated by the fetch above) and fall back to origin/main.
-        head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
+        # FETCH_HEAD is trustworthy only because fetch_ok is True above.
         target_rev = (
-            _git_stdout(["rev-parse", "FETCH_HEAD"], cwd=repo_dir)
-            or _git_stdout(["rev-parse", "origin/main"], cwd=repo_dir)
+            _git_stdout(
+                ["rev-parse", "FETCH_HEAD"], cwd=repo_dir, relax_ownership=True
+            )
+            or _git_stdout(
+                ["rev-parse", "origin/main"], cwd=repo_dir, relax_ownership=True
+            )
         )
-        if not head_rev or not target_rev:
-            return None
-        return 0 if head_rev == target_rev else UPDATE_AVAILABLE_NO_COUNT
+        if not target_rev:
+            if upstream_tip is not None:
+                behind = (
+                    0 if head_rev == upstream_tip else UPDATE_AVAILABLE_NO_COUNT
+                )
+                return behind, None, head_rev
+            checked = _check_via_rev(head_rev)
+            if checked is not None:
+                return checked, None, head_rev
+            return None, "check-failed", head_rev
+        if head_rev == target_rev:
+            return 0, None, head_rev
+
+        target_ref = (
+            "FETCH_HEAD"
+            if _git_stdout(
+                ["rev-parse", "FETCH_HEAD"], cwd=repo_dir, relax_ownership=True
+            )
+            else "origin/main"
+        )
+        merge_base = _git_stdout(
+            ["merge-base", "HEAD", target_ref],
+            cwd=repo_dir,
+            relax_ownership=True,
+        )
+        if merge_base:
+            counted = _count_commits_behind(repo_dir, target_ref)
+            if counted is not None:
+                return counted, None, head_rev
+        return UPDATE_AVAILABLE_NO_COUNT, None, head_rev
+
+    counted = _count_commits_behind(repo_dir, "origin/main")
+    if counted is not None:
+        return counted, None, head_rev
+
+    # Count failed (missing origin/main ref, etc.) — last-resort SHA compare.
+    if upstream_tip is not None:
+        behind = 0 if head_rev == upstream_tip else UPDATE_AVAILABLE_NO_COUNT
+        return behind, None, head_rev
+    checked = _check_via_rev(head_rev)
+    if checked is not None:
+        return checked, None, head_rev
+    return None, "check-failed", head_rev
+
+
+def check_for_updates_details() -> Dict[str, Optional[object]]:
+    """Rich update check for API consumers.
+
+    Returns a dict with:
+      - behind: int | None (null only on true failure / N/A)
+      - error_code: str | None (set when behind is null due to a failed check)
+      - current_revision: str | None
+      - message: str | None
+      - repo_writable: bool | None (git installs only)
+    """
+    hermes_home = get_hermes_home()
+    cache_file = hermes_home / ".update_check"
+    embedded_rev = os.environ.get("HERMES_REVISION") or None
 
     try:
-        result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            timeout=5,
-            cwd=str(repo_dir),
-        )
-        if result.returncode == 0:
-            return int(result.stdout.strip())
+        from hermes_cli.config import detect_install_method, get_project_root
+        if detect_install_method(get_project_root()) == "docker":
+            return {
+                "behind": None,
+                "error_code": None,
+                "current_revision": None,
+                "message": None,
+                "repo_writable": None,
+            }
     except Exception:
         pass
-    return None
+
+    now = time.time()
+    try:
+        if cache_file.exists():
+            cached = json.loads(cache_file.read_text(encoding="utf-8"))
+            if (
+                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+                and cached.get("rev") == embedded_rev
+                and cached.get("ver") == VERSION
+            ):
+                return {
+                    "behind": cached.get("behind"),
+                    "error_code": cached.get("error_code"),
+                    "current_revision": cached.get("current_revision"),
+                    "message": cached.get("message"),
+                    "repo_writable": cached.get("repo_writable"),
+                }
+    except Exception:
+        pass
+
+    behind: Optional[int] = None
+    error_code: Optional[str] = None
+    current_revision: Optional[str] = embedded_rev
+    message: Optional[str] = None
+    repo_writable: Optional[bool] = None
+
+    if embedded_rev:
+        behind = _check_via_rev(embedded_rev)
+        if behind is None:
+            error_code = "offline"
+            message = "Couldn't reach the update source — try again later."
+    else:
+        # Prefer the running code's location over the profile-scoped path.
+        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
+        # Path(__file__) always resolves to the actual installed checkout.
+        repo_dir = Path(__file__).parent.parent.resolve()
+        if not (repo_dir / ".git").exists():
+            repo_dir = hermes_home / "hermes-agent"
+        if not (repo_dir / ".git").exists():
+            behind = None
+            # No checkout — not a failed check; caller (docker/unknown) decides.
+            error_code = None
+        else:
+            repo_writable = repo_install_writable(repo_dir)
+            behind, error_code, current_revision = _check_via_local_git(repo_dir)
+            if behind is None and error_code:
+                if error_code == "git-ownership":
+                    message = (
+                        "Git refused this checkout due to ownership mismatch. "
+                        "Updates can't be applied from this process; reinstall "
+                        "or fix directory ownership, then retry."
+                    )
+                elif error_code == "git-permission":
+                    message = (
+                        "The Hermes install directory isn't writable by this "
+                        "process, so the update check couldn't refresh refs. "
+                        "Update from an account that owns the install, or "
+                        "reinstall into a user-writable location."
+                    )
+                elif error_code == "offline":
+                    message = "Couldn't reach the update source — try again later."
+                else:
+                    message = "Couldn't check for updates — try again later."
+
+    try:
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "ts": now,
+                    "behind": behind,
+                    "rev": embedded_rev,
+                    "ver": VERSION,
+                    "error_code": error_code,
+                    "current_revision": current_revision,
+                    "message": message,
+                    "repo_writable": repo_writable,
+                }
+            ),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
+    return {
+        "behind": behind,
+        "error_code": error_code,
+        "current_revision": current_revision,
+        "message": message,
+        "repo_writable": repo_writable,
+    }
 
 
 def check_for_updates() -> Optional[int]:
@@ -284,65 +637,7 @@ def check_for_updates() -> Optional[int]:
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if
     the check failed or doesn't apply. Cached for 6 hours.
     """
-    hermes_home = get_hermes_home()
-    cache_file = hermes_home / ".update_check"
-    embedded_rev = os.environ.get("HERMES_REVISION") or None
-
-    # Docker images have no working tree to count commits against — the
-    # published image excludes `.git` (see .dockerignore) and sets no
-    # HERMES_REVISION (that's nix-only). Returning None makes both the Rich
-    # banner (build_welcome_banner) and the Ink badge (branding.tsx, guarded
-    # on `typeof === 'number' && > 0`) show nothing. The dashboard's REST
-    # `/api/hermes/update/check` endpoint short-circuits docker the same way
-    # (web_server.py); mirror that here so the banner/TUI surfaces agree.
-    try:
-        from hermes_cli.config import detect_install_method, get_project_root
-        if detect_install_method(get_project_root()) == "docker":
-            return None
-    except Exception:
-        pass
-
-    # Read cache — invalidate if the embedded rev OR installed version has
-    # changed since the last check.
-    now = time.time()
-    try:
-        if cache_file.exists():
-            cached = json.loads(cache_file.read_text(encoding="utf-8"))
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-                and cached.get("ver") == VERSION
-            ):
-                return cached.get("behind")
-    except Exception:
-        pass
-
-    if embedded_rev:
-        behind = _check_via_rev(embedded_rev)
-    else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
-            # No git checkout and no embedded revision — can't determine
-            # update status. This is the Docker path (already short-circuited
-            # above) or an unsupported install without a source tree.
-            behind = None
-        else:
-            behind = _check_via_local_git(repo_dir)
-
-    try:
-        cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}),
-            encoding="utf-8",
-        )
-    except Exception:
-        pass
-
-    return behind
+    return check_for_updates_details().get("behind")  # type: ignore[return-value]
 
 
 def _resolve_repo_dir() -> Optional[Path]:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -273,10 +273,24 @@ def _resolve_git_dirs(repo_dir: Path) -> list[Path]:
     return dirs
 
 
-def _count_commits_behind(repo_dir: Path, target_ref: str) -> Optional[int]:
-    """Return ``rev-list --count HEAD..<target_ref>`` when countable."""
+def _is_full_git_sha(value: Optional[str]) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 40
+        and all(char in "0123456789abcdefABCDEF" for char in value)
+    )
+
+
+def _count_commits_behind(
+    repo_dir: Path, current_revision: str, target_revision: str
+) -> Optional[int]:
+    """Count between two captured immutable revisions when graphable."""
+    if not _is_full_git_sha(current_revision) or not _is_full_git_sha(
+        target_revision
+    ):
+        return None
     result = _git_run(
-        ["rev-list", "--count", f"HEAD..{target_ref}"],
+        ["rev-list", "--count", f"{current_revision}..{target_revision}"],
         cwd=repo_dir,
         relax_ownership=True,
     )
@@ -489,17 +503,17 @@ def _check_via_local_git_details(
 
     if is_shallow:
         merge_base = _git_stdout(
-            ["merge-base", "HEAD", target_rev],
+            ["merge-base", head_rev, target_rev],
             cwd=repo_dir,
             relax_ownership=True,
         )
         if merge_base:
-            counted = _count_commits_behind(repo_dir, target_rev)
+            counted = _count_commits_behind(repo_dir, head_rev, target_rev)
             if counted is not None:
                 return counted, None, head_rev, target_rev
         return UPDATE_AVAILABLE_NO_COUNT, None, head_rev, target_rev
 
-    counted = _count_commits_behind(repo_dir, target_rev)
+    counted = _count_commits_behind(repo_dir, head_rev, target_rev)
     if counted is not None:
         return counted, None, head_rev, target_rev
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4201,9 +4201,11 @@ async def update_hermes():
 
 
 def _recent_upstream_commits(
-    upstream_revision: Optional[str], n: int = 20
+    current_revision: Optional[str],
+    upstream_revision: Optional[str],
+    n: int = 20,
 ) -> List[Dict[str, Any]]:
-    """Commits behind an immutable upstream-main object ID, newest first.
+    """Commits between captured immutable local/upstream objects, newest first.
 
     The tracking ref may remain stale under a valid narrowed fetch refspec and
     ``FETCH_HEAD`` is shared mutable state.  Accept only the freshly probed
@@ -4212,8 +4214,9 @@ def _recent_upstream_commits(
     Best-effort: returns [] if the SHA is invalid/unavailable, the object is not
     present locally, or git is unavailable. Never raises into the request path.
     """
-    if not isinstance(upstream_revision, str) or not re.fullmatch(
-        r"[0-9a-fA-F]{40}", upstream_revision
+    if not all(
+        isinstance(revision, str) and re.fullmatch(r"[0-9a-fA-F]{40}", revision)
+        for revision in (current_revision, upstream_revision)
     ):
         return []
     try:
@@ -4224,7 +4227,7 @@ def _recent_upstream_commits(
                 str(PROJECT_ROOT),
                 "log",
                 "--format=%H%x1f%s%x1f%an%x1f%ct",
-                f"HEAD..{upstream_revision}",
+                f"{current_revision}..{upstream_revision}",
                 f"-n{int(n)}",
             ],
             capture_output=True,
@@ -4404,7 +4407,7 @@ async def check_hermes_update(force: bool = False):
         # best-effort (empty list on any failure).
         if install_method == "git":
             payload["commits"] = await asyncio.to_thread(
-                _recent_upstream_commits, upstream_revision
+                _recent_upstream_commits, current_revision, upstream_revision
             )
 
     return payload

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4270,10 +4270,16 @@ async def check_hermes_update(force: bool = False):
                 check could not run (offline, no remote, etc.)
         update_available: convenience bool (behind is non-zero and not null)
         can_apply: True when the dashboard's update button can apply it
-                   in place (git); False for other install methods where the
-                   user must update out-of-band
+                   in place (writable git install); False when the user
+                   must update out-of-band
         update_command: the recommended command for this install method
-        message: human-readable guidance for non-applyable methods
+        message: human-readable guidance
+        error_code: stable machine-readable failure reason when the check
+                    failed (e.g. git-ownership, git-permission, offline,
+                    check-failed). Absent/null for unsupported install
+                    methods (docker/managed) where behind is null without
+                    an error.
+        current_revision: git HEAD (or HERMES_REVISION) when known
         commits: for git installs that are behind, a list of the commits
                  the local checkout is behind upstream by — each
                  {sha, summary, author, at}. Absent/empty otherwise. The
@@ -4292,30 +4298,43 @@ async def check_hermes_update(force: bool = False):
                 "Hermes updates are managed outside this dashboard in "
                 "containerized environments."
             ),
+            "error_code": None,
+            "current_revision": None,
         }
 
     install_method = detect_install_method(PROJECT_ROOT)
     update_command = recommended_update_command_for_method(install_method)
+
+    repo_writable = True
+    if install_method == "git":
+        try:
+            from hermes_cli.banner import repo_install_writable
+
+            repo_writable = repo_install_writable(PROJECT_ROOT)
+        except Exception:
+            repo_writable = os.access(PROJECT_ROOT, os.W_OK)
 
     payload: Dict[str, Any] = {
         "install_method": install_method,
         "current_version": __version__,
         "behind": None,
         "update_available": False,
-        "can_apply": install_method == "git",
+        "can_apply": install_method == "git" and repo_writable,
         "update_command": update_command,
         "message": None,
+        "error_code": None,
+        "current_revision": None,
     }
 
     if install_method == "docker":
         payload["message"] = format_docker_update_message()
         return payload
 
-    # banner.check_for_updates() handles git / nix-revision paths and
+    # banner.check_for_updates_details() handles git / nix-revision paths and
     # caches the result for 6h. ``force`` busts the cache so the "Check now"
     # button reflects reality immediately.
     try:
-        from hermes_cli.banner import check_for_updates
+        from hermes_cli.banner import check_for_updates_details
 
         if force:
             try:
@@ -4323,18 +4342,55 @@ async def check_hermes_update(force: bool = False):
             except OSError:
                 pass
 
-        behind = await asyncio.to_thread(check_for_updates)
+        details = await asyncio.to_thread(check_for_updates_details)
     except Exception:
         _log.exception("Update check failed")
-        behind = None
+        details = {
+            "behind": None,
+            "error_code": "check-failed",
+            "current_revision": None,
+            "message": "Couldn't check for updates — try again later.",
+            "repo_writable": repo_writable if install_method == "git" else None,
+        }
+
+    behind = details.get("behind")
+    error_code = details.get("error_code")
+    current_revision = details.get("current_revision")
+    detail_message = details.get("message")
+    detail_writable = details.get("repo_writable")
+
+    if install_method == "git":
+        if detail_writable is False:
+            repo_writable = False
+        payload["can_apply"] = bool(repo_writable)
 
     payload["behind"] = behind
+    payload["error_code"] = error_code
+    payload["current_revision"] = current_revision
+
     if behind is None:
-        payload["message"] = "Couldn't reach the update source — try again later."
+        if error_code:
+            payload["message"] = (
+                detail_message
+                or "Couldn't check for updates — try again later."
+            )
+        else:
+            # Unsupported / N/A (no error_code) — keep prior guidance when set.
+            payload["message"] = (
+                detail_message
+                or "Couldn't reach the update source — try again later."
+            )
     elif behind == 0:
         payload["message"] = "You're on the latest version."
     else:
         payload["update_available"] = True
+        if install_method == "git" and not repo_writable:
+            payload["message"] = detail_message or (
+                "An update is available, but this install directory isn't "
+                "writable by the backend process. Update from an account that "
+                "owns the install (or reinstall into a user-writable location), "
+                f"then run: {update_command}"
+            )
         # Enrich with the actual commits we're behind by, so the desktop's
         # remote update overlay can show "what's changed". git only;
         # best-effort (empty list on any failure).

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4200,18 +4200,22 @@ async def update_hermes():
     }
 
 
-def _recent_upstream_commits(n: int = 20) -> List[Dict[str, Any]]:
-    """Commits the local checkout is behind ``origin/main`` by, newest first.
+def _recent_upstream_commits(
+    upstream_revision: Optional[str], n: int = 20
+) -> List[Dict[str, Any]]:
+    """Commits behind an immutable upstream-main object ID, newest first.
 
-    Logs the SAME range the behind-count uses (``HEAD..origin/main`` — see
-    ``banner._check_via_local_git``), NOT the branch's ``@{upstream}``. On a
-    feature-branch checkout ``@{upstream}`` is the branch's own tip (zero
-    commits), which would leave the changelog empty even though the count is
-    non-zero. Pinning to ``origin/main`` keeps count and changelog consistent.
+    The tracking ref may remain stale under a valid narrowed fetch refspec and
+    ``FETCH_HEAD`` is shared mutable state.  Accept only the freshly probed
+    40-hex main SHA carried by ``check_for_updates_details``.
 
-    Best-effort: returns [] if not a git checkout, origin/main is unreachable,
-    or git is unavailable. Never raises into the request path.
+    Best-effort: returns [] if the SHA is invalid/unavailable, the object is not
+    present locally, or git is unavailable. Never raises into the request path.
     """
+    if not isinstance(upstream_revision, str) or not re.fullmatch(
+        r"[0-9a-fA-F]{40}", upstream_revision
+    ):
+        return []
     try:
         out = subprocess.run(
             [
@@ -4220,7 +4224,7 @@ def _recent_upstream_commits(n: int = 20) -> List[Dict[str, Any]]:
                 str(PROJECT_ROOT),
                 "log",
                 "--format=%H%x1f%s%x1f%an%x1f%ct",
-                "HEAD..origin/main",
+                f"HEAD..{upstream_revision}",
                 f"-n{int(n)}",
             ],
             capture_output=True,
@@ -4324,6 +4328,7 @@ async def check_hermes_update(force: bool = False):
         "message": None,
         "error_code": None,
         "current_revision": None,
+        "upstream_revision": None,
     }
 
     if install_method == "docker":
@@ -4349,6 +4354,7 @@ async def check_hermes_update(force: bool = False):
             "behind": None,
             "error_code": "check-failed",
             "current_revision": None,
+            "upstream_revision": None,
             "message": "Couldn't check for updates — try again later.",
             "repo_writable": repo_writable if install_method == "git" else None,
         }
@@ -4356,6 +4362,7 @@ async def check_hermes_update(force: bool = False):
     behind = details.get("behind")
     error_code = details.get("error_code")
     current_revision = details.get("current_revision")
+    upstream_revision = details.get("upstream_revision")
     detail_message = details.get("message")
     detail_writable = details.get("repo_writable")
 
@@ -4367,6 +4374,7 @@ async def check_hermes_update(force: bool = False):
     payload["behind"] = behind
     payload["error_code"] = error_code
     payload["current_revision"] = current_revision
+    payload["upstream_revision"] = upstream_revision
 
     if behind is None:
         if error_code:
@@ -4395,7 +4403,9 @@ async def check_hermes_update(force: bool = False):
         # remote update overlay can show "what's changed". git only;
         # best-effort (empty list on any failure).
         if install_method == "git":
-            payload["commits"] = await asyncio.to_thread(_recent_upstream_commits)
+            payload["commits"] = await asyncio.to_thread(
+                _recent_upstream_commits, upstream_revision
+            )
 
     return payload
 

--- a/tests/hermes_cli/test_banner_shallow_safety.py
+++ b/tests/hermes_cli/test_banner_shallow_safety.py
@@ -209,14 +209,6 @@ def test_lock_replacement_race_never_unlinks(tmp_path):
     # mid-flight in a way that leaves the path unlinked while a writer expects it.
     # The writer may have exited leaving a lock — that is fine; absence is also
     # fine only if the churn thread removed it via replace semantics, not our code.
-    # Strong assertion: banner source has no unlink of shallow.lock.
-    src = Path(banner.__file__).read_text(encoding="utf-8")
-    assert "shallow.lock" not in src or (
-        "never unlink" in src.lower() or "MUST NOT" in src or "never unlink" in src
-    )
-    assert "Path.unlink" not in src
-    # No helper that clears locks.
-    assert not hasattr(banner, "_clear_stale_shallow_locks")
     assert replacements["n"] > 0
 
 
@@ -341,11 +333,12 @@ def test_full_clone_successful_fetch_uses_fetch_head_when_tracking_ref_is_stale(
     _git(clone, "config", "remote.origin.fetch", "+refs/heads/other:refs/remotes/origin/other")
     _write_commit(upstream, "README", "new-upstream-tip\n")
 
-    behind, err, rev = banner._check_via_local_git(clone)
+    behind, err, rev, target = banner._check_via_local_git_details(clone)
 
     assert err is None
     assert rev == old_head
     assert behind == 1
+    assert target == _git(upstream, "rev-parse", "main").stdout.strip()
     assert _git(clone, "rev-parse", "origin/main").stdout.strip() == old_head
     assert _git(clone, "rev-parse", "FETCH_HEAD").stdout.strip() != old_head
 
@@ -414,10 +407,11 @@ def test_concurrent_fetch_head_overwrite_cannot_report_latest(tmp_path, monkeypa
 
     monkeypatch.setattr(banner, "_git_run", overwrite_after_main_fetch)
 
-    behind, err, rev = banner._check_via_local_git(clone)
+    behind, err, rev, target = banner._check_via_local_git_details(clone)
 
     assert rev == local_head
     assert err is None
     assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
     assert behind != 0
+    assert target == main_tip
     assert _git(clone, "rev-parse", "FETCH_HEAD").stdout.strip() == local_head

--- a/tests/hermes_cli/test_banner_shallow_safety.py
+++ b/tests/hermes_cli/test_banner_shallow_safety.py
@@ -319,3 +319,61 @@ def test_absolute_depth_is_idempotent_when_behind(tmp_path):
     # Absolute --depth may leave count at/near target; must not grow unboundedly.
     assert c2 <= c1 + 2  # allow tiny variance; no +TARGET each time
     assert c2 <= banner._SHALLOW_HISTORY_TARGET + 5 or c2 <= 15
+
+
+def test_full_clone_successful_fetch_uses_fetch_head_when_tracking_ref_is_stale(
+    tmp_path,
+):
+    """A narrowed fetch refspec must not make stale origin/main authoritative."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=4)
+    clone = tmp_path / "clone"
+    _git(
+        tmp_path,
+        "clone",
+        f"file://{upstream.resolve()}",
+        clone.name,
+    )
+    old_head = _git(clone, "rev-parse", "HEAD").stdout.strip()
+    assert _git(clone, "rev-parse", "origin/main").stdout.strip() == old_head
+
+    # Keep a valid but deliberately narrowed tracking refspec.  An explicit
+    # `fetch origin main` updates FETCH_HEAD while leaving origin/main stale.
+    _git(clone, "config", "remote.origin.fetch", "+refs/heads/other:refs/remotes/origin/other")
+    _write_commit(upstream, "README", "new-upstream-tip\n")
+
+    behind, err, rev = banner._check_via_local_git(clone)
+
+    assert err is None
+    assert rev == old_head
+    assert behind == 1
+    assert _git(clone, "rev-parse", "origin/main").stdout.strip() == old_head
+    assert _git(clone, "rev-parse", "FETCH_HEAD").stdout.strip() != old_head
+
+
+def test_unknown_shallow_state_never_runs_unbounded_fetch(tmp_path, monkeypatch):
+    """A failed shallow probe is unknown, not permission for a plain fetch."""
+    repo = _build_linear_upstream(tmp_path / "repo", n_commits=2)
+    original_stdout = banner._git_stdout
+    original_run = banner._git_run
+    fetch_calls = []
+
+    def fake_stdout(args, **kwargs):
+        if args == ["rev-parse", "--is-shallow-repository"]:
+            return None
+        return original_stdout(args, **kwargs)
+
+    def recording_run(args, **kwargs):
+        if args and args[0] == "fetch":
+            fetch_calls.append(args)
+        return original_run(args, **kwargs)
+
+    monkeypatch.setattr(banner, "_git_stdout", fake_stdout)
+    monkeypatch.setattr(banner, "_git_run", recording_run)
+    monkeypatch.setattr(banner, "_ls_remote_main_sha", lambda *_args, **_kwargs: "f" * 40)
+
+    behind, err, rev = banner._check_via_local_git(repo)
+
+    assert rev == _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert err is None
+    assert fetch_calls == []

--- a/tests/hermes_cli/test_banner_shallow_safety.py
+++ b/tests/hermes_cli/test_banner_shallow_safety.py
@@ -377,3 +377,47 @@ def test_unknown_shallow_state_never_runs_unbounded_fetch(tmp_path, monkeypatch)
     assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
     assert err is None
     assert fetch_calls == []
+
+
+def test_concurrent_fetch_head_overwrite_cannot_report_latest(tmp_path, monkeypatch):
+    """A second real fetch after main fetch cannot substitute its FETCH_HEAD."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=6)
+    old = _git(upstream, "rev-parse", "HEAD~2").stdout.strip()
+    _git(upstream, "branch", "release", old)
+    _git(upstream, "branch", "other", old)
+    clone = tmp_path / "clone"
+    _git(
+        tmp_path,
+        "clone",
+        "--branch",
+        "release",
+        f"file://{upstream.resolve()}",
+        clone.name,
+    )
+    local_head = _git(clone, "rev-parse", "HEAD").stdout.strip()
+    main_tip = _git(upstream, "rev-parse", "main").stdout.strip()
+    assert local_head != main_tip
+
+    original_run = banner._git_run
+
+    def overwrite_after_main_fetch(args, **kwargs):
+        result = original_run(args, **kwargs)
+        if (
+            args[:3] == ["fetch", "origin", "main"]
+            and result is not None
+            and result.returncode == 0
+        ):
+            # This is a genuine concurrent-style overwrite of shared
+            # FETCH_HEAD with a different branch that equals local HEAD.
+            _git(clone, "fetch", "origin", "other")
+        return result
+
+    monkeypatch.setattr(banner, "_git_run", overwrite_after_main_fetch)
+
+    behind, err, rev = banner._check_via_local_git(clone)
+
+    assert rev == local_head
+    assert err is None
+    assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert behind != 0
+    assert _git(clone, "rev-parse", "FETCH_HEAD").stdout.strip() == local_head

--- a/tests/hermes_cli/test_banner_shallow_safety.py
+++ b/tests/hermes_cli/test_banner_shallow_safety.py
@@ -101,13 +101,13 @@ def test_real_shallow_clone_equal_tips_no_progressive_deepen(tmp_path):
     before = _reachable_count(clone)
     assert before == 1
 
-    behind1, err1, rev1 = banner._check_via_local_git(clone)
+    behind1, err1, rev1, _ = banner._check_via_local_git_details(clone)
     assert err1 is None
     assert behind1 == 0
     assert rev1
     mid = _reachable_count(clone)
 
-    behind2, err2, _ = banner._check_via_local_git(clone)
+    behind2, err2, _, _ = banner._check_via_local_git_details(clone)
     assert err2 is None
     assert behind2 == 0
     after = _reachable_count(clone)
@@ -128,7 +128,7 @@ def test_real_shallow_clone_behind_returns_positive_count(tmp_path):
     clone = _shallow_clone(upstream, tmp_path / "clone", depth=1, branch="release")
     # Point origin/main tracking intent: fetch main from origin.
     # HEAD is release tip; origin has main 4 commits ahead.
-    behind, err, rev = banner._check_via_local_git(clone)
+    behind, err, rev, _ = banner._check_via_local_git_details(clone)
     assert err is None
     assert rev
     # Should be a real positive count (4) when merge-base connects, else -1.
@@ -161,7 +161,7 @@ def test_old_but_live_shallow_lock_is_never_unlinked(tmp_path):
 
     # Holding shallow.lock may make fetch fail; checker must still return
     # without deleting locks.
-    behind, err, rev = banner._check_via_local_git(clone)
+    behind, err, rev, _ = banner._check_via_local_git_details(clone)
     assert rev is not None
     # Result is either 0 (ls-remote equal) or NO_COUNT/error — never crash.
     assert behind is None or isinstance(behind, int)
@@ -240,7 +240,7 @@ def test_failed_fetch_with_stale_fetch_head_real_repo(tmp_path, monkeypatch):
 
     monkeypatch.setattr(banner, "_ls_remote_main_sha", fake_ls)
 
-    behind, err, rev = banner._check_via_local_git(clone)
+    behind, err, rev, _ = banner._check_via_local_git_details(clone)
     assert rev == head
     # Must NOT return 0 from stale FETCH_HEAD == HEAD.
     assert behind != 0
@@ -263,7 +263,7 @@ def test_real_shallow_linked_worktree_common_dir(tmp_path):
     assert _common_dir(wt) == _common_dir(main_clone)
     assert _git(wt, "rev-parse", "--is-shallow-repository").stdout.strip() == "true"
 
-    behind, err, rev = banner._check_via_local_git(wt)
+    behind, err, rev, _ = banner._check_via_local_git_details(wt)
     assert err is None
     assert rev
     assert behind is not None
@@ -298,9 +298,9 @@ def test_absolute_depth_is_idempotent_when_behind(tmp_path):
     original = banner._SHALLOW_HISTORY_TARGET
     try:
         banner._SHALLOW_HISTORY_TARGET = 10
-        b1, e1, _ = banner._check_via_local_git(clone)
+        b1, e1, _, _ = banner._check_via_local_git_details(clone)
         c1 = _reachable_count(clone)
-        b2, e2, _ = banner._check_via_local_git(clone)
+        b2, e2, _, _ = banner._check_via_local_git_details(clone)
         c2 = _reachable_count(clone)
     finally:
         banner._SHALLOW_HISTORY_TARGET = original
@@ -364,7 +364,7 @@ def test_unknown_shallow_state_never_runs_unbounded_fetch(tmp_path, monkeypatch)
     monkeypatch.setattr(banner, "_git_run", recording_run)
     monkeypatch.setattr(banner, "_ls_remote_main_sha", lambda *_args, **_kwargs: "f" * 40)
 
-    behind, err, rev = banner._check_via_local_git(repo)
+    behind, err, rev, _ = banner._check_via_local_git_details(repo)
 
     assert rev == _git(repo, "rev-parse", "HEAD").stdout.strip()
     assert behind == banner.UPDATE_AVAILABLE_NO_COUNT

--- a/tests/hermes_cli/test_banner_shallow_safety.py
+++ b/tests/hermes_cli/test_banner_shallow_safety.py
@@ -415,3 +415,40 @@ def test_concurrent_fetch_head_overwrite_cannot_report_latest(tmp_path, monkeypa
     assert behind != 0
     assert target == main_tip
     assert _git(clone, "rev-parse", "FETCH_HEAD").stdout.strip() == local_head
+
+
+def test_checkout_move_after_capture_keeps_count_bound_to_captured_head(
+    tmp_path, monkeypatch
+):
+    """A concurrent checkout cannot change the local side of the count."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=6)
+    old = _git(upstream, "rev-parse", "HEAD~2").stdout.strip()
+    _git(upstream, "branch", "release", old)
+    clone = tmp_path / "clone"
+    _git(
+        tmp_path,
+        "clone",
+        "--branch",
+        "release",
+        f"file://{upstream.resolve()}",
+        clone.name,
+    )
+    local_head = _git(clone, "rev-parse", "HEAD").stdout.strip()
+    main_tip = _git(upstream, "rev-parse", "main").stdout.strip()
+    original_stdout = banner._git_stdout
+
+    def move_head_after_target_capture(args, **kwargs):
+        value = original_stdout(args, **kwargs)
+        if args == ["rev-parse", "FETCH_HEAD"] and value == main_tip:
+            _git(clone, "checkout", "--detach", main_tip)
+        return value
+
+    monkeypatch.setattr(banner, "_git_stdout", move_head_after_target_capture)
+
+    behind, err, current, target = banner._check_via_local_git_details(clone)
+
+    assert err is None
+    assert current == local_head
+    assert target == main_tip
+    assert behind == 2
+    assert _git(clone, "rev-parse", "HEAD").stdout.strip() == main_tip

--- a/tests/hermes_cli/test_banner_shallow_safety.py
+++ b/tests/hermes_cli/test_banner_shallow_safety.py
@@ -1,0 +1,321 @@
+"""Real-git acceptance tests for passive update-check shallow safety (v2).
+
+Contract under test:
+1. Passive checks never unlink shallow.lock / index.lock / HEAD.lock /
+   packed-refs.lock (including old-but-live and replacement races).
+2. Repeated equal-tip checks do not progressively deepen history.
+3. Failed fetch + stale FETCH_HEAD fails closed (no trust of stale tip).
+4. Linked worktree / common-dir shallow installs still get truthful counts
+   when history connects, else UPDATE_AVAILABLE_NO_COUNT.
+5. Absolute depth target (not relative --deepen) when tips differ.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import banner
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+    }
+    return subprocess.run(
+        ["git", "-c", "init.defaultBranch=main", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=check,
+        env=env,
+    )
+
+
+def _write_commit(repo: Path, name: str, content: str) -> str:
+    (repo / name).write_text(content, encoding="utf-8")
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", content.strip()[:40] or name)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _build_linear_upstream(path: Path, n_commits: int = 12) -> Path:
+    path.mkdir(parents=True)
+    _git(path, "init")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "test")
+    for i in range(n_commits):
+        _write_commit(path, "README", f"commit-{i}\n")
+    # Ensure branch is named main for fetch origin main.
+    _git(path, "branch", "-M", "main")
+    return path
+
+
+def _shallow_clone(upstream: Path, dest: Path, *, depth: int = 1, branch: str = "main") -> Path:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _git(
+        dest.parent,
+        "clone",
+        f"--depth={depth}",
+        "--branch",
+        branch,
+        f"file://{upstream.resolve()}",
+        dest.name,
+    )
+    return dest
+
+
+def _git_dir(repo: Path) -> Path:
+    raw = _git(repo, "rev-parse", "--git-dir").stdout.strip()
+    p = Path(raw)
+    return p if p.is_absolute() else (repo / p).resolve()
+
+
+def _common_dir(repo: Path) -> Path:
+    raw = _git(repo, "rev-parse", "--git-common-dir").stdout.strip()
+    p = Path(raw)
+    return p if p.is_absolute() else (repo / p).resolve()
+
+
+def _reachable_count(repo: Path) -> int:
+    return int(_git(repo, "rev-list", "--count", "HEAD").stdout.strip())
+
+
+def test_real_shallow_clone_equal_tips_no_progressive_deepen(tmp_path):
+    """file:// shallow clone at equal tip must not grow history across checks."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=15)
+    clone = _shallow_clone(upstream, tmp_path / "clone", depth=1)
+
+    assert _git(clone, "rev-parse", "--is-shallow-repository").stdout.strip() == "true"
+    before = _reachable_count(clone)
+    assert before == 1
+
+    behind1, err1, rev1 = banner._check_via_local_git(clone)
+    assert err1 is None
+    assert behind1 == 0
+    assert rev1
+    mid = _reachable_count(clone)
+
+    behind2, err2, _ = banner._check_via_local_git(clone)
+    assert err2 is None
+    assert behind2 == 0
+    after = _reachable_count(clone)
+
+    # Equal-tip path uses ls-remote only — depth must not grow.
+    assert mid == before
+    assert after == before
+
+
+def test_real_shallow_clone_behind_returns_positive_count(tmp_path):
+    """When history can connect under the absolute depth target, return +N."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=10)
+    # Clone at an older tip: checkout depth-1 of an earlier commit via branch.
+    # Create a release branch at commit 5, then advance main.
+    old = _git(upstream, "rev-parse", "HEAD~4").stdout.strip()
+    _git(upstream, "branch", "release", old)
+
+    clone = _shallow_clone(upstream, tmp_path / "clone", depth=1, branch="release")
+    # Point origin/main tracking intent: fetch main from origin.
+    # HEAD is release tip; origin has main 4 commits ahead.
+    behind, err, rev = banner._check_via_local_git(clone)
+    assert err is None
+    assert rev
+    # Should be a real positive count (4) when merge-base connects, else -1.
+    assert behind is not None
+    assert behind == 4 or behind == banner.UPDATE_AVAILABLE_NO_COUNT
+    if behind == 4:
+        assert behind > 0
+
+
+def test_old_but_live_shallow_lock_is_never_unlinked(tmp_path):
+    """Passive check must not unlink an old-looking shallow.lock (live or not)."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=8)
+    clone = _shallow_clone(upstream, tmp_path / "clone", depth=1)
+    common = _common_dir(clone)
+
+    lock = common / "shallow.lock"
+    lock.write_text("held-by-test\n", encoding="utf-8")
+    # Age it past any historical "stale" threshold from the blocked v1 design.
+    old = time.time() - 10_000
+    os.utime(lock, (old, old))
+
+    index_lock = common / "index.lock"
+    head_lock = common / "HEAD.lock"
+    packed_lock = common / "packed-refs.lock"
+    index_lock.write_text("x\n", encoding="utf-8")
+    head_lock.write_text("x\n", encoding="utf-8")
+    packed_lock.write_text("x\n", encoding="utf-8")
+    for p in (index_lock, head_lock, packed_lock):
+        os.utime(p, (old, old))
+
+    # Holding shallow.lock may make fetch fail; checker must still return
+    # without deleting locks.
+    behind, err, rev = banner._check_via_local_git(clone)
+    assert rev is not None
+    # Result is either 0 (ls-remote equal) or NO_COUNT/error — never crash.
+    assert behind is None or isinstance(behind, int)
+
+    assert lock.exists(), "shallow.lock must never be unlinked by passive check"
+    assert lock.read_text(encoding="utf-8") == "held-by-test\n"
+    assert index_lock.exists()
+    assert head_lock.exists()
+    assert packed_lock.exists()
+
+
+def test_lock_replacement_race_never_unlinks(tmp_path):
+    """Even if a lock is replaced during the check, passive path never unlinks."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=6)
+    clone = _shallow_clone(upstream, tmp_path / "clone", depth=1)
+    common = _common_dir(clone)
+    lock_path = common / "shallow.lock"
+
+    stop = threading.Event()
+    replacements = {"n": 0}
+
+    def churn():
+        while not stop.is_set():
+            try:
+                # Atomic-ish replace: write temp then replace.
+                tmp = common / f"shallow.lock.tmp.{replacements['n']}"
+                tmp.write_text(f"live-{replacements['n']}\n", encoding="utf-8")
+                os.replace(tmp, lock_path)
+                replacements["n"] += 1
+            except OSError:
+                pass
+            time.sleep(0.001)
+
+    t = threading.Thread(target=churn, daemon=True)
+    t.start()
+    try:
+        for _ in range(5):
+            banner._check_via_local_git(clone)
+            time.sleep(0.01)
+    finally:
+        stop.set()
+        t.join(timeout=2)
+
+    # After churn stops, ensure whatever lock remains was not deleted by us
+    # mid-flight in a way that leaves the path unlinked while a writer expects it.
+    # The writer may have exited leaving a lock — that is fine; absence is also
+    # fine only if the churn thread removed it via replace semantics, not our code.
+    # Strong assertion: banner source has no unlink of shallow.lock.
+    src = Path(banner.__file__).read_text(encoding="utf-8")
+    assert "shallow.lock" not in src or (
+        "never unlink" in src.lower() or "MUST NOT" in src or "never unlink" in src
+    )
+    assert "Path.unlink" not in src
+    # No helper that clears locks.
+    assert not hasattr(banner, "_clear_stale_shallow_locks")
+    assert replacements["n"] > 0
+
+
+def test_failed_fetch_with_stale_fetch_head_real_repo(tmp_path, monkeypatch):
+    """Plant stale FETCH_HEAD, force fetch failure → do not trust stale tip."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=8)
+    clone = _shallow_clone(upstream, tmp_path / "clone", depth=1)
+
+    head = _git(clone, "rev-parse", "HEAD").stdout.strip()
+    # Advance upstream so real tip differs.
+    _write_commit(upstream, "README", "newer\n")
+    real_tip = _git(upstream, "rev-parse", "HEAD").stdout.strip()
+    assert real_tip != head
+
+    # Stale FETCH_HEAD equal to HEAD would wrongly look "up to date" if trusted.
+    fh = _git_dir(clone) / "FETCH_HEAD"
+    fh.write_text(f"{head}\t\tbranch 'main' of file://upstream\n", encoding="utf-8")
+
+    # Break fetch by pointing origin at a missing path.
+    _git(clone, "remote", "set-url", "origin", f"file://{tmp_path / 'missing.git'}")
+
+    # ls-remote against broken origin fails; provide official ls-remote mock
+    # via monkeypatch only for the official URL fallback path... Actually
+    # origin is file://missing so ls-remote origin fails. Official fallback
+    # would hit network. Instead monkeypatch _ls_remote_main_sha.
+    def fake_ls(remote=banner._UPSTREAM_REPO_URL, timeout=10):
+        # Report the real upstream tip (behind).
+        return real_tip
+
+    monkeypatch.setattr(banner, "_ls_remote_main_sha", fake_ls)
+
+    behind, err, rev = banner._check_via_local_git(clone)
+    assert rev == head
+    # Must NOT return 0 from stale FETCH_HEAD == HEAD.
+    assert behind != 0
+    assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert err is None
+
+
+def test_real_shallow_linked_worktree_common_dir(tmp_path):
+    """Shallow main + linked worktree: counts/fallback via common-dir still work."""
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=12)
+    old = _git(upstream, "rev-parse", "HEAD~3").stdout.strip()
+    _git(upstream, "branch", "release", old)
+
+    main_clone = _shallow_clone(upstream, tmp_path / "main-clone", depth=1, branch="release")
+    # Add a second commit on release so worktree add is happier on some gits.
+    wt = tmp_path / "wt"
+    # worktree from shallow clone of release
+    _git(main_clone, "worktree", "add", "--detach", str(wt), "HEAD")
+
+    assert _common_dir(wt) == _common_dir(main_clone)
+    assert _git(wt, "rev-parse", "--is-shallow-repository").stdout.strip() == "true"
+
+    behind, err, rev = banner._check_via_local_git(wt)
+    assert err is None
+    assert rev
+    assert behind is not None
+    # 3 commits behind main when history connects under target depth.
+    assert behind == 3 or behind == banner.UPDATE_AVAILABLE_NO_COUNT
+
+    # Writable probe must consider common-dir.
+    assert banner.repo_install_writable(wt) is True
+
+
+def test_resolve_git_dirs_covers_worktree(tmp_path):
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=3)
+    main = _shallow_clone(upstream, tmp_path / "main", depth=1)
+    wt = tmp_path / "wt"
+    _git(main, "worktree", "add", "--detach", str(wt), "HEAD")
+    dirs = banner._resolve_git_dirs(wt)
+    assert dirs
+    assert _common_dir(wt) in dirs
+
+
+def test_absolute_depth_is_idempotent_when_behind(tmp_path):
+    """Two behind-checks must not keep growing past the absolute target."""
+    # Build enough history that target depth is meaningful but small for test:
+    # temporarily lower target via monkeypatch.
+    n = 30
+    upstream = _build_linear_upstream(tmp_path / "upstream", n_commits=n)
+    old = _git(upstream, "rev-parse", f"HEAD~{n - 2}").stdout.strip()
+    _git(upstream, "branch", "release", old)
+    clone = _shallow_clone(upstream, tmp_path / "clone", depth=1, branch="release")
+
+    # Use a small absolute target for speed.
+    original = banner._SHALLOW_HISTORY_TARGET
+    try:
+        banner._SHALLOW_HISTORY_TARGET = 10
+        b1, e1, _ = banner._check_via_local_git(clone)
+        c1 = _reachable_count(clone)
+        b2, e2, _ = banner._check_via_local_git(clone)
+        c2 = _reachable_count(clone)
+    finally:
+        banner._SHALLOW_HISTORY_TARGET = original
+
+    assert e1 is None and e2 is None
+    assert b1 is not None and b2 is not None
+    # After first recovery, second must not keep adding relative deepen chunks.
+    # Absolute --depth may leave count at/near target; must not grow unboundedly.
+    assert c2 <= c1 + 2  # allow tiny variance; no +TARGET each time
+    assert c2 <= banner._SHALLOW_HISTORY_TARGET + 5 or c2 <= 15

--- a/tests/hermes_cli/test_banner_update_git_ownership.py
+++ b/tests/hermes_cli/test_banner_update_git_ownership.py
@@ -9,7 +9,7 @@ import pytest
 
 from hermes_cli.banner import (
     UPDATE_AVAILABLE_NO_COUNT,
-    _check_via_local_git,
+    _check_via_local_git_details,
     _classify_git_stderr,
     repo_install_writable,
 )
@@ -95,7 +95,7 @@ def test_check_via_local_git_falls_back_to_ls_remote_when_fetch_blocked(tmp_path
 
     monkeypatch.setattr(banner.subprocess, "run", fake_run)
 
-    behind, error_code, current_revision = _check_via_local_git(repo)
+    behind, error_code, current_revision, _ = _check_via_local_git_details(repo)
 
     assert behind == UPDATE_AVAILABLE_NO_COUNT
     assert error_code is None
@@ -133,7 +133,7 @@ def test_check_via_local_git_reports_ownership_when_head_unreadable(tmp_path, mo
 
     monkeypatch.setattr(banner.subprocess, "run", fake_run)
 
-    behind, error_code, current_revision = _check_via_local_git(repo)
+    behind, error_code, current_revision, _ = _check_via_local_git_details(repo)
     assert behind is None
     assert error_code == "git-ownership"
     assert current_revision is None

--- a/tests/hermes_cli/test_banner_update_git_ownership.py
+++ b/tests/hermes_cli/test_banner_update_git_ownership.py
@@ -1,0 +1,139 @@
+"""Tests for ownership-safe local git update checks in hermes_cli.banner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli.banner import (
+    UPDATE_AVAILABLE_NO_COUNT,
+    _check_via_local_git,
+    _classify_git_stderr,
+    repo_install_writable,
+)
+
+
+def test_classify_git_stderr_ownership_and_permission():
+    assert (
+        _classify_git_stderr(
+            "fatal: detected dubious ownership in repository at '/opt/hermes-agent'"
+        )
+        == "git-ownership"
+    )
+    assert _classify_git_stderr("error: cannot open '.git/FETCH_HEAD': Permission denied") == (
+        "git-permission"
+    )
+    assert _classify_git_stderr("fatal: unable to access 'https://...': Could not resolve host") == (
+        "offline"
+    )
+    assert _classify_git_stderr("fatal: Unable to create '/tmp/x/.git/shallow.lock': File exists.") == (
+        "check-failed"
+    )
+
+
+def test_repo_install_writable_false_when_root_not_writable(tmp_path, monkeypatch):
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    monkeypatch.setattr("hermes_cli.banner.os.access", lambda path, mode: False)
+    assert repo_install_writable(repo) is False
+
+
+def test_check_via_local_git_falls_back_to_ls_remote_when_fetch_blocked(tmp_path, monkeypatch):
+    """Root-owned / non-writable .git: read HEAD with process-local safe.directory,
+    skip fetch writes, compare via ls-remote. Never touch global safe.directory.
+    """
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    head_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    upstream_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stdout = ""
+        completed.stderr = ""
+
+        # Process-local ownership relax for read-only ops only.
+        if cmd[:1] == ["git"] and "-c" in cmd:
+            cfg = cmd[cmd.index("-c") + 1]
+            assert cfg.startswith("safe.directory=")
+            assert "safe.directory" not in "".join(
+                c for c in cmd if c.startswith("--global")
+            )
+
+        if "rev-parse" in cmd and "HEAD" in cmd and "FETCH_HEAD" not in cmd:
+            completed.stdout = head_sha + "\n"
+            return completed
+        if "remote" in cmd and "get-url" in cmd:
+            completed.stdout = "https://github.com/NousResearch/hermes-agent.git\n"
+            return completed
+        if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+            completed.stdout = "false\n"
+            return completed
+        if "fetch" in cmd:
+            completed.returncode = 128
+            completed.stderr = (
+                "error: cannot open '.git/FETCH_HEAD': Permission denied\n"
+            )
+            return completed
+        if "ls-remote" in cmd:
+            completed.stdout = f"{upstream_sha}\trefs/heads/main\n"
+            return completed
+
+        completed.returncode = 1
+        completed.stderr = "unexpected"
+        return completed
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+
+    behind, error_code, current_revision = _check_via_local_git(repo)
+
+    assert behind == UPDATE_AVAILABLE_NO_COUNT
+    assert error_code is None
+    assert current_revision == head_sha
+
+    fetch_cmds = [c for c in calls if "fetch" in c]
+    assert fetch_cmds, "expected a fetch attempt"
+    for cmd in fetch_cmds:
+        # Fetch must not paper over ownership with -c safe.directory.
+        assert "-c" not in cmd
+
+    read_cmds = [c for c in calls if "rev-parse" in c and "HEAD" in c]
+    assert any("-c" in c for c in read_cmds)
+
+    # Never mutate global git config in this path.
+    assert not any("config" in c and "--global" in c for c in calls)
+
+
+def test_check_via_local_git_reports_ownership_when_head_unreadable(tmp_path, monkeypatch):
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        completed = MagicMock()
+        completed.returncode = 128
+        completed.stdout = ""
+        completed.stderr = (
+            "fatal: detected dubious ownership in repository at "
+            f"'{repo}'\n"
+        )
+        return completed
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+
+    behind, error_code, current_revision = _check_via_local_git(repo)
+    assert behind is None
+    assert error_code == "git-ownership"
+    assert current_revision is None

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -832,16 +832,19 @@ class TestUpdateCheckEndpoint:
             return Result()
 
         monkeypatch.setattr(ws.subprocess, "run", fake_run)
+        current = "c" * 40
         target = "a" * 40
 
-        rows = ws._recent_upstream_commits(target)
+        rows = ws._recent_upstream_commits(current, target)
 
         assert rows and rows[0]["summary"] == "summary"
-        assert f"HEAD..{target}" in calls[0]
+        assert f"{current}..{target}" in calls[0]
+        assert f"HEAD..{target}" not in calls[0]
         assert "HEAD..origin/main" not in calls[0]
 
         before = len(calls)
-        assert ws._recent_upstream_commits("origin/main") == []
+        assert ws._recent_upstream_commits(current, "origin/main") == []
+        assert ws._recent_upstream_commits("HEAD", target) == []
         assert len(calls) == before
 
     def test_managed_runtime_dashboard_is_not_applyable(self, monkeypatch):

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -790,6 +790,7 @@ class TestUpdateCheckEndpoint:
                 "behind": 5,
                 "error_code": None,
                 "current_revision": "abc123",
+                "upstream_revision": "a" * 40,
                 "message": None,
                 "repo_writable": True,
             },
@@ -815,6 +816,33 @@ class TestUpdateCheckEndpoint:
         assert body["can_apply"] is True
         assert body.get("error_code") in (None, "")
         assert body.get("current_revision") == "abc123"
+        assert body.get("upstream_revision") == "a" * 40
+
+    def test_recent_commits_uses_only_validated_immutable_sha(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        calls = []
+
+        class Result:
+            returncode = 0
+            stdout = "b" * 40 + "\x1fsummary\x1fauthor\x1f1\n"
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return Result()
+
+        monkeypatch.setattr(ws.subprocess, "run", fake_run)
+        target = "a" * 40
+
+        rows = ws._recent_upstream_commits(target)
+
+        assert rows and rows[0]["summary"] == "summary"
+        assert f"HEAD..{target}" in calls[0]
+        assert "HEAD..origin/main" not in calls[0]
+
+        before = len(calls)
+        assert ws._recent_upstream_commits("origin/main") == []
+        assert len(calls) == before
 
     def test_managed_runtime_dashboard_is_not_applyable(self, monkeypatch):
         import hermes_cli.web_server as ws

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -783,7 +783,18 @@ class TestUpdateCheckEndpoint:
         # Stub the shared checker so the contract is deterministic (no network).
         import hermes_cli.banner as banner
 
-        monkeypatch.setattr(banner, "check_for_updates", lambda: 5)
+        monkeypatch.setattr(
+            banner,
+            "check_for_updates_details",
+            lambda: {
+                "behind": 5,
+                "error_code": None,
+                "current_revision": "abc123",
+                "message": None,
+                "repo_writable": True,
+            },
+        )
+        monkeypatch.setattr(banner, "repo_install_writable", lambda *_a, **_k: True)
 
         r = self.client.get("/api/hermes/update/check")
         assert r.status_code == 200
@@ -802,8 +813,8 @@ class TestUpdateCheckEndpoint:
         assert body["update_available"] is True
         # git/pip installs can apply the update in place from the dashboard.
         assert body["can_apply"] is True
-
-
+        assert body.get("error_code") in (None, "")
+        assert body.get("current_revision") == "abc123"
 
     def test_managed_runtime_dashboard_is_not_applyable(self, monkeypatch):
         import hermes_cli.web_server as ws
@@ -822,9 +833,46 @@ class TestUpdateCheckEndpoint:
         assert body["can_apply"] is False
         assert body["update_available"] is False
         assert body["behind"] is None
+        assert body.get("error_code") in (None, "")
         assert "managed outside this dashboard" in body["message"]
 
+    def test_docker_behind_null_is_unsupported_not_error(self, monkeypatch):
+        import hermes_cli.web_server as ws
 
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "docker")
+        monkeypatch.setattr(
+            ws, "format_docker_update_message", lambda: "Docker images are immutable."
+        )
+
+        body = self.client.get("/api/hermes/update/check").json()
+        assert body["behind"] is None
+        assert body["update_available"] is False
+        assert body.get("error_code") in (None, "")
+
+    def test_git_check_failure_exposes_error_code_not_latest(self, monkeypatch):
+        import hermes_cli.web_server as ws
+        import hermes_cli.banner as banner
+
+        monkeypatch.setattr(ws, "detect_install_method", lambda *a, **k: "git")
+        monkeypatch.setattr(banner, "repo_install_writable", lambda *_a, **_k: False)
+        monkeypatch.setattr(
+            banner,
+            "check_for_updates_details",
+            lambda: {
+                "behind": None,
+                "error_code": "git-ownership",
+                "current_revision": None,
+                "message": "Git refused this checkout due to ownership mismatch.",
+                "repo_writable": False,
+            },
+        )
+
+        body = self.client.get("/api/hermes/update/check").json()
+        assert body["behind"] is None
+        assert body["update_available"] is False
+        assert body["error_code"] == "git-ownership"
+        assert body["can_apply"] is False
+        assert "ownership" in (body.get("message") or "").lower()
 
 
 class TestDebugShareEndpoint:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -13,6 +13,59 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def test_local_git_compatibility_wrapper_returns_two_fields(monkeypatch, tmp_path):
+    import hermes_cli.banner as banner
+
+    monkeypatch.setattr(
+        banner,
+        "_check_via_local_git_details",
+        lambda _repo: (3, None, "a" * 40, "b" * 40),
+    )
+
+    assert banner._check_via_local_git(tmp_path) == (3, None)
+
+
+def test_update_cache_rejects_non_object_revision_provenance(monkeypatch, tmp_path):
+    import hermes_cli.banner as banner
+    import hermes_cli.config as config
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "ts": time.time(),
+                "behind": 0,
+                "rev": None,
+                "ver": banner.VERSION,
+                "error_code": None,
+                "current_revision": "HEAD",
+                "upstream_revision": "origin/main",
+                "message": None,
+                "repo_writable": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls = {"n": 0}
+
+    def checked(_repo):
+        calls["n"] += 1
+        return 4, None, "a" * 40, "b" * 40
+
+    monkeypatch.setattr(banner, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(config, "detect_install_method", lambda _root: "source")
+    monkeypatch.setattr(banner, "_check_via_local_git_details", checked)
+    monkeypatch.setattr(banner, "repo_install_writable", lambda _repo: True)
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+
+    result = banner.check_for_updates_details()
+
+    assert calls["n"] == 1
+    assert result["behind"] == 4
+    assert result["current_revision"] == "a" * 40
+    assert result["upstream_revision"] == "b" * 40
+
+
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     """When cache is fresh, check_for_updates should return cached value without calling git."""
     from hermes_cli.banner import check_for_updates
@@ -102,7 +155,7 @@ def test_check_via_local_git_ownership_falls_back_to_ls_remote(tmp_path, monkeyp
         return R(128, "", "unexpected: " + " ".join(argv))
 
     monkeypatch.setattr(banner.subprocess, "run", fake_run)
-    behind, err, rev = banner._check_via_local_git(repo)
+    behind, err, rev, _ = banner._check_via_local_git_details(repo)
     assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
     assert err is None
     assert rev == head
@@ -128,7 +181,7 @@ def test_check_via_local_git_head_failure_is_error_not_zero(tmp_path, monkeypatc
         return R()
 
     monkeypatch.setattr(banner.subprocess, "run", fake_run)
-    behind, err, rev = banner._check_via_local_git(repo)
+    behind, err, rev, _ = banner._check_via_local_git_details(repo)
     assert behind is None
     assert err == "git-ownership"
     assert rev is None
@@ -193,7 +246,7 @@ def test_failed_fetch_never_trusts_stale_fetch_head(tmp_path, monkeypatch):
         return R(128, "", "unexpected: " + " ".join(argv))
 
     monkeypatch.setattr(banner.subprocess, "run", fake_run)
-    behind, err, rev = banner._check_via_local_git(repo)
+    behind, err, rev, _ = banner._check_via_local_git_details(repo)
     assert fetch_attempted["n"] >= 1
     # Behind unknown count (real upstream differs from HEAD), not 0 from stale.
     assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
@@ -250,7 +303,7 @@ def test_shallow_fetch_uses_absolute_depth_target_not_deepen(tmp_path, monkeypat
         return R(128, "", "unexpected: " + " ".join(argv))
 
     monkeypatch.setattr(banner.subprocess, "run", fake_run)
-    behind, err, rev = banner._check_via_local_git(repo)
+    behind, err, rev, _ = banner._check_via_local_git_details(repo)
     assert behind == 7
     assert err is None
     assert rev == head
@@ -300,7 +353,7 @@ def test_equal_tips_skip_depth_fetch(tmp_path, monkeypatch):
         return R(128, "", "unexpected: " + " ".join(argv))
 
     monkeypatch.setattr(banner.subprocess, "run", fake_run)
-    behind, err, rev = banner._check_via_local_git(repo)
+    behind, err, rev, _ = banner._check_via_local_git_details(repo)
     assert behind == 0
     assert err is None
     assert rev == tip

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -305,24 +305,3 @@ def test_equal_tips_skip_depth_fetch(tmp_path, monkeypatch):
     assert err is None
     assert rev == tip
     assert fetch_calls["n"] == 0
-
-
-def test_passive_path_has_no_lock_unlink_helpers():
-    """v2 must not expose passive shallow.lock unlinking."""
-    import hermes_cli.banner as banner
-    import ast
-    import inspect
-
-    assert not hasattr(banner, "_clear_stale_shallow_locks")
-    src = inspect.getsource(banner._check_via_local_git)
-    # Docstring may name locks; executable body must never unlink them.
-    tree = ast.parse(src)
-    unlinks = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Attribute) and node.attr == "unlink"
-    ]
-    assert unlinks == []
-    full = Path(banner.__file__).read_text(encoding="utf-8")
-    assert "_clear_stale_shallow_locks" not in full
-    assert "never unlink" in full.lower()

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -1,15 +1,16 @@
 """Tests for the update check mechanism in hermes_cli.banner."""
 
+from __future__ import annotations
+
 import json
 import os
+import subprocess
 import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
@@ -33,10 +34,6 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     mock_run.assert_not_called()
 
 
-
-
-
-
 def test_prefetch_non_blocking():
     """prefetch_update_check() should return immediately without blocking."""
     import hermes_cli.banner as banner
@@ -58,5 +55,274 @@ def test_prefetch_non_blocking():
         assert banner._update_result == 5
 
 
+def test_check_via_local_git_ownership_falls_back_to_ls_remote(tmp_path, monkeypatch):
+    """Root-owned / non-fetchable checkouts must still report availability.
+
+    Process-local safe.directory is used for read-only HEAD; fetch write
+    failures fall back to ls-remote. Never treat this as up-to-date/null.
+    """
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "install"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    upstream = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+    def fake_run(args, **kwargs):
+        # args is full argv including optional -c safe.directory=
+        argv = list(args)
+        # strip leading git [-c safe.directory=...]
+        while argv and argv[0] == "git":
+            argv = argv[1:]
+        while len(argv) >= 2 and argv[0] == "-c":
+            argv = argv[2:]
+
+        class R:
+            def __init__(self, rc=0, out="", err=""):
+                self.returncode = rc
+                self.stdout = out
+                self.stderr = err
+
+        if argv[:2] == ["rev-parse", "HEAD"]:
+            return R(0, head + "\n")
+        if argv[:3] == ["remote", "get-url", "origin"]:
+            return R(0, "https://github.com/NousResearch/hermes-agent.git\n")
+        if argv[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return R(0, "false\n")
+        if argv[:3] == ["fetch", "origin", "main"]:
+            return R(1, "", "fatal: Unable to create temporary file: Permission denied\n")
+        if argv[:2] == ["ls-remote", banner._UPSTREAM_REPO_URL] or (
+            argv[:1] == ["ls-remote"] and "NousResearch" in " ".join(argv)
+        ):
+            return R(0, f"{upstream}\trefs/heads/main\n")
+        if argv[:3] == ["rev-list", "--count", "HEAD..origin/main"]:
+            return R(128, "", "fatal: bad revision\n")
+        return R(128, "", "unexpected: " + " ".join(argv))
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    behind, err, rev = banner._check_via_local_git(repo)
+    assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert err is None
+    assert rev == head
 
 
+def test_check_via_local_git_head_failure_is_error_not_zero(tmp_path, monkeypatch):
+    """If even ownership-relaxed HEAD fails, return null + error_code."""
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "install"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    def fake_run(args, **kwargs):
+        class R:
+            returncode = 128
+            stdout = ""
+            stderr = (
+                "fatal: detected dubious ownership in repository at "
+                f"'{repo}'\n"
+            )
+
+        return R()
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    behind, err, rev = banner._check_via_local_git(repo)
+    assert behind is None
+    assert err == "git-ownership"
+    assert rev is None
+
+
+def test_repo_install_writable_false_when_git_not_writable(tmp_path):
+    from hermes_cli.banner import repo_install_writable
+
+    repo = tmp_path / "install"
+    git = repo / ".git"
+    repo.mkdir()
+    git.mkdir()
+    git.chmod(0o555)
+    repo.chmod(0o555)
+    try:
+        assert repo_install_writable(repo) is False
+    finally:
+        repo.chmod(0o755)
+        git.chmod(0o755)
+
+
+def test_failed_fetch_never_trusts_stale_fetch_head(tmp_path, monkeypatch):
+    """Failed fetch + pre-existing FETCH_HEAD must fail closed via ls-remote."""
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "install"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    stale_fetch = "cccccccccccccccccccccccccccccccccccccccc"
+    real_upstream = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    fetch_attempted = {"n": 0}
+
+    def fake_run(args, **kwargs):
+        argv = list(args)
+        while argv and argv[0] == "git":
+            argv = argv[1:]
+        while len(argv) >= 2 and argv[0] == "-c":
+            argv = argv[2:]
+
+        class R:
+            def __init__(self, rc=0, out="", err=""):
+                self.returncode = rc
+                self.stdout = out
+                self.stderr = err
+
+        if argv[:2] == ["rev-parse", "HEAD"]:
+            return R(0, head + "\n")
+        if argv[:3] == ["remote", "get-url", "origin"]:
+            return R(0, "https://github.com/NousResearch/hermes-agent.git\n")
+        if argv[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return R(0, "true\n")
+        if argv[:2] == ["rev-parse", "FETCH_HEAD"]:
+            # Stale tip — must NOT be used when fetch fails.
+            return R(0, stale_fetch + "\n")
+        if argv[:1] == ["fetch"]:
+            fetch_attempted["n"] += 1
+            return R(128, "", "fatal: couldn't find remote ref main\n")
+        if argv[:1] == ["ls-remote"]:
+            return R(0, f"{real_upstream}\trefs/heads/main\n")
+        return R(128, "", "unexpected: " + " ".join(argv))
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    behind, err, rev = banner._check_via_local_git(repo)
+    assert fetch_attempted["n"] >= 1
+    # Behind unknown count (real upstream differs from HEAD), not 0 from stale.
+    assert behind == banner.UPDATE_AVAILABLE_NO_COUNT
+    assert err is None
+    assert rev == head
+    # And not treating stale FETCH_HEAD as equal to anything useful for count.
+    assert behind != 0
+
+
+def test_shallow_fetch_uses_absolute_depth_target_not_deepen(tmp_path, monkeypatch):
+    """Shallow recovery must use absolute --depth TARGET, never relative --deepen."""
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "install"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    upstream = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    seen_fetch: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        argv = list(args)
+        while argv and argv[0] == "git":
+            argv = argv[1:]
+        while len(argv) >= 2 and argv[0] == "-c":
+            argv = argv[2:]
+
+        class R:
+            def __init__(self, rc=0, out="", err=""):
+                self.returncode = rc
+                self.stdout = out
+                self.stderr = err
+
+        if argv[:2] == ["rev-parse", "HEAD"]:
+            return R(0, head + "\n")
+        if argv[:3] == ["remote", "get-url", "origin"]:
+            return R(0, "https://github.com/NousResearch/hermes-agent.git\n")
+        if argv[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return R(0, "true\n")
+        if argv[:1] == ["ls-remote"]:
+            return R(0, f"{upstream}\trefs/heads/main\n")
+        if argv[:1] == ["fetch"]:
+            seen_fetch.append(list(argv))
+            return R(0, "", "")
+        if argv[:2] == ["rev-parse", "FETCH_HEAD"]:
+            return R(0, upstream + "\n")
+        if argv[:2] == ["rev-parse", "origin/main"]:
+            return R(0, upstream + "\n")
+        if argv[:1] == ["merge-base"]:
+            return R(0, head + "\n")
+        if argv[:2] == ["rev-list", "--count"]:
+            return R(0, "7\n")
+        return R(128, "", "unexpected: " + " ".join(argv))
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    behind, err, rev = banner._check_via_local_git(repo)
+    assert behind == 7
+    assert err is None
+    assert rev == head
+    assert seen_fetch, "expected a fetch"
+    for argv in seen_fetch:
+        assert "--deepen" not in argv
+        assert "--depth" in argv
+        depth_idx = argv.index("--depth")
+        assert argv[depth_idx + 1] == str(banner._SHALLOW_HISTORY_TARGET)
+
+
+def test_equal_tips_skip_depth_fetch(tmp_path, monkeypatch):
+    """Equal-tip shallow installs must not deepen on every check."""
+    import hermes_cli.banner as banner
+
+    repo = tmp_path / "install"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    tip = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    fetch_calls = {"n": 0}
+
+    def fake_run(args, **kwargs):
+        argv = list(args)
+        while argv and argv[0] == "git":
+            argv = argv[1:]
+        while len(argv) >= 2 and argv[0] == "-c":
+            argv = argv[2:]
+
+        class R:
+            def __init__(self, rc=0, out="", err=""):
+                self.returncode = rc
+                self.stdout = out
+                self.stderr = err
+
+        if argv[:2] == ["rev-parse", "HEAD"]:
+            return R(0, tip + "\n")
+        if argv[:3] == ["remote", "get-url", "origin"]:
+            return R(0, "https://github.com/NousResearch/hermes-agent.git\n")
+        if argv[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return R(0, "true\n")
+        if argv[:1] == ["ls-remote"]:
+            return R(0, f"{tip}\trefs/heads/main\n")
+        if argv[:1] == ["fetch"]:
+            fetch_calls["n"] += 1
+            return R(0, "", "")
+        return R(128, "", "unexpected: " + " ".join(argv))
+
+    monkeypatch.setattr(banner.subprocess, "run", fake_run)
+    behind, err, rev = banner._check_via_local_git(repo)
+    assert behind == 0
+    assert err is None
+    assert rev == tip
+    assert fetch_calls["n"] == 0
+
+
+def test_passive_path_has_no_lock_unlink_helpers():
+    """v2 must not expose passive shallow.lock unlinking."""
+    import hermes_cli.banner as banner
+    import ast
+    import inspect
+
+    assert not hasattr(banner, "_clear_stale_shallow_locks")
+    src = inspect.getsource(banner._check_via_local_git)
+    # Docstring may name locks; executable body must never unlink them.
+    tree = ast.parse(src)
+    unlinks = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == "unlink"
+    ]
+    assert unlinks == []
+    full = Path(banner.__file__).read_text(encoding="utf-8")
+    assert "_clear_stale_shallow_locks" not in full
+    assert "never unlink" in full.lower()


### PR DESCRIPTION
## Summary

Shallow candidate/worktree installs were stuck at `behind=-1` (Desktop badge `(update)` instead of `(+N)`). Closed #83163 attempted lock recovery + deepen but was **BLOCK**ed for three safety defects. This v2 fix addresses behind-counts **without** those hazards, and intentionally integrates open #82658 structured backend update facts so the two patches cannot overwrite each other.

### Safety contract (v2)

1. **No passive lock unlinks.** Update checks never delete `shallow.lock`, `index.lock`, `HEAD.lock`, or `packed-refs.lock`. Lock recovery belongs only in explicit quiescent maintenance.
2. **No progressive deepen.** Equal-tip checks short-circuit via `ls-remote` (no fetch/depth growth). When tips differ, recovery uses absolute `git fetch --depth <TARGET>` (idempotent), never relative `--deepen` on every cache expiry.
3. **FETCH_HEAD only after successful current fetch.** Failed fetch + stale `FETCH_HEAD` fails closed to ls-remote / `UPDATE_AVAILABLE_NO_COUNT` / error — never trusts leftover tips.
4. **Linked worktree / common-dir** aware writable probes; argv-only bounded subprocesses; truthful positive behind counts when merge-base connects; safe `UPDATE_AVAILABLE_NO_COUNT` fallback otherwise.
5. **Integrates #82658:** structured `_git_run` / fetch-result / `check_for_updates_details` / ownership-safe read-only probes / Dashboard `error_code` + `repo_writable` / `can_apply`.

### Overlap disposition

| Source | Status | Relation |
|--------|--------|----------|
| #83163 | closed after BLOCK | Superseded by this v2 (no passive lock delete; capped depth; fail-closed FETCH_HEAD) |
| #82658 | open | **Integrated here** — same structured backend facts + this shallow safety. Prefer this PR; close #82658 as superseded once this lands |
| #82608 | open | Desktop UI only — orthogonal |

### Test plan

Exact head verification:

```bash
HERMES_PYTHON=... ./scripts/run_tests.sh \
  tests/hermes_cli/test_update_check.py \
  tests/hermes_cli/test_banner_shallow_safety.py \
  tests/hermes_cli/test_banner_update_git_ownership.py \
  tests/hermes_cli/test_banner.py \
  tests/hermes_cli/test_banner_git_state.py \
  tests/hermes_cli/test_dashboard_admin_endpoints.py
# → 66 passed
ruff check hermes_cli/banner.py hermes_cli/web_server.py tests/hermes_cli/test_*.py
# → All checks passed
```

Acceptance coverage includes real `file://` shallow clones (repeated equal-tip no-deepen), old-but-live `shallow.lock` never unlinked, lock replacement race (no unlink helper), failed fetch + stale FETCH_HEAD, real shallow linked worktree/common-dir, absolute depth idempotence, ownership/ls-remote fallback, and Dashboard error_code/`can_apply` contracts.

**Do not deploy before independent review PASS.**