### PR TITLE
fix(gateway): tolerate list-shaped gateway.platforms from setup (#83185)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4731,6 +4731,12 @@ class TurnRunner:
         # slower than Linux. Off by default; soul identity is preserved so
         # the persona survives even with minimal context.
         _platforms_gw_cfg = (ctx.user_config.get("gateway") or {}).get("platforms") or {}
+        # ``hermes gateway setup`` writes ``gateway.platforms`` as a LIST of
+        # enabled platform names (e.g. ``- telegram``), not a dict.  Treat any
+        # non-dict shape as "no per-platform overrides" instead of crashing
+        # on ``.get()`` for every incoming turn (#83185).
+        if not isinstance(_platforms_gw_cfg, dict):
+            _platforms_gw_cfg = {}
         _plat_gw_cfg = _platforms_gw_cfg.get(platform_key) or {}
         _skip_context = _plat_gw_cfg.get("skip_context_files")
         skip_context_files = bool(_skip_context) if _skip_context is not None else False

--- a/tests/gateway/test_skip_context_files_wiring.py
+++ b/tests/gateway/test_skip_context_files_wiring.py
@@ -72,11 +72,17 @@ class TestSkipContextFilesConfigResolution:
             ({"gateway": {"platforms": {"discord": {"skip_context_files": True}}}}, "telegram", False),
             # Truthy non-bool values coerce.
             ({"gateway": {"platforms": {"telegram": {"skip_context_files": 1}}}}, "telegram", True),
+            # ``hermes gateway setup`` writes platforms as a LIST of enabled
+            # platform names — must not crash and must default to False (#83185).
+            ({"gateway": {"platforms": ["telegram", "discord"]}}, "telegram", False),
+            ({"gateway": {"platforms": []}}, "telegram", False),
         ],
     )
     def test_resolution(self, cfg, platform_key, expected):
         # Mirror the production resolution in TurnRunner exactly.
         _platforms_gw_cfg = (cfg.get("gateway") or {}).get("platforms") or {}
+        if not isinstance(_platforms_gw_cfg, dict):
+            _platforms_gw_cfg = {}
         _plat_gw_cfg = _platforms_gw_cfg.get(platform_key) or {}
         _skip_context = _plat_gw_cfg.get("skip_context_files")
         skip_context_files = bool(_skip_context) if _skip_context is not None else False


### PR DESCRIPTION
## What does this PR do?

`hermes gateway setup` writes `gateway.platforms` as a **list** of enabled platform names (e.g. `- telegram`), but the per-platform `skip_context_files` resolution in `TurnRunner` assumed it was always a dict and called `.get()` on it. With the standard setup-generated config, **every** incoming gateway turn (Telegram, Discord, etc.) crashed with `AttributeError: 'list' object has no attribute 'get'` and returned "Sorry, I encountered an unexpected error."

The fix treats any non-dict `gateway.platforms` value as "no per-platform overrides" (defaults to `False`), which is the same safe-default behavior used elsewhere in the config layer.

## Related Issue

Fixes #83185

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: guard `_platforms_gw_cfg` with `isinstance(..., dict)` before `.get(platform_key)` (in the per-platform `skip_context_files` resolution added by 003b4c889).
- `tests/gateway/test_skip_context_files_wiring.py`: add parametrized cases for list-shaped `gateway.platforms` (`["telegram", "discord"]` and `[]`) — must not crash and must resolve to `False`.

## How to Test

1. Reproduce: config with `gateway.platforms: [telegram, discord]` (what `hermes gateway setup` writes) and send any message to a connected platform → previously crashed every turn.
2. Verify: with this fix the turn resolves `skip_context_files=False` and the message is processed normally.
3. Unit: the new parametrized cases in `TestSkipContextFilesConfigResolution.test_resolution` cover list shapes. (Full `pytest` suite requires the repo's Python env; the mirrored resolution logic was also verified standalone for all 10 cases.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (no local pytest; resolution logic verified standalone for all parametrized cases)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (logic-level verification; change is platform-neutral)

### Documentation & Housekeeping

- [x] N/A — no docs, config-keys, or architecture changes.