### PR TITLE
fix: recover Telegram thread id for orchestrator replies on synthetic/recovered events (fixes #83180)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -752,11 +752,36 @@ class GatewayKanbanWatchersMixin:
                                             _delivery_meta.get("chat_type") or ""
                                         ).strip()
                                 _chat_type = _chat_type or "group"
+                                _thread_id = sub.get("thread_id") or None
+                                # KNOWN LIMITATION (preserved): chat_type is not
+                                # persisted reliably on every subscription row
+                                # (legacy/#60600 rows fall back to delivery_metadata
+                                # then "group"), so a DM whose thread_id we recover
+                                # here is still gated on the actual platform below.
+                                if not _thread_id and plat == _Platform.TELEGRAM and _chat_type == "dm":
+                                    # Defense-in-depth: a Telegram DM subscription
+                                    # whose row has no thread_id (synthetic /
+                                    # recovered creator) must not wake the agent
+                                    # into the General topic. Recover the task's
+                                    # session topic binding and stamp it so the
+                                    # synthetic wake routes to the correct lane.
+                                    try:
+                                        from gateway.session import recover_telegram_dm_thread_id
+                                        _session_db = getattr(self, "_session_db", None)
+                                        if _session_db is not None:
+                                            _recovered_tid = recover_telegram_dm_thread_id(
+                                                _session_db,
+                                                session_id=_session_key,
+                                            )
+                                            if _recovered_tid:
+                                                _thread_id = _recovered_tid
+                                    except Exception:
+                                        _thread_id = None
                                 _source = SessionSource(
                                     platform=plat,
                                     chat_id=sub["chat_id"],
                                     chat_type=_chat_type,
-                                    thread_id=sub.get("thread_id") or None,
+                                    thread_id=_thread_id,
                                     user_id=sub.get("user_id"),
                                     profile=sub_profile or None,
                                 )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -92,7 +92,12 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
-def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
+def _thread_metadata_for_source(
+    source,
+    reply_to_message_id: str | None = None,
+    *,
+    session_db=None,
+) -> dict | None:
     """Build platform-aware thread metadata for adapter sends.
 
     Most platforms route threaded sends with a generic ``thread_id`` metadata
@@ -101,8 +106,30 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     user-message replies route with ``message_thread_id`` + ``reply_to_message_id``;
     synthetic/resumed sends that have no reply anchor fall back to Telegram's
     ``direct_messages_topic_id`` when the Bot API supports it.
+
+    ``session_db`` (optional) is the sync ``SessionDB`` (or ``AsyncSessionDB``
+    wrapper). When a Telegram DM source has no ``thread_id`` (synthetic /
+    recovered / post-session-split events), it is used to recover the topic's
+    ``thread_id`` from the DM topic binding so the reply routes to the correct
+    topic instead of the General home topic.
     """
     thread_id = getattr(source, "thread_id", None)
+    if (
+        thread_id is None
+        and session_db is not None
+        and _platform_name(getattr(source, "platform", None)) == "telegram"
+        and getattr(source, "chat_type", None) == "dm"
+    ):
+        # Lazy import to keep gateway.platforms.base's import graph light and
+        # avoid a hard dependency at module load.
+        from gateway.session import recover_telegram_dm_thread_id
+
+        recovered = recover_telegram_dm_thread_id(
+            session_db,
+            source=source,
+        )
+        if recovered:
+            thread_id = recovered
     metadata = {"thread_id": thread_id} if thread_id is not None else {}
     # Slack workspace identity is durable routing state, not ephemeral event
     # metadata. Carry it on every outbound path (including unthreaded sends)
@@ -3696,6 +3723,22 @@ class BasePlatformAdapter(ABC):
         thread replies without explicit mentions).
         """
         self._session_store = session_store
+
+    def _sync_session_db(self) -> Any:
+        """Return the sync ``SessionDB`` reachable from this adapter, if any.
+
+        The gateway runner hosts the session DB (``_runner._session_db``, an
+        ``AsyncSessionDB`` wrapper). Unwrap it to the sync ``SessionDB`` so the
+        reply path can run the Telegram DM topic-binding recovery synchronously.
+        Returns None when no runner / DB is attached (tests, bare adapters).
+        """
+        runner = getattr(self, "gateway_runner", None)
+        if runner is None:
+            return None
+        session_db = getattr(runner, "_session_db", None)
+        if session_db is None:
+            return None
+        return getattr(session_db, "_db", session_db)
     
     def _history_media_paths_for_session(self, session_key: str) -> Optional[set]:
         """Return media paths already delivered in prior turns of this session.
@@ -5879,7 +5922,7 @@ class BasePlatformAdapter(ABC):
         current_guard = self._active_sessions.get(session_key)
         command_guard = asyncio.Event()
         self._active_sessions[session_key] = command_guard
-        thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event), session_db=self._sync_session_db())
 
         try:
             response = await self._message_handler(event)
@@ -6009,7 +6052,7 @@ class BasePlatformAdapter(ABC):
                     self.name, cmd, session_key,
                 )
                 try:
-                    _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                    _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event), session_db=self._sync_session_db())
                     response = await self._message_handler(event)
                     _text, _eph_ttl = self._unwrap_ephemeral(response)
                     if _text:
@@ -6184,7 +6227,7 @@ class BasePlatformAdapter(ABC):
         # Gated per-platform: when typing_indicator=False the refresh loop is
         # never spawned, so no "typing…" / "is thinking…" status is shown.
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
-        _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event), session_db=self._sync_session_db())
         typing_task: Optional[asyncio.Task] = None
         if getattr(self.config, "typing_indicator", True):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
@@ -6751,7 +6794,7 @@ class BasePlatformAdapter(ABC):
             try:
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event), session_db=self._sync_session_db())
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1084,6 +1084,82 @@ def _session_key_namespace(profile: Optional[str]) -> str:
     return f"agent:{profile}"
 
 
+def _sync_session_db(session_db: Any) -> Any:
+    """Unwrap a possibly-async session DB handle to its sync ``SessionDB``.
+
+    ``GatewayRunner._session_db`` is an ``AsyncSessionDB`` (a thin
+    ``asyncio.to_thread`` forwarder over a sync ``SessionDB``); other callers
+    hold the sync ``SessionDB`` directly. Both expose the sync handle under
+    ``_db`` when wrapped, so normalize here so the recovery helpers can call
+    the sync binding lookups directly.
+    """
+    if session_db is None:
+        return None
+    return getattr(session_db, "_db", session_db)
+
+
+def recover_telegram_dm_thread_id(
+    session_db: Any,
+    *,
+    source: Optional[SessionSource] = None,
+    session_id: Optional[str] = None,
+) -> Optional[str]:
+    """Recover a Telegram DM topic ``thread_id`` for an outbound send with no anchor.
+
+    Synthetic / recovered / post-session-split events carry a ``SessionSource``
+    whose ``thread_id`` is ``None``. Sent as-is, the Telegram adapter emits no
+    ``message_thread_id`` and the reply lands in the General (home) topic. When
+    the target session has a DM topic binding, recover its ``thread_id`` so the
+    reply routes to the correct topic instead.
+
+    Two lookup modes, both best-effort and fail-open (return ``None`` on any
+    miss or error — never raise):
+
+    * ``session_id`` provided -> ``get_telegram_topic_binding_by_session``
+      (primary path; the kanban-watcher wake-synth / orchestrator reply knows
+      the raw session id of the task being woken).
+    * otherwise a Telegram DM ``source`` -> the newest topic binding for the
+      chat, mirroring ``GatewayRunner._recover_telegram_topic_thread_id``
+      (covers the outbound reply path before a session id is resolved).
+
+    ``session_db`` may be either the sync ``SessionDB`` or an ``AsyncSessionDB``
+    wrapper; both are handled.
+    """
+    db = _sync_session_db(session_db)
+    if db is None:
+        return None
+    try:
+        if session_id:
+            binding = db.get_telegram_topic_binding_by_session(
+                session_id=str(session_id),
+            )
+            if binding and binding.get("thread_id"):
+                return str(binding["thread_id"])
+            # A resolved session id with no binding is authoritative: there is
+            # no topic lane to recover, so do not fall through to the chat-wide
+            # scan (which could pin the reply to a different session's topic).
+            return None
+        if (
+            source is None
+            or source.platform != Platform.TELEGRAM
+            or source.chat_type != "dm"
+            or not source.chat_id
+        ):
+            return None
+        bindings = db.list_telegram_topic_bindings_for_chat(
+            chat_id=str(source.chat_id),
+        )
+        user_id = str(source.user_id or "")
+        for b in bindings:  # newest-first
+            if user_id and str(b.get("user_id") or "") == user_id:
+                recovered = str(b.get("thread_id") or "")
+                if recovered:
+                    return recovered
+    except Exception:
+        return None
+    return None
+
+
 def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -759,6 +759,98 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Orchestrator-reply thread recovery (issue #83180)
+# ---------------------------------------------------------------------------
+
+def _make_topic_db(tmp_path, *, session_id="sess-83180", thread_id="17585"):
+    """Build a SessionDB with a Telegram DM topic binding for one session."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(session_id=session_id, source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id=thread_id,
+        user_id="208214988",
+        session_key=f"agent:main:telegram:dm:208214988:{thread_id}",
+        session_id=session_id,
+    )
+    return db
+
+
+def test_thread_metadata_recovers_thread_id_when_source_has_none(tmp_path):
+    """Reply path recovers thread_id from the DM topic binding when source.thread_id is None."""
+    from gateway.platforms.base import _thread_metadata_for_source
+
+    db = _make_topic_db(tmp_path)
+    source = _make_source(thread_id=None)  # Telegram DM, no thread anchor
+
+    meta = _thread_metadata_for_source(source, session_db=db)
+
+    assert meta is not None
+    assert meta["thread_id"] == "17585"
+    assert meta.get("telegram_dm_topic_reply_fallback") is True
+
+
+def test_thread_metadata_keeps_explicit_thread_id_when_present(tmp_path):
+    """Reply path does NOT overwrite a real thread_id with the binding."""
+    from gateway.platforms.base import _thread_metadata_for_source
+
+    db = _make_topic_db(tmp_path)
+    source = _make_source(thread_id="9999")
+
+    meta = _thread_metadata_for_source(source, session_db=db)
+
+    assert meta["thread_id"] == "9999"
+
+
+def test_thread_metadata_no_recovery_without_session_db(tmp_path):
+    """Without a session DB handle the reply path stays unthreaded (fail-open)."""
+    from gateway.platforms.base import _thread_metadata_for_source
+
+    db = _make_topic_db(tmp_path)
+    source = _make_source(thread_id=None)
+
+    meta = _thread_metadata_for_source(source, session_db=None)
+
+    assert meta is None
+
+
+def test_recover_telegram_dm_thread_id_by_session(tmp_path):
+    """Wake-synth recovery by raw session id returns the bound thread_id."""
+    from gateway.session import recover_telegram_dm_thread_id
+
+    db = _make_topic_db(tmp_path)
+
+    tid = recover_telegram_dm_thread_id(db, session_id="sess-83180")
+
+    assert tid == "17585"
+
+
+def test_recover_telegram_dm_thread_id_unknown_session_returns_none(tmp_path):
+    """A session id with no binding is authoritative — no chat-wide fallback."""
+    from gateway.session import recover_telegram_dm_thread_id
+
+    db = _make_topic_db(tmp_path)
+
+    tid = recover_telegram_dm_thread_id(db, session_id="sess-unknown")
+
+    assert tid is None
+
+
+def test_recover_telegram_dm_thread_id_unwraps_async_db(tmp_path):
+    """The helper accepts an AsyncSessionDB wrapper the same as the sync handle."""
+    from hermes_state import AsyncSessionDB
+    from gateway.session import recover_telegram_dm_thread_id
+
+    db = _make_topic_db(tmp_path)
+    async_db = AsyncSessionDB(db)
+
+    tid = recover_telegram_dm_thread_id(async_db, session_id="sess-83180")
+
+    assert tid == "17585"
+
+
+# ---------------------------------------------------------------------------
 # Test for session-split thread_id recovery (issue #27166)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #83180

## Summary

Orchestrator-reply messages lose their Telegram thread after **synthetic / recovered / post-session-split** events and fall back to the **General (home) topic**. When a `SessionSource` has `thread_id=None`, `_thread_metadata_for_source` returns no `thread_id` metadata and the Telegram adapter sends with no `message_thread_id`. The existing recovery guard in `gateway/run.py` only restores `thread_id` after `_session_split_entry_persisted` is True, so wake / synthetic / first-reply-after-recovery paths are unprotected.

Severity is **low**: Telegram's default (no thread anchor → General topic) largely accounts for the symptom, and this is a recoverable-context gap rather than a hard functional break.

## Fix

Added a shared helper `recover_telegram_dm_thread_id` in `gateway/session.py` that looks up the DM topic binding's `thread_id` for a session, and wired it into both affected paths:

1. **Reply path** — `_thread_metadata_for_source` (`gateway/platforms/base.py`). When the source is a Telegram DM with `thread_id=None`, it now recovers the thread from the newest topic binding for the chat (mirroring the existing `_recover_telegram_topic_thread_id`). The module-level function has no `self._session_db`, so the DB handle is threaded in as an optional `session_db` keyword from the adapter callers, which resolve it via a new small `BasePlatformAdapter._sync_session_db()` helper off `self.gateway_runner._session_db`. This is the least-invasive seam: the function stays pure/testable and existing callers that pass no `session_db` behave exactly as before (fail-open).

2. **Kanban-watcher wake-synth** (`gateway/kanban_watchers.py`) — defense in depth. When a Telegram DM subscription row has no `thread_id`, the synthetic wake `SessionSource` now recovers the thread from the task's session binding (by raw `session_id`) and stamps it, so the wake routes to the correct topic lane instead of General.

Both lookups are best-effort and fail-open (return `None` on any miss/error — never raise).

## Seam choice (DB handle)

`_thread_metadata_for_source` is a module-level function without `self._session_db`. I threaded the sync `SessionDB` in as an optional keyword from the adapter callers rather than adding a global/registered accessor, keeping the change minimal and the function unit-testable. The new `recover_telegram_dm_thread_id` accepts either the sync `SessionDB` or an `AsyncSessionDB` wrapper (unwrapping via `_db`).

## Tests

- Added 6 focused unit tests in `tests/gateway/test_telegram_topic_mode.py` covering: reply-path recovery from the binding when `source.thread_id is None`; explicit thread_id preserved; fail-open without a DB handle; wake-synth recovery by session id; unknown session returns None; and `AsyncSessionDB` unwrapping.
- `tests/gateway/test_telegram_topic_mode.py` — 23 passed
- `tests/gateway/test_kanban_notifier.py` + `test_compression_failure_session_sync.py` — 10 passed
- Tight-scoped regression subset (telegram + kanban + slack + choice_picker + confirm + voice/stream/media tests) — 218 passed
- `python -m py_compile` on all changed files — OK

Note: the full `tests/gateway` suite has 10 pre-existing failures (Discord send kwargs, Matrix crypto/pickle, multiplex config, telegram closewait, send_multiple_images) that reproduce identically on clean `main` in this environment and are unrelated to this change.