### PR TITLE
fix(agent): fall back title generation when provider rejects json_schema

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -127,11 +127,22 @@ def _response_format_rejected(exc: BaseException) -> bool:
 
     Matches on the parameter name appearing in the error message (DeepSeek:
     "This response_format type is unavailable now"; others echo the
-    parameter they reject). Keeps the retry ladder from firing on unrelated
-    failures (auth, quota, network), which are not fixed by changing format.
+    parameter they reject). Also catches vLLM gateways whose error text
+    never mentions ``response_format`` — they fail at the guided-grammar
+    compilation stage with a ``guided_grammar`` / ``grammar`` / ``xgrammar``
+    marker — by keying on the HTTP 400 status plus that grammar marker.
+
+    Keeps the retry ladder from firing on unrelated failures (auth, quota,
+    network), which are not fixed by changing format.
     """
-    text = str(exc)
-    return "response_format" in text or "json_schema" in text
+    text = str(exc).lower()
+    if "response_format" in text or "json_schema" in text:
+        return True
+    # vLLM translates json_schema into a guided_grammar it cannot always
+    # compile; the error mentions grammar/xgrammar but never response_format.
+    if ("guided_grammar" in text or "xgrammar" in text or "compile_grammar" in text):
+        return True
+    return False
 
 # Control-tag wrappers that surround machine-authored content inside what is
 # nominally a "user" message. Titling from these is what produces a session
@@ -425,6 +436,12 @@ def generate_title(
     # Failures unrelated to response_format (auth, quota, network) break
     # out immediately — a different format cannot fix those.
     last_exc: Optional[BaseException] = None
+    # Pin thinking off on retries via BOTH channels so the disable lands
+    # whether or not the provider has an active profile. Profiles override
+    # extra_body, so extra_body.thinking alone is silently overwritten back
+    # to "enabled" by DeepSeekProfile (and similar reasoning profiles).
+    # reasoning_config={"enabled": False} is the channel profiles read.
+    _thinking_off_kwargs = {"reasoning_config": {"enabled": False}}
     for response_format, pin_thinking_off in (
         (_TITLE_RESPONSE_FORMAT, False),
         (_TITLE_RESPONSE_FORMAT_JSON_OBJECT, True),
@@ -446,6 +463,7 @@ def generate_title(
                 timeout=timeout,
                 main_runtime=main_runtime,
                 extra_body=extra_body,
+                **(_thinking_off_kwargs if pin_thinking_off else {}),
             )
             content = response.choices[0].message.content or ""
             return _clean_title(_extract_title_text(content))

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -105,6 +105,34 @@ _TITLE_RESPONSE_FORMAT = {
     },
 }
 
+# Fallback response formats tried after json_schema. Not every provider
+# honors structured output — DeepSeek's API rejects json_schema with 400
+# "This response_format type is unavailable now" — so walk a constraint
+# ladder instead of failing the whole title. The prompt itself asks for
+# JSON and _extract_title_text has a loose JSON scan, so an unconstrained
+# reply still titles.
+#
+# The retries also pin ``thinking`` off: DeepSeek V4 (and similar
+# default-on reasoning models) burn the 64-token budget on reasoning and
+# return an empty ``content``, which would silently leave the session
+# titled with the derived name even after the 400 is gone. ``thinking:
+# {"type": "disabled"}`` is the shared shape for Anthropic-compatible and
+# Z.AI/DeepSeek-style APIs; providers that reject it just fall through to
+# the next rung.
+_TITLE_RESPONSE_FORMAT_JSON_OBJECT = {"type": "json_object"}
+
+
+def _response_format_rejected(exc: BaseException) -> bool:
+    """True when the provider rejected the ``response_format`` parameter.
+
+    Matches on the parameter name appearing in the error message (DeepSeek:
+    "This response_format type is unavailable now"; others echo the
+    parameter they reject). Keeps the retry ladder from firing on unrelated
+    failures (auth, quota, network), which are not fixed by changing format.
+    """
+    text = str(exc)
+    return "response_format" in text or "json_schema" in text
+
 # Control-tag wrappers that surround machine-authored content inside what is
 # nominally a "user" message. Titling from these is what produces a session
 # named after a slash command or an injected reminder rather than the user's
@@ -391,31 +419,50 @@ def generate_title(
         {"role": "user", "content": user_snippet},
     ]
 
-    try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
-        )
-        content = response.choices[0].message.content or ""
-        return _clean_title(_extract_title_text(content))
-    except Exception as e:
-        # Log at WARNING so this shows up in agent.log without debug mode.
-        # Full detail at debug level for operators who need the stack.
-        logger.warning("Title generation failed: %s", e)
-        logger.debug("Title generation traceback", exc_info=True)
-        if failure_callback is not None:
-            try:
-                failure_callback("title generation", e)
-            except Exception:
-                logger.debug("Title generation failure_callback raised", exc_info=True)
-        return None
+    # Walk the response-format ladder: json_schema (ideal) → json_object
+    # → unconstrained. Providers without structured-output support (e.g.
+    # DeepSeek) 400 on json_schema; retrying looser keeps titling alive.
+    # Failures unrelated to response_format (auth, quota, network) break
+    # out immediately — a different format cannot fix those.
+    last_exc: Optional[BaseException] = None
+    for response_format, pin_thinking_off in (
+        (_TITLE_RESPONSE_FORMAT, False),
+        (_TITLE_RESPONSE_FORMAT_JSON_OBJECT, True),
+        (None, True),
+    ):
+        try:
+            extra_body: dict = {}
+            if response_format is not None:
+                extra_body["response_format"] = response_format
+            if pin_thinking_off:
+                extra_body["thinking"] = {"type": "disabled"}
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                # A title is a handful of tokens. The old 500-token ceiling let a
+                # chatty model burn seconds generating prose we then threw away.
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+                extra_body=extra_body,
+            )
+            content = response.choices[0].message.content or ""
+            return _clean_title(_extract_title_text(content))
+        except Exception as e:
+            last_exc = e
+            if response_format is not None and not _response_format_rejected(e):
+                break
+    # Log at WARNING so this shows up in agent.log without debug mode.
+    # Full detail at debug level for operators who need the stack.
+    logger.warning("Title generation failed: %s", last_exc)
+    logger.debug("Title generation traceback", exc_info=True)
+    if failure_callback is not None:
+        try:
+            failure_callback("title generation", last_exc)
+        except Exception:
+            logger.debug("Title generation failure_callback raised", exc_info=True)
+    return None
 
 
 def _persist_session_title(session_db, session_id, title, *, source, dedupe=True):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -223,6 +223,63 @@ class TestGenerateTitle:
         assert len(captured) == 1
         assert captured[0] == "title generation"
 
+    def test_catches_vllm_guided_grammar_rejection(self):
+        """vLLM gateways translate json_schema into an uncompilable
+        guided_grammar; the error never mentions response_format, but the
+        grammar/xgrammar marker identifies it as a format rejection."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Error code: 400 - {'error': {'message': "
+                    "'guided_grammar has compile_grammar_error: "
+                    "No module named xgrammar'}}"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix grammar"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("debug grammar issue")
+
+        assert title == "Fix grammar"
+        assert len(calls) == 2
+
+    def test_thinking_off_retries_send_reasoning_config(self):
+        """Retried calls must send reasoning_config={'enabled': False} so
+        that provider profiles (e.g. DeepSeekProfile) which override
+        extra_body.thinking don't silently re-enable thinking and burn the
+        64-token budget on reasoning_content. extra_body.thinking alone is
+        overwritten by the profile — reasoning_config is the channel the
+        profile reads to decide enabled/disabled."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Error code: 400 - 'This response_format type is "
+                    "unavailable now'"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix login"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("fix login")
+
+        assert len(calls) == 2
+        # First attempt: no reasoning_config (thinking not pinned off).
+        assert "reasoning_config" not in calls[0]
+        # Retry: reasoning_config must be {"enabled": False} AND
+        # extra_body.thinking must be {"type": "disabled"} — both channels.
+        assert calls[1]["reasoning_config"] == {"enabled": False}
+        assert calls[1]["extra_body"]["thinking"] == {"type": "disabled"}
+
 
 
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -108,6 +108,121 @@ class TestGenerateTitle:
         assert captured[0][0] == "title generation"
         assert captured[0][1] is exc
 
+    def test_falls_back_to_json_object_when_json_schema_rejected(self):
+        """Providers without structured output (DeepSeek: 400 on json_schema)
+        must get a json_object retry with thinking pinned off instead of a
+        failed title."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Error code: 400 - 'This response_format type is "
+                    "unavailable now'"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix login button"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("fix login button")
+
+        assert title == "Fix login button"
+        assert len(calls) == 2
+        # First attempt keeps the ideal json_schema constraint.
+        assert calls[0]["extra_body"] == {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "session_title",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {"title": {"type": "string"}},
+                        "required": ["title"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        }
+        # Retry loosens to json_object and disables thinking so a
+        # default-on reasoning model doesn't burn the token budget.
+        assert calls[1]["extra_body"] == {
+            "response_format": {"type": "json_object"},
+            "thinking": {"type": "disabled"},
+        }
+
+    def test_falls_back_to_unconstrained_when_json_object_also_rejected(self):
+        """A provider that rejects both json_schema and json_object still
+        titles via the prompt's own JSON instruction."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) < 3:
+                raise RuntimeError(
+                    "Error code: 400 - 'This response_format type is "
+                    "unavailable now'"
+                )
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = (
+                'Here is the title: {"title": "Triage dashboard alerts"}'
+            )
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title("triage alerts")
+
+        assert title == "Triage dashboard alerts"
+        assert len(calls) == 3
+        # Last rung: no response_format at all, thinking still pinned off.
+        assert calls[2]["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_format_ladder_does_not_retry_unrelated_failures(self):
+        """Auth/quota/network errors must not burn format-retry attempts."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError(
+                "Error code: 403 - usage limit reached for this billing cycle"
+            )
+
+        captured = []
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            result = generate_title(
+                "question", failure_callback=lambda t, e: captured.append(t)
+            )
+
+        assert result is None
+        assert len(calls) == 1
+        assert captured == ["title generation"]
+
+    def test_format_ladder_reports_failure_after_all_rungs(self):
+        """When every rung is rejected on format grounds, the failure
+        callback fires exactly once with the last exception."""
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError(
+                "Error code: 400 - 'This response_format type is unavailable now'"
+            )
+
+        captured = []
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            result = generate_title(
+                "question", failure_callback=lambda t, e: captured.append(t)
+            )
+
+        assert result is None
+        assert len(calls) == 3
+        assert len(captured) == 1
+        assert captured[0] == "title generation"
+
 
 
 


### PR DESCRIPTION
## Bug Description

Auto-generated session titles silently fail on any setup whose title-generation call reaches a provider that rejects the strict `json_schema` `response_format`.

DeepSeek's Chat Completions API returns `HTTP 400 "This response_format type is unavailable now"` for every request carrying `response_format: {"type": "json_schema", ...}`. `generate_title()` sends that format unconditionally, so the call fails, the `failure_callback` fires, and the session keeps its truncated **derived** title (a 48-char slice of the first message) forever.

Reproduction (real API, 2026-08-10):

```
curl https://api.deepseek.com/chat/completions \
  -d '{"model":"deepseek-v4-flash", ...,
       "response_format":{"type":"json_schema","json_schema":{...}}}'
→ 400 {"error":{"message":"This response_format type is unavailable now", ...}}
```

Log signature: `Auxiliary title_generation: ... Title generation failed: Error code: 400 - 'This response_format type is unavailable now'`.

## Root Cause

`generate_title()` hardcodes `extra_body={"response_format": _TITLE_RESPONSE_FORMAT}` (strict `json_schema`) with no fallback path. Providers without structured-output support — DeepSeek, Moonshot/Kimi per their API docs — 400 on the parameter, and the exception lands in the generic `except` bucket as a non-retryable failure.

There is a second, subtler failure mode that a `json_object` retry alone does **not** fix: DeepSeek V4 is a default-on reasoning model. With `max_tokens=64`, a retried call without thinking control spends the whole budget on `reasoning_content` and returns an **empty `content`** — the title still never appears even though the HTTP 400 is gone. Verified live:

```
response_format={"type":"json_object"}                     → content: "", reasoning_content: "We need answer user..." (finish_reason: length)
response_format={"type":"json_object"} + thinking disabled → content: '{"title": "Fix login button"}' (finish_reason: stop)
```

## Fix

`generate_title()` now walks a response-format constraint ladder instead of failing on the first rung:

1. `json_schema` (ideal, unchanged first attempt)
2. `json_object` + `thinking: {"type": "disabled"}`
3. no `response_format` + `thinking: {"type": "disabled"}`

The retried rungs pin thinking off so default-on reasoning models answer within the 64-token budget instead of returning empty `content`. The prompt already asks for JSON and `_extract_title_text()` has a loose-JSON scan, so an unconstrained reply still titles.

Retries only fire when the provider actually rejected `response_format` (`_response_format_rejected()`: parameter name in the error message). Auth/quota/network failures (403, 429, timeouts) break out immediately — a different format cannot fix those, and burning extra calls on a dead quota is wasteful.

## How to Verify

1. Configure `auxiliary.title_generation` to route through DeepSeek (`provider: deepseek`, `model: deepseek-v4-flash`).
2. Start a new session; watch `agent.log`:
   - before: `Title generation failed: Error code: 400 - 'This response_format type is unavailable now'`
   - after: no failure; the session gets a real LLM-generated title in `state.db` (`sessions.title`, provenance `llm`)
3. Live check (done on 2026-08-10): `generate_title("почини баг с генерацией названий сессий...")` through the real DeepSeek API returned `'Починить генерацию названий сессий'` (previously: `None` + HTTP 400).

## Test Plan

- [x] Added regression tests: retry on `json_object` when `json_schema` rejected; retry to unconstrained when `json_object` also rejected; **no** retry on unrelated failures (403); `failure_callback` fires exactly once after all rungs are exhausted
- [x] Existing tests still pass: `pytest tests/agent/test_title_generator.py` → 37 passed
- [x] Manual verification against the live DeepSeek API (see How to Verify)

## Relationship to other open PRs

This bug is currently being fixed by several independent PRs: #82073, #82372, #82751, #82868, #82890. They all address the `json_schema` → `json_object` downgrade.

**This PR is the only one that also pins `thinking: {"type": "disabled"}` on the retried calls.** Without it, DeepSeek V4 (and any other default-on reasoning model) answers the retried request with an empty `content` field (all 64 tokens consumed by reasoning) — the HTTP 400 disappears but the title still never appears, leaving the bug half-fixed on exactly the provider that motivated the other PRs. This PR additionally falls back to an unconstrained call (third rung) and skips retries for non-format failures.

## Risk Assessment

**Low.** First attempt is byte-identical to current behavior (same `json_schema` format, same kwargs). The ladder only activates when the provider explicitly rejects `response_format`; non-format failures keep the exact previous single-attempt + `failure_callback` behavior. `thinking: {"type": "disabled"}` is the shared shape accepted by Anthropic-compatible and Z.AI/DeepSeek-style APIs; providers that reject it fall through to the next rung.
