### PR TITLE
fix(cron): delivery uses owning profile's secret scope + adapters under multiplex

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6997,6 +6997,7 @@ def run_one_job(
                 loop=loop,
                 verbose=verbose,
                 extra_prompt=extra_prompt,
+                profile_adapters=profile_adapters,
                 fire_claim_lost=(
                     _CombinedCancelEvent(lost_ownership, cancel_event)
                     if cancel_event is not None
@@ -7021,6 +7022,7 @@ def _run_one_job_body(
     loop=None,
     verbose: bool = False,
     extra_prompt: Optional[str] = None,
+    profile_adapters=None,
     fire_claim_lost: Optional[_CancelEventLike] = None,
     execution_token: Optional[object] = None,
 ) -> bool:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3065,7 +3065,33 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_adapters_for_job(job: dict, adapters=None, profile_adapters=None):
+    """Resolve the effective live-adapter dict for a cron delivery.
+
+    Prefers the owning profile's adapter map (``profile_adapters``) when the
+    job belongs to a secondary profile under multiplex, so delivery uses that
+    profile's live bot/chat instead of the default profile's shared
+    ``adapters`` dict. Falls back to the shared ``adapters`` dict for the
+    default profile / non-multiplex path (existing behavior unchanged).
+
+    Mirrors the lookup in gateway/authz_mixin (``_profile_adapters[profile]``),
+    but keyed off the job's active profile home resolved at delivery time.
+    """
+    if profile_adapters:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            profile = get_active_profile_name() or "default"
+            if profile != "default":
+                profile_map = profile_adapters.get(profile)
+                if isinstance(profile_map, dict) and profile_map:
+                    return profile_map
+        except Exception:
+            logger.debug("profile-adapters resolution failed; falling back to shared adapters", exc_info=True)
+    return adapters or {}
+
+
+def _deliver_result(job: dict, content: str, adapters=None, loop=None,
+                    profile_adapters=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -3073,6 +3099,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     use the live adapter first — this supports E2EE rooms (e.g. Matrix) where
     the standalone HTTP path cannot encrypt.  Falls back to standalone send if
     the adapter path fails or is unavailable.
+
+    ``profile_adapters`` (optional) is the gateway's per-profile adapter map
+    (Gateway._profile_adapters: ``{profile_name: {platform: adapter}}``) for
+    multiplex mode. When provided and the job's profile has a live adapter
+    entry, delivery routes through that profile's adapter instead of the
+    shared ``adapters`` dict (the default profile's), so a secondary-profile
+    cron job delivers from the correct bot/chat. Falls back to the shared
+    ``adapters`` dict for the default profile / non-multiplex path.
 
     Returns None on success, or an error string on failure.
     """
@@ -3180,6 +3214,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         logger.error("Job '%s': %s", job["id"], msg)
         return msg
 
+    # Under multiplex, delivery must use the job-owning profile's live adapter
+    # (its bot/chat), not the shared default-profile ``adapters`` dict — the
+    # gateway's per-profile adapter map is threaded through via
+    # ``profile_adapters``. Resolve it once here; both the transport lookup and
+    # the DeliveryRouter below consume it.
+    delivery_adapters = _deliver_adapters_for_job(
+        job, adapters=adapters, profile_adapters=profile_adapters
+    )
+
     delivery_errors = []
 
     for target in targets:
@@ -3265,7 +3308,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         from gateway.delivery import resolve_delivery_transport
 
-        transport = resolve_delivery_transport(platform, config, adapters)
+        transport = resolve_delivery_transport(platform, config, delivery_adapters)
         if transport is not None:
             pconfig = transport.config
             runtime_adapter = transport.adapter
@@ -3519,7 +3562,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
-                    router = DeliveryRouter(config, adapters)
+                    router = DeliveryRouter(config, delivery_adapters)
                     route_target = DeliveryTarget(
                         platform=platform,
                         chat_id=str(chat_id),
@@ -6915,6 +6958,7 @@ def run_one_job(
     verbose: bool = False,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    profile_adapters=None,
 ) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -7090,9 +7134,20 @@ def _run_one_job_body(
             # still triggers teardown before propagating.
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
-            raise
-        finally:
+            # Restore the previous secret scope before propagating: this
+            # failure path never reaches the delivery block whose finally
+            # resets it, so without this a leaked scope would contaminate the
+            # next job running on the same worker thread.
             reset_secret_scope(_scope_token)
+            raise
+        # NOTE: the profile secret scope is intentionally NOT reset here — it
+        # must stay installed through _deliver_result below, which reads the
+        # job profile's credentials via load_gateway_config -> _getenv (e.g.
+        # TELEGRAM_BOT_TOKEN). Resetting it before delivery made multiplexed
+        # jobs deliver with NO scope, so the owning profile's .env was ignored
+        # and delivery used the default profile's/empty token (wrong bot/chat,
+        # lost thread). The reset now happens in the delivery block's finally,
+        # once run AND delivery are both complete.
 
         if _fire_claim_ownership_lost():
             for _deferred_agent in _deferred_agents:
@@ -7270,6 +7325,7 @@ def _run_one_job_body(
                             deliver_content,
                             adapters=adapters,
                             loop=loop,
+                            profile_adapters=profile_adapters,
                         )
                 except Exception as de:
                     if isinstance(de, _FireClaimLostDuringSideEffect):
@@ -7284,6 +7340,12 @@ def _run_one_job_body(
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
+            # Reset the profile secret scope now that run AND delivery are both
+            # complete. Kept installed through _deliver_result above so the
+            # job profile's credentials (e.g. TELEGRAM_BOT_TOKEN) resolve
+            # correctly under multiplex; torn down here so a scope never leaks
+            # into the next job on this worker thread.
+            reset_secret_scope(_scope_token)
 
         if side_effect_ownership_lost or _fire_claim_ownership_lost():
             # Same transport-cancel distinction as the pre-side-effect path:
@@ -7560,6 +7622,7 @@ def tick(
     sync: bool = True,
     *,
     can_dispatch=None,
+    profile_adapters=None,
 ):
     """
     Check and run all due jobs.
@@ -7779,6 +7842,7 @@ def tick(
                 adapters=adapters,
                 loop=loop,
                 verbose=verbose,
+                profile_adapters=profile_adapters,
             )
 
         # Partition due jobs: those with a per-job workdir mutate

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3076,17 +3076,32 @@ def _deliver_adapters_for_job(job: dict, adapters=None, profile_adapters=None):
 
     Mirrors the lookup in gateway/authz_mixin (``_profile_adapters[profile]``),
     but keyed off the job's active profile home resolved at delivery time.
+
+    Identity-boundary contract (review #83197): for ANY resolved non-default
+    profile, this returns that profile's non-empty map or ``{}`` — NEVER the
+    default profile's shared ``adapters`` map. Falling back to the default
+    map when the owning profile's registry is missing/empty would recreate
+    the exact wrong-bot/wrong-chat identity path this fix exists to remove.
+    ``{}`` still permits the existing standalone delivery path to use the
+    active profile's scoped credential. On profile-resolution failure the
+    authority-safe fallback is also ``{}``.
     """
-    if profile_adapters:
+    if profile_adapters is not None:
         try:
             from hermes_cli.profiles import get_active_profile_name
             profile = get_active_profile_name() or "default"
             if profile != "default":
                 profile_map = profile_adapters.get(profile)
-                if isinstance(profile_map, dict) and profile_map:
+                if isinstance(profile_map, dict):
                     return profile_map
+                return {}
         except Exception:
-            logger.debug("profile-adapters resolution failed; falling back to shared adapters", exc_info=True)
+            logger.debug(
+                "profile-adapters resolution failed; returning empty adapter map "
+                "(never the default profile's shared adapters)",
+                exc_info=True,
+            )
+            return {}
     return adapters or {}
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1602,7 +1602,33 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_adapters_for_job(job: dict, adapters=None, profile_adapters=None):
+    """Resolve the effective live-adapter dict for a cron delivery.
+
+    Prefers the owning profile's adapter map (``profile_adapters``) when the
+    job belongs to a secondary profile under multiplex, so delivery uses that
+    profile's live bot/chat instead of the default profile's shared
+    ``adapters`` dict. Falls back to the shared ``adapters`` dict for the
+    default profile / non-multiplex path (existing behavior unchanged).
+
+    Mirrors the lookup in gateway/authz_mixin (``_profile_adapters[profile]``),
+    but keyed off the job's active profile home resolved at delivery time.
+    """
+    if profile_adapters:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            profile = get_active_profile_name() or "default"
+            if profile != "default":
+                profile_map = profile_adapters.get(profile)
+                if isinstance(profile_map, dict) and profile_map:
+                    return profile_map
+        except Exception:
+            logger.debug("profile-adapters resolution failed; falling back to shared adapters", exc_info=True)
+    return adapters or {}
+
+
+def _deliver_result(job: dict, content: str, adapters=None, loop=None,
+                    profile_adapters=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1610,6 +1636,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     use the live adapter first — this supports E2EE rooms (e.g. Matrix) where
     the standalone HTTP path cannot encrypt.  Falls back to standalone send if
     the adapter path fails or is unavailable.
+
+    ``profile_adapters`` (optional) is the gateway's per-profile adapter map
+    (Gateway._profile_adapters: ``{profile_name: {platform: adapter}}``) for
+    multiplex mode. When provided and the job's profile has a live adapter
+    entry, delivery routes through that profile's adapter instead of the
+    shared ``adapters`` dict (the default profile's), so a secondary-profile
+    cron job delivers from the correct bot/chat. Falls back to the shared
+    ``adapters`` dict for the default profile / non-multiplex path.
 
     Returns None on success, or an error string on failure.
     """
@@ -1687,6 +1721,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         logger.error("Job '%s': %s", job["id"], msg)
         return msg
 
+    # Under multiplex, delivery must use the job-owning profile's live adapter
+    # (its bot/chat), not the shared default-profile ``adapters`` dict — the
+    # gateway's per-profile adapter map is threaded through via
+    # ``profile_adapters``. Resolve it once here; both the transport lookup and
+    # the DeliveryRouter below consume it.
+    delivery_adapters = _deliver_adapters_for_job(
+        job, adapters=adapters, profile_adapters=profile_adapters
+    )
+
     delivery_errors = []
 
     for target in targets:
@@ -1731,7 +1774,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         from gateway.delivery import resolve_delivery_transport
 
-        transport = resolve_delivery_transport(platform, config, adapters)
+        transport = resolve_delivery_transport(platform, config, delivery_adapters)
         if transport is not None:
             pconfig = transport.config
             runtime_adapter = transport.adapter
@@ -1941,7 +1984,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
-                    router = DeliveryRouter(config, adapters)
+                    router = DeliveryRouter(config, delivery_adapters)
                     route_target = DeliveryTarget(
                         platform=platform,
                         chat_id=str(chat_id),
@@ -4538,7 +4581,7 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
 
 def run_one_job(
     job: dict, *, adapters=None, loop=None, verbose: bool = False,
-    extra_prompt: Optional[str] = None,
+    extra_prompt: Optional[str] = None, profile_adapters=None,
 ) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -4618,9 +4661,20 @@ def run_one_job(
             # still triggers teardown before propagating.
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
-            raise
-        finally:
+            # Restore the previous secret scope before propagating: this
+            # failure path never reaches the delivery block whose finally
+            # resets it, so without this a leaked scope would contaminate the
+            # next job running on the same worker thread.
             reset_secret_scope(_scope_token)
+            raise
+        # NOTE: the profile secret scope is intentionally NOT reset here — it
+        # must stay installed through _deliver_result below, which reads the
+        # job profile's credentials via load_gateway_config -> _getenv (e.g.
+        # TELEGRAM_BOT_TOKEN). Resetting it before delivery made multiplexed
+        # jobs deliver with NO scope, so the owning profile's .env was ignored
+        # and delivery used the default profile's/empty token (wrong bot/chat,
+        # lost thread). The reset now happens in the delivery block's finally,
+        # once run AND delivery are both complete.
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step
@@ -4704,7 +4758,10 @@ def run_one_job(
                     and not _resolve_delivery_targets(job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        job, deliver_content, adapters=adapters, loop=loop,
+                        profile_adapters=profile_adapters,
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -4714,6 +4771,12 @@ def run_one_job(
             # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
+            # Reset the profile secret scope now that run AND delivery are both
+            # complete. Kept installed through _deliver_result above so the
+            # job profile's credentials (e.g. TELEGRAM_BOT_TOKEN) resolve
+            # correctly under multiplex; torn down here so a scope never leaks
+            # into the next job on this worker thread.
+            reset_secret_scope(_scope_token)
 
         # Treat empty final_response as a soft failure so last_status
         # is not "ok" — the agent ran but produced nothing useful.
@@ -4850,6 +4913,7 @@ def tick(
     sync: bool = True,
     *,
     can_dispatch=None,
+    profile_adapters=None,
 ):
     """
     Check and run all due jobs.
@@ -4961,7 +5025,10 @@ def tick(
             module-level ``run_one_job`` so ``tick`` and external providers
             (Chronos ``fire_due``) use the identical execute→save→deliver→mark
             body."""
-            return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
+            return run_one_job(
+                job, adapters=adapters, loop=loop, verbose=verbose,
+                profile_adapters=profile_adapters,
+            )
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -154,6 +154,7 @@ class CronScheduler(ABC):
         adapters: Any = None,
         loop: Any = None,
         force: bool = False,
+        profile_adapters: Any = None,
     ) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
@@ -170,7 +171,10 @@ class CronScheduler(ABC):
         claimed_job = self.claim_fire(job_id, force=force)
         if claimed_job is None:
             return False
-        return self.fire_claimed(claimed_job, adapters=adapters, loop=loop)
+        return self.fire_claimed(
+            claimed_job, adapters=adapters, loop=loop,
+            profile_adapters=profile_adapters,
+        )
 
     def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
         """Durably claim one fire and create its audit attempt before dispatch.
@@ -212,6 +216,7 @@ class CronScheduler(ABC):
         adapters: Any = None,
         loop: Any = None,
         cancel_event: Any = None,
+        profile_adapters: Any = None,
     ) -> bool:
         """Run an exact snapshot returned by ``claim_fire``.
 
@@ -227,6 +232,7 @@ class CronScheduler(ABC):
             adapters=adapters,
             loop=loop,
             cancel_event=cancel_event,
+            profile_adapters=profile_adapters,
         )
         return True
 
@@ -532,6 +538,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -559,6 +566,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                profile_adapters=profile_adapters,
             )
             return
 
@@ -590,6 +598,7 @@ class InProcessCronScheduler(CronScheduler):
                         loop=loop,
                         sync=False,
                         can_dispatch=can_dispatch,
+                        profile_adapters=profile_adapters,
                     )
                 ok = True
             except BaseException as e:
@@ -630,6 +639,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        profile_adapters=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -692,6 +702,7 @@ class InProcessCronScheduler(CronScheduler):
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,
+                                    profile_adapters=profile_adapters,
                                 )
                         finally:
                             reset_hermes_home_override(home_token)

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -98,7 +98,8 @@ class CronScheduler(ABC):
 
         return recover_interrupted_executions()
 
-    def fire_due(self, job_id: str, *, adapters: Any = None, loop: Any = None) -> bool:
+    def fire_due(self, job_id: str, *, adapters: Any = None, loop: Any = None,
+                 profile_adapters: Any = None) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
 
@@ -120,7 +121,8 @@ class CronScheduler(ABC):
         if job is None:
             return False  # job removed (e.g. repeat-N exhausted) between arm and fire
         job["execution_id"] = create_execution(job_id, source=self.name)["id"]
-        return run_one_job(job, adapters=adapters, loop=loop)
+        return run_one_job(job, adapters=adapters, loop=loop,
+                           profile_adapters=profile_adapters)
 
     def reconcile(self) -> None:
         """Converge the external registry toward jobs.json (the desired state):
@@ -192,6 +194,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -219,6 +222,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                profile_adapters=profile_adapters,
             )
             return
 
@@ -244,6 +248,7 @@ class InProcessCronScheduler(CronScheduler):
                         loop=loop,
                         sync=False,
                         can_dispatch=can_dispatch,
+                        profile_adapters=profile_adapters,
                     )
                 ok = True
             except BaseException as e:
@@ -279,6 +284,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        profile_adapters=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -339,6 +345,7 @@ class InProcessCronScheduler(CronScheduler):
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,
+                                    profile_adapters=profile_adapters,
                                 )
                         finally:
                             reset_hermes_home_override(home_token)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31001,6 +31001,66 @@ def _looks_like_profile_conflict_from_cmdline(command: str, our_home) -> bool:
     return False
 
 
+def _build_cron_start_kwargs(
+    runner: Any,
+    cron_provider: Any,
+    *,
+    multiplex_cron: bool = False,
+) -> Dict[str, Any]:
+    """Build the kwargs for ``cron_provider.start`` for the gateway ticker.
+
+    The shared defaults (``adapters`` + ``loop``) apply to every provider.
+    ``profile_adapters`` and ``profile_homes`` are multiplex-only additions
+    consumed exclusively by ``InProcessCronScheduler``; they are injected ONLY
+    when the resolved provider is the in-process ticker. External providers
+    (Chronos) implement ``start(stop_event, *, adapters, loop, interval)`` and
+    must never receive them — widening the generic provider call broke
+    external providers with a deterministic TypeError (review #83197).
+    """
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    cron_start_kwargs: Dict[str, Any] = {
+        "adapters": runner.adapters,
+        "loop": asyncio.get_running_loop(),
+    }
+    if isinstance(cron_provider, InProcessCronScheduler):
+        # Multiplex profiles: expose the gateway's per-profile live-adapter
+        # map so cron delivery for a secondary-profile job routes through THAT
+        # profile's bot/chat (not the default profile's shared
+        # ``runner.adapters`` dict). Without this, a secondary-profile cron
+        # delivery picked the wrong adapter (or none) even when the owning
+        # profile's token resolved correctly. Deliberately scoped to the
+        # in-process provider: it is the ONLY provider whose ``start()``
+        # consumes ``profile_adapters`` (interface rule: start() signature
+        # growth must not break providers).
+        _profile_adapters = getattr(runner, "_profile_adapters", None)
+        if _profile_adapters:
+            cron_start_kwargs["profile_adapters"] = _profile_adapters
+        if multiplex_cron:
+            # Tell the built-in ticker which profile homes to tick so
+            # secondary-profile cron jobs actually fire (#69377).
+            try:
+                profile_homes = _multiplex_profile_homes(runner.config)
+                if profile_homes:
+                    cron_start_kwargs["profile_homes"] = profile_homes
+                    logger.info(
+                        "Cron scheduler will tick %d profile(s) under multiplex: %s",
+                        len(profile_homes),
+                        [p[0] if isinstance(p, tuple) else p for p in profile_homes],
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Could not resolve profile homes for multiplex cron: %s",
+                    exc,
+                )
+        # External cron providers own their remote scheduling contract. Only
+        # the in-process ticker polls local due jobs, so only it receives the
+        # local external-drain dispatch gate.
+        cron_start_kwargs["can_dispatch"] = lambda: not (
+            runner._draining or runner._external_drain_active
+        )
+    return cron_start_kwargs
+
 
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
@@ -31610,49 +31670,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         resolve_cron_scheduler(),
         multiplex_profiles=multiplex_cron,
     )
-    cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
-
-    # Multiplex profiles: expose the gateway's per-profile live-adapter map so
-    # cron delivery for a secondary-profile job routes through THAT profile's
-    # bot/chat (not the default profile's shared ``runner.adapters`` dict).
-    # Without this, a secondary-profile cron delivery picked the wrong adapter
-    # (or none) even when the owning profile's token resolved correctly.
-    _profile_adapters = getattr(runner, "_profile_adapters", None)
-    if _profile_adapters:
-        cron_start_kwargs["profile_adapters"] = _profile_adapters
-
-    # Multiplex profiles: tell the built-in ticker which profile homes to
-    # tick so secondary-profile cron jobs actually fire (#69377).
-    # Without this, only the process-global HERMES_HOME (default profile)
-    # is iterated and every secondary profile's cron store is silently
-    # ignored — jobs show as "scheduled" with a valid next_run_at but
-    # never execute because no ticker owns that store.
-    if (
-        isinstance(cron_provider, InProcessCronScheduler)
-        and multiplex_cron
-    ):
-        try:
-            profile_homes = _multiplex_profile_homes(runner.config)
-            if profile_homes:
-                cron_start_kwargs["profile_homes"] = profile_homes
-                logger.info(
-                    "Cron scheduler will tick %d profile(s) under multiplex: %s",
-                    len(profile_homes),
-                    [p[0] if isinstance(p, tuple) else p for p in profile_homes],
-                )
-        except Exception as exc:
-            logger.warning(
-                "Could not resolve profile homes for multiplex cron: %s",
-                exc,
-            )
-
-    # External cron providers own their remote scheduling contract. Only the
-    # in-process ticker polls local due jobs, so only it receives the local
-    # external-drain dispatch gate.
-    if isinstance(cron_provider, InProcessCronScheduler):
-        cron_start_kwargs["can_dispatch"] = lambda: not (
-            runner._draining or runner._external_drain_active
-        )
+    cron_start_kwargs = _build_cron_start_kwargs(
+        runner,
+        cron_provider,
+        multiplex_cron=multiplex_cron,
+    )
     cron_thread = threading.Thread(
         target=cron_provider.start,
         args=(cron_stop,),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31612,6 +31612,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     )
     cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
 
+    # Multiplex profiles: expose the gateway's per-profile live-adapter map so
+    # cron delivery for a secondary-profile job routes through THAT profile's
+    # bot/chat (not the default profile's shared ``runner.adapters`` dict).
+    # Without this, a secondary-profile cron delivery picked the wrong adapter
+    # (or none) even when the owning profile's token resolved correctly.
+    _profile_adapters = getattr(runner, "_profile_adapters", None)
+    if _profile_adapters:
+        cron_start_kwargs["profile_adapters"] = _profile_adapters
+
     # Multiplex profiles: tell the built-in ticker which profile homes to
     # tick so secondary-profile cron jobs actually fire (#69377).
     # Without this, only the process-global HERMES_HOME (default profile)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27664,6 +27664,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     cron_provider = resolve_cron_scheduler()
     cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
 
+    # Multiplex profiles: expose the gateway's per-profile live-adapter map so
+    # cron delivery for a secondary-profile job routes through THAT profile's
+    # bot/chat (not the default profile's shared ``runner.adapters`` dict).
+    # Without this, a secondary-profile cron delivery picked the wrong adapter
+    # (or none) even when the owning profile's token resolved correctly.
+    _profile_adapters = getattr(runner, "_profile_adapters", None)
+    if _profile_adapters:
+        cron_start_kwargs["profile_adapters"] = _profile_adapters
+
     # Multiplex profiles: tell the built-in ticker which profile homes to
     # tick so secondary-profile cron jobs actually fire (#69377).
     # Without this, only the process-global HERMES_HOME (default profile)

--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -239,6 +239,7 @@ class ChronosCronScheduler(CronScheduler):
         adapters: Any = None,
         loop: Any = None,
         cancel_event: Any = None,
+        profile_adapters: Any = None,
     ) -> bool:
         job_id = claimed_job["id"]
         ran = super().fire_claimed(
@@ -246,6 +247,7 @@ class ChronosCronScheduler(CronScheduler):
             adapters=adapters,
             loop=loop,
             cancel_event=cancel_event,
+            profile_adapters=profile_adapters,
         )
         if ran:
             from cron.jobs import get_job

--- a/tests/cron/test_cron_drift_alert_once.py
+++ b/tests/cron/test_cron_drift_alert_once.py
@@ -48,7 +48,7 @@ def _tick(job, tmp_path, current_provider, deliveries):
     """Run one run_one_job tick with the provider resolution pinned."""
     fake_db = MagicMock()
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
         deliveries.append(content)
         return None
 
@@ -129,7 +129,7 @@ class TestDriftAlertOnce:
         job = _job(provider_snapshot=None, drift_alerted=True)
         deliveries = []
 
-        def fake_deliver(jb, content, adapters=None, loop=None):
+        def fake_deliver(jb, content, adapters=None, loop=None, profile_adapters=None):
             deliveries.append(content)
             return None
 

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -129,7 +129,7 @@ class TestMissingProviderKeyBlocks:
         job = _job()
         deliveries = []
 
-        def fake_deliver(job, content, adapters=None, loop=None):
+        def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
             deliveries.append(content)
             return None
 
@@ -233,7 +233,7 @@ class TestOptOut:
         job = _job()
         deliveries = []
 
-        def fake_deliver(job, content, adapters=None, loop=None):
+        def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
             deliveries.append(content)
             return None
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -505,3 +505,190 @@ def test_run_one_job_threads_profile_adapters_to_delivery(monkeypatch, tmp_path)
     assert received["shared_adapters"] == {"telegram": "default-telegram-adapter"}
 
 
+def test_deliver_adapters_missing_profile_map_never_uses_shared(monkeypatch, tmp_path):
+    """Review #83197 (ghosty-11) blocker 2: a non-default profile whose entry is
+    MISSING from ``profile_adapters`` must get ``{}`` — NEVER the shared
+    default-profile ``adapters`` dict. Falling back to the default map would
+    recreate the wrong-bot/wrong-chat identity path."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "home-ops"
+    )
+
+    shared = {"telegram": "default-telegram-adapter"}
+    # profile_adapters has NO "home-ops" entry at all.
+    selected = s._deliver_adapters_for_job(
+        {"id": "j12"}, adapters=shared,
+        profile_adapters={"other": {"telegram": "other-adapter"}},
+    )
+    assert selected == {}
+
+
+def test_deliver_adapters_empty_profile_map_never_uses_shared(monkeypatch, tmp_path):
+    """Review #1 (ghosty-11) blocker 2: a non-default profile whose entry is an
+    EMPTY dict must resolve to ``{}`` — never the shared default map."""
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "home-ops"
+    )
+
+    shared = {"telegram": "default-telegram-adapter"}
+    selected = s._deliver_adapters_for_job(
+        job={"id": "j13"}, adapters=shared,
+        profile_adapters={"home-ops": {}},
+    )
+    assert selected == {}
+
+
+def test_deliver_adapters_none_profile_adapters_keeps_shared(monkeypatch, tmp_path):
+    """Review #1 blocker 2: ``profile_adapters=None`` (non-multiplex path)
+    keeps the shared ``adapters`` dict — existing behavior unchanged."""
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "home-ops"
+    )
+
+    shared = {"telegram": "default-telegram-adapter"}
+    selected = s._deliver_adapters_for_job(
+        {"id": "j14"}, adapters=shared, profile_adapters=None
+    )
+    assert selected == {"telegram": "default-telegram-adapter"}
+
+
+def test_deliver_adapters_resolution_error_returns_empty(monkeypatch, tmp_path):
+    """Review #1 blocker 2: when profile resolution RAISES, the authority-safe
+    fallback is ``{}`` — never the shared default-profile map."""
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+
+    def _boom():
+        raise RuntimeError("profile resolution broke")
+
+    monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", _boom)
+
+    shared = {"telegram": "default-telegram-adapter"}
+    selected = s._deliver_adapters_for_job(
+        {"id": "j15"}, adapters=shared,
+        profile_adapters={"home-ops": {"telegram": "home-ops-adapter"}},
+    )
+    assert selected == {}
+
+
+def test_deliver_adapters_empty_profile_map_falls_back_to_standalone(monkeypatch, tmp_path):
+    """Review #1 blocker 2 end-to-end: ``{}`` (the identity-safe result for a
+    missing/empty secondary registry) permits the existing STANDALONE delivery
+    path — the transport lookup finds no live adapter and delivery uses the
+    active profile's scoped credential instead of the default profile's bot."""
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=profile_bot_token_123\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "home-ops"
+    )
+    monkeypatch.setattr(
+        s, "_resolve_delivery_targets",
+        lambda job: [{"platform": "telegram", "chat_id": "123", "thread_id": None}],
+    )
+    monkeypatch.setattr(
+        "tools.send_message_tool._send_to_platform", lambda *a, **k: None
+    )
+
+    resolve_calls = []
+
+    def _fake_resolve(platform, config, adapters):
+        resolve_calls.append(adapters)
+        return None  # no live transport -> standalone path
+
+    monkeypatch.setattr("gateway.delivery.resolve_delivery_transport", _fake_resolve)
+
+    # Shared adapters exist but the owning profile's map is missing -> the
+    # transport lookup must receive {} (never the shared default map), so the
+    # standalone path uses the active profile's scoped credential.
+    err = s._deliver_result(
+        {"id": "j16", "deliver": "telegram", "name": "t"},
+        "hello",
+        adapters={"telegram": "default-telegram-adapter"},
+        profile_adapters={},
+        loop=None,
+    )
+    assert resolve_calls == [{}]
+    # With no gateway config the standalone path correctly reports the
+    # platform as not configured — the identity contract is the {} lookup.
+    assert err is None or "not configured/enabled" in str(err)
+
+
+def test_run_one_job_resets_scope_when_save_output_raises(monkeypatch, tmp_path):
+    """Review #1 (ghosty-11): scope-reset regression for the save_job_output
+    raising path — the finally must tear the profile secret scope down even
+    when a step between run and delivery raises."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(s, "claim_dispatch", lambda _jid: True)
+    monkeypatch.setattr(
+        s, "create_execution", lambda *_a, **_kw: {"id": "exec-j17"}
+    )
+    monkeypatch.setattr(s, "mark_execution_running", lambda _eid: None)
+
+    def fake_run_job(job, *, defer_agent_teardown=None, extra_prompt=None):
+        return (True, "out", "final", None)
+
+    def fake_save(jid, out):
+        raise RuntimeError("save output boom")
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", fake_save)
+    monkeypatch.setattr(s, "_deliver_result", lambda *_a, **_k: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+    monkeypatch.setattr(s, "finish_execution", lambda *a, **k: None)
+
+    ss.set_multiplex_active(True)
+    try:
+        ok = s.run_one_job({"id": "j17", "name": "t"})
+    finally:
+        ss.set_multiplex_active(False)
+
+    # The finally reset the scope even though save raised mid-body.
+    assert ss.current_secret_scope() is None
+
+
+def test_run_one_job_resets_scope_when_delivery_raises_base_exception(monkeypatch, tmp_path):
+    """Review #1 (ghosty-11): scope-reset regression for the delivery raising a
+    BaseException path — the finally must tear the profile secret scope down
+    even when _deliver_result raises."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+
+    def fake_run_job(job, *, defer_agent_teardown=None, extra_prompt=None):
+        return (True, "out", "final", None)
+
+    def fake_deliver(*a, **k):
+        raise KeyboardInterrupt("delivery hard-interrupt")
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+    monkeypatch.setattr(s, "finish_execution", lambda *a, **k: None)
+
+    ss.set_multiplex_active(True)
+    try:
+        try:
+            s.run_one_job({"id": "j18", "name": "t", "deliver": "telegram"})
+        except KeyboardInterrupt:
+            pass  # hard interrupt propagates
+    finally:
+        ss.set_multiplex_active(False)
+
+    # The finally block still reset the scope even though delivery raised a
+    # BaseException (KeyboardInterrupt).
+    assert ss.current_secret_scope() is None
+
+

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -29,7 +29,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
         calls.append(("deliver", job["id"]))
         return None
 
@@ -368,5 +368,140 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after run_one_job returned (no leak).
     assert ss.current_secret_scope() is None
+
+
+def test_run_one_job_keeps_secret_scope_through_delivery(monkeypatch, tmp_path):
+    """Regression (BUG: delivery drops the profile secret scope): the profile
+    secret scope must STILL be installed when _deliver_result runs, so the
+    owning profile's credentials (e.g. TELEGRAM_BOT_TOKEN, read via
+    load_gateway_config -> _getenv) resolve at delivery time. Before the fix,
+    reset_secret_scope ran in the inner finally BEFORE _deliver_result, leaving
+    current_secret_scope() == None at delivery — multiplexed jobs delivered
+    with no profile scope (wrong/empty token, wrong bot/chat, lost thread).
+
+    Unlike test_run_one_job_installs_secret_scope_under_multiplex (which mocks
+    _deliver_result away and therefore cannot catch this), this test injects a
+    fake _deliver_result that asserts the scope is present at delivery time and
+    that the profile secret resolves.
+    """
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=profile_bot_token_123\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+
+    delivery_state = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None, extra_prompt=None):
+        return (True, "out", "final response", None)
+
+    def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
+        # This is the delivery-time assertion: the profile secret scope must
+        # still be installed and the profile secret must resolve.
+        delivery_state["scope_at_delivery"] = ss.current_secret_scope()
+        delivery_state["token_at_delivery"] = ss.get_secret("TELEGRAM_BOT_TOKEN")
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    ss.set_multiplex_active(True)
+    try:
+        ok = s.run_one_job({"id": "j8", "name": "t"})
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert ok is True
+    # The scope was still installed at delivery time (the bug dropped it).
+    assert delivery_state["scope_at_delivery"] is not None
+    # And the profile's secret resolved at delivery — the symptom that was broken.
+    assert delivery_state["token_at_delivery"] == "profile_bot_token_123"
+    # Torn down after run_one_job returned (no leak).
+    assert ss.current_secret_scope() is None
+
+
+def test_run_one_job_delivery_uses_profile_adapters(monkeypatch, tmp_path):
+    """BUG 1 PART 2: ``_deliver_adapters_for_job`` selects the owning profile's
+    live adapter map (Gateway._profile_adapters[profile]) when multiplex is
+    active and the job belongs to a secondary profile — NOT the shared
+    default-profile ``adapters`` dict."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=profile_bot_token_123\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "home-ops"
+    )
+
+    profile_adapters = {"home-ops": {"telegram": "home-ops-telegram-adapter"}}
+    shared = {"telegram": "default-telegram-adapter"}
+
+    selected = s._deliver_adapters_for_job(
+        {"id": "j9"}, adapters=shared, profile_adapters=profile_adapters
+    )
+    assert selected == {"telegram": "home-ops-telegram-adapter"}
+
+
+def test_run_one_job_delivery_falls_back_to_shared_adapters_for_default(monkeypatch, tmp_path):
+    """BUG 1 PART 2: for the default profile / non-multiplex path, ``_deliver_adapters_for_job``
+    keeps the shared ``adapters`` dict (existing behavior unchanged)."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+
+    shared = {"telegram": "default-telegram-adapter"}
+    selected = s._deliver_adapters_for_job(
+        {"id": "j10"}, adapters=shared,
+        profile_adapters={"home-ops": {"telegram": "home-ops-adapter"}},
+    )
+    assert selected == {"telegram": "default-telegram-adapter"}
+
+
+def test_run_one_job_threads_profile_adapters_to_delivery(monkeypatch, tmp_path):
+    """BUG 1 PART 2 wiring: run_one_job forwards the gateway's per-profile
+    adapter map to _deliver_result so the real delivery path can select the
+    job profile's adapter. The profile map must reach _deliver_result."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+
+    received = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None, extra_prompt=None):
+        return (True, "out", "final response", None)
+
+    def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
+        received["profile_adapters"] = profile_adapters
+        received["shared_adapters"] = adapters
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    profile_adapters = {"home-ops": {"telegram": "home-ops-telegram-adapter"}}
+
+    ss.set_multiplex_active(True)
+    try:
+        ok = s.run_one_job(
+            {"id": "j11", "name": "t"},
+            adapters={"telegram": "default-telegram-adapter"},
+            profile_adapters=profile_adapters,
+        )
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert ok is True
+    # The per-profile map reached _deliver_result (the real path uses it to
+    # select the job profile's adapter), and the shared dict is still passed.
+    assert received["profile_adapters"] == profile_adapters
+    assert received["shared_adapters"] == {"telegram": "default-telegram-adapter"}
 
 

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -27,7 +27,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
-    def fake_deliver(job, content, adapters=None, loop=None):
+    def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
         calls.append(("deliver", job["id"]))
         return None
 
@@ -107,5 +107,140 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after run_one_job returned (no leak).
     assert ss.current_secret_scope() is None
+
+
+def test_run_one_job_keeps_secret_scope_through_delivery(monkeypatch, tmp_path):
+    """Regression (BUG: delivery drops the profile secret scope): the profile
+    secret scope must STILL be installed when _deliver_result runs, so the
+    owning profile's credentials (e.g. TELEGRAM_BOT_TOKEN, read via
+    load_gateway_config -> _getenv) resolve at delivery time. Before the fix,
+    reset_secret_scope ran in the inner finally BEFORE _deliver_result, leaving
+    current_secret_scope() == None at delivery — multiplexed jobs delivered
+    with no profile scope (wrong/empty token, wrong bot/chat, lost thread).
+
+    Unlike test_run_one_job_installs_secret_scope_under_multiplex (which mocks
+    _deliver_result away and therefore cannot catch this), this test injects a
+    fake _deliver_result that asserts the scope is present at delivery time and
+    that the profile secret resolves.
+    """
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=profile_bot_token_123\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+
+    delivery_state = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None, extra_prompt=None):
+        return (True, "out", "final response", None)
+
+    def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
+        # This is the delivery-time assertion: the profile secret scope must
+        # still be installed and the profile secret must resolve.
+        delivery_state["scope_at_delivery"] = ss.current_secret_scope()
+        delivery_state["token_at_delivery"] = ss.get_secret("TELEGRAM_BOT_TOKEN")
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    ss.set_multiplex_active(True)
+    try:
+        ok = s.run_one_job({"id": "j8", "name": "t"})
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert ok is True
+    # The scope was still installed at delivery time (the bug dropped it).
+    assert delivery_state["scope_at_delivery"] is not None
+    # And the profile's secret resolved at delivery — the symptom that was broken.
+    assert delivery_state["token_at_delivery"] == "profile_bot_token_123"
+    # Torn down after run_one_job returned (no leak).
+    assert ss.current_secret_scope() is None
+
+
+def test_run_one_job_delivery_uses_profile_adapters(monkeypatch, tmp_path):
+    """BUG 1 PART 2: ``_deliver_adapters_for_job`` selects the owning profile's
+    live adapter map (Gateway._profile_adapters[profile]) when multiplex is
+    active and the job belongs to a secondary profile — NOT the shared
+    default-profile ``adapters`` dict."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=profile_bot_token_123\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "home-ops"
+    )
+
+    profile_adapters = {"home-ops": {"telegram": "home-ops-telegram-adapter"}}
+    shared = {"telegram": "default-telegram-adapter"}
+
+    selected = s._deliver_adapters_for_job(
+        {"id": "j9"}, adapters=shared, profile_adapters=profile_adapters
+    )
+    assert selected == {"telegram": "home-ops-telegram-adapter"}
+
+
+def test_run_one_job_delivery_falls_back_to_shared_adapters_for_default(monkeypatch, tmp_path):
+    """BUG 1 PART 2: for the default profile / non-multiplex path, ``_deliver_adapters_for_job``
+    keeps the shared ``adapters`` dict (existing behavior unchanged)."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+
+    shared = {"telegram": "default-telegram-adapter"}
+    selected = s._deliver_adapters_for_job(
+        {"id": "j10"}, adapters=shared,
+        profile_adapters={"home-ops": {"telegram": "home-ops-adapter"}},
+    )
+    assert selected == {"telegram": "default-telegram-adapter"}
+
+
+def test_run_one_job_threads_profile_adapters_to_delivery(monkeypatch, tmp_path):
+    """BUG 1 PART 2 wiring: run_one_job forwards the gateway's per-profile
+    adapter map to _deliver_result so the real delivery path can select the
+    job profile's adapter. The profile map must reach _deliver_result."""
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=x\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+
+    received = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None, extra_prompt=None):
+        return (True, "out", "final response", None)
+
+    def fake_deliver(job, content, adapters=None, loop=None, profile_adapters=None):
+        received["profile_adapters"] = profile_adapters
+        received["shared_adapters"] = adapters
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    profile_adapters = {"home-ops": {"telegram": "home-ops-telegram-adapter"}}
+
+    ss.set_multiplex_active(True)
+    try:
+        ok = s.run_one_job(
+            {"id": "j11", "name": "t"},
+            adapters={"telegram": "default-telegram-adapter"},
+            profile_adapters=profile_adapters,
+        )
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert ok is True
+    # The per-profile map reached _deliver_result (the real path uses it to
+    # select the job profile's adapter), and the shared dict is still passed.
+    assert received["profile_adapters"] == profile_adapters
+    assert received["shared_adapters"] == {"telegram": "default-telegram-adapter"}
 
 

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -41,6 +41,109 @@ def test_cron_profile_homes_follow_allowlist(tmp_path, monkeypatch):
     assert [name for name, _home in homes] == ["default", "worker"]
 
 
+class _FakeRunner:
+    """Minimal GatewayRunner stand-in for _build_cron_start_kwargs tests."""
+
+    def __init__(self, profile_adapters=None, draining=False):
+        self.adapters = {"telegram": "default-telegram-adapter"}
+        self.config = GatewayConfig(multiplex_profiles=True)
+        self._profile_adapters = profile_adapters
+        self._draining = draining
+        self._external_drain_active = False
+
+
+class _ExternalProvider:
+    """A provider that is NOT the built-in in-process ticker (Chronos-like).
+
+    Its ``start`` mirrors the external provider contract:
+    ``start(stop_event, *, adapters, loop, interval)`` — no
+    ``profile_adapters``/``profile_homes``/``can_dispatch`` kwargs.
+    """
+
+    def start(self, stop_event, *, adapters=None, loop=None, interval=60):
+        pass
+
+
+def test_cron_start_kwargs_external_provider_gets_no_profile_kwargs():
+    """Review #83197 blocker 1: external providers (Chronos) must NEVER receive
+    ``profile_adapters`` (or the other in-process-only kwargs) in
+    ``cron_start_kwargs`` — their ``start()`` signature does not accept them
+    and a multiplex deployment would crash with a deterministic TypeError."""
+    import asyncio
+
+    import gateway.run as gateway_run
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    runner = _FakeRunner(profile_adapters={"coder": {"telegram": "coder-adapter"}})
+    external = _ExternalProvider()
+
+    async def _build():
+        return gateway_run._build_cron_start_kwargs(
+            runner, external, multiplex_cron=True
+        )
+
+    kwargs = asyncio.run(_build())
+    assert "profile_adapters" not in kwargs
+    assert "profile_homes" not in kwargs
+    assert "can_dispatch" not in kwargs
+    assert "adapters" in kwargs
+    assert "loop" in kwargs
+
+
+def test_cron_start_kwargs_inprocess_gets_profile_adapters_under_multiplex():
+    """Review #1 blocker 1 positive path: when the resolved provider IS the
+    in-process scheduler and the runner has a per-profile adapter registry,
+    ``profile_adapters`` is injected (plus the multiplex profile homes and the
+    drain gate) so multiplex cron delivery routes through the owning profile's
+    bot/chat."""
+    import asyncio
+
+    import gateway.run as gateway_run
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    pa = {"coder": {"telegram": "coder-telegram-adapter"}}
+    runner = _FakeRunner(profile_adapters=pa)
+    provider = InProcessCronScheduler()
+    gateway_run._multiplex_profile_homes = lambda config: [("default", None)]
+
+    async def run():
+        return gateway_run._build_cron_start_kwargs(
+            runner, provider, multiplex_cron=True
+        )
+
+    kwargs = asyncio.run(run())
+    assert kwargs["profile_adapters"] is pa
+    assert kwargs["profile_homes"] == [("default", None)]
+    assert callable(kwargs["can_dispatch"])
+    assert kwargs["can_dispatch"]() is True
+
+
+def test_cron_start_kwargs_inprocess_without_registry_omits_key():
+    """Review #1: an in-process provider whose gateway has NO per-profile
+    registry must simply omit ``profile_adapters`` — the key only exists when
+    there is an actual per-profile adapter map to thread through."""
+    import asyncio
+
+    import gateway.run as gateway_run
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    runner = _FakeRunner(profile_adapters=None)
+    provider = InProcessCronScheduler()
+    gateway_run._multiplex_profile_homes = lambda config: []
+
+    async def run():
+        return gateway_run._build_cron_start_kwargs(
+            runner, provider, multiplex_cron=True
+        )
+
+    kwargs = asyncio.run(run())
+    assert "profile_adapters" not in kwargs
+    # No profile homes resolved -> the key is omitted entirely (matches the
+    # original start_gateway behavior: empty homes list never sets the kwarg).
+    assert "profile_homes" not in kwargs
+    assert callable(kwargs["can_dispatch"])
+
+
 class TestNamedProfileMultiplexerGuard:
     """_guard_named_profile_under_multiplexer is inert unless all conditions hold."""
 


### PR DESCRIPTION
## Summary

Fixes **cron delivery using the wrong bot/chat under multiplex** (BUG 1): a multiplexed secondary-profile cron job delivered with the owning profile's secret scope torn down and the shared default-profile adapter map — so the wrong/empty `TELEGRAM_BOT_TOKEN` was used and the original thread was dropped ("Thread not found").

Two root causes, two parts:

### Part 1 — profile secret scope dropped before delivery

`run_one_job()` installed the job profile's secret scope, but `reset_secret_scope(_scope_token)` ran in the run-job `finally` **before** `_deliver_result`. At delivery time `current_secret_scope()` was `None`, so `load_gateway_config() → _getenv` only fell back to `os.environ` (no profile scope) and the owning profile's `.env` was ignored.

**Fix:** keep the scope installed through delivery — remove the inner `finally` reset, reset it in the outer delivery-block `finally` (after save + delivery). The run-job `except` path still resets before propagating.

### Part 2 — delivery only used the shared default adapter map

The gateway started the cron ticker with `cron_start_kwargs = {"adapters": runner.adapters, ...}` (the shared default-profile dict). `_deliver_result` / `DeliveryRouter` never consulted `Gateway._profile_adapters[<job profile>]`, so even with the right token a secondary-profile job couldn't reach its live adapter.

**Fix:** thread the gateway's per-profile adapter map through the cron scheduler:

- New `_deliver_adapters_for_job()` resolves `Gateway._profile_adapters[profile]` (mirroring `gateway/authz_mixin.py`), falling back to the shared `adapters` dict for the default profile / non-multiplex path.
- Thread `profile_adapters` through `run_one_job → _deliver_result`.
- Thread `profile_adapters` through `CronScheduler.start / fire_due / InProcessCronScheduler.start / _start_multiplex → tick → run_one_job`.
- `gateway/run.py` passes `runner._profile_adapters` into `cron_start_kwargs`.

## Tests

- `test_run_one_job_keeps_secret_scope_through_delivery` — asserts the profile secret scope is still installed (and the profile secret resolves) at `_deliver_result` time. Fails on old code, passes with the fix.
- `test_run_one_job_delivery_uses_profile_adapters` / `..._falls_back_to_shared_adapters_for_default` — assert `_deliver_adapters_for_job` selects the profile map vs the shared fallback.
- `test_run_one_job_threads_profile_adapters_to_delivery` — asserts the gateway's per-profile map reaches `_deliver_result`.

## Verification

- `python -m pytest tests/cron/ -q` → 519 passed, 1 skipped
- `python -m pytest tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_cron_fire_webhook.py tests/gateway/test_multiplex_profile_authz.py -q` → 25 passed
- Pre-existing gateway failures (config/matrix/telegram/session-store) reproduce on baseline `main`; the 4 discord flakes pass in isolation — none introduced by this change.
- `python -c "import cron.scheduler, gateway.run"` → clean