### PR TITLE
fix(tools): adapt daemon_pool to Python 3.14 ThreadPoolExecutor internals

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,7 +38,7 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation (3.8–3.14) with two changes:
         # daemon=True and no _threads_queues registration.
         if self._idle_semaphore.acquire(timeout=0):
             return
@@ -49,15 +49,27 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if hasattr(self, "_create_worker_context"):
+                # Python 3.14+: initializer/initargs live in a per-worker
+                # context created by ThreadPoolExecutor.__init__.
+                worker_args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                # Python 3.8–3.13: _worker(executor_reference, work_queue,
+                # initializer, initargs).
+                worker_args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=worker_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
## Problem

On Python 3.14, `concurrent.futures.ThreadPoolExecutor` was reworked: `__init__` no longer stores `self._initializer`/`self._initargs`, and `_worker`'s signature changed to `(executor_reference, ctx, work_queue)` with initializer state carried in a per-worker context from `prepare_context()`.

`DaemonThreadPoolExecutor._adjust_thread_count` (in `tools/daemon_pool.py`) was mirroring the CPython 3.8–3.13 internals, so spawning a new worker on 3.14 raised `AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'` — breaking concurrent tool execution intermittently (only when the pool needed a fresh thread, hence the flaky appearance).

## Fix

Detect the 3.14 layout at runtime (`hasattr(self, "_create_worker_context")`) and build `_worker` args accordingly, preserving the `daemon=True` / no-`_threads_queues`-registration behavior on both code paths. Behavior on 3.8–3.13 is unchanged.

## Verification

`scripts/run_tests.sh` on Python 3.14.4:
- `tests/tools/test_daemon_pool.py` — 3 passed
- `tests/agent/test_compress_context_progress_timeout.py` — 15 passed (indirect user of the daemon pool, timeout path)

Also exercised manually: basic execution, `initializer=` propagation, 8 tasks / 4 workers concurrency, daemon flag and `_threads_queues` non-registration all verified.