### PR TITLE
fix(agent): clamp authorization gate lock timeout to prevent OverflowError on macOS (#83220)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -125,7 +125,12 @@ def _authorization_gate_lock_timeout() -> float:
     try:
         from tools.approval import human_wait_ceiling
 
-        return human_wait_ceiling()
+        # Clamp to _AUTHORIZATION_GATE_LOCK_TIMEOUT_S: the gate serializes
+        # parallel dispatch — it should never wait longer than a wedged-holder
+        # timeout even when approvals.timeout is set very large (or infinite).
+        # On macOS, unbounded values overflow threading.Lock.acquire's timespec
+        # and raise OverflowError (#83220).
+        return min(human_wait_ceiling(), _AUTHORIZATION_GATE_LOCK_TIMEOUT_S)
     except Exception:
         return _AUTHORIZATION_GATE_LOCK_TIMEOUT_S
 


### PR DESCRIPTION
## Summary

The `_ConcurrentToolAuthorizationGate` uses `threading.Lock.acquire(timeout=...)` where the timeout comes from `human_wait_ceiling()` (`approvals.timeout + 60s`). When `approvals.timeout` is set very large (e.g. `999999999999` to effectively disable timeouts), this overflows macOS's timespec and raises:

```
OverflowError: timestamp out of range for platform time_t
```

This causes **every parallel tool call** to fail, even though single tool calls work fine.

## Root Cause

In `agent/tool_executor.py`, `_authorization_gate_lock_timeout()` returns `human_wait_ceiling()` unclamped. The gate is a *serialization lock* for parallel dispatch — it should never need to wait longer than the wedged-holder bound (`_AUTHORIZATION_GATE_LOCK_TIMEOUT_S = 360s`). But with a huge configured `approvals.timeout`, it receives a value of ~1 trillion seconds, which overflows on macOS.

## Fix

Clamp the return value with `min(human_wait_ceiling(), _AUTHORIZATION_GATE_LOCK_TIMEOUT_S)` so the lock timeout is bounded regardless of `approvals.timeout`.

## Testing

- Verified lint passes (ruff)
- The change is a single `min()` wrapper — no behavioral change for normal `approvals.timeout` values (they're always < 360s)
- For huge values, the gate now uses 360s (the existing fallback bound), preventing the overflow

Fixes #83220