### PR TITLE
fix(buzz): honor scoped identity lock result

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -496,7 +496,8 @@ class BuzzAdapter(BasePlatformAdapter):
             from gateway.status import acquire_scoped_lock
 
             lock_key = f"{self.relay_url}:{self._self_pubkey}"
-            if not acquire_scoped_lock("buzz", lock_key):
+            acquired, _existing_lock = acquire_scoped_lock("buzz", lock_key)
+            if not acquired:
                 logger.error(
                     "Buzz: identity %s… on %s already in use by another profile",
                     self._self_pubkey[:8],

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -451,7 +451,9 @@ class TestBuzzAdapterLifecycle:
         import gateway.status as gateway_status
 
         monkeypatch.setattr(
-            gateway_status, "acquire_scoped_lock", lambda platform, key: False
+            gateway_status,
+            "acquire_scoped_lock",
+            lambda platform, key: (False, None),
         )
         adapter = _make_adapter()
         adapter.cli_path = "/fake/buzz"
@@ -536,5 +538,4 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -117,7 +117,7 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 
 ## Notes and limitations
 
-- **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
+- **WebSocket reconnect does not switch to polling.** With `transport: auto`, the adapter falls back to CLI polling only when the initial WebSocket connection cannot be established. After a WebSocket connection succeeds, later disconnects stay on the WebSocket reconnect loop with backoff. Use `transport: poll` when polling-only behavior is required; `poll_interval` controls that mode and the initial `auto` fallback.
 - On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
 - New DM conversations are discovered automatically (every few poll sweeps).
 - The private key is passed to the CLI via the subprocess environment — it never appears in argv or logs.


### PR DESCRIPTION
## What changed

- Unpack the `(acquired, existing)` result from `acquire_scoped_lock()` before deciding whether a Buzz identity lock was obtained.
- Update the existing lifecycle test mock to use the real lock API contract.
- Replace the stale polling-only limitation with the current WebSocket startup fallback and reconnect behavior.

## Root cause

The Buzz adapter treated the lock function's tuple return value as a Boolean. A non-empty tuple is truthy even when its first element is `False`, so a second local profile could proceed with the same relay and pubkey. That could produce duplicate replies and split de-duplication state.

The user guide also described inbound transport as polling-only even though the adapter now uses a NIP-42-authenticated WebSocket by default.

This keeps two local profiles from becoming *Two of Us* on one Buzz identity while making the transport documentation match the shipped code.

## Validation

- Existing lifecycle tests only: `2 passed, 0 failed`
- `python3 -m py_compile plugins/platforms/buzz/adapter.py`
- `git diff --check`

No new test was added.
