### PR TITLE
fix(install): abort Windows venv recreate when rename-aside fails (#83149)

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -28,14 +28,28 @@ _SENSITIVE_LONG_FLAGS: list[str] = [
 ]
 
 
-def _probe_fail_json() -> str:
-    """Return the standard probe-failure JSON document."""
-    return json.dumps({"ok": False, "blocked": False, "processes": []})
+def _probe_fail_json(diagnostic: str = "probe failed") -> str:
+    """Return the standard probe-failure JSON document.
+
+    ``ok: false`` plus ``probe_failed: true`` means the detector itself could
+    not run — this is *not* a clear scan. Callers must treat
+    ``ok is not True`` / non-zero exit as probe failure, never as
+    ``blocked: false`` "clear" (#83149).
+    """
+    return json.dumps(
+        {
+            "ok": False,
+            "probe_failed": True,
+            "blocked": False,
+            "processes": [],
+            "error": diagnostic,
+        }
+    )
 
 
 def _emit_probe_fail(diagnostic: str) -> NoReturn:
     """Print one JSON to stdout, diagnostic to stderr, exit non-zero."""
-    print(_probe_fail_json())
+    print(_probe_fail_json(diagnostic))
     print(diagnostic, file=sys.stderr)
     sys.exit(1)
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2372,28 +2372,26 @@ function Install-Venv {
         # one immediately even if some straggler still holds a .pyd from the
         # old tree; the renamed dir is deleted best-effort (now, and by the
         # cleanup pass below on the NEXT install if a handle outlives this one).
+        #
+        # NEVER fall back to in-place delete when rename is denied (#83149):
+        # Remove-Item -Recurse can delete most of site-packages and then fail on
+        # one locked .pyd, leaving a gutted venv with no rollback. Abort with the
+        # previous install intact so the user can close holders and retry.
         $staleName = "venv.stale.{0}" -f (Get-Date -Format "yyyyMMddHHmmss")
-        $renamed = $false
         try {
             Rename-Item -Path "venv" -NewName $staleName -ErrorAction Stop
-            $renamed = $true
         } catch {
-            Write-Warn "Could not rename venv aside ($($_.Exception.Message)); falling back to in-place delete"
+            $renameErr = $_.Exception.Message
+            throw (
+                "Could not move the existing venv aside ($renameErr). " +
+                "A process still has the install directory open (often a non-Hermes " +
+                "python.exe that resolved into this venv via PATH). Close those " +
+                "processes and retry - the previous install was left intact."
+            )
         }
-        if ($renamed) {
-            Remove-Item -Recurse -Force $staleName -ErrorAction SilentlyContinue
-            if (Test-Path $staleName) {
-                Write-Warn "Old venv parked at $staleName (a process still holds files in it); it will be cleaned up on the next install"
-            }
-        } else {
-            Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue
-            # A killed process can take a moment to release its file handles, so a
-            # first Remove-Item may still hit a locked .pyd. Retry once after a short
-            # pause before giving up and letting the stage fail loudly.
-            if (Test-Path "venv") {
-                Start-Sleep -Seconds 2
-                Remove-Item -Recurse -Force "venv"
-            }
+        Remove-Item -Recurse -Force $staleName -ErrorAction SilentlyContinue
+        if (Test-Path $staleName) {
+            Write-Warn "Old venv parked at $staleName (a process still holds files in it); it will be cleaned up on the next install"
         }
     }
 

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -18,6 +18,7 @@ import pytest
 import agent.redact as redact_module
 from hermes_cli._scan_venv_blockers import (
     _is_pausable_gateway,
+    _probe_fail_json,
     _redact_sensitive_cmdline,
     main,
 )
@@ -162,6 +163,43 @@ def _run_main_with_detector(monkeypatch, capsys, matches):
         main()
     out = capsys.readouterr().out
     return excinfo.value.code, json.loads(out)
+
+
+def test_probe_fail_json_is_unambiguous_failure() -> None:
+    """A failed probe must not look like a clear scan (#83149).
+
+    Humans and naive callers used to read ``blocked: false`` as "no holders"
+    when psutil was missing after a gutted venv. The document must mark
+    ``probe_failed`` and keep ``ok`` false.
+    """
+    data = json.loads(_probe_fail_json("psutil is not available: No module named 'psutil'"))
+    assert data["ok"] is False
+    assert data["probe_failed"] is True
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert "psutil" in data["error"]
+
+
+def test_main_psutil_missing_is_probe_failure_not_clear(monkeypatch, capsys):
+    """Missing psutil exits non-zero with probe_failed JSON — never a clear scan."""
+    real_import = builtins.__import__
+
+    def _no_psutil(name, *args, **kwargs):
+        if name == "psutil" or name.startswith("psutil."):
+            raise ImportError("No module named 'psutil'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_psutil)
+    monkeypatch.delitem(sys.modules, "psutil", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    data = json.loads(captured.out)
+    assert data["ok"] is False
+    assert data["probe_failed"] is True
+    assert "psutil" in captured.err.lower()
 
 
 def test_main_exempts_gateway_chain_but_keeps_other_holders(monkeypatch, capsys):

--- a/tests/test_install_ps1_venv_rename_abort.py
+++ b/tests/test_install_ps1_venv_rename_abort.py
@@ -1,0 +1,61 @@
+"""Regression: Windows installer must not gut the venv on rename failure (#83149).
+
+When recreating an existing venv, ``Install-Venv`` renames the directory aside
+first. An older fallback deleted the tree in place when rename was denied; a
+partial ``Remove-Item`` could wipe most of ``site-packages`` and then fail on
+one locked ``.pyd``, leaving Hermes unusable with no rollback.
+
+These tests lock the contract at the source level (the script only runs on
+Windows, so Linux CI cannot execute the PowerShell path).
+"""
+
+from pathlib import Path
+
+import pytest
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def _function_body(source: str, name: str) -> str:
+    """Return the text of a PowerShell ``function <name> { ... }`` block."""
+    start = source.index(f"function {name}")
+    brace = source.index("{", start)
+    depth = 0
+    for i in range(brace, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace : i + 1]
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+def test_install_venv_aborts_when_rename_aside_fails(source: str):
+    """Rename failure must throw with the previous install left intact."""
+    body = _function_body(source, "Install-Venv")
+    assert "Rename-Item -Path \"venv\"" in body or "Rename-Item -Path 'venv'" in body
+    assert "falling back to in-place delete" not in body
+    throw_at = body.find("Could not move the existing venv aside")
+    assert throw_at != -1, "rename failure must abort with an actionable error"
+    assert "throw" in body[max(0, throw_at - 80) : throw_at + 40]
+
+
+def test_install_venv_never_removes_live_venv_in_place_on_rename_fail(source: str):
+    """After a failed rename, Install-Venv must not Remove-Item the live venv.
+
+    Parked ``venv.stale.*`` trees may still be deleted best-effort; the live
+    ``venv`` directory must only disappear via Rename-Item.
+    """
+    body = _function_body(source, "Install-Venv")
+    # The only Remove-Item targeting the active tree used to be the fallback:
+    #   Remove-Item -Recurse -Force "venv"
+    # That path must be gone. Stale-parking cleanup uses $staleName / filter.
+    assert 'Remove-Item -Recurse -Force "venv"' not in body
+    assert "Remove-Item -Recurse -Force 'venv'" not in body
+    assert "venv.stale." in body

--- a/tests/test_install_unmerged_index.py
+++ b/tests/test_install_unmerged_index.py
@@ -154,14 +154,15 @@ def test_install_sh_clears_unmerged_index_before_stash_source_order() -> None:
 
 def test_install_ps1_stops_venv_resident_processes_before_removing_venv() -> None:
     """The Windows venv-recreate path must stop every process running out of the
-    old venv before deleting it.
+    old venv before moving it aside.
 
     A gateway autostarted by a scheduled task runs as
     ``venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run`` — image name
     ``pythonw``, not ``hermes.exe`` — so the ``taskkill /IM hermes.exe`` guard
-    misses it, the loaded ``.pyd`` stays locked, and ``Remove-Item venv`` fails
-    mid-recursion (issues #47036/#47557/#47910). The recreate branch must also
-    sweep by venv path prefix, and that sweep must run before the delete.
+    misses it and the loaded ``.pyd`` stays locked (issues #47036/#47557/#47910).
+    The recreate branch must sweep by venv path prefix before Rename-Item, and
+    must never fall back to an in-place ``Remove-Item`` of the live ``venv``
+    (#83149 — that path can gut site-packages with no rollback).
     """
     text = INSTALL_PS1.read_text()
 
@@ -179,8 +180,12 @@ def test_install_ps1_stops_venv_resident_processes_before_removing_venv() -> Non
         "the -like wildcard match must not be used for venv path scoping"
     )
 
-    # The process sweep must run before the venv is removed, or it is a no-op.
-    idx_remove = text.index('Remove-Item -Recurse -Force "venv"', idx_recreate)
-    assert idx_sweep < idx_remove, (
-        "venv-resident processes must be stopped before Remove-Item deletes the venv"
+    # The process sweep must run before the live venv is moved aside.
+    idx_rename = text.index('Rename-Item -Path "venv"', idx_recreate)
+    assert idx_sweep < idx_rename, (
+        "venv-resident processes must be stopped before Rename-Item moves the venv aside"
     )
+    assert 'Remove-Item -Recurse -Force "venv"' not in text[idx_recreate:], (
+        "must not fall back to in-place delete of the live venv (#83149)"
+    )
+    assert "Could not move the existing venv aside" in text[idx_recreate:]


### PR DESCRIPTION
## Summary
- When Windows cannot rename the existing `venv` aside during recreate, abort instead of falling back to an in-place delete that can gut `site-packages` and leave no rollback.
- Mark venv-blocker probe failures with `probe_failed: true` so a missing `psutil` after a broken install cannot be read as a clear scan.
- Fixes #83149.

## Test plan
- [x] `scripts/run_tests.sh tests/test_install_ps1_venv_rename_abort.py tests/hermes_cli/test_scan_venv_blockers.py`
- [x] `scripts/run_tests.sh tests/test_install_ps1_ascii_only.py`
- [ ] On Windows: start a foreign `python.exe` from the Hermes venv, run update/bootstrap, confirm it aborts with the install left intact (no emptied `site-packages`)