### PR TITLE
feat(skills): add crypto-tax-workflow optional skill

### DIFF
--- a/optional-skills/productivity/crypto-tax-workflow/SKILL.md
+++ b/optional-skills/productivity/crypto-tax-workflow/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: crypto-tax-workflow
+description: Fetch CEX trades (via CCXT) and on-chain wallet transactions (via Blockscout), then compute FIFO/LIFO capital gains / tax obligations using the installed `crypto_tax` Hermes plugin.
+tags: [crypto, tax, binance, ccxt, fifo, capital-gains, plugin]
+---
+
+# Crypto Tax Workflow
+
+Fetch spot trade history from a CEX supported by CCXT, or on-chain native ETH / ERC-20 transactions from an EVM wallet via Blockscout. Classify disposals with FIFO, split short-term vs long-term, and produce a per-event ledger + tax estimate.
+
+**Install:** `hermes skills install JackTheGit/hermes-crypto-tax-plugin/skills/crypto-tax-workflow`
+**Plugin:** Install from `~/.hermes/plugins/` or `git clone https://github.com/JackTheGit/hermes-crypto-tax-plugin`
+
+## When to use
+
+- User asks to fetch trades from Binance / another CEX and compute taxes or gains.
+- User provides a wallet address (0x...) on Ethereum, Polygon, Arbitrum, Base, or Optimism and asks for tax obligations.
+- User references the `crypto_tax` tool, `calculate_crypto_gains`, `fetch_wallet_transactions`, `fetch_cex_transactions`, or asks for "FIFO", "crypto taxes", "capital gains", "cost basis".
+- User provides an `ANNUAL_INCOME_USD` or tax-year in env for bracket-accurate estimates.
+
+The plugin supports BOTH CEX trades (via CCXT) and on-chain wallet transactions (via Blockscout API, no API key required).
+
+## The crypto_tax plugin
+
+Located at `.hermes/plugins/crypto_tax/`. Three tools exposed:
+
+### `fetch_wallet_transactions(address, chain="ethereum", max_pages=20, min_value_eth=0.0, include_erc20=False)`
+
+- `address`: EVM wallet address (0x...).
+- `chain`: `"ethereum"` (default), `"polygon"`, `"arbitrum"`, `"base"`, `"optimism"`.
+- `max_pages`: Pages to paginate (50 txs/page). Default 20 = 1000 txs. Raise for very active wallets.
+- `min_value_eth`: Dust filter — skip native ETH transfers below this threshold. Use `0.0001` to filter noise.
+- `include_erc20`: If True, also fetches ERC-20 token transfers for common tokens (USDT, USDC, DAI, WBTC, LINK, UNI, SHIB, AAVE).
+- Uses Blockscout open API (no key required). Falls back to CoinGecko for historical ETH prices when available.
+- **Caveat**: Only native ETH transfers + optional ERC-20. No internal tx tracing, no DEX swap detection, no NFT sales.
+- **Caveat**: Outgoing ETH = "SELL" (taxable disposition). This is simplistic — wallet-to-wallet transfers and contract interactions are NOT real sales but are classified as such. Flag this to the user.
+- Returns `{ "address", "chain", "total_fetched", "transactions": [...] }`.
+
+### `fetch_cex_transactions(exchange_id, api_key=None, secret=None, symbols=None)`
+
+- `exchange_id`: any CCXT id (`"binance"`, `"coinbase"`, `"kraken"`, …).
+- Credentials fallback: pass `api_key`/`secret` explicitly, or set the env vars `EXCHANGE_API_KEY` + `EXCHANGE_SECRET` (the plugin reads them via the Hermes env system).
+- **Pitfall**: if `symbols` is omitted, the plugin DEFAULTS to only `["BTC/USDT", "ETH/USDT"]`. That misses most of the user's history. ALWAYS pass a comprehensive `symbols` list. See `references/common-symbols.md` for a ready-to-use Binance list (~70 pairs).
+- Returns `{ "exchange": str, "total_fetched": int, "transactions": [...] }`. Each transaction has `timestamp` (ISO 8601 Z-suffixed), `type` (BUY/SELL), `asset`, `amount`, `price_usd`, `fee_usd`.
+- **Important**: `type` from CCXT is `side.upper()` only — STAKING, AIRDROP, MINING do NOT surface through this tool.
+
+### `calculate_crypto_gains(transactions, method="FIFO", jurisdiction="GENERIC", annual_income_usd=0.0)`
+
+- `method`: `"FIFO"` (default), `"LIFO"`, `"SPECIFIC_ID"` support varies.
+- `jurisdiction`: `"US"` gives 2024-friendly bracket handling; `"GENERIC"` produces no bracket math.
+- Returns dict with, at minimum:
+  - `capital_gains_summary`: `{total_realized_gain_loss_usd, short_term_gain_loss_usd, long_term_gain_loss_usd}`
+  - `ordinary_income_summary`: `{total_income_usd, staking_usd, airdrops_usd, mining_usd}`
+  - `sales_detail`: list of disposals. **This IS the ledger** — each row is one lot-matched disposal event. Fields: `asset`, `sell_date`, `sold_amount`, `sell_price_usd`, `proceeds`, `cost_basis`, `gain_loss`, and usually `long_term` (bool).
+  - `dispositions` may be present synonymously; trust `sales_detail` as the canonical key.
+
+## Step-by-step workflow
+
+### For CEX trades
+
+1. **Load env before the plugin import.** The `.env` sits at `.hermes/.env` and holds `BINANCE_API_KEY` / `BINANCE_SECRET`. Use `python-dotenv` with `override=True` before calling into the plugin so `os.getenv` finds them.
+2. **Call `fetch_cex_transactions`** with `exchange_id="binance"`, explicit credentials pulled from env, and a broad `symbols` list (references/common-symbols.md).
+3. **Call `calculate_crypto_gains`** with the transactions, `method="FIFO"`, `jurisdiction="US"`, and `annual_income_usd` from env (default 80000 if unset).
+4. **Persist the raw result as JSON** — e.g. `crypto_tax_raw.json`. Do NOT ask the plugin to write CSV; it doesn't. You do the CSV/analysis step yourself.
+
+### For on-chain wallet addresses
+
+1. **Call `fetch_wallet_transactions`** with `address=<the wallet>`, `chain="ethereum"`, `max_pages=30`, `min_value_eth=0.0001`. This paginates Blockscout and filters dust.
+2. If the user mentions ERC-20 tokens, add `include_erc20=True`.
+3. **Call `calculate_crypto_gains`** with the returned transactions, `method="FIFO"`, `jurisdiction="US"`.
+4. **Persist the raw result as JSON** for downstream analysis.
+5. **Analyze with stdlib only.** `execute_code` sandbox does NOT share user-space pip (no pandas, no numpy). Either:
+   - (a) Write a post-analysis script in `/home/hermes/` and run it via `terminal` with system python (which has the user-installed pandas), OR
+   - (b) Use `execute_code` with `csv` and `json` stdlib only.
+6. **Report in a clean flat structure**: totals (proceeds, basis, net gain), STCG/LTCG split, per-asset breakdown, estimated tax (22% ST / 15% LT brackets for mid-income US single-filer; scale with `annual_income_usd`). Include the unknown-basis caveat.
+
+## Pitfalls
+
+- **`pip install` fails on PEP 668 hosts (Debian/Ubuntu 24.04+).** Escape hatch:
+  ```bash
+  pip3 install --user --break-system-packages --quiet python-binance pandas python-dotenv ccxt
+  ```
+  If that's not acceptable, use `pipx` or a container instead.
+- **`execute_code` sandbox is isolated from user pip.** The script has Python stdlib + what's pre-installed in the sandbox — typically NOT pandas. If you need pandas, run the analysis via `terminal` where system python sees the user-site installs.
+- **Unknown-basis disposals are common.** For any sell where the FIFO queue has no matching buy (e.g., asset bought on another exchange, transferred in, or received as income), the plugin records `cost_basis = 0` and reports gain = full proceeds. In the report:
+  - Always print a separate line for `$N of unknown-basis gains` and the percentage.
+  - Conservatively treat unknown-basis events as SHORT-TERM (no acquisition date means the user can't substantiate long-term holding for the IRS).
+  - Advise the user to export records from other platforms / wallets to fill basis gaps.
+- **Binance scans time out if you iterate every symbol.** The plugin's `fetch_cex_transactions` only queries the pairs you pass. The full-exchange iteration in `fetch_binance_and_tax.py` takes >10 minutes. Use the fixed common-symbols list (~70 pairs covers BTC/ETH/BNB/SOL/XRP/ADA/DOGE/AVAX/… and stable-quoted variants) for the plugin path.
+- **`sales_detail` ≠ `transactions` input.** The input `transactions` list contains both BUYs and SELLs; `sales_detail` is the filtered, lot-matched disposal ledger. When post-processing for tax, operate on `sales_detail`, not the input.
+- **The plugin does not deduct fees.** Fees are recorded per-transaction but do NOT reduce proceeds in `sales_detail`. Flag this to the user as a separate schedule-D line item.
+- **Very active wallets (5,000+ transactions) will time out.** Always pass `max_pages=30` and `min_value_eth=0.0001` for wallet addresses. The Blockscout API returns 50 txs/page with a 0.3s politeness delay — a full scan of a busy wallet can take 10+ minutes and produce mostly noise (dust transfers, MEV spam). Caps and dust filters are NOT optional for on-chain addresses; apply them BEFORE calling `fetch_wallet_transactions`, not after.
+- **Verify the ST/LT split after every calculation.** The `capital_gains_summary.short_term_gain_loss_usd + long_term_gain_loss_usd` MUST equal `total_realized_gain_loss_usd` (within $0.02). If they don't match, the plugin has a bug — unmatched disposals (no cost basis) are silently dropped from the split. See `references/st-lt-split-debugging.md` for the root cause and fix.
+
+## Output
+
+- `crypto_tax_raw.json` — full plugin return (referenceable JSON, re-analyzable).
+- Stdout summary with: totals, STCG/LTCG split, per-asset breakdown (asset, events, proceeds, basis, gain), estimated federal tax.
+- Save a human-readable CSV if asked (`sales_detail` + a `year` column); do not default to CSV — JSON is the canonical artifact.

--- a/optional-skills/productivity/crypto-tax-workflow/references/common-symbols.md
+++ b/optional-skills/productivity/crypto-tax-workflow/references/common-symbols.md
@@ -1,0 +1,52 @@
+# Common Binance Trading Pairs (CCXT Symbols)
+
+Ready-to-use list for `fetch_cex_transactions(symbols=...)`. Covers the ~70
+pairs we've exercised. Pass as-is to the plugin — it skips pairs with no
+user trades silently.
+
+```python
+COMMON_SYMBOLS = [
+    # Major majors
+    "BTC/USDT", "ETH/USDT", "BNB/USDT", "SOL/USDT", "XRP/USDT",
+    "ADA/USDT", "DOGE/USDT", "AVAX/USDT", "DOT/USDT", "MATIC/USDT",
+    "POL/USDT", "LINK/USDT", "LTC/USDT", "SHIB/USDT", "TRX/USDT",
+    "UNI/USDT", "ATOM/USDT", "FIL/USDT", "ETC/USDT", "AAVE/USDT",
+    "ALGO/USDT", "ARB/USDT", "OP/USDT", "NEAR/USDT", "APT/USDT",
+    "SUI/USDT", "SEI/USDT", "PEPE/USDT", "BONK/USDT", "WIF/USDT",
+    "FET/USDT", "RNDR/USDT", "IMX/USDT", "MKR/USDT", "SNX/USDT",
+    "CRV/USDT", "COMP/USDT", "SUSHI/USDT", "YFI/USDT", "BAL/USDT",
+    "LDO/USDT", "RPL/USDT", "TIA/USDT", "INJ/USDT", "JUP/USDT",
+    "WLD/USDT", "TON/USDT", "ICP/USDT", "VET/USDT", "HBAR/USDT",
+    "XLM/USDT", "NEO/USDT", "EOS/USDT", "THETA/USDT", "FTM/USDT",
+    "MANA/USDT", "SAND/USDT", "AXS/USDT", "GALA/USDT", "APE/USDT",
+
+    # BUSD (still traded on some pairs)
+    "BTC/BUSD", "ETH/BUSD", "BNB/BUSD", "SOL/BUSD",
+
+    # USDC
+    "BTC/USDC", "ETH/USDC",
+
+    # FDUSD
+    "BTC/FDUSD", "ETH/FDUSD",
+
+    # Fiat-direct
+    "BTC/USD", "ETH/USD", "SOL/USD",
+]
+```
+
+## Coverage notes
+
+- **USDT** pairs = most liquid, catch the bulk of user activity.
+- **BUSD** pairs are being sunset by Binance; keep for legacy history but
+  don't expect them on new accounts post-2024.
+- **USDC/FDUSD** pairs matter for US-based users who prefer fiat-pegged
+  non-Tether stables.
+- **BTC/USD, ETH/USD, SOL/USD** — only relevant if the user has directly
+  traded with deposited fiat (not a swap from a stable).
+
+## Expanding the list
+
+If the user reports missing assets, append to the list rather than falling
+back to a full-exchange scan (which times out). Common omissions from
+above that users hold: `DOT`, `FIL`, `NEAR`, `APT`, `SUI`, `SEI`, `STX`,
+`RUNE`, `GRT`, `ENS`, `1INCH`, `DYDX` — all end in USDT.

--- a/optional-skills/productivity/crypto-tax-workflow/references/st-lt-split-debugging.md
+++ b/optional-skills/productivity/crypto-tax-workflow/references/st-lt-split-debugging.md
@@ -1,0 +1,50 @@
+# Debugging the ST/LT Split Mismatch
+
+## Symptom
+
+`capital_gains_summary.short_term_gain_loss_usd + long_term_gain_loss_usd` does NOT equal `total_realized_gain_loss_usd`. Example: total = $510,526 but ST ($934) + LT ($0) = $934.
+
+## Root Cause
+
+The original `calculate_crypto_gains` only classified gains from *matched* lots. When a SELL exceeded available buy lots (no cost basis), `lots_used` was empty for the unmatched portion. The `for li in lots_used:` loop never executed, so the unmatched gain was silently dropped from the ST/LT split while still correctly included in `total_realized_gain_loss_usd`.
+
+## Reproduction
+
+A wallet with 37 incoming transfers (BUYs) and 15 outgoing (SELLs). The SELLs total 224+ ETH but the BUYs only provide ~20 ETH of cost-basis lots. Two large SELLs (64 ETH and 160 ETH) exceed the FIFO queue:
+
+```
+SELL 64.000000 ETH proceeds=$122,807 basis=$794 gain=$122,013
+  lots_used: 19 (covering ~0.4 ETH total)
+  ST portion: $787  LT portion: $0    ← only matched 0.4 ETH worth!
+
+SELL 160.000000 ETH proceeds=$307,019 basis=$0 gain=$307,019
+  lots_used: 0                        ← no lots at all!
+  ST portion: $0  LT portion: $0      ← ENTIRE $307K gain lost from split!
+```
+
+## Fix (in v1.2.0)
+
+After the `for li in lots_used:` loop, add unmatched-portion fallback:
+
+```python
+# After processing all matched lots:
+if remaining_to_sell > 1e-12 and amount > 0:
+    unmatched_ratio = remaining_to_sell / amount
+    unmatched_gain = gain_loss * unmatched_ratio
+    sale_st_gain += unmatched_gain  # no basis → can't prove LT → short-term
+```
+
+## Verification
+
+Always run this check after `calculate_crypto_gains` returns:
+
+```python
+cg = result["capital_gains_summary"]
+match = abs(cg["total_realized_gain_loss_usd"] -
+            (cg["short_term_gain_loss_usd"] + cg["long_term_gain_loss_usd"])) < 0.02
+assert match, f"ST/LT split mismatch: total={cg['total']} vs ST+LT={cg['st']+cg['lt']}"
+```
+
+## Instrumentation Pattern
+
+To trace the lot-matching logic, replicate the core loop with print statements. Key points to log per SELL: amount, proceeds, basis, gain, number of lots used, ST/LT portions, and remaining unmatched amount.

--- a/optional-skills/productivity/crypto-tax-workflow/scripts/run_crypto_tax.py
+++ b/optional-skills/productivity/crypto-tax-workflow/scripts/run_crypto_tax.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Bootstrap runner: fetch Binance trades via the crypto_tax plugin, compute
+FIFO gains, and dump raw JSON for downstream analysis.
+
+Usage:
+    python3 run_crypto_tax.py                      # uses BINANCE_* from .hermes/.env
+    TAX_YEAR=2023 python3 run_crypto_tax.py        # override tax year
+    ANNUAL_INCOME_USD=120000 python3 ...           # override bracket calc
+
+Output:
+    crypto_tax_raw.json   — full plugin return (canonical artifact)
+    stdout                — summary + per-event ledger preview
+
+Requirements (system python user-site):
+    pip3 install --user --break-system-packages ccxt python-dotenv pandas
+"""
+import sys
+import os
+import json
+from pathlib import Path
+
+# --- 1. Find & load the crypto_tax plugin ---------------------------------
+PLUGIN_ROOT = Path.home() / ".hermes" / "plugins" / "crypto_tax"
+if not PLUGIN_ROOT.exists():
+    sys.exit(f"Plugin not found: {PLUGIN_ROOT}")
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+# --- 2. Load .env BEFORE imports so os.getenv sees credentials ----------
+from dotenv import load_dotenv
+env_path = Path.home() / ".hermes" / ".env"
+if not env_path.exists():
+    sys.exit(f".env not found: {env_path}")
+load_dotenv(env_path, override=True)
+
+from tools import fetch_cex_transactions, calculate_crypto_gains
+
+# --- 3. Symbol list (see references/common-symbols.md in the skill) ------
+# Inline short copy so this script is self-contained. For the full list,
+# read references/common-symbols.md.
+COMMON_SYMBOLS = [
+    "BTC/USDT","ETH/USDT","BNB/USDT","SOL/USDT","XRP/USDT","ADA/USDT",
+    "DOGE/USDT","AVAX/USDT","DOT/USDT","MATIC/USDT","POL/USDT","LINK/USDT",
+    "LTC/USDT","SHIB/USDT","TRX/USDT","UNI/USDT","ATOM/USDT","FIL/USDT",
+    "ETC/USDT","AAVE/USDT","ALGO/USDT","ARB/USDT","OP/USDT","NEAR/USDT",
+    "APT/USDT","SUI/USDT","SEI/USDT","PEPE/USDT","BONK/USDT","WIF/USDT",
+    "FET/USDT","RNDR/USDT","IMX/USDT","MKR/USDT","SNX/USDT","CRV/USDT",
+    "COMP/USDT","SUSHI/USDT","YFI/USDT","BAL/USDT","LDO/USDT","RPL/USDT",
+    "TIA/USDT","INJ/USDT","JUP/USDT","WLD/USDT","TON/USDT","ICP/USDT",
+    "VET/USDT","HBAR/USDT","XLM/USDT","NEO/USDT","EOS/USDT","THETA/USDT",
+    "FTM/USDT","MANA/USDT","SAND/USDT","AXS/USDT","GALA/USDT","APE/USDT",
+    "BTC/BUSD","ETH/BUSD","BNB/BUSD","SOL/BUSD",
+    "BTC/USDC","ETH/USDC","BTC/FDUSD","ETH/FDUSD","BTC/USD","ETH/USD","SOL/USD",
+]
+
+# --- 4. Fetch --------------------------------------------------------------
+print("Fetching Binance trades via crypto_tax plugin...")
+binance_key = os.getenv("BINANCE_API_KEY") or os.getenv("BINANCE_KEY")
+binance_secret = os.getenv("BINANCE_SECRET") or os.getenv("BINANCE_API_SECRET")
+result = fetch_cex_transactions(
+    exchange_id="binance",
+    api_key=binance_key,
+    secret=binance_secret,
+    symbols=COMMON_SYMBOLS,
+)
+if "error" in result:
+    sys.exit(f"fetch_cex_transactions error: {result['error']}")
+
+txs = result.get("transactions", [])
+print(f"Fetched {result['total_fetched']} transactions across {len(COMMON_SYMBOLS)} pairs.")
+if not txs:
+    sys.exit("No trades found. Check API key permissions.")
+
+# --- 5. Compute gains -----------------------------------------------------
+tax_year = int(os.getenv("TAX_YEAR", "2024"))
+annual_income = float(os.getenv("ANNUAL_INCOME_USD", "80000"))
+
+tax_result = calculate_crypto_gains(
+    transactions=txs,
+    method="FIFO",
+    jurisdiction="US",
+    annual_income_usd=annual_income,
+)
+
+# --- 6. Persist raw JSON -------------------------------------------------
+out_path = Path.cwd() / "crypto_tax_raw.json"
+with open(out_path, "w") as f:
+    json.dump(tax_result, f, indent=2, default=str)
+print(f"\nRaw tax result: {out_path}")
+
+# --- 7. Quick summary to stdout -----------------------------------------
+summary = {k: v for k, v in tax_result.items() if k not in ("sales_detail", "transactions", "dispositions")}
+print("\n" + "=" * 70)
+print(f"  CRYPTO TAX REPORT (FIFO · US · Tax Year {tax_year})")
+print("=" * 70)
+for k, v in summary.items():
+    print(f"  {k:<30}: {v}")
+
+# Per-event ledger preview (first 30)
+detail = tax_result.get("sales_detail") or tax_result.get("dispositions") or []
+if detail:
+    print(f"\n--- Disposals ({len(detail)} in ledger, showing first 30) ---")
+    for d in detail[:30]:
+        lt = "LTCG" if d.get("long_term") else "STCG"
+        print(f"  {d.get('sell_date','')[:10]}  {d.get('asset',''):>6s}  "
+              f"qty={d.get('sold_amount',0):>10.6f}  "
+              f"proceeds=${d.get('proceeds',0):>10,.2f}  "
+              f"basis=${d.get('cost_basis',0):>10,.2f}  "
+              f"gain=${d.get('gain_loss',0):>+10,.2f}  {lt}")
+    if len(detail) > 30:
+        print(f"  ... and {len(detail) - 30} more")


### PR DESCRIPTION
## Summary

Adds an optional skill that teaches Hermes how to use the `crypto_tax` plugin for on-chain wallet and CEX crypto tax calculations.

### What the skill covers

- **`fetch_wallet_transactions`** — Scan EVM wallets (Ethereum, Polygon, Arbitrum, Base, Optimism) via Blockscout
- **`fetch_cex_transactions`** — Pull CEX trade history via CCXT (Binance, Coinbase, etc.)
- **`calculate_crypto_gains`** — FIFO/LIFO lot matching with ST/LT split, ordinary income classification

### Plugin dependency

This skill references the standalone `crypto_tax` plugin:
  https://github.com/JackTheGit/hermes-crypto-tax-plugin

Users install the plugin separately, then load the skill for agent guidance.

### Placement

Filed under `optional-skills/productivity/` per CONTRIBUTING.md — useful but requires an external plugin dependency, not universally needed by all users.

### Files

- `optional-skills/productivity/crypto-tax-workflow/SKILL.md`
- `optional-skills/productivity/crypto-tax-workflow/references/common-symbols.md`
- `optional-skills/productivity/crypto-tax-workflow/references/st-lt-split-debugging.md`
- `optional-skills/productivity/crypto-tax-workflow/scripts/run_crypto_tax.py`