### PR TITLE
fix(gateway): classify real token locks and keep lifecycle running

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -10,10 +10,57 @@ from hermes_cli.config import DEFAULT_CONFIG
 GATEWAY_SERVICE_RESTART_EXIT_CODE = 75
 
 # EX_CONFIG from sysexits.h — fatal configuration error (e.g. token
-# collision, no messaging platforms).  The s6 finish script translates
-# this into exit 125 (permanent failure) so the supervisor stops
-# restarting the gateway.  See #51228.
+# collision / single-writer lock conflict).  The s6 finish script
+# translates this into exit 125 (permanent failure) so the supervisor
+# stops restarting the gateway.  See #51228.
+#
+# Platform-local auth/config failures (missing membership, unpaired
+# bridge, missing adapter credentials) are NOT EX_CONFIG: they park the
+# affected adapter and leave cron/Kanban/other platforms running.
 GATEWAY_FATAL_CONFIG_EXIT_CODE = 78
+
+
+def is_global_startup_conflict(
+    error_code: str | None = None,
+    message: str | None = None,
+) -> bool:
+    """Return True when a platform failure is a gateway-global single-writer conflict.
+
+    Production token locks (Discord/Telegram/Slack/WhatsApp/Signal) are
+    emitted by ``BasePlatformAdapter._acquire_platform_lock`` with
+    ``retryable=True`` so a *later* reconnect can recover after a live
+    holder exits. At zero-connected startup, however, those failures are
+    still exclusive-ownership conflicts and must force
+    ``GATEWAY_FATAL_CONFIG_EXIT_CODE`` — classification inspects the
+    conflict semantics (code/message), not the retryable flag alone.
+
+    Platform-local auth/config errors (Buzz membership, missing
+    credentials, unpaired bridges) must stay isolated so optional
+    adapters cannot take down unrelated gateway duties.
+    """
+    code = (error_code or "").strip().lower()
+    if code:
+        if code == "lock_conflict":
+            return True
+        if code.endswith("_lock"):
+            return True
+        if "polling_conflict" in code:
+            return True
+        return False
+
+    msg = (message or "").lower()
+    if "already in use" not in msg:
+        return False
+    return any(
+        marker in msg
+        for marker in (
+            "stop the other gateway",
+            "another local hermes",
+            "another profile",
+            "pid ",
+        )
+    )
+
 
 # Set by ``hermes gateway run --external-supervisor``. Unlike systemd's
 # INVOCATION_ID and launchd's XPC_SERVICE_NAME, this survives wrappers that

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -20,6 +20,31 @@ GATEWAY_SERVICE_RESTART_EXIT_CODE = 75
 GATEWAY_FATAL_CONFIG_EXIT_CODE = 78
 
 
+def _message_looks_like_polling_conflict(message: str) -> bool:
+    """Return True when *message* matches a Telegram getUpdates single-writer 409.
+
+    Production Telegram connect can surface a live foreign poller as a generic
+    ``telegram_connect_error`` whose body still carries the Bot API 409 text
+    (``Conflict: terminated by other getUpdates request``). Classification must
+    recognize that payload even when the structured code was not upgraded to
+    ``telegram_polling_conflict``.
+    """
+    msg = (message or "").lower()
+    if not msg:
+        return False
+    if "terminated by other getupdates request" in msg:
+        return True
+    if "another bot instance is running" in msg:
+        return True
+    if "another getupdates request" in msg:
+        return True
+    # Narrow 409 + getUpdates pairing avoids treating unrelated HTTP 409s as
+    # exclusive-ownership conflicts.
+    if "409" in msg and "getupdates" in msg:
+        return True
+    return False
+
+
 def is_global_startup_conflict(
     error_code: str | None = None,
     message: str | None = None,
@@ -34,11 +59,15 @@ def is_global_startup_conflict(
     ``GATEWAY_FATAL_CONFIG_EXIT_CODE`` — classification inspects the
     conflict semantics (code/message), not the retryable flag alone.
 
+    Telegram production 409 getUpdates conflicts must also fail closed even
+    when the adapter only recorded a generic ``telegram_connect_error``.
+
     Platform-local auth/config errors (Buzz membership, missing
     credentials, unpaired bridges) must stay isolated so optional
     adapters cannot take down unrelated gateway duties.
     """
     code = (error_code or "").strip().lower()
+    msg = message or ""
     if code:
         if code == "lock_conflict":
             return True
@@ -46,13 +75,18 @@ def is_global_startup_conflict(
             return True
         if "polling_conflict" in code:
             return True
+        # Generic Telegram connect envelope still carrying a production 409.
+        if code == "telegram_connect_error" and _message_looks_like_polling_conflict(msg):
+            return True
         return False
 
-    msg = (message or "").lower()
-    if "already in use" not in msg:
+    msg_l = msg.lower()
+    if _message_looks_like_polling_conflict(msg_l):
+        return True
+    if "already in use" not in msg_l:
         return False
     return any(
-        marker in msg
+        marker in msg_l
         for marker in (
             "stop the other gateway",
             "another local hermes",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2460,6 +2460,7 @@ from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
+    is_global_startup_conflict,
     parse_restart_after_turn_timeout,
     parse_restart_drain_timeout,
 )
@@ -11295,9 +11296,109 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         connected_count = 0
         enabled_platform_count = 0
-        startup_nonretryable_errors: list[str] = []
+        # Startup failure buckets. Classification inspects real conflict
+        # semantics (lock / polling ownership) before the adapter's
+        # retryable flag — production token locks are emitted retryable
+        # so reconnect can recover later, but pure single-writer conflicts
+        # at zero-connected startup still exit 78.
+        # global/local entries: (label, error_code|None, human message)
+        startup_global_conflicts: list[tuple[str, str | None, str]] = []
+        startup_local_nonretryable: list[tuple[str, str | None, str]] = []
         startup_retryable_errors: list[str] = []
-        
+
+        def _format_startup_entries(
+            entries: list[tuple[str, str | None, str]],
+        ) -> str:
+            return "; ".join(f"{label}: {msg}" for label, _code, msg in entries)
+
+        def _record_startup_adapter_failure(
+            platform: Platform,
+            adapter: "BasePlatformAdapter | None",
+            *,
+            platform_config: "PlatformConfig | None" = None,
+            profile_name: str | None = None,
+            fallback_message: str = "failed to connect",
+            queue_retry: bool = True,
+        ) -> None:
+            """Classify one failed connect before generic retry routing."""
+            label = (
+                f"{profile_name}/{platform.value}"
+                if profile_name
+                else platform.value
+            )
+            if adapter is not None and adapter.has_fatal_error:
+                code = adapter.fatal_error_code
+                message = adapter.fatal_error_message or fallback_message
+                detail = f"{label}: {message}"
+                if is_global_startup_conflict(code, message):
+                    # True single-writer conflict — park fatal, never
+                    # retry-storm the token/identity while a live holder
+                    # owns it. Exit-78 decision uses this bucket alone.
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="fatal",
+                        error_code=code,
+                        error_message=message,
+                    )
+                    startup_global_conflicts.append((label, code, message))
+                    return
+                if adapter.fatal_error_retryable:
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="retrying",
+                        error_code=code,
+                        error_message=message,
+                    )
+                    startup_retryable_errors.append(detail)
+                    if queue_retry and profile_name is None and platform_config is not None:
+                        self._failed_platforms[platform] = {
+                            "config": platform_config,
+                            "attempts": 1,
+                            "next_retry": time.monotonic() + 30,
+                            "credential_claim": self._adapter_credential_claim(
+                                platform, adapter
+                            ),
+                            "listener_claim": self._adapter_listener_claim(
+                                platform, adapter
+                            ),
+                        }
+                    return
+                self._update_platform_runtime_status(
+                    platform.value,
+                    platform_state="fatal",
+                    error_code=code,
+                    error_message=message,
+                )
+                startup_local_nonretryable.append((label, code, message))
+                return
+
+            message = fallback_message
+            detail = f"{label}: {message}"
+            self._update_platform_runtime_status(
+                platform.value,
+                platform_state="retrying",
+                error_code=None,
+                error_message=message,
+            )
+            startup_retryable_errors.append(detail)
+            if (
+                queue_retry
+                and profile_name is None
+                and platform_config is not None
+                and adapter is not None
+            ):
+                self._failed_platforms[platform] = {
+                    "config": platform_config,
+                    "attempts": 1,
+                    "next_retry": time.monotonic() + 30,
+                    "credential_claim": self._adapter_credential_claim(
+                        platform, adapter
+                    ),
+                    "listener_claim": self._adapter_listener_claim(
+                        platform, adapter
+                    ),
+                }
+
         # Initialize and connect each configured platform
         _multiplex_on = bool(getattr(self.config, "multiplex_profiles", False))
         _multiplex_skipped_platforms: list[Platform] = []
@@ -11394,81 +11495,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # are expected to be idempotent and tolerate
                     # partial-init state.
                     await self._safe_adapter_disconnect(adapter, platform)
-                    if adapter.has_fatal_error:
-                        self._update_platform_runtime_status(
-                            platform.value,
-                            platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
-                            error_code=adapter.fatal_error_code,
-                            error_message=adapter.fatal_error_message,
-                        )
-                        target = (
-                            startup_retryable_errors
-                            if adapter.fatal_error_retryable
-                            else startup_nonretryable_errors
-                        )
-                        target.append(
-                            f"{platform.value}: {adapter.fatal_error_message}"
-                        )
-                        # Queue for reconnection if the error is retryable
-                        if adapter.fatal_error_retryable:
-                            self._failed_platforms[platform] = {
-                                "config": platform_config,
-                                "attempts": 1,
-                                "next_retry": time.monotonic() + 30,
-                                "credential_claim": self._adapter_credential_claim(
-                                    platform, adapter
-                                ),
-                                "listener_claim": self._adapter_listener_claim(
-                                    platform, adapter
-                                ),
-                            }
-                    else:
-                        self._update_platform_runtime_status(
-                            platform.value,
-                            platform_state="retrying",
-                            error_code=None,
-                            error_message="failed to connect",
-                        )
-                        startup_retryable_errors.append(
-                            f"{platform.value}: failed to connect"
-                        )
-                        # No fatal error info means likely a transient issue — queue for retry
-                        self._failed_platforms[platform] = {
-                            "config": platform_config,
-                            "attempts": 1,
-                            "next_retry": time.monotonic() + 30,
-                            "credential_claim": self._adapter_credential_claim(
-                                platform, adapter
-                            ),
-                            "listener_claim": self._adapter_listener_claim(
-                                platform, adapter
-                            ),
-                        }
+                    _record_startup_adapter_failure(
+                        platform,
+                        adapter,
+                        platform_config=platform_config,
+                    )
             except Exception as e:
                 logger.error("✗ %s error: %s", platform.value, e)
                 # Same defensive cleanup path for exceptions — an adapter
                 # that raised mid-connect may still have a live
                 # aiohttp.ClientSession or child subprocess.
                 await self._safe_adapter_disconnect(adapter, platform)
-                self._update_platform_runtime_status(
-                    platform.value,
-                    platform_state="retrying",
-                    error_code=None,
-                    error_message=str(e),
+                _record_startup_adapter_failure(
+                    platform,
+                    adapter if "adapter" in locals() else None,
+                    platform_config=platform_config,
+                    fallback_message=str(e),
                 )
-                startup_retryable_errors.append(f"{platform.value}: {e}")
-                # Unexpected exceptions are typically transient — queue for retry
-                self._failed_platforms[platform] = {
-                    "config": platform_config,
-                    "attempts": 1,
-                    "next_retry": time.monotonic() + 30,
-                    "credential_claim": self._adapter_credential_claim(
-                        platform, adapter
-                    ),
-                    "listener_claim": self._adapter_listener_claim(
-                        platform, adapter
-                    ),
-                }
             if await self._abort_startup_if_shutdown_requested():
                 return True
 
@@ -11476,8 +11519,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # this gateway serves. Each profile's adapters connect under that
         # profile's home + credential scope and stamp their inbound events with
         # the profile so the agent turn resolves correctly. No-op when off.
+        # Secondary lock_conflict / token-lock failures feed the same
+        # classification buckets as primary — they are not silently dropped.
         try:
-            _secondary_connected = await self._start_secondary_profile_adapters()
+            _secondary_connected = await self._start_secondary_profile_adapters(
+                record_startup_failure=_record_startup_adapter_failure,
+            )
             connected_count += _secondary_connected
         except MultiplexConfigError as e:
             # Invalid multiplexer config — abort startup cleanly so the operator
@@ -11520,8 +11567,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         if connected_count == 0:
-            if startup_nonretryable_errors and not startup_retryable_errors:
-                reason = "; ".join(startup_nonretryable_errors)
+            # True single-writer / exclusive-ownership conflicts remain fatal
+            # whenever nothing is connected and nothing is merely retryable.
+            # Classification already peeled lock conflicts out of the
+            # retryable bucket even when adapters emit retryable=True
+            # (production _acquire_platform_lock).
+            # Platform-local auth/config failures alone must not kill
+            # cron/Kanban/other gateway duties (production: optional Buzz
+            # relay_membership_required previously exited 78).
+            if startup_global_conflicts and not startup_retryable_errors:
+                reason = _format_startup_entries(startup_global_conflicts)
+                if startup_local_nonretryable:
+                    reason = (
+                        f"{reason}; also parked: "
+                        f"{_format_startup_entries(startup_local_nonretryable)}"
+                    )
                 logger.error("Gateway hit a non-retryable startup conflict: %s", reason)
                 try:
                     from gateway.status import write_runtime_status
@@ -11532,26 +11592,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._request_clean_exit(reason)
                 self._startup_restore_in_progress = False
                 return True
-            if startup_nonretryable_errors:
-                # Mixed failure mode (NS-609): some platforms are fatally
-                # misconfigured (e.g. WhatsApp enabled but never paired) while
-                # others hit merely transient errors (e.g. Telegram TimedOut
-                # during polling startup).  Exiting with
+            parked = startup_local_nonretryable + (
+                startup_global_conflicts if startup_retryable_errors else []
+            )
+            if parked:
+                # Platform-local-only and/or mixed-with-retryable failure mode
+                # (NS-609 + optional-platform isolation). Exiting with
                 # GATEWAY_FATAL_CONFIG_EXIT_CODE here is wrong in both
                 # supervision worlds: under supervisors that honor the
                 # exit-78 contract (systemd RestartPreventExitStatus, s6
                 # finish→125 since #51228) the gateway goes PERMANENTLY down
-                # over a network blip; under anything else it crash-loops.
-                # Either way the retryable platforms never get their retry.
-                # Log the fatal side loudly, then fall through to the
-                # degraded/retry path below: the reconnect watcher recovers
-                # the retryable platforms; the non-retryable ones remain
-                # fatal-parked and visible in runtime status.
+                # over an optional adapter; under anything else it crash-loops.
+                # Log the fatal side loudly, then fall through so cron/Kanban
+                # and any retryable platforms keep running. Lifecycle stays
+                # "running" — per-platform fatal/retrying status holds the
+                # detail. Do NOT persist gateway_state=degraded: busy/drain
+                # controls only treat "running" as busy/drainable.
                 logger.error(
                     "%d platform(s) fatally misconfigured and parked: %s. "
-                    "Staying alive so retryable platforms can recover.",
-                    len(startup_nonretryable_errors),
-                    "; ".join(startup_nonretryable_errors),
+                    "Staying alive so gateway duties and any recoverable "
+                    "platforms can continue.",
+                    len(parked),
+                    _format_startup_entries(parked),
                 )
             if enabled_platform_count > 0:
                 if startup_retryable_errors:
@@ -11571,26 +11633,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "%d platform(s) queued for retry: %s",
                         len(self._failed_platforms), reason,
                     )
-                    try:
-                        from gateway.status import write_runtime_status
-                        write_runtime_status(
-                            gateway_state="degraded",
-                            exit_reason=None,
-                        )
-                    except Exception:
-                        pass
                     # Fall through to the normal "running" state — reconnect
-                    # watcher takes it from here.
-                # All enabled platforms had no adapter (missing library or credentials).
-                # In fleet deployments the same config.yaml is shared across nodes that
-                # may only have credentials for a subset of platforms.  Rather than
-                # failing hard, degrade gracefully and allow cron jobs to run (#5196).
-                logger.warning(
-                    "No adapter could be created for any of the %d configured platform(s). "
-                    "Check that required dependencies are installed and credentials are set. "
-                    "Gateway will continue for cron job execution.",
-                    enabled_platform_count,
-                )
+                    # watcher takes it from here. Lifecycle remains "running"
+                    # so busy/drain contracts stay valid while cron/Kanban work.
+                elif not startup_local_nonretryable and not startup_global_conflicts:
+                    # All enabled platforms had no adapter (missing library or credentials).
+                    # In fleet deployments the same config.yaml is shared across nodes that
+                    # may only have credentials for a subset of platforms.  Rather than
+                    # failing hard, degrade gracefully and allow cron jobs to run (#5196).
+                    logger.warning(
+                        "No adapter could be created for any of the %d configured platform(s). "
+                        "Check that required dependencies are installed and credentials are set. "
+                        "Gateway will continue for cron job execution.",
+                        enabled_platform_count,
+                    )
             else:
                 logger.warning("No messaging platforms enabled.")
                 logger.info("Gateway will continue running for cron job execution.")
@@ -11602,6 +11658,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._wire_teams_pipeline_runtime()
 
         self._running = True
+        # Always publish lifecycle "running" once startup continues. Optional
+        # platform fatal/retrying detail lives on per-platform status so
+        # busy/drain controls keep working for active cron/Kanban work.
         self._update_runtime_status("running")
 
         # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
@@ -13468,7 +13527,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Wait for shutdown signal."""
         await self._shutdown_event.wait()
 
-    async def _start_secondary_profile_adapters(self) -> int:
+    async def _start_secondary_profile_adapters(
+        self,
+        record_startup_failure: "Callable[..., None] | None" = None,
+    ) -> int:
         """Bring up adapters for every non-active profile this gateway serves.
 
         Returns the number of secondary adapters that connected. No-op (returns
@@ -13482,6 +13544,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         skills, and credentials. Same-platform credential collisions (two
         profiles polling the same bot token) are detected and refused here, the
         only point that sees every profile's resolved credentials together.
+
+        ``record_startup_failure`` (when provided) receives secondary connect
+        failures so lock_conflict / token-lock errors follow the same fatal
+        contract as primary adapters instead of being silently disconnected.
         """
         if not getattr(self.config, "multiplex_profiles", False):
             return 0
@@ -13518,7 +13584,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue  # handled by the primary startup loop
             try:
                 connected += await self._start_one_profile_adapters(
-                    profile_name, profile_home, claimed
+                    profile_name,
+                    profile_home,
+                    claimed,
+                    record_startup_failure=record_startup_failure,
                 )
             except SecondaryPortBindingConfigError as e:
                 logger.warning(
@@ -13557,7 +13626,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return connected
 
     async def _start_one_profile_adapters(
-        self, profile_name: str, profile_home: "Path", claimed: Dict[tuple, str]
+        self,
+        profile_name: str,
+        profile_home: "Path",
+        claimed: Dict[tuple, str],
+        record_startup_failure: "Callable[..., None] | None" = None,
     ) -> int:
         """Create+connect one profile's adapters under its runtime scope."""
         from gateway.config import load_gateway_config
@@ -13680,9 +13753,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
                 else:
                     logger.warning("✗ %s failed to connect (profile: %s)", platform.value, profile_name)
+                    if record_startup_failure is not None:
+                        # Secondary lock_conflict / token-lock must follow the
+                        # same fatal contract as primary — not a silent drop.
+                        record_startup_failure(
+                            platform,
+                            adapter,
+                            platform_config=platform_config,
+                            profile_name=profile_name,
+                            queue_retry=False,
+                        )
                     await self._safe_adapter_disconnect(adapter, platform)
             except Exception as e:
                 logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
+                if record_startup_failure is not None:
+                    record_startup_failure(
+                        platform,
+                        adapter,
+                        platform_config=platform_config,
+                        profile_name=profile_name,
+                        fallback_message=str(e),
+                        queue_retry=False,
+                    )
                 await self._safe_adapter_disconnect(adapter, platform)
         return connected
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5884,6 +5884,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _stop_task: Optional[asyncio.Task] = None
     _restart_task: Optional[asyncio.Task] = None
     _profile_failed_platforms: Optional[Dict[str, Dict[Platform, asyncio.Task]]] = None
+    # profile -> platform -> {credential_claim, listener_claim} held while a
+    # secondary is queued for reconnect. Same-process machine locks are not
+    # enough: another multiplexed profile must not consume the credential.
+    _profile_retry_resource_claims: Optional[
+        Dict[str, Dict[Platform, Dict[str, Any]]]
+    ] = None
     _systemd_watchdog: Optional[Any] = None
     _startup_restore_in_progress: bool = False
 
@@ -6044,6 +6050,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._exit_code: Optional[int] = None
         self._draining = False
         self._profile_failed_platforms: Dict[str, Dict[Platform, asyncio.Task]] = {}
+        self._profile_retry_resource_claims: Dict[
+            str, Dict[Platform, Dict[str, Any]]
+        ] = {}
         self._systemd_watchdog = None
         # External (NAS-driven) drain state — distinct from the shutdown
         # ``_draining`` flag above. Set by ``_drain_control_watcher`` when the
@@ -10799,9 +10808,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _startup_should_abort(self) -> bool:
         return (
-            self._restart_requested
-            or self._draining
-            or self._shutdown_event.is_set()
+            bool(getattr(self, "_restart_requested", False))
+            or bool(getattr(self, "_draining", False))
+            or bool(
+                getattr(getattr(self, "_shutdown_event", None), "is_set", lambda: False)()
+            )
         )
 
     async def _abort_startup_if_shutdown_requested(
@@ -11325,8 +11336,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile_name: str | None = None,
             fallback_message: str = "failed to connect",
             queue_retry: bool = True,
-        ) -> None:
-            """Classify one failed connect before generic retry routing."""
+        ) -> bool:
+            """Classify one failed connect before generic retry routing.
+
+            Returns True when the failure was entered into a retry registry
+            (primary ``_failed_platforms`` or secondary startup retry list).
+            Callers use that to hold credential/listener claims across the
+            retry window so another profile cannot consume the same resource.
+            """
             label = (
                 f"{profile_name}/{platform.value}"
                 if profile_name
@@ -11347,7 +11364,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         error_message=message,
                     )
                     startup_global_conflicts.append((label, code, message))
-                    return
+                    return False
                 if adapter.fatal_error_retryable:
                     self._update_platform_runtime_status(
                         platform.value,
@@ -11362,7 +11379,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         startup_secondary_retries.append(
                             (profile_name, platform, adapter)
                         )
-                        return
+                        return True
                     if queue_retry and platform_config is not None:
                         self._failed_platforms[platform] = {
                             "config": platform_config,
@@ -11375,7 +11392,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 platform, adapter
                             ),
                         }
-                    return
+                        return True
+                    return False
                 self._update_platform_runtime_status(
                     platform.value,
                     platform_state="fatal",
@@ -11383,7 +11401,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     error_message=message,
                 )
                 startup_local_nonretryable.append((label, code, message))
-                return
+                return False
 
             message = fallback_message
             detail = f"{label}: {message}"
@@ -11398,7 +11416,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Treat unknown secondary connect failure as retryable and
                 # enter the profile-scoped reconnect registry.
                 startup_secondary_retries.append((profile_name, platform, adapter))
-                return
+                return True
             if (
                 queue_retry
                 and profile_name is None
@@ -11416,6 +11434,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         platform, adapter
                     ),
                 }
+                return True
+            return False
 
         # Initialize and connect each configured platform
         _multiplex_on = bool(getattr(self.config, "multiplex_profiles", False))
@@ -12993,6 +13013,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     len(unfinished),
                 )
         pending.clear()
+        retry_claims = getattr(self, "_profile_retry_resource_claims", None)
+        if isinstance(retry_claims, dict):
+            retry_claims.clear()
 
     def _start_systemd_watchdog(self) -> bool:
         """Start sd_notify only after a configured gateway is truly running."""
@@ -13568,7 +13591,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _start_secondary_profile_adapters(
         self,
-        record_startup_failure: "Callable[..., None] | None" = None,
+        record_startup_failure: "Callable[..., bool | None] | None" = None,
     ) -> int:
         """Bring up adapters for every non-active profile this gateway serves.
 
@@ -13617,6 +13640,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 retry_claim = retry_info.get(claim_name)
                 if isinstance(retry_claim, tuple):
                     claimed[retry_claim] = active
+        # Same hold for secondary profiles already queued for reconnect — a
+        # transient failure must keep exclusive ownership of the credential
+        # until reconnect succeeds or the claim is explicitly released.
+        retry_claims = getattr(self, "_profile_retry_resource_claims", {})
+        if isinstance(retry_claims, dict):
+            for prof_name, platforms in retry_claims.items():
+                if not isinstance(platforms, dict):
+                    continue
+                for _plat, info in platforms.items():
+                    if not isinstance(info, dict):
+                        continue
+                    for claim_name in ("credential_claim", "listener_claim"):
+                        retry_claim = info.get(claim_name)
+                        if isinstance(retry_claim, tuple):
+                            claimed.setdefault(retry_claim, prof_name)
 
         for profile_name, profile_home in profiles_to_serve(multiplex=True):
             if profile_name == active:
@@ -13669,7 +13707,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         profile_name: str,
         profile_home: "Path",
         claimed: Dict[tuple, str],
-        record_startup_failure: "Callable[..., None] | None" = None,
+        record_startup_failure: "Callable[..., bool | None] | None" = None,
     ) -> int:
         """Create+connect one profile's adapters under its runtime scope."""
         from gateway.config import load_gateway_config
@@ -13782,6 +13820,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     success = await self._connect_initial_adapter_with_timeout(
                         adapter, platform
                     )
+                # stop()/registry teardown can complete while connect is blocked.
+                # Fence publication on the same startup/shutdown state primary
+                # uses: disconnect the late-success adapter and never register it.
+                if success and self._startup_should_abort():
+                    logger.warning(
+                        "✗ %s connected after shutdown began — discarding "
+                        "(profile: %s)",
+                        platform.value,
+                        profile_name,
+                    )
+                    try:
+                        await adapter.cancel_background_tasks()
+                    except Exception as e:
+                        logger.debug(
+                            "✗ %s background-task cancel error: %s",
+                            platform.value,
+                            e,
+                        )
+                    await self._safe_adapter_disconnect(adapter, platform)
+                    continue
                 if success:
                     profile_map[platform] = adapter
                     if credential_claim is not None:
@@ -13792,27 +13850,58 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
                 else:
                     logger.warning("✗ %s failed to connect (profile: %s)", platform.value, profile_name)
+                    queued_retry = False
                     if record_startup_failure is not None:
                         # Secondary lock_conflict / token-lock must follow the
                         # same fatal contract as primary — not a silent drop.
+                        queued_retry = bool(
+                            record_startup_failure(
+                                platform,
+                                adapter,
+                                platform_config=platform_config,
+                                profile_name=profile_name,
+                                queue_retry=False,
+                            )
+                        )
+                    if queued_retry:
+                        # Hold exclusive claims while the secondary is queued
+                        # for reconnect so another profile cannot consume the
+                        # same token/listener before the retry runs.
+                        if credential_claim is not None:
+                            claimed[credential_claim] = profile_name
+                        if listener_claim is not None:
+                            claimed[listener_claim] = profile_name
+                        self._remember_secondary_retry_claims(
+                            profile_name,
+                            platform,
+                            credential_claim=credential_claim,
+                            listener_claim=listener_claim,
+                        )
+                    await self._safe_adapter_disconnect(adapter, platform)
+            except Exception as e:
+                logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
+                queued_retry = False
+                if record_startup_failure is not None:
+                    queued_retry = bool(
                         record_startup_failure(
                             platform,
                             adapter,
                             platform_config=platform_config,
                             profile_name=profile_name,
+                            fallback_message=str(e),
                             queue_retry=False,
                         )
-                    await self._safe_adapter_disconnect(adapter, platform)
-            except Exception as e:
-                logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
-                if record_startup_failure is not None:
-                    record_startup_failure(
+                    )
+                if queued_retry:
+                    if credential_claim is not None:
+                        claimed[credential_claim] = profile_name
+                    if listener_claim is not None:
+                        claimed[listener_claim] = profile_name
+                    self._remember_secondary_retry_claims(
+                        profile_name,
                         platform,
-                        adapter,
-                        platform_config=platform_config,
-                        profile_name=profile_name,
-                        fallback_message=str(e),
-                        queue_retry=False,
+                        credential_claim=credential_claim,
+                        listener_claim=listener_claim,
                     )
                 await self._safe_adapter_disconnect(adapter, platform)
         return connected
@@ -13856,6 +13945,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     with _profile_runtime_scope(profile_home):
                         profile_config = load_gateway_config().platforms.get(platform)
                         if profile_config is None or not profile_config.enabled:
+                            self._forget_secondary_retry_claims(profile_name, platform)
                             return
                         adapter = self._create_adapter(platform, profile_config)
                         if adapter is None:
@@ -13864,10 +13954,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 platform.value,
                                 profile_name,
                             )
+                            self._forget_secondary_retry_claims(profile_name, platform)
                             return
                         self._configure_profile_adapter(
                             adapter, profile_name, platform
                         )
+                        # Enforce the same shared ownership registry used at
+                        # startup *before* any external connect/publication.
+                        # Machine locks alone cannot stop two in-process
+                        # profiles from polling one Telegram token.
+                        conflict_owner = self._secondary_reconnect_claim_conflict(
+                            profile_name, platform, adapter
+                        )
+                        if conflict_owner is not None:
+                            logger.error(
+                                "Secondary %s reconnect refused for profile '%s': "
+                                "credential/listener already owned by profile '%s'",
+                                platform.value,
+                                profile_name,
+                                conflict_owner,
+                            )
+                            await self._safe_adapter_disconnect(adapter, platform)
+                            self._forget_secondary_retry_claims(profile_name, platform)
+                            return
                         success = await self._connect_adapter_with_timeout(
                             adapter, platform, is_reconnect=True
                         )
@@ -13876,6 +13985,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         profile_map = self._profile_adapters.setdefault(profile_name, {})
                         if platform not in profile_map:
                             profile_map[platform] = adapter
+                            self._forget_secondary_retry_claims(profile_name, platform)
                             self._sync_voice_mode_state_to_adapter(adapter)
                             logger.info(
                                 "✓ %s reconnected (profile: %s)",
@@ -13900,6 +14010,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         getattr(adapter, "has_fatal_error", False)
                         and not getattr(adapter, "fatal_error_retryable", True)
                     ):
+                        self._forget_secondary_retry_claims(profile_name, platform)
                         return
                 except asyncio.CancelledError:
                     if adapter is not None:
@@ -13950,6 +14061,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         profile_pending = pending.setdefault(profile_name, {})
         if platform in profile_pending:
             return
+        # Preserve exclusive claims for the duration of the reconnect window.
+        self._remember_secondary_retry_claims(
+            profile_name,
+            platform,
+            credential_claim=self._adapter_credential_claim(platform, adapter),
+            listener_claim=self._adapter_listener_claim(platform, adapter),
+        )
         task = asyncio.create_task(
             self._run_secondary_profile_reconnect(profile_name, platform),
             name=f"secondary-reconnect:{profile_name}:{platform.value}",
@@ -14081,6 +14199,119 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except (TypeError, ValueError):
             return None
         return ("listener", "photon", bind.strip().lower(), port)
+
+    def _remember_secondary_retry_claims(
+        self,
+        profile_name: str,
+        platform: Platform,
+        *,
+        credential_claim: Optional[tuple] = None,
+        listener_claim: Optional[tuple] = None,
+    ) -> None:
+        """Hold exclusive resource claims while a secondary reconnect is pending."""
+        claims = getattr(self, "_profile_retry_resource_claims", None)
+        if not isinstance(claims, dict):
+            claims = {}
+            self._profile_retry_resource_claims = claims
+        profile_claims = claims.setdefault(profile_name, {})
+        entry = profile_claims.get(platform)
+        if not isinstance(entry, dict):
+            entry = {}
+            profile_claims[platform] = entry
+        if isinstance(credential_claim, tuple):
+            entry["credential_claim"] = credential_claim
+        if isinstance(listener_claim, tuple):
+            entry["listener_claim"] = listener_claim
+
+    def _forget_secondary_retry_claims(
+        self, profile_name: str, platform: Platform
+    ) -> None:
+        """Drop secondary retry claims after success, refusal, or non-retryable exit."""
+        claims = getattr(self, "_profile_retry_resource_claims", None)
+        if not isinstance(claims, dict):
+            return
+        profile_claims = claims.get(profile_name)
+        if not isinstance(profile_claims, dict):
+            return
+        profile_claims.pop(platform, None)
+        if not profile_claims:
+            claims.pop(profile_name, None)
+
+    def _collect_adapter_resource_ownership(self) -> Dict[tuple, str]:
+        """Map exclusive credential/listener claims to the owning profile name."""
+        ownership: Dict[tuple, str] = {}
+
+        def _take(claim: Any, owner: str) -> None:
+            if isinstance(claim, tuple) and claim not in ownership:
+                ownership[claim] = owner
+
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            active = get_active_profile_name() or "default"
+        except Exception:
+            active = "default"
+
+        for plat, adapter in list(getattr(self, "adapters", {}).items()):
+            _take(self._adapter_credential_claim(plat, adapter), active)
+            _take(self._adapter_listener_claim(plat, adapter), active)
+
+        for info in list(getattr(self, "_failed_platforms", {}).values()):
+            if not isinstance(info, dict):
+                continue
+            _take(info.get("credential_claim"), active)
+            _take(info.get("listener_claim"), active)
+
+        for prof, amap in list(getattr(self, "_profile_adapters", {}).items()):
+            if not isinstance(amap, dict):
+                continue
+            for plat, adapter in list(amap.items()):
+                _take(self._adapter_credential_claim(plat, adapter), prof)
+                _take(self._adapter_listener_claim(plat, adapter), prof)
+
+        retry_claims = getattr(self, "_profile_retry_resource_claims", {})
+        if isinstance(retry_claims, dict):
+            for prof, platforms in retry_claims.items():
+                if not isinstance(platforms, dict):
+                    continue
+                for _plat, info in platforms.items():
+                    if not isinstance(info, dict):
+                        continue
+                    _take(info.get("credential_claim"), prof)
+                    _take(info.get("listener_claim"), prof)
+        return ownership
+
+    def _secondary_reconnect_claim_conflict(
+        self,
+        profile_name: str,
+        platform: Platform,
+        adapter: Any,
+    ) -> Optional[str]:
+        """Return the foreign owner of a reconnect adapter's claims, if any.
+
+        The reconnecting profile may already hold the claims via the retry
+        registry. Any other profile that currently owns the credential or
+        listener wins — reconnect must not connect or publish in that case.
+        """
+        ownership = self._collect_adapter_resource_ownership()
+        for claim in (
+            self._adapter_credential_claim(platform, adapter),
+            self._adapter_listener_claim(platform, adapter),
+        ):
+            if not isinstance(claim, tuple):
+                continue
+            owner = ownership.get(claim)
+            if owner is not None and owner != profile_name:
+                return owner
+        # Re-assert our hold before external connect so a racing secondary
+        # startup sees the same shared registry.
+        self._remember_secondary_retry_claims(
+            profile_name,
+            platform,
+            credential_claim=self._adapter_credential_claim(platform, adapter),
+            listener_claim=self._adapter_listener_claim(platform, adapter),
+        )
+        return None
 
     @staticmethod
     def _adapter_credential_fingerprint(adapter: Any) -> Optional[str]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11305,6 +11305,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         startup_global_conflicts: list[tuple[str, str | None, str]] = []
         startup_local_nonretryable: list[tuple[str, str | None, str]] = []
         startup_retryable_errors: list[str] = []
+        # Secondary multiplex retryable failures cannot use the primary
+        # ``_failed_platforms`` registry (different HERMES_HOME/secrets).
+        # Collect them here and arm ``_profile_failed_platforms`` once the
+        # runner is marked running — otherwise exit-78 is suppressed while
+        # nothing ever retries (live but deaf secondary).
+        startup_secondary_retries: list[tuple[str, "Platform", "BasePlatformAdapter"]] = []
 
         def _format_startup_entries(
             entries: list[tuple[str, str | None, str]],
@@ -11350,7 +11356,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         error_message=message,
                     )
                     startup_retryable_errors.append(detail)
-                    if queue_retry and profile_name is None and platform_config is not None:
+                    if profile_name is not None:
+                        # Profile-scoped retry registry (not primary
+                        # _failed_platforms — secrets/home differ).
+                        startup_secondary_retries.append(
+                            (profile_name, platform, adapter)
+                        )
+                        return
+                    if queue_retry and platform_config is not None:
                         self._failed_platforms[platform] = {
                             "config": platform_config,
                             "attempts": 1,
@@ -11381,6 +11394,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 error_message=message,
             )
             startup_retryable_errors.append(detail)
+            if profile_name is not None and adapter is not None:
+                # Treat unknown secondary connect failure as retryable and
+                # enter the profile-scoped reconnect registry.
+                startup_secondary_retries.append((profile_name, platform, adapter))
+                return
             if (
                 queue_retry
                 and profile_name is None
@@ -11627,11 +11645,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     #     proxy, etc.)
                     # Exiting here used to convert a single misconfigured
                     # platform into an infinite systemd restart loop.
+                    # Secondary multiplex failures land in the profile-
+                    # scoped retry registry (armed after _running=True);
+                    # primary failures land in ``_failed_platforms``.
                     reason = "; ".join(startup_retryable_errors)
+                    queued = len(self._failed_platforms) + len(startup_secondary_retries)
                     logger.warning(
                         "Gateway started with no connected platforms — "
                         "%d platform(s) queued for retry: %s",
-                        len(self._failed_platforms), reason,
+                        queued, reason,
                     )
                     # Fall through to the normal "running" state — reconnect
                     # watcher takes it from here. Lifecycle remains "running"
@@ -11662,6 +11684,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # platform fatal/retrying detail lives on per-platform status so
         # busy/drain controls keep working for active cron/Kanban work.
         self._update_runtime_status("running")
+
+        # Arm profile-scoped reconnects only after _running is True —
+        # ``_schedule_secondary_profile_reconnect`` refuses work while the
+        # runner is still starting. Secondary retryable startup failures
+        # must not suppress exit 78 without entering this registry.
+        for _sec_profile, _sec_platform, _sec_adapter in startup_secondary_retries:
+            try:
+                self._schedule_secondary_profile_reconnect(
+                    _sec_profile, _sec_platform, _sec_adapter
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to schedule secondary %s reconnect for profile %s",
+                    _sec_platform.value,
+                    _sec_profile,
+                    exc_info=True,
+                )
 
         # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
         # stops refreshing ``state/gateway.heartbeat``. Cancelled with the

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -496,7 +496,10 @@ class BuzzAdapter(BasePlatformAdapter):
             from gateway.status import acquire_scoped_lock
 
             lock_key = f"{self.relay_url}:{self._self_pubkey}"
-            if not acquire_scoped_lock("buzz", lock_key):
+            # acquire_scoped_lock returns (acquired, existing) — never treat the
+            # tuple itself as a boolean (non-empty failure tuples are truthy).
+            acquired, _existing = acquire_scoped_lock("buzz", lock_key)
+            if not acquired:
                 logger.error(
                     "Buzz: identity %s… on %s already in use by another profile",
                     self._self_pubkey[:8],

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -191,7 +191,10 @@ class IRCAdapter(BasePlatformAdapter):
         try:
             from gateway.status import acquire_scoped_lock, release_scoped_lock
             lock_key = f"{self.server}:{self.nickname}"
-            if not acquire_scoped_lock("irc", lock_key):
+            # acquire_scoped_lock returns (acquired, existing) — unpack before
+            # the boolean check so lock-conflict branches remain reachable.
+            acquired, _existing = acquire_scoped_lock("irc", lock_key)
+            if not acquired:
                 logger.error("IRC: %s@%s already in use by another profile", self.nickname, self.server)
                 self._set_fatal_error("lock_conflict", "IRC identity in use by another profile", retryable=False)
                 return False

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -811,7 +811,10 @@ class LineAdapter(BasePlatformAdapter):
             from gateway.status import acquire_scoped_lock
             # Use a hash of the token so we don't write the secret to disk.
             tok_hash = hashlib.sha256(self.channel_access_token.encode()).hexdigest()[:16]
-            if not acquire_scoped_lock("line", tok_hash):
+            # acquire_scoped_lock returns (acquired, existing) — unpack so a
+            # production (False, holder) conflict is not treated as success.
+            acquired, _existing = acquire_scoped_lock("line", tok_hash)
+            if not acquired:
                 self._set_fatal_error(
                     "lock_conflict",
                     "LINE channel already in use by another profile",

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -451,7 +451,10 @@ class TestBuzzAdapterLifecycle:
         import gateway.status as gateway_status
 
         monkeypatch.setattr(
-            gateway_status, "acquire_scoped_lock", lambda platform, key: False
+            gateway_status,
+            "acquire_scoped_lock",
+            # Production returns (acquired, existing) — never a bare bool.
+            lambda platform, key, metadata=None: (False, {"pid": 99999}),
         )
         adapter = _make_adapter()
         adapter.cli_path = "/fake/buzz"

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -284,7 +284,7 @@ class TestSecondaryProfileConfigHandling:
         runner.adapters = {}
         runner._profile_adapters = {}
 
-        async def fake_start_one(profile_name, profile_home, claimed):
+        async def fake_start_one(profile_name, profile_home, claimed, **kwargs):
             if profile_name == "bad":
                 from gateway.run import SecondaryPortBindingConfigError
                 raise SecondaryPortBindingConfigError("bad enables webhook")
@@ -328,7 +328,7 @@ class TestSecondaryProfileConfigHandling:
         runner.adapters = {}
         runner._profile_adapters = {}
 
-        async def fake_start_one(profile_name, profile_home, claimed):
+        async def fake_start_one(profile_name, profile_home, claimed, **kwargs):
             raise MultiplexConfigError(
                 f"Profile '{profile_name}' enables open policy without allow-all opt-in"
             )

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -238,6 +238,264 @@ class TestSecondaryProfileFatalRecovery:
         assert runner._profile_failed_platforms == {}
 
 
+class TestSecondaryRetryOwnershipAndStartupShutdown:
+    """HIGH-2 regressions: exclusive secondary claims + late-connect fence."""
+
+    @pytest.mark.asyncio
+    async def test_secondary_retry_holds_credential_against_peer_and_reconnect(
+        self, monkeypatch
+    ):
+        """A fails transiently, B presents the same Telegram token, A retries.
+
+        Exactly one profile may own/connect the credential; reconnect must
+        consult the shared ownership registry before any external connect.
+        """
+        shared_token = "shared-telegram-token"
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._running = True
+        runner._draining = False
+        runner._restart_requested = False
+        runner._shutdown_event = asyncio.Event()
+        runner._profile_adapters = {}
+        runner._profile_failed_platforms = {}
+        runner._profile_retry_resource_claims = {}
+        runner._failed_platforms = {}
+        runner.adapters = {}
+        runner.session_store = object()
+        runner._busy_text_mode = "queue"
+        runner._background_tasks = set()
+        runner._make_adapter_auth_check = lambda platform, profile_name=None: object()
+        runner._adapter_disconnect_timeout_secs = lambda: 0
+        runner._sync_voice_mode_state_to_adapter = lambda adapter: None
+        runner._handle_active_session_busy_message = object()
+        runner._recover_telegram_topic_thread_id = object()
+
+        class _TokAdapter:
+            platform = Platform.TELEGRAM
+
+            def __init__(self, token, *, fail_once=False):
+                self.token = token
+                self.config = PlatformConfig(enabled=True, token=token)
+                self.fail_once = fail_once
+                self.has_fatal_error = False
+                self.fatal_error_retryable = True
+                self.fatal_error_code = "telegram_connect_error"
+                self.fatal_error_message = "temporary upstream blip"
+                self.connected = False
+                self.disconnect_called = False
+                self.connect_calls = 0
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnect_called = True
+                self.connected = False
+
+            async def cancel_background_tasks(self):
+                return None
+
+        a_first = _TokAdapter(shared_token, fail_once=True)
+        a_retry = _TokAdapter(shared_token)
+        b_adapter = _TokAdapter(shared_token)
+        a_adapters = iter((a_first, a_retry))
+
+        claimed: dict = {}
+        startup_retries: list = []
+
+        def record_failure(platform, adapter, **kwargs):
+            profile_name = kwargs.get("profile_name")
+            if profile_name is not None and adapter is not None:
+                adapter.has_fatal_error = True
+                startup_retries.append((profile_name, platform, adapter))
+                return True
+            return False
+
+        async def connect_initial(adapter, platform, *, is_reconnect=False):
+            adapter.connect_calls += 1
+            if getattr(adapter, "fail_once", False):
+                adapter.has_fatal_error = True
+                return False
+            adapter.connected = True
+            adapter.has_fatal_error = False
+            return True
+
+        # Profile A: transient failure → holds claim.
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config",
+            lambda: GatewayConfig(
+                multiplex_profiles=True,
+                platforms={
+                    Platform.TELEGRAM: PlatformConfig(
+                        enabled=True, token=shared_token
+                    )
+                },
+            ),
+        )
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: next(a_adapters))
+        monkeypatch.setattr(
+            runner, "_connect_initial_adapter_with_timeout", connect_initial
+        )
+        monkeypatch.setattr(
+            runner, "_connect_adapter_with_timeout", connect_initial
+        )
+
+        a_connected = await runner._start_one_profile_adapters(
+            "alpha", "/tmp/alpha", claimed, record_startup_failure=record_failure
+        )
+        assert a_connected == 0
+        assert startup_retries and startup_retries[0][0] == "alpha"
+        claim = GatewayRunner._adapter_credential_claim(Platform.TELEGRAM, a_first)
+        assert claim is not None
+        assert claimed.get(claim) == "alpha"
+        assert (
+            runner._profile_retry_resource_claims.get("alpha", {})
+            .get(Platform.TELEGRAM, {})
+            .get("credential_claim")
+            == claim
+        )
+
+        # Profile B: same token — must be refused before connect/publication.
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: b_adapter)
+        b_connected = await runner._start_one_profile_adapters(
+            "bravo", "/tmp/bravo", claimed, record_startup_failure=record_failure
+        )
+        assert b_connected == 0
+        assert b_adapter.connect_calls == 0
+        assert b_adapter.connected is False
+        assert Platform.TELEGRAM not in runner._profile_adapters.get("bravo", {})
+        assert claimed.get(claim) == "alpha"
+
+        # Profile A reconnects: shared registry allows A only; B never owns it.
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: a_retry)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir",
+            lambda name: Path("/tmp") / name,
+        )
+        await runner._run_secondary_profile_reconnect("alpha", Platform.TELEGRAM)
+
+        assert runner._profile_adapters.get("alpha", {}).get(Platform.TELEGRAM) is a_retry
+        assert a_retry.connected is True
+        assert Platform.TELEGRAM not in runner._profile_adapters.get("bravo", {})
+        # Exactly one live owner; retry claim released after successful publish.
+        assert (
+            Platform.TELEGRAM
+            not in runner._profile_retry_resource_claims.get("alpha", {})
+        )
+        owners = runner._collect_adapter_resource_ownership()
+        assert owners.get(claim) == "alpha"
+
+        # If bravo somehow scheduled a reconnect, shared registry must refuse
+        # before connect — no duplicate poller.
+        b_retry = _TokAdapter(shared_token)
+        b_connect_calls = {"n": 0}
+
+        async def b_connect(adapter, platform, *, is_reconnect=False):
+            b_connect_calls["n"] += 1
+            adapter.connected = True
+            return True
+
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: b_retry)
+        monkeypatch.setattr(runner, "_connect_adapter_with_timeout", b_connect)
+        await runner._run_secondary_profile_reconnect("bravo", Platform.TELEGRAM)
+        assert b_connect_calls["n"] == 0
+        assert b_retry.connected is False
+        assert Platform.TELEGRAM not in runner._profile_adapters.get("bravo", {})
+        assert runner._profile_adapters["alpha"][Platform.TELEGRAM] is a_retry
+
+    @pytest.mark.asyncio
+    async def test_secondary_initial_connect_discarded_after_stop_teardown(
+        self, monkeypatch
+    ):
+        """Blocked initial connect + completed stop() → disconnect, never register."""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._running = False
+        runner._draining = False
+        runner._restart_requested = False
+        runner._shutdown_event = asyncio.Event()
+        runner._stop_task = None
+        runner._profile_adapters = {}
+        runner._profile_failed_platforms = {}
+        runner._profile_retry_resource_claims = {}
+        runner._failed_platforms = {}
+        runner.adapters = {}
+        runner.session_store = object()
+        runner._busy_text_mode = "queue"
+        runner._make_adapter_auth_check = lambda platform, profile_name=None: object()
+        runner._adapter_disconnect_timeout_secs = lambda: 0
+        runner._sync_voice_mode_state_to_adapter = lambda adapter: None
+        runner._handle_active_session_busy_message = object()
+        runner._recover_telegram_topic_thread_id = object()
+
+        class _LateAdapter:
+            platform = Platform.TELEGRAM
+            token = "late-token"
+            config = PlatformConfig(enabled=True, token="late-token")
+            connected = False
+            disconnect_called = False
+            cancel_called = False
+
+            def __getattr__(self, name):
+                if name.startswith("set_"):
+                    return lambda *args, **kwargs: None
+                raise AttributeError(name)
+
+            async def disconnect(self):
+                self.disconnect_called = True
+                self.connected = False
+
+            async def cancel_background_tasks(self):
+                self.cancel_called = True
+
+        adapter = _LateAdapter()
+        connect_started = asyncio.Event()
+        release_connect = asyncio.Event()
+
+        async def blocked_connect(adapter_arg, platform):
+            connect_started.set()
+            await release_connect.wait()
+            adapter_arg.connected = True
+            return True
+
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config",
+            lambda: GatewayConfig(
+                multiplex_profiles=True,
+                platforms={
+                    Platform.TELEGRAM: PlatformConfig(
+                        enabled=True, token="late-token"
+                    )
+                },
+            ),
+        )
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: adapter)
+        monkeypatch.setattr(
+            runner, "_connect_initial_adapter_with_timeout", blocked_connect
+        )
+
+        start_task = asyncio.create_task(
+            runner._start_one_profile_adapters("work", "/tmp/work", {})
+        )
+        await connect_started.wait()
+
+        # Simulate stop() completing: drain flag + registry teardown.
+        runner._draining = True
+        runner._running = False
+        runner._profile_adapters.clear()
+        release_connect.set()
+        connected = await asyncio.wait_for(start_task, timeout=0.5)
+
+        assert connected == 0
+        assert adapter.disconnect_called is True
+        assert adapter.connected is False
+        assert runner._profile_adapters == {}
+        assert "work" not in runner._profile_adapters
+
+
 class TestSecondaryProfileConfigHandling:
     """Secondary config errors degrade only when the profile is safe to skip."""
 

--- a/tests/gateway/test_multiplex_pairing_stores.py
+++ b/tests/gateway/test_multiplex_pairing_stores.py
@@ -39,7 +39,7 @@ def test_secondary_profile_pairing_stores_created(tmp_path, monkeypatch):
 
     runner = _bare_runner()
 
-    async def _no_secondary(profile_name, profile_home, claimed):
+    async def _no_secondary(profile_name, profile_home, claimed, **kwargs):
         return 0
 
     runner._start_one_profile_adapters = _no_secondary
@@ -68,7 +68,7 @@ def test_pairing_store_scoped_to_profile_dir(tmp_path, monkeypatch):
 
     runner = _bare_runner()
 
-    async def _no_secondary(profile_name, profile_home, claimed):
+    async def _no_secondary(profile_name, profile_home, claimed, **kwargs):
         return 0
 
     runner._start_one_profile_adapters = _no_secondary

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -48,8 +48,8 @@ class _DisabledAdapter(BasePlatformAdapter):
 
 
 class _SuccessfulAdapter(BasePlatformAdapter):
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.DISCORD)
+    def __init__(self, platform: Platform = Platform.DISCORD):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         return True
@@ -350,9 +350,9 @@ class _NonRetryableFailureAdapter(BasePlatformAdapter):
 
 @pytest.mark.asyncio
 async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeypatch, tmp_path):
-    """Non-retryable startup errors (token collision, no platforms) must
-    set exit_code to 78 (EX_CONFIG) so the s6 finish script can translate
-    it to exit 125 (permanent failure).  See #51228."""
+    """Non-retryable startup errors (token collision) must set exit_code to 78
+    (EX_CONFIG) so the s6 finish script can translate it to exit 125
+    (permanent failure).  See #51228."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     config = GatewayConfig(
         platforms={
@@ -413,3 +413,468 @@ async def test_start_gateway_propagates_fatal_config_exit_code(monkeypatch, tmp_
     assert exc_info.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
 
+
+
+def _optional_platform() -> Platform:
+    try:
+        return Platform("buzz")
+    except Exception:
+        return Platform.TELEGRAM
+
+
+class _ProductionTokenLockAdapter(BasePlatformAdapter):
+    """Calls the real ``_acquire_platform_lock`` path (retryable=True)."""
+
+    def __init__(
+        self,
+        platform: Platform = Platform.DISCORD,
+        *,
+        token: str = "live-foreign-token-xyz",
+        scope: str = "discord-bot-token",
+        resource_desc: str = "Discord bot token",
+    ):
+        super().__init__(PlatformConfig(enabled=True, token=token), platform)
+        self._lock_token = token
+        self._lock_scope = scope
+        self._lock_resource_desc = resource_desc
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        # Production shape: adapters call _acquire_platform_lock which emits
+        # ``{scope}_lock`` with retryable=True. Classification must still treat
+        # a live foreign holder as a global single-writer conflict.
+        if not self._acquire_platform_lock(
+            self._lock_scope, self._lock_token, self._lock_resource_desc
+        ):
+            return False
+        return True
+
+    async def disconnect(self) -> None:
+        self._release_platform_lock()
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+class _PlatformLocalAuthFailureAdapter(BasePlatformAdapter):
+    """Optional adapter auth/config failure (e.g. Buzz membership rejected)."""
+
+    def __init__(self, platform: Platform | None = None):
+        super().__init__(
+            PlatformConfig(enabled=True, token="***"),
+            platform or _optional_platform(),
+        )
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        # Production shape: Buzz CLI exit 3 auth_error, non-retryable,
+        # not a single-writer lock conflict.
+        self._set_fatal_error(
+            "connect_failed",
+            "auth_error: relay error 403: relay_membership_required (exit 3)",
+            retryable=False,
+        )
+        return False
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+class _SecondaryLockConflictAdapter(BasePlatformAdapter):
+    """Secondary multiplex adapter that hits a real token lock."""
+
+    def __init__(self, platform: Platform = Platform.TELEGRAM):
+        super().__init__(
+            PlatformConfig(enabled=True, token="secondary-token"),
+            platform,
+        )
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self._acquire_platform_lock(
+            "telegram-bot-token",
+            "secondary-token",
+            "Telegram bot token",
+        ):
+            return False
+        return True
+
+    async def disconnect(self) -> None:
+        self._release_platform_lock()
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _seed_live_foreign_token_lock(
+    monkeypatch,
+    *,
+    scope: str,
+    identity: str,
+    foreign_pid: int = 424242,
+) -> None:
+    """Plant a live foreign gateway lock that production acquire will refuse."""
+    import gateway.status as status_mod
+
+    lock_path = status_mod._get_scope_lock_path(scope, identity)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    status_mod._write_json_file(
+        lock_path,
+        {
+            "pid": foreign_pid,
+            "start_time": 1_700_000_000,
+            "scope": scope,
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "metadata": {"platform": "discord"},
+            "updated_at": "2026-08-10T00:00:00+00:00",
+        },
+    )
+
+    real_pid_exists = status_mod._pid_exists
+    real_start = status_mod._get_process_start_time
+    real_looks = status_mod._looks_like_gateway_process
+
+    def _pid_exists(pid: int) -> bool:
+        if pid == foreign_pid:
+            return True
+        return real_pid_exists(pid)
+
+    def _start_time(pid: int):
+        if pid == foreign_pid:
+            return 1_700_000_000
+        return real_start(pid)
+
+    def _looks(pid: int) -> bool:
+        if pid == foreign_pid:
+            return True
+        return real_looks(pid)
+
+    monkeypatch.setattr(status_mod, "_pid_exists", _pid_exists)
+    monkeypatch.setattr(status_mod, "_get_process_start_time", _start_time)
+    monkeypatch.setattr(status_mod, "_looks_like_gateway_process", _looks)
+
+
+@pytest.mark.asyncio
+async def test_runner_exits_78_on_real_foreign_token_lock(monkeypatch, tmp_path):
+    """Live foreign holder via real ``_acquire_platform_lock`` must exit 78.
+
+    Production emits discord/telegram/... token-lock failures with
+    retryable=True. Classification must inspect conflict semantics, not the
+    retryable flag, and must not queue a retry storm.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token = "live-foreign-token-xyz"
+    _seed_live_foreign_token_lock(
+        monkeypatch, scope="discord-bot-token", identity=token
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token=token),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda platform, platform_config: _ProductionTokenLockAdapter(token=token),
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+    assert Platform.DISCORD not in runner._failed_platforms
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
+    plat = state.get("platforms", {}).get("discord", {})
+    assert plat.get("state") == "fatal"
+    assert plat.get("error_code") == "discord-bot-token_lock"
+    assert "already in use" in (plat.get("error_message") or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_runner_secondary_multiplex_lock_conflict_exits_78(monkeypatch, tmp_path):
+    """Secondary multiplex token-lock must follow the same fatal exit-78 contract."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token = "secondary-token"
+    _seed_live_foreign_token_lock(
+        monkeypatch, scope="telegram-bot-token", identity=token, foreign_pid=515151
+    )
+
+    config = GatewayConfig(
+        platforms={},  # primary has nothing enabled
+        sessions_dir=tmp_path / "sessions",
+        multiplex_profiles=True,
+    )
+    runner = GatewayRunner(config)
+
+    secondary_home = tmp_path / "profiles" / "work"
+    secondary_home.mkdir(parents=True)
+
+    def _profiles_to_serve(multiplex=True):
+        return [("work", secondary_home)]
+
+    def _create(platform, platform_config):
+        return _SecondaryLockConflictAdapter(platform)
+
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "profiles_to_serve", _profiles_to_serve)
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "default")
+
+    secondary_cfg = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token=token)},
+        sessions_dir=secondary_home / "sessions",
+    )
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: secondary_cfg)
+    monkeypatch.setattr(runner, "_create_adapter", _create)
+    monkeypatch.setattr(
+        "gateway.run._own_policy_open_startup_violation",
+        lambda cfg: None,
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
+    plat = state.get("platforms", {}).get("telegram", {})
+    assert plat.get("state") == "fatal"
+    assert plat.get("error_code") == "telegram-bot-token_lock"
+
+
+@pytest.mark.asyncio
+async def test_runner_stays_alive_on_platform_local_auth_failure(monkeypatch, tmp_path, caplog):
+    """Optional adapter auth/config failure must not kill gateway duties.
+
+    Production outage: Buzz returned relay_membership_required (non-retryable)
+    and the gateway exited 78, stopping scheduler/Kanban ownership until the
+    platform was manually disabled. Platform-local failures park the adapter
+    and leave the process running for cron/Kanban and other platforms.
+    Lifecycle stays ``running`` so busy/drain contracts remain valid.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    local_platform = _optional_platform()
+    config = GatewayConfig(
+        platforms={
+            local_platform: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    spawned: list[str] = []
+
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda platform, platform_config: _PlatformLocalAuthFailureAdapter(platform),
+    )
+
+    def _capture_spawn(coro_factory, name, **kwargs):
+        spawned.append(name)
+        # Do not schedule real background loops in the unit test.
+        return None
+
+    monkeypatch.setattr(runner, "_spawn_supervised", _capture_spawn)
+
+    import logging
+    with caplog.at_level(logging.ERROR):
+        ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert runner.exit_code in (None, 0)
+    assert runner.adapters == {}
+    # Non-retryable local auth must be parked, not queued for retry storms.
+    assert local_platform not in runner._failed_platforms
+    state = read_runtime_status()
+    # Lifecycle stays running — per-platform fatal holds the detail.
+    assert state["gateway_state"] == "running"
+    plat_state = state.get("platforms", {}).get(local_platform.value, {})
+    assert plat_state.get("state") == "fatal"
+    assert plat_state.get("error_code") == "connect_failed"
+    assert "relay_membership_required" in (plat_state.get("error_message") or "")
+    assert any(
+        "fatally misconfigured and parked" in record.message
+        for record in caplog.records
+    ), "expected platform-local failure to be parked, not exit-78"
+    # Unrelated gateway duties still wire up.
+    assert "kanban_dispatcher_watcher" in spawned
+    assert "kanban_notifier_watcher" in spawned
+    assert "session_expiry_watcher" in spawned
+
+    # Busy/drain contract: lifecycle running + active work must still work
+    # while the optional platform is parked (cron/Kanban in flight).
+    from gateway.status import (
+        derive_gateway_busy,
+        derive_gateway_drainable,
+        write_runtime_status,
+    )
+
+    write_runtime_status(active_agents=2)
+    state = read_runtime_status()
+    assert state["gateway_state"] == "running"
+    assert state["active_agents"] == 2
+    assert derive_gateway_busy(
+        gateway_running=True,
+        gateway_state=state["gateway_state"],
+        active_agents=state["active_agents"],
+    ) is True
+    assert derive_gateway_drainable(
+        gateway_running=True,
+        gateway_state=state["gateway_state"],
+    ) is True
+    # Explicit regression: degraded would break busy/drain — must not be used.
+    assert derive_gateway_busy(
+        gateway_running=True, gateway_state="degraded", active_agents=2
+    ) is False
+    assert derive_gateway_drainable(
+        gateway_running=True, gateway_state="degraded"
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_runner_keeps_healthy_platform_when_optional_adapter_fails(
+    monkeypatch, tmp_path
+):
+    """One failed optional platform must not prevent other platforms or duties."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    local_platform = _optional_platform()
+    healthy = Platform.DISCORD if local_platform != Platform.DISCORD else Platform.TELEGRAM
+    config = GatewayConfig(
+        platforms={
+            local_platform: PlatformConfig(enabled=True, token="***"),
+            healthy: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    spawned: list[str] = []
+
+    def _create(platform, platform_config):
+        if platform == local_platform:
+            return _PlatformLocalAuthFailureAdapter(local_platform)
+        return _SuccessfulAdapter(healthy)
+
+    monkeypatch.setattr(runner, "_create_adapter", _create)
+    monkeypatch.setattr(
+        runner,
+        "_spawn_supervised",
+        lambda coro_factory, name, **kwargs: spawned.append(name) or None,
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert runner.exit_code in (None, 0)
+    assert healthy in runner.adapters
+    assert local_platform not in runner.adapters
+    assert local_platform not in runner._failed_platforms
+    state = read_runtime_status()
+    assert state["gateway_state"] == "running"
+    assert state["platforms"][local_platform.value]["state"] == "fatal"
+    assert state["platforms"][healthy.value]["state"] == "connected"
+    assert "kanban_dispatcher_watcher" in spawned
+
+
+@pytest.mark.asyncio
+async def test_runner_stays_alive_on_mixed_retryable_and_nonretryable_errors(
+    monkeypatch, tmp_path, caplog
+):
+    """Mixed startup failures must NOT exit with EX_CONFIG (NS-609)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    def _make_adapter(platform, platform_config):
+        if platform == Platform.DISCORD:
+            # Platform-local non-retryable (not a global lock conflict).
+            return _PlatformLocalAuthFailureAdapter(Platform.DISCORD)
+        return _RetryableFailureAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+    monkeypatch.setattr(
+        runner,
+        "_spawn_supervised",
+        lambda coro_factory, name, **kwargs: None,
+    )
+
+    import logging
+    with caplog.at_level(logging.ERROR):
+        ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert runner.exit_code in (None, 0)
+    state = read_runtime_status()
+    assert state["gateway_state"] == "running"
+    assert Platform.TELEGRAM in runner._failed_platforms
+    assert state["platforms"]["telegram"]["state"] == "retrying"
+    assert Platform.DISCORD not in runner._failed_platforms
+    assert state["platforms"]["discord"]["state"] == "fatal"
+    assert any(
+        "fatally misconfigured" in record.message for record in caplog.records
+    )
+
+
+def test_is_global_startup_conflict_contract():
+    from gateway.restart import is_global_startup_conflict
+
+    assert is_global_startup_conflict("discord-bot-token_lock", "token already in use")
+    assert is_global_startup_conflict("lock_conflict", "Buzz identity in use by another profile")
+    assert is_global_startup_conflict("telegram_polling_conflict", "getUpdates conflict")
+    assert not is_global_startup_conflict(
+        "connect_failed",
+        "auth_error: relay error 403: relay_membership_required (exit 3)",
+    )
+    assert not is_global_startup_conflict("config_missing", "BUZZ_PRIVATE_KEY must be set")
+    assert not is_global_startup_conflict("missing_credentials", "No bot token configured")
+    # Message fallback when adapters omit a structured code.
+    assert is_global_startup_conflict(
+        None,
+        "Telegram bot token already in use (PID 42). Stop the other gateway first.",
+    )
+
+
+def test_production_acquire_platform_lock_still_retryable_for_reconnect(monkeypatch, tmp_path):
+    """Adapter-level lock failures remain retryable for post-startup reconnect (#54167)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token = "reconnect-token"
+    _seed_live_foreign_token_lock(
+        monkeypatch, scope="telegram-bot-token", identity=token, foreign_pid=606060
+    )
+    adapter = _ProductionTokenLockAdapter(
+        Platform.TELEGRAM,
+        token=token,
+        scope="telegram-bot-token",
+        resource_desc="Telegram bot token",
+    )
+    assert adapter._acquire_platform_lock(
+        "telegram-bot-token", token, "Telegram bot token"
+    ) is False
+    assert adapter.fatal_error_retryable is True
+    assert adapter.fatal_error_code == "telegram-bot-token_lock"

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -858,6 +858,25 @@ def test_is_global_startup_conflict_contract():
         None,
         "Telegram bot token already in use (PID 42). Stop the other gateway first.",
     )
+    # Production Telegram connect can wrap a live 409 getUpdates conflict in
+    # the generic telegram_connect_error envelope — still a single-writer gate.
+    assert is_global_startup_conflict(
+        "telegram_connect_error",
+        "Telegram startup failed: Conflict: terminated by other getUpdates request",
+    )
+    assert is_global_startup_conflict(
+        "telegram_connect_error",
+        "Telegram startup failed: HTTP 409 Conflict: another getUpdates request is active",
+    )
+    assert is_global_startup_conflict(
+        None,
+        "Conflict: terminated by other getUpdates request",
+    )
+    # Unrelated transient telegram_connect_error must stay retryable, not fatal.
+    assert not is_global_startup_conflict(
+        "telegram_connect_error",
+        "Telegram startup failed: temporary DNS resolution failure.",
+    )
 
 
 def test_production_acquire_platform_lock_still_retryable_for_reconnect(monkeypatch, tmp_path):
@@ -877,4 +896,247 @@ def test_production_acquire_platform_lock_still_retryable_for_reconnect(monkeypa
         "telegram-bot-token", token, "Telegram bot token"
     ) is False
     assert adapter.fatal_error_retryable is True
-    assert adapter.fatal_error_code == "telegram-bot-token_lock"
+
+
+class _SecondaryRetryableFailureAdapter(BasePlatformAdapter):
+    """Secondary multiplex adapter with a transient (non-conflict) failure."""
+
+    def __init__(self, platform: Platform = Platform.TELEGRAM):
+        super().__init__(
+            PlatformConfig(enabled=True, token="secondary-retry-token"),
+            platform,
+        )
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        self._set_fatal_error(
+            "telegram_connect_error",
+            "Telegram startup failed: temporary DNS resolution failure.",
+            retryable=True,
+        )
+        return False
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+class _Telegram409ConnectErrorAdapter(BasePlatformAdapter):
+    """Production shape: outer connect exception records telegram_connect_error
+    while the body still carries a Bot API 409 getUpdates conflict."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        self._set_fatal_error(
+            "telegram_connect_error",
+            "Telegram startup failed: Conflict: terminated by other getUpdates request",
+            retryable=True,
+        )
+        return False
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise NotImplementedError
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_runner_exits_78_on_telegram_connect_error_409(monkeypatch, tmp_path):
+    """Production 409 getUpdates under telegram_connect_error must fail closed."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda platform, platform_config: _Telegram409ConnectErrorAdapter(),
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+    assert Platform.TELEGRAM not in runner._failed_platforms
+    state = read_runtime_status()
+    assert state["gateway_state"] == "startup_failed"
+    plat = state.get("platforms", {}).get("telegram", {})
+    assert plat.get("state") == "fatal"
+    assert plat.get("error_code") == "telegram_connect_error"
+    assert "getupdates" in (plat.get("error_message") or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_runner_secondary_retryable_enters_profile_retry_registry(
+    monkeypatch, tmp_path
+):
+    """Secondary retryable startup failure must arm profile-scoped reconnect.
+
+    Previously queue_retry=False left startup_retryable_errors non-empty
+    (suppressing exit 78) while neither ``_failed_platforms`` nor
+    ``_profile_failed_platforms`` received the secondary — live but deaf.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={},  # primary has nothing enabled
+        sessions_dir=tmp_path / "sessions",
+        multiplex_profiles=True,
+    )
+    runner = GatewayRunner(config)
+
+    secondary_home = tmp_path / "profiles" / "work"
+    secondary_home.mkdir(parents=True)
+
+    def _profiles_to_serve(multiplex=True):
+        return [("work", secondary_home)]
+
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "profiles_to_serve", _profiles_to_serve)
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "default")
+
+    secondary_cfg = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="secondary-retry-token")},
+        sessions_dir=secondary_home / "sessions",
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: secondary_cfg)
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda platform, platform_config: _SecondaryRetryableFailureAdapter(platform),
+    )
+    monkeypatch.setattr(
+        "gateway.run._own_policy_open_startup_violation",
+        lambda cfg: None,
+    )
+    # Do not run real reconnect loops in the unit test.
+    monkeypatch.setattr(
+        runner,
+        "_spawn_supervised",
+        lambda coro_factory, name, **kwargs: None,
+    )
+    scheduled: list[tuple[str, Platform]] = []
+
+    def _capture_schedule(profile_name, platform, adapter):
+        scheduled.append((profile_name, platform))
+        # Mirror production bookkeeping without starting the reconnect task.
+        pending = runner._profile_failed_platforms
+        if not isinstance(pending, dict):
+            pending = {}
+            runner._profile_failed_platforms = pending
+        profile_pending = pending.setdefault(profile_name, {})
+        # Placeholder non-task marker so the registry is observable.
+        profile_pending[platform] = object()
+
+    monkeypatch.setattr(runner, "_schedule_secondary_profile_reconnect", _capture_schedule)
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False
+    assert runner.exit_code in (None, 0)
+    # Must not claim a primary-slot retry for a secondary failure.
+    assert Platform.TELEGRAM not in runner._failed_platforms
+    # Must enter the profile-scoped retry registry.
+    assert scheduled == [("work", Platform.TELEGRAM)]
+    assert Platform.TELEGRAM in runner._profile_failed_platforms.get("work", {})
+    state = read_runtime_status()
+    assert state["gateway_state"] == "running"
+    plat = state.get("platforms", {}).get("telegram", {})
+    assert plat.get("state") == "retrying"
+
+
+@pytest.mark.asyncio
+async def test_production_scoped_lock_tuple_unreachable_without_unpack(monkeypatch, tmp_path):
+    """Buzz/IRC/LINE must unpack acquire_scoped_lock's (False, existing) tuple.
+
+    A non-empty failure tuple is truthy in Python; ``if not acquire_scoped_lock()``
+    never enters the lock_conflict branch. Production shape: real status helper
+    returning (False, holder) must set lock_conflict and refuse connect.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import gateway.status as status_mod
+
+    holder = {"pid": 777001, "scope": "buzz"}
+
+    def _fail_lock(scope, identity, metadata=None):
+        return (False, holder)
+
+    monkeypatch.setattr(status_mod, "acquire_scoped_lock", _fail_lock)
+
+    from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+    # --- Buzz ---
+    buzz_mod = load_plugin_adapter("buzz")
+    from gateway.config import PlatformConfig as PC
+
+    buzz = buzz_mod.BuzzAdapter(
+        PC(enabled=True, extra={"relay_url": "wss://relay.example", "private_key": "nsec1test"})
+    )
+    # Minimal scripted connect path up to the lock.
+    buzz.cli_path = "/fake/buzz"
+    monkeypatch.setattr(buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+
+    async def _buzz_cli(args):
+        if args[:2] == ["users", "get"]:
+            return 0, '[{"pubkey":"' + ("ab" * 32) + '","display_name":"T"}]', ""
+        return 1, "", "unexpected"
+
+    buzz._run_cli = _buzz_cli
+    assert await buzz.connect() is False
+    assert buzz.has_fatal_error is True
+    assert buzz.fatal_error_code == "lock_conflict"
+    assert buzz._lock_key is None
+
+    # --- IRC ---
+    irc_mod = load_plugin_adapter("irc")
+    irc = irc_mod.IRCAdapter(
+        PC(
+            enabled=True,
+            extra={
+                "server": "irc.example",
+                "port": 6667,
+                "nickname": "hermes",
+                "channel": "#test",
+                "use_tls": False,
+            },
+        )
+    )
+    assert await irc.connect() is False
+    assert irc.has_fatal_error is True
+    assert irc.fatal_error_code == "lock_conflict"
+    assert getattr(irc, "_lock_key", None) in (None, "")
+
+    # --- LINE ---
+    line_mod = load_plugin_adapter("line")
+    line = line_mod.LineAdapter(
+        PC(
+            enabled=True,
+            extra={
+                "channel_access_token": "line-token-xyz",
+                "channel_secret": "line-secret-xyz",
+            },
+        )
+    )
+    # LINE may read token/secret from env or extra depending on version.
+    if not getattr(line, "channel_access_token", None):
+        line.channel_access_token = "line-token-xyz"
+    if not getattr(line, "channel_secret", None):
+        line.channel_secret = "line-secret-xyz"
+    assert await line.connect() is False
+    assert line.has_fatal_error is True
+    assert line.fatal_error_code == "lock_conflict"
+    assert getattr(line, "_lock_key", None) in (None, "")


### PR DESCRIPTION
## Bug Description

Optional platform startup auth/config failures (production: Buzz `relay_membership_required`) previously forced gateway exit 78 and stopped scheduler/Kanban. PR #83161 tried to isolate them but was closed after independent BLOCK: production token-lock conflicts are emitted `retryable=True` and bypassed the fatal classifier, and `gateway_state=degraded` is neither busy nor drainable.

## Root Cause

1. `BasePlatformAdapter._acquire_platform_lock` marks live foreign holders `retryable=True` (for later reconnect). Startup routed solely on that flag, so pure single-writer conflicts stayed alive / retry-queued instead of exit 78.
2. Multiplex secondary lock failures were logged and disconnected without feeding the fatal classifier.
3. Persisting lifecycle `degraded` breaks `derive_gateway_busy` / `derive_gateway_drainable` (only `running` is drainable).

## Fix

- Add `is_global_startup_conflict()` and classify lock/polling ownership **before** generic retry routing.
- Pure global conflicts at zero-connected startup → exit 78; never retry-queue them at startup.
- Secondary multiplex lock failures use the same classifier.
- Platform-local auth/config (Buzz membership, missing credentials) parks fatal per-platform; gateway stays alive for cron/Kanban/healthy peers.
- Lifecycle stays `running`; per-platform fatal/retrying holds detail (no non-drainable degraded lifecycle).

## How to Verify

```bash
uv run --extra dev pytest \
  tests/gateway/test_runner_startup_failures.py \
  tests/gateway/test_stale_platform_lock_retryable.py \
  tests/gateway/test_runner_fatal_adapter.py \
  tests/gateway/test_platform_reconnect.py \
  tests/gateway/test_status.py::TestGatewayBusyDerivation \
  tests/gateway/test_multiplex_adapter_registry.py \
  tests/gateway/test_multiplex_pairing_stores.py -q
# 59 passed
uv run --extra dev ruff check gateway/restart.py gateway/run.py \
  tests/gateway/test_runner_startup_failures.py \
  tests/gateway/test_multiplex_adapter_registry.py \
  tests/gateway/test_multiplex_pairing_stores.py
```

## Test Plan

- [x] Real foreign lock-holder via production `_acquire_platform_lock` (retryable=True) exits 78, not retry-queued
- [x] Secondary multiplex token-lock exits 78
- [x] Buzz-style platform-local auth parks fatal; lifecycle `running`; Kanban watchers spawn; busy/drain true with active_agents
- [x] Healthy peer continues when optional adapter fails
- [x] NS-609 mixed retryable + local nonretryable stays alive
- [x] Adapter-level lock remains retryable for post-startup reconnect (#54167)
- [x] Existing fatal/reconnect/lock/status/multiplex tests + Ruff pass

## Risk Assessment

Low–medium. Narrow startup classification change; pure lock conflicts and multiplex config errors keep exit-78; optional platforms no longer take down duties; lifecycle busy/drain preserved.

## Notes

- Supersedes closed #83161 (branch preserved). Do not deploy before independent exact-head review PASS.
- Exact tested SHA: will match PR head after create.