### PR TITLE
feat: add Claude CLI subscription-auth provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -634,7 +634,7 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "claude_cli"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -796,7 +796,7 @@ def init_agent(
     agent._interrupt_thread_signal_pending = False
     agent._client_lock = threading.RLock()
     agent._model_request_active = threading.Event()
-    agent._supports_active_turn_redirect = True
+    agent._supports_active_turn_redirect = agent.api_mode != "claude_cli"
 
     # /steer mechanism — inject a user note into the next tool result
     # without interrupting the agent. Unlike interrupt(), steer() does
@@ -1041,7 +1041,23 @@ def init_agent(
     # Claude uses its own timeout path and is not covered here.
     _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
 
-    if agent.api_mode == "anthropic_messages":
+    if agent.api_mode == "claude_cli":
+        if agent.provider != "claude-cli":
+            raise ValueError("claude_cli api_mode requires provider='claude-cli'")
+        if agent.model != "claude-opus-5":
+            raise ValueError("claude-cli Stage 0 supports only model 'claude-opus-5'")
+        if api_key:
+            raise ValueError("claude-cli does not accept api_key")
+        if base_url:
+            raise ValueError("claude-cli does not accept base_url")
+        agent.api_key = ""
+        agent.base_url = ""
+        agent.client = None
+        agent._client_kwargs = {}
+        agent._claude_cli_session = None
+        if not agent.quiet_mode:
+            print(f"AI Agent initialized with model: {agent.model} (official Claude CLI)")
+    elif agent.api_mode == "anthropic_messages":
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
         # Bedrock + Claude → use AnthropicBedrock SDK for full feature parity
         # (prompt caching, thinking budgets, adaptive thinking).

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1617,6 +1617,17 @@ def run_conversation(
     # stale prior turn's usage.
     agent._last_turn_usage = None
 
+    # Optional opt-in text-only runtime backed by one persistent official
+    # Claude CLI subprocess. Authentication/session/policy stay inside the CLI.
+    if agent.api_mode == "claude_cli":
+        return agent._run_claude_cli_turn(
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=_should_review_memory,
+        )
+
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
     # all run inside Codex). Default Hermes path is bypassed entirely.

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -66,3 +66,7 @@ def _discover_transports() -> None:
         import agent.transports.bedrock  # noqa: F401
     except ImportError:
         pass
+    try:
+        import agent.transports.claude_cli  # noqa: F401
+    except ImportError:
+        pass

--- a/agent/transports/claude_cli.py
+++ b/agent/transports/claude_cli.py
@@ -356,6 +356,12 @@ class ClaudeCLIClient:
             raise ClaudeCLIError("claude-cli session is closed", category="closed")
         if self.is_alive():
             return
+        if self._completed_turns:
+            raise ClaudeCLIError(
+                "Claude CLI process exited after a completed turn; refusing to respawn "
+                "without the previous session context",
+                category="lifecycle",
+            )
         if self._popen_factory is _DEFAULT_POPEN:
             available, reason = check_claude_cli_available()
             if not available:

--- a/agent/transports/claude_cli.py
+++ b/agent/transports/claude_cli.py
@@ -1,0 +1,1067 @@
+"""Persistent, text-only transport for the official Claude CLI.
+
+This module deliberately delegates authentication, subscription billing, session
+state, hooks, and managed policy to the installed ``claude`` executable. Hermes
+never reads Claude credentials and never speaks to an Anthropic HTTP endpoint on
+this path.
+
+Stage 0 is intentionally narrow: one exact model, no tools, no vision, no MCP,
+no reasoning projection, and no native cancellation/steering protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import re
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Optional
+
+from agent.transports.base import ProviderTransport
+from agent.transports.types import NormalizedResponse, Usage
+from tools.environments.local import hermes_subprocess_env
+
+
+CLAUDE_CLI_MODEL = "claude-opus-5"
+CLAUDE_CLI_MIN_VERSION = (2, 1, 221)
+CLAUDE_CLI_EXECUTABLE = "claude"
+CLAUDE_CLI_REQUIRED_FLAGS = frozenset(
+    {
+        "--input-format",
+        "--output-format",
+        "--include-partial-messages",
+        "--replay-user-messages",
+        "--model",
+        "--tools",
+        "--verbose",
+        "--strict-mcp-config",
+    }
+)
+CLAUDE_CLI_FORBIDDEN_FLAGS = frozenset(
+    {"--bare", "--dangerously-skip-permissions", "--allow-dangerously-skip-permissions"}
+)
+CLAUDE_CLI_ENV_BLOCKLIST = frozenset(
+    {"CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX"}
+)
+_DEFAULT_POPEN = subprocess.Popen
+
+
+def build_claude_cli_argv(model: str = CLAUDE_CLI_MODEL) -> list[str]:
+    """Return the only Stage-0 command line Hermes is allowed to spawn."""
+    if model != CLAUDE_CLI_MODEL:
+        raise ValueError(
+            f"claude-cli Stage 0 supports only model {CLAUDE_CLI_MODEL!r}"
+        )
+    argv = [
+        CLAUDE_CLI_EXECUTABLE,
+        "-p",
+        "--verbose",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        "--replay-user-messages",
+        "--model",
+        CLAUDE_CLI_MODEL,
+        "--tools",
+        "",
+        "--strict-mcp-config",
+    ]
+    if CLAUDE_CLI_FORBIDDEN_FLAGS.intersection(argv):  # pragma: no cover
+        raise AssertionError("forbidden Claude CLI flag in fixed argv")
+    return argv
+
+
+def build_claude_cli_env(
+    source_env: Optional[Mapping[str, str]] = None,
+) -> dict[str, str]:
+    """Build the official CLI child environment at its managed-policy boundary.
+
+    All inherited ``ANTHROPIC_*`` request shaping and the explicitly blocked
+    Claude CLI backend selectors are removed. ``HOME``, ``USERPROFILE``, and
+    ``CLAUDE_CODE_OAUTH_TOKEN`` are deliberately preserved so the official CLI
+    can use its own login/keychain and managed policy. Values are never
+    inspected or logged.
+    """
+    if source_env is None:
+        env = hermes_subprocess_env(inherit_credentials=False)
+    else:
+        env = dict(source_env)
+    for name in tuple(env):
+        normalized = name.upper()
+        if normalized.startswith("ANTHROPIC_") or normalized in CLAUDE_CLI_ENV_BLOCKLIST:
+            env.pop(name, None)
+    return env
+
+
+def parse_claude_cli_version(output: str) -> Optional[tuple[int, int, int]]:
+    match = re.search(r"(?:^|\s)(\d+)\.(\d+)\.(\d+)(?:\s|$)", output or "")
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+@dataclass(frozen=True)
+class ClaudeCLICapabilities:
+    stream_json_input: bool
+    stream_json_output: bool
+    partial_messages: bool
+    replay_user_messages: bool
+    model_selection: bool
+    tools_selection: bool
+    verbose: bool
+    strict_mcp_config: bool
+    persistent_session: bool = True
+    zero_tools: bool = True
+    cancellation: bool = False
+    native_steer: bool = False
+    vision: bool = False
+    reasoning: bool = False
+
+    @property
+    def stage0_ready(self) -> bool:
+        return all(
+            (
+                self.stream_json_input,
+                self.stream_json_output,
+                self.partial_messages,
+                self.replay_user_messages,
+                self.model_selection,
+                self.tools_selection,
+                self.verbose,
+                self.strict_mcp_config,
+                self.persistent_session,
+                self.zero_tools,
+            )
+        )
+
+
+def parse_claude_cli_help(output: str) -> ClaudeCLICapabilities:
+    text = output or ""
+    return ClaudeCLICapabilities(
+        stream_json_input="--input-format" in text and "stream-json" in text,
+        stream_json_output="--output-format" in text and "stream-json" in text,
+        partial_messages="--include-partial-messages" in text,
+        replay_user_messages="--replay-user-messages" in text,
+        model_selection="--model" in text,
+        tools_selection="--tools" in text,
+        verbose="--verbose" in text,
+        strict_mcp_config="--strict-mcp-config" in text,
+    )
+
+
+def check_claude_cli_available(timeout: float = 10.0) -> tuple[bool, str]:
+    """Check the installed binary without accessing credentials or the network."""
+    env = build_claude_cli_env()
+    try:
+        version_proc = subprocess.run(
+            [CLAUDE_CLI_EXECUTABLE, "--version"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            env=env,
+            shell=False,
+        )
+        help_proc = subprocess.run(
+            [CLAUDE_CLI_EXECUTABLE, "--help"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            env=env,
+            shell=False,
+        )
+    except FileNotFoundError:
+        return False, "official Claude CLI executable not found"
+    except subprocess.TimeoutExpired:
+        return False, "Claude CLI capability check timed out"
+    if version_proc.returncode != 0 or help_proc.returncode != 0:
+        return False, "Claude CLI capability check failed"
+    version = parse_claude_cli_version(version_proc.stdout)
+    if version is None or version < CLAUDE_CLI_MIN_VERSION:
+        return False, "Claude CLI version is below the Stage-0 minimum"
+    capabilities = parse_claude_cli_help(help_proc.stdout)
+    if not capabilities.stage0_ready:
+        return False, "Claude CLI is missing required Stage-0 capabilities"
+    return True, ".".join(str(part) for part in version)
+
+
+class ClaudeCLIError(RuntimeError):
+    """Sanitized provider error safe for user-visible reporting."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        transient: bool = False,
+        visible_output: bool = False,
+        category: str = "protocol",
+    ) -> None:
+        super().__init__(message)
+        self.transient = transient
+        self.visible_output = visible_output
+        self.category = category
+
+
+class ClaudeCLIBusyError(ClaudeCLIError):
+    pass
+
+
+@dataclass
+class ClaudeCLITurnResult:
+    final_text: str
+    usage: dict[str, int] = field(default_factory=dict)
+    session_id: Optional[str] = None
+    event_counts: dict[str, int] = field(default_factory=dict)
+    generation: int = 0
+    interrupted: bool = False
+
+
+@dataclass(frozen=True)
+class _WireItem:
+    generation: int
+    kind: str
+    event: Optional[dict[str, Any]] = None
+
+
+class ClaudeCLIEventProjector:
+    """Project Claude stream-json frames without exposing raw payloads."""
+
+    @staticmethod
+    def text_delta(event: Mapping[str, Any]) -> str:
+        if event.get("type") != "stream_event":
+            return ""
+        inner = event.get("event")
+        if not isinstance(inner, Mapping) or inner.get("type") != "content_block_delta":
+            return ""
+        delta = inner.get("delta")
+        if not isinstance(delta, Mapping) or delta.get("type") != "text_delta":
+            return ""
+        text = delta.get("text")
+        return text if isinstance(text, str) else ""
+
+    @staticmethod
+    def assistant_text(event: Mapping[str, Any]) -> str:
+        if event.get("type") != "assistant":
+            return ""
+        message = event.get("message")
+        if not isinstance(message, Mapping):
+            return ""
+        content = message.get("content")
+        if not isinstance(content, list):
+            return ""
+        chunks: list[str] = []
+        for block in content:
+            if isinstance(block, Mapping) and block.get("type") == "text":
+                value = block.get("text")
+                if isinstance(value, str):
+                    chunks.append(value)
+        return "".join(chunks)
+
+    @staticmethod
+    def result_text(event: Mapping[str, Any]) -> str:
+        value = event.get("result")
+        return value if isinstance(value, str) else ""
+
+    @staticmethod
+    def usage(event: Mapping[str, Any]) -> dict[str, int]:
+        raw = event.get("usage")
+        if not isinstance(raw, Mapping):
+            return {}
+        allowed = (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+        )
+        return {
+            key: max(int(raw.get(key) or 0), 0)
+            for key in allowed
+            if isinstance(raw.get(key), (int, float))
+        }
+
+
+class ClaudeCLIClient:
+    """One persistent shell-free Claude CLI process with one active turn."""
+
+    def __init__(
+        self,
+        *,
+        model: str = CLAUDE_CLI_MODEL,
+        cwd: Optional[str] = None,
+        env: Optional[Mapping[str, str]] = None,
+        popen_factory: Callable[..., Any] = _DEFAULT_POPEN,
+        queue_size: int = 512,
+        generation_start: int = 0,
+    ) -> None:
+        self.model = model
+        self.cwd = cwd
+        self._env = build_claude_cli_env(env)
+        self._popen_factory = popen_factory
+        self._queue_size = queue_size
+        self._proc: Any = None
+        self._generation = generation_start
+        self._events: queue.Queue[_WireItem] = queue.Queue(maxsize=queue_size)
+        self._reader_error: Optional[ClaudeCLIError] = None
+        self._reader_error_lock = threading.Lock()
+        self._stdout_reader: Optional[threading.Thread] = None
+        self._stderr_reader: Optional[threading.Thread] = None
+        self._stderr_line_count = 0
+        self._stderr_lock = threading.Lock()
+        self._session_id: Optional[str] = None
+        self._initialized_generation: Optional[int] = None
+        self._turn_lock = threading.Lock()
+        self._write_lock = threading.Lock()
+        self._lifecycle_lock = threading.Lock()
+        self._closed = False
+        self._cancelled = False
+        self._completed_turns = 0
+
+    @property
+    def pid(self) -> Optional[int]:
+        return getattr(self._proc, "pid", None)
+
+    @property
+    def generation(self) -> int:
+        return self._generation
+
+    @property
+    def completed_turns(self) -> int:
+        return self._completed_turns
+
+    def is_alive(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def _set_reader_error(self, error: ClaudeCLIError) -> None:
+        with self._reader_error_lock:
+            if self._reader_error is None:
+                self._reader_error = error
+
+    def start(self) -> None:
+        with self._lifecycle_lock:
+            self._start_locked()
+
+    def _start_locked(self) -> None:
+        if self._closed:
+            raise ClaudeCLIError("claude-cli session is closed", category="closed")
+        if self.is_alive():
+            return
+        if self._popen_factory is _DEFAULT_POPEN:
+            available, reason = check_claude_cli_available()
+            if not available:
+                raise ClaudeCLIError(reason, category="unavailable")
+        self._generation += 1
+        self._events = queue.Queue(maxsize=self._queue_size)
+        self._reader_error = None
+        self._session_id = None
+        self._initialized_generation = None
+        self._cancelled = False
+        try:
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
+            self._proc = self._popen_factory(
+                build_claude_cli_argv(self.model),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=0,
+                cwd=self.cwd,
+                env=dict(self._env),
+                shell=False,
+                creationflags=windows_hide_flags(),
+            )
+        except FileNotFoundError as exc:
+            raise ClaudeCLIError(
+                "official Claude CLI executable not found", category="unavailable"
+            ) from exc
+        except OSError as exc:
+            raise ClaudeCLIError(
+                "Claude CLI subprocess could not be started",
+                transient=True,
+                category="spawn",
+            ) from exc
+        generation = self._generation
+        self._stdout_reader = threading.Thread(
+            target=self._read_stdout,
+            args=(generation,),
+            name=f"claude-cli-stdout-{generation}",
+            daemon=True,
+        )
+        self._stderr_reader = threading.Thread(
+            target=self._read_stderr,
+            args=(generation,),
+            name=f"claude-cli-stderr-{generation}",
+            daemon=True,
+        )
+        self._stdout_reader.start()
+        self._stderr_reader.start()
+
+    def _enqueue(self, item: _WireItem) -> None:
+        try:
+            self._events.put(item, timeout=0.25)
+        except queue.Full:
+            self._set_reader_error(
+                ClaudeCLIError("Claude CLI event buffer overflow", category="protocol")
+            )
+
+    def _read_stdout(self, generation: int) -> None:
+        stream = getattr(self._proc, "stdout", None)
+        if stream is None:
+            self._enqueue(_WireItem(generation, "eof"))
+            return
+        try:
+            for raw in iter(stream.readline, b""):
+                if not raw:
+                    break
+                try:
+                    event = json.loads(raw.decode("utf-8", "strict"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    self._set_reader_error(
+                        ClaudeCLIError(
+                            "Claude CLI emitted malformed stream-json",
+                            category="protocol",
+                        )
+                    )
+                    break
+                if not isinstance(event, dict):
+                    self._set_reader_error(
+                        ClaudeCLIError(
+                            "Claude CLI emitted a non-object stream event",
+                            category="protocol",
+                        )
+                    )
+                    break
+                self._enqueue(_WireItem(generation, "event", event))
+        except Exception:
+            self._set_reader_error(
+                ClaudeCLIError(
+                    "Claude CLI stdout reader failed",
+                    transient=True,
+                    category="pipe",
+                )
+            )
+        finally:
+            self._enqueue(_WireItem(generation, "eof"))
+
+    def _read_stderr(self, generation: int) -> None:
+        del generation
+        stream = getattr(self._proc, "stderr", None)
+        if stream is None:
+            return
+        try:
+            for _raw in iter(stream.readline, b""):
+                with self._stderr_lock:
+                    self._stderr_line_count = min(self._stderr_line_count + 1, 10_000)
+        except Exception:
+            return
+
+    def stderr_summary(self) -> str:
+        with self._stderr_lock:
+            count = self._stderr_line_count
+        return f"stderr_lines={count}" if count else "stderr_lines=0"
+
+    def _write_user_frame(self, text: str) -> None:
+        if not isinstance(text, str):
+            raise TypeError("claude-cli input must be text")
+        frame = {"type": "user", "message": {"role": "user", "content": text}}
+        payload = (json.dumps(frame, ensure_ascii=False, separators=(",", ":")) + "\n").encode(
+            "utf-8"
+        )
+        stream = getattr(self._proc, "stdin", None)
+        if stream is None:
+            raise ClaudeCLIError(
+                "Claude CLI stdin is unavailable", transient=True, category="pipe"
+            )
+        try:
+            with self._write_lock:
+                stream.write(payload)
+                stream.flush()
+        except (BrokenPipeError, OSError, ValueError) as exc:
+            raise ClaudeCLIError(
+                "Claude CLI stdin closed unexpectedly",
+                transient=True,
+                category="pipe",
+            ) from exc
+
+    def run_turn(
+        self,
+        text: str,
+        *,
+        on_delta: Optional[Callable[[str], None]] = None,
+        first_event_timeout: float = 30.0,
+        idle_timeout: float = 60.0,
+        total_timeout: float = 300.0,
+    ) -> ClaudeCLITurnResult:
+        if not self._turn_lock.acquire(blocking=False):
+            raise ClaudeCLIBusyError("claude-cli already has an active turn")
+        visible_output = False
+        try:
+            self.start()
+            generation = self._generation
+            self._write_user_frame(text)
+            started = time.monotonic()
+            deadline = started + total_timeout
+            event_deadline = started + first_event_timeout
+            ack_seen = False
+            init_seen = self._initialized_generation == generation
+            assistant_text = ""
+            delta_text: list[str] = []
+            event_counts: dict[str, int] = {}
+
+            def interrupted_result() -> ClaudeCLITurnResult:
+                return ClaudeCLITurnResult(
+                    final_text=assistant_text or "".join(delta_text),
+                    session_id=self._session_id,
+                    event_counts=event_counts,
+                    generation=generation,
+                    interrupted=True,
+                )
+
+            while True:
+                if self._cancelled:
+                    return interrupted_result()
+                with self._reader_error_lock:
+                    reader_error = self._reader_error
+                if reader_error is not None:
+                    reader_error.visible_output = visible_output
+                    raise reader_error
+                now = time.monotonic()
+                if now >= deadline:
+                    raise ClaudeCLIError(
+                        "Claude CLI turn timed out",
+                        visible_output=visible_output,
+                        category="timeout",
+                    )
+                wait = max(min(event_deadline, deadline) - now, 0.01)
+                try:
+                    item = self._events.get(timeout=wait)
+                except queue.Empty:
+                    if self._cancelled:
+                        return interrupted_result()
+                    raise ClaudeCLIError(
+                        "Claude CLI stream became idle",
+                        visible_output=visible_output,
+                        category="timeout",
+                    )
+                if item.generation != generation:
+                    continue
+                if item.kind == "eof":
+                    if self._cancelled:
+                        return interrupted_result()
+                    raise ClaudeCLIError(
+                        "Claude CLI exited before the turn result",
+                        transient=not visible_output,
+                        visible_output=visible_output,
+                        category="eof",
+                    )
+                event = item.event or {}
+                event_deadline = time.monotonic() + idle_timeout
+                event_type = str(event.get("type") or "unknown")
+                event_counts[event_type] = event_counts.get(event_type, 0) + 1
+                event_session_id = event.get("session_id")
+                if event_session_id is not None:
+                    if not isinstance(event_session_id, str):
+                        raise ClaudeCLIError(
+                            "Claude CLI emitted an invalid session identifier",
+                            visible_output=visible_output,
+                            category="correlation",
+                        )
+                    if self._session_id is None:
+                        self._session_id = event_session_id
+                    elif event_session_id != self._session_id:
+                        raise ClaudeCLIError(
+                            "Claude CLI session correlation changed unexpectedly",
+                            visible_output=visible_output,
+                            category="correlation",
+                        )
+                if event_type == "user":
+                    ack_seen = True
+                    continue
+                if event_type == "system" and event.get("subtype") == "init":
+                    tools = event.get("tools")
+                    if not isinstance(tools, list) or tools:
+                        raise ClaudeCLIError(
+                            "Claude CLI did not honor the Stage-0 zero-tool contract",
+                            visible_output=visible_output,
+                            category="capability",
+                        )
+                    self._initialized_generation = generation
+                    init_seen = True
+                    continue
+                message = event.get("message")
+                if isinstance(message, Mapping):
+                    content = message.get("content")
+                    if isinstance(content, list) and any(
+                        isinstance(block, Mapping) and block.get("type") == "tool_use"
+                        for block in content
+                    ):
+                        raise ClaudeCLIError(
+                            "Claude CLI emitted a tool event in text-only Stage 0",
+                            visible_output=visible_output,
+                            category="capability",
+                        )
+                delta = ClaudeCLIEventProjector.text_delta(event)
+                if delta:
+                    visible_output = True
+                    delta_text.append(delta)
+                    if on_delta is not None:
+                        on_delta(delta)
+                    continue
+                projected = ClaudeCLIEventProjector.assistant_text(event)
+                if projected:
+                    visible_output = True
+                    assistant_text = projected
+                    continue
+                if event_type != "result":
+                    continue
+                if not ack_seen:
+                    raise ClaudeCLIError(
+                        "Claude CLI result arrived without the replay acknowledgment",
+                        visible_output=visible_output,
+                        category="correlation",
+                    )
+                if not init_seen:
+                    raise ClaudeCLIError(
+                        "Claude CLI result arrived before Stage-0 initialization",
+                        visible_output=visible_output,
+                        category="correlation",
+                    )
+                if event.get("is_error"):
+                    subtype = str(event.get("subtype") or "provider_error")
+                    category = (
+                        "policy"
+                        if any(word in subtype.lower() for word in ("auth", "billing", "policy", "permission"))
+                        else "provider"
+                    )
+                    raise ClaudeCLIError(
+                        f"Claude CLI turn failed ({category})",
+                        visible_output=visible_output,
+                        category=category,
+                    )
+                if self._proc.poll() is not None:
+                    raise ClaudeCLIError(
+                        "Claude CLI exited instead of preserving the persistent session",
+                        visible_output=visible_output,
+                        category="lifecycle",
+                    )
+                final_text = ClaudeCLIEventProjector.result_text(event) or assistant_text or "".join(delta_text)
+                self._completed_turns += 1
+                return ClaudeCLITurnResult(
+                    final_text=final_text,
+                    usage=ClaudeCLIEventProjector.usage(event),
+                    session_id=self._session_id,
+                    event_counts=event_counts,
+                    generation=generation,
+                )
+        except ClaudeCLIError as exc:
+            exc.visible_output = exc.visible_output or visible_output
+            raise
+        finally:
+            self._turn_lock.release()
+
+    def request_interrupt(self) -> None:
+        """Fail closed by retiring the process; no native cancel frame is claimed."""
+        self._cancelled = True
+        self.close()
+
+    def close(self, grace: float = 1.0, terminate_timeout: float = 2.0) -> None:
+        with self._lifecycle_lock:
+            self._close_locked(grace, terminate_timeout)
+
+    def _close_locked(self, grace: float, terminate_timeout: float) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        proc = self._proc
+        if proc is None:
+            return
+        stdin = getattr(proc, "stdin", None)
+        try:
+            if stdin is not None and not stdin.closed:
+                stdin.close()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=grace)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.terminate()
+                proc.wait(timeout=terminate_timeout)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=1.0)
+                except Exception:
+                    pass
+            except Exception:
+                pass
+        for reader in (self._stdout_reader, self._stderr_reader):
+            if reader is not None and reader is not threading.current_thread():
+                reader.join(timeout=1.0)
+
+
+class ClaudeCLISession:
+    """Persistent session facade with the single permitted pre-output retry."""
+
+    def __init__(self, **client_kwargs: Any) -> None:
+        self._client_kwargs = dict(client_kwargs)
+        self._client: Optional[ClaudeCLIClient] = None
+        self._closed = False
+        self._process_generation = 0
+
+    @property
+    def client(self) -> Optional[ClaudeCLIClient]:
+        return self._client
+
+    def _new_client(self) -> ClaudeCLIClient:
+        self._client = ClaudeCLIClient(
+            **self._client_kwargs,
+            generation_start=self._process_generation,
+        )
+        self._process_generation += 1
+        return self._client
+
+    def run_turn(self, text: str, **kwargs: Any) -> ClaudeCLITurnResult:
+        if self._closed:
+            raise ClaudeCLIError("claude-cli session is closed", category="closed")
+        client = self._client or self._new_client()
+        try:
+            return client.run_turn(text, **kwargs)
+        except ClaudeCLIBusyError:
+            raise
+        except ClaudeCLIError as exc:
+            can_retry = (
+                not getattr(client, "_cancelled", False)
+                and not self._closed
+                and exc.transient
+                and not exc.visible_output
+                and client.completed_turns == 0
+                and exc.category in {"spawn", "pipe", "eof"}
+            )
+            client.close()
+            if self._client is client:
+                self._client = None
+            if not can_retry:
+                raise
+            return self._new_client().run_turn(text, **kwargs)
+
+    def request_interrupt(self) -> None:
+        if self._client is not None:
+            self._client.request_interrupt()
+            self._client = None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+class ClaudeCLITransport(ProviderTransport):
+    """Registry adapter for the special ``claude_cli`` runtime."""
+
+    @property
+    def api_mode(self) -> str:
+        return "claude_cli"
+
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs: Any) -> str:
+        del kwargs
+        if not messages or messages[-1].get("role") != "user":
+            raise ValueError("claude-cli requires a trailing text user message")
+        content = messages[-1].get("content")
+        if not isinstance(content, str):
+            raise ValueError("claude-cli Stage 0 is text-only")
+        return content
+
+    def convert_tools(self, tools: list[dict[str, Any]]) -> list[Any]:
+        if tools:
+            raise ValueError("claude-cli Stage 0 does not expose tools")
+        return []
+
+    def build_kwargs(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: Optional[list[dict[str, Any]]] = None,
+        **params: Any,
+    ) -> dict[str, Any]:
+        if params.get("api_key") or params.get("base_url"):
+            raise ValueError("claude-cli does not accept api_key or base_url")
+        build_claude_cli_argv(model)
+        self.convert_tools(tools or [])
+        return {"model": model, "text": self.convert_messages(messages)}
+
+    def normalize_response(self, response: Any, **kwargs: Any) -> NormalizedResponse:
+        del kwargs
+        if not isinstance(response, ClaudeCLITurnResult):
+            raise TypeError("expected ClaudeCLITurnResult")
+        prompt = int(response.usage.get("input_tokens", 0))
+        cached = int(response.usage.get("cache_read_input_tokens", 0))
+        completion = int(response.usage.get("output_tokens", 0))
+        return NormalizedResponse(
+            content=response.final_text,
+            tool_calls=None,
+            finish_reason="stop",
+            usage=Usage(
+                prompt_tokens=prompt,
+                completion_tokens=completion,
+                total_tokens=prompt + completion,
+                cached_tokens=cached,
+            ),
+        )
+
+
+def _usage_int(usage: Mapping[str, Any], key: str) -> int:
+    value = usage.get(key)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return max(int(value), 0)
+    return 0
+
+
+def _record_claude_cli_usage(agent: Any, turn: ClaudeCLITurnResult) -> dict[str, Any]:
+    """Route CLI-reported usage through Hermes' canonical accounting wrapper."""
+    from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+
+    agent.session_api_calls = getattr(agent, "session_api_calls", 0) + 1
+    raw = turn.usage if isinstance(turn.usage, dict) else {}
+    canonical = CanonicalUsage(
+        input_tokens=_usage_int(raw, "input_tokens"),
+        output_tokens=_usage_int(raw, "output_tokens"),
+        cache_read_tokens=_usage_int(raw, "cache_read_input_tokens"),
+        cache_write_tokens=_usage_int(raw, "cache_creation_input_tokens"),
+        reasoning_tokens=0,
+        raw_usage=raw,
+    )
+    usage = {
+        "prompt_tokens": canonical.prompt_tokens,
+        "completion_tokens": canonical.output_tokens,
+        "total_tokens": canonical.total_tokens,
+        "input_tokens": canonical.input_tokens,
+        "output_tokens": canonical.output_tokens,
+        "cache_read_tokens": canonical.cache_read_tokens,
+        "cache_write_tokens": canonical.cache_write_tokens,
+        "reasoning_tokens": 0,
+    }
+    agent._last_turn_usage = usage
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        try:
+            compressor.update_from_response(usage)
+        except Exception:
+            pass
+
+    counter_fields = {
+        "session_prompt_tokens": canonical.prompt_tokens,
+        "session_completion_tokens": canonical.output_tokens,
+        "session_total_tokens": canonical.total_tokens,
+        "session_input_tokens": canonical.input_tokens,
+        "session_output_tokens": canonical.output_tokens,
+        "session_cache_read_tokens": canonical.cache_read_tokens,
+        "session_cache_write_tokens": canonical.cache_write_tokens,
+        "session_reasoning_tokens": 0,
+    }
+    for name, value in counter_fields.items():
+        setattr(agent, name, getattr(agent, name, 0) + value)
+
+    cost = estimate_usage_cost(
+        agent.model,
+        canonical,
+        provider=agent.provider,
+        base_url=agent.base_url,
+        api_key="",
+    )
+    if cost.amount_usd is not None:
+        agent.session_estimated_cost_usd = getattr(
+            agent, "session_estimated_cost_usd", 0.0
+        ) + float(cost.amount_usd)
+    agent.session_cost_status = cost.status
+    agent.session_cost_source = cost.source
+
+    if getattr(agent, "_session_db", None) is not None and getattr(agent, "session_id", None):
+        try:
+            if not getattr(agent, "_session_db_created", False):
+                agent._ensure_db_session()
+            agent._session_db.queue_token_counts(
+                agent.session_id,
+                input_tokens=canonical.input_tokens,
+                output_tokens=canonical.output_tokens,
+                cache_read_tokens=canonical.cache_read_tokens,
+                cache_write_tokens=canonical.cache_write_tokens,
+                reasoning_tokens=0,
+                estimated_cost_usd=float(cost.amount_usd)
+                if cost.amount_usd is not None
+                else None,
+                cost_status=cost.status,
+                cost_source=cost.source,
+                billing_provider=agent.provider,
+                billing_base_url="",
+                billing_mode="subscription_included",
+                model=agent.model,
+                api_call_count=1,
+            )
+        except Exception:
+            pass
+
+    return {
+        **usage,
+        "last_prompt_tokens": canonical.prompt_tokens,
+        "estimated_cost_usd": float(cost.amount_usd)
+        if cost.amount_usd is not None
+        else None,
+        "cost_status": cost.status,
+        "cost_source": cost.source,
+    }
+
+
+def run_claude_cli_turn(
+    agent: Any,
+    *,
+    user_message: str,
+    original_user_message: Any,
+    messages: list[dict[str, Any]],
+    effective_task_id: str,
+    should_review_memory: bool = False,
+) -> dict[str, Any]:
+    """Run one normal Hermes turn through the persistent text-only session."""
+    del effective_task_id
+
+    def on_delta(text: str) -> None:
+        callback = getattr(agent, "_fire_stream_delta", None)
+        if callable(callback):
+            callback(text)
+
+    if getattr(agent, "_claude_cli_session", None) is None:
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
+        agent._claude_cli_session = ClaudeCLISession(model=agent.model, cwd=cwd)
+
+    try:
+        turn = agent._claude_cli_session.run_turn(user_message, on_delta=on_delta)
+    except ClaudeCLIBusyError as exc:
+        return {
+            "final_response": f"Claude CLI turn failed: {exc}",
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": False,
+            "interrupted": False,
+            "error": str(exc),
+        }
+    except ClaudeCLIError as exc:
+        try:
+            agent._claude_cli_session.close()
+        except Exception:
+            pass
+        agent._claude_cli_session = None
+        interrupted = bool(getattr(agent, "_interrupt_requested", False))
+        interrupt_message = getattr(agent, "_interrupt_message", None) if interrupted else None
+        if interrupted:
+            agent.clear_interrupt()
+        return {
+            "final_response": f"Claude CLI turn failed: {exc}",
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": bool(exc.visible_output),
+            "interrupted": interrupted,
+            **({"interrupt_message": interrupt_message} if interrupt_message else {}),
+            "error": str(exc),
+        }
+
+    interrupt_requested = bool(getattr(agent, "_interrupt_requested", False))
+    user_interrupted = bool(turn.interrupted and interrupt_requested)
+    interrupt_message = (
+        getattr(agent, "_interrupt_message", None) if user_interrupted else None
+    )
+    if interrupt_requested:
+        agent.clear_interrupt()
+
+    messages.append({"role": "assistant", "content": turn.final_text})
+    if getattr(agent, "_session_db", None) is not None:
+        try:
+            agent._flush_messages_to_session_db(messages)
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "claude-cli turn was delivered but could not be persisted",
+                exc_info=True,
+            )
+
+    usage = _record_claude_cli_usage(agent, turn)
+    agent._iters_since_skill = getattr(agent, "_iters_since_skill", 0) + 1
+
+    if not turn.interrupted:
+        try:
+            agent._sync_external_memory_for_turn(
+                original_user_message=original_user_message,
+                final_response=turn.final_text,
+                interrupted=False,
+                messages=messages,
+            )
+        except Exception:
+            pass
+
+    if should_review_memory and turn.final_text and not turn.interrupted:
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=list(messages),
+                review_memory=True,
+                review_skills=False,
+            )
+        except Exception:
+            pass
+
+    return {
+        "final_response": turn.final_text,
+        "messages": messages,
+        "api_calls": 1,
+        "completed": not turn.interrupted,
+        "partial": turn.interrupted,
+        "interrupted": user_interrupted,
+        **({"interrupt_message": interrupt_message} if interrupt_message else {}),
+        "error": None,
+        "agent_persisted": True,
+        "claude_cli_generation": turn.generation,
+        **usage,
+    }
+
+
+from agent.transports import register_transport
+
+register_transport("claude_cli", ClaudeCLITransport)
+
+
+__all__ = [
+    "CLAUDE_CLI_MODEL",
+    "CLAUDE_CLI_MIN_VERSION",
+    "CLAUDE_CLI_ENV_BLOCKLIST",
+    "ClaudeCLIBusyError",
+    "ClaudeCLICapabilities",
+    "ClaudeCLIClient",
+    "ClaudeCLIError",
+    "ClaudeCLIEventProjector",
+    "ClaudeCLISession",
+    "ClaudeCLITurnResult",
+    "ClaudeCLITransport",
+    "build_claude_cli_argv",
+    "build_claude_cli_env",
+    "check_claude_cli_available",
+    "parse_claude_cli_help",
+    "parse_claude_cli_version",
+    "run_claude_cli_turn",
+]

--- a/docs/development/2026-08-10-claude-cli-credential-gate-options.md
+++ b/docs/development/2026-08-10-claude-cli-credential-gate-options.md
@@ -1,0 +1,188 @@
+# Claude CLI credential gate options
+
+Date: 2026-08-10
+Status: **decision required; no implementation authorized**
+
+## Decision summary
+
+The defect is a contract mismatch, not a missing credential.
+
+`claude-cli` is intentionally an `external_process` provider. Its resolver rejects
+both `api_key` and `base_url`, while the common CLI gate requires both values after
+resolution. The existing native `anthropic` provider does not hit this mismatch:
+it resolves an Anthropic token and the HTTPS API base URL before entering the same
+gate.
+
+**Recommendation: Option B — add an explicit runtime credential contract and make
+the existing gate validate that contract.** This preserves fail-closed validation,
+does not fabricate credentials, keeps native `anthropic` unchanged, and gives
+future non-HTTP runtimes a typed path without adding more provider-name exceptions.
+
+No option is implemented by this document.
+
+## Scope and evidence boundary
+
+This decision uses only source and tests in this worktree. It does not read
+`config.yaml`, credentials, tokens, keychains, or the installed Hermes tree. No
+provider was activated and no CLI login was invoked.
+
+CodeGraph was attempted first but this worktree has no initialized `.codegraph`
+index, so the evidence below comes from direct source reads.
+
+## Verified current behavior
+
+### 1. Where the credential gate is and what it requires
+
+The interactive gate is
+`hermes_cli/cli_agent_setup_mixin.py::_ensure_runtime_credentials`.
+
+1. It calls `resolve_runtime_provider(...)` (`cli_agent_setup_mixin.py:38-45`).
+2. It reads `api_key`, `base_url`, `provider`, and `api_mode` from the returned
+   runtime dictionary (`:86-91`).
+3. Unless `api_key` is a callable, it rejects an empty key (`:98-121`). The only
+   exception is a non-OpenRouter custom/local HTTP endpoint with a non-empty
+   `base_url`; that path substitutes the literal placeholder
+   `no-key-required` (`:100-112`).
+4. It then rejects every empty `base_url` (`:122-125`).
+5. Only after those checks does it copy the resolved provider/routing state into
+   the CLI (`:127-141`).
+
+The silent first-run probe
+`CLIAgentSetupMixin._runtime_credentials_ready` repeats the same assumptions:
+a callable or non-empty string key still requires a non-empty base URL, and a
+keyless runtime is ready only when it has a non-empty non-OpenRouter base URL
+(`:187-219`).
+
+Therefore the post-resolver gate is effectively uniform. It does not consult
+`ProviderProfile.auth_type` or a provider-specific credential policy. It reads
+`source` for diagnostics and state propagation but does not branch on it. It
+already has two non-uniform cases—callable bearer tokens
+and keyless local HTTP endpoints—but no external-process case.
+
+### 2. Why `claude-cli` cannot pass
+
+The provider profile declares:
+
+- `api_mode="claude_cli"`;
+- `env_vars=()`;
+- `base_url=""`;
+- `auth_type="external_process"`;
+- no HTTP health check.
+
+Source: `plugins/model-providers/claude-cli/__init__.py:13-25`.
+
+The runtime resolver identifies the exact provider/model pair and deliberately
+rejects any supplied key or URL. On success it returns both values empty and
+marks the source as `external-process`
+(`hermes_cli/runtime_provider.py:1706-1734`). The provider regression test fixes
+that exact dictionary as the intended contract
+(`tests/providers/test_claude_cli_provider.py:18-45`).
+
+The downstream agent constructor independently enforces the same design: for
+`api_mode="claude_cli"` it requires provider `claude-cli`, model
+`claude-opus-5`, and empty `api_key` and `base_url`; non-empty values raise
+`ValueError` (`agent/agent_init.py:1034-1047`). Thus the empty values are not a
+resolver accident—the common CLI gate is the inconsistent layer.
+
+The transport module states that authentication, subscription billing, session
+state, hooks, and managed policy remain owned by the official CLI, and that Hermes
+never reads Claude credentials or calls an Anthropic HTTP endpoint
+(`agent/transports/claude_cli.py:1-9`). Before a production process spawn it
+validates the executable version and required help flags without reading
+credentials (`:158-196`, `:354-362`).
+
+This means resolution succeeds exactly as designed and the later common gate
+rejects that successful result. The third independent review
+reproduced the real method printing `No API key found for provider 'claude-cli'`
+and returning `False`; both
+selection routes are consequently unreachable.
+
+### 3. How native `anthropic` passes
+
+The native profile is a different transport contract:
+
+- `api_mode="anthropic_messages"`;
+- `auth_type="api_key"`;
+- API-key/token environment names are declared;
+- `base_url="https://api.anthropic.com"`.
+
+Source: `plugins/model-providers/anthropic/__init__.py:44-52`.
+
+Its runtime branch selects the Anthropic base URL, resolves an Anthropic token,
+raises `AuthError` if no credential exists, and returns a non-empty `api_key`
+and `base_url` (`hermes_cli/runtime_provider.py:2072-2139`). It therefore passes
+the existing uniform checks without an exception.
+
+No proposed option removes or changes this native provider. `anthropic` and
+`claude-cli` remain separate, coexisting routes.
+
+## What counts as a valid fix
+
+A valid fix must keep validation enabled while validating the correct runtime
+contract:
+
+- HTTP/API-key providers still require their current credentials and endpoint.
+- Native `anthropic` retains its current token resolution and errors.
+- `claude-cli` must continue to reject supplied `api_key` and `base_url`.
+- The official executable/version/help and process protocol checks remain the
+  external-process readiness boundary.
+- No placeholder secret, fake HTTP URL, direct Anthropic API call, provider
+  activation, permission bypass, or credential-store inspection is allowed.
+- Both `_ensure_runtime_credentials` and `_runtime_credentials_ready` must use
+  the same decision rule; fixing only one leaves either chat reachability or
+  first-run routing broken.
+
+## Options
+
+| Option | What changes | Impact scope | Main risks | Rollback |
+|---|---|---|---|---|
+| **A. Exact `claude_cli` branch in both gate methods** | In `_ensure_runtime_credentials` and `_runtime_credentials_ready`, recognize the exact tuple `provider=claude-cli`, `api_mode=claude_cli`, `source=external-process`; require both key and URL to remain empty, then allow normal routing. All other branches keep current checks. | Two gate methods plus focused CLI tests. Resolver and transport stay unchanged. | Lowest code volume, but duplicates identity checks in two methods; future external-process providers need more exceptions; the two branches can drift. A loose check on only provider name or only API mode could accept a malformed runtime. | Remove the two exact branches and their tests. Existing behavior returns immediately. |
+| **B. Typed runtime credential contract — recommended** | Add an explicit resolver field such as `credential_contract="external_process"` (or an equivalent typed value) to the `claude-cli` runtime result. Route both gate methods through one shared validator. For `external_process`, require the exact dedicated provider/API mode, empty key, empty URL, and the expected source; for the default HTTP contract, preserve the current callable/key/local-endpoint/base-URL checks. The transport's existing executable/version/help probe remains the later process-readiness check. | Resolver result schema, one shared validation helper, two gate callers, and focused regression tests. Existing runtime dictionaries without the field default to the present HTTP behavior. | Wider than A and requires careful backward-compatible defaulting. If the contract field is trusted without checking the provider/API-mode tuple, a malformed plugin could claim `external_process`; fail closed by validating the tuple and unknown contract values. | Delete the new field/helper branch and restore both callers to their current inline checks. Because untagged runtimes retain current behavior, rollback is localized. |
+| **C. Provider-profile validation hook** | Add a declarative hook or method to `ProviderProfile`, such as `validate_runtime_credentials(runtime)`, and have the CLI gate resolve the active profile and call it. The Claude CLI profile would require empty key/URL and its dedicated mode; the base profile would implement today's HTTP checks. | Shared provider abstraction, profile lookup, gate methods, Claude CLI profile, and broader provider-contract tests. | Most extensible but largest abstraction change. `ProviderProfile` is documented as declarative and as not owning client construction, credential rotation, or streaming; a validation hook broadens that boundary. Alias/profile lookup failures could change unrelated providers unless fallback behavior is strictly fail-closed. Existing `copilot-acp` also declares `external_process` but has a different ACP/base-URL contract, so branching on `auth_type` alone is unsafe. | Remove the hook override and restore the gate's local validator. Revert profile tests. |
+| **D. Synthetic key and URL sentinels — reject** | Return values such as `api_key="external-process"` and `base_url="claude-cli://local"` solely to satisfy the current gate. | Resolver, `agent_init.py`, the transport, and their tests, because both downstream layers reject non-empty values. | Semantically false and guaranteed to raise `ValueError` during Claude CLI agent construction and transport kwargs validation. It contradicts the explicit empty-value contract and hides rather than resolves the type mismatch. | Restore empty values and remove any compensating downstream exceptions. |
+
+## Recommendation
+
+Choose **Option B**.
+
+The current code already treats the runtime dictionary as the handoff between
+provider resolution and CLI construction, and `claude-cli` already has a unique
+resolver branch. Adding a typed contract at that handoff makes the difference
+explicit where it originates while keeping the gate responsible for validation.
+It is not a bypass: the gate still rejects malformed external-process results,
+unknown contract values, unexpected credentials, wrong provider/model routing,
+and all existing invalid HTTP credentials.
+
+Option A is an acceptable emergency minimum but hard-codes the same special case
+in two places. Option C is better suited to a separate provider-contract
+refactor, not this blocked Stage-0 slice. Option D should not be adopted.
+
+## Required verification if Option B is approved
+
+These are acceptance criteria for a later implementation; they are not executed
+or implemented by this document.
+
+1. Resolver tests prove that `claude-cli` returns the typed external-process
+   contract only for the exact `claude-opus-5` pair and still rejects any key or
+   URL.
+2. `_ensure_runtime_credentials` accepts that exact result and updates provider,
+   API mode, source, key, and URL without fabricating values.
+3. `_runtime_credentials_ready` returns true for the same exact result and false
+   for malformed provider/mode/source combinations.
+4. Empty credentials for OpenRouter/API-key providers still fail; keyless local
+   HTTP endpoints and callable bearer-token providers retain existing behavior.
+5. Native `anthropic` still fails without a token and passes with its resolved
+   token and HTTPS base URL.
+6. Unknown credential-contract values fail closed.
+7. Existing `copilot-acp` behavior is unchanged; `auth_type="external_process"`
+   alone does not select the Claude CLI contract.
+8. The dedicated Claude CLI spawn path still runs the version/help capability
+   check and still rejects forbidden flags, tools, non-empty init tools, and
+   invalid process generations.
+9. OCR preview/rule, fresh independent review, and repository quality gates pass
+   on the final implementation diff before any commit or provider activation.
+
+## User decision
+
+Select A, B, or C before implementation. No implementation should begin from
+this document alone.

--- a/docs/development/claude-cli-stage0-probe-2026-08-09.md
+++ b/docs/development/claude-cli-stage0-probe-2026-08-09.md
@@ -1,0 +1,75 @@
+# Claude CLI Stage-0 subprocess probe
+
+Status: **tracked harness available; live managed-wrapper oracle not rerun in this change**
+
+The reproducible harness is `scripts/claude_cli_stage0_probe.py`. It launches
+the official Claude CLI through an approved transparent managed-policy wrapper,
+uses the same fixed argv and environment shaping as the runtime, and emits one
+sanitized JSON object. It never prints prompt/response content, environment
+values, session identifiers, PIDs, credential paths, or raw stderr.
+
+## Exact command
+
+From the repository root on Windows PowerShell:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\claude_cli_stage0_probe.py `
+  --managed-wrapper C:\approved\managed-policy-wrapper.exe `
+  --claude-executable claude
+```
+
+The wrapper must accept the official executable and its argv as separate
+arguments and remain attached for the subprocess lifetime. If it needs fixed,
+non-secret arguments, append one `--wrapper-arg <value>` per argument. Do not
+place credentials, tokens, or environment values in wrapper arguments.
+
+The harness first runs `claude --version` and `claude --help` through that same
+wrapper boundary. It then sends two static user frames over one persistent
+stdin/stdout stream and closes stdin after the second result. `shell=False` is
+used for every child process.
+
+## Environment contract
+
+The child environment enforcement is exact:
+
+- remove every inherited `ANTHROPIC_*` request-shaping variable;
+- remove the named CLI backend selectors `CLAUDE_CODE_USE_BEDROCK` and
+  `CLAUDE_CODE_USE_VERTEX`;
+- deliberately preserve `CLAUDE_CODE_OAUTH_TOKEN` without reading or logging
+  its value, so the official CLI owns authentication;
+- preserve `HOME` and `USERPROFILE`, so the official CLI can resolve its own
+  login/keychain and managed policy.
+
+No wildcard removal of `CLAUDE_CODE_*` variables is performed.
+
+## Evidence semantics
+
+A zero exit status and `"status":"PASS"` require all of these observations in
+the same run:
+
+- `same_child_pid=true`: both turns were handled by the same wrapper/CLI process;
+- `session_consistent=true`: the opaque session identifier was present and
+  stable, but its value was not retained in output;
+- `process_generations=1`;
+- `replay_acknowledgements=2`;
+- `results=2`;
+- `init_tools_empty=true`: the runtime accepted an init event only with
+  `tools=[]`;
+- `tool_events=0`;
+- `forbidden_flags=0` for `--bare`, `--dangerously-skip-permissions`, and
+  `--allow-dangerously-skip-permissions`;
+- `clean_exit=true`: stdin close produced exit code 0;
+- `bounded_exit=true`: cleanup completed within the harness's eight-second
+  upper bound.
+
+Any mismatch returns a nonzero exit status. Capability and protocol failures
+are classified with sanitized messages; raw stderr is never emitted.
+
+## Current evidence
+
+The harness parser/help, syntax, and deterministic evaluator tests are local
+verification only. This change does **not** claim a current live oracle PASS,
+because the tracked harness was not executed through an approved managed-policy
+wrapper in this worktree. A release operator may replace this paragraph with
+the emitted sanitized JSON only after the exact managed-wrapper command above
+returns all required counters.

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -5,11 +5,11 @@ Extracted from ``cli.py`` as part of the god-file decomposition campaign
 the agent lifecycle/setup cluster: runtime-credential resolution, per-turn agent
 config, first-use agent construction, and resumed-session preload + history recap.
 
-Behavior-neutral: every method is lifted verbatim from ``HermesCLI``. ``self.*``
-calls resolve unchanged via the MRO. Neutral dependencies are imported at module
-top level; ``cli.py``-internal helpers/constants are imported lazily inside each
-method (``from cli import ...`` resolves at call time, when ``cli`` is fully
-loaded) so this module never imports ``cli`` at import time -> no import cycle.
+``self.*`` calls resolve unchanged via the MRO. Neutral dependencies are imported
+at module top level; ``cli.py``-internal helpers/constants are imported lazily
+inside each method (``from cli import ...`` resolves at call time, when ``cli``
+is fully loaded) so this module never imports ``cli`` at import time -> no import
+cycle.
 """
 
 from __future__ import annotations
@@ -17,6 +17,52 @@ from __future__ import annotations
 import sys
 
 from rich.markup import escape as _escape
+
+
+def _validate_runtime_credentials(runtime: object) -> tuple[bool, object, str | None]:
+    """Validate and normalize the resolver's typed credential contract.
+
+    Untagged runtimes retain the existing HTTP credential rules. The dedicated
+    external-process contract is deliberately exact so another provider cannot
+    opt into the Claude CLI path by sharing only ``auth_type``.
+    """
+    if not isinstance(runtime, dict):
+        return False, None, "invalid_runtime"
+
+    api_key = runtime.get("api_key")
+    base_url = runtime.get("base_url")
+
+    if "credential_contract" in runtime:
+        if runtime.get("credential_contract") != "external_process":
+            return False, api_key, "unknown_contract"
+        valid_external_process = (
+            runtime.get("provider") == "claude-cli"
+            and runtime.get("api_mode") == "claude_cli"
+            and runtime.get("source") == "external-process"
+            and api_key == ""
+            and base_url == ""
+        )
+        return (
+            valid_external_process,
+            api_key,
+            None if valid_external_process else "invalid_external_process",
+        )
+
+    has_base_url = isinstance(base_url, str) and bool(base_url)
+    is_callable_provider = callable(api_key) and not isinstance(api_key, str)
+    if is_callable_provider or (isinstance(api_key, str) and bool(api_key)):
+        return (
+            has_base_url,
+            api_key,
+            None if has_base_url else "empty_base_url",
+        )
+
+    # Custom/local HTTP endpoints often ignore auth, but the OpenAI SDK still
+    # requires a non-empty value. Preserve the established placeholder.
+    if has_base_url and "openrouter.ai" not in base_url:
+        return True, "no-key-required", None
+
+    return False, api_key, "missing_api_key"
 
 
 class CLIAgentSetupMixin:
@@ -90,27 +136,11 @@ class CLIAgentSetupMixin:
         resolved_acp_command = runtime.get("command")
         resolved_acp_args = list(runtime.get("args") or [])
         resolved_credential_pool = runtime.get("credential_pool")
-        # A callable api_key is a bearer-token provider (Azure Foundry
-        # Entra ID — ``azure_identity_adapter.build_token_provider``).
-        # The OpenAI SDK accepts ``Callable[[], str]`` for ``api_key`` and
-        # invokes it before every request. Skip the string-only validation
-        # and placeholder substitution for callables.
-        _is_callable_provider = callable(api_key) and not isinstance(api_key, str)
-        if not _is_callable_provider and (not isinstance(api_key, str) or not api_key):
-            # Custom / local endpoints (llama.cpp, ollama, vLLM, etc.) often
-            # don't require authentication.  When a base_url IS configured but
-            # no API key was found, use a placeholder so the OpenAI SDK
-            # doesn't reject the request and local servers just ignore it.
-            _source = runtime.get("source", "")
-            _has_custom_base = isinstance(base_url, str) and base_url and "openrouter.ai" not in base_url
-            if _has_custom_base:
-                api_key = "no-key-required"
-                logger.debug(
-                    "No API key for custom endpoint %s (source=%s), "
-                    "using placeholder — local servers typically ignore auth",
-                    base_url, _source,
-                )
-            else:
+        credentials_valid, normalized_api_key, credential_error = (
+            _validate_runtime_credentials(runtime)
+        )
+        if not credentials_valid:
+            if credential_error == "missing_api_key":
                 _prov = (resolved_provider or self.requested_provider or "").strip()
                 if _prov and _prov != "auto":
                     print(f"\n⚠️  No API key found for provider '{_prov}'.")
@@ -119,10 +149,21 @@ class CLIAgentSetupMixin:
                 print("   Run 'hermes model' to choose a provider, or "
                       "'hermes setup' for first-time setup.")
                 return False
-        if not isinstance(base_url, str) or not base_url:
-            print("\n⚠️  Provider resolver returned an empty base URL. "
+            if credential_error == "empty_base_url":
+                print("\n⚠️  Provider resolver returned an empty base URL. "
+                      "Check your provider config or run: hermes setup")
+                return False
+            print("\n⚠️  Provider resolver returned an invalid credential contract. "
                   "Check your provider config or run: hermes setup")
             return False
+        if normalized_api_key == "no-key-required" and api_key != normalized_api_key:
+            logger.debug(
+                "No API key for custom endpoint %s (source=%s), "
+                "using placeholder — local servers typically ignore auth",
+                base_url,
+                runtime.get("source", ""),
+            )
+        api_key = normalized_api_key
 
         credentials_changed = api_key != self.api_key or base_url != self.base_url
         routing_changed = (
@@ -203,20 +244,8 @@ class CLIAgentSetupMixin:
             )
         except Exception:
             return False
-        if not isinstance(runtime, dict):
-            return False
-        api_key = runtime.get("api_key")
-        base_url = runtime.get("base_url")
-        if callable(api_key) and not isinstance(api_key, str):
-            return bool(base_url)
-        if isinstance(api_key, str) and api_key:
-            return bool(base_url)
-        # Keyless custom/local endpoints (ollama, llama.cpp, vLLM…) are fine.
-        return bool(
-            isinstance(base_url, str)
-            and base_url
-            and "openrouter.ai" not in base_url
-        )
+        credentials_valid, _, _ = _validate_runtime_credentials(runtime)
+        return credentials_valid
 
     def _offer_first_run_setup(self) -> bool:
         """Offer the provider picker when no provider is configured at all.

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -393,6 +393,7 @@ _VALID_API_MODES = {
     # `model.openai_runtime == "codex_app_server"` AND provider in
     # {"openai", "openai-codex"}. Default is unchanged.
     "codex_app_server",
+    "claude_cli",
 }
 
 
@@ -1701,6 +1702,36 @@ def resolve_runtime_provider(
                 f"provider {requested_provider!r} is disabled in config "
                 f"(providers.{requested_provider}.enabled: false)"
             )
+
+    _claude_model_cfg = _get_model_config()
+    _configured_provider = str(
+        _claude_model_cfg.get("provider") or ""
+    ).strip().lower()
+    _claude_cli_explicit = requested_provider in {"claude-cli", "claude_cli"} or (
+        requested_provider == "auto"
+        and _configured_provider in {"claude-cli", "claude_cli"}
+    )
+    if _claude_cli_explicit:
+        if explicit_api_key or _claude_model_cfg.get("api_key"):
+            raise ValueError("claude-cli does not accept api_key")
+        if explicit_base_url or _claude_model_cfg.get("base_url"):
+            raise ValueError("claude-cli does not accept base_url")
+        _claude_target_model = target_model or str(
+            _claude_model_cfg.get("default") or ""
+        ).strip()
+        if _claude_target_model != "claude-opus-5":
+            raise ValueError(
+                "claude-cli Stage 0 requires the exact provider/model pair "
+                "provider=claude-cli, model=claude-opus-5"
+            )
+        return {
+            "provider": "claude-cli",
+            "api_mode": "claude_cli",
+            "base_url": "",
+            "api_key": "",
+            "source": "external-process",
+            "requested_provider": "claude-cli",
+        }
 
     if requested_provider == "moa":
         return {

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1730,6 +1730,7 @@ def resolve_runtime_provider(
             "base_url": "",
             "api_key": "",
             "source": "external-process",
+            "credential_contract": "external_process",
             "requested_provider": "claude-cli",
         }
 

--- a/plugins/model-providers/claude-cli/__init__.py
+++ b/plugins/model-providers/claude-cli/__init__.py
@@ -1,0 +1,27 @@
+"""Official Claude CLI external-process provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClaudeCLIProfile(ProviderProfile):
+    def fetch_models(self, *, api_key=None, base_url=None, timeout=8.0):
+        del api_key, base_url, timeout
+        return ["claude-opus-5"]
+
+
+claude_cli = ClaudeCLIProfile(
+    name="claude-cli",
+    aliases=("claude_cli",),
+    api_mode="claude_cli",
+    env_vars=(),
+    base_url="",
+    auth_type="external_process",
+    supports_health_check=False,
+    supports_vision=False,
+    fallback_models=("claude-opus-5",),
+    display_name="Claude CLI",
+    description="Official Claude CLI via the existing local login and policy boundary",
+)
+
+register_provider(claude_cli)

--- a/plugins/model-providers/claude-cli/plugin.yaml
+++ b/plugins/model-providers/claude-cli/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-cli-provider
+kind: model-provider
+version: 1.0.0
+description: Official Claude CLI persistent subprocess provider
+author: Nous Research

--- a/run_agent.py
+++ b/run_agent.py
@@ -3168,6 +3168,20 @@ class AIAgent:
                         exc_info=True,
                     )
 
+        # Stage 0 has no claimed native cancellation frame. Retire the child
+        # process so a stop cannot leak late deltas into a later turn.
+        if getattr(self, "api_mode", None) == "claude_cli":
+            _claude_session = getattr(self, "_claude_cli_session", None)
+            _request_interrupt = getattr(_claude_session, "request_interrupt", None)
+            if callable(_request_interrupt):
+                try:
+                    _request_interrupt()
+                except Exception:
+                    logger.debug(
+                        "Failed to retire Claude CLI subprocess during interrupt",
+                        exc_info=True,
+                    )
+
         # A cron turn performs its API request on the conversation thread to
         # avoid the nested interrupt-worker deadlock.  Unlike the normal worker
         # path, its client is registered here so this cross-thread interrupt can
@@ -4384,6 +4398,17 @@ class AIAgent:
             if codex_session is not None:
                 self._codex_session = None
                 codex_session.close()
+        except Exception:
+            pass
+
+        # 6d. Close the persistent official Claude CLI subprocess. As above,
+        # clear the attribute before close so repeated/concurrent teardown is
+        # idempotent and cannot reuse a half-closed session.
+        try:
+            claude_cli_session = getattr(self, "_claude_cli_session", None)
+            if claude_cli_session is not None:
+                self._claude_cli_session = None
+                claude_cli_session.close()
         except Exception:
             pass
 
@@ -8082,6 +8107,26 @@ class AIAgent:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
+    def _run_claude_cli_turn(
+        self,
+        user_message,
+        original_user_message,
+        messages,
+        effective_task_id,
+        should_review_memory=False,
+    ):
+        """Forwarder for the official Claude CLI special runtime."""
+        from agent.transports.claude_cli import run_claude_cli_turn
+
+        return run_claude_cli_turn(
+            self,
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=should_review_memory,
+        )
 
 def main(
     query: str = None,

--- a/scripts/claude_cli_stage0_probe.py
+++ b/scripts/claude_cli_stage0_probe.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Sanitized live oracle for the Claude CLI Stage-0 subprocess contract.
+
+The managed wrapper is a transparent launcher: the harness appends the official
+Claude executable and fixed Stage-0 argv, never invokes a shell, and emits only
+bounded counters/booleans. Prompt text, response text, environment values,
+session identifiers, PIDs, and raw stderr are never printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from agent.transports.claude_cli import (  # noqa: E402
+    CLAUDE_CLI_FORBIDDEN_FLAGS,
+    CLAUDE_CLI_MIN_VERSION,
+    ClaudeCLIClient,
+    ClaudeCLIError,
+    ClaudeCLITurnResult,
+    build_claude_cli_env,
+    parse_claude_cli_help,
+    parse_claude_cli_version,
+)
+
+_CAPABILITY_TIMEOUT_SECONDS = 10.0
+_FIRST_EVENT_TIMEOUT_SECONDS = 30.0
+_IDLE_TIMEOUT_SECONDS = 60.0
+_TOTAL_TIMEOUT_SECONDS = 300.0
+_CLEAN_EXIT_GRACE_SECONDS = 1.0
+_CLEAN_EXIT_TERMINATE_SECONDS = 2.0
+_BOUNDED_EXIT_SECONDS = 8.0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the official Claude CLI through an approved managed-policy "
+            "wrapper and print sanitized Stage-0 evidence."
+        )
+    )
+    parser.add_argument(
+        "--managed-wrapper",
+        required=True,
+        help="Transparent policy-wrapper executable (no shell command string).",
+    )
+    parser.add_argument(
+        "--wrapper-arg",
+        action="append",
+        default=[],
+        help="Non-secret wrapper argument; repeat to preserve argument boundaries.",
+    )
+    parser.add_argument(
+        "--claude-executable",
+        default="claude",
+        help="Official Claude CLI executable passed to the wrapper (default: claude).",
+    )
+    return parser
+
+
+def _boundary_prefix(args: argparse.Namespace) -> list[str]:
+    return [args.managed_wrapper, *args.wrapper_arg, args.claude_executable]
+
+
+def _check_capabilities(prefix: Sequence[str], env: dict[str, str]) -> str:
+    completed = []
+    for flag in ("--version", "--help"):
+        try:
+            proc = subprocess.run(
+                [*prefix, flag],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                timeout=_CAPABILITY_TIMEOUT_SECONDS,
+                env=env,
+                shell=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ClaudeCLIError(
+                "managed Claude CLI capability check could not complete",
+                category="unavailable",
+            ) from exc
+        completed.append(proc)
+    if any(proc.returncode != 0 for proc in completed):
+        raise ClaudeCLIError(
+            "managed Claude CLI capability check failed", category="unavailable"
+        )
+
+    version_text = completed[0].stdout.decode("utf-8", "replace")
+    help_text = completed[1].stdout.decode("utf-8", "replace")
+    version = parse_claude_cli_version(version_text)
+    if version is None or version < CLAUDE_CLI_MIN_VERSION:
+        raise ClaudeCLIError(
+            "managed Claude CLI version is below the Stage-0 minimum",
+            category="unavailable",
+        )
+    if not parse_claude_cli_help(help_text).stage0_ready:
+        raise ClaudeCLIError(
+            "managed Claude CLI is missing required Stage-0 capabilities",
+            category="unavailable",
+        )
+    return ".".join(str(part) for part in version)
+
+
+def evaluate_probe(
+    *,
+    version: str,
+    first: ClaudeCLITurnResult,
+    second: ClaudeCLITurnResult,
+    first_pid: int | None,
+    second_pid: int | None,
+    spawned_argv: Sequence[str],
+    returncode: int | None,
+    cleanup_seconds: float,
+) -> dict[str, Any]:
+    """Evaluate only sanitized observations; never include content or identifiers."""
+    turns = (first, second)
+    replay_acknowledgements = sum(
+        turn.event_counts.get("user", 0) for turn in turns
+    )
+    results = sum(turn.event_counts.get("result", 0) for turn in turns)
+    tool_events = sum(
+        count
+        for turn in turns
+        for event_type, count in turn.event_counts.items()
+        if "tool" in event_type.lower()
+    )
+    forbidden_flags = sum(
+        1 for token in spawned_argv if token in CLAUDE_CLI_FORBIDDEN_FLAGS
+    )
+    same_child_pid = first_pid is not None and first_pid == second_pid
+    session_consistent = bool(
+        first.session_id and first.session_id == second.session_id
+    )
+    process_generations = len({first.generation, second.generation})
+    init_tools_empty = first.event_counts.get("system", 0) >= 1
+    clean_exit = returncode == 0
+    bounded_exit = cleanup_seconds <= _BOUNDED_EXIT_SECONDS
+
+    passed = all(
+        (
+            same_child_pid,
+            session_consistent,
+            process_generations == 1,
+            replay_acknowledgements == 2,
+            results == 2,
+            init_tools_empty,
+            tool_events == 0,
+            forbidden_flags == 0,
+            clean_exit,
+            bounded_exit,
+            not first.interrupted,
+            not second.interrupted,
+        )
+    )
+    return {
+        "status": "PASS" if passed else "FAIL",
+        "version": version,
+        "same_child_pid": same_child_pid,
+        "session_consistent": session_consistent,
+        "process_generations": process_generations,
+        "replay_acknowledgements": replay_acknowledgements,
+        "results": results,
+        "init_tools_empty": init_tools_empty,
+        "tool_events": tool_events,
+        "forbidden_flags": forbidden_flags,
+        "clean_exit": clean_exit,
+        "bounded_exit": bounded_exit,
+    }
+
+
+def run_probe(args: argparse.Namespace) -> dict[str, Any]:
+    env = build_claude_cli_env()
+    prefix = _boundary_prefix(args)
+    version = _check_capabilities(prefix, env)
+    spawned: list[list[str]] = []
+
+    def spawn(argv: Sequence[str], **kwargs: Any) -> subprocess.Popen[bytes]:
+        boundary_argv = [*prefix, *list(argv)[1:]]
+        spawned.append(boundary_argv)
+        return subprocess.Popen(boundary_argv, **kwargs)
+
+    client = ClaudeCLIClient(env=env, popen_factory=spawn)
+    proc: subprocess.Popen[bytes] | None = None
+    try:
+        first = client.run_turn(
+            "Reply with the single word one.",
+            first_event_timeout=_FIRST_EVENT_TIMEOUT_SECONDS,
+            idle_timeout=_IDLE_TIMEOUT_SECONDS,
+            total_timeout=_TOTAL_TIMEOUT_SECONDS,
+        )
+        first_pid = client.pid
+        second = client.run_turn(
+            "Reply with the single word two.",
+            first_event_timeout=_FIRST_EVENT_TIMEOUT_SECONDS,
+            idle_timeout=_IDLE_TIMEOUT_SECONDS,
+            total_timeout=_TOTAL_TIMEOUT_SECONDS,
+        )
+        second_pid = client.pid
+        proc = client._proc
+    finally:
+        cleanup_started = time.monotonic()
+        client.close(
+            grace=_CLEAN_EXIT_GRACE_SECONDS,
+            terminate_timeout=_CLEAN_EXIT_TERMINATE_SECONDS,
+        )
+        cleanup_seconds = time.monotonic() - cleanup_started
+
+    return evaluate_probe(
+        version=version,
+        first=first,
+        second=second,
+        first_pid=first_pid,
+        second_pid=second_pid,
+        spawned_argv=spawned[0] if spawned else (),
+        returncode=getattr(proc, "returncode", None),
+        cleanup_seconds=cleanup_seconds,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        result = run_probe(args)
+    except ClaudeCLIError as exc:
+        result = {
+            "status": "FAIL",
+            "error_category": exc.category,
+            "error": str(exc),
+        }
+    except Exception:
+        result = {
+            "status": "FAIL",
+            "error_category": "harness",
+            "error": "Stage-0 probe could not complete",
+        }
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0 if result.get("status") == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/transports/test_claude_cli.py
+++ b/tests/agent/transports/test_claude_cli.py
@@ -226,6 +226,80 @@ def test_two_turns_use_same_process_and_session_with_ordered_deltas():
     assert process.returncode == 0
 
 
+def test_completed_session_refuses_silent_respawn_after_process_exit():
+    first_process = FakeProcess(_turn("session-one", "first", include_init=True))
+    replacement_process = FakeProcess(
+        _turn("session-two", "replacement", include_init=True)
+    )
+    processes = [first_process, replacement_process]
+    spawns = []
+
+    def popen(argv, **kwargs):
+        process = processes[len(spawns)]
+        spawns.append((argv, kwargs))
+        return process
+
+    client = ClaudeCLIClient(popen_factory=popen, env={"HOME": "x"})
+    assert client.run_turn("first").final_text == "first"
+    first_process.returncode = 1
+
+    with pytest.raises(ClaudeCLIError, match="refusing to respawn.*context"):
+        client.run_turn("second")
+
+    assert len(spawns) == 1
+    assert client.completed_turns == 1
+    client.close()
+
+
+@pytest.mark.parametrize(
+    ("replacement_events", "match"),
+    [
+        (_turn("respawned", "unexpected", include_init=False), "Stage-0 initialization"),
+        (
+            [
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "session_id": "respawned",
+                    "tools": ["Read"],
+                },
+                {"type": "user", "session_id": "respawned"},
+                {
+                    "type": "result",
+                    "session_id": "respawned",
+                    "result": "unexpected",
+                    "is_error": False,
+                },
+            ],
+            "zero-tool",
+        ),
+    ],
+)
+def test_retry_generation_requires_fresh_zero_tool_initialization(
+    replacement_events, match
+):
+    first_process = FakeProcess([])
+    replacement_process = FakeProcess(replacement_events)
+    processes = [first_process, replacement_process]
+    spawns = []
+
+    def popen(*args, **kwargs):
+        del args, kwargs
+        process = processes[len(spawns)]
+        spawns.append(process)
+        return process
+
+    session = ClaudeCLISession(popen_factory=popen, env={"HOME": "x"})
+
+    with pytest.raises(ClaudeCLIError, match=match):
+        session.run_turn("input")
+
+    assert spawns == processes
+    assert session.client is not None
+    assert session.client.generation == 2
+    session.close()
+
+
 @pytest.mark.parametrize(
     "events,match",
     [

--- a/tests/agent/transports/test_claude_cli.py
+++ b/tests/agent/transports/test_claude_cli.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports.claude_cli import (
+    CLAUDE_CLI_FORBIDDEN_FLAGS,
+    ClaudeCLIBusyError,
+    ClaudeCLIClient,
+    ClaudeCLIError,
+    ClaudeCLISession,
+    ClaudeCLITransport,
+    build_claude_cli_argv,
+    build_claude_cli_env,
+    check_claude_cli_available,
+    parse_claude_cli_help,
+    parse_claude_cli_version,
+)
+
+
+def _line(event):
+    if isinstance(event, bytes):
+        return event + b"\n"
+    return json.dumps(event).encode() + b"\n"
+
+
+def _turn(session_id, text, *, include_init=False):
+    events = []
+    if include_init:
+        events.append(
+            {"type": "system", "subtype": "init", "session_id": session_id, "tools": []}
+        )
+    events.extend(
+        [
+            {"type": "user", "session_id": session_id},
+            {
+                "type": "stream_event",
+                "session_id": session_id,
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": text},
+                },
+            },
+            {
+                "type": "result",
+                "session_id": session_id,
+                "is_error": False,
+                "result": text,
+                "usage": {"input_tokens": 2, "output_tokens": 1},
+            },
+        ]
+    )
+    return events
+
+
+class FakeProcess:
+    next_pid = 4000
+
+    def __init__(self, events):
+        type(self).next_pid += 1
+        self.pid = type(self).next_pid
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO(b"".join(_line(event) for event in events))
+        self.stderr = io.BytesIO()
+        self.returncode = None
+        self.terminate_calls = 0
+        self.kill_calls = 0
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        del timeout
+        if self.stdin.closed:
+            self.returncode = 0
+            return 0
+        raise subprocess.TimeoutExpired("claude", 0)
+
+    def terminate(self):
+        self.terminate_calls += 1
+        self.returncode = 0
+
+    def kill(self):
+        self.kill_calls += 1
+        self.returncode = -9
+
+
+def test_fixed_argv_is_exact_shell_safe_and_stage0_only():
+    argv = build_claude_cli_argv("claude-opus-5")
+    assert argv == [
+        "claude",
+        "-p",
+        "--verbose",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        "--replay-user-messages",
+        "--model",
+        "claude-opus-5",
+        "--tools",
+        "",
+        "--strict-mcp-config",
+    ]
+    assert not CLAUDE_CLI_FORBIDDEN_FLAGS.intersection(argv)
+    with pytest.raises(ValueError, match="only model"):
+        build_claude_cli_argv("claude-sonnet-5")
+
+
+def test_env_strips_request_and_cli_backend_shaping_but_preserves_cli_oauth():
+    env = build_claude_cli_env(
+        {
+            "HOME": "home-marker",
+            "USERPROFILE": "profile-marker",
+            "PATH": "path-marker",
+            "ANTHROPIC_API_KEY": "secret-marker",
+            "ANTHROPIC_AUTH_TOKEN": "secret-marker",
+            "ANTHROPIC_BASE_URL": "endpoint-marker",
+            "ANTHROPIC_MODEL": "model-marker",
+            "ANTHROPIC_CUSTOM_SHAPING": "shape-marker",
+            "CLAUDE_CODE_USE_BEDROCK": "1",
+            "CLAUDE_CODE_USE_VERTEX": "1",
+            "CLAUDE_CODE_OAUTH_TOKEN": "oauth-marker",
+        }
+    )
+    assert env["HOME"] == "home-marker"
+    assert env["USERPROFILE"] == "profile-marker"
+    assert env["PATH"] == "path-marker"
+    assert not any(key.startswith("ANTHROPIC_") for key in env)
+    assert "CLAUDE_CODE_USE_BEDROCK" not in env
+    assert "CLAUDE_CODE_USE_VERTEX" not in env
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-marker"
+
+
+def test_version_and_help_capability_parsers_fail_closed():
+    assert parse_claude_cli_version("2.1.221 (Claude Code)") == (2, 1, 221)
+    assert parse_claude_cli_version("unknown") is None
+    help_text = " ".join(
+        [
+            "--input-format stream-json",
+            "--output-format stream-json",
+            "--include-partial-messages",
+            "--replay-user-messages",
+            "--model",
+            "--tools",
+            "--verbose",
+            "--strict-mcp-config",
+        ]
+    )
+    assert parse_claude_cli_help(help_text).stage0_ready is True
+    assert parse_claude_cli_help("--input-format stream-json").stage0_ready is False
+
+
+def test_availability_gate_checks_version_and_help_shell_free(monkeypatch):
+    calls = []
+    help_text = " ".join(
+        [
+            "--input-format stream-json",
+            "--output-format stream-json",
+            "--include-partial-messages",
+            "--replay-user-messages",
+            "--model",
+            "--tools",
+            "--verbose",
+            "--strict-mcp-config",
+        ]
+    )
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        stdout = "2.1.221 (Claude Code)" if argv[-1] == "--version" else help_text
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("agent.transports.claude_cli.subprocess.run", run)
+    assert check_claude_cli_available() == (True, "2.1.221")
+    assert [call[0] for call in calls] == [
+        ["claude", "--version"],
+        ["claude", "--help"],
+    ]
+    assert all(call[1]["shell"] is False for call in calls)
+
+
+def test_real_spawn_path_fails_closed_when_capability_gate_fails(monkeypatch):
+    monkeypatch.setattr(
+        "agent.transports.claude_cli.check_claude_cli_available",
+        lambda: (False, "capability unavailable"),
+    )
+    client = ClaudeCLIClient(env={"HOME": "x"})
+    with pytest.raises(ClaudeCLIError, match="capability unavailable"):
+        client.start()
+    assert client.pid is None
+
+
+def test_two_turns_use_same_process_and_session_with_ordered_deltas():
+    process = FakeProcess(
+        _turn("session-one", "A", include_init=True) + _turn("session-one", "B")
+    )
+    spawns = []
+
+    def popen(argv, **kwargs):
+        spawns.append((argv, kwargs))
+        return process
+
+    client = ClaudeCLIClient(popen_factory=popen, env={"HOME": "x"})
+    deltas = []
+    first = client.run_turn("first", on_delta=deltas.append)
+    first_pid = client.pid
+    assert client.is_alive()
+    second = client.run_turn("second", on_delta=deltas.append)
+    assert client.pid == first_pid
+    assert first.session_id == second.session_id == "session-one"
+    assert first.generation == second.generation == 1
+    assert first.final_text == "A"
+    assert second.final_text == "B"
+    assert deltas == ["A", "B"]
+    assert len(spawns) == 1
+    assert spawns[0][1]["shell"] is False
+    client.close()
+    client.close()
+    assert process.returncode == 0
+
+
+@pytest.mark.parametrize(
+    "events,match",
+    [
+        ([b"not-json"], "malformed"),
+        (
+            [
+                {"type": "system", "subtype": "init", "session_id": "one", "tools": []},
+                {"type": "user", "session_id": "one"},
+                {"type": "result", "session_id": "two", "result": "x"},
+            ],
+            "correlation",
+        ),
+        (
+            [
+                {"type": "system", "subtype": "init", "session_id": "one", "tools": ["Read"]},
+            ],
+            "zero-tool",
+        ),
+    ],
+)
+def test_protocol_and_capability_failures_are_closed(events, match):
+    client = ClaudeCLIClient(
+        popen_factory=lambda *a, **k: FakeProcess(events), env={"HOME": "x"}
+    )
+    with pytest.raises(ClaudeCLIError, match=match):
+        client.run_turn("input")
+    client.close()
+
+
+def test_pre_output_eof_retries_once_but_post_output_does_not():
+    processes = [
+        FakeProcess([]),
+        FakeProcess(_turn("stable", "ok", include_init=True)),
+    ]
+    calls = []
+
+    def factory(*args, **kwargs):
+        del args, kwargs
+        calls.append(1)
+        return processes[len(calls) - 1]
+
+    session = ClaudeCLISession(popen_factory=factory, env={"HOME": "x"})
+    retried = session.run_turn("input")
+    assert retried.final_text == "ok"
+    assert retried.generation == 2
+    assert len(calls) == 2
+    session.close()
+
+    partial = _turn("partial", "seen", include_init=True)[:-1]
+    calls.clear()
+    session = ClaudeCLISession(
+        popen_factory=lambda *a, **k: (calls.append(1) or FakeProcess(partial)),
+        env={"HOME": "x"},
+    )
+    with pytest.raises(ClaudeCLIError) as exc:
+        session.run_turn("input")
+    assert exc.value.visible_output is True
+    assert len(calls) == 1
+
+
+def test_busy_rejection_preserves_active_client_process_and_stdin():
+    process = FakeProcess([])
+    client = ClaudeCLIClient(popen_factory=lambda *a, **k: process, env={"HOME": "x"})
+    client._proc = process
+    client._generation = 1
+    session = ClaudeCLISession(env={"HOME": "x"})
+    session._client = client
+    client._turn_lock.acquire()
+    try:
+        with pytest.raises(ClaudeCLIBusyError):
+            session.run_turn("concurrent")
+
+        assert session.client is client
+        assert client._proc is process
+        assert client.is_alive()
+        assert process.stdin.closed is False
+    finally:
+        client._turn_lock.release()
+        session.close()
+
+
+def test_interrupt_during_pre_output_failure_never_respawns_or_resends(monkeypatch):
+    entered = threading.Event()
+    interrupted = threading.Event()
+    instances = []
+
+    class BlockingClient:
+        def __init__(self, **kwargs):
+            del kwargs
+            self.completed_turns = 0
+            self._cancelled = False
+            self.calls = []
+            instances.append(self)
+
+        def run_turn(self, text, **kwargs):
+            del kwargs
+            self.calls.append(text)
+            entered.set()
+            assert interrupted.wait(timeout=1.0)
+            raise ClaudeCLIError(
+                "synthetic pipe closure", transient=True, category="pipe"
+            )
+
+        def request_interrupt(self):
+            self._cancelled = True
+            interrupted.set()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("agent.transports.claude_cli.ClaudeCLIClient", BlockingClient)
+    session = ClaudeCLISession(env={"HOME": "x"})
+    errors = []
+
+    def run():
+        try:
+            session.run_turn("once")
+        except ClaudeCLIError as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    assert entered.wait(timeout=1.0)
+    session.request_interrupt()
+    worker.join(timeout=1.0)
+
+    assert not worker.is_alive()
+    assert len(instances) == 1
+    assert instances[0].calls == ["once"]
+    assert len(errors) == 1
+
+
+def test_close_racing_reader_thread_start_does_not_raise(monkeypatch):
+    process = FakeProcess([])
+    real_thread = threading.Thread
+    second_reader_constructing = threading.Event()
+    allow_second_reader = threading.Event()
+    reader_count = 0
+
+    def gated_reader_thread(*args, **kwargs):
+        nonlocal reader_count
+        reader_count += 1
+        if reader_count == 2:
+            second_reader_constructing.set()
+            assert allow_second_reader.wait(timeout=1.0)
+        return real_thread(*args, **kwargs)
+
+    monkeypatch.setattr("agent.transports.claude_cli.threading.Thread", gated_reader_thread)
+    client = ClaudeCLIClient(popen_factory=lambda *a, **k: process, env={"HOME": "x"})
+    errors = []
+
+    def call(method):
+        try:
+            method()
+        except Exception as exc:  # pragma: no branch - asserted below
+            errors.append(exc)
+
+    starter = real_thread(target=call, args=(client.start,))
+    starter.start()
+    assert second_reader_constructing.wait(timeout=1.0)
+    closer = real_thread(target=call, args=(client.close,))
+    closer.start()
+    allow_second_reader.set()
+    starter.join(timeout=1.0)
+    closer.join(timeout=1.0)
+
+    assert not starter.is_alive()
+    assert not closer.is_alive()
+    assert errors == []
+    assert process.returncode == 0
+
+
+def test_first_event_timeout_and_interrupt_close_are_bounded(monkeypatch):
+    process = FakeProcess([])
+    client = ClaudeCLIClient(env={"HOME": "x"})
+    client._proc = process
+    client._generation = 1
+    monkeypatch.setattr(client, "start", lambda: None)
+    with pytest.raises(ClaudeCLIError, match="idle"):
+        client.run_turn("input", first_event_timeout=0.01, total_timeout=0.1)
+    client.request_interrupt()
+    client.close()
+    assert process.returncode == 0
+
+
+def test_transport_rejects_tools_keys_urls_and_non_text():
+    transport = ClaudeCLITransport()
+    with pytest.raises(ValueError, match="tools"):
+        transport.build_kwargs(
+            "claude-opus-5", [{"role": "user", "content": "x"}], tools=[{"x": 1}]
+        )
+    with pytest.raises(ValueError, match="api_key"):
+        transport.build_kwargs(
+            "claude-opus-5",
+            [{"role": "user", "content": "x"}],
+            api_key="not-allowed",
+        )
+    with pytest.raises(ValueError, match="text-only"):
+        transport.build_kwargs(
+            "claude-opus-5", [{"role": "user", "content": [{"type": "image"}]}]
+        )

--- a/tests/cli/test_cli_first_run_setup.py
+++ b/tests/cli/test_cli_first_run_setup.py
@@ -137,6 +137,73 @@ def test_credentials_ready_true_for_callable_bearer_provider(monkeypatch):
     assert shell._runtime_credentials_ready() is True
 
 
+def test_credentials_ready_true_for_exact_external_process_contract(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: {
+            "provider": "claude-cli",
+            "api_mode": "claude_cli",
+            "api_key": "",
+            "base_url": "",
+            "source": "external-process",
+            "credential_contract": "external_process",
+        },
+    )
+    shell = _make_shell(cli, monkeypatch)
+    assert shell._runtime_credentials_ready() is True
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"provider": "copilot-acp"},
+        {"api_mode": "chat_completions"},
+        {"source": "env/config"},
+        {"api_key": "not-allowed"},
+        {"base_url": "https://not-allowed.invalid"},
+    ],
+)
+def test_credentials_ready_false_for_malformed_external_process_contract(
+    monkeypatch, override
+):
+    cli = _import_cli()
+    runtime = {
+        "provider": "claude-cli",
+        "api_mode": "claude_cli",
+        "api_key": "",
+        "base_url": "",
+        "source": "external-process",
+        "credential_contract": "external_process",
+    }
+    runtime.update(override)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: runtime,
+    )
+    shell = _make_shell(cli, monkeypatch)
+    assert shell._runtime_credentials_ready() is False
+
+
+def test_credentials_ready_fails_closed_for_unknown_contract(monkeypatch):
+    cli = _import_cli()
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "api_key": "sk-test",
+            "base_url": "https://example.invalid/v1",
+            "source": "test",
+            "credential_contract": "future_contract",
+        },
+    )
+    shell = _make_shell(cli, monkeypatch)
+    assert shell._runtime_credentials_ready() is False
+
+
 def test_credentials_ready_never_prints(monkeypatch, capsys):
     cli = _import_cli()
 
@@ -250,3 +317,32 @@ def test_empty_key_error_names_actual_provider(monkeypatch, capsys):
     assert "fireworks" in out
     assert "OPENROUTER_API_KEY" not in out
     assert "hermes model" in out or "hermes setup" in out
+
+
+def test_ensure_runtime_credentials_accepts_exact_external_process_contract(
+    monkeypatch, capsys
+):
+    cli = _import_cli()
+    runtime = {
+        "provider": "claude-cli",
+        "api_mode": "claude_cli",
+        "api_key": "",
+        "base_url": "",
+        "source": "external-process",
+        "credential_contract": "external_process",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: runtime,
+    )
+    shell = _make_shell(cli, monkeypatch)
+    shell.requested_provider = "claude-cli"
+    shell.model = "claude-opus-5"
+    capsys.readouterr()
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.provider == "claude-cli"
+    assert shell.api_mode == "claude_cli"
+    assert shell._provider_source == "external-process"
+    assert shell.api_key == ""
+    assert shell.base_url == ""

--- a/tests/providers/test_claude_cli_provider.py
+++ b/tests/providers/test_claude_cli_provider.py
@@ -1,0 +1,67 @@
+import pytest
+
+from hermes_cli.runtime_provider import resolve_runtime_provider
+from providers import get_provider_profile
+
+
+def test_claude_cli_provider_profile_is_external_process_and_text_only():
+    profile = get_provider_profile("claude-cli")
+    assert profile is not None
+    assert profile.api_mode == "claude_cli"
+    assert profile.auth_type == "external_process"
+    assert profile.base_url == ""
+    assert profile.env_vars == ()
+    assert profile.supports_vision is False
+    assert profile.fetch_models() == ["claude-opus-5"]
+
+
+def test_explicit_runtime_resolution_requires_exact_pair(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    resolved = resolve_runtime_provider(
+        requested="claude-cli", target_model="claude-opus-5"
+    )
+    assert resolved == {
+        "provider": "claude-cli",
+        "api_mode": "claude_cli",
+        "base_url": "",
+        "api_key": "",
+        "source": "external-process",
+        "requested_provider": "claude-cli",
+    }
+
+    with pytest.raises(ValueError, match="exact provider/model pair"):
+        resolve_runtime_provider(requested="claude-cli", target_model="claude-sonnet-5")
+    with pytest.raises(ValueError, match="api_key"):
+        resolve_runtime_provider(
+            requested="claude-cli",
+            target_model="claude-opus-5",
+            explicit_api_key="not-allowed",
+        )
+    with pytest.raises(ValueError, match="base_url"):
+        resolve_runtime_provider(
+            requested="claude-cli",
+            target_model="claude-opus-5",
+            explicit_base_url="https://not-allowed.invalid",
+        )
+
+
+def test_configured_provider_is_explicit_but_auto_remains_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {"provider": "claude-cli", "default": "claude-opus-5"},
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    resolved = resolve_runtime_provider(requested="auto")
+    assert resolved["provider"] == "claude-cli"
+    assert resolved["api_mode"] == "claude_cli"
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._get_model_config",
+        lambda: {
+            "provider": "claude-cli",
+            "default": "claude-opus-5",
+            "base_url": "https://not-allowed.invalid",
+        },
+    )
+    with pytest.raises(ValueError, match="base_url"):
+        resolve_runtime_provider(requested="auto")

--- a/tests/providers/test_claude_cli_provider.py
+++ b/tests/providers/test_claude_cli_provider.py
@@ -26,6 +26,7 @@ def test_explicit_runtime_resolution_requires_exact_pair(monkeypatch):
         "base_url": "",
         "api_key": "",
         "source": "external-process",
+        "credential_contract": "external_process",
         "requested_provider": "claude-cli",
     }
 

--- a/tests/run_agent/test_callable_api_key.py
+++ b/tests/run_agent/test_callable_api_key.py
@@ -235,32 +235,29 @@ class TestBatchRunnerCallableHandling:
 
 
 class TestCliEnsureRuntimeCredentialsCallable:
-    """Regression: ``cli.py:_ensure_runtime_credentials`` previously
-    treated a callable ``api_key`` as "not a string" and overwrote it
-    with the ``"no-key-required"`` placeholder, which then got sent as
-    ``Authorization: Bearer no-key-required`` and rejected by Azure
-    with a 401. This is the most subtle of the callable-api_key audit
-    sites — gated by ``not isinstance(api_key, str)`` rather than the
-    cleaner ``callable(...)`` check used elsewhere.
+    """Regression: runtime credential validation preserves callable keys.
 
-    We verify the source pattern (rather than spinning up a real
-    ``HermesCLI`` instance) — the predicate change is the load-bearing
-    fix and is invariant under the surrounding orchestration code."""
+    A callable ``api_key`` is an Entra bearer-token provider. It must remain
+    callable rather than being normalized to the ``"no-key-required"``
+    placeholder, which would be sent to Azure and rejected with a 401.
+    """
 
-    def test_callable_predicate_present_in_cli_runtime_validation(self):
-        from pathlib import Path
-        # ``_ensure_runtime_credentials`` was extracted from cli.py into the
-        # ``CLIAgentSetupMixin`` (god-file decomposition Phase 4). Read the
-        # module the method actually lives in now.
-        src = (Path(__file__).resolve().parent.parent.parent
-               / "hermes_cli" / "cli_agent_setup_mixin.py").read_text()
-        # The fix introduces ``_is_callable_provider`` which gates the
-        # string-only check so callable token providers survive.
-        assert "_is_callable_provider = callable(api_key)" in src, (
-            "_ensure_runtime_credentials must preserve a callable "
-            "api_key (Entra ID bearer provider). Without the guard, the "
-            "callable is stringified to 'no-key-required' and Azure 401s."
+    def test_callable_key_is_preserved_by_cli_runtime_validation(self):
+        from hermes_cli.cli_agent_setup_mixin import _validate_runtime_credentials
+
+        token_provider = lambda: "synthetic-token"
+        valid, normalized_key, error = _validate_runtime_credentials(
+            {
+                "provider": "azure-foundry",
+                "api_key": token_provider,
+                "base_url": "https://foundry.example.invalid/v1",
+                "source": "entra",
+            }
         )
+
+        assert valid is True
+        assert normalized_key is token_provider
+        assert error is None
 
 
 class TestInlinedDisplayMasks:

--- a/tests/run_agent/test_claude_cli_integration.py
+++ b/tests/run_agent/test_claude_cli_integration.py
@@ -1,0 +1,162 @@
+from types import SimpleNamespace
+
+from agent.transports import claude_cli
+
+
+class FakeSession:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.calls = []
+
+    def run_turn(self, text, on_delta=None):
+        self.calls.append(text)
+        if on_delta:
+            on_delta("one")
+            on_delta("two")
+        return claude_cli.ClaudeCLITurnResult(
+            final_text="onetwo",
+            usage={"input_tokens": 3, "output_tokens": 2},
+            session_id="opaque",
+            generation=1,
+        )
+
+    def close(self):
+        return None
+
+
+def _agent(**overrides):
+    values = {
+        "model": "claude-opus-5",
+        "provider": "claude-cli",
+        "base_url": "",
+        "session_cwd": ".",
+        "_claude_cli_session": None,
+        "_session_db": None,
+        "_fire_stream_delta": lambda text: None,
+        "_sync_external_memory_for_turn": lambda **kwargs: None,
+        "_iters_since_skill": 0,
+        "_interrupt_requested": False,
+        "_interrupt_message": None,
+    }
+    values.update(overrides)
+    agent = SimpleNamespace(**values)
+
+    def clear_interrupt():
+        agent._interrupt_requested = False
+        agent._interrupt_message = None
+
+    agent.clear_interrupt = clear_interrupt
+    return agent
+
+
+def test_special_turn_streams_persists_and_preserves_role_alternation(monkeypatch):
+    monkeypatch.setattr(claude_cli, "ClaudeCLISession", FakeSession)
+    deltas = []
+    persisted = []
+    agent = SimpleNamespace(
+        model="claude-opus-5",
+        provider="claude-cli",
+        base_url="",
+        session_cwd=".",
+        _claude_cli_session=None,
+        _session_db=object(),
+        _fire_stream_delta=deltas.append,
+        _flush_messages_to_session_db=lambda messages: persisted.append(list(messages)),
+        _sync_external_memory_for_turn=lambda **kwargs: None,
+        _iters_since_skill=0,
+    )
+    messages = [{"role": "user", "content": "input"}]
+    result = claude_cli.run_claude_cli_turn(
+        agent,
+        user_message="input",
+        original_user_message="input",
+        messages=messages,
+        effective_task_id="task",
+    )
+    assert deltas == ["one", "two"]
+    assert [message["role"] for message in messages] == ["user", "assistant"]
+    assert messages[-1]["content"] == "onetwo"
+    assert persisted and persisted[-1] == messages
+    assert result["completed"] is True
+    assert result["prompt_tokens"] == 3
+    assert result["completion_tokens"] == 2
+    assert agent._last_turn_usage["total_tokens"] == 5
+
+
+def test_interrupted_turn_result_is_propagated_and_skips_memory(monkeypatch):
+    memory_calls = []
+
+    class InterruptedSession(FakeSession):
+        def run_turn(self, text, on_delta=None):
+            del text, on_delta
+            return claude_cli.ClaudeCLITurnResult(
+                final_text="partial",
+                generation=1,
+                interrupted=True,
+            )
+
+    monkeypatch.setattr(claude_cli, "ClaudeCLISession", InterruptedSession)
+    agent = _agent(
+        _interrupt_requested=True,
+        _interrupt_message="stop now",
+        _sync_external_memory_for_turn=lambda **kwargs: memory_calls.append(kwargs),
+    )
+    messages = [{"role": "user", "content": "input"}]
+
+    result = claude_cli.run_claude_cli_turn(
+        agent,
+        user_message="input",
+        original_user_message="input",
+        messages=messages,
+        effective_task_id="task",
+    )
+
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert result["interrupted"] is True
+    assert result["interrupt_message"] == "stop now"
+    assert agent._interrupt_requested is False
+    assert memory_calls == []
+
+
+def test_successful_non_interrupted_turn_clears_late_interrupt(monkeypatch):
+    monkeypatch.setattr(claude_cli, "ClaudeCLISession", FakeSession)
+    agent = _agent(_interrupt_requested=True, _interrupt_message="late")
+
+    result = claude_cli.run_claude_cli_turn(
+        agent,
+        user_message="input",
+        original_user_message="input",
+        messages=[{"role": "user", "content": "input"}],
+        effective_task_id="task",
+    )
+
+    assert result["completed"] is True
+    assert result["interrupted"] is False
+    assert agent._interrupt_requested is False
+
+
+def test_busy_rejection_does_not_retire_runtime_session():
+    class BusySession:
+        close_calls = 0
+
+        def run_turn(self, text, on_delta=None):
+            del text, on_delta
+            raise claude_cli.ClaudeCLIBusyError("active")
+
+        def close(self):
+            self.close_calls += 1
+
+    session = BusySession()
+    agent = _agent(_claude_cli_session=session)
+    result = claude_cli.run_claude_cli_turn(
+        agent,
+        user_message="input",
+        original_user_message="input",
+        messages=[{"role": "user", "content": "input"}],
+        effective_task_id="task",
+    )
+
+    assert result["completed"] is False
+    assert session.close_calls == 0
+    assert agent._claude_cli_session is session

--- a/tests/scripts/test_claude_cli_stage0_probe.py
+++ b/tests/scripts/test_claude_cli_stage0_probe.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from agent.transports.claude_cli import ClaudeCLITurnResult
+
+
+def _load_probe_module():
+    path = Path(__file__).resolve().parents[2] / "scripts" / "claude_cli_stage0_probe.py"
+    spec = importlib.util.spec_from_file_location("claude_cli_stage0_probe", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stage0_probe_evaluation_requires_exact_sanitized_contract():
+    probe = _load_probe_module()
+    first = ClaudeCLITurnResult(
+        final_text="not inspected",
+        session_id="opaque-session",
+        event_counts={"system": 1, "user": 1, "result": 1},
+        generation=1,
+    )
+    second = ClaudeCLITurnResult(
+        final_text="not inspected",
+        session_id="opaque-session",
+        event_counts={"user": 1, "result": 1},
+        generation=1,
+    )
+
+    result = probe.evaluate_probe(
+        version="2.1.221",
+        first=first,
+        second=second,
+        first_pid=123,
+        second_pid=123,
+        spawned_argv=["wrapper", "claude", "-p", "--tools", ""],
+        returncode=0,
+        cleanup_seconds=0.1,
+    )
+
+    assert result == {
+        "status": "PASS",
+        "version": "2.1.221",
+        "same_child_pid": True,
+        "session_consistent": True,
+        "process_generations": 1,
+        "replay_acknowledgements": 2,
+        "results": 2,
+        "init_tools_empty": True,
+        "tool_events": 0,
+        "forbidden_flags": 0,
+        "clean_exit": True,
+        "bounded_exit": True,
+    }
+    assert "opaque-session" not in str(result)
+    assert "not inspected" not in str(result)
+
+
+def test_stage0_probe_evaluation_fails_for_forbidden_flag_or_unclean_exit():
+    probe = _load_probe_module()
+    turn = ClaudeCLITurnResult(
+        final_text="",
+        session_id="opaque-session",
+        event_counts={"system": 1, "user": 1, "result": 1},
+        generation=1,
+    )
+
+    result = probe.evaluate_probe(
+        version="2.1.221",
+        first=turn,
+        second=turn,
+        first_pid=123,
+        second_pid=123,
+        spawned_argv=["wrapper", "claude", "--dangerously-skip-permissions"],
+        returncode=-1,
+        cleanup_seconds=0.1,
+    )
+
+    assert result["status"] == "FAIL"
+    assert result["forbidden_flags"] == 1
+    assert result["clean_exit"] is False


### PR DESCRIPTION
## Summary

- add an opt-in `claude-cli` model provider backed by a persistent, shell-free external process
- enforce version/help capability checks, fixed argv, zero-tool initialization, session correlation, process-generation checks, and fail-closed lifecycle handling
- add typed `credential_contract="external_process"` resolution for the exact `claude-cli` / `claude-opus-5` runtime tuple
- route `_ensure_runtime_credentials` and `_runtime_credentials_ready` through one shared validator while preserving existing HTTP, Anthropic, callable-token, keyless-local, and copilot-acp behavior
- include a Stage 0 probe, decision record, and focused regression coverage

## Safety properties

- unknown credential contracts fail closed
- API key or base URL injection is rejected for the Claude CLI contract
- forbidden flags, tools, non-empty init tools, and invalid process generations are rejected
- a completed conversation cannot silently respawn into a context-free process after exit
- no provider activation, config change, credential read, or deployment is included

## Verification

- `144 passed` in the focused Claude CLI, credential-gate, provider-resolution, callable-key, and copilot-acp suite
- Ruff: passed
- `git diff --check`: passed
- rebased onto current upstream `main`; `range-diff` reports all three commits patch-equivalent
- OpenCodeReview preview/rule: passed for the reviewed change set
- independent Claude Opus 5 final review: PASS with no blockers
