### PR TITLE
fix(desktop): keep compressed user prompts before their replies

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -6408,14 +6408,33 @@ This compaction should PRIORITISE preserving all information related to the focu
             ):
                 prev_content = prev["content"]
                 new_content = msg["content"]
-                prev["content"] = (
+                merged_content = (
                     (prev_content + "\n\n" + new_content)
                     if prev_content and new_content
                     else (prev_content or new_content)
                 )
-                # Merged content invalidates the api_content sidecar (exact
-                # bytes previously sent for the pre-merge message).
-                drop_stale_api_content(prev)
+                if prev.get("display_kind") and not msg.get("display_kind"):
+                    # A timeline marker can be the surviving first row after a
+                    # marker supersede. Keep its bytes in the model-facing
+                    # sidecar, but let the absorbed human turn own transcript
+                    # presentation; otherwise frontends hide the whole carrier
+                    # (including the real prompt) as the marker event.
+                    msg_api_content = msg.get("api_content")
+                    if not isinstance(msg_api_content, str):
+                        msg_api_content = new_content
+                    prev["api_content"] = (
+                        (prev_content + "\n\n" + msg_api_content)
+                        if prev_content and msg_api_content
+                        else (prev_content or msg_api_content)
+                    )
+                    prev["content"] = new_content
+                    prev.pop("display_kind", None)
+                    prev.pop("display_metadata", None)
+                else:
+                    prev["content"] = merged_content
+                    # Merged content invalidates the api_content sidecar (exact
+                    # bytes previously sent for the pre-merge message).
+                    drop_stale_api_content(prev)
                 continue
             merged.append(msg)
         return merged

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -200,6 +200,32 @@ class TestMicroCompaction:
                 f"user text {original!r} must survive verbatim"
             )
 
+    def test_timeline_marker_absorbing_user_keeps_prompt_displayable(self):
+        marker = (
+            "[System: The active model for this chat has changed to k3. "
+            "From this point forward, use this runtime metadata.]"
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": marker,
+                "display_kind": "model_switch",
+                "display_metadata": {"provider": "openrouter"},
+            },
+            {
+                "role": "user",
+                "content": "the newest real prompt",
+                "api_content": "the newest real prompt\n\nplugin context",
+            },
+        ]
+
+        [merged] = ContextCompressor._merge_adjacent_user_turns(messages)
+
+        assert merged["content"] == "the newest real prompt"
+        assert merged["api_content"] == f"{marker}\n\nthe newest real prompt\n\nplugin context"
+        assert "display_kind" not in merged
+        assert "display_metadata" not in merged
+
     def test_cursor_is_derived_from_the_spliced_list(self):
         """The cursor must never carry over a pre-splice index.
 


### PR DESCRIPTION
## What does this PR do?

Preserves the newest real user prompt as an authoritative transcript message when context compression merges it with a synthetic timeline carrier. Without this fix, Desktop can render the completed assistant reply before the optimistic user bubble and then hide the prompt entirely after reload, even though the prompt remains in session storage.

### Symptom

After in-place context compression in a long Desktop session, the newest user bubble can appear after its completed assistant reply. Reloading the session can replace that bubble with a model-change event and omit the real prompt from the transcript.

### Impact

Affected Desktop sessions show a misleading conversation order during warm reconciliation and can hide the newest user prompt after fresh hydration. The persisted prompt is not deleted, but users cannot reliably see the request that produced the reply.

### Bug Cause

**Trigger:** `agent/context_compressor.py` / `ContextCompressor._merge_adjacent_user_turns()` when a `display_kind=model_switch` user carrier is adjacent to a real user prompt after marker supersession.

**Causal chain:**
1. Micro-compaction supersedes an older summary marker and leaves a synthetic model-switch user carrier adjacent to the newest real user prompt.
2. The alternation repair joins their content but retains the first row's display metadata, so the merged active row is still classified as a model-switch event.
3. Desktop projects that row as a system event. Warm reconciliation appends the unmatched optimistic user after the completed reply, while fresh hydration hides the prompt inside the system event.

**Why it is wrong:** The synthetic carrier's presentation metadata incorrectly takes ownership of an absorbed human turn, even though the merged bytes must remain available to the model.

**Working sibling / contrast:** Ordinary adjacent real-user rows already merge correctly because neither row has synthetic display metadata. Marker-only rows also remain valid timeline events when they do not absorb a real prompt.

**Ruled out:** Session data deletion was ruled out by inspecting the persisted active rows. The real prompt remained stored inside the synthetic carrier, and the failure was reproduced through SessionDB persistence plus Desktop warm reconciliation and fresh hydration.

### Fix

When a typed synthetic user carrier absorbs an untyped real user turn, the compressor now keeps the full merged model-facing bytes in `api_content` while promoting the real prompt to display `content` and removing the stale timeline metadata. Other adjacent-user merges retain their existing behavior. A focused regression test covers the model-switch carrier sequence and verifies both display and model-facing content.

## Related Issue

Closes #83154

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` - preserve merged model-facing bytes while making an absorbed real prompt authoritative for transcript display.
- `tests/agent/test_micro_compaction.py` - cover a model-switch carrier absorbing a real user prompt with an API sidecar.

## How to Test

1. Run the focused compression and API-sidecar tests; 64 tests passed locally.
2. Run the Desktop projection and reconciliation tests; 135 tests passed locally.
3. Reproduce the merge through SessionDB persistence, then verify Desktop warm reconciliation and fresh hydration both place exactly one newest user prompt before its completed assistant reply while retaining the model-facing marker bytes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 with the Desktop projection and reconciliation path

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A because this change restores existing transcript behavior
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the fix changes platform-independent persisted message semantics
- [x] Tool description and schema updates are N/A because no tool behavior changed

## Screenshots / Logs

N/A. The regression is covered by automated tests and an end-to-end persistence, reconciliation, and hydration verification.
