### PR TITLE
fix(desktop): dispose the HUD snap shortcut on native window close

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9457,8 +9457,14 @@ function spawnHudWindow(sessionId, profile) {
       hudWindow = null
     }
 
-    // Closed from its own side (⌘W) — put the app back so the user is never
-    // left with no surface, and correct every window's toggle.
+    // Closed from its own side (⌘W) — closeHudWindow()'s dispose() never ran,
+    // so the global snap shortcut would otherwise stay registered (and stuck
+    // taken) with no HUD left to apply it to. dispose() is idempotent, so
+    // this is safe even if closeHudWindow() already released it.
+    hudSnapShortcut.dispose()
+
+    // Put the app back so the user is never left with no surface, and
+    // correct every window's toggle.
     restoreMainWindowFromHud()
     broadcastHudState(false)
   })


### PR DESCRIPTION
## Summary

`9c75e4863f` added the global ⌘⇧G snap-to-cursor shortcut for the HUD window and wired its `dispose()` call into `closeHudWindow()` and the app's `before-quit` handler. It missed the HUD's own `'closed'` event listener (in `spawnHudWindow`) — which fires when the window is closed from its own side (⌘W, or any native OS close) without going through `closeHudWindow()` first. That handler's own comment ("Closed from its own side (⌘W)") confirms this is exactly that path.

After a ⌘W close, `CommandOrControl+Shift+G` stays registered globally with no HUD left for it to act on. Harmless — `applyHudSnapToPointer()` guards on a destroyed/null `hudWindow` — but it keeps the chord claimed until the HUD is reopened (`register()` releases first) or the app quits, which reads as a stuck shortcut to anything else that might want it.

## Fix

Call `hudSnapShortcut.dispose()` in the `'closed'` handler. `dispose()` is idempotent (it guards on its own `active` chord reference), so calling it unconditionally here is safe even on paths where `closeHudWindow()` already released it first.

## Test plan

- [x] `apps/desktop`: `npx tsc -p tsconfig.electron.json --noEmit` — clean, no type errors.
- [x] `npx vitest run electron/hud-snap-shortcut.test.ts` — 3/3 pass.
- [x] No dedicated test seam exists for `main.ts`'s internal HUD window lifecycle (it's an 8000+ line Electron entry script with no exports; no `electron/*.test.ts` file references `hudWindow`/`spawnHudWindow`/`closeHudWindow`) — verified manually by tracing all four places that null/create `hudWindow` (`closeHudWindow()`, the profile-respawn branch, `before-quit`, and this `'closed'` handler) and confirming this was the only one missing the dispose call.
- [x] Fresh rival-PR search (`hud snap shortcut dispose`, `hudSnapShortcut`, `HUD closed globalShortcut`) found no open PR touching this.