### PR TITLE
fix(utils): honor default in env_bool, catch RecursionError in safe_json_loads

### DIFF
--- a/tests/test_utils_env_and_json_helpers.py
+++ b/tests/test_utils_env_and_json_helpers.py
@@ -1,0 +1,76 @@
+"""Tests for shared env-var helpers and safe_json_loads."""
+
+import json
+
+import pytest
+
+from utils import env_bool, env_float, env_int, safe_json_loads
+
+
+# ─── env_int / env_float / env_bool ────────────────────────────────────────
+
+
+def test_env_int_parses_and_falls_back(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_INT", "42")
+    assert env_int("HERMES_TEST_INT") == 42
+
+    monkeypatch.setenv("HERMES_TEST_INT", " 7 ")
+    assert env_int("HERMES_TEST_INT") == 7
+
+    monkeypatch.setenv("HERMES_TEST_INT", "not-a-number")
+    assert env_int("HERMES_TEST_INT") == 0
+    assert env_int("HERMES_TEST_INT", default=5) == 5
+
+    monkeypatch.delenv("HERMES_TEST_INT", raising=False)
+    assert env_int("HERMES_TEST_INT") == 0
+    assert env_int("HERMES_TEST_INT", default=-1) == -1
+
+
+def test_env_float_parses_and_falls_back(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_FLOAT", "3.5")
+    assert env_float("HERMES_TEST_FLOAT") == 3.5
+
+    monkeypatch.setenv("HERMES_TEST_FLOAT", "not-a-float")
+    assert env_float("HERMES_TEST_FLOAT") == 0.0
+    assert env_float("HERMES_TEST_FLOAT", default=1.5) == 1.5
+
+    monkeypatch.delenv("HERMES_TEST_FLOAT", raising=False)
+    assert env_float("HERMES_TEST_FLOAT") == 0.0
+
+
+def test_env_bool_uses_shared_truthy_rules(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_BOOL", "yes")
+    assert env_bool("HERMES_TEST_BOOL") is True
+
+    monkeypatch.setenv("HERMES_TEST_BOOL", "0")
+    assert env_bool("HERMES_TEST_BOOL") is False
+
+    monkeypatch.delenv("HERMES_TEST_BOOL", raising=False)
+    assert env_bool("HERMES_TEST_BOOL") is False
+    assert env_bool("HERMES_TEST_BOOL", default=True) is True
+
+
+# ─── safe_json_loads ───────────────────────────────────────────────────────
+
+
+def test_safe_json_loads_parses_valid_json():
+    assert safe_json_loads('{"a": 1}') == {"a": 1}
+    assert safe_json_loads("[1, 2, 3]") == [1, 2, 3]
+
+
+def test_safe_json_loads_returns_default_on_malformed_json():
+    assert safe_json_loads("{not json", default="fallback") == "fallback"
+    assert safe_json_loads("", default="fallback") == "fallback"
+
+
+def test_safe_json_loads_returns_default_on_non_string_input():
+    assert safe_json_loads(None, default="fallback") == "fallback"
+    assert safe_json_loads(12345, default="fallback") == "fallback"
+
+
+def test_safe_json_loads_returns_default_on_deeply_nested_json():
+    """Deeply nested JSON raises RecursionError inside json.loads, which is
+    not a JSONDecodeError — it must still fall back to default instead of
+    crashing the caller (tool_guardrails parses untrusted tool output)."""
+    deep = "[" * 100_000 + "]" * 100_000
+    assert safe_json_loads(deep, default="fallback") == "fallback"

--- a/utils.py
+++ b/utils.py
@@ -610,7 +610,7 @@ def safe_json_loads(text: str, default: Any = None) -> Any:
     """
     try:
         return json.loads(text)
-    except (json.JSONDecodeError, TypeError, ValueError):
+    except (json.JSONDecodeError, TypeError, ValueError, RecursionError):
         return default
 
 
@@ -669,7 +669,10 @@ def env_float(key: str, default: float = 0.0) -> float:
 
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
-    return is_truthy_value(os.getenv(key, ""), default=default)
+    value = os.getenv(key)
+    # Pass None (not "") when the variable is unset so is_truthy_value
+    # honors the caller's default instead of treating "" as false.
+    return is_truthy_value(value, default=default)
 
 
 # ─── Proxy Helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Two small correctness bugs in shared helpers, each with a regression test:

1. **`env_bool(key, default=True)` returned `False` for unset variables** — `os.getenv(key, "")` produced an empty string, and `is_truthy_value` only honors `default` for `None`. Callers who wanted an opt-in default got the opposite of what they asked for. Fix: pass `None` through when unset.
2. **`safe_json_loads` documented "returns default on any parse error" but `RecursionError` escaped** — `json.loads` raises it on deeply nested input. `agent/tool_guardrails.py` parses untrusted tool output through this helper, so a deep JSON blob could crash the agent process instead of falling back.

Also adds the first direct unit tests for `env_int`/`env_float`/`env_bool` (used in auth, security, gateway code, previously untested directly).

**Verified:** `python3 -m pytest tests/test_utils_env_and_json_helpers.py tests/test_utils_truthy_values.py tests/test_stale_utils_module_import.py` → 14 passed. (The email/telegram gateway suites fail identically on unmodified main in this environment due to a pre-existing plugin-load issue.)