### PR TITLE
fix(agent): misleading "Response truncated" error when tool_call args are malformed (not truncated)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6183,7 +6183,13 @@ def run_conversation(
                         )
                         agent._invalid_json_retries = 0
                         agent._cleanup_task_resources(effective_task_id)
-                        _final_response = "Response truncated due to output length limit"
+                        if finish_reason == "length":
+                            _final_response = "Response truncated due to output length limit"
+                        else:
+                            _final_response = (
+                                "Tool call arguments were truncated or malformed and could not "
+                                "be repaired after retries. The tool was not executed."
+                            )
                         # Same tool-tail close as interrupt / invalid-tool
                         # exhaustion — this path never reaches finalize_turn.
                         close_interrupted_tool_sequence(messages, _final_response)


### PR DESCRIPTION
## Problem

When a model returns `tool_calls` with **malformed JSON arguments** (e.g. `{"action": listt_windows"}` — missing opening quote + enum typo), and the malformed arguments happen to not end with `}` or `]`, the conversation loop returns:

> "Response truncated due to output length limit"

This message is **factually wrong** when `finish_reason` is `"tool_calls"` (not `"length"`). The response was NOT truncated by token limits — the model produced invalid JSON within a normal-length response. The misleading error makes it impossible for users to diagnose the actual problem.

### Observed in production

```
22:38:46 API call #1: model=zai-org/GLM-5.2 in=28669 out=189 latency=4.3s
22:38:46 computer_use completed (0.38s) → 0x0 empty capture
22:38:48 Unrepairable: {"action": listt_windows"}  ← malformed JSON (finish_reason=tool_calls, NOT length)
22:38:53 Unrepairable: {"action": listt_apps"}     ← retry
22:38:56 Unrepairable: {"action": listt_apps"}     ← retry
22:39:01 Unrepairable: {"action": listt_windows"}  ← retry
22:39:04 Unrepairable: {"action": listt_windows"}  ← retry
→ User sees: "Response truncated due to output length limit"
```

The response was 189 tokens — well under `max_tokens=4096`. There was no truncation.

## Fix

Gate the truncation message on `finish_reason == "length"` at line 6186 in `conversation_loop.py`. When `finish_reason` is anything else (e.g. `"tool_calls"`), use a new message that accurately describes the failure:

> "Tool call arguments were truncated or malformed and could not be repaired after retries. The tool was not executed."

### Why not also fix the other occurrences?

Lines 3251, 3276, and 3289 of `conversation_loop.py` also use `"Response truncated due to output length limit"`, but those are all inside the `if finish_reason == "length":` block (line 2974) — so the message is accurate there. Only line 6186 is reachable when `finish_reason` is NOT `"length"`, because the `_truncated` heuristic (args not ending with `}` or `]`) can fire on malformed JSON that is structurally complete but syntactically invalid.

## Testing

The change is a conditional message string — no logic change to retry counts, tool execution, or message routing. The existing test suite covers both paths.

```python
# Before (always):
_final_response = "Response truncated due to output length limit"

# After:
if finish_reason == "length":
    _final_response = "Response truncated due to output length limit"
else:
    _final_response = (
        "Tool call arguments were truncated or malformed and could not "
        "be repaired after retries. The tool was not executed."
    )
```

## Related issues

- #35151 — Truncated tool_call arguments silently succeed instead of returning error
- #72770 — Truncated tool-call retries re-send identical request
- #26425 — "Response truncated due to output length limit" still occurring
- #62978 — fix(agent): surface unrepairable tool arguments