### PR TITLE
Add bounded provider transport evidence

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2260,12 +2260,28 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # copy locks the contract so future transport/keepalive work can't reintroduce
     # the same class of bug.
     client_kwargs = dict(client_kwargs)
+    from agent.provider_wire_instrumentation import (
+        ProviderWireEvidenceError,
+        current_provider_wire_recorder,
+    )
+
+    wire_evidence_active = current_provider_wire_recorder() is not None
+    if wire_evidence_active and "http_client" in client_kwargs:
+        # A caller-owned client can bypass the owned direct HTTPX transports,
+        # so its sends cannot satisfy the exact one-attempt contract.
+        raise ProviderWireEvidenceError(
+            "provider_wire_custom_http_client_unsupported"
+        )
     ssl_ca_cert = client_kwargs.pop("ssl_ca_cert", None)
     ssl_verify_cfg = client_kwargs.pop("ssl_verify", None)
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
     if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+        if wire_evidence_active:
+            raise ProviderWireEvidenceError(
+                "provider_wire_non_httpx_transport_unsupported"
+            )
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)
@@ -2281,6 +2297,10 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
 
         base_url = str(client_kwargs.get("base_url", "") or "")
         if is_native_gemini_base_url(base_url):
+            if wire_evidence_active:
+                raise ProviderWireEvidenceError(
+                    "provider_wire_non_httpx_transport_unsupported"
+                )
             safe_kwargs = {
                 k: v for k, v in client_kwargs.items()
                 if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
@@ -2330,7 +2350,10 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # OpenAI/aggregator client passes through (init, switch_model, recovery,
     # restore, request-scoped); auxiliary_client builds its own clients and keeps
     # SDK retries because it is NOT wrapped by the conversation loop.
-    client_kwargs.setdefault("max_retries", 0)
+    if wire_evidence_active:
+        client_kwargs["max_retries"] = 0
+    else:
+        client_kwargs.setdefault("max_retries", 0)
     # Defense-in-depth: guarantee Copilot requests carry the integration
     # headers regardless of which build path we came through. The primary
     # header wiring lives in `_apply_client_headers_for_base_url`, but two

--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -186,9 +186,25 @@ def build_keepalive_http_client(
         client_cls = httpx.AsyncClient if async_mode else httpx.Client
         mounts = {}
         if proxy is None:
+            from agent.provider_wire_instrumentation import (
+                instrument_async_httpx_transport,
+                instrument_httpx_transport,
+            )
+
+            wrap_transport = (
+                instrument_async_httpx_transport
+                if async_mode
+                else instrument_httpx_transport
+            )
             mounts = {
-                "http://": transport_cls(verify=verify),
-                "https://": transport_cls(verify=verify),
+                "http://": wrap_transport(
+                    transport_cls(verify=verify, retries=0),
+                    transport_role="auxiliary",
+                ),
+                "https://": wrap_transport(
+                    transport_cls(verify=verify, retries=0),
+                    transport_role="auxiliary",
+                ),
             }
         return client_cls(
             limits=limits,

--- a/agent/provider_wire_instrumentation.py
+++ b/agent/provider_wire_instrumentation.py
@@ -284,6 +284,13 @@ def instrument_httpx_transport(
                 ),
             )
             response = transport.handle_request(request)
+            # A transport may return a response whose body is already fully
+            # materialized (for example HTTPX MockTransport with ``json=``).
+            # In that case there is no later stream EOF for a wrapper to
+            # observe, but completion is already an established fact.
+            if response.is_stream_consumed:
+                active.record_completed_response()
+                return response
             inner = response.stream
 
             class _ResponseStream(httpx.SyncByteStream):
@@ -295,15 +302,21 @@ def instrument_httpx_transport(
                     try:
                         for chunk in self._stream:
                             yield chunk
-                        self._eof = True
-                        active.record_completed_response()
+                        if not self._eof:
+                            self._eof = True
+                            active.record_completed_response()
                     except BaseException:
                         raise
 
                 def close(self):
                     return self._stream.close()
 
-            response.stream = _ResponseStream(inner)
+            wrapped_stream = _ResponseStream(inner)
+            response.stream = wrapped_stream
+            # httpx versions used by Hermes mirror the public stream on the
+            # private slot while eager reads; keep both references aligned.
+            if hasattr(response, "_stream"):
+                response._stream = wrapped_stream
             return response
 
         def close(self):
@@ -337,6 +350,9 @@ def instrument_async_httpx_transport(
                 ),
             )
             response = await transport.handle_async_request(request)
+            if response.is_stream_consumed:
+                active.record_completed_response()
+                return response
             inner = response.stream
 
             class _ResponseStream(httpx.AsyncByteStream):
@@ -348,15 +364,19 @@ def instrument_async_httpx_transport(
                     try:
                         async for chunk in self._stream:
                             yield chunk
-                        self._eof = True
-                        active.record_completed_response()
+                        if not self._eof:
+                            self._eof = True
+                            active.record_completed_response()
                     except BaseException:
                         raise
 
                 async def aclose(self):
                     return await self._stream.aclose()
 
-            response.stream = _ResponseStream(inner)
+            wrapped_stream = _ResponseStream(inner)
+            response.stream = wrapped_stream
+            if hasattr(response, "_stream"):
+                response._stream = wrapped_stream
             return response
 
         async def aclose(self):

--- a/agent/provider_wire_instrumentation.py
+++ b/agent/provider_wire_instrumentation.py
@@ -1,0 +1,365 @@
+"""Request-scoped evidence for bounded provider HTTP transport attempts.
+
+This module is inert unless an authenticated API request explicitly binds a
+``ProviderWireRecorder``.  It retains only counters and domain-separated
+digests.  Prompt text, request/response bodies, headers, URLs, credentials,
+model output, and raw exceptions are never retained.
+
+The exact claim is deliberately narrow: a recorded attempt is one call into a
+client HTTP transport, immediately before the inner transport is invoked.  It
+is not provider-side telemetry and does not prove what a provider did after it
+received the HTTP exchange.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Iterator, Mapping
+from urllib.parse import urlsplit
+
+
+PROVIDER_WIRE_EVIDENCE_HEADER = "X-Hermes-Provider-Wire-Evidence"
+PROVIDER_WIRE_EVIDENCE_SCHEMA = "hermes.provider-wire-attempt-evidence.v1"
+PROVIDER_WIRE_EVIDENCE_SCOPE = "client_http_transport_attempt"
+PROVIDER_RECEIPT_STATUS = "UNPROVEN"
+
+_NONCE = re.compile(r"^[0-9a-f]{32}$")
+_DOMAIN = b"hermes.provider-wire-attempt-evidence.correlation.v1\n"
+_TARGET_DOMAIN = b"hermes.provider-wire-attempt-evidence.target.v1\n"
+_CURRENT_RECORDER: ContextVar["ProviderWireRecorder | None"] = ContextVar(
+    "provider_wire_recorder", default=None
+)
+_CURRENT_DISPATCH: ContextVar["_Dispatch | None"] = ContextVar(
+    "provider_wire_dispatch", default=None
+)
+
+
+class ProviderWireEvidenceError(ValueError):
+    """Fixed-code validation error safe to return at the API boundary."""
+
+
+class ProviderWireLimitError(RuntimeError):
+    """Raised before a second provider transport attempt is dispatched."""
+
+    def __init__(self) -> None:
+        super().__init__("provider_wire_attempt_budget_exceeded")
+
+
+@dataclass(frozen=True)
+class _Dispatch:
+    dispatch_id: int
+    role: str
+    transport_attempts_at_start: int
+
+
+def validate_provider_wire_nonce(value: Any) -> str:
+    nonce = str(value or "")
+    if not _NONCE.fullmatch(nonce):
+        raise ProviderWireEvidenceError("provider_wire_evidence_nonce_invalid")
+    return nonce
+
+
+def provider_wire_correlation_sha256(nonce: str) -> str:
+    valid = validate_provider_wire_nonce(nonce)
+    return hashlib.sha256(_DOMAIN + valid.encode("ascii")).hexdigest()
+
+
+def provider_wire_request_target_sha256(method: Any, url: Any) -> str:
+    """Digest the outbound method/origin/path without retaining the raw URL."""
+    verb = str(method or "").strip().upper()
+    parsed = urlsplit(str(url or ""))
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    if (
+        not verb
+        or scheme not in {"http", "https"}
+        or not host
+        or parsed.username is not None
+        or parsed.password is not None
+        or bool(parsed.query)
+        or bool(parsed.fragment)
+    ):
+        raise ProviderWireEvidenceError("provider_wire_request_target_invalid")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ProviderWireEvidenceError(
+            "provider_wire_request_target_invalid"
+        ) from exc
+    if port is None:
+        port = 443 if scheme == "https" else 80
+    path = parsed.path or "/"
+    canonical = f"{verb}\n{scheme}://{host}:{port}{path}".encode("utf-8")
+    return hashlib.sha256(_TARGET_DOMAIN + canonical).hexdigest()
+
+
+class ProviderWireRecorder:
+    """Thread-safe, request-local recorder with a hard one-attempt budget."""
+
+    def __init__(self, nonce: str, *, max_transport_attempts: int = 1) -> None:
+        if max_transport_attempts != 1:
+            raise ProviderWireEvidenceError("provider_wire_attempt_budget_invalid")
+        self._correlation_sha256 = provider_wire_correlation_sha256(nonce)
+        self._max_transport_attempts = max_transport_attempts
+        self._lock = threading.RLock()
+        self._transport_registered = False
+        self._primary_transport_registered = False
+        self._request_target_sha256 = ""
+        self._transport_attempt_count = 0
+        self._completed_response_count = 0
+        self._blocked_attempt_count = 0
+        self._retry_count = 0
+        self._fallback_count = 0
+        self._dispatch_count = 0
+        self._active_dispatch_count = 0
+        self._unmatched_dispatch_count = 0
+        self._unmatched_transport_count = 0
+
+    def register_transport(self, *, transport_role: str) -> None:
+        with self._lock:
+            self._transport_registered = True
+            if transport_role == "primary":
+                self._primary_transport_registered = True
+
+    def require_registered_transport(self) -> None:
+        with self._lock:
+            if not self._primary_transport_registered:
+                raise ProviderWireEvidenceError(
+                    "provider_wire_exact_transport_unavailable"
+                )
+
+    def begin_dispatch(self, metadata: Mapping[str, Any] | None = None) -> _Dispatch:
+        role = str((metadata or {}).get("call_role") or "primary")
+        with self._lock:
+            self._dispatch_count += 1
+            dispatch = _Dispatch(
+                dispatch_id=self._dispatch_count,
+                role=role,
+                transport_attempts_at_start=self._transport_attempt_count,
+            )
+            if role == "fallback":
+                self._fallback_count += 1
+            # The semantic dispatch boundary is the broadest provider-call
+            # chokepoint.  Block a second dispatch even when the first used an
+            # unsupported transport and therefore produced no matched HTTPX
+            # event; otherwise an uninstrumented first attempt could be
+            # followed by a real second provider call before evidence falls
+            # back to UNKNOWN.
+            if (
+                self._dispatch_count > self._max_transport_attempts
+                or self._transport_attempt_count >= self._max_transport_attempts
+            ):
+                self._blocked_attempt_count += 1
+                if role != "fallback":
+                    self._retry_count += 1
+                raise ProviderWireLimitError()
+            self._active_dispatch_count += 1
+            return dispatch
+
+    def finish_dispatch(self, dispatch: _Dispatch) -> None:
+        with self._lock:
+            self._active_dispatch_count = max(0, self._active_dispatch_count - 1)
+            if self._transport_attempt_count == dispatch.transport_attempts_at_start:
+                self._unmatched_dispatch_count += 1
+
+    def record_transport_attempt(
+        self,
+        dispatch: _Dispatch | None,
+        *,
+        request_target_sha256: str,
+    ) -> None:
+        with self._lock:
+            if self._transport_attempt_count >= self._max_transport_attempts:
+                self._blocked_attempt_count += 1
+                self._retry_count += 1
+                raise ProviderWireLimitError()
+            self._transport_attempt_count += 1
+            self._request_target_sha256 = request_target_sha256
+            if dispatch is None:
+                self._unmatched_transport_count += 1
+
+    def record_completed_response(self) -> None:
+        with self._lock:
+            self._completed_response_count += 1
+
+    def evidence(self, *, terminal_success: bool) -> dict[str, Any]:
+        with self._lock:
+            exact = (
+                terminal_success
+                and self._primary_transport_registered
+                and self._transport_attempt_count == 1
+                and bool(self._request_target_sha256)
+                and self._completed_response_count == 1
+                and self._blocked_attempt_count == 0
+                and self._retry_count == 0
+                and self._fallback_count == 0
+                and self._unmatched_dispatch_count == 0
+                and self._unmatched_transport_count == 0
+                and self._active_dispatch_count == 0
+            )
+            return {
+                "schema_version": PROVIDER_WIRE_EVIDENCE_SCHEMA,
+                "correlation_sha256": self._correlation_sha256,
+                "request_target_sha256": self._request_target_sha256,
+                "scope": PROVIDER_WIRE_EVIDENCE_SCOPE,
+                "client_transport_status": "EXACT" if exact else "UNKNOWN",
+                "attempt_count": self._transport_attempt_count,
+                "blocked_attempt_count": self._blocked_attempt_count,
+                "retry_count": self._retry_count,
+                "fallback_count": self._fallback_count,
+                "completed_response_count": self._completed_response_count,
+                "provider_receipt_status": PROVIDER_RECEIPT_STATUS,
+            }
+
+
+@contextmanager
+def bind_provider_wire_recorder(
+    recorder: ProviderWireRecorder | None,
+) -> Iterator[ProviderWireRecorder | None]:
+    token = _CURRENT_RECORDER.set(recorder)
+    try:
+        yield recorder
+    finally:
+        _CURRENT_RECORDER.reset(token)
+
+
+def current_provider_wire_recorder() -> ProviderWireRecorder | None:
+    return _CURRENT_RECORDER.get()
+
+
+@contextmanager
+def provider_wire_dispatch(
+    metadata: Mapping[str, Any] | None = None,
+) -> Iterator[None]:
+    recorder = current_provider_wire_recorder()
+    if recorder is None:
+        yield
+        return
+    dispatch = recorder.begin_dispatch(metadata)
+    token = _CURRENT_DISPATCH.set(dispatch)
+    try:
+        yield
+    finally:
+        _CURRENT_DISPATCH.reset(token)
+        recorder.finish_dispatch(dispatch)
+
+
+def sanitized_provider_wire_evidence(
+    recorder: ProviderWireRecorder | None,
+    *,
+    terminal_success: bool,
+) -> dict[str, Any] | None:
+    if recorder is None:
+        return None
+    return recorder.evidence(terminal_success=terminal_success)
+
+
+def instrument_httpx_transport(
+    transport: Any,
+    recorder: ProviderWireRecorder | None = None,
+    *,
+    transport_role: str = "primary",
+) -> Any:
+    """Wrap a synchronous HTTPX transport when an evidence scope is active."""
+    active = recorder or current_provider_wire_recorder()
+    if active is None:
+        return transport
+
+    import httpx
+
+    active.register_transport(transport_role=transport_role)
+
+    class _InstrumentedTransport(httpx.BaseTransport):
+        def handle_request(self, request):
+            active.record_transport_attempt(
+                _CURRENT_DISPATCH.get(),
+                request_target_sha256=provider_wire_request_target_sha256(
+                    request.method,
+                    request.url,
+                ),
+            )
+            response = transport.handle_request(request)
+            inner = response.stream
+
+            class _ResponseStream(httpx.SyncByteStream):
+                def __init__(self, stream):
+                    self._stream = stream
+                    self._eof = False
+
+                def __iter__(self):
+                    try:
+                        for chunk in self._stream:
+                            yield chunk
+                        self._eof = True
+                        active.record_completed_response()
+                    except BaseException:
+                        raise
+
+                def close(self):
+                    return self._stream.close()
+
+            response.stream = _ResponseStream(inner)
+            return response
+
+        def close(self):
+            return transport.close()
+
+    return _InstrumentedTransport()
+
+
+def instrument_async_httpx_transport(
+    transport: Any,
+    recorder: ProviderWireRecorder | None = None,
+    *,
+    transport_role: str = "primary",
+) -> Any:
+    """Wrap an asynchronous HTTPX transport when an evidence scope is active."""
+    active = recorder or current_provider_wire_recorder()
+    if active is None:
+        return transport
+
+    import httpx
+
+    active.register_transport(transport_role=transport_role)
+
+    class _InstrumentedAsyncTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request):
+            active.record_transport_attempt(
+                _CURRENT_DISPATCH.get(),
+                request_target_sha256=provider_wire_request_target_sha256(
+                    request.method,
+                    request.url,
+                ),
+            )
+            response = await transport.handle_async_request(request)
+            inner = response.stream
+
+            class _ResponseStream(httpx.AsyncByteStream):
+                def __init__(self, stream):
+                    self._stream = stream
+                    self._eof = False
+
+                async def __aiter__(self):
+                    try:
+                        async for chunk in self._stream:
+                            yield chunk
+                        self._eof = True
+                        active.record_completed_response()
+                    except BaseException:
+                        raise
+
+                async def aclose(self):
+                    return await self._stream.aclose()
+
+            response.stream = _ResponseStream(inner)
+            return response
+
+        async def aclose(self):
+            return await transport.aclose()
+
+    return _InstrumentedAsyncTransport()

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -24,6 +24,11 @@ _RELAY_INTERNAL_PROVIDER_HEADERS = frozenset(
 )
 
 
+def _provider_dispatch(metadata: dict[str, Any] | None = None):
+    from agent.provider_wire_instrumentation import provider_wire_dispatch
+    return provider_wire_dispatch(metadata)
+
+
 def execute(
     request: dict[str, Any],
     callback: Callable[[dict[str, Any]], Any],
@@ -37,7 +42,8 @@ def execute(
     """Run one non-streaming physical provider attempt through Relay."""
     runtime, session, parent = relay_runtime.resolve_execution_context(session_id)
     if runtime is None or session is None or not runtime.managed_execution_enabled():
-        return callback(request)
+        with _provider_dispatch(metadata):
+            return callback(request)
     logical = _logical_parent(runtime, session, parent, metadata)
     parent = logical[1] if logical is not None else parent
 
@@ -60,7 +66,8 @@ def execute(
             # Nested relay calls inside a managed provider callback must run
             # unmanaged (#77244) — see relay_runtime.managed_callback_guard.
             with relay_runtime.managed_callback_guard():
-                return callback(final)
+                with _provider_dispatch(metadata):
+                    return callback(final)
 
         try:
             final_request = _provider_request(
@@ -129,7 +136,8 @@ async def execute_async(
     """Run one asynchronous physical provider attempt through Relay."""
     runtime, session, parent = relay_runtime.resolve_execution_context(session_id)
     if runtime is None or session is None or not runtime.managed_execution_enabled():
-        return await callback(request)
+        with _provider_dispatch(metadata):
+            return await callback(request)
     logical = _logical_parent(runtime, session, parent, metadata)
     parent = logical[1] if logical is not None else parent
 
@@ -159,7 +167,8 @@ async def execute_async(
                 # Nested relay calls inside a managed provider callback must
                 # run unmanaged (#77244).
                 with relay_runtime.managed_callback_guard():
-                    return await callback(final_request)
+                    with _provider_dispatch(metadata):
+                        return await callback(final_request)
 
             task = callback_context.copy().run(
                 asyncio.create_task,
@@ -221,7 +230,8 @@ def execute_current(
     """Run a provider attempt under the inherited Hermes turn when present."""
     turn = relay_runtime.active_turn()
     if turn is None:
-        return callback(request)
+        with _provider_dispatch(metadata):
+            return callback(request)
     return execute(
         request,
         callback,
@@ -245,7 +255,8 @@ async def execute_current_async(
     """Run an async provider attempt under the inherited turn when present."""
     turn = relay_runtime.active_turn()
     if turn is None:
-        return await callback(request)
+        with _provider_dispatch(metadata):
+            return await callback(request)
     return await execute_async(
         request,
         callback,
@@ -289,7 +300,8 @@ def stream_current(
     """
     turn = relay_runtime.active_turn()
     if turn is None:
-        return stream_factory(request)
+        with _provider_dispatch(metadata):
+            return stream_factory(request)
     if _has_running_event_loop():
         # Managed provider callbacks execute on the Relay session's event
         # loop. A nested ManagedLlmStream built here would be synchronously
@@ -300,7 +312,8 @@ def stream_current(
         # own completed_response_predicate traps a completed response (e.g.
         # the MoA facade's auxiliary ``call_llm(stream=True)`` returning a
         # full response when an adapter ignores ``stream=True``).
-        return stream_factory(request)
+        with _provider_dispatch(metadata):
+            return stream_factory(request)
     managed = stream(
         request,
         stream_factory,
@@ -421,7 +434,8 @@ class ManagedLlmStream(Iterator[Any]):
             or session is None
             or not runtime.managed_execution_enabled()
         ):
-            raw_stream = stream_factory(request)
+            with _provider_dispatch(metadata):
+                raw_stream = stream_factory(request)
             if completed_response_predicate is not None and completed_response_predicate(
                 raw_stream
             ):
@@ -449,16 +463,17 @@ class ManagedLlmStream(Iterator[Any]):
         async def provider_stream(next_request: Any):
             raw_stream = None
             try:
-                raw_stream = run_callback(
-                    stream_factory,
-                    _provider_request(
-                        request,
-                        next_request,
-                        relay_request_body=relay_request_body,
-                        codec_baseline_body=codec_baseline_body,
-                        metadata=metadata,
-                    )
+                final_request = _provider_request(
+                    request,
+                    next_request,
+                    relay_request_body=relay_request_body,
+                    codec_baseline_body=codec_baseline_body,
+                    metadata=metadata,
                 )
+                def open_provider_stream():
+                    with _provider_dispatch(metadata):
+                        return stream_factory(final_request)
+                raw_stream = run_callback(open_provider_stream)
                 if (
                     completed_response_predicate is not None
                     and run_callback(

--- a/docs/provider-wire-instrumentation.md
+++ b/docs/provider-wire-instrumentation.md
@@ -1,0 +1,50 @@
+# Provider client-transport attempt evidence
+
+Hermes can expose narrowly scoped, request-local evidence for an owner-reviewed
+non-streaming `POST /v1/chat/completions`. The feature is off by default. It is
+enabled only when an authenticated request includes
+`X-Hermes-Provider-Wire-Evidence: <nonce>`, where `<nonce>` is exactly 32
+lowercase hexadecimal characters.
+
+The evidence claim is deliberately limited to `client_http_transport_attempt`:
+Hermes observed exactly one call into its instrumented HTTPX client transport
+and one returned HTTP response. It is not provider-side telemetry, and
+`provider_receipt_status` therefore remains `UNPROVEN` even when the client
+transport evidence `client_transport_status` is `EXACT`. This field is not a
+provider receipt and must never be interpreted as one.
+
+## Fail-closed contract
+
+Evidence mode:
+
+- requires a configured API key and successful gateway authentication;
+- supports only non-streaming requests and rejects `Idempotency-Key`;
+- admits at most one semantic provider dispatch and at most one HTTP transport
+  attempt, rejecting a retry or fallback before its callback or transport is
+  invoked;
+- configures the owned HTTPX transports with SDK transport retries disabled;
+- requires the request's agent to construct a registered, instrumented
+  transport before conversation execution begins; and
+- reports `EXACT` only after a successful terminal agent result with one
+  matched transport attempt and response, and zero blocked attempts, retries,
+  fallbacks, unmatched dispatches, or unmatched transports.
+
+Proxy-backed transports, caller-supplied/custom clients, and provider paths
+that do not use the owned HTTPX transport cannot satisfy this proof. They fail
+before conversation execution with `UNKNOWN` evidence instead of weakening the
+claim.
+
+## Evidence and privacy
+
+The response adds `hermes.provider_wire_evidence` only for an opted-in request.
+The object contains domain-separated SHA-256 correlation and outbound
+method/origin/path digests, the fixed scope and provider-receipt status, and
+integer counters. The owner-side caller must bind both digests to its approved
+plan and expected loopback target. The inbound nonce is not echoed or forwarded
+to the provider. The recorder retains no prompt,
+request or response body, URL, headers, credentials, model output, or raw
+exception text. It writes no database or file, emits no telemetry, and does not
+alter prompt construction or prompt caching.
+
+Without the opt-in header, transport wrapping is inert and the gateway response
+shape and existing retry behavior are unchanged.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -93,6 +93,13 @@ from gateway.platforms.base import (
 )
 from agent.redact import redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
+from agent.provider_wire_instrumentation import (
+    PROVIDER_WIRE_EVIDENCE_HEADER,
+    ProviderWireEvidenceError,
+    ProviderWireRecorder,
+    bind_provider_wire_recorder,
+    sanitized_provider_wire_evidence,
+)
 from gateway.readiness import collect_runtime_readiness
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
@@ -4040,6 +4047,45 @@ class APIServerAdapter(BasePlatformAdapter):
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
 
+        provider_wire_recorder = None
+        provider_wire_nonce = request.headers.get(PROVIDER_WIRE_EVIDENCE_HEADER)
+        if provider_wire_nonce is not None:
+            # The evidence mode can constrain provider execution and therefore
+            # is available only on a configured, authenticated listener.  The
+            # decorator already validated the bearer token; this additional
+            # guard closes the historical no-key test/manual-listener path.
+            if not self._expected_api_key():
+                return web.json_response(
+                    _openai_error(
+                        "provider_wire_evidence_requires_authenticated_gateway",
+                        code="provider_wire_evidence_auth_required",
+                    ),
+                    status=403,
+                )
+            if stream:
+                return web.json_response(
+                    _openai_error(
+                        "provider_wire_evidence_requires_nonstreaming_request",
+                        code="provider_wire_evidence_stream_unsupported",
+                    ),
+                    status=400,
+                )
+            if request.headers.get("Idempotency-Key"):
+                return web.json_response(
+                    _openai_error(
+                        "provider_wire_evidence_forbids_idempotency_cache",
+                        code="provider_wire_evidence_idempotency_forbidden",
+                    ),
+                    status=400,
+                )
+            try:
+                provider_wire_recorder = ProviderWireRecorder(provider_wire_nonce)
+            except ProviderWireEvidenceError as exc:
+                return web.json_response(
+                    _openai_error(str(exc), code="provider_wire_evidence_invalid"),
+                    status=400,
+                )
+
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
         conversation_messages: List[Dict[str, str]] = []
@@ -4264,7 +4310,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
         async def _compute_completion():
-            return await self._run_agent(
+            run_kwargs = dict(
                 user_message=user_message,
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
@@ -4273,6 +4319,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 **agent_overrides,
                 route=route,
             )
+            if provider_wire_recorder is not None:
+                run_kwargs["provider_wire_recorder"] = provider_wire_recorder
+            return await self._run_agent(**run_kwargs)
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
@@ -4284,19 +4333,43 @@ class APIServerAdapter(BasePlatformAdapter):
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
-                return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
-                    status=500,
+                public_error = (
+                    _redact_api_error_text(e)
+                    if provider_wire_recorder is not None
+                    else f"Internal server error: {e}"
                 )
+                error_body = _openai_error(
+                    public_error, err_type="server_error"
+                )
+                evidence = sanitized_provider_wire_evidence(
+                    provider_wire_recorder, terminal_success=False
+                )
+                if evidence is not None:
+                    error_body["error"]["hermes"] = {
+                        "provider_wire_evidence": evidence
+                    }
+                return web.json_response(error_body, status=500)
         else:
             try:
                 result, usage = await _compute_completion()
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
-                return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
-                    status=500,
+                public_error = (
+                    _redact_api_error_text(e)
+                    if provider_wire_recorder is not None
+                    else f"Internal server error: {e}"
                 )
+                error_body = _openai_error(
+                    public_error, err_type="server_error"
+                )
+                evidence = sanitized_provider_wire_evidence(
+                    provider_wire_recorder, terminal_success=False
+                )
+                if evidence is not None:
+                    error_body["error"]["hermes"] = {
+                        "provider_wire_evidence": evidence
+                    }
+                return web.json_response(error_body, status=500)
 
         final_response = _resolve_media_to_data_urls(result.get("final_response") or "")
         is_partial = bool(result.get("partial"))
@@ -4335,6 +4408,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "partial": is_partial,
                 "failed": is_failed,
             }
+            evidence = sanitized_provider_wire_evidence(
+                provider_wire_recorder, terminal_success=False
+            )
+            if evidence is not None:
+                err_body["error"]["hermes"]["provider_wire_evidence"] = evidence
             response_headers["X-Hermes-Completed"] = "false"
             response_headers["X-Hermes-Partial"] = "true" if is_partial else "false"
             return web.json_response(err_body, status=502, headers=response_headers)
@@ -4375,6 +4453,15 @@ class APIServerAdapter(BasePlatformAdapter):
             response_headers["X-Hermes-Partial"] = "true" if is_partial else "false"
             if err_msg:
                 response_headers["X-Hermes-Error"] = _redact_api_error_text(err_msg, limit=200)
+
+        evidence = sanitized_provider_wire_evidence(
+            provider_wire_recorder,
+            terminal_success=not (is_partial or is_failed or not completed),
+        )
+        if evidence is not None:
+            response_data.setdefault("hermes", {})[
+                "provider_wire_evidence"
+            ] = evidence
 
         return web.json_response(response_data, headers=response_headers)
 
@@ -6119,6 +6206,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        provider_wire_recorder: Optional[ProviderWireRecorder] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -6154,7 +6242,12 @@ class APIServerAdapter(BasePlatformAdapter):
         def _run():
             from gateway.session_context import clear_session_vars
 
-            with self._profile_scope(request_profile):
+            wire_scope = (
+                bind_provider_wire_recorder(provider_wire_recorder)
+                if provider_wire_recorder is not None
+                else nullcontext()
+            )
+            with wire_scope, self._profile_scope(request_profile):
                 tokens = self._bind_api_server_session(
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
@@ -6177,6 +6270,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         session_model=session_model,
                         confirmed_runtime_lock=confirmed_runtime_lock,
                     )
+                    if provider_wire_recorder is not None:
+                        provider_wire_recorder.require_registered_transport()
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     effective_task_id = session_id or str(uuid.uuid4())

--- a/run_agent.py
+++ b/run_agent.py
@@ -4885,9 +4885,19 @@ class AIAgent:
             # NO_PROXY resolution.
             _mounts = {}
             if _proxy is None:
+                from agent.provider_wire_instrumentation import (
+                    instrument_httpx_transport,
+                )
+
                 _mounts = {
-                    "http://": _httpx.HTTPTransport(verify=verify),
-                    "https://": _httpx.HTTPTransport(verify=verify),
+                    "http://": instrument_httpx_transport(
+                        _httpx.HTTPTransport(verify=verify, retries=0),
+                        transport_role="primary",
+                    ),
+                    "https://": instrument_httpx_transport(
+                        _httpx.HTTPTransport(verify=verify, retries=0),
+                        transport_role="primary",
+                    ),
                 }
             return _httpx.Client(
                 limits=_limits,
@@ -5086,6 +5096,7 @@ class AIAgent:
 
     def _create_request_openai_client(self, *, reason: str, api_kwargs: Optional[dict] = None) -> Any:
         from unittest.mock import Mock
+        from agent.provider_wire_instrumentation import current_provider_wire_recorder
 
         primary_client = self._ensure_primary_openai_client(reason=reason)
         if self.provider == "moa":
@@ -5094,6 +5105,7 @@ class AIAgent:
             return primary_client
         with self._openai_client_lock():
             request_kwargs = dict(self._client_kwargs)
+        wire_evidence_active = current_provider_wire_recorder() is not None
         # Per-request OpenAI-wire clients (used by both the non-streaming
         # chat-completions path and the streaming chat-completions path
         # in `_interruptible_api_call`) should not run the SDK's built-in
@@ -5123,7 +5135,8 @@ class AIAgent:
             cached = cache["client"]
             if cached is not None and not cache["in_use"]:
                 if (
-                    not cache["poisoned"]
+                    not wire_evidence_active
+                    and not cache["poisoned"]
                     and cache["kwargs"] == request_kwargs
                     and not self._is_openai_client_closed(cached)
                 ):
@@ -5142,6 +5155,13 @@ class AIAgent:
             # with an in-flight request on another thread).
             self._close_openai_client(stale, reason=f"reuse_evict:{reason}", shared=False)
         client = self._create_openai_client(request_kwargs, reason=reason, shared=False)
+        if wire_evidence_active:
+            # The transport closes over this request's recorder.  Never put
+            # it in the cross-turn warm-client cache: a later uninstrumented
+            # or differently-correlated request must not reuse or mutate the
+            # previous request's evidence context.  As an untracked client it
+            # is closed by _close_request_openai_client even on clean success.
+            return client
         with self._openai_client_lock():
             cache = self._request_client_cache_ref()
             if cache["client"] is None:

--- a/tests/gateway/test_api_server_provider_wire_evidence.py
+++ b/tests/gateway/test_api_server_provider_wire_evidence.py
@@ -1,0 +1,219 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from agent.provider_wire_instrumentation import (
+    PROVIDER_WIRE_EVIDENCE_HEADER,
+    bind_provider_wire_recorder,
+    instrument_httpx_transport,
+    provider_wire_correlation_sha256,
+    provider_wire_dispatch,
+    provider_wire_request_target_sha256,
+)
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+API_KEY = "test-provider-wire-key-123456"
+NONCE = "0123456789abcdef0123456789abcdef"
+BODY = {
+    "model": "hermes-agent",
+    "messages": [{"role": "user", "content": "bounded request"}],
+}
+
+
+def _adapter(api_key=""):
+    extra = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _app(adapter):
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    return app
+
+
+def _headers(nonce=NONCE):
+    return {
+        "Authorization": f"Bearer {API_KEY}",
+        PROVIDER_WIRE_EVIDENCE_HEADER: nonce,
+    }
+
+
+def test_default_request_has_no_evidence_and_preserves_existing_shape():
+    async def exercise():
+        adapter = _adapter()
+        result = {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+        async with TestClient(TestServer(_app(adapter))) as client:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as run_agent:
+                run_agent.return_value = (result, usage)
+                response = await client.post("/v1/chat/completions", json=BODY)
+                payload = await response.json()
+
+        assert response.status == 200
+        assert "hermes" not in payload
+        assert "provider_wire_recorder" not in run_agent.call_args.kwargs
+
+    asyncio.run(exercise())
+
+
+def test_evidence_requires_a_configured_authenticated_gateway():
+    async def exercise():
+        adapter = _adapter()
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                json=BODY,
+                headers={PROVIDER_WIRE_EVIDENCE_HEADER: NONCE},
+            )
+            payload = await response.json()
+        assert response.status == 403
+        assert payload["error"]["code"] == "provider_wire_evidence_auth_required"
+
+    asyncio.run(exercise())
+
+
+def test_evidence_header_with_invalid_bearer_never_reaches_agent():
+    async def exercise():
+        adapter = _adapter(API_KEY)
+        async with TestClient(TestServer(_app(adapter))) as client:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as run_agent:
+                response = await client.post(
+                    "/v1/chat/completions",
+                    json=BODY,
+                    headers={
+                        "Authorization": "Bearer wrong-key",
+                        PROVIDER_WIRE_EVIDENCE_HEADER: NONCE,
+                    },
+                )
+        assert response.status == 401
+        run_agent.assert_not_awaited()
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize(
+    ("nonce", "extra_body", "extra_headers", "expected_code"),
+    [
+        ("BAD", {}, {}, "provider_wire_evidence_invalid"),
+        (NONCE, {"stream": True}, {}, "provider_wire_evidence_stream_unsupported"),
+        (NONCE, {}, {"Idempotency-Key": "cached"}, "provider_wire_evidence_idempotency_forbidden"),
+    ],
+)
+def test_invalid_or_replayable_evidence_requests_fail_before_agent_run(
+    nonce, extra_body, extra_headers, expected_code
+):
+    async def exercise():
+        adapter = _adapter(API_KEY)
+        headers = {**_headers(nonce), **extra_headers}
+        async with TestClient(TestServer(_app(adapter))) as client:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as run_agent:
+                response = await client.post(
+                    "/v1/chat/completions",
+                    json={**BODY, **extra_body},
+                    headers=headers,
+                )
+                payload = await response.json()
+        assert response.status == 400
+        assert payload["error"]["code"] == expected_code
+        run_agent.assert_not_awaited()
+
+    asyncio.run(exercise())
+
+
+def test_authenticated_one_transport_exchange_returns_sanitized_exact_evidence():
+    async def exercise():
+        adapter = _adapter(API_KEY)
+        provider_calls = 0
+
+        async def fake_run_agent(**kwargs):
+            nonlocal provider_calls
+            recorder = kwargs["provider_wire_recorder"]
+
+            def provider(_request):
+                nonlocal provider_calls
+                provider_calls += 1
+                return httpx.Response(200, json={"choices": []})
+
+            with bind_provider_wire_recorder(recorder):
+                transport = instrument_httpx_transport(httpx.MockTransport(provider))
+                with provider_wire_dispatch({"call_role": "primary"}):
+                    with httpx.Client(transport=transport) as provider_client:
+                        provider_client.post(
+                            "http://127.0.0.1:8080/v1/chat/completions"
+                        )
+
+            return (
+                {"final_response": "ok", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            with patch.object(adapter, "_run_agent", side_effect=fake_run_agent):
+                response = await client.post(
+                    "/v1/chat/completions", json=BODY, headers=_headers()
+                )
+                payload = await response.json()
+
+        assert response.status == 200
+        evidence = payload["hermes"]["provider_wire_evidence"]
+        assert provider_calls == 1
+        assert evidence == {
+            "schema_version": "hermes.provider-wire-attempt-evidence.v1",
+            "correlation_sha256": provider_wire_correlation_sha256(NONCE),
+            "request_target_sha256": provider_wire_request_target_sha256(
+                "POST", "http://127.0.0.1:8080/v1/chat/completions"
+            ),
+            "scope": "client_http_transport_attempt",
+            "client_transport_status": "EXACT",
+            "attempt_count": 1,
+            "blocked_attempt_count": 0,
+            "retry_count": 0,
+            "fallback_count": 0,
+            "completed_response_count": 1,
+            "provider_receipt_status": "UNPROVEN",
+        }
+        serialized = json.dumps(evidence)
+        assert NONCE not in serialized
+        assert "bounded request" not in serialized
+        assert "127.0.0.1" not in serialized
+
+    asyncio.run(exercise())
+
+
+def test_failed_run_can_only_return_unknown_sanitized_evidence():
+    async def exercise():
+        adapter = _adapter(API_KEY)
+
+        async def fail_run(**kwargs):
+            recorder = kwargs["provider_wire_recorder"]
+            with bind_provider_wire_recorder(recorder):
+                instrument_httpx_transport(
+                    httpx.MockTransport(lambda request: httpx.Response(200))
+                )
+            raise RuntimeError("OPENAI_API_KEY=sk-never-return-this")
+
+        async with TestClient(TestServer(_app(adapter))) as client:
+            with patch.object(adapter, "_run_agent", side_effect=fail_run):
+                response = await client.post(
+                    "/v1/chat/completions", json=BODY, headers=_headers()
+                )
+                payload = await response.json()
+
+        assert response.status == 500
+        assert "sk-never-return-this" not in json.dumps(payload)
+        evidence = payload["error"]["hermes"]["provider_wire_evidence"]
+        assert evidence["client_transport_status"] == "UNKNOWN"
+        assert "sk-never-return-this" not in json.dumps(evidence)
+
+    asyncio.run(exercise())

--- a/tests/test_provider_wire_instrumentation.py
+++ b/tests/test_provider_wire_instrumentation.py
@@ -398,6 +398,8 @@ def test_lazy_stream_response_is_not_executed_outside_dispatch_and_loss_is_unkno
 def test_lazy_async_stream_counts_only_eof_and_marks_cancelled_body_unknown():
     class BrokenAsyncStream(httpx.AsyncByteStream):
         async def __aiter__(self):
+            if False:
+                yield b""
             raise asyncio.CancelledError()
 
         async def aclose(self):

--- a/tests/test_provider_wire_instrumentation.py
+++ b/tests/test_provider_wire_instrumentation.py
@@ -1,0 +1,435 @@
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from agent import relay_llm
+from agent.agent_runtime_helpers import create_openai_client
+from agent.chat_completion_helpers import _context_thread_target
+from agent.provider_wire_instrumentation import (
+    PROVIDER_RECEIPT_STATUS,
+    PROVIDER_WIRE_EVIDENCE_SCHEMA,
+    PROVIDER_WIRE_EVIDENCE_SCOPE,
+    ProviderWireEvidenceError,
+    ProviderWireLimitError,
+    ProviderWireRecorder,
+    bind_provider_wire_recorder,
+    current_provider_wire_recorder,
+    instrument_async_httpx_transport,
+    instrument_httpx_transport,
+    provider_wire_correlation_sha256,
+    provider_wire_dispatch,
+    provider_wire_request_target_sha256,
+    sanitized_provider_wire_evidence,
+)
+
+
+NONCE = "0123456789abcdef0123456789abcdef"
+
+
+def _success_evidence(recorder):
+    return sanitized_provider_wire_evidence(recorder, terminal_success=True)
+
+
+def test_nonce_is_strict_and_only_its_digest_is_exposed():
+    recorder = ProviderWireRecorder(NONCE)
+    evidence = _success_evidence(recorder)
+
+    assert evidence["correlation_sha256"] == provider_wire_correlation_sha256(NONCE)
+    assert NONCE not in repr(evidence)
+    assert evidence["schema_version"] == PROVIDER_WIRE_EVIDENCE_SCHEMA
+    assert evidence["scope"] == PROVIDER_WIRE_EVIDENCE_SCOPE
+    assert evidence["provider_receipt_status"] == PROVIDER_RECEIPT_STATUS
+    assert set(evidence) == {
+        "schema_version",
+        "correlation_sha256",
+        "request_target_sha256",
+        "scope",
+        "client_transport_status",
+        "attempt_count",
+        "blocked_attempt_count",
+        "retry_count",
+        "fallback_count",
+        "completed_response_count",
+        "provider_receipt_status",
+    }
+
+    for invalid in ("", "A" * 32, "0" * 31, "0" * 33, "g" * 32, None):
+        with pytest.raises(ProviderWireEvidenceError):
+            ProviderWireRecorder(invalid)
+
+    with pytest.raises(
+        ProviderWireEvidenceError,
+        match="provider_wire_request_target_invalid",
+    ):
+        provider_wire_request_target_sha256(
+            "POST",
+            "http://127.0.0.1:8080/v1/chat/completions?secret=value",
+        )
+
+
+def test_instrumentation_is_inert_without_an_explicit_scope():
+    transport = httpx.MockTransport(lambda request: httpx.Response(200))
+    assert instrument_httpx_transport(transport) is transport
+    assert sanitized_provider_wire_evidence(None, terminal_success=True) is None
+
+
+def test_caller_supplied_http_client_is_rejected_before_provider_execution():
+    recorder = ProviderWireRecorder(NONCE)
+    agent = SimpleNamespace(provider="custom")
+
+    with bind_provider_wire_recorder(recorder):
+        with pytest.raises(
+            ProviderWireEvidenceError,
+            match="provider_wire_custom_http_client_unsupported",
+        ):
+            create_openai_client(
+                agent,
+                {"http_client": object()},
+                reason="owner_one_shot",
+                shared=False,
+            )
+
+    assert _success_evidence(recorder)["attempt_count"] == 0
+
+
+def test_real_agent_constructor_registers_owned_transport_without_provider_io(
+    tmp_path,
+    monkeypatch,
+):
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    recorder = ProviderWireRecorder(NONCE)
+    with bind_provider_wire_recorder(recorder):
+        agent = AIAgent(
+            provider="custom",
+            model="hermes-agent",
+            base_url="http://127.0.0.1:8080/v1",
+            api_key="test-only",
+            enabled_toolsets=[],
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=None,
+            fallback_model=None,
+            max_iterations=1,
+            quiet_mode=True,
+        )
+        try:
+            recorder.require_registered_transport()
+        finally:
+            agent.close()
+
+    evidence = sanitized_provider_wire_evidence(
+        recorder,
+        terminal_success=False,
+    )
+    assert evidence["attempt_count"] == 0
+    assert evidence["completed_response_count"] == 0
+    assert evidence["client_transport_status"] == "UNKNOWN"
+
+
+def test_one_relay_dispatch_and_one_transport_response_is_exact():
+    recorder = ProviderWireRecorder(NONCE)
+    calls = []
+    inner = httpx.MockTransport(
+        lambda request: calls.append((request.method, request.url.path))
+        or httpx.Response(200, json={"ok": True})
+    )
+
+    with bind_provider_wire_recorder(recorder):
+        transport = instrument_httpx_transport(inner)
+
+        def callback(_request):
+            with httpx.Client(transport=transport) as client:
+                return client.post("http://127.0.0.1:8080/v1/chat/completions")
+
+        response = relay_llm.execute_current(
+            {},
+            callback,
+            name="local",
+            model_name="local-model",
+            metadata={"api_request_id": "request-1", "call_role": "primary"},
+        )
+
+    assert response.status_code == 200
+    assert calls == [("POST", "/v1/chat/completions")]
+    assert _success_evidence(recorder) == {
+        "schema_version": PROVIDER_WIRE_EVIDENCE_SCHEMA,
+        "correlation_sha256": provider_wire_correlation_sha256(NONCE),
+        "request_target_sha256": provider_wire_request_target_sha256(
+            "POST", "http://127.0.0.1:8080/v1/chat/completions"
+        ),
+        "scope": PROVIDER_WIRE_EVIDENCE_SCOPE,
+        "client_transport_status": "EXACT",
+        "attempt_count": 1,
+        "blocked_attempt_count": 0,
+        "retry_count": 0,
+        "fallback_count": 0,
+        "completed_response_count": 1,
+        "provider_receipt_status": "UNPROVEN",
+    }
+
+
+def test_second_transport_attempt_is_blocked_before_inner_transport():
+    recorder = ProviderWireRecorder(NONCE)
+    calls = 0
+
+    def respond(_request):
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200)
+
+    with bind_provider_wire_recorder(recorder):
+        transport = instrument_httpx_transport(httpx.MockTransport(respond))
+        with provider_wire_dispatch({"call_role": "primary"}):
+            with httpx.Client(transport=transport) as client:
+                assert client.post("http://127.0.0.1:8080/v1/chat/completions").status_code == 200
+                with pytest.raises(ProviderWireLimitError):
+                    client.post("http://127.0.0.1:8080/v1/chat/completions")
+
+    evidence = _success_evidence(recorder)
+    assert calls == 1
+    assert evidence["attempt_count"] == 1
+    assert evidence["blocked_attempt_count"] == 1
+    assert evidence["retry_count"] == 1
+    assert evidence["client_transport_status"] == "UNKNOWN"
+
+
+def test_second_relay_dispatch_is_blocked_and_fallback_is_distinct():
+    recorder = ProviderWireRecorder(NONCE)
+    inner = httpx.MockTransport(lambda request: httpx.Response(200))
+    with bind_provider_wire_recorder(recorder):
+        transport = instrument_httpx_transport(inner)
+        with provider_wire_dispatch({"call_role": "primary"}):
+            with httpx.Client(transport=transport) as client:
+                client.post("http://127.0.0.1:8080/v1/chat/completions")
+        with pytest.raises(ProviderWireLimitError):
+            with provider_wire_dispatch({"call_role": "fallback"}):
+                raise AssertionError("fallback body must not execute")
+
+    evidence = _success_evidence(recorder)
+    assert evidence["attempt_count"] == 1
+    assert evidence["blocked_attempt_count"] == 1
+    assert evidence["fallback_count"] == 1
+    assert evidence["retry_count"] == 0
+    assert evidence["client_transport_status"] == "UNKNOWN"
+
+
+def test_unmatched_auxiliary_attempt_blocks_later_primary_dispatch():
+    recorder = ProviderWireRecorder(NONCE)
+    calls = 0
+
+    def respond(_request):
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200)
+
+    with bind_provider_wire_recorder(recorder):
+        transport = instrument_httpx_transport(
+            httpx.MockTransport(respond),
+            transport_role="auxiliary",
+        )
+        with httpx.Client(transport=transport) as client:
+            client.post("http://127.0.0.1:8080/v1/chat/completions")
+        with pytest.raises(ProviderWireLimitError):
+            with provider_wire_dispatch({"call_role": "primary"}):
+                raise AssertionError("primary body must not execute")
+
+    evidence = _success_evidence(recorder)
+    assert calls == 1
+    assert evidence["attempt_count"] == 1
+    assert evidence["blocked_attempt_count"] == 1
+    assert evidence["client_transport_status"] == "UNKNOWN"
+
+
+def test_dispatch_without_wrapped_transport_is_unknown():
+    recorder = ProviderWireRecorder(NONCE)
+    with bind_provider_wire_recorder(recorder):
+        with provider_wire_dispatch({"call_role": "primary"}):
+            pass
+        with pytest.raises(ProviderWireLimitError):
+            with provider_wire_dispatch({"call_role": "primary"}):
+                raise AssertionError("second unmatched dispatch must not execute")
+    evidence = _success_evidence(recorder)
+    assert evidence["blocked_attempt_count"] == 1
+    assert evidence["retry_count"] == 1
+    assert evidence["client_transport_status"] == "UNKNOWN"
+
+
+def test_recorder_is_request_local_across_threads():
+    seen = []
+    first = ProviderWireRecorder(NONCE)
+    second = ProviderWireRecorder("fedcba9876543210fedcba9876543210")
+
+    def run(recorder):
+        with bind_provider_wire_recorder(recorder):
+            transport = instrument_httpx_transport(
+                httpx.MockTransport(lambda request: httpx.Response(200))
+            )
+            with provider_wire_dispatch({"call_role": "primary"}):
+                with httpx.Client(transport=transport) as client:
+                    client.post("http://127.0.0.1:8080/v1/chat/completions")
+        seen.append(_success_evidence(recorder))
+
+    threads = [threading.Thread(target=run, args=(recorder,)) for recorder in (first, second)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(seen) == 2
+    assert {item["correlation_sha256"] for item in seen} == {
+        provider_wire_correlation_sha256(NONCE),
+        provider_wire_correlation_sha256("fedcba9876543210fedcba9876543210"),
+    }
+    assert all(item["client_transport_status"] == "EXACT" for item in seen)
+
+
+def test_interrupt_worker_target_copies_the_request_evidence_context():
+    recorder = ProviderWireRecorder(NONCE)
+    seen = []
+
+    with bind_provider_wire_recorder(recorder):
+        target = _context_thread_target(
+            lambda: seen.append(
+                sanitized_provider_wire_evidence(
+                    current_provider_wire_recorder(),
+                    terminal_success=False,
+                )["correlation_sha256"]
+            )
+        )
+    worker = threading.Thread(target=target)
+    worker.start()
+    worker.join()
+
+    assert seen == [provider_wire_correlation_sha256(NONCE)]
+
+
+def test_recorder_bound_request_clients_are_never_put_in_the_warm_cache():
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = "custom"
+    agent._client_kwargs = {
+        "api_key": "test",
+        "base_url": "http://127.0.0.1:8080/v1",
+    }
+    agent._ensure_primary_openai_client = MagicMock(return_value=object())
+    first_client = SimpleNamespace(name="first")
+    second_client = SimpleNamespace(name="second")
+    agent._create_openai_client = MagicMock(
+        side_effect=(first_client, second_client)
+    )
+    agent._close_openai_client = MagicMock()
+
+    with bind_provider_wire_recorder(ProviderWireRecorder(NONCE)):
+        first = agent._create_request_openai_client(reason="owner_one_shot")
+        agent._close_request_openai_client(first, reason="request_complete")
+    with bind_provider_wire_recorder(
+        ProviderWireRecorder("fedcba9876543210fedcba9876543210")
+    ):
+        second = agent._create_request_openai_client(reason="owner_one_shot")
+        agent._close_request_openai_client(second, reason="request_complete")
+
+    assert first is first_client
+    assert second is second_client
+    assert agent._create_openai_client.call_count == 2
+    assert agent._request_client_cache["client"] is None
+    assert agent._close_openai_client.call_count == 2
+
+
+def test_async_transport_has_the_same_one_attempt_boundary():
+    recorder = ProviderWireRecorder(NONCE)
+    calls = 0
+
+    async def respond(_request):
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200)
+
+    async def exercise():
+        with bind_provider_wire_recorder(recorder):
+            transport = instrument_async_httpx_transport(httpx.MockTransport(respond))
+            with provider_wire_dispatch({"call_role": "primary"}):
+                async with httpx.AsyncClient(transport=transport) as client:
+                    response = await client.post(
+                        "http://127.0.0.1:8080/v1/chat/completions"
+                    )
+                    assert response.status_code == 200
+                    with pytest.raises(ProviderWireLimitError):
+                        await client.post(
+                            "http://127.0.0.1:8080/v1/chat/completions"
+                        )
+
+    asyncio.run(exercise())
+    assert calls == 1
+    assert _success_evidence(recorder)["client_transport_status"] == "UNKNOWN"
+
+
+def test_lazy_stream_response_is_not_executed_outside_dispatch_and_loss_is_unknown():
+    class BrokenStream(httpx.SyncByteStream):
+        def __iter__(self):
+            raise RuntimeError("late stream failure")
+
+    recorder = ProviderWireRecorder(NONCE)
+    with bind_provider_wire_recorder(recorder):
+        transport = instrument_httpx_transport(
+            httpx.MockTransport(lambda request: httpx.Response(200, stream=BrokenStream()))
+        )
+        with provider_wire_dispatch({"call_role": "primary"}):
+            with httpx.Client(transport=transport) as client:
+                response = client.send(
+                    httpx.Request("POST", "http://127.0.0.1:8080/v1/chat/completions"),
+                    stream=True,
+                )
+        with pytest.raises(RuntimeError, match="late stream failure"):
+            next(response.iter_bytes())
+        response.close()
+    evidence = _success_evidence(recorder)
+    assert evidence["attempt_count"] == 1
+    assert evidence["completed_response_count"] == 0
+    assert evidence["client_transport_status"] == "UNKNOWN"
+
+
+def test_lazy_async_stream_counts_only_eof_and_marks_cancelled_body_unknown():
+    class BrokenAsyncStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            raise asyncio.CancelledError()
+
+        async def aclose(self):
+            return None
+
+    recorder = ProviderWireRecorder(NONCE)
+
+    async def exercise():
+        with bind_provider_wire_recorder(recorder):
+            transport = instrument_async_httpx_transport(
+                httpx.MockTransport(lambda request: httpx.Response(200, stream=BrokenAsyncStream()))
+            )
+            with provider_wire_dispatch({"call_role": "primary"}):
+                async with httpx.AsyncClient(transport=transport) as client:
+                    response = await client.send(
+                        httpx.Request("POST", "http://127.0.0.1:8080/v1/chat/completions"),
+                        stream=True,
+                    )
+            with pytest.raises(asyncio.CancelledError):
+                await response.aread()
+            await response.aclose()
+
+    asyncio.run(exercise())
+    evidence = _success_evidence(recorder)
+    assert evidence["attempt_count"] == 1
+    assert evidence["completed_response_count"] == 0
+    assert evidence["client_transport_status"] == "UNKNOWN"
+
+
+def test_proxy_path_without_owned_transport_fails_closed():
+    recorder = ProviderWireRecorder(NONCE)
+    # Proxy/custom clients bypass owned HTTPX mounts; no registration is made.
+    with bind_provider_wire_recorder(recorder):
+        with pytest.raises(ProviderWireEvidenceError, match="provider_wire_exact_transport_unavailable"):
+            recorder.require_registered_transport()


### PR DESCRIPTION
## Summary

- add opt-in, request-scoped evidence for client HTTP transport attempts
- bind authenticated non-stream gateway requests to a strict 32-hex correlation nonce
- enforce a one-attempt transport budget with retry and fallback counters
- preserve latest relay behavior while instrumenting primary, auxiliary, sync, async, and managed stream dispatch boundaries
- defer response completion evidence until an eager body is already materialized or a lazy body reaches EOF
- classify partial reads, exceptions, cancellation, unsupported transports, and missing correlation as `UNKNOWN`

## Why

A successful gateway POST or usage record does not prove how many physical client transport attempts Hermes initiated. This change adds a narrow, opt-in evidence boundary without altering the default uninstrumented path. It also fixes response lifecycle accounting so lazy-stream failures cannot be reported as completed responses.

## Safety boundary

- evidence scope is `client_http_transport_attempt`
- `provider_receipt_status` remains `UNPROVEN`; this is not provider-ingress proof
- no raw prompt, response, URL, credential, header, or exception is retained
- the second transport attempt is blocked before the inner transport is called
- stream and idempotency evidence modes fail closed
- no runtime installation, activation, deployment, service control, or state mutation is included

## Validation

- `scripts/run_tests.sh tests/test_provider_wire_instrumentation.py tests/gateway/test_api_server_provider_wire_evidence.py tests/agent/test_relay_llm.py tests/agent/test_auxiliary_relay.py tests/agent/test_relay_nested_execution.py -q` — 53 passed
- focused independent re-run — 42 passed
- Python bytecode compilation passed for all affected Python modules
- `git diff --check origin/main..HEAD` passed

Base: `03fa32c92dd445eb64c7f67434dd91b32c40701d`

Head: `a1077d66f54d053994f4960ce92f3c3dc0a06ebb`
