### PR TITLE
fix(tui): stop stripping ANSI from completed tool result_text

### DIFF
--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1133,7 +1133,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         const inlineDiffText =
           ev.payload.inline_diff && getUiState().inlineDiffs ? stripAnsi(String(ev.payload.inline_diff)).trim() : ''
 
-        const resultText = ev.payload.result_text ? stripAnsi(String(ev.payload.result_text)) : undefined
+        const resultText = ev.payload.result_text ? String(ev.payload.result_text) : undefined
 
         if (inlineDiffText) {
           turnController.recordInlineDiffToolComplete(


### PR DESCRIPTION
## Summary

`tool.complete`'s `result_text` (`ui-tui/src/app/createGatewayEventHandler.ts:1136`) was passed
through `stripAnsi()` before being handed to `recordToolComplete` /
`recordInlineDiffToolComplete`. That destroys any color a tool intentionally emitted —
colored diffs, `--color` command output, colored test-runner output — so a completed
tool's result always rendered monochrome in the tool trail even when the underlying
command produced real ANSI color.

`args_text` and `inline_diff` still go through `stripAnsi()` on purpose: those render as
plain labels / diff text, not as passthrough terminal output, so stripping is correct
there.

## Change

One line: `result_text` is now passed through as-is (`String(...)` instead of
`stripAnsi(String(...))`).

## Testing

- `npm run build` in `ui-tui/` and confirmed the compiled `dist/entry.js` no longer routes
  `result_text` through the `stripAnsi` call site (checked via `grep -o
  "resultText.*stripAnsi\|resultText.*String" dist/entry.js`).
- Ran a local Hermes session and re-triggered a colored tool result; the trail now renders
  the tool's original ANSI color instead of flattening it to plain text.

Happy to add a regression test around `recordToolComplete` receiving ANSI-colored
`result_text` if that's the preferred coverage — let me know the convention used elsewhere
in `ui-tui/src/__tests__/`.