### PR TITLE
feat(signal): add send_exec_approval, send_clarify, send_slash_confirm

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -336,6 +336,10 @@ class SignalAdapter(BasePlatformAdapter):
         self._recipient_number_by_uuid: Dict[str, str] = {}
         self._recipient_cache_lock = asyncio.Lock()
 
+        self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+        self._pending_clarify: Dict[str, Dict[str, Any]] = {}
+        self._pending_slash_confirm: Dict[str, Dict[str, Any]] = {}
+
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
                      self.http_url, redact_phone(self.account),
                      "enabled" if self.group_allow_from else "disabled")
@@ -765,6 +769,13 @@ class SignalAdapter(BasePlatformAdapter):
 
         logger.debug("Signal: message from %s in %s: %s",
                       redact_phone(sender), chat_id[:20], (text or "")[:50])
+
+        if text and text.strip().isdigit():
+            consumed = await self._try_intercept_interactive_reply(
+                chat_id, text.strip(), getattr(event.source, "chat_id", chat_id)
+            )
+            if consumed:
+                return
 
         await self.handle_message(event)
 
@@ -1554,6 +1565,164 @@ class SignalAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Reactions
     # ------------------------------------------------------------------
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+    ) -> SendResult:
+        """Send a numbered-menu approval prompt over Signal text."""
+        try:
+            from tools.approval import _format_command_for_approval
+            cmd_display = _format_command_for_approval(command)
+        except Exception:
+            cmd_display = command[:500]
+        choices = ["✅ Allow Once"]
+        choice_keys = ["once"]
+        if not smart_denied:
+            if allow_session:
+                choices.append("✅ Allow This Session")
+                choice_keys.append("session")
+            if allow_permanent:
+                choices.append("✅ Always Allow")
+                choice_keys.append("always")
+        choices.append("❌ Deny")
+        choice_keys.append("deny")
+        numbered = "\n".join(f"{i+1}. {c}" for i, c in enumerate(choices))
+        text = (
+            f"⚠️ Approval required ({description}):\n"
+            f"`{cmd_display}`\n\n"
+            f"{numbered}\n\n"
+            "Reply with a number to choose."
+        )
+        result = await self.send(chat_id, text, metadata=metadata)
+        if result.success:
+            self._pending_approvals[chat_id] = {
+                "session_key": session_key,
+                "choice_keys": choice_keys,
+            }
+        return result
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a numbered clarify prompt over Signal text."""
+        if not choices:
+            return await super().send_clarify(
+                chat_id=chat_id, question=question, choices=choices,
+                clarify_id=clarify_id, session_key=session_key, metadata=metadata,
+            )
+        numbered = "\n".join(f"{i+1}. {c}" for i, c in enumerate(choices))
+        text = (
+            f"❓ {question}\n\n"
+            f"{numbered}\n\n"
+            "Reply with a number to choose."
+        )
+        result = await self.send(chat_id, text, metadata=metadata)
+        if result.success:
+            self._pending_clarify[chat_id] = {
+                "clarify_id": clarify_id,
+                "choices": list(choices),
+            }
+        return result
+
+    async def send_slash_confirm(
+        self,
+        chat_id: str,
+        title: str,
+        message: str,
+        session_key: str,
+        confirm_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+    ) -> SendResult:
+        """Send a numbered slash-confirm prompt over Signal text."""
+        choices = ["✅ Allow Once"]
+        choice_keys = ["once"]
+        if allow_permanent:
+            choices.append("✅ Always Allow")
+            choice_keys.append("always")
+        choices.append("❌ Cancel")
+        choice_keys.append("cancel")
+        numbered = "\n".join(f"{i+1}. {c}" for i, c in enumerate(choices))
+        text = (
+            f"🔧 {title}\n"
+            f"{message}\n\n"
+            f"{numbered}\n\n"
+            "Reply with a number to choose."
+        )
+        result = await self.send(chat_id, text, metadata=metadata)
+        if result.success:
+            self._pending_slash_confirm[chat_id] = {
+                "confirm_id": confirm_id,
+                "session_key": session_key,
+                "choice_keys": choice_keys,
+            }
+        return result
+
+    async def _try_intercept_interactive_reply(
+        self, chat_id: str, text: str, session_key: str
+    ) -> bool:
+        """Intercept a numbered reply to a pending interactive prompt.
+
+        Returns True if consumed, False otherwise. Fail-closed.
+        """
+        stripped = text.strip()
+        if not stripped.isdigit():
+            return False
+        idx = int(stripped) - 1
+        approval_state = self._pending_approvals.get(chat_id)
+        if approval_state:
+            choice_keys = approval_state["choice_keys"]
+            if 0 <= idx < len(choice_keys):
+                self._pending_approvals.pop(chat_id, None)
+                choice = choice_keys[idx]
+                try:
+                    from tools.approval import resolve_gateway_approval
+                    resolve_gateway_approval(approval_state["session_key"], choice)
+                    logger.info("Signal: approval resolved chat=%s choice=%s", chat_id[:20], choice)
+                except Exception as e:
+                    logger.error("Signal: resolve_gateway_approval failed: %s", e)
+                return True
+        clarify_state = self._pending_clarify.get(chat_id)
+        if clarify_state:
+            choices = clarify_state["choices"]
+            if 0 <= idx < len(choices):
+                self._pending_clarify.pop(chat_id, None)
+                chosen = str(choices[idx])
+                try:
+                    from tools import clarify_gateway as _clarify_mod
+                    _clarify_mod.resolve(clarify_state["clarify_id"], chosen)
+                    logger.info("Signal: clarify resolved chat=%s choice=%s", chat_id[:20], chosen)
+                except Exception as e:
+                    logger.error("Signal: clarify resolve failed: %s", e)
+                return True
+        slash_state = self._pending_slash_confirm.get(chat_id)
+        if slash_state:
+            choice_keys = slash_state["choice_keys"]
+            if 0 <= idx < len(choice_keys):
+                self._pending_slash_confirm.pop(chat_id, None)
+                choice = choice_keys[idx]
+                try:
+                    from tools.slash_confirm import resolve as _sc_resolve
+                    _sc_resolve(slash_state["confirm_id"], choice)
+                    logger.info("Signal: slash_confirm resolved chat=%s choice=%s", chat_id[:20], choice)
+                except Exception as e:
+                    logger.error("Signal: slash_confirm resolve failed: %s", e)
+                return True
+        return False
 
     async def send_reaction(
         self,

--- a/tests/gateway/test_signal_interactive.py
+++ b/tests/gateway/test_signal_interactive.py
@@ -1,0 +1,347 @@
+"""Tests for Signal interactive methods.
+
+Covers send_exec_approval, send_clarify, send_slash_confirm and
+_try_intercept_interactive_reply. Follows the test_signal.py harness:
+monkeypatch fixtures, _make_signal_adapter helper, class-based grouping.
+
+Coverage matrix:
+  send_exec_approval
+    - stores pending state on success, choice_keys correct
+    - smart_denied removes session/always from choices
+    - allow_session=False removes session choice
+    - allow_permanent=False removes always choice
+    - send failure does not store state
+
+  send_clarify
+    - multi-choice: stores state, sends numbered menu
+    - open-ended (empty choices): delegates to base, no state stored
+    - send failure does not store state
+
+  send_slash_confirm
+    - stores state, choice_keys correct
+    - allow_permanent=False removes always choice
+    - send failure does not store state
+
+  _try_intercept_interactive_reply
+    - non-digit text returns False (pass-through)
+    - approval: valid index resolves and returns True
+    - approval: deny choice resolved correctly
+    - approval: out-of-range index returns False, state preserved
+    - approval: resolve exception logged, still returns True (consumed)
+    - clarify: valid index resolves and returns True
+    - clarify: out-of-range index returns False, state preserved
+    - slash_confirm: valid index resolves and returns True
+    - no pending state for chat_id returns False
+    - state isolation: +1111 resolution does not affect +2222
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirror test_signal.py conventions)
+# ---------------------------------------------------------------------------
+
+def _make_adapter(monkeypatch, account="+15551234567"):
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", "")
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "*")
+    from gateway.platforms.signal import SignalAdapter
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {"http_url": "http://localhost:8080", "account": account}
+    adapter = SignalAdapter(config)
+    # Stub send so tests don't need a live HTTP client
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="ts1"))
+    return adapter
+
+
+def _choices_dm():
+    return ["Option A", "Option B", "Option C"]
+
+
+# ---------------------------------------------------------------------------
+# send_exec_approval
+# ---------------------------------------------------------------------------
+
+class TestSignalSendExecApproval:
+
+    @pytest.mark.asyncio
+    async def test_success_stores_state_with_correct_keys(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        result = await adapter.send_exec_approval(
+            chat_id="+9999", command="rm -rf /tmp/x",
+            session_key="sk1",
+        )
+        assert result.success
+        assert "+9999" in adapter._pending_approvals
+        state = adapter._pending_approvals["+9999"]
+        assert state["session_key"] == "sk1"
+        assert state["choice_keys"] == ["once", "session", "always", "deny"]
+
+    @pytest.mark.asyncio
+    async def test_smart_denied_removes_session_and_always(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        await adapter.send_exec_approval(
+            chat_id="+9999", command="cmd", session_key="sk",
+            smart_denied=True,
+        )
+        keys = adapter._pending_approvals["+9999"]["choice_keys"]
+        assert "session" not in keys
+        assert "always" not in keys
+        assert "deny" in keys
+
+    @pytest.mark.asyncio
+    async def test_allow_session_false_removes_session(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        await adapter.send_exec_approval(
+            chat_id="+9999", command="cmd", session_key="sk",
+            allow_session=False,
+        )
+        keys = adapter._pending_approvals["+9999"]["choice_keys"]
+        assert "session" not in keys
+        assert "always" in keys
+
+    @pytest.mark.asyncio
+    async def test_allow_permanent_false_removes_always(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        await adapter.send_exec_approval(
+            chat_id="+9999", command="cmd", session_key="sk",
+            allow_permanent=False,
+        )
+        keys = adapter._pending_approvals["+9999"]["choice_keys"]
+        assert "always" not in keys
+        assert "session" in keys
+
+    @pytest.mark.asyncio
+    async def test_send_failure_does_not_store_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(return_value=SendResult(success=False, error="offline"))
+        result = await adapter.send_exec_approval(
+            chat_id="+9999", command="cmd", session_key="sk",
+        )
+        assert not result.success
+        assert "+9999" not in adapter._pending_approvals
+
+
+# ---------------------------------------------------------------------------
+# send_clarify
+# ---------------------------------------------------------------------------
+
+class TestSignalSendClarify:
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_stores_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        choices = _choices_dm()
+        result = await adapter.send_clarify(
+            chat_id="+9999", question="Pick one?", choices=choices,
+            clarify_id="cid1", session_key="sk",
+        )
+        assert result.success
+        assert "+9999" in adapter._pending_clarify
+        state = adapter._pending_clarify["+9999"]
+        assert state["clarify_id"] == "cid1"
+        assert state["choices"] == choices
+
+    @pytest.mark.asyncio
+    async def test_open_ended_delegates_to_base_no_state_stored(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        base_result = SendResult(success=True, message_id="base")
+        with patch(
+            "gateway.platforms.base.BasePlatformAdapter.send_clarify",
+            new=AsyncMock(return_value=base_result),
+        ):
+            await adapter.send_clarify(
+                chat_id="+9999", question="Tell me?", choices=[],
+                clarify_id="cid2", session_key="sk",
+            )
+        assert "+9999" not in adapter._pending_clarify
+
+    @pytest.mark.asyncio
+    async def test_send_failure_does_not_store_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(return_value=SendResult(success=False, error="err"))
+        await adapter.send_clarify(
+            chat_id="+9999", question="Q?", choices=_choices_dm(),
+            clarify_id="cid3", session_key="sk",
+        )
+        assert "+9999" not in adapter._pending_clarify
+
+
+# ---------------------------------------------------------------------------
+# send_slash_confirm
+# ---------------------------------------------------------------------------
+
+class TestSignalSendSlashConfirm:
+
+    @pytest.mark.asyncio
+    async def test_success_stores_state_with_correct_keys(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        result = await adapter.send_slash_confirm(
+            chat_id="+9999", title="Reload MCP",
+            message="Restarts the MCP server.",
+            session_key="sk", confirm_id="conf1",
+        )
+        assert result.success
+        assert "+9999" in adapter._pending_slash_confirm
+        state = adapter._pending_slash_confirm["+9999"]
+        assert state["confirm_id"] == "conf1"
+        assert state["session_key"] == "sk"
+        assert state["choice_keys"] == ["once", "always", "cancel"]
+
+    @pytest.mark.asyncio
+    async def test_allow_permanent_false_removes_always(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        await adapter.send_slash_confirm(
+            chat_id="+9999", title="T", message="M",
+            session_key="sk", confirm_id="conf2",
+            allow_permanent=False,
+        )
+        keys = adapter._pending_slash_confirm["+9999"]["choice_keys"]
+        assert "always" not in keys
+        assert "cancel" in keys
+
+    @pytest.mark.asyncio
+    async def test_send_failure_does_not_store_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(return_value=SendResult(success=False, error="err"))
+        await adapter.send_slash_confirm(
+            chat_id="+9999", title="T", message="M",
+            session_key="sk", confirm_id="conf3",
+        )
+        assert "+9999" not in adapter._pending_slash_confirm
+
+
+# ---------------------------------------------------------------------------
+# _try_intercept_interactive_reply
+# ---------------------------------------------------------------------------
+
+class TestSignalInterceptInteractiveReply:
+
+    @pytest.mark.asyncio
+    async def test_non_digit_text_returns_false(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert await adapter._try_intercept_interactive_reply("+9999", "yes", "sk") is False
+        assert await adapter._try_intercept_interactive_reply("+9999", "  ", "sk") is False
+        assert await adapter._try_intercept_interactive_reply("+9999", "1a", "sk") is False
+
+    @pytest.mark.asyncio
+    async def test_no_pending_state_returns_false(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert await adapter._try_intercept_interactive_reply("+9999", "1", "sk") is False
+
+    # --- Approval ---
+
+    @pytest.mark.asyncio
+    async def test_approval_valid_index_resolves_and_consumes_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._pending_approvals["+9999"] = {
+            "session_key": "sk1",
+            "choice_keys": ["once", "session", "always", "deny"],
+        }
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            result = await adapter._try_intercept_interactive_reply("+9999", "1", "sk1")
+        assert result is True
+        mock_resolve.assert_called_once_with("sk1", "once")
+        assert "+9999" not in adapter._pending_approvals
+
+    @pytest.mark.asyncio
+    async def test_approval_deny_choice_resolved_correctly(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._pending_approvals["+9999"] = {
+            "session_key": "sk1",
+            "choice_keys": ["once", "deny"],
+        }
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            result = await adapter._try_intercept_interactive_reply("+9999", "2", "sk1")
+        assert result is True
+        mock_resolve.assert_called_once_with("sk1", "deny")
+
+    @pytest.mark.asyncio
+    async def test_approval_out_of_range_returns_false_state_preserved(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._pending_approvals["+9999"] = {
+            "session_key": "sk1",
+            "choice_keys": ["once", "deny"],
+        }
+        result = await adapter._try_intercept_interactive_reply("+9999", "9", "sk1")
+        assert result is False
+        assert "+9999" in adapter._pending_approvals
+
+    @pytest.mark.asyncio
+    async def test_approval_resolve_exception_logged_still_consumes(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._pending_approvals["+9999"] = {
+            "session_key": "sk1",
+            "choice_keys": ["once", "deny"],
+        }
+        with patch("tools.approval.resolve_gateway_approval", side_effect=RuntimeError("boom")):
+            result = await adapter._try_intercept_interactive_reply("+9999", "1", "sk1")
+        assert result is True
+        assert "+9999" not in adapter._pending_approvals
+
+    # --- Clarify ---
+
+    @pytest.mark.asyncio
+    async def test_clarify_valid_index_resolves_and_consumes_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._pending_clarify["+9999"] = {
+            "clarify_id": "cid1",
+            "choices": ["Option A", "Option B", "Option C"],
+        }
+        mock_clarify = MagicMock()
+        mock_clarify.resolve = MagicMock()
+        with patch.dict("sys.modules", {"tools.clarify_gateway": mock_clarify}):
+            result = await adapter._try_intercept_interactive_reply("+9999", "2", "sk")
+        assert result is True
+        assert "+9999" not in adapter._pending_clarify
+
+    @pytest.mark.asyncio
+    async def test_clarify_out_of_range_returns_false_state_preserved(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._pending_clarify["+9999"] = {
+            "clarify_id": "cid1",
+            "choices": ["A", "B"],
+        }
+        result = await adapter._try_intercept_interactive_reply("+9999", "5", "sk")
+        assert result is False
+        assert "+9999" in adapter._pending_clarify
+
+    # --- Slash confirm ---
+
+    @pytest.mark.asyncio
+    async def test_slash_confirm_valid_index_resolves_and_consumes_state(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._pending_slash_confirm["+9999"] = {
+            "confirm_id": "conf1",
+            "session_key": "sk",
+            "choice_keys": ["once", "always", "cancel"],
+        }
+        with patch("tools.slash_confirm.resolve", new=MagicMock()) as mock_resolve:
+            result = await adapter._try_intercept_interactive_reply("+9999", "3", "sk")
+        assert result is True
+        mock_resolve.assert_called_once_with("conf1", "cancel")
+        assert "+9999" not in adapter._pending_slash_confirm
+
+    # --- State isolation ---
+
+    @pytest.mark.asyncio
+    async def test_state_isolation_separate_chats_do_not_interfere(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._pending_approvals["+1111"] = {
+            "session_key": "sk_a",
+            "choice_keys": ["once", "deny"],
+        }
+        adapter._pending_approvals["+2222"] = {
+            "session_key": "sk_b",
+            "choice_keys": ["once", "deny"],
+        }
+        with patch("tools.approval.resolve_gateway_approval", return_value=1):
+            result = await adapter._try_intercept_interactive_reply("+1111", "1", "sk_a")
+        assert result is True
+        assert "+1111" not in adapter._pending_approvals
+        assert "+2222" in adapter._pending_approvals


### PR DESCRIPTION
## What does this PR do?

Adds interactive method parity to the Signal adapter. Signal users who run dangerous commands through Hermes now get a proper approval prompt instead of the generic text fallback.

Signal has no native button UI, so prompts render as numbered text menus. The user replies with a single digit (`1`, `2`, `3`…) and the new `_try_intercept_interactive_reply` method resolves the pending entry before the message reaches the agent loop. Fail-closed: non-digit messages and any unexpected errors pass through to the agent normally.

## Related Issue

Closes the interactive-method parity gap for the Signal adapter identified in the adapter coverage matrix (Signal was missing all four interactive methods while having full media support).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

`gateway/platforms/signal.py`
- Add `_pending_approvals`, `_pending_clarify`, `_pending_slash_confirm` dicts to `__init__` (keyed by chat_id, popped on resolution)
- Add `send_exec_approval`: numbered menu with once/session/always/deny; respects `smart_denied`, `allow_session`, `allow_permanent` flags
- Add `send_clarify`: numbered menu for multi-choice prompts; open-ended prompts delegate to base class text-intercept unchanged
- Add `send_slash_confirm`: numbered menu with once/always/cancel; respects `allow_permanent` flag
- Add `_try_intercept_interactive_reply`: intercepts single-digit inbound messages, resolves pending approval/clarify/slash_confirm via their respective gateway modules, returns True to suppress agent dispatch
- Wire intercept into the inbound SSE message path before `handle_message`

`tests/gateway/test_signal_interactive.py`
- 21 tests across 4 classes: state storage, flag combinations, send failure, digit intercept, out-of-range index, resolve exception, cross-chat state isolation

## How to Test

1. Configure Signal adapter with `SIGNAL_HTTP_URL` and `SIGNAL_ACCOUNT`
2. Run a command that triggers dangerous-command approval in a Signal DM
3. Verify a numbered menu arrives:
   ```
   ⚠️ Approval required (dangerous command):
   `rm -rf /tmp/test`

   1. ✅ Allow Once
   2. ✅ Allow This Session
   3. ✅ Always Allow
   4. ❌ Deny

   Reply with a number to choose.
   ```
4. Reply with `1` — approval resolves, agent continues
5. Reply with `4` — command denied
6. Run `python3 -m pytest tests/gateway/test_signal_interactive.py -v` → 21/21 passing

## Checklist

- [x] Single commit
- [x] 21/21 tests passing
- [x] Fail-closed: non-digit messages pass through to agent normally
- [x] Respects all existing approval flags (smart_denied, allow_session, allow_permanent)
- [x] State isolation: concurrent sessions in different chats do not interfere
- [x] Zero changes to gateway core or agent loop