### PR TITLE
fix(copilot-acp): allow opting in to answering permission prompts

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -134,6 +134,68 @@ def _permission_denied(message_id: Any) -> dict[str, Any]:
     }
 
 
+# ACP option kinds we are willing to pick, most durable first. Kinds are defined
+# by the protocol; agents also send `reject_once` / `reject_always`, which we
+# never select automatically.
+_AUTO_APPROVE_OPTION_KINDS = ("allow_always", "allow_once")
+
+
+def _auto_approve_enabled() -> bool:
+    """True when the operator has opted into answering permission prompts.
+
+    Off by default, so interactive behaviour is unchanged: a human is present to
+    see the prompt, and cancelling is the safe answer.
+
+    It matters for unattended runs (cron, headless agents). There is nobody to
+    answer, so an unconditional cancel means every write-shaped tool call is
+    aborted. The agent still narrates what it intended to do, which makes the
+    failure look like a model that chose not to act rather than a client that
+    refused it.
+    """
+    raw = os.getenv("HERMES_COPILOT_ACP_AUTO_APPROVE", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _permission_response(message_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Answer `session/request_permission`.
+
+    Auto-approval is not a hole in Hermes' file policy: it decides only whether
+    the agent may *ask*. The actual enforcement happens when the request comes
+    back as `fs/write_text_file`, which still goes through
+    `_ensure_path_within_cwd` and `get_write_denied_error`, exactly as it does
+    for prompts a human approved by hand.
+
+    Falls back to cancelling whenever the agent offers no option we recognise,
+    so a malformed or reject-only prompt is never silently treated as consent.
+    """
+    if not _auto_approve_enabled():
+        return _permission_denied(message_id)
+
+    options = params.get("options")
+    if not isinstance(options, list):
+        return _permission_denied(message_id)
+
+    for kind in _AUTO_APPROVE_OPTION_KINDS:
+        for option in options:
+            if not isinstance(option, dict) or option.get("kind") != kind:
+                continue
+            option_id = str(option.get("optionId") or "").strip()
+            if not option_id:
+                continue
+            return {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {
+                    "outcome": {
+                        "outcome": "selected",
+                        "optionId": option_id,
+                    }
+                },
+            }
+
+    return _permission_denied(message_id)
+
+
 def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
     model: str | None = None,
@@ -700,7 +762,7 @@ class CopilotACPClient:
         params = msg.get("params") or {}
 
         if method == "session/request_permission":
-            response = _permission_denied(message_id)
+            response = _permission_response(message_id, params)
         elif method == "fs/read_text_file":
             try:
                 path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -160,6 +160,96 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertIn("HERMES_WRITE_SAFE_ROOT", str(response["error"]))
         self.assertFalse(outside.exists())
 
+    def _request_permission(self, options: object) -> dict:
+        return self._dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "session/request_permission",
+                "params": {"sessionId": "s1", "options": options},
+            },
+            cwd="/tmp",
+        )
+
+    _ALLOW_ALWAYS = {"kind": "allow_always", "name": "Always Allow", "optionId": "allow_always"}
+    _ALLOW_ONCE = {"kind": "allow_once", "name": "Allow", "optionId": "allow"}
+    _REJECT_ONCE = {"kind": "reject_once", "name": "Reject", "optionId": "reject"}
+
+    def test_permission_is_cancelled_by_default(self) -> None:
+        """Unset env must keep the historical behaviour, so interactive runs
+        still surface the prompt to the human rather than self-approving."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_COPILOT_ACP_AUTO_APPROVE", None)
+            response = self._request_permission([self._ALLOW_ALWAYS, self._REJECT_ONCE])
+        self.assertEqual(response["result"]["outcome"], {"outcome": "cancelled"})
+
+    def test_permission_prefers_allow_always_when_auto_approve_enabled(self) -> None:
+        with patch.dict(os.environ, {"HERMES_COPILOT_ACP_AUTO_APPROVE": "1"}):
+            response = self._request_permission(
+                [self._REJECT_ONCE, self._ALLOW_ONCE, self._ALLOW_ALWAYS]
+            )
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "selected", "optionId": "allow_always"},
+        )
+
+    def test_permission_falls_back_to_allow_once(self) -> None:
+        with patch.dict(os.environ, {"HERMES_COPILOT_ACP_AUTO_APPROVE": "true"}):
+            response = self._request_permission([self._ALLOW_ONCE, self._REJECT_ONCE])
+        self.assertEqual(
+            response["result"]["outcome"],
+            {"outcome": "selected", "optionId": "allow"},
+        )
+
+    def test_permission_cancels_when_only_reject_offered(self) -> None:
+        """A reject-only prompt must never be read as consent."""
+        with patch.dict(os.environ, {"HERMES_COPILOT_ACP_AUTO_APPROVE": "1"}):
+            response = self._request_permission([self._REJECT_ONCE])
+        self.assertEqual(response["result"]["outcome"], {"outcome": "cancelled"})
+
+    def test_permission_cancels_on_malformed_options(self) -> None:
+        with patch.dict(os.environ, {"HERMES_COPILOT_ACP_AUTO_APPROVE": "1"}):
+            self.assertEqual(
+                self._request_permission("nonsense")["result"]["outcome"],
+                {"outcome": "cancelled"},
+            )
+            self.assertEqual(
+                self._request_permission([{"kind": "allow_always", "optionId": ""}])[
+                    "result"
+                ]["outcome"],
+                {"outcome": "cancelled"},
+            )
+
+    def test_auto_approve_does_not_bypass_write_safety(self) -> None:
+        """Approving the prompt only lets the agent ask. The write itself is
+        still refused by the safe-root check, which is where policy lives."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "root"
+            root.mkdir()
+            outside = Path(tmpdir) / "outside.txt"
+            with patch.dict(
+                os.environ,
+                {
+                    "HERMES_COPILOT_ACP_AUTO_APPROVE": "1",
+                    "HERMES_WRITE_SAFE_ROOT": str(root),
+                },
+            ):
+                self.assertEqual(
+                    self._request_permission([self._ALLOW_ALWAYS])["result"]["outcome"],
+                    {"outcome": "selected", "optionId": "allow_always"},
+                )
+                response = self._dispatch(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 8,
+                        "method": "fs/write_text_file",
+                        "params": {"path": str(outside), "content": "nope"},
+                    },
+                    cwd=str(root),
+                )
+            self.assertIn("error", response)
+            self.assertFalse(outside.exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`agent/copilot_acp_client.py` answers **every** `session/request_permission` with `outcome: "cancelled"`. It is hardcoded, with no config, env var or session mode that changes it, so there is no way to run an ACP backend unattended: the agent asks before any write-shaped tool call, the client refuses, and the call is aborted.

The failure is silent, and it reads as a model problem rather than a client one. The agent still streams its narration, so a transcript shows stated intent and no tool call:

> Now I'll write the complete weekly audit. / Now I'll update the concept documents...

The run then completes with **zero tool errors and zero output**. Reads and shell work throughout, because only writes round-trip for permission, which makes it look like a model that chose not to act. In our case a scheduled agent produced nothing for a week before the cause was found, behind several unrelated issues.

## Reproduction

Speaking ACP to `@zed-industries/claude-code-acp` directly, with the same handshake this client uses, and varying only the answer to `session/request_permission`:

| Answer to `session/request_permission` | Result |
|---|---|
| `{"outcome": "cancelled"}` (current behaviour) | no `fs/write_text_file`, no file, agent reports a "permission issue or hook configuration" |
| `{"outcome": "selected", "optionId": "allow_always"}` | `fs/write_text_file` arrives, file written |

The agent offers `allow_always`, `allow_once` and `reject_once` on every prompt.

## Change

Adds `HERMES_COPILOT_ACP_AUTO_APPROVE`, **off by default**, so interactive behaviour is unchanged: a human is present to see the prompt and cancelling is the right answer.

When set, the client selects the agent's `allow_always` option, falls back to `allow_once`, and cancels when neither is offered, so a reject-only or malformed prompt is never read as consent.

## This does not widen the file policy

Approval governs only whether the agent may *ask*. Enforcement stays where it already is: the write arrives as `fs/write_text_file` and still goes through `_ensure_path_within_cwd` and `get_write_denied_error`, exactly as for a prompt a human approved by hand.

That redundancy is the argument for the change. The blanket cancel duplicates a guard that already exists, while breaking every write.

A test covers this directly: with auto-approve on, a write outside `HERMES_WRITE_SAFE_ROOT` still fails.

## Tests

Six added to `tests/agent/test_copilot_acp_client.py`, covering the default-cancel path, `allow_always` preference, `allow_once` fallback, reject-only, malformed options, and the safe-root assertion above.

```
12 passed in 0.45s
```

## Note for reviewers

There is a second, separate issue in the same area that this PR does not address: `_format_messages_as_prompt` tells an agentic backend both to "use ACP capabilities to complete tasks" and to emit `<tool_call>` blocks for Hermes to execute. Claude Code resolves that differently from run to run, and the conversation loop only continues while it can parse a tool call, so a run can end after one message having done nothing. Happy to open a separate issue with the reproduction if that would be useful.
