### PR TITLE
fix(installer): make Windows venv recreation transactional (#83149)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2280,22 +2280,26 @@ function Install-Venv {
     # exits. Populated only with tasks that were ENABLED before we touched
     # them, so a task the user deliberately disabled is never re-armed.
     $gatewayTasksDisabled = @()
+    $venvHadExistingVenv = $false
+    $venvBackupName = $null
+    $venvParked = $false
     try {
-    if (Test-Path "venv") {
+    if (Test-Path -LiteralPath "venv") {
+        $venvHadExistingVenv = $true
         Write-Info "Virtual environment already exists, recreating..."
         # On Windows, native Python extensions (e.g. _bcrypt.pyd, tornado's
         # speedups.pyd) are loaded as DLLs by any running hermes process.
         # Windows denies deletion of loaded DLLs, so every process running out
-        # of this venv must be stopped before removing it -- otherwise
-        # Remove-Item fails with "Access to the path '...' is denied" and the
-        # whole install/update aborts at this stage.
+        # of this venv must be stopped before retiring it. This keeps cleanup
+        # from accumulating locked stale trees and avoids carrying a live
+        # gateway into the replacement venv.
         if ($env:OS -eq "Windows_NT") {
             $myPid = $PID
             Write-Info "Stopping any running hermes processes before recreating venv..."
             # Disarm the respawner FIRST: the gateway autostart Scheduled Task
             # relaunches a killed gateway within seconds, and losing that race
             # re-locks the venv's .pyd files between our kill sweep and
-            # Remove-Item (the July 2026 _brotlicffi.pyd incident). schtasks
+            # venv parking/cleanup (the July 2026 _brotlicffi.pyd incident). schtasks
             # /End stops a running task instance; /Change /DISABLE stops it
             # from re-firing mid-install. (The Startup-folder .vbs fallback is
             # NOT touched: it only fires at logon, so it cannot respawn a
@@ -2341,7 +2345,7 @@ function Install-Venv {
             #
             # The sweep is a bounded LOOP, not single-shot: supervised processes
             # (the Desktop app's backend, a watchdog-managed gateway) respawn in
-            # the window between one kill pass and the delete. Each pass re-
+            # the window between one kill pass and venv parking. Each pass re-
             # enumerates; three consecutive clean passes (or the attempt cap)
             # ends the loop.
             $venvPrefix = [System.IO.Path]::GetFullPath((Join-Path $InstallDir "venv")).TrimEnd('\') + '\'
@@ -2365,42 +2369,18 @@ function Install-Venv {
                 Start-Sleep -Milliseconds 400
             }
         }
-        # Rename-then-delete: on Windows a directory RENAME succeeds even while
-        # files inside it are mapped as DLLs (only in-place delete/replace of
-        # the mapped file is denied, and only same-volume renames are atomic
-        # moves). Moving the old venv aside means `uv venv` can create a fresh
-        # one immediately even if some straggler still holds a .pyd from the
-        # old tree; the renamed dir is deleted best-effort (now, and by the
-        # cleanup pass below on the NEXT install if a handle outlives this one).
-        $staleName = "venv.stale.{0}" -f (Get-Date -Format "yyyyMMddHHmmss")
-        $renamed = $false
+        # Move the old venv aside before creating its replacement. A directory
+        # rename is atomic on the same volume and does not require deleting
+        # files mapped as DLLs. Never fall back to deleting the live venv:
+        # Windows can remove unlocked files first, then fail on one locked
+        # file, leaving no usable interpreter and no rollback source.
+        $venvBackupName = "venv.stale.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
         try {
-            Rename-Item -Path "venv" -NewName $staleName -ErrorAction Stop
-            $renamed = $true
+            Rename-Item -LiteralPath "venv" -NewName $venvBackupName -ErrorAction Stop
+            $venvParked = $true
         } catch {
-            Write-Warn "Could not rename venv aside ($($_.Exception.Message)); falling back to in-place delete"
+            throw "Could not move existing venv aside without deleting it. Close running Hermes processes and retry. $($_.Exception.Message)"
         }
-        if ($renamed) {
-            Remove-Item -Recurse -Force $staleName -ErrorAction SilentlyContinue
-            if (Test-Path $staleName) {
-                Write-Warn "Old venv parked at $staleName (a process still holds files in it); it will be cleaned up on the next install"
-            }
-        } else {
-            Remove-Item -Recurse -Force "venv" -ErrorAction SilentlyContinue
-            # A killed process can take a moment to release its file handles, so a
-            # first Remove-Item may still hit a locked .pyd. Retry once after a short
-            # pause before giving up and letting the stage fail loudly.
-            if (Test-Path "venv") {
-                Start-Sleep -Seconds 2
-                Remove-Item -Recurse -Force "venv"
-            }
-        }
-    }
-
-    # Clean up parked venvs from previous installs whose handles have since
-    # been released. Best-effort -- a still-held tree just stays for next time.
-    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
-        Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
     }
     
     # uv creates the venv and pins the Python version in one step.  uv emits
@@ -2417,6 +2397,32 @@ function Install-Venv {
         throw "Failed to create virtual environment (uv venv exited with $venvExitCode)"
     }
 
+    # uv can return success without leaving the interpreter expected by the
+    # installer (for example after an interrupted filesystem operation). Treat
+    # that as a failed transaction so the previous venv can be restored.
+    $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
+    if (-not (Test-Path -LiteralPath $venvPythonExe -PathType Leaf)) {
+        throw "uv reported success but venv interpreter is missing at $venvPythonExe"
+    }
+
+    # The replacement is usable. The old tree is no longer needed for rollback;
+    # deletion is safe here because it cannot gut the live venv. A locked old
+    # tree remains parked and is retried by the cleanup pass below.
+    if ($venvParked) {
+        Remove-Item -LiteralPath $venvBackupName -Recurse -Force -ErrorAction SilentlyContinue
+        if (Test-Path -LiteralPath $venvBackupName) {
+            Write-Warn "Old venv parked at $venvBackupName (a process still holds files in it); it will be cleaned up on the next install"
+        } else {
+            $venvParked = $false
+        }
+    }
+
+    # Clean up parked venvs from previous installs whose handles have since
+    # been released. Best-effort -- a still-held tree just stays for next time.
+    Get-ChildItem -Directory -Filter "venv.stale.*" -ErrorAction SilentlyContinue | ForEach-Object {
+        Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
+    }
+
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
     # the user's shell). uv honours UV_PYTHON over an existing venv for the
     # later `uv sync` / `uv pip install` tiers, so without this it would
@@ -2424,10 +2430,43 @@ function Install-Venv {
     # -- building Rust transitives that have no wheel for that version from
     # source via maturin, which fails. Pinning UV_PYTHON to the interpreter we
     # just created forces every subsequent uv command onto it.
-    $venvPythonExe = Join-Path $InstallDir "venv\Scripts\python.exe"
-    if (Test-Path $venvPythonExe) {
-        $env:UV_PYTHON = $venvPythonExe
-    }
+    $env:UV_PYTHON = $venvPythonExe
+    } catch {
+        $originalError = $_
+        $rollbackError = $null
+
+        if ($venvParked -and $venvBackupName -and (Test-Path -LiteralPath $venvBackupName)) {
+            try {
+                if (Test-Path -LiteralPath "venv") {
+                    $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+                    Rename-Item -LiteralPath "venv" -NewName $failedVenvName -ErrorAction Stop
+                    Write-Warn "Failed replacement parked at $failedVenvName"
+                }
+                Rename-Item -LiteralPath $venvBackupName -NewName "venv" -ErrorAction Stop
+                Write-Warn "Restored previous virtual environment after failed recreate"
+            } catch {
+                $rollbackError = $_.Exception.Message
+            }
+
+            if ($rollbackError) {
+                throw "Virtual environment recreate failed: $($originalError.Exception.Message). Rollback failed: $rollbackError. Previous venv remains at $venvBackupName."
+            }
+        } elseif (-not $venvHadExistingVenv -and (Test-Path -LiteralPath "venv")) {
+            # Preserve a partial first install too. This branch must not touch a
+            # pre-existing venv whose move-aside failed above.
+            try {
+                $failedVenvName = "venv.failed.{0}-{1}" -f (Get-Date -Format "yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+                Rename-Item -LiteralPath "venv" -NewName $failedVenvName -ErrorAction Stop
+                Write-Warn "Partial virtual environment parked at $failedVenvName"
+            } catch {
+                $rollbackError = $_.Exception.Message
+            }
+            if ($rollbackError) {
+                throw "Virtual environment creation failed: $($originalError.Exception.Message). Could not park partial venv: $rollbackError"
+            }
+        }
+
+        throw $originalError
     } finally {
         Pop-Location
         # Re-arm the gateway autostart tasks disabled during the venv teardown
@@ -2598,7 +2637,7 @@ except Exception:
     if (-not $NoVenv) {
         $venvPython = "$InstallDir\venv\Scripts\python.exe"
         if (-not (Test-Path $venvPython)) {
-            throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling .venv\ directory. Re-run the installer; if it persists, manually: cd '$InstallDir'; Remove-Item -Recurse -Force venv,.venv; uv venv venv --python $PythonVersion; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
+            throw "Install reported success but $venvPython does not exist. The dependency sync likely landed in a sibling .venv\ directory. Re-run the installer; if it persists, close Hermes processes and preserve existing venv directories before retrying. Do not delete venv in place."
         }
         # Relax EAP=Stop while running the import probe.  Python writes
         # deprecation warnings and import-system info to stderr; under
@@ -2614,7 +2653,7 @@ except Exception:
         if ($importExitCode -ne 0) {
             $sibling = "$InstallDir\.venv"
             $hint = if (Test-Path $sibling) {
-                "Detected sibling .venv\ at $sibling -- uv synced there instead of venv\. Recover with: cd '$InstallDir'; Remove-Item -Recurse -Force venv; Move-Item .venv venv"
+                "Detected sibling .venv\ at $sibling -- uv synced there instead of venv\. Close Hermes processes, preserve the existing venv, and rerun the installer so the transactional recovery path can move directories safely."
             } else {
                 "Recover with: cd '$InstallDir'; `$env:UV_PROJECT_ENVIRONMENT='$InstallDir\venv'; uv sync --extra all --locked"
             }

--- a/tests/test_install_ps1_venv_recreate_safety.py
+++ b/tests/test_install_ps1_venv_recreate_safety.py
@@ -1,0 +1,75 @@
+"""Regression tests for transactional Windows venv recreation (#83149).
+
+The installer must never delete the live venv in place. Windows can remove
+unlocked files before it reaches a locked interpreter or native extension,
+leaving a half-installed venv that the next health/blocker probe cannot use.
+"""
+
+from pathlib import Path
+
+
+INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+def _function_body(source: str, function_name: str) -> str:
+    start = source.index(f"function {function_name}")
+    opening_brace = source.index("{", start)
+    depth = 0
+    for index in range(opening_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening_brace : index + 1]
+    raise AssertionError(f"unterminated function: {function_name}")
+
+
+def _install_venv_body() -> str:
+    return _function_body(INSTALL_PS1.read_text(encoding="ascii"), "Install-Venv")
+
+
+def test_rename_failure_cannot_fall_back_to_destructive_delete() -> None:
+    body = _install_venv_body()
+
+    assert "falling back to in-place delete" not in body.lower()
+    assert 'Remove-Item -Recurse -Force "venv"' not in body
+
+
+def test_manual_recovery_hints_do_not_delete_live_venv() -> None:
+    source = INSTALL_PS1.read_text(encoding="ascii")
+
+    assert "Remove-Item -Recurse -Force venv" not in source
+    assert "Do not delete venv in place" in source
+
+
+def test_previous_venv_survives_until_replacement_is_ready() -> None:
+    body = _install_venv_body()
+
+    create = body.index("& $UvCmd venv venv")
+    stale_cleanup = body.index('Get-ChildItem -Directory -Filter "venv.stale.*"')
+    assert create < stale_cleanup, (
+        "stale backups must not be cleaned before uv can succeed or rollback"
+    )
+
+
+def test_recreate_restores_parked_venv_after_failure() -> None:
+    body = _install_venv_body()
+
+    failure = body.index("Failed to create virtual environment")
+    restore = body.index(
+        'Rename-Item -LiteralPath $venvBackupName -NewName "venv"'
+    )
+    assert failure < restore
+    assert "rollback failed" in body.lower()
+
+
+def test_recreate_rejects_success_without_venv_interpreter() -> None:
+    body = _install_venv_body()
+
+    missing_python = body.index("$venvPythonExe")
+    success = body.index("Virtual environment ready")
+    assert "Test-Path -LiteralPath $venvPythonExe -PathType Leaf" in body[
+        missing_python:success
+    ]
+    assert "throw" in body[missing_python:success]

--- a/tests/test_install_unmerged_index.py
+++ b/tests/test_install_unmerged_index.py
@@ -152,9 +152,9 @@ def test_install_sh_clears_unmerged_index_before_stash_source_order() -> None:
     assert idx_unmerged < idx_stash
 
 
-def test_install_ps1_stops_venv_resident_processes_before_removing_venv() -> None:
+def test_install_ps1_stops_venv_resident_processes_before_parking_venv() -> None:
     """The Windows venv-recreate path must stop every process running out of the
-    old venv before deleting it.
+    old venv before moving it aside.
 
     A gateway autostarted by a scheduled task runs as
     ``venv\\Scripts\\pythonw.exe -m hermes_cli.main gateway run`` — image name
@@ -179,8 +179,8 @@ def test_install_ps1_stops_venv_resident_processes_before_removing_venv() -> Non
         "the -like wildcard match must not be used for venv path scoping"
     )
 
-    # The process sweep must run before the venv is removed, or it is a no-op.
-    idx_remove = text.index('Remove-Item -Recurse -Force "venv"', idx_recreate)
-    assert idx_sweep < idx_remove, (
-        "venv-resident processes must be stopped before Remove-Item deletes the venv"
+    # The process sweep must run before the venv is parked, or it is a no-op.
+    idx_park = text.index('Rename-Item -LiteralPath "venv"', idx_recreate)
+    assert idx_sweep < idx_park, (
+        "venv-resident processes must be stopped before Rename-Item parks the venv"
     )

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -108,6 +108,14 @@ Close the listed processes and re-run. If you're sure the concurrent process won
 
 A second, separate guard refuses to touch the venv while any process is running from its Python interpreter (the Desktop app's backend, a gateway, a Python REPL). Those processes keep native extension files (`.pyd`) locked, and a dependency sync that dies partway on an access-denied error strands the install between versions. This guard is **not** bypassed by `--force`; if you're certain the detected holders are false positives, use the explicit `hermes update --force-venv`.
 
+#### Windows venv recreation is transactional
+
+When the Windows installer must recreate an existing `venv`, it first moves the old directory to a unique `venv.stale.*` name, then creates and verifies the replacement. The old tree is deleted only after `venv\Scripts\python.exe` exists in the new tree.
+
+If the move cannot be completed, the installer stops and leaves the live `venv` untouched. If `uv` fails or reports success without creating the interpreter, any partial replacement is moved to `venv.failed.*` and the previous venv is restored. This keeps the health and blocker checks usable after a failed install.
+
+A `venv.stale.*` or `venv.failed.*` directory can remain when another process still owns a file handle. Close Hermes Desktop, gateways, and Python processes using the install, then retry the install/update; parked directories are cleaned up best-effort after a successful recreation.
+
 Expected output looks like:
 
 ```


### PR DESCRIPTION
## Summary

Fixes #83149.

Windows venv recreation was not transactional. When the live `venv` directory could not be renamed, the installer recursively deleted it in place. Windows could remove unlocked files, hit a locked interpreter/native extension, and leave the install gutted. The next health/blocker probe then had no usable interpreter.

## Root cause

- `scripts/install.ps1::Install-Venv` fell back from `Rename-Item` to `Remove-Item -Recurse -Force "venv"`.
- The fallback had no rollback source after partial deletion.
- Parked venv cleanup ran before `uv venv`, so a failed recreate could not retain the previous tree.
- A zero exit from `uv` was accepted without verifying `venv\\Scripts\\python.exe`.

## Fix

- Move the existing venv to a unique `venv.stale.*` name; fail safely if that move cannot complete.
- Keep the parked tree until the replacement contains a regular interpreter file.
- On uv failure or invalid replacement, park partial output as `venv.failed.*` and restore the previous venv.
- Surface rollback failure with the retained backup path; never silently delete the live venv.
- Run stale cleanup only after successful replacement validation.
- Remove destructive manual recovery hints and update Windows update documentation.

## Validation

- 5 new regression tests: RED on the old implementation, GREEN on this implementation.
- 12 relevant installer/source tests passed; 1 unrelated live `tmp_path` test was deselected because this Windows runner denies pytest-created basetemp ACLs.
- Real PowerShell harness passed uv-failure rollback, missing-interpreter rollback, partial-tree parking, and successful replacement cases.
- PowerShell parser: OK.
- Ruff: OK.

## Infographic :


 
<img width="1024" height="1024" alt="infographic" src="https://github.com/user-attachments/assets/050b4ed1-a2f4-4ba5-9ec3-e12b74d50b32" />

