### PR TITLE
feat(desktop): add Ran Mode focus preset

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -27,7 +27,7 @@ import * as path from 'node:path'
 
 import { _electron, type ElectronApplication, type Page } from '@playwright/test'
 
-import { startMockServer, type MockServerOptions } from './mock-server'
+import { type MockServerOptions, startMockServer } from './mock-server'
 import { installErrorBannerGuard } from './test'
 
 const DESKTOP_ROOT = path.resolve(import.meta.dirname, '..')
@@ -287,7 +287,8 @@ export function findElectron(): string {
   // In dev mode, we use the `electron` binary directly (not the packaged app).
   // The dev:electron script in package.json does exactly this: `electron .`
   // after building. We replicate that here.
-  const localElectron = path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', 'electron')
+  const electronBinary = process.platform === 'win32' ? 'electron.exe' : 'electron'
+  const localElectron = path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', electronBinary)
 
   if (fs.existsSync(localElectron)) {
     return localElectron
@@ -316,25 +317,55 @@ export function findElectron(): string {
  */
 export async function launchDesktop(
   env: Record<string, string>,
+  onWindow?: (page: Page) => void,
 ): Promise<{ app: ElectronApplication; page: Page }> {
   assertDistBuilt()
 
   const electronBin = findElectron()
 
-  // `electron .` loads from the package.json `main` field
-  // (dist/electron-main.mjs after build).
+  // Production main installs the bounded E2E startup observer before creating
+  // any window. This closes the interval before Playwright receives a Page.
   const app = await _electron.launch({
     executablePath: electronBin,
     args: [
-      DESKTOP_ROOT, // `electron .` — the `.` is the desktop package dir
+      DESKTOP_ROOT,
       '--disable-gpu',
       '--no-sandbox',
     ],
-    env,
+    env: {
+      ...env,
+      HERMES_E2E_OBSERVE_RENDERER_STARTUP: '1',
+    },
     cwd: DESKTOP_ROOT,
   })
 
+  if (onWindow) {
+    // Later HUD/secondary/peer windows are observed before test actions can
+    // trigger their creation. The require-hook above covers earlier startup.
+    app.on('window', onWindow)
+  }
+
   const page = await app.firstWindow()
+
+  onWindow?.(page)
+
+  await page.waitForLoadState('domcontentloaded')
+
+  const startupRendererErrors = await app.evaluate(async ({ app: electronApp }) => {
+    const observedApp = electronApp as typeof electronApp & {
+      __hermesE2EStartupRendererErrors?: string[]
+      __hermesE2EStartupRendererPending?: Promise<void>[]
+    }
+
+    await Promise.all(observedApp.__hermesE2EStartupRendererPending ?? [])
+
+    return [...(observedApp.__hermesE2EStartupRendererErrors ?? [])]
+  })
+
+  if (startupRendererErrors.length > 0) {
+    await app.close().catch(() => undefined)
+    throw new Error(`Renderer startup errors:\n${startupRendererErrors.join('\n')}`)
+  }
 
   // Install the error-banner guard so any [role="alert"] that appears
   // during a test is collected and surfaced in afterEach.
@@ -365,6 +396,9 @@ export interface MockBackendOptions {
   extraConfig?: string
   /** Override the mock model's context window for compression scenarios. */
   modelContextLength?: number
+  mockServer?: MockServerOptions
+  /** Observe each renderer as soon as Electron announces the window. */
+  onWindow?: (page: Page) => void
 }
 
 /**
@@ -374,10 +408,6 @@ export interface MockBackendOptions {
  *   3. Launch the desktop app
  *   4. Return handles for test interaction
  */
-export interface MockBackendOptions {
-  mockServer?: MockServerOptions
-}
-
 export async function setupMockBackend(options: MockBackendOptions = {}): Promise<MockBackendFixture> {
   // 1. Start mock server
   const mock = await startMockServer(options.mockServer)
@@ -395,7 +425,7 @@ export async function setupMockBackend(options: MockBackendOptions = {}): Promis
 
   // 3. Build env + launch
   const env = buildAppEnv(sandbox)
-  const { app, page } = await launchDesktop(env)
+  const { app, page } = await launchDesktop(env, options.onWindow)
 
   return {
     app,
@@ -632,6 +662,7 @@ export async function waitForAppReady(fixture: MockBackendFixture | NoProviderFi
       // `position: fixed; inset: 0`. If the hit element or an ancestor
       // is a full-viewport fixed overlay, we're still covered.
       let node: Element | null = el
+
       while (node) {
         const cs = window.getComputedStyle(node)
 

--- a/apps/desktop/e2e/ran-mode.spec.ts
+++ b/apps/desktop/e2e/ran-mode.spec.ts
@@ -1,0 +1,550 @@
+import type { Page } from '@playwright/test'
+
+import {
+  buildAppEnv,
+  launchDesktop,
+  type MockBackendFixture,
+  setupMockBackend,
+  waitForAppReady
+} from './fixtures'
+import { expect, test } from './test'
+
+const LAYOUT_TREE_KEY = 'hermes.desktop.layoutTree.v2'
+const ACTIVE_PRESET_KEY = 'hermes.desktop.layoutPreset.active'
+const COMPOSER_POPOUT_KEY = 'hermes.desktop.composerPopout.zones.v1'
+const PANE_STATES_KEY = 'hermes.desktop.paneStates.v1'
+const RAN_MODE_KEY = 'hermes.desktop.ranMode.v1'
+const RAN_MODE_LOCK_KEY = 'hermes.desktop.ranMode.journal.v1'
+
+const RAN_OWNED_STORAGE_KEYS = [
+  ACTIVE_PRESET_KEY,
+  'hermes.desktop.composerPopout.zones.v1',
+  'hermes.desktop.dismissedPanes.v1',
+  LAYOUT_TREE_KEY,
+  PANE_STATES_KEY,
+  'hermes.desktop.panesFlipped',
+  'hermes.desktop.reviewOpen',
+  'hermes.desktop.rightRailActiveTab',
+  'hermes.desktop.statusbarVisible',
+  'hermes.desktop.terminalTakeover',
+  'hermes.desktop.toolView.technical',
+  'hermes.desktop.userPlacedPanes.v1'
+] as const
+
+let fixture: MockBackendFixture | null = null
+let rendererErrors: string[] = []
+const watchedRendererPages = new WeakSet<Page>()
+
+function watchRendererErrors(page: Page): void {
+  if (watchedRendererPages.has(page)) {
+    return
+  }
+
+  watchedRendererPages.add(page)
+  page.on('pageerror', error => rendererErrors.push(`pageerror: ${error.message}`))
+  page.on('console', message => {
+    if (message.type() === 'error') {
+      rendererErrors.push(`console: ${message.text()}`)
+    }
+  })
+}
+
+async function openAppearance(page: Page): Promise<void> {
+  const settingsButton = page.getByRole('button', { name: 'Open settings' })
+  await settingsButton.click()
+  await page.getByRole('button', { name: 'Appearance', exact: true }).click()
+  await expect(page.getByTestId('ran-mode-toggle')).toBeVisible()
+  await expect(page.getByText('Status Bar', { exact: true })).toBeVisible()
+}
+
+async function setRanMode(page: Page, enabled: boolean): Promise<void> {
+  await openAppearance(page)
+  await page
+    .getByTestId('ran-mode-toggle')
+    .getByRole('button', { name: enabled ? 'On' : 'Off', exact: true })
+    .click()
+  await expect(page.locator('[data-ran-mode="true"]')).toHaveCount(enabled ? 1 : 0)
+  await page.getByRole('button', { name: 'Close settings' }).click()
+}
+
+async function expectAuxiliaryLayoutControlsAbsent(page: Page): Promise<void> {
+  await expect(page.getByRole('button', { name: 'Layout editor' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Open settings' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Swap sidebar sides' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: /^(Default|Ran Mode|Focus|Terminal deck|Quad)$/ })).toHaveCount(0)
+  await expect(page.getByTestId('ran-mode-toggle')).toHaveCount(0)
+
+  await page.keyboard.press('Control+K')
+  const palette = page.getByRole('dialog')
+
+  await expect(palette).toBeVisible()
+  const search = palette.getByRole('combobox')
+
+  for (const command of [
+    'Swap sidebar sides',
+    'Toggle Ran Mode',
+    'Toggle layout edit mode',
+    'Toggle status bar',
+    'Toggle terminal',
+    'Settings',
+    'Keyboard shortcuts',
+    'Change Theme',
+    'Change Color Mode',
+    'Reset layout'
+  ]) {
+    await search.fill(command)
+    await expect(palette.getByRole('option', { name: new RegExp(command, 'i') })).toHaveCount(0)
+  }
+
+  await page.keyboard.press('Escape')
+  await expect(palette).not.toBeVisible()
+}
+
+async function captureOwnedUiState(page: Page): Promise<Record<string, string | null>> {
+  return page.evaluate(
+    ({ activePresetKey, composerPopoutKey, layoutTreeKey, paneStatesKey }) => ({
+      activePreset:
+        document.querySelector('[data-layout-preset]')?.getAttribute('data-layout-preset') ??
+        window.localStorage.getItem(activePresetKey),
+      composerPopout: window.localStorage.getItem(composerPopoutKey),
+      layoutTree: window.localStorage.getItem(layoutTreeKey),
+      paneStates: window.localStorage.getItem(paneStatesKey)
+    }),
+    {
+      activePresetKey: ACTIVE_PRESET_KEY,
+      composerPopoutKey: COMPOSER_POPOUT_KEY,
+      layoutTreeKey: LAYOUT_TREE_KEY,
+      paneStatesKey: PANE_STATES_KEY
+    }
+  )
+}
+
+async function captureRanOwnedStorage(page: Page): Promise<Record<string, string | null>> {
+  return page.evaluate(
+    keys => Object.fromEntries(keys.map(key => [key, window.localStorage.getItem(key)])),
+    RAN_OWNED_STORAGE_KEYS
+  )
+}
+
+async function pressAuxiliaryMutationAndExpectPrimaryStorageUnchanged(
+  auxiliary: Page,
+  primary: Page,
+  durableBefore: Record<string, string | null>,
+  key: string
+): Promise<void> {
+  await auxiliary.keyboard.press(key)
+  expect(await captureRanOwnedStorage(primary)).toEqual(durableBefore)
+}
+
+async function chooseQuadLayout(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Layout editor' }).click()
+  await page.getByRole('button', { name: /Quad/ }).click()
+  await page.waitForFunction(key => window.localStorage.getItem(key) === 'quad', ACTIVE_PRESET_KEY)
+  expect(await page.evaluate(key => window.localStorage.getItem(key), ACTIVE_PRESET_KEY)).toBe('quad')
+  await page.getByRole('button', { name: 'Done', exact: true }).click()
+}
+
+async function send(page: Page, text: string): Promise<void> {
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.waitFor({ state: 'visible', timeout: 15_000 })
+  await composer.click()
+  await composer.type(text, { delay: 4 })
+  await page.keyboard.press('Enter')
+}
+
+test.describe.serial('Ran Mode / Focus preset', () => {
+  test.beforeAll(async () => {
+    rendererErrors = []
+    fixture = await setupMockBackend({ onWindow: watchRendererErrors })
+    await waitForAppReady(fixture, 120_000)
+  })
+
+  test.afterEach(() => {
+    expect(rendererErrors).toEqual([])
+  })
+
+  test.afterAll(async () => {
+    if (!fixture) {
+      return
+    }
+
+    try {
+      await fixture.app.close()
+    } catch {
+      // The restart test may already have closed a prior Electron handle.
+    }
+
+    await fixture.mock.close()
+    fixture.sandbox.cleanup()
+    fixture = null
+  })
+
+  test('serializes the named Ran journal lock across full instance renderers', async () => {
+    const page = fixture!.page
+    let peer: Page | null = null
+
+    try {
+      const peerPromise = fixture!.app.waitForEvent('window')
+      await expect(
+        page.evaluate(() =>
+          (
+            window as unknown as Window & {
+              hermesDesktop: { openWindow: () => Promise<{ ok: boolean }> }
+            }
+          ).hermesDesktop.openWindow()
+        )
+      ).resolves.toMatchObject({ ok: true })
+      peer = await peerPromise
+      await peer.waitForLoadState('domcontentloaded')
+
+      await page.evaluate(lockName => {
+        const state = window as Window & { __ranLockProbe?: { held: boolean; release?: () => void } }
+        state.__ranLockProbe = { held: false }
+        void navigator.locks.request(lockName, { mode: 'exclusive' }, async () => {
+          state.__ranLockProbe!.held = true
+          await new Promise<void>(resolve => {
+            state.__ranLockProbe!.release = resolve
+          })
+          state.__ranLockProbe!.held = false
+        })
+      }, RAN_MODE_LOCK_KEY)
+
+      await page.waitForFunction(() =>
+        Boolean((window as Window & { __ranLockProbe?: { held: boolean } }).__ranLockProbe?.held)
+      )
+
+      await peer.evaluate(lockName => {
+        const state = window as Window & { __ranPeerProbe?: { entered: boolean; resolved: boolean } }
+        state.__ranPeerProbe = { entered: false, resolved: false }
+        void navigator.locks
+          .request(lockName, { mode: 'exclusive' }, () => {
+            state.__ranPeerProbe!.entered = true
+          })
+          .then(() => {
+            state.__ranPeerProbe!.resolved = true
+          })
+      }, RAN_MODE_LOCK_KEY)
+
+      await peer.waitForTimeout(500)
+      expect(
+        await peer.evaluate(
+          () =>
+            (window as Window & { __ranPeerProbe?: { entered: boolean; resolved: boolean } }).__ranPeerProbe
+        )
+      ).toEqual({ entered: false, resolved: false })
+
+      const peerQuery = await peer.evaluate(() => navigator.locks.query())
+      expect((peerQuery.pending ?? []).some(lock => lock.name === RAN_MODE_LOCK_KEY)).toBe(true)
+
+      await page.evaluate(() =>
+        (window as Window & { __ranLockProbe?: { release?: () => void } }).__ranLockProbe?.release?.()
+      )
+      await peer.waitForFunction(
+        () => {
+          const probe = (window as Window & { __ranPeerProbe?: { entered: boolean; resolved: boolean } }).__ranPeerProbe
+
+          return probe?.entered === true && probe.resolved === true
+        },
+        undefined
+      )
+      expect(
+        await peer.evaluate(
+          () => (window as Window & { __ranPeerProbe?: { entered: boolean; resolved: boolean } }).__ranPeerProbe
+        )
+      ).toEqual({ entered: true, resolved: true })
+    } finally {
+      await page
+        .evaluate(() =>
+          (window as Window & { __ranLockProbe?: { release?: () => void } }).__ranLockProbe?.release?.()
+        )
+        .catch(() => undefined)
+      await peer?.close().catch(() => undefined)
+    }
+  })
+
+  test('activates, presents a chat-first layout, and restores the prior state', async () => {
+    const page = fixture!.page
+
+    const originalComposerPopout = await page.evaluate(
+      ({ composerPopoutKey, layoutTreeKey }) => {
+        const tree = JSON.parse(window.localStorage.getItem(layoutTreeKey) ?? 'null') as null | {
+          children?: unknown[]
+          id?: string
+          type?: string
+        }
+
+        const groupIds: string[] = []
+
+        const visit = (node: unknown) => {
+          if (!node || typeof node !== 'object') {
+            return
+          }
+
+          const candidate = node as { children?: unknown[]; id?: string; type?: string }
+
+          if (candidate.type === 'group' && typeof candidate.id === 'string') {
+            groupIds.push(candidate.id)
+          }
+
+          candidate.children?.forEach(visit)
+        }
+
+        visit(tree)
+
+        const removedByRan = groupIds.find(id => id !== 'ran-mode-sessions' && id !== 'ran-mode-workspace')
+
+        if (!removedByRan) {
+          throw new Error('E2E requires a pre-Ran layout group removed by the Ran layout')
+        }
+
+        const value = JSON.stringify({
+          [removedByRan]: { poppedOut: true, position: { bottom: 43, right: 71 } }
+        })
+
+        window.localStorage.setItem(composerPopoutKey, value)
+
+        return value
+      },
+      { composerPopoutKey: COMPOSER_POPOUT_KEY, layoutTreeKey: LAYOUT_TREE_KEY }
+    )
+
+    await page.reload()
+    await expect(page.getByRole('button', { name: 'Open settings' })).toBeVisible({ timeout: 30_000 })
+
+    const before = await captureOwnedUiState(page)
+
+    expect(before.composerPopout).toBe(originalComposerPopout)
+
+    await setRanMode(page, true)
+
+    await expect(page.locator('[data-ran-mode="true"]')).toBeVisible()
+    await expect(page.locator('[data-layout-preset="ran-mode"]')).toHaveCount(1)
+    await expect(page.locator('[data-terminal-slot]:visible')).toHaveCount(0)
+    await expect(page.locator('[data-review-pane]:visible')).toHaveCount(0)
+    await expect(page.locator('[data-statusbar]:visible')).toHaveCount(0)
+    await expect(page.locator('[contenteditable="true"]').first()).toBeVisible()
+
+    for (const viewport of [
+      { height: 768, width: 1366 },
+      { height: 1080, width: 1920 }
+    ]) {
+      await page.setViewportSize(viewport)
+      await expect(page.locator('[data-ran-mode="true"]')).toBeVisible()
+      await expect(page.locator('[contenteditable="true"]').first()).toBeVisible()
+    }
+
+    const record = await page.evaluate(key => window.localStorage.getItem(key), RAN_MODE_KEY)
+    expect(JSON.parse(record ?? '{}')).toMatchObject({ enabled: true, phase: 'active', version: 1 })
+    expect(await page.evaluate(key => window.localStorage.getItem(key), COMPOSER_POPOUT_KEY)).toBe('{}')
+
+    await setRanMode(page, false)
+    expect(await captureOwnedUiState(page)).toEqual(before)
+    expect(await page.evaluate(key => window.localStorage.getItem(key), RAN_MODE_KEY)).toBeNull()
+
+    await page.evaluate(key => window.localStorage.removeItem(key), COMPOSER_POPOUT_KEY)
+    await page.reload()
+    await expect(page.getByRole('button', { name: 'Open settings' })).toBeVisible({ timeout: 30_000 })
+  })
+
+  test('restores an explicitly customized layout instead of defaults', async () => {
+    const page = fixture!.page
+    await chooseQuadLayout(page)
+    const customized = await captureOwnedUiState(page)
+
+    await setRanMode(page, true)
+    await expect(page.locator('[data-ran-mode="true"]')).toBeVisible()
+    await setRanMode(page, false)
+
+    expect(await captureOwnedUiState(page)).toEqual(customized)
+  })
+
+  test('enters through the command palette and the layout picker', async () => {
+    const page = fixture!.page
+
+    await page.keyboard.press('Control+K')
+    const palette = page.getByRole('dialog')
+    await expect(palette).toBeVisible()
+    const commandSearch = palette.getByRole('combobox')
+    await commandSearch.fill('Toggle Ran Mode')
+    const ranCommand = palette.getByRole('option', { name: /Toggle Ran Mode/ })
+    await expect(ranCommand).toBeVisible()
+    await ranCommand.dispatchEvent('pointermove')
+    await expect(ranCommand).toHaveAttribute('aria-selected', 'true')
+    await commandSearch.press('Enter')
+    await expect(page.locator('[data-ran-mode="true"]')).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(palette).not.toBeVisible()
+    await setRanMode(page, false)
+
+    await page.getByRole('button', { name: 'Layout editor' }).click()
+    await page.getByRole('button', { name: /Ran Mode/ }).click()
+    await expect(page.locator('[data-ran-mode="true"]')).toBeVisible()
+    await expect(page.locator('[data-layout-preset="ran-mode"]')).toHaveCount(1)
+    await setRanMode(page, false)
+  })
+
+  test('omits Ran Mode and layout mutation controls from HUD and secondary renderers', async () => {
+    const page = fixture!.page
+    await page.evaluate(() => {
+      window.localStorage.setItem(
+        'hermes.desktop.composerPopout.zones.v1',
+        JSON.stringify({
+          'primary-custom-zone': { poppedOut: true, position: { bottom: 37, right: 53 } }
+        })
+      )
+      window.localStorage.setItem('hermes.desktop.panesFlipped', 'true')
+      window.localStorage.setItem('hermes.desktop.reviewOpen', 'true')
+      window.localStorage.setItem('hermes.desktop.statusbarVisible', 'true')
+      window.localStorage.setItem('hermes.desktop.terminalTakeover', 'true')
+      window.localStorage.setItem('hermes.desktop.toolView.technical', 'true')
+    })
+    const durableBefore = await captureRanOwnedStorage(page)
+    let hud: Page | null = null
+    let secondary: Page | null = null
+
+    try {
+      const hudPromise = fixture!.app.waitForEvent('window')
+      await expect(
+        page.evaluate(() =>
+          (
+            window as unknown as Window & {
+              hermesDesktop: { hud?: { open: () => Promise<{ ok: boolean }> } }
+            }
+          ).hermesDesktop.hud?.open()
+        )
+      ).resolves.toMatchObject({ ok: true })
+      hud = await hudPromise
+      await hud.waitForLoadState('domcontentloaded')
+      await expect(hud.locator('[contenteditable="true"]').first()).toBeVisible({ timeout: 30_000 })
+      await expectAuxiliaryLayoutControlsAbsent(hud)
+
+      for (const key of [
+        'Control+Backslash',
+        'Control+G',
+        'Control+Backquote',
+        'Control+Shift+Backquote',
+        'Control+Comma',
+        'Control+Slash',
+        'Control+Shift+S'
+      ]) {
+        await pressAuxiliaryMutationAndExpectPrimaryStorageUnchanged(hud, page, durableBefore, key)
+      }
+
+      await expect(hud.getByRole('button', { name: 'Appearance', exact: true })).toHaveCount(0)
+      await expect(hud.getByText('Tool Call Display', { exact: true })).toHaveCount(0)
+
+      const secondaryPromise = fixture!.app.waitForEvent('window')
+      await expect(
+        page.evaluate(() =>
+          (
+            window as unknown as Window & {
+              hermesDesktop: { openSessionWindow: (sessionId: string) => Promise<{ ok: boolean }> }
+            }
+          ).hermesDesktop.openSessionWindow('ran-mode-auxiliary-e2e')
+        )
+      ).resolves.toMatchObject({ ok: true })
+      secondary = await secondaryPromise
+      await secondary.waitForLoadState('domcontentloaded')
+      await expect(secondary.locator('[contenteditable="true"]').first()).toBeVisible({ timeout: 30_000 })
+      await expectAuxiliaryLayoutControlsAbsent(secondary)
+
+      for (const key of [
+        'Control+Backslash',
+        'Control+G',
+        'Control+Backquote',
+        'Control+Shift+Backquote',
+        'Control+Comma',
+        'Control+Slash',
+        'Control+Shift+S'
+      ]) {
+        await pressAuxiliaryMutationAndExpectPrimaryStorageUnchanged(secondary, page, durableBefore, key)
+      }
+
+      await expect(secondary.getByRole('button', { name: 'Appearance', exact: true })).toHaveCount(0)
+      await expect(secondary.getByText('Tool Call Display', { exact: true })).toHaveCount(0)
+
+      expect(await captureRanOwnedStorage(page)).toEqual(durableBefore)
+    } finally {
+      await secondary?.close().catch(() => undefined)
+      await hud?.close().catch(() => undefined)
+      await page
+        .evaluate(() =>
+          (
+            window as unknown as Window & {
+              hermesDesktop: { hud?: { close: () => Promise<{ ok: boolean }> } }
+            }
+          ).hermesDesktop.hud?.close()
+        )
+        .catch(() => undefined)
+      await page.evaluate(key => window.localStorage.removeItem(key), COMPOSER_POPOUT_KEY)
+    }
+  })
+
+  test('remains coherent across a Desktop restart and then restores the original state', async () => {
+    const before = await captureOwnedUiState(fixture!.page)
+    await setRanMode(fixture!.page, true)
+
+    await fixture!.app.close()
+    const restartEnv = buildAppEnv(fixture!.sandbox)
+
+    await expect(
+      launchDesktop({ ...restartEnv, HERMES_E2E_INJECT_STARTUP_RENDERER_ERROR: '1' })
+    ).rejects.toThrow(/HERMES_E2E_STARTUP_RENDERER_ERROR_SENTINEL/)
+
+    const relaunched = await launchDesktop(restartEnv, watchRendererErrors)
+    fixture!.app = relaunched.app
+    fixture!.page = relaunched.page
+    await waitForAppReady(fixture!, 120_000)
+
+    const page = fixture!.page
+    await expect(page.locator('[data-ran-mode="true"]')).toBeVisible()
+    expect(await page.evaluate(key => window.localStorage.getItem(key), RAN_MODE_KEY)).not.toBeNull()
+
+    await setRanMode(page, false)
+    expect(await captureOwnedUiState(page)).toEqual(before)
+  })
+
+  test('treats Reset Layout as an explicit exit instead of a hidden rollback', async () => {
+    const page = fixture!.page
+    await chooseQuadLayout(page)
+    await setRanMode(page, true)
+
+    await page.getByRole('button', { name: 'Layout editor' }).click({ modifiers: ['Control'] })
+
+    await expect(page.locator('[data-ran-mode="false"]')).toBeVisible()
+    await expect(page.locator('[data-layout-preset="default"]')).toBeVisible()
+    expect(await page.evaluate(key => window.localStorage.getItem(key), RAN_MODE_KEY)).toBeNull()
+
+    const done = page.getByRole('button', { name: 'Done', exact: true })
+
+    if (await done.isVisible()) {
+      await done.click()
+    }
+  })
+
+  test('keeps live and approval activity visible, collapses settled tool details, and works in a narrow window', async () => {
+    const page = fixture!.page
+    await page.setViewportSize({ width: 900, height: 700 })
+    await setRanMode(page, true)
+
+    await send(page, 'E2E_CORRECTION_SWITCH_TRIGGER')
+    const liveTool = page.locator('[data-tool-row]').last()
+    await expect(liveTool).toBeVisible({ timeout: 30_000 })
+    await expect(liveTool).toContainText(/Running|terminal/i)
+    await expect(
+      page.getByRole('paragraph').filter({ hasText: /^The corrected task finished\.$/ })
+    ).toBeVisible({ timeout: 45_000 })
+    await expect(liveTool).not.toHaveAttribute('data-tool-open', '')
+
+    await liveTool.getByRole('button').first().click()
+    await expect(liveTool).toHaveAttribute('data-tool-open', '')
+
+    await send(page, 'E2E_QUEUE_STOP_TRIGGER')
+    await expect(page.getByText('Keep working?', { exact: true })).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByRole('button', { name: /Yes|No/ }).first()).toBeVisible()
+
+    await expect(page.locator('[contenteditable="true"]').first()).toBeVisible()
+
+    await setRanMode(page, false)
+  })
+})

--- a/apps/desktop/electron/e2e-renderer-startup-observer.test.ts
+++ b/apps/desktop/electron/e2e-renderer-startup-observer.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import type { App, WebContents } from 'electron'
+import { test, vi } from 'vitest'
+
+import {
+  E2E_RENDERER_STARTUP_ERRORS_PROPERTY,
+  installE2ERendererStartupObserver
+} from './e2e-renderer-startup-observer'
+
+interface ObservedApp extends App {
+  [E2E_RENDERER_STARTUP_ERRORS_PROPERTY]?: string[]
+}
+
+function createHarness(env: NodeJS.ProcessEnv = { HERMES_E2E_OBSERVE_RENDERER_STARTUP: '1' }) {
+  const appEvents = new EventEmitter()
+  const contentsEvents = new EventEmitter()
+
+  const executeJavaScript = vi.fn(async (source: string) => {
+    contentsEvents.emit('console-message', {}, {
+      level: 3,
+      lineNumber: 1,
+      message: source.includes('HERMES_E2E_STARTUP_RENDERER_ERROR_SENTINEL')
+        ? 'HERMES_E2E_STARTUP_RENDERER_ERROR_SENTINEL'
+        : source,
+      sourceUrl: 'e2e://startup-observer'
+    })
+  })
+
+  const app = appEvents as unknown as App
+  const contents = Object.assign(contentsEvents, { executeJavaScript }) as unknown as WebContents
+
+  installE2ERendererStartupObserver(app, env)
+  appEvents.emit('web-contents-created', {}, contents)
+
+  return {
+    contentsEvents,
+    errors: (app as ObservedApp)[E2E_RENDERER_STARTUP_ERRORS_PROPERTY] ?? [],
+    executeJavaScript
+  }
+}
+
+test('captures the Electron 36+ console-message details shape', () => {
+  const harness = createHarness()
+
+  harness.contentsEvents.emit('console-message', {}, {
+    level: 3,
+    lineNumber: 7,
+    message: 'modern startup failure',
+    sourceUrl: 'e2e://renderer'
+  })
+
+  assert.deepEqual(harness.errors, ['console: modern startup failure'])
+})
+
+test('injects the E2E sentinel through the real renderer console event path', async () => {
+  const harness = createHarness({
+    HERMES_E2E_INJECT_STARTUP_RENDERER_ERROR: '1',
+    HERMES_E2E_OBSERVE_RENDERER_STARTUP: '1'
+  })
+
+  assert.deepEqual(harness.errors, [])
+  harness.contentsEvents.emit('dom-ready')
+  await Promise.resolve()
+
+  assert.equal(harness.executeJavaScript.mock.calls.length, 1)
+  assert.deepEqual(harness.errors, ['console: HERMES_E2E_STARTUP_RENDERER_ERROR_SENTINEL'])
+})

--- a/apps/desktop/electron/e2e-renderer-startup-observer.ts
+++ b/apps/desktop/electron/e2e-renderer-startup-observer.ts
@@ -1,0 +1,73 @@
+import type { App } from 'electron'
+
+export const E2E_RENDERER_STARTUP_ERRORS_PROPERTY = '__hermesE2EStartupRendererErrors'
+export const E2E_RENDERER_STARTUP_PENDING_PROPERTY = '__hermesE2EStartupRendererPending'
+const E2E_STARTUP_RENDERER_ERROR_SENTINEL = 'HERMES_E2E_STARTUP_RENDERER_ERROR_SENTINEL'
+
+interface ObservedApp extends App {
+  [E2E_RENDERER_STARTUP_ERRORS_PROPERTY]?: string[]
+  [E2E_RENDERER_STARTUP_PENDING_PROPERTY]?: Promise<void>[]
+}
+
+interface ConsoleMessageDetails {
+  level: number
+  message: string
+}
+
+/**
+ * Test-only renderer diagnostics installed before Desktop creates any window.
+ * The normal Playwright Page observer can attach after the initial renderer has
+ * already emitted an error; this bounded buffer closes that startup interval.
+ */
+export function installE2ERendererStartupObserver(app: App, env: NodeJS.ProcessEnv = process.env): void {
+  if (env.HERMES_E2E_OBSERVE_RENDERER_STARTUP !== '1') {
+    return
+  }
+
+  const observedApp = app as ObservedApp
+
+  if (observedApp[E2E_RENDERER_STARTUP_ERRORS_PROPERTY]) {
+    return
+  }
+
+  const errors: string[] = []
+  const pending: Promise<void>[] = []
+  const record = (kind: string, detail: unknown) => errors.push(`${kind}: ${String(detail)}`)
+
+  observedApp[E2E_RENDERER_STARTUP_ERRORS_PROPERTY] = errors
+  observedApp[E2E_RENDERER_STARTUP_PENDING_PROPERTY] = pending
+
+  app.on('web-contents-created', (_event, contents) => {
+    contents.on('console-message', (_consoleEvent, detailsOrLevel, message) => {
+      const details =
+        detailsOrLevel && typeof detailsOrLevel === 'object'
+          ? (detailsOrLevel as unknown as ConsoleMessageDetails)
+          : null
+
+      const level = details ? details.level : detailsOrLevel
+
+      if (level === 3) {
+        record('console', details ? details.message : message)
+      }
+    })
+    contents.on('did-fail-load', (_loadEvent, code, description, url, isMainFrame) => {
+      if (isMainFrame) {
+        record('did-fail-load', `${code} ${description} ${url}`)
+      }
+    })
+    contents.on('render-process-gone', (_goneEvent, details) => {
+      record('render-process-gone', `${details.reason} (${details.exitCode})`)
+    })
+
+    if (env.HERMES_E2E_INJECT_STARTUP_RENDERER_ERROR === '1') {
+      contents.once('dom-ready', () => {
+        const injection = contents
+          .executeJavaScript(`console.error(${JSON.stringify(E2E_STARTUP_RENDERER_ERROR_SENTINEL)})`)
+          .then(() => undefined)
+          .catch(error => record('console-injection-failed', error))
+
+        pending.push(injection)
+      })
+    }
+  })
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -89,6 +89,7 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
+import { installE2ERendererStartupObserver } from './e2e-renderer-startup-observer'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import { findGitBash as _findGitBash } from './find-git-bash'
@@ -1019,6 +1020,8 @@ const STREAMABLE_MEDIA_EXTS = new Set([
   '.wav',
   '.webm'
 ])
+
+installE2ERendererStartupObserver(app)
 
 protocol.registerSchemesAsPrivileged([
   {

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -25,6 +25,8 @@ import {
 } from '@/store/composer-status'
 import { refreshSessionGoal } from '@/store/goals'
 import { $previewStatusBySession, dismissPreviewArtifact } from '@/store/preview-status'
+import { $ranModeEnabled } from '@/store/ran-mode'
+import { ranModeStatusStackMaxClass } from '@/store/ran-mode-presentation'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { openSessionInNewWindow } from '@/store/windows'
 
@@ -84,6 +86,7 @@ interface ComposerStatusStackProps {
 export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackProps) {
   const { t } = useI18n()
   const navigate = useNavigate()
+  const ranModeEnabled = useStore($ranModeEnabled)
   // Subscribe to THIS session's slice only. Both maps churn on other
   // sessions' activity (subagent ticks, background polls, preview updates in
   // any tile); a whole-map `useStore` re-rendered every mounted stack — one
@@ -226,7 +229,8 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
       // In flow in the dock column, directly above the composer. The dock is
       // bottom-anchored, so this grows upward over the thread without needing
       // to be positioned — and it shares the dock's left edge for free.
-      className="flex max-h-[40vh] min-h-0 flex-col overflow-y-auto"
+      className={cn('flex min-h-0 flex-col overflow-y-auto', ranModeStatusStackMaxClass(ranModeEnabled))}
+      data-composer-status-stack=""
       onPointerDownCapture={() => blurComposerInput()}
     >
       {/* The card paints the shared --composer-fill (rest / scrolled / focused

--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -29,7 +29,7 @@ const rowPadX = 'pl-2 pr-1'
 const rowGap = 'gap-1.5'
 const rowLead = 'grid size-3.5 shrink-0 place-items-center'
 const rowInset = cn(rowPadX, rowGap, 'flex h-full min-w-0 items-center self-stretch py-0.5')
-const rowLabel = 'min-w-0 truncate text-[0.8125rem] leading-none text-(--ui-text-secondary)'
+const rowLabel = 'min-w-0 truncate text-start text-[0.8125rem] leading-none text-(--ui-text-secondary)'
 
 /** Codicon size in sidebar row leads — matches the file tree (`tree.tsx`). */
 export const SIDEBAR_LEAD_ICON_SIZE = '0.875rem' as const
@@ -108,7 +108,9 @@ export function SidebarRowLink({
 }: React.ComponentProps<'button'> & { labelClassName?: string }) {
   return (
     <RowButton className={cn('min-w-0 shrink bg-transparent p-0 text-left', className)} {...props}>
-      <span className={cn(rowLabel, labelClassName)}>{children}</span>
+      <span className={cn(rowLabel, labelClassName)} dir="auto">
+        {children}
+      </span>
     </RowButton>
   )
 }
@@ -120,7 +122,7 @@ export function SidebarRowLead({ className, ...props }: React.ComponentProps<'sp
 
 /** Standard row label typography. */
 export function SidebarRowLabel({ className, ...props }: React.ComponentProps<'span'>) {
-  return <span className={cn(rowLabel, className)} {...props} />
+  return <span className={cn(rowLabel, className)} dir="auto" {...props} />
 }
 
 /** What a group's sessions add up to, for the Show options that count something. */

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -104,6 +104,8 @@ import {
   refreshPullRequests,
   sessionPrKey
 } from '@/store/pull-requests'
+import { $ranModeEnabled } from '@/store/ran-mode'
+import { shouldShowPinnedSection } from '@/store/ran-mode-presentation'
 import { openRouteTile } from '@/store/route-tiles'
 import {
   $cronSessions,
@@ -340,6 +342,7 @@ export function ChatSidebar({
   // dividers; groups apply it to their own lanes.
   const sortOrderIds = useStore($sidebarSessionRankIds)
   const agentsGrouped = grouping === 'project'
+  const ranModeEnabled = useStore($ranModeEnabled)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const pinsOpen = useStore($sidebarPinsOpen)
   const agentsOpen = useStore($sidebarRecentsOpen)
@@ -1523,7 +1526,8 @@ export function ChatSidebar({
               />
             )}
 
-            {!trimmedQuery && (
+            {!trimmedQuery &&
+              shouldShowPinnedSection({ pinnedCount: pinnedSessions.length, ranModeEnabled }) && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}
                 contentClassName="flex flex-col gap-px rounded-lg pb-2 pt-1"

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -79,7 +79,7 @@ import {
   $updateStatus,
   requestActiveUpdate
 } from '@/store/updates'
-import { canOpenNewWindow, openNewWindow } from '@/store/windows'
+import { canOpenNewWindow, isAuxiliaryWindow, openNewWindow } from '@/store/windows'
 import { luminance } from '@/themes/color'
 import { type ThemeMode, useTheme } from '@/themes/context'
 import { isUserTheme, resolveTheme } from '@/themes/user-themes'
@@ -635,7 +635,10 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
   // Deep-link into a nested page (e.g. `/pet list` → pets picker).
   useEffect(() => {
     if (pendingPage) {
-      setPage(pendingPage)
+      if (!isAuxiliaryWindow()) {
+        setPage(pendingPage)
+      }
+
       $commandPalettePage.set(null)
     }
   }, [pendingPage])
@@ -769,13 +772,17 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
                 }
               ]
             : []),
-          {
-            action: 'nav.settings',
-            icon: Settings,
-            id: 'nav-settings',
-            label: cc.nav.settings.title,
-            run: go(SETTINGS_ROUTE)
-          },
+          ...(!isAuxiliaryWindow()
+            ? [
+                {
+                  action: 'nav.settings',
+                  icon: Settings,
+                  id: 'nav-settings',
+                  label: cc.nav.settings.title,
+                  run: go(SETTINGS_ROUTE)
+                }
+              ]
+            : []),
           {
             action: 'nav.skills',
             icon: Wrench,
@@ -881,61 +888,65 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
           }
         ]
       },
-      {
-        // Declared before Settings: cmdk keeps group order, so this keeps the
-        // theme/mode pickers on top for "theme"/"color" queries instead of
-        // buried under a fuzzy Settings match.
-        heading: cc.appearance,
-        items: [
-          {
-            icon: Palette,
-            id: 'appearance-theme',
-            keywords: ['theme', 'appearance', 'color', 'palette', 'skin', 'dark', 'light', 'look'],
-            label: cc.changeTheme,
-            to: 'theme'
-          },
-          {
-            icon: Sun,
-            id: 'appearance-mode',
-            keywords: ['appearance', 'color mode', 'brightness', 'dark', 'light', 'system'],
-            label: cc.changeColorMode,
-            to: 'color-mode'
-          },
-          {
-            icon: PawPrint,
-            id: 'appearance-pets',
-            keywords: ['pet', 'petdex', 'mascot', 'pets', '/pet', 'paw'],
-            label: cc.pets.title,
-            to: 'pets'
-          },
-          {
-            icon: Egg,
-            id: 'appearance-generate-pet',
-            keywords: ['pet', 'generate', 'create', 'make', 'new pet', 'mascot', 'hatch', 'ai'],
-            label: cc.generatePet.title,
-            run: () => openPetGenerate()
-          }
-        ]
-      },
-      {
-        heading: cc.settings,
-        items: [
-          ...SECTIONS.map(section => ({
-            icon: section.icon,
-            id: `set-config-${section.id}`,
-            keywords: ['settings', section.label, settingsSectionLabel(section)],
-            label: settingsSectionLabel(section),
-            run: go(settingsTab(`config:${section.id}`))
-          })),
-          ...NON_CONFIG_SETTINGS.map(entry => ({
-            icon: entry.icon,
-            id: `set-${entry.tab}`,
-            keywords: ['settings', ...(entry.keywords ?? [])],
-            label: t.settings.nav[entry.labelKey],
-            run: go(settingsTab(entry.tab))
-          }))
-        ]
-      }
+      ...(!isAuxiliaryWindow()
+        ? [
+            {
+              // Declared before Settings: cmdk keeps group order, so this keeps the
+              // theme/mode pickers on top for "theme"/"color" queries instead of
+              // buried under a fuzzy Settings match.
+              heading: cc.appearance,
+              items: [
+                {
+                  icon: Palette,
+                  id: 'appearance-theme',
+                  keywords: ['theme', 'appearance', 'color', 'palette', 'skin', 'dark', 'light', 'look'],
+                  label: cc.changeTheme,
+                  to: 'theme'
+                },
+                {
+                  icon: Sun,
+                  id: 'appearance-mode',
+                  keywords: ['appearance', 'color mode', 'brightness', 'dark', 'light', 'system'],
+                  label: cc.changeColorMode,
+                  to: 'color-mode'
+                },
+                {
+                  icon: PawPrint,
+                  id: 'appearance-pets',
+                  keywords: ['pet', 'petdex', 'mascot', 'pets', '/pet', 'paw'],
+                  label: cc.pets.title,
+                  to: 'pets'
+                },
+                {
+                  icon: Egg,
+                  id: 'appearance-generate-pet',
+                  keywords: ['pet', 'generate', 'create', 'make', 'new pet', 'mascot', 'hatch', 'ai'],
+                  label: cc.generatePet.title,
+                  run: () => openPetGenerate()
+                }
+              ]
+            },
+            {
+              heading: cc.settings,
+              items: [
+                ...SECTIONS.map(section => ({
+                  icon: section.icon,
+                  id: `set-config-${section.id}`,
+                  keywords: ['settings', section.label, settingsSectionLabel(section)],
+                  label: settingsSectionLabel(section),
+                  run: go(settingsTab(`config:${section.id}`))
+                })),
+                ...NON_CONFIG_SETTINGS.map(entry => ({
+                  icon: entry.icon,
+                  id: `set-${entry.tab}`,
+                  keywords: ['settings', ...(entry.keywords ?? [])],
+                  label: t.settings.nav[entry.labelKey],
+                  run: go(settingsTab(entry.tab))
+                }))
+              ]
+            }
+          ]
+        : [])
     ]
     // `selectTick` is a deliberate re-read trigger, not a value: rows report
     // live state through `detail()`, so the groups must rebuild after a select
@@ -1126,6 +1137,17 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
           run: go(`${SETTINGS_ROUTE}?tab=sessions&session=${encodeURIComponent(session.id)}`)
         }))
       })
+    }
+
+    if (isAuxiliaryWindow()) {
+      const settingsItemPrefixes = ['search-theme-', 'search-mode-', 'field-', 'archived-']
+
+      return result
+        .map(group => ({
+          ...group,
+          items: group.items.filter(item => !settingsItemPrefixes.some(prefix => item.id.startsWith(prefix)))
+        }))
+        .filter(group => group.items.length > 0)
     }
 
     return result

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -12,6 +12,7 @@ import { allPaneIds, group, groupLeafIds, split } from '@/components/pane-shell/
 import { LayoutTreeRoot } from '@/components/pane-shell/tree/renderer'
 import type { DoubleTapContext } from '@/components/pane-shell/tree/renderer/drag-session'
 import {
+  $activePresetId,
   $layoutTree,
   bindPaneVisibility,
   bindToolPaneCollapse,
@@ -26,7 +27,6 @@ import {
   registerPaneCloser,
   registerPaneOpener,
   removeTreePane,
-  resetLayoutTree,
   revealTreePane,
   togglePaneVisible,
   watchContributedPanes
@@ -55,11 +55,20 @@ import {
   SIDEBAR_MAX_WIDTH
 } from '@/store/layout'
 import { runExportProfileFlow, runImportProfileFlow } from '@/store/profile-share'
+import {
+  $ranModeEnabled,
+  disableRanMode,
+  enableRanMode,
+  initializeRanMode,
+  RAN_MODE_PRESET_ID,
+  RAN_MODE_TREE,
+  resetLayoutFromRanMode
+} from '@/store/ran-mode'
 import { $reviewOpen, closeReview, openReview, REVIEW_PANE_ID } from '@/store/review'
 import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
-import { isHudWindow } from '@/store/windows'
+import { isAuxiliaryWindow, isHudWindow } from '@/store/windows'
 
 import type { SessionDragPayload } from '../chat/composer/inline-refs'
 import { watchPreviewTiles } from '../chat/preview-tile'
@@ -228,32 +237,83 @@ registry.registerMany([
 // auto-discovered by discoverBundledPlugins() below.
 // ---------------------------------------------------------------------------
 
+const primaryLayoutChromeContributions = isAuxiliaryWindow()
+  ? []
+  : [
+      {
+        id: 'layout.editMode',
+        area: KEYBINDS_AREA,
+        data: {
+          id: 'layout.editMode',
+          label: 'Toggle layout edit mode',
+          defaults: ['mod+shift+\\'],
+          run: toggleLayoutEditMode
+        } satisfies KeybindContribution
+      },
+      paletteToggle({
+        id: 'layout.editMode',
+        label: 'Toggle layout edit mode',
+        action: 'layout.editMode',
+        icon: LayoutDashboard,
+        keywords: ['layout', 'zones', 'panes', 'edit', 'rearrange'],
+        get: () => $layoutEditMode.get(),
+        set: enabled => $layoutEditMode.set(enabled)
+      }),
+      {
+        id: 'layout.reset',
+        area: PALETTE_AREA,
+        data: {
+          id: 'layout.reset',
+          label: 'Reset layout',
+          icon: LayoutDashboard,
+          keywords: ['layout', 'reset', 'default', 'panes'],
+          run: resetLayoutFromRanMode
+        } satisfies PaletteContribution
+      },
+      paletteToggle({
+        id: 'view.toggleRanMode',
+        label: 'Toggle Ran Mode',
+        action: 'view.toggleRanMode',
+        icon: Zap,
+        keywords: ['ran mode', 'focus', 'chat first', 'quiet', 'workspace', 'preset'],
+        get: () => $ranModeEnabled.get(),
+        set: enabled => {
+          if (enabled) {
+            enableRanMode()
+          } else {
+            disableRanMode()
+          }
+        }
+      }),
+      // Hiding the bar removes the surface that would otherwise offer it back,
+      // so the primary command palette is the guaranteed door in. Auxiliary
+      // renderers must not advertise or mutate this shared preference.
+      paletteToggle({
+        id: 'view.toggleStatusbar',
+        label: 'Toggle status bar',
+        action: 'view.toggleStatusbar',
+        icon: PanelBottom,
+        keywords: ['status bar', 'statusbar', 'bottom bar', 'hide', 'show', 'chrome'],
+        get: () => $statusbarVisible.get(),
+        set: enabled => $statusbarVisible.set(enabled)
+      }),
+      {
+        id: 'keybinds.panel',
+        area: PALETTE_AREA,
+        data: {
+          id: 'keybinds.panel',
+          label: 'Keyboard shortcuts',
+          keywords: ['keybinds', 'shortcuts', 'hotkeys', 'keyboard'],
+          run: () => window.dispatchEvent(new CustomEvent('hermes:open-keybinds'))
+        } satisfies PaletteContribution
+      }
+    ]
+
 registry.registerMany([
+  ...primaryLayoutChromeContributions,
   // Titlebar center stays empty on purpose: session title lives in tabs +
   // sidebar; place/cwd lives in the sidebar project tree. Center is drag
   // chrome (plugins can still contribute to titleBar.center if needed).
-  // Layout edit mode registers through the SAME declarative surfaces plugins
-  // use: a rebindable keybind (collision-checked in the panel) + a ⌘K row
-  // whose hotkey hint tracks the live binding.
-  {
-    id: 'layout.editMode',
-    area: KEYBINDS_AREA,
-    data: {
-      id: 'layout.editMode',
-      label: 'Toggle layout edit mode',
-      defaults: ['mod+shift+\\'],
-      run: toggleLayoutEditMode
-    } satisfies KeybindContribution
-  },
-  paletteToggle({
-    id: 'layout.editMode',
-    label: 'Toggle layout edit mode',
-    action: 'layout.editMode',
-    icon: LayoutDashboard,
-    keywords: ['layout', 'zones', 'panes', 'edit', 'rearrange'],
-    get: () => $layoutEditMode.get(),
-    set: enabled => $layoutEditMode.set(enabled)
-  }),
   // The agent's write -> see loop: rescan <hermes home>/desktop-plugins
   // without relaunching (same-id reloads dispose the previous incarnation).
   {
@@ -266,39 +326,7 @@ registry.registerMany([
       run: () => void discoverRuntimePlugins()
     } satisfies PaletteContribution
   },
-  {
-    id: 'layout.reset',
-    area: PALETTE_AREA,
-    data: {
-      id: 'layout.reset',
-      label: 'Reset layout',
-      icon: LayoutDashboard,
-      keywords: ['layout', 'reset', 'default', 'panes'],
-      run: resetLayoutTree
-    } satisfies PaletteContribution
-  },
-  // Hiding the bar removes the surface that would otherwise offer it back, so
-  // ⌘K is the guaranteed door in (alongside the rebindable ⌘⇧S).
-  paletteToggle({
-    id: 'view.toggleStatusbar',
-    label: 'Toggle status bar',
-    action: 'view.toggleStatusbar',
-    icon: PanelBottom,
-    keywords: ['status bar', 'statusbar', 'bottom bar', 'hide', 'show', 'chrome'],
-    get: () => $statusbarVisible.get(),
-    set: enabled => $statusbarVisible.set(enabled)
-  }),
-  // The keybind panel's non-titlebar door (the keyboard icon is gone).
-  {
-    id: 'keybinds.panel',
-    area: PALETTE_AREA,
-    data: {
-      id: 'keybinds.panel',
-      label: 'Keyboard shortcuts',
-      keywords: ['keybinds', 'shortcuts', 'hotkeys', 'keyboard'],
-      run: () => window.dispatchEvent(new CustomEvent('hermes:open-keybinds'))
-    } satisfies PaletteContribution
-  },
+
   // Profile sharing: bundle the active profile (config, skills, theme, layout)
   // into a portable archive, or adopt someone else's. Both open native dialogs,
   // so the palette closing on select is correct.
@@ -383,14 +411,21 @@ const QUAD_TREE = split(
   [3, 1]
 )
 
-registry.registerMany([
-  { id: 'default', area: 'layouts', title: 'Default', order: 0, data: DEFAULT_TREE },
-  { id: 'focus', area: 'layouts', title: 'Focus', order: 10, data: FOCUS_TREE },
-  { id: 'terminal-deck', area: 'layouts', title: 'Terminal deck', order: 20, data: TERMINAL_TREE },
-  { id: 'quad', area: 'layouts', title: 'Quad', order: 30, data: QUAD_TREE }
-])
+if (!isAuxiliaryWindow()) {
+  registry.registerMany([
+    { id: 'default', area: 'layouts', title: 'Default', order: 0, data: DEFAULT_TREE },
+    { id: RAN_MODE_PRESET_ID, area: 'layouts', title: 'Ran Mode', order: 5, data: RAN_MODE_TREE },
+    { id: 'focus', area: 'layouts', title: 'Focus', order: 10, data: FOCUS_TREE },
+    { id: 'terminal-deck', area: 'layouts', title: 'Terminal deck', order: 20, data: TERMINAL_TREE },
+    { id: 'quad', area: 'layouts', title: 'Quad', order: 30, data: QUAD_TREE }
+  ])
+}
 
 declareDefaultTree(DEFAULT_TREE)
+
+if (!isAuxiliaryWindow()) {
+  void initializeRanMode()
+}
 
 // Bundled plugins load AFTER core, so a same-id contribution from a plugin
 // deliberately overrides the core default (last writer wins). Third-party
@@ -563,17 +598,20 @@ bindToolPaneCollapse(
 // Reads the TREE like every other pane toggle: `$terminalTakeover` stays true
 // behind a stacked sibling tab or a minimized zone, which would light the row
 // "on" for a terminal that isn't on screen.
-registry.register(
-  paletteToggle({
-    id: 'view.showTerminal',
-    label: 'Toggle terminal',
-    action: 'view.showTerminal',
-    icon: Terminal,
-    keywords: ['terminal', 'shell', 'console', 'pty'],
-    get: () => isPaneVisible('terminal'),
-    set: () => togglePaneVisible('terminal')
-  })
-)
+
+if (!isAuxiliaryWindow()) {
+  registry.register(
+    paletteToggle({
+      id: 'view.showTerminal',
+      label: 'Toggle terminal',
+      action: 'view.showTerminal',
+      icon: Terminal,
+      keywords: ['terminal', 'shell', 'console', 'pty'],
+      get: () => isPaneVisible('terminal'),
+      set: () => togglePaneVisible('terminal')
+    })
+  )
+}
 
 // Logs are ⌘K-ONLY chrome: the pane contribution EXISTS only while $logsOpen
 // is on. Off (the default) keeps logs out of the registry and the tree
@@ -695,6 +733,8 @@ function TitlebarSlot({ area, className, style }: TitlebarSlotProps) {
 }
 
 export function ContribController() {
+  const activePresetId = useStore($activePresetId)
+  const ranModeEnabled = useStore($ranModeEnabled)
   const sidebarOpen = useStore($sidebarOpen)
   const statusbarVisible = useStore($statusbarVisible)
 
@@ -713,6 +753,8 @@ export function ContribController() {
   return (
     <SidebarProvider
       className="h-screen min-h-0 flex-col bg-background"
+      data-layout-preset={activePresetId}
+      data-ran-mode={ranModeEnabled ? 'true' : 'false'}
       onOpenChange={setSidebarOpen}
       open={sidebarOpen}
       style={{ '--sidebar-width': '100%' } as CSSProperties}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -291,7 +291,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // Palette "Keyboard shortcuts" entry dispatches a custom event (contributions
   // don't have router access); listen and navigate to the settings keybinds tab.
   useEffect(() => {
-    const onOpenKeybinds = () => navigate(`${SETTINGS_ROUTE}?tab=keybinds`)
+    const onOpenKeybinds = () => {
+      if (!isAuxiliaryWindow()) {
+        navigate(`${SETTINGS_ROUTE}?tab=keybinds`)
+      }
+    }
+
     window.addEventListener('hermes:open-keybinds', onOpenKeybinds)
 
     return () => window.removeEventListener('hermes:open-keybinds', onOpenKeybinds)

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -58,7 +58,7 @@ import {
   switcherJustClosed
 } from '@/store/session-switcher'
 import { toggleStatusbarVisible } from '@/store/statusbar-prefs'
-import { openNewWindow } from '@/store/windows'
+import { isAuxiliaryWindow, openNewWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
 import { requestComposerFocus, requestModelMenuToggle, requestVoiceToggle } from '../chat/composer/focus'
@@ -173,7 +173,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
   }
 
   handlersRef.current = {
-    'keybinds.openPanel': () => navigate(`${SETTINGS_ROUTE}?tab=keybinds`),
+    'keybinds.openPanel': () => !isAuxiliaryWindow() && navigate(`${SETTINGS_ROUTE}?tab=keybinds`),
 
     'composer.focus': () => requestComposerFocus('active'),
     // Toggle the composer pill's live model dropdown (pane under the pointer,
@@ -187,7 +187,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
 
     'nav.commandPalette': toggleCommandPalette,
     'nav.commandCenter': deps.toggleCommandCenter,
-    'nav.settings': () => navigate(SETTINGS_ROUTE),
+    'nav.settings': () => !isAuxiliaryWindow() && navigate(SETTINGS_ROUTE),
     'nav.profiles': () => navigate(PROFILES_ROUTE),
     'nav.skills': () => navigateToWorkspacePage(navigate, SKILLS_ROUTE),
     'nav.messaging': () => navigateToWorkspacePage(navigate, MESSAGING_ROUTE),
@@ -226,14 +226,18 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     // terminal there. The single "secondary panel" toggle.
     'view.toggleRightSidebar': () =>
       layoutHasRootSide('right') ? toggleFileBrowserOpen() : togglePaneVisible('terminal'),
-    'view.toggleReview': toggleReview,
-    'view.toggleStatusbar': toggleStatusbarVisible,
+    'view.toggleReview': isAuxiliaryWindow() ? () => undefined : toggleReview,
+    'view.toggleStatusbar': isAuxiliaryWindow() ? () => undefined : toggleStatusbarVisible,
     'view.showFiles': showFiles,
     'view.toggleHud': () => toggleHud(hudTargetSessionId()),
-    'view.showTerminal': () => togglePaneVisible('terminal'),
+    'view.showTerminal': () => !isAuxiliaryWindow() && togglePaneVisible('terminal'),
     // Create first so the pane's open-effect ensure sees a non-empty set and
     // doesn't also spawn one — net effect is exactly one fresh terminal.
     'view.newTerminal': () => {
+      if (isAuxiliaryWindow()) {
+        return
+      }
+
       createTerminal()
       setTerminalTakeover(true)
     },
@@ -243,7 +247,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     'view.nextTerminal': () => isPaneVisible('terminal') && cycleTerminal(1),
     'view.prevTerminal': () => isPaneVisible('terminal') && cycleTerminal(-1),
     'view.closeTerminal': () => isPaneVisible('terminal') && closeActiveTerminal(),
-    'view.flipPanes': togglePanesFlipped,
+    'view.flipPanes': isAuxiliaryWindow() ? () => undefined : togglePanesFlipped,
     // ⌘W: close the focused tab (terminal / preview target / zone tree tab).
     // On the main tab with session tabs stacked, it shifts the next one in —
     // the loader navigates to that session's route (loads it into main). On

--- a/apps/desktop/src/app/right-sidebar/store.ts
+++ b/apps/desktop/src/app/right-sidebar/store.ts
@@ -1,12 +1,16 @@
 import { atom } from 'nanostores'
 
 import { persistBoolean, storedBoolean } from '@/lib/storage'
+import { isAuxiliaryWindow } from '@/store/windows'
 
 const TAKEOVER_KEY = 'hermes.desktop.terminalTakeover'
+const terminalStorageEnabled = !isAuxiliaryWindow()
 
-export const $terminalTakeover = atom(storedBoolean(TAKEOVER_KEY, false))
+export const $terminalTakeover = atom(terminalStorageEnabled ? storedBoolean(TAKEOVER_KEY, false) : false)
 
-$terminalTakeover.subscribe(active => persistBoolean(TAKEOVER_KEY, active))
+if (terminalStorageEnabled) {
+  $terminalTakeover.subscribe(active => persistBoolean(TAKEOVER_KEY, active))
+}
 
 export const setTerminalTakeover = (active: boolean) => $terminalTakeover.set(active)
 

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -18,6 +18,7 @@ import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/p
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
+import { isAuxiliaryWindow } from '@/store/windows'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
 import { getBaseColors, useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
@@ -27,6 +28,8 @@ import { $marketplaceInstalls, isUserTheme, removeUserTheme } from '@/themes/use
 import { MODE_OPTIONS } from './constants'
 import { PetSettings } from './pet-settings'
 import { ListRow, SectionHeading, SettingsContent } from './primitives'
+import { RanModeSetting } from './ran-mode-setting'
+import { StatusbarVisibilitySetting } from './statusbar-visibility-setting'
 import { TerminalFontSetting } from './terminal-font-setting'
 
 function ThemePreview({ name, mode }: { name: string; mode: 'light' | 'dark' }) {
@@ -495,20 +498,26 @@ export function AppearanceSettings() {
             title={a.reactionsTitle}
           />
 
-          <ListRow
-            action={
-              <SegmentedControl
-                onChange={id => {
-                  triggerHaptic('selection')
-                  setToolViewMode(id)
-                }}
-                options={toolOptions}
-                value={toolViewMode}
-              />
-            }
-            description={a.toolViewDesc}
-            title={a.toolViewTitle}
-          />
+          <RanModeSetting />
+
+          <StatusbarVisibilitySetting />
+
+          {!isAuxiliaryWindow() && (
+            <ListRow
+              action={
+                <SegmentedControl
+                  onChange={id => {
+                    triggerHaptic('selection')
+                    setToolViewMode(id)
+                  }}
+                  options={toolOptions}
+                  value={toolViewMode}
+                />
+              }
+              description={a.toolViewDesc}
+              title={a.toolViewTitle}
+            />
+          )}
 
           <ListRow
             action={

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -23,6 +23,7 @@ import {
   Zap
 } from '@/lib/icons'
 import { notifyError } from '@/store/notifications'
+import { isAuxiliaryWindow } from '@/store/windows'
 
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
 import { OverlayIconButton } from '../overlays/overlay-chrome'
@@ -57,7 +58,11 @@ const SETTINGS_VIEWS: readonly SettingsViewId[] = [
   'about'
 ]
 
-export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: SettingsPageProps) {
+export function SettingsView(props: SettingsPageProps) {
+  return isAuxiliaryWindow() ? null : <PrimarySettingsView {...props} />
+}
+
+function PrimarySettingsView({ onClose, onConfigSaved, onMainModelChanged }: SettingsPageProps) {
   const { t } = useI18n()
   const navigate = useNavigate()
   const { hash, pathname, search } = useLocation()

--- a/apps/desktop/src/app/settings/ran-mode-auxiliary-presentation.test.tsx
+++ b/apps/desktop/src/app/settings/ran-mode-auxiliary-presentation.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $layoutEditMode } from '@/components/pane-shell/edit-mode'
+import { TreeEditBar } from '@/components/pane-shell/tree/renderer/edit-bar'
+
+import { RanModeSetting } from './ran-mode-setting'
+import { StatusbarVisibilitySetting } from './statusbar-visibility-setting'
+
+import { SettingsView } from './index'
+
+const windowKind = vi.hoisted(() => ({ auxiliary: false }))
+
+vi.mock('@/store/windows', () => ({
+  isAuxiliaryWindow: () => windowKind.auxiliary,
+  isHudWindow: () => windowKind.auxiliary,
+  isSecondaryWindow: () => windowKind.auxiliary
+}))
+
+vi.mock('@/i18n', () => ({
+  translateNow: (key: string) => key,
+  useI18n: () => ({
+    t: {
+      common: { done: 'Done', off: 'Off', on: 'On' },
+      settings: {
+        appearance: {
+          ranModeDesc: 'Keep chat first.',
+          ranModeTitle: 'Ran Mode',
+          statusBarDesc: 'Show the global status bar.',
+          statusBarTitle: 'Status Bar'
+        }
+      },
+      zones: {
+        editHint: 'Arrange panes.',
+        editTitle: 'Layouts',
+        reset: 'Reset layout'
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+
+beforeEach(() => {
+  windowKind.auxiliary = false
+  $layoutEditMode.set(false)
+})
+
+afterEach(() => {
+  cleanup()
+  $layoutEditMode.set(false)
+})
+
+describe('Ran Mode auxiliary presentation isolation', () => {
+  it('keeps the Appearance toggle available on the primary renderer', () => {
+    render(<RanModeSetting />)
+
+    expect(screen.getByTestId('ran-mode-toggle')).toBeTruthy()
+  })
+
+  it('omits the Appearance toggle from auxiliary and HUD renderers', () => {
+    windowKind.auxiliary = true
+    render(<RanModeSetting />)
+
+    expect(screen.queryByTestId('ran-mode-toggle')).toBeNull()
+  })
+
+  it('omits the primary-owned status-bar preference from auxiliary settings', () => {
+    windowKind.auxiliary = true
+    render(<StatusbarVisibilitySetting />)
+
+    expect(screen.queryByText('Status Bar')).toBeNull()
+  })
+
+  it('fails closed when an auxiliary renderer reaches the Settings route directly', () => {
+    windowKind.auxiliary = true
+    const { container } = render(<SettingsView onClose={vi.fn()} />)
+
+    expect(container.firstChild).toBeNull()
+    expect(screen.queryByText('Tool Call Display')).toBeNull()
+  })
+
+
+  it('omits the reset action and layout picker from auxiliary edit surfaces', () => {
+    windowKind.auxiliary = true
+    $layoutEditMode.set(true)
+    render(<TreeEditBar />)
+
+    expect(screen.queryByText('Layouts')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reset layout' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/settings/ran-mode-setting.tsx
+++ b/apps/desktop/src/app/settings/ran-mode-setting.tsx
@@ -1,0 +1,45 @@
+import { useStore } from '@nanostores/react'
+
+import { SegmentedControl } from '@/components/ui/segmented-control'
+import { useI18n } from '@/i18n'
+import { triggerHaptic } from '@/lib/haptics'
+import { $ranModeEnabled, disableRanMode, enableRanMode } from '@/store/ran-mode'
+import { isAuxiliaryWindow } from '@/store/windows'
+
+import { ListRow } from './primitives'
+
+export function RanModeSetting() {
+  const { t } = useI18n()
+  const enabled = useStore($ranModeEnabled)
+
+  if (isAuxiliaryWindow()) {
+    return null
+  }
+
+  return (
+    <ListRow
+      action={
+        <div data-testid="ran-mode-toggle">
+          <SegmentedControl
+            onChange={id => {
+              triggerHaptic('selection')
+
+              if (id === 'on') {
+                enableRanMode()
+              } else {
+                disableRanMode()
+              }
+            }}
+            options={[
+              { id: 'off', label: t.common.off },
+              { id: 'on', label: t.common.on }
+            ]}
+            value={enabled ? 'on' : 'off'}
+          />
+        </div>
+      }
+      description={t.settings.appearance.ranModeDesc}
+      title={t.settings.appearance.ranModeTitle}
+    />
+  )
+}

--- a/apps/desktop/src/app/settings/statusbar-visibility-setting.test.tsx
+++ b/apps/desktop/src/app/settings/statusbar-visibility-setting.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $statusbarVisible } from '@/store/statusbar-prefs'
+
+import { StatusbarVisibilitySetting } from './statusbar-visibility-setting'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { off: 'Off', on: 'On' },
+      settings: {
+        appearance: {
+          statusBarDesc: 'Keep the bottom status surface visible.',
+          statusBarTitle: 'Status Bar'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+
+beforeEach(() => {
+  $statusbarVisible.set(false)
+})
+
+afterEach(cleanup)
+
+describe('StatusbarVisibilitySetting', () => {
+  it('exposes the existing status-bar preference in Appearance settings', () => {
+    render(<StatusbarVisibilitySetting />)
+
+    expect(screen.getByText('Status Bar')).toBeTruthy()
+    expect(screen.getByText('Keep the bottom status surface visible.')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'On' }))
+    expect($statusbarVisible.get()).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/settings/statusbar-visibility-setting.tsx
+++ b/apps/desktop/src/app/settings/statusbar-visibility-setting.tsx
@@ -1,0 +1,39 @@
+import { useStore } from '@nanostores/react'
+
+import { SegmentedControl } from '@/components/ui/segmented-control'
+import { useI18n } from '@/i18n'
+import { triggerHaptic } from '@/lib/haptics'
+import { $statusbarVisible } from '@/store/statusbar-prefs'
+import { isAuxiliaryWindow } from '@/store/windows'
+
+import { ListRow } from './primitives'
+
+export function StatusbarVisibilitySetting() {
+  const { t } = useI18n()
+  const visible = useStore($statusbarVisible)
+  const copy = t.settings.appearance
+
+  if (isAuxiliaryWindow()) {
+    return null
+  }
+
+  return (
+    <ListRow
+      action={
+        <SegmentedControl
+          onChange={id => {
+            triggerHaptic('selection')
+            $statusbarVisible.set(id === 'on')
+          }}
+          options={[
+            { id: 'off', label: t.common.off },
+            { id: 'on', label: t.common.on }
+          ]}
+          value={visible ? 'on' : 'off'}
+        />
+      }
+      description={copy.statusBarDesc}
+      title={copy.statusBarTitle}
+    />
+  )
+}

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate } from 'react-router'
 
 import { hudTargetSessionId } from '@/app/hud/handoff'
 import { toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
-import { resetLayoutTree } from '@/components/pane-shell/tree/store'
 import { Button } from '@/components/ui/button'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
@@ -19,6 +18,8 @@ import {
   togglePanesFlipped,
   toggleSidebarOpen
 } from '@/store/layout'
+import { resetLayoutFromRanMode } from '@/store/ran-mode'
+import { isAuxiliaryWindow } from '@/store/windows'
 
 import { appViewForPath, isOverlayView } from '../routes'
 
@@ -141,16 +142,20 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         leftEdge.toggle()
       }
     },
-    {
-      actionId: 'view.flipPanes',
-      icon: <TitlebarIcon name="arrow-swap" />,
-      id: 'flip-panes',
-      label: t.titlebar.swapSidebarSides,
-      onSelect: () => {
-        triggerHaptic('tap')
-        togglePanesFlipped()
-      }
-    },
+    ...(!isAuxiliaryWindow()
+      ? [
+          {
+            actionId: 'view.flipPanes',
+            icon: <TitlebarIcon name="arrow-swap" />,
+            id: 'flip-panes',
+            label: t.titlebar.swapSidebarSides,
+            onSelect: () => {
+              triggerHaptic('tap')
+              togglePanesFlipped()
+            }
+          }
+        ]
+      : []),
     ...leftTools
   ]
 
@@ -167,26 +172,30 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   // Static system tools — always pinned to the screen's right edge.
   const systemTools: TitlebarTool[] = [
-    {
-      className: 'group/tool',
-      // Hover + held ⌘/Ctrl morphs the glyph into its reset form (see
-      // LayoutGlyph) — the mod-click telegraphs itself before it happens.
-      icon: <LayoutGlyph modHeld={modHeld} />,
-      id: 'layout',
-      label: t.titlebar.layoutEditor,
-      onSelect: event => {
-        if (event?.metaKey || event?.ctrlKey) {
-          triggerHaptic('warning')
-          resetLayoutTree()
+    ...(!isAuxiliaryWindow()
+      ? [
+          {
+            className: 'group/tool',
+            // Hover + held ⌘/Ctrl morphs the glyph into its reset form (see
+            // LayoutGlyph) — the mod-click telegraphs itself before it happens.
+            icon: <LayoutGlyph modHeld={modHeld} />,
+            id: 'layout',
+            label: t.titlebar.layoutEditor,
+            onSelect: (event?: MouseEvent) => {
+              if (event?.metaKey || event?.ctrlKey) {
+                triggerHaptic('warning')
+                resetLayoutFromRanMode()
 
-          return
-        }
+                return
+              }
 
-        triggerHaptic('open')
-        toggleLayoutEditMode()
-      },
-      title: t.titlebar.layoutEditorTitle
-    },
+              triggerHaptic('open')
+              toggleLayoutEditMode()
+            },
+            title: t.titlebar.layoutEditorTitle
+          }
+        ]
+      : []),
     {
       // No `title`: TitlebarToolButton passes `title` to TipKeybindLabel as a
       // text OVERRIDE, so a long sentence there replaces the short label and
@@ -208,16 +217,20 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
       label: hapticsMuted ? t.titlebar.unmuteHaptics : t.titlebar.muteHaptics,
       onSelect: toggleHaptics
     },
-    {
-      actionId: 'nav.settings',
-      icon: <TitlebarIcon name="settings-gear" />,
-      id: 'settings',
-      label: t.titlebar.openSettings,
-      onSelect: () => {
-        triggerHaptic('open')
-        onOpenSettings()
-      }
-    }
+    ...(!isAuxiliaryWindow()
+      ? [
+          {
+            actionId: 'nav.settings',
+            icon: <TitlebarIcon name="settings-gear" />,
+            id: 'settings',
+            label: t.titlebar.openSettings,
+            onSelect: () => {
+              triggerHaptic('open')
+              onOpenSettings()
+            }
+          }
+        ]
+      : [])
   ]
 
   // While a full-screen overlay (settings, command center, …) is open it should

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -42,6 +42,8 @@ import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { recordPreviewArtifact } from '@/store/preview-status'
 import { sessionApprovalRequest } from '@/store/prompts'
+import { $ranModeEnabled } from '@/store/ran-mode'
+import { shouldAutoOpenToolDiff } from '@/store/ran-mode-presentation'
 import { $toolInlineDiff } from '@/store/tool-diffs'
 import { $toolRowDismissed, dismissToolRow } from '@/store/tool-dismiss'
 import { $anyToolDisclosureOpen, $toolDisclosureOpen, $toolViewMode, setToolDisclosureOpen } from '@/store/tool-view'
@@ -347,6 +349,7 @@ function ToolEntry({ part }: ToolEntryProps) {
   const messageId = useAuiState(s => s.message.id)
   const messageRunning = useAuiState(selectMessageRunning)
   const embedded = useContext(ToolEmbedContext)
+  const ranModeEnabled = useStore($ranModeEnabled)
   const toolViewMode = useStore($toolViewMode)
 
   // `ToolFallback` rebuilds the `part` wrapper each render, defeating the memos
@@ -368,7 +371,14 @@ function ToolEntry({ part }: ToolEntryProps) {
   const sideDiff = useStore($toolInlineDiff(toolCallId ?? ''))
   const inlineDiff = stripInlineDiffChrome(sideDiff) || inlineDiffFromResult(result)
   const isFileEdit = isFileEditTool(toolName)
-  const defaultOpen = Boolean(inlineDiff)
+
+  const defaultOpen = shouldAutoOpenToolDiff({
+    hasInlineDiff: Boolean(inlineDiff),
+    isError: Boolean(isError),
+    isPending,
+    ranModeEnabled
+  })
+
   const open = useDisclosureOpen(disclosureId, defaultOpen)
   const canDismiss = !isPending && !embedded
   // Only animate entries that mount while their message is actively

--- a/apps/desktop/src/components/pane-shell/tree/presets.ts
+++ b/apps/desktop/src/components/pane-shell/tree/presets.ts
@@ -10,9 +10,10 @@
 
 import { registry } from '@/contrib/registry'
 import { readJson, writeJson, writeKey } from '@/lib/storage'
+import { applyLayoutPresetWithRanMode } from '@/store/ran-mode'
 
 import { isLayoutNode, type LayoutNode } from './model'
-import { $layoutTree, applyTree, markActivePreset } from './store'
+import { $layoutTree, markActivePreset } from './store'
 
 export const LAYOUTS_AREA = 'layouts'
 
@@ -107,5 +108,5 @@ export const isUserPreset = (id: string) => id in userPresets
 
 /** Apply a preset's tree (deep-cloned so live edits never mutate the preset). */
 export function applyLayoutPreset(id: string, tree: LayoutNode) {
-  applyTree(structuredClone(tree), id)
+  return applyLayoutPresetWithRanMode(id, tree)
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/edit-bar.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/edit-bar.tsx
@@ -12,9 +12,10 @@ import { Button } from '@/components/ui/button'
 import { useI18n } from '@/i18n'
 import { formatCombo } from '@/lib/keybinds/combo'
 import { $bindings, bindingsFor } from '@/store/keybinds'
+import { resetLayoutFromRanMode } from '@/store/ran-mode'
+import { isAuxiliaryWindow } from '@/store/windows'
 
 import { $layoutEditMode } from '../../edit-mode'
-import { resetLayoutTree } from '../store'
 
 import { LayoutPicker } from './layout-picker'
 
@@ -70,7 +71,7 @@ export function TreeEditBar() {
     window.addEventListener('pointerup', onUp, true)
   }, [])
 
-  if (!editMode) {
+  if (!editMode || isAuxiliaryWindow()) {
     return null
   }
 
@@ -97,7 +98,7 @@ export function TreeEditBar() {
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1.5" onPointerDown={e => e.stopPropagation()}>
-          <Button onClick={resetLayoutTree} size="sm" variant="ghost">
+          <Button onClick={resetLayoutFromRanMode} size="sm" variant="ghost">
             {t.zones.reset}
           </Button>
           <Button onClick={() => $layoutEditMode.set(false)} size="sm" variant="outline">

--- a/apps/desktop/src/components/pane-shell/tree/renderer/layout-picker.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/layout-picker.tsx
@@ -15,6 +15,7 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import type { Contribution } from '@/contrib/types'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { isAuxiliaryWindow } from '@/store/windows'
 
 import type { LayoutNode } from '../model'
 import { isLayoutNode } from '../model'
@@ -113,6 +114,10 @@ export function LayoutPicker() {
   const presets = useContributions(LAYOUTS_AREA)
   const [name, setName] = useState('')
   const [saving, setSaving] = useState(false)
+
+  if (isAuxiliaryWindow()) {
+    return null
+  }
 
   const templates = presets.filter(p => !isUserPreset(p.id) && isLayoutNode(p.data))
   const custom = presets.filter(p => isUserPreset(p.id) && isLayoutNode(p.data))

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -13,7 +13,7 @@ import { translateNow } from '@/i18n'
 import { readJson, readKey, writeJson, writeKey } from '@/lib/storage'
 import { notify } from '@/store/notifications'
 import { clearAllPaneSizeOverrides } from '@/store/panes'
-import { isSecondaryWindow } from '@/store/windows'
+import { isAuxiliaryWindow } from '@/store/windows'
 
 import {
   allPaneIds,
@@ -45,8 +45,11 @@ import { rootChildSide } from './renderer/track-model'
 // v2: v1 trees were saved against placeholder panes with index-order zone
 // assignment (chat could land in a corner cell). Retire them wholesale.
 const STORAGE_KEY = 'hermes.desktop.layoutTree.v2'
+const layoutStorageEnabled = !isAuxiliaryWindow()
 
-writeKey('hermes.desktop.layoutTree.v1', null)
+if (layoutStorageEnabled) {
+  writeKey('hermes.desktop.layoutTree.v1', null)
+}
 
 let defaultTree: LayoutNode | null = null
 
@@ -59,29 +62,41 @@ function loadPersisted(): LayoutNode | null {
 }
 
 function persist(tree: LayoutNode | null) {
-  // A secondary window (single-chat pop-out) shares the origin's localStorage;
-  // writing its stripped-down DEFAULT tree back would wipe the primary's layout.
-  if (isSecondaryWindow()) {
+  // Auxiliary renderers share the primary origin but own only an ephemeral
+  // presentation tree. Their plugin/session adoption must never rewrite the
+  // primary window's durable layout.
+  if (!layoutStorageEnabled) {
     return
   }
 
   writeJson(STORAGE_KEY, tree)
 }
 
-/** The live tree (null until a default is declared). A secondary window ignores
- *  the persisted (primary) layout and boots to the default — nothing but its
- *  own routed session. */
-export const $layoutTree = atom<LayoutNode | null>(isSecondaryWindow() ? null : loadPersisted())
+/** The live tree (null until a default is declared). Auxiliary windows ignore
+ *  the persisted primary layout and boot to their own presentation default. */
+export const $layoutTree = atom<LayoutNode | null>(layoutStorageEnabled ? loadPersisted() : null)
 
 /**
  * Which layout preset the current tree came from; `'custom'` after the user
  * rearranges anything. Drives the picker's active highlight.
  */
-export const $activePresetId = atom<string>(readKey('hermes.desktop.layoutPreset.active') ?? 'default')
+export const $activePresetId = atom<string>(
+  layoutStorageEnabled ? (readKey('hermes.desktop.layoutPreset.active') ?? 'default') : 'default'
+)
+
+/** Exact layout-owned state captured by temporary workspace modes. */
+export interface LayoutStateSnapshot {
+  activePresetId: string
+  tree: LayoutNode
+  userPlacedPaneIds: string[]
+}
 
 export function markActivePreset(id: string) {
   $activePresetId.set(id)
-  writeKey('hermes.desktop.layoutPreset.active', id)
+
+  if (layoutStorageEnabled) {
+    writeKey('hermes.desktop.layoutPreset.active', id)
+  }
 }
 
 /** Pane id being dragged (tree drag session), null when idle. Also set to the
@@ -179,14 +194,17 @@ function frontPaneInGroup(paneId: string) {
 const DISMISSED_KEY = 'hermes.desktop.dismissedPanes.v1'
 
 function loadDismissed(): ReadonlySet<string> {
-  return new Set(readJson<string[]>(DISMISSED_KEY) ?? [])
+  return new Set(layoutStorageEnabled ? (readJson<string[]>(DISMISSED_KEY) ?? []) : [])
 }
 
 export const $dismissedPanes = atom<ReadonlySet<string>>(loadDismissed())
 
 function saveDismissed(next: ReadonlySet<string>) {
   $dismissedPanes.set(next)
-  writeJson(DISMISSED_KEY, next.size === 0 ? null : [...next])
+
+  if (layoutStorageEnabled) {
+    writeJson(DISMISSED_KEY, next.size === 0 ? null : [...next])
+  }
 }
 
 function setDismissed(paneId: string, dismissed: boolean) {
@@ -1095,7 +1113,7 @@ interface PaneDockHint {
   before?: null | string
 }
 
-function adoptContributedPanes(): void {
+export function adoptContributedPanes(): void {
   const tree = $layoutTree.get()
 
   if (!tree) {
@@ -1212,11 +1230,38 @@ function commit(next: LayoutNode | null) {
 
 const USER_PLACED_KEY = 'hermes.desktop.userPlacedPanes.v1'
 
-export const $userPlacedPanes = atom<ReadonlySet<string>>(new Set(readJson<string[]>(USER_PLACED_KEY) ?? []))
+export const $userPlacedPanes = atom<ReadonlySet<string>>(
+  new Set(layoutStorageEnabled ? (readJson<string[]>(USER_PLACED_KEY) ?? []) : [])
+)
 
 function saveUserPlaced(next: ReadonlySet<string>) {
   $userPlacedPanes.set(next)
-  writeJson(USER_PLACED_KEY, next.size === 0 ? null : [...next])
+
+  if (layoutStorageEnabled) {
+    writeJson(USER_PLACED_KEY, next.size === 0 ? null : [...next])
+  }
+}
+
+/** Capture every layout field that applying a preset can mutate. */
+export function captureLayoutStateSnapshot(): LayoutStateSnapshot {
+  const tree = $layoutTree.get()
+
+  if (!tree) {
+    throw new Error('Cannot capture layout state before the default tree is declared')
+  }
+
+  return {
+    activePresetId: $activePresetId.get(),
+    tree: structuredClone(tree),
+    userPlacedPaneIds: [...$userPlacedPanes.get()]
+  }
+}
+
+/** Restore exact pre-mode state; temporary modes must never fall back to defaults. */
+export function restoreLayoutStateSnapshot(snapshot: LayoutStateSnapshot): void {
+  commit(structuredClone(snapshot.tree))
+  saveUserPlaced(new Set(snapshot.userPlacedPaneIds))
+  markActivePreset(snapshot.activePresetId)
 }
 
 function markPaneUserPlaced(paneId: string) {
@@ -1704,7 +1749,7 @@ export function persistTree() {
   persist($layoutTree.get())
 }
 
-export function resetLayoutTree() {
+export function resetLayoutTree(): boolean {
   persist(null)
   clearAllPaneSizeOverrides()
   // Reset restores EVERYTHING — closed panes included — and hands pane
@@ -1720,6 +1765,13 @@ export function resetLayoutTree() {
   // Everything still missing (plugin panes) adopts by placement.
   adoptContributedPanes()
 
+  // Reset handlers may use the public move/apply operations to pre-place panes.
+  // Those operations correctly mark ordinary user moves as custom and pinned,
+  // but handler-driven placement is still part of the canonical default reset.
+  // Reassert the reset-owned metadata after every handler/adoption write.
+  saveUserPlaced(new Set())
+  markActivePreset('default')
+
   // "Restore everything" includes collapsed SIDES: reopen every bound side
   // (through its store, so $sidebarOpen / the toggles stay truthful). Without
   // this a sidebar hidden before the reset silently survives it, flipping the
@@ -1727,6 +1779,12 @@ export function resetLayoutTree() {
   for (const side of Object.keys(sideOpeners) as TreeSide[]) {
     sideOpeners[side]?.(true)
   }
+
+  // Object identity remains the declared default only when no reset handler or
+  // contributed-pane adoption committed a concrete replacement tree. Callers
+  // that verify durable reset completion use this to distinguish canonical
+  // `null` persistence from a required concrete final-tree write.
+  return $layoutTree.get() !== defaultTree
 }
 
 // Dev hook for automation.

--- a/apps/desktop/src/components/ui/content-direction.test.tsx
+++ b/apps/desktop/src/components/ui/content-direction.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SidebarRowLabel, SidebarRowLink } from '@/app/chat/sidebar/chrome'
+
+import { SearchField } from './search-field'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({ t: { ui: { search: { clear: 'Clear search' } } } })
+}))
+
+afterEach(cleanup)
+
+describe('content-aware direction', () => {
+  it('lets shared search fields resolve Hebrew and mixed queries from their content', () => {
+    render(<SearchField onChange={vi.fn()} placeholder="Search" value="שלום Hermes" />)
+
+    const input = screen.getByRole('textbox', { name: 'Search' })
+    expect(input.getAttribute('dir')).toBe('auto')
+    expect(input.classList.contains('text-start')).toBe(true)
+  })
+
+  it('keeps search direction automatic as the query changes', () => {
+    const onChange = vi.fn()
+    render(<SearchField onChange={onChange} placeholder="Search" value="" />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search' }), { target: { value: 'Hermes בעברית' } })
+    expect(onChange).toHaveBeenCalledWith('Hermes בעברית')
+  })
+
+  it('lets shared sidebar labels resolve their own direction without mirroring row chrome', () => {
+    render(
+      <>
+        <SidebarRowLabel>ניהול גרסאות Hermes</SidebarRowLabel>
+        <SidebarRowLink>פרויקט Daber Elai</SidebarRowLink>
+      </>
+    )
+
+    const label = screen.getByText('ניהול גרסאות Hermes')
+    const link = screen.getByText('פרויקט Daber Elai')
+
+    expect(label.getAttribute('dir')).toBe('auto')
+    expect(label.classList.contains('text-start')).toBe(true)
+    expect(link.getAttribute('dir')).toBe('auto')
+    expect(link.classList.contains('text-start')).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/ui/search-field.tsx
+++ b/apps/desktop/src/components/ui/search-field.tsx
@@ -74,9 +74,10 @@ export function SearchField({
           // text; min-w-0 lets it shrink back below content size when the
           // context is narrower — long queries scroll inside the field.
           // text-xs matches the form controls (Input/Select via controlVariants).
-          'h-7 min-w-0 max-w-full bg-transparent text-xs text-foreground [field-sizing:content] placeholder:text-muted-foreground focus:outline-none',
+          'h-7 min-w-0 max-w-full bg-transparent text-start text-xs text-foreground [field-sizing:content] placeholder:text-muted-foreground focus:outline-none',
           inputClassName
         )}
+        dir="auto"
         onChange={event => onChange(event.target.value)}
         placeholder={effectivePlaceholder}
         ref={inputRef}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -456,6 +456,11 @@ export const en: Translations = {
       colorModeDesc: 'Pick a fixed mode or let Hermes follow your system setting.',
       toolViewTitle: 'Tool Call Display',
       toolViewDesc: 'Product hides raw tool payloads; Technical shows full input/output.',
+      ranModeTitle: 'Ran Mode',
+      ranModeDesc:
+        'Chat first. Temporarily minimizes the sessions rail and hides secondary panes and chrome, then restores your exact prior workspace.',
+      statusBarTitle: 'Status Bar',
+      statusBarDesc: 'Show backend, model, and project status along the bottom. Keep it off for a quieter workspace.',
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -359,6 +359,10 @@ export interface Translations {
       colorModeDesc: string
       toolViewTitle: string
       toolViewDesc: string
+      ranModeTitle: string
+      ranModeDesc: string
+      statusBarTitle: string
+      statusBarDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
       terminalFontTitle: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -446,6 +446,10 @@ export const zh: Translations = {
       colorModeDesc: '选择固定模式，或让 Hermes 跟随系统设置。',
       toolViewTitle: '工具调用显示',
       toolViewDesc: '产品模式隐藏原始工具数据；技术模式显示完整输入/输出。',
+      ranModeTitle: 'Ran 模式',
+      ranModeDesc: '以对话为中心。临时最小化会话栏并隐藏次要面板和界面元素，退出时精确恢复之前的工作区。',
+      statusBarTitle: '状态栏',
+      statusBarDesc: '在底部显示后端、模型和项目状态。关闭可获得更安静的工作区。',
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,

--- a/apps/desktop/src/store/composer-popout.test.ts
+++ b/apps/desktop/src/store/composer-popout.test.ts
@@ -2,11 +2,14 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   $composerPopoutZones,
+  captureComposerPopoutSnapshot,
   clampPopoutPosition,
   getComposerPopoutZone,
   POPOUT_WIDTH_REM,
   type PopoutBounds,
   pruneComposerPopoutZones,
+  reconcileComposerPopoutSnapshot,
+  restoreComposerPopoutSnapshot,
   setComposerPopoutPosition,
   setComposerPoppedOut
 } from './composer-popout'
@@ -80,6 +83,7 @@ describe('clampPopoutPosition', () => {
 
 describe('pop-out state is scoped to a layout zone', () => {
   beforeEach(() => {
+    window.localStorage.clear()
     $composerPopoutZones.set({})
   })
 
@@ -126,5 +130,58 @@ describe('pop-out state is scoped to a layout zone', () => {
     pruneComposerPopoutZones([LEFT_ZONE])
 
     expect(Object.keys($composerPopoutZones.get())).toEqual([LEFT_ZONE])
+  })
+})
+
+describe('transactional composer placement snapshots', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $composerPopoutZones.set({})
+  })
+
+  it.each([
+    ['absent', null],
+    ['explicitly empty', '{}']
+  ])('distinguishes %s durable placement while restoring an empty map', (_label, durableValue) => {
+    if (durableValue !== null) {
+      window.localStorage.setItem('hermes.desktop.composerPopout.zones.v1', durableValue)
+    }
+
+    const snapshot = captureComposerPopoutSnapshot()
+
+    setComposerPoppedOut(LEFT_ZONE, true)
+    restoreComposerPopoutSnapshot(snapshot)
+
+    expect($composerPopoutZones.get()).toEqual({})
+    expect(window.localStorage.getItem('hermes.desktop.composerPopout.zones.v1')).toBe(durableValue)
+  })
+
+  it('captures and restores one concrete pop-out without sharing object identity', () => {
+    const zones = { [LEFT_ZONE]: { poppedOut: true, position: { bottom: 91, right: 113 } } }
+
+    window.localStorage.setItem('hermes.desktop.composerPopout.zones.v1', JSON.stringify(zones))
+    $composerPopoutZones.set(structuredClone(zones))
+    const snapshot = captureComposerPopoutSnapshot()
+
+    pruneComposerPopoutZones([])
+    restoreComposerPopoutSnapshot(snapshot)
+
+    expect($composerPopoutZones.get()).toEqual(zones)
+    expect($composerPopoutZones.get()).not.toBe(snapshot.zones)
+    expect(window.localStorage.getItem('hermes.desktop.composerPopout.zones.v1')).toBe(JSON.stringify(zones))
+  })
+
+  it('derives explicit-layout settlement state from the snapshot and surviving groups', () => {
+    const zones = {
+      [LEFT_ZONE]: { poppedOut: true, position: { bottom: 17, right: 19 } },
+      [RIGHT_ZONE]: { poppedOut: false, position: { bottom: 23, right: 29 } }
+    }
+
+    const snapshot = { storageValue: JSON.stringify(zones), zones }
+
+    expect(reconcileComposerPopoutSnapshot(snapshot, [RIGHT_ZONE])).toEqual({
+      storageValue: JSON.stringify({ [RIGHT_ZONE]: zones[RIGHT_ZONE] }),
+      zones: { [RIGHT_ZONE]: zones[RIGHT_ZONE] }
+    })
   })
 })

--- a/apps/desktop/src/store/composer-popout.ts
+++ b/apps/desktop/src/store/composer-popout.ts
@@ -2,12 +2,15 @@ import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { persistString, storedString } from '@/lib/storage'
 
+import { isAuxiliaryWindow } from './windows'
+
 const POPOUT_STORAGE_KEY = 'hermes.desktop.composerPopout.zones.v1'
 
 // Pre-zone keys: one flag + one position for the whole window. Read at load to
 // seed the first zone the user touches (see `legacySeed`), never written again.
 const LEGACY_ENABLED_KEY = 'hermes.desktop.composerPopout.enabled'
 const LEGACY_POSITION_KEY = 'hermes.desktop.composerPopout.position'
+const composerStorageEnabled = !isAuxiliaryWindow()
 
 /** Where the floating composer's bottom-right corner sits, measured as an inset
  *  from the viewport's bottom/right edges. Anchoring to the bottom-right keeps
@@ -26,6 +29,14 @@ export interface PopoutZoneState {
   position: PopoutPosition
 }
 
+/** Transactional composer placement captured by temporary layout modes.
+ * `storageValue` preserves absent-vs-explicitly-empty durable semantics while
+ * `zones` preserves the canonical in-memory placement map. */
+export interface ComposerPopoutSnapshot {
+  storageValue: null | string
+  zones: Record<string, PopoutZoneState>
+}
+
 // Floating composer width (rem). Shared by the inline style that sets
 // --composer-popout-width and the peel-off drag math.
 export const POPOUT_WIDTH_REM = 19.5
@@ -42,6 +53,25 @@ const isPosition = (value: unknown): value is PopoutPosition => {
   return typeof r?.bottom === 'number' && typeof r?.right === 'number'
 }
 
+const isZoneState = (value: unknown): value is PopoutZoneState => {
+  const zone = value as null | Partial<PopoutZoneState>
+
+  return typeof zone?.poppedOut === 'boolean' && isPosition(zone.position)
+}
+
+export function isComposerPopoutSnapshot(value: unknown): value is ComposerPopoutSnapshot {
+  const snapshot = value as null | Partial<ComposerPopoutSnapshot>
+
+  return (
+    (snapshot?.storageValue === null || typeof snapshot?.storageValue === 'string') &&
+    typeof snapshot?.zones === 'object' &&
+    snapshot.zones !== null &&
+    !Array.isArray(snapshot.zones) &&
+    Object.values(snapshot.zones).every(isZoneState) &&
+    (snapshot.storageValue === null || snapshot.storageValue === JSON.stringify(snapshot.zones))
+  )
+}
+
 /** The pre-zone position, if the user had one. */
 function legacyPosition(): PopoutPosition {
   try {
@@ -56,13 +86,17 @@ function legacyPosition(): PopoutPosition {
 function load(): Record<string, PopoutZoneState> {
   const out: Record<string, PopoutZoneState> = {}
 
+  if (!composerStorageEnabled) {
+    return out
+  }
+
   try {
     const parsed = JSON.parse(storedString(POPOUT_STORAGE_KEY) || 'null') as unknown
 
     for (const [id, value] of Object.entries((parsed as Record<string, unknown>) ?? {})) {
       const zone = value as null | Partial<PopoutZoneState>
 
-      if (typeof zone?.poppedOut === 'boolean' && isPosition(zone.position)) {
+      if (isZoneState(zone)) {
         out[id] = { poppedOut: zone.poppedOut, position: { ...zone.position } }
       }
     }
@@ -81,17 +115,55 @@ function load(): Record<string, PopoutZoneState> {
  *  left doesn't fling a composer out of the right. */
 export const $composerPopoutZones = atom<Record<string, PopoutZoneState>>(load())
 
+export function captureComposerPopoutSnapshot(): ComposerPopoutSnapshot {
+  const zones = structuredClone($composerPopoutZones.get())
+  const persisted = composerStorageEnabled ? window.localStorage.getItem(POPOUT_STORAGE_KEY) : null
+
+  return { storageValue: persisted === null ? null : JSON.stringify(zones), zones }
+}
+
+export function restoreComposerPopoutSnapshot(snapshot: ComposerPopoutSnapshot): void {
+  if (!composerStorageEnabled) {
+    return
+  }
+
+  $composerPopoutZones.set(structuredClone(snapshot.zones))
+  persistString(POPOUT_STORAGE_KEY, snapshot.storageValue)
+}
+
+/** Apply the same filtering semantics as `pruneComposerPopoutZones` without
+ * mutating the store. Used to verify explicit preset/reset exit outcomes. */
+export function reconcileComposerPopoutSnapshot(
+  snapshot: ComposerPopoutSnapshot,
+  liveGroupIds: Iterable<string>
+): ComposerPopoutSnapshot {
+  const live = new Set(liveGroupIds)
+  const zones = Object.fromEntries(Object.entries(snapshot.zones).filter(([id]) => live.has(id)))
+  const removed = Object.keys(zones).length !== Object.keys(snapshot.zones).length
+
+  return {
+    storageValue: removed ? JSON.stringify(zones) : snapshot.storageValue,
+    zones
+  }
+}
+
 /** Write-through to storage. Called explicitly — NOT on every store change: a
  *  drag updates the position once per frame, and serializing every zone to
  *  localStorage at 60Hz is exactly the IO the drag path was built to avoid. */
-const persistZones = () => persistString(POPOUT_STORAGE_KEY, JSON.stringify($composerPopoutZones.get()))
+const persistZones = () => {
+  if (composerStorageEnabled) {
+    persistString(POPOUT_STORAGE_KEY, JSON.stringify($composerPopoutZones.get()))
+  }
+}
 
 /** Whether the user had a float before zones existed. Seeds a zone's first read
  *  so an upgrade doesn't silently dock someone who left their composer floating
  *  — but ONLY until they touch any zone. Once real per-zone state exists, that
  *  is the truth, and a zone split later starts docked like any other. */
 let legacySeed: PopoutZoneState | null =
-  storedString(LEGACY_ENABLED_KEY) === 'true' ? { poppedOut: true, position: legacyPosition() } : null
+  composerStorageEnabled && storedString(LEGACY_ENABLED_KEY) === 'true'
+    ? { poppedOut: true, position: legacyPosition() }
+    : null
 
 const zoneState = (zones: Record<string, PopoutZoneState>, groupId: string): PopoutZoneState =>
   zones[groupId] ?? legacySeed ?? DEFAULT_ZONE

--- a/apps/desktop/src/store/layout-session-page-size.test.ts
+++ b/apps/desktop/src/store/layout-session-page-size.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  $sessionsLimit,
+  bumpSessionsLimit,
+  resetSessionsLimit,
+  SIDEBAR_FILTERED_PAGE_SIZE,
+  SIDEBAR_SESSIONS_PAGE_SIZE
+} from './layout'
+
+describe('sidebar session page size', () => {
+  it('preserves the upstream page windows and keeps load-more incremental', () => {
+    resetSessionsLimit()
+
+    expect(SIDEBAR_SESSIONS_PAGE_SIZE).toBe(50)
+    expect(SIDEBAR_FILTERED_PAGE_SIZE).toBe(300)
+    expect($sessionsLimit.get()).toBe(50)
+
+    bumpSessionsLimit()
+    expect($sessionsLimit.get()).toBe(100)
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -11,6 +11,7 @@ import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride, t
 import { $showAllProfiles, setShowAllProfiles } from './profile'
 import type { PullRequestBucket } from './pull-requests'
 import type { SessionStatusBucket } from './session-dot-state'
+import { isAuxiliaryWindow } from './windows'
 
 export const SIDEBAR_DEFAULT_WIDTH = 237
 export const SIDEBAR_MAX_WIDTH = 360
@@ -77,10 +78,12 @@ export const $fileBrowserOpen: ReadableAtom<boolean> = computed(
 
 // Persisted so a relaunch reopens the same rail tab. Null when the rail has no
 // tabs; a restored id with no matching tab is reconciled in the preview store.
-export const $rightRailActiveTabId = persistentAtom<RightRailTabId | null>(RIGHT_RAIL_ACTIVE_TAB_STORAGE_KEY, null, {
-  decode: raw => (raw ? (raw as RightRailTabId) : null),
-  encode: tabId => tabId ?? ''
-})
+export const $rightRailActiveTabId = isAuxiliaryWindow()
+  ? atom<RightRailTabId | null>(null)
+  : persistentAtom<RightRailTabId | null>(RIGHT_RAIL_ACTIVE_TAB_STORAGE_KEY, null, {
+      decode: raw => (raw ? (raw as RightRailTabId) : null),
+      encode: tabId => tabId ?? ''
+    })
 
 export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states => {
   const override = states[CHAT_SIDEBAR_PANE_ID]?.widthOverride
@@ -345,7 +348,9 @@ export const $sidebarViewCustomized: ReadableAtom<boolean> = computed(
 
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
-export const $panesFlipped = persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Codecs.bool)
+export const $panesFlipped = isAuxiliaryWindow()
+  ? atom(false)
+  : persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Codecs.bool)
 export const $isSidebarResizing = atom(false)
 export const $sessionsLimit = atom(SIDEBAR_SESSIONS_PAGE_SIZE)
 

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -78,12 +78,10 @@ export const $fileBrowserOpen: ReadableAtom<boolean> = computed(
 
 // Persisted so a relaunch reopens the same rail tab. Null when the rail has no
 // tabs; a restored id with no matching tab is reconciled in the preview store.
-export const $rightRailActiveTabId = isAuxiliaryWindow()
-  ? atom<RightRailTabId | null>(null)
-  : persistentAtom<RightRailTabId | null>(RIGHT_RAIL_ACTIVE_TAB_STORAGE_KEY, null, {
-      decode: raw => (raw ? (raw as RightRailTabId) : null),
-      encode: tabId => tabId ?? ''
-    })
+export const $rightRailActiveTabId = persistentAtom<RightRailTabId | null>(RIGHT_RAIL_ACTIVE_TAB_STORAGE_KEY, null, {
+  decode: raw => (raw ? (raw as RightRailTabId) : null),
+  encode: tabId => tabId ?? ''
+})
 
 export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states => {
   const override = states[CHAT_SIDEBAR_PANE_ID]?.widthOverride

--- a/apps/desktop/src/store/panes.ts
+++ b/apps/desktop/src/store/panes.ts
@@ -1,5 +1,7 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
+import { isAuxiliaryWindow } from './windows'
+
 export interface PaneStateSnapshot {
   open: boolean
   widthOverride?: number
@@ -13,6 +15,7 @@ export interface PaneRegisterDefaults {
 }
 
 const STORAGE_KEY = 'hermes.desktop.paneStates.v1'
+const paneStorageEnabled = !isAuxiliaryWindow()
 
 function isSnapshot(value: unknown): value is PaneStateSnapshot {
   if (!value || typeof value !== 'object') {
@@ -35,7 +38,7 @@ function isSnapshot(value: unknown): value is PaneStateSnapshot {
 }
 
 function load(): Record<string, PaneStateSnapshot> {
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || !paneStorageEnabled) {
     return {}
   }
 
@@ -66,7 +69,7 @@ function load(): Record<string, PaneStateSnapshot> {
 
 // Persists both open state and resize width; load() validates each snapshot.
 function persist(states: Record<string, PaneStateSnapshot>) {
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || !paneStorageEnabled) {
     return
   }
 

--- a/apps/desktop/src/store/ran-mode-presentation.test.ts
+++ b/apps/desktop/src/store/ran-mode-presentation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ranModeStatusStackMaxClass,
+  shouldAutoOpenToolDiff,
+  shouldShowPinnedSection
+} from './ran-mode-presentation'
+
+describe('Ran Mode presentation policy', () => {
+  it('collapses successful settled diffs but never hides running or failed work', () => {
+    expect(
+      shouldAutoOpenToolDiff({ hasInlineDiff: true, isError: false, isPending: false, ranModeEnabled: true })
+    ).toBe(false)
+    expect(
+      shouldAutoOpenToolDiff({ hasInlineDiff: true, isError: false, isPending: true, ranModeEnabled: true })
+    ).toBe(true)
+    expect(
+      shouldAutoOpenToolDiff({ hasInlineDiff: true, isError: true, isPending: false, ranModeEnabled: true })
+    ).toBe(true)
+    expect(
+      shouldAutoOpenToolDiff({ hasInlineDiff: true, isError: false, isPending: false, ranModeEnabled: false })
+    ).toBe(true)
+    expect(
+      shouldAutoOpenToolDiff({ hasInlineDiff: false, isError: true, isPending: false, ranModeEnabled: true })
+    ).toBe(false)
+  })
+
+  it('hides only an empty pinned section while Ran Mode is active', () => {
+    expect(shouldShowPinnedSection({ pinnedCount: 0, ranModeEnabled: true })).toBe(false)
+    expect(shouldShowPinnedSection({ pinnedCount: 1, ranModeEnabled: true })).toBe(true)
+    expect(shouldShowPinnedSection({ pinnedCount: 0, ranModeEnabled: false })).toBe(true)
+  })
+
+  it('uses the bounded 30vh status stack only while Ran Mode is active', () => {
+    expect(ranModeStatusStackMaxClass(true)).toBe('max-h-[30vh]')
+    expect(ranModeStatusStackMaxClass(false)).toBe('max-h-[40vh]')
+  })
+})

--- a/apps/desktop/src/store/ran-mode-presentation.ts
+++ b/apps/desktop/src/store/ran-mode-presentation.ts
@@ -1,0 +1,37 @@
+export interface ToolDiffOpenPolicy {
+  hasInlineDiff: boolean
+  isError: boolean
+  isPending: boolean
+  ranModeEnabled: boolean
+}
+
+/**
+ * Ran Mode hides settled-success noise only. Live work and failures keep the
+ * same visible disclosure behavior as the normal Desktop experience.
+ */
+export function shouldAutoOpenToolDiff({
+  hasInlineDiff,
+  isError,
+  isPending,
+  ranModeEnabled
+}: ToolDiffOpenPolicy): boolean {
+  if (!hasInlineDiff) {
+    return false
+  }
+
+  return !ranModeEnabled || isPending || isError
+}
+
+export function shouldShowPinnedSection({
+  pinnedCount,
+  ranModeEnabled
+}: {
+  pinnedCount: number
+  ranModeEnabled: boolean
+}): boolean {
+  return !ranModeEnabled || pinnedCount > 0
+}
+
+export function ranModeStatusStackMaxClass(ranModeEnabled: boolean): 'max-h-[30vh]' | 'max-h-[40vh]' {
+  return ranModeEnabled ? 'max-h-[30vh]' : 'max-h-[40vh]'
+}

--- a/apps/desktop/src/store/ran-mode.test.ts
+++ b/apps/desktop/src/store/ran-mode.test.ts
@@ -1,0 +1,2412 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const DEFAULT_TREE = {
+  type: 'split' as const,
+  id: 'test-default-root',
+  orientation: 'row' as const,
+  weights: [0.3, 0.7],
+  children: [
+    { type: 'group' as const, id: 'test-default-sessions', panes: ['sessions'], active: 'sessions' },
+    { type: 'group' as const, id: 'test-default-workspace', panes: ['workspace'], active: 'workspace' }
+  ]
+}
+
+const OWNED_STORAGE_KEYS = [
+  'hermes.desktop.layoutPreset.active',
+  'hermes.desktop.composerPopout.zones.v1',
+  'hermes.desktop.dismissedPanes.v1',
+  'hermes.desktop.layoutTree.v2',
+  'hermes.desktop.paneStates.v1',
+  'hermes.desktop.panesFlipped',
+  'hermes.desktop.reviewOpen',
+  'hermes.desktop.rightRailActiveTab',
+  'hermes.desktop.statusbarVisible',
+  'hermes.desktop.terminalTakeover',
+  'hermes.desktop.toolView.technical',
+  'hermes.desktop.userPlacedPanes.v1'
+]
+
+const RAN_MODE_BACKUP_KEY = 'hermes.desktop.ranMode.v1.backup'
+const COMPOSER_POPOUT_STORAGE_KEY = 'hermes.desktop.composerPopout.zones.v1'
+
+function backupPayload(value: null | string): null | Record<string, unknown> {
+  if (value === null) {
+    return null
+  }
+
+  try {
+    const envelope = JSON.parse(value) as { payload?: unknown }
+
+    return typeof envelope.payload === 'string' ? (JSON.parse(envelope.payload) as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function captureOwnedStorageFingerprint() {
+  return JSON.stringify(OWNED_STORAGE_KEYS.map(key => [key, window.localStorage.getItem(key)]))
+}
+
+async function loadHarness() {
+  const presets = await import('@/components/pane-shell/tree/presets')
+  const tree = await import('@/components/pane-shell/tree/store')
+  const composer = await import('@/store/composer-popout')
+  const layout = await import('@/store/layout')
+  const panes = await import('@/store/panes')
+  const statusbar = await import('@/store/statusbar-prefs')
+  const tools = await import('@/store/tool-view')
+  const review = await import('@/store/review')
+  const terminal = await import('@/app/right-sidebar/store')
+  const ran = await import('./ran-mode')
+
+  tree.declareDefaultTree(DEFAULT_TREE)
+  panes.ensurePaneRegistered('chat-sidebar', { open: true })
+  panes.ensurePaneRegistered('file-browser', { open: false })
+
+  return { composer, layout, panes, presets, ran, review, statusbar, terminal, tools, tree }
+}
+
+function installQueuedLockHarness() {
+  let activeLocks = 0
+  let maxActiveLocks = 0
+  let releaseFirst!: () => void
+  let firstRequestStarted!: () => void
+
+  const firstStarted = new Promise<void>(resolve => {
+    firstRequestStarted = resolve
+  })
+
+  const firstGate = new Promise<void>(resolve => {
+    releaseFirst = resolve
+  })
+
+  const requests: Array<{ mode: LockOptions['mode']; name: string }> = []
+  let tail = Promise.resolve()
+
+  Object.defineProperty(navigator, 'locks', {
+    configurable: true,
+    value: {
+      request: (name: string, options: LockOptions, callback: () => Promise<boolean>) => {
+        const requestIndex = requests.length
+        const predecessor = tail
+
+        requests.push({ mode: options.mode, name })
+
+        let releaseSlot!: () => void
+
+        tail = new Promise<void>(resolve => {
+          releaseSlot = resolve
+        })
+
+        return predecessor.then(async () => {
+          activeLocks += 1
+          maxActiveLocks = Math.max(maxActiveLocks, activeLocks)
+
+          try {
+            if (requestIndex === 0) {
+              firstRequestStarted()
+              await firstGate
+            }
+
+            return await callback()
+          } finally {
+            activeLocks -= 1
+            releaseSlot()
+          }
+        })
+      }
+    }
+  })
+
+  return {
+    activeLocks: () => activeLocks,
+    firstStarted,
+    idle: () => tail,
+    maxActiveLocks: () => maxActiveLocks,
+    releaseFirst,
+    requests
+  }
+}
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'locks', {
+    configurable: true,
+    value: { request: async (_name: string, _options: LockOptions, callback: () => Promise<boolean>) => callback() }
+  })
+  window.localStorage.clear()
+  vi.resetModules()
+})
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, 'locks')
+  window.localStorage.clear()
+  vi.restoreAllMocks()
+  vi.doUnmock('@/store/windows')
+  vi.resetModules()
+})
+
+describe('Ran Mode state transaction', () => {
+  it('leaves upstream sidebar grouping, ordering, archive, and filters unchanged across a Ran cycle', async () => {
+    const { layout, ran } = await loadHarness()
+
+    layout.setSidebarGrouping('project')
+    layout.setSidebarOrdering('cost')
+    layout.setSidebarShowArchived(true)
+    layout.toggleSidebarStatusFilter('working')
+    layout.toggleSidebarProjectFilter('project-1')
+    layout.toggleSidebarPrFilter('open')
+    layout.$sidebarRowMeta.set(['pr', 'tokens'])
+
+    const captureSidebarView = () => ({
+      filtersActive: layout.$sidebarFiltersActive.get(),
+      grouping: layout.$sidebarGrouping.get(),
+      ordering: layout.$sidebarOrdering.get(),
+      prFilter: layout.$sidebarPrFilter.get(),
+      projectFilter: layout.$sidebarProjectFilter.get(),
+      rowMeta: layout.$sidebarRowMeta.get(),
+      showArchived: layout.$sidebarShowArchived.get(),
+      statusFilter: layout.$sidebarStatusFilter.get()
+    })
+    const upstreamView = {
+      filtersActive: true,
+      grouping: 'project',
+      ordering: 'cost',
+      prFilter: ['open'],
+      projectFilter: ['project-1'],
+      rowMeta: ['pr', 'tokens'],
+      showArchived: true,
+      statusFilter: ['working']
+    }
+
+    expect(captureSidebarView()).toEqual(upstreamView)
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(captureSidebarView()).toEqual(upstreamView)
+    expect(await ran.disableRanMode()).toBe(true)
+    expect(captureSidebarView()).toEqual(upstreamView)
+  })
+
+  it('writes the shared journal only while holding the cross-window exclusive lock', async () => {
+    const nativeSetItem = Storage.prototype.setItem
+    const originalLocks = Object.getOwnPropertyDescriptor(navigator, 'locks')
+    let lockHeld = false
+    let lockRequests = 0
+    let requestedMode: LockOptions['mode']
+    let requestedName: string | null = null
+
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: async (name: string, options: LockOptions, callback: () => Promise<boolean>) => {
+          lockRequests += 1
+          requestedMode = options.mode
+          requestedName = name
+          lockHeld = true
+
+          try {
+            return await callback()
+          } finally {
+            lockHeld = false
+          }
+        }
+      }
+    })
+
+    try {
+      const { ran } = await loadHarness()
+
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+        if ((key === ran.RAN_MODE_STORAGE_KEY || key === RAN_MODE_BACKUP_KEY) && !lockHeld) {
+          throw new DOMException('journal write escaped the exclusive lock', 'InvalidStateError')
+        }
+
+        nativeSetItem.call(this, key, value)
+      })
+
+      expect(await ran.enableRanMode()).toBe(true)
+      expect(lockRequests).toBe(1)
+      expect(requestedName).toBe(ran.RAN_MODE_LOCK_NAME)
+      expect(requestedMode).toBe('exclusive')
+    } finally {
+      if (originalLocks) {
+        Object.defineProperty(navigator, 'locks', originalLocks)
+      } else {
+        Reflect.deleteProperty(navigator, 'locks')
+      }
+    }
+  })
+
+  it('serializes two renderer instances that enable from the same empty journal', async () => {
+    let activeLocks = 0
+    let maxActiveLocks = 0
+    let releaseFirst!: () => void
+    let firstRequestStarted!: () => void
+
+    const firstStarted = new Promise<void>(resolve => {
+      firstRequestStarted = resolve
+    })
+
+    const firstGate = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+
+    let requestCount = 0
+    let tail = Promise.resolve()
+
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: (_name: string, _options: LockOptions, callback: () => Promise<boolean>) => {
+          const requestIndex = requestCount++
+          const predecessor = tail
+          let releaseSlot!: () => void
+          tail = new Promise<void>(resolve => {
+            releaseSlot = resolve
+          })
+
+          return predecessor.then(async () => {
+            activeLocks += 1
+            maxActiveLocks = Math.max(maxActiveLocks, activeLocks)
+
+            try {
+              if (requestIndex === 0) {
+                firstRequestStarted()
+                await firstGate
+              }
+
+              return await callback()
+            } finally {
+              activeLocks -= 1
+              releaseSlot()
+            }
+          })
+        }
+      }
+    })
+
+    const first = await loadHarness()
+    const firstEnable = first.ran.enableRanMode()
+    await firstStarted
+
+    vi.resetModules()
+    const second = await loadHarness()
+    const secondEnable = second.ran.enableRanMode()
+
+    expect(requestCount).toBe(2)
+    expect(activeLocks).toBe(1)
+    releaseFirst()
+
+    await expect(Promise.all([firstEnable, secondEnable])).resolves.toEqual([true, false])
+    expect(maxActiveLocks).toBe(1)
+    expect(JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'active'
+    })
+  })
+
+  it('serializes ordinary preset decisions through the Ran journal authority', async () => {
+    let lockRequests = 0
+
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: async (_name: string, _options: LockOptions, callback: () => Promise<boolean>) => {
+          lockRequests += 1
+
+          return callback()
+        }
+      }
+    })
+
+    const { presets, ran, tree } = await loadHarness()
+
+    const chosenTree = {
+      type: 'group' as const,
+      id: 'serialized-preset',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    expect(await presets.applyLayoutPreset('serialized-choice', chosenTree)).toBe(true)
+    expect(lockRequests).toBe(1)
+    expect(tree.$activePresetId.get()).toBe('serialized-choice')
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps a newer enabled transaction after a queued peer disables the prior transaction', async () => {
+    const first = await loadHarness()
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+
+    const firstTransactionId = JSON.parse(
+      window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}'
+    ).transactionId
+
+    const locks = installQueuedLockHarness()
+    const firstDisable = first.ran.disableRanMode()
+
+    await locks.firstStarted
+    vi.resetModules()
+
+    const second = await loadHarness()
+    const secondEnable = second.ran.enableRanMode()
+
+    expect(locks.requests).toEqual([
+      { mode: 'exclusive', name: first.ran.RAN_MODE_LOCK_NAME },
+      { mode: 'exclusive', name: first.ran.RAN_MODE_LOCK_NAME }
+    ])
+    locks.releaseFirst()
+
+    await expect(Promise.all([firstDisable, secondEnable])).resolves.toEqual([true, true])
+
+    const durable = JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    expect(durable).toMatchObject({ enabled: true, phase: 'active' })
+    expect(durable.transactionId).not.toBe(firstTransactionId)
+    expect(locks.maxActiveLocks()).toBe(1)
+  })
+
+  it('cannot let completed-record cleanup remove a queued newer generation', async () => {
+    const first = await loadHarness()
+    const nativeRemoveItem = Storage.prototype.removeItem
+
+    const removeSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function (this: Storage, key) {
+      if (key !== first.ran.RAN_MODE_STORAGE_KEY) {
+        nativeRemoveItem.call(this, key)
+      }
+    })
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+    expect(await first.ran.disableRanMode()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: true,
+      enabled: false
+    })
+    removeSpy.mockRestore()
+
+    const locks = installQueuedLockHarness()
+    const cleanup = first.ran.initializeRanMode()
+
+    await locks.firstStarted
+    vi.resetModules()
+
+    const second = await loadHarness()
+    const secondEnable = second.ran.enableRanMode()
+
+    locks.releaseFirst()
+    await expect(Promise.all([cleanup, secondEnable])).resolves.toEqual([false, true])
+    expect(JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'active'
+    })
+    expect(locks.maxActiveLocks()).toBe(1)
+  })
+
+  it('serializes malformed cleanup before a queued valid generation is created', async () => {
+    window.localStorage.setItem('hermes.desktop.ranMode.v1', '{"version":1')
+
+    const locks = installQueuedLockHarness()
+    const first = await loadHarness()
+    const cleanup = first.ran.initializeRanMode()
+
+    await locks.firstStarted
+    vi.resetModules()
+
+    const second = await loadHarness()
+    const secondEnable = second.ran.enableRanMode()
+
+    locks.releaseFirst()
+    await expect(Promise.all([cleanup, secondEnable])).resolves.toEqual([false, true])
+    expect(JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'active'
+    })
+    expect(locks.maxActiveLocks()).toBe(1)
+  })
+
+  it('rejects an overlapping opposite intent from the same renderer while its lock request is pending', async () => {
+    const locks = installQueuedLockHarness()
+    const { ran } = await loadHarness()
+    const enable = ran.enableRanMode()
+
+    await locks.firstStarted
+
+    const overlappingDisable = ran.disableRanMode()
+
+    expect(locks.requests).toEqual([{ mode: 'exclusive', name: ran.RAN_MODE_LOCK_NAME }])
+    locks.releaseFirst()
+    await expect(Promise.all([enable, overlappingDisable])).resolves.toEqual([true, false])
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'active'
+    })
+  })
+
+  it('fails closed without Web Locks instead of mutating the journal', async () => {
+    Reflect.deleteProperty(navigator, 'locks')
+
+    const { ran } = await loadHarness()
+
+    expect(await ran.enableRanMode()).toBe(false)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+  })
+
+  it('captures once, applies idempotently, and restores the exact owned layout state once', async () => {
+    const { panes, ran, review, statusbar, terminal, tools, tree } = await loadHarness()
+
+    const customTree = {
+      type: 'split' as const,
+      id: 'custom-root',
+      orientation: 'row' as const,
+      weights: [0.42, 0.58],
+      children: [
+        { type: 'group' as const, id: 'custom-sessions', panes: ['sessions'], active: 'sessions' },
+        {
+          type: 'group' as const,
+          id: 'custom-workspace',
+          panes: ['workspace', 'file-browser'],
+          active: 'file-browser'
+        }
+      ]
+    }
+
+    tree.applyTree(customTree, 'custom-before-ran')
+    panes.$paneStates.set({
+      'chat-sidebar': { open: false, widthOverride: 311 },
+      'file-browser': { open: true, widthOverride: 407 }
+    })
+    statusbar.$statusbarVisible.set(true)
+    tools.$toolViewMode.set('technical')
+    review.$reviewOpen.set(true)
+    terminal.$terminalTakeover.set(true)
+
+    const before = {
+      layout: tree.captureLayoutStateSnapshot(),
+      panes: structuredClone(panes.$paneStates.get()),
+      review: review.$reviewOpen.get(),
+      statusbar: statusbar.$statusbarVisible.get(),
+      terminal: terminal.$terminalTakeover.get(),
+      tools: tools.$toolViewMode.get()
+    }
+
+    expect(await ran.enableRanMode()).toBe(true)
+    const persistedAfterFirstEnable = window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)
+
+    expect(ran.$ranModeEnabled.get()).toBe(true)
+    expect(tree.$activePresetId.get()).toBe(ran.RAN_MODE_PRESET_ID)
+    const ranTree = tree.$layoutTree.get()
+    expect(ranTree?.type).toBe('split')
+    expect(ranTree?.type === 'split' ? ranTree.children[0] : null).toMatchObject({
+      type: 'group',
+      id: 'ran-mode-sessions',
+      minimized: true
+    })
+    expect(panes.$paneStates.get()['chat-sidebar']?.open).toBe(true)
+    expect(panes.$paneStates.get()['file-browser']?.open).toBe(false)
+    expect(statusbar.$statusbarVisible.get()).toBe(false)
+    expect(tools.$toolViewMode.get()).toBe('product')
+    expect(review.$reviewOpen.get()).toBe(false)
+    expect(terminal.$terminalTakeover.get()).toBe(false)
+
+    expect(await ran.enableRanMode()).toBe(false)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBe(persistedAfterFirstEnable)
+
+    // Layout/pane state is snapshot-owned while the mode is active: temporary
+    // expansion is allowed, but leaving Ran Mode restores the original workspace.
+    tree.setTreeGroupMinimized('ran-mode-sessions', false)
+    panes.setPaneOpen('file-browser', true)
+
+    expect(await ran.disableRanMode()).toBe(true)
+    expect(tree.captureLayoutStateSnapshot()).toEqual(before.layout)
+    expect(panes.$paneStates.get()).toEqual(before.panes)
+    expect(review.$reviewOpen.get()).toBe(before.review)
+    expect(statusbar.$statusbarVisible.get()).toBe(before.statusbar)
+    expect(terminal.$terminalTakeover.get()).toBe(before.terminal)
+    expect(tools.$toolViewMode.get()).toBe(before.tools)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+
+    const afterFirstDisable = JSON.stringify({
+      layout: tree.captureLayoutStateSnapshot(),
+      panes: panes.$paneStates.get()
+    })
+
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(JSON.stringify({ layout: tree.captureLayoutStateSnapshot(), panes: panes.$paneStates.get() })).toBe(
+      afterFirstDisable
+    )
+  })
+
+  it('restores composer pop-out placement after the Ran layout prunes removed live-session and contributed zones', async () => {
+    const originalComposerZones = {
+      'contributed-zone': { poppedOut: true, position: { bottom: 73, right: 89 } },
+      'ran-mode-workspace': { poppedOut: true, position: { bottom: 31, right: 47 } },
+      'session-zone-one': { poppedOut: true, position: { bottom: 41, right: 59 } },
+      'session-zone-two': { poppedOut: false, position: { bottom: 53, right: 67 } }
+    }
+
+    window.localStorage.setItem(COMPOSER_POPOUT_STORAGE_KEY, JSON.stringify(originalComposerZones))
+
+    const { composer, ran, tree } = await loadHarness()
+    const { groupLeafIds } = await import('@/components/pane-shell/tree/model')
+
+    const beforeTree = {
+      type: 'split' as const,
+      id: 'composer-before-ran-root',
+      orientation: 'row' as const,
+      weights: [1, 1, 1, 1],
+      children: [
+        { type: 'group' as const, id: 'session-zone-one', panes: ['session-tile:one'], active: 'session-tile:one' },
+        { type: 'group' as const, id: 'session-zone-two', panes: ['session-tile:two'], active: 'session-tile:two' },
+        { type: 'group' as const, id: 'ran-mode-workspace', panes: ['workspace'], active: 'workspace' },
+        { type: 'group' as const, id: 'contributed-zone', panes: ['plugin-pane'], active: 'plugin-pane' }
+      ]
+    }
+
+    tree.applyTree(beforeTree, 'composer-before-ran')
+
+    const unlisten = tree.$layoutTree.subscribe(layout => {
+      if (layout) {
+        composer.pruneComposerPopoutZones(groupLeafIds(layout))
+      }
+    })
+
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(composer.$composerPopoutZones.get()).toEqual({
+      'ran-mode-workspace': originalComposerZones['ran-mode-workspace']
+    })
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe(
+      JSON.stringify({ 'ran-mode-workspace': originalComposerZones['ran-mode-workspace'] })
+    )
+
+    expect(await ran.disableRanMode()).toBe(true)
+    expect(composer.$composerPopoutZones.get()).toEqual(originalComposerZones)
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe(JSON.stringify(originalComposerZones))
+    expect(groupLeafIds(tree.$layoutTree.get()!)).toEqual(
+      expect.arrayContaining(['session-zone-one', 'session-zone-two', 'ran-mode-workspace', 'contributed-zone'])
+    )
+
+    unlisten()
+  })
+
+  it.each([
+    ['absent', null],
+    ['explicitly empty', '{}']
+  ])('preserves an %s composer placement through repeated enable and disable', async (_label, durableValue) => {
+    if (durableValue !== null) {
+      window.localStorage.setItem(COMPOSER_POPOUT_STORAGE_KEY, durableValue)
+    }
+
+    const { composer, ran } = await loadHarness()
+
+    expect(composer.$composerPopoutZones.get()).toEqual({})
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(await ran.enableRanMode()).toBe(false)
+    expect(await ran.disableRanMode()).toBe(true)
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(composer.$composerPopoutZones.get()).toEqual({})
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe(durableValue)
+  })
+
+  it('restores composer placement after restart while Ran Mode is active', async () => {
+    const originalComposerZones = {
+      'restart-removed-zone': { poppedOut: true, position: { bottom: 61, right: 79 } }
+    }
+
+    window.localStorage.setItem(COMPOSER_POPOUT_STORAGE_KEY, JSON.stringify(originalComposerZones))
+
+    const first = await loadHarness()
+
+    first.composer.pruneComposerPopoutZones(['restart-removed-zone'])
+    expect(await first.ran.enableRanMode()).toBe(true)
+    first.composer.pruneComposerPopoutZones([])
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe('{}')
+
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+
+    expect(await restarted.ran.initializeRanMode()).toBe(true)
+    expect(restarted.composer.$composerPopoutZones.get()).toEqual({})
+    expect(await restarted.ran.disableRanMode()).toBe(true)
+    expect(restarted.composer.$composerPopoutZones.get()).toEqual(originalComposerZones)
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe(JSON.stringify(originalComposerZones))
+  })
+
+  it('keeps composer restoration incomplete when persistence is swallowed and retries after restart', async () => {
+    const originalComposerZones = {
+      'retry-removed-zone': { poppedOut: true, position: { bottom: 83, right: 97 } }
+    }
+
+    window.localStorage.setItem(COMPOSER_POPOUT_STORAGE_KEY, JSON.stringify(originalComposerZones))
+
+    const first = await loadHarness()
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+    first.composer.pruneComposerPopoutZones([])
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe('{}')
+
+    const nativeSetItem = Storage.prototype.setItem
+
+    const set = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === COMPOSER_POPOUT_STORAGE_KEY) {
+        throw new DOMException('composer persistence unavailable', 'QuotaExceededError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await first.ran.disableRanMode()).toBe(false)
+    expect(first.ran.$ranModeEnabled.get()).toBe(true)
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe('{}')
+    expect(JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      phase: 'inactive'
+    })
+
+    set.mockRestore()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restarted.ran.$ranModeEnabled.get()).toBe(false)
+    expect(restarted.composer.$composerPopoutZones.get()).toEqual(originalComposerZones)
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe(JSON.stringify(originalComposerZones))
+    expect(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps composer restoration incomplete when the composer store rejects its restore and retries after restart', async () => {
+    const originalComposerZones = {
+      'store-retry-zone': { poppedOut: true, position: { bottom: 89, right: 107 } }
+    }
+
+    window.localStorage.setItem(COMPOSER_POPOUT_STORAGE_KEY, JSON.stringify(originalComposerZones))
+
+    const first = await loadHarness()
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+    first.composer.pruneComposerPopoutZones([])
+
+    const set = vi.spyOn(first.composer.$composerPopoutZones, 'set').mockImplementation(() => {
+      throw new Error('composer store restore failed')
+    })
+
+    expect(await first.ran.disableRanMode()).toBe(false)
+    expect(first.ran.$ranModeEnabled.get()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      phase: 'inactive'
+    })
+
+    set.mockRestore()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restarted.composer.$composerPopoutZones.get()).toEqual(originalComposerZones)
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe(JSON.stringify(originalComposerZones))
+    expect(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('restores composer persistence only while holding the existing Ran Web Lock authority', async () => {
+    const originalComposerZones = {
+      'locked-zone': { poppedOut: true, position: { bottom: 101, right: 127 } }
+    }
+
+    let lockHeld = false
+
+    window.localStorage.setItem(COMPOSER_POPOUT_STORAGE_KEY, JSON.stringify(originalComposerZones))
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: {
+        request: async (_name: string, _options: LockOptions, callback: () => Promise<boolean>) => {
+          lockHeld = true
+
+          try {
+            return await callback()
+          } finally {
+            lockHeld = false
+          }
+        }
+      }
+    })
+
+    const first = await loadHarness()
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+    first.composer.pruneComposerPopoutZones([])
+
+    const nativeSetItem = Storage.prototype.setItem
+
+    const set = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === COMPOSER_POPOUT_STORAGE_KEY && value === JSON.stringify(originalComposerZones) && !lockHeld) {
+        throw new DOMException('composer restore escaped the Ran lock', 'InvalidStateError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await first.ran.disableRanMode()).toBe(true)
+    expect(first.composer.$composerPopoutZones.get()).toEqual(originalComposerZones)
+    set.mockRestore()
+  })
+
+  it('keeps Reset Layout authoritative by reconciling the captured composer map to the reset tree', async () => {
+    const originalComposerZones = {
+      'reset-removed-zone': { poppedOut: true, position: { bottom: 137, right: 149 } }
+    }
+
+    window.localStorage.setItem(COMPOSER_POPOUT_STORAGE_KEY, JSON.stringify(originalComposerZones))
+
+    const { composer, ran, tree } = await loadHarness()
+    const { groupLeafIds } = await import('@/components/pane-shell/tree/model')
+
+    const unlisten = tree.$layoutTree.subscribe(layout => {
+      if (layout) {
+        composer.pruneComposerPopoutZones(groupLeafIds(layout))
+      }
+    })
+
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe('{}')
+    expect(await ran.resetLayoutFromRanMode()).toBe(true)
+    expect(composer.$composerPopoutZones.get()).toEqual({})
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe('{}')
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+
+    unlisten()
+  })
+
+  it('preserves explicit user-owned status bar and tool-view changes made while active', async () => {
+    const { ran, statusbar, tools } = await loadHarness()
+
+    statusbar.$statusbarVisible.set(false)
+    tools.$toolViewMode.set('product')
+    expect(await ran.enableRanMode()).toBe(true)
+
+    statusbar.$statusbarVisible.set(true)
+    tools.$toolViewMode.set('technical')
+
+    expect(await ran.disableRanMode()).toBe(true)
+    expect(statusbar.$statusbarVisible.get()).toBe(true)
+    expect(tools.$toolViewMode.get()).toBe('technical')
+  })
+
+  it('survives a module restart and restores the pre-entry state afterward', async () => {
+    const first = await loadHarness()
+
+    const customTree = {
+      type: 'split' as const,
+      id: 'restart-root',
+      orientation: 'row' as const,
+      weights: [0.36, 0.64],
+      children: [
+        { type: 'group' as const, id: 'restart-sessions', panes: ['sessions'], active: 'sessions' },
+        { type: 'group' as const, id: 'restart-workspace', panes: ['workspace'], active: 'workspace' }
+      ]
+    }
+
+    first.tree.applyTree(customTree, 'restart-custom')
+    first.panes.$paneStates.set({
+      'chat-sidebar': { open: true, widthOverride: 287 },
+      'file-browser': { open: true, widthOverride: 333 }
+    })
+    first.statusbar.$statusbarVisible.set(true)
+    first.tools.$toolViewMode.set('technical')
+    const originalLayout = first.tree.captureLayoutStateSnapshot()
+    const originalPanes = structuredClone(first.panes.$paneStates.get())
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'active',
+      version: 1
+    })
+
+    vi.resetModules()
+
+    const second = await loadHarness()
+    expect(await second.ran.initializeRanMode()).toBe(true)
+    expect(second.ran.$ranModeEnabled.get()).toBe(true)
+    expect(second.tree.$activePresetId.get()).toBe(second.ran.RAN_MODE_PRESET_ID)
+    expect(second.statusbar.$statusbarVisible.get()).toBe(false)
+    expect(second.tools.$toolViewMode.get()).toBe('product')
+
+    vi.resetModules()
+
+    const third = await loadHarness()
+    expect(await third.ran.initializeRanMode()).toBe(true)
+    expect(third.ran.$ranModeEnabled.get()).toBe(true)
+    expect(third.tree.$activePresetId.get()).toBe(third.ran.RAN_MODE_PRESET_ID)
+
+    expect(await third.ran.disableRanMode()).toBe(true)
+    expect(third.tree.captureLayoutStateSnapshot()).toEqual(originalLayout)
+    expect(third.panes.$paneStates.get()).toEqual(originalPanes)
+    expect(third.statusbar.$statusbarVisible.get()).toBe(true)
+    expect(third.tools.$toolViewMode.get()).toBe('technical')
+  })
+
+  it('recovers an interrupted applying phase without losing the snapshot', async () => {
+    const first = await loadHarness()
+
+    first.statusbar.$statusbarVisible.set(true)
+    first.tools.$toolViewMode.set('technical')
+    const originalLayout = first.tree.captureLayoutStateSnapshot()
+    const originalPanes = structuredClone(first.panes.$paneStates.get())
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+    const interrupted = JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+    interrupted.phase = 'applying'
+    window.localStorage.setItem(first.ran.RAN_MODE_STORAGE_KEY, JSON.stringify(interrupted))
+
+    // Simulate a crash between durable snapshot creation and preset application.
+    first.tree.restoreLayoutStateSnapshot(originalLayout)
+    first.panes.$paneStates.set(originalPanes)
+    first.statusbar.$statusbarVisible.set(true)
+    first.tools.$toolViewMode.set('technical')
+
+    vi.resetModules()
+
+    const recovered = await loadHarness()
+    expect(await recovered.ran.initializeRanMode()).toBe(true)
+    expect(recovered.ran.$ranModeEnabled.get()).toBe(true)
+    expect(recovered.tree.$activePresetId.get()).toBe(recovered.ran.RAN_MODE_PRESET_ID)
+    expect(recovered.statusbar.$statusbarVisible.get()).toBe(false)
+    expect(recovered.tools.$toolViewMode.get()).toBe('product')
+
+    expect(await recovered.ran.disableRanMode()).toBe(true)
+    expect(recovered.tree.captureLayoutStateSnapshot()).toEqual(originalLayout)
+    expect(recovered.panes.$paneStates.get()).toEqual(originalPanes)
+    expect(recovered.statusbar.$statusbarVisible.get()).toBe(true)
+    expect(recovered.tools.$toolViewMode.get()).toBe('technical')
+  })
+
+  it('lets an explicit layout-preset choice exit the mode without restoring over that choice', async () => {
+    const { ran, tree } = await loadHarness()
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const chosenTree = {
+      type: 'group' as const,
+      id: 'chosen-after-ran',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    expect(await ran.leaveRanModeForLayoutChange('chosen-layout', chosenTree)).toBe(true)
+
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+    expect(tree.$activePresetId.get()).toBe('chosen-layout')
+    expect(tree.$layoutTree.get()).toMatchObject({ id: 'chosen-after-ran', type: 'group' })
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not mutate UI state when the recovery snapshot cannot be durably written', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+    const nativeSetItem = Storage.prototype.setItem
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === ran.RAN_MODE_STORAGE_KEY || key === RAN_MODE_BACKUP_KEY) {
+        throw new DOMException('quota exceeded', 'QuotaExceededError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.enableRanMode()).toBe(false)
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+    expect(tree.captureLayoutStateSnapshot()).toEqual(before)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not mutate UI state when a partial snapshot write fails exact readback', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+    const nativeSetItem = Storage.prototype.setItem
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      nativeSetItem.call(
+        this,
+        key,
+        key === ran.RAN_MODE_STORAGE_KEY || key === RAN_MODE_BACKUP_KEY ? value.slice(0, -1) : value
+      )
+    })
+
+    expect(await ran.enableRanMode()).toBe(false)
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+    expect(tree.captureLayoutStateSnapshot()).toEqual(before)
+
+    vi.restoreAllMocks()
+    expect(await ran.initializeRanMode()).toBe(false)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps the recoverable applying predecessor when active-successor staging is truncated', async () => {
+    const { ran } = await loadHarness()
+    const nativeSetItem = Storage.prototype.setItem
+    let backupWrites = 0
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === RAN_MODE_BACKUP_KEY) {
+        backupWrites += 1
+        nativeSetItem.call(this, key, backupWrites === 2 ? value.slice(0, -1) : value)
+
+        return
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'applying'
+    })
+
+    vi.restoreAllMocks()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(true)
+    expect(restarted.ran.$ranModeEnabled.get()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'active'
+    })
+  })
+
+  it('rejects a checksum-corrupt successor slot without retiring the applying predecessor', async () => {
+    const { ran } = await loadHarness()
+    const nativeSetItem = Storage.prototype.setItem
+    let backupWrites = 0
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === RAN_MODE_BACKUP_KEY) {
+        backupWrites += 1
+
+        if (backupWrites === 2) {
+          const envelope = JSON.parse(value) as Record<string, unknown>
+
+          envelope.checksum = '00000000'
+          nativeSetItem.call(this, key, JSON.stringify(envelope))
+
+          return
+        }
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'applying'
+    })
+
+    vi.restoreAllMocks()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      enabled: true,
+      phase: 'active'
+    })
+  })
+
+  it('ignores a stale predecessor slot after cleanup and a newer transaction generation', async () => {
+    const first = await loadHarness()
+    const nativeSetItem = Storage.prototype.setItem
+    let staleBackup: null | string = null
+
+    const set = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === RAN_MODE_BACKUP_KEY && staleBackup === null && backupPayload(value)?.phase === 'active') {
+        staleBackup = value
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+
+    const oldTransactionId = JSON.parse(
+      window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}'
+    ).transactionId
+
+    expect(await first.ran.disableRanMode()).toBe(true)
+    expect(await first.ran.enableRanMode()).toBe(true)
+    const newer = JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    expect(newer.transactionId).not.toBe(oldTransactionId)
+    expect(staleBackup).not.toBeNull()
+    set.mockRestore()
+    nativeSetItem.call(window.localStorage, RAN_MODE_BACKUP_KEY, staleBackup!)
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      transactionId: newer.transactionId
+    })
+    expect(window.localStorage.getItem(RAN_MODE_BACKUP_KEY)).toBeNull()
+  })
+
+  it('recovers a validated tombstone successor when its primary mirror is truncated', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+    const nativeSetItem = Storage.prototype.setItem
+    let primaryWrites = 0
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === ran.RAN_MODE_STORAGE_KEY) {
+        primaryWrites += 1
+        nativeSetItem.call(this, key, primaryWrites >= 3 ? value.slice(0, -1) : value)
+
+        return
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(window.localStorage.getItem(RAN_MODE_BACKUP_KEY)).not.toBeNull()
+
+    vi.restoreAllMocks()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restarted.ran.$ranModeEnabled.get()).toBe(false)
+    expect(restarted.tree.captureLayoutStateSnapshot()).toEqual(before)
+  })
+
+  it('recovers from a validated backup successor while primary repair remains unavailable', async () => {
+    const first = await loadHarness()
+    const nativeSetItem = Storage.prototype.setItem
+    let primaryWrites = 0
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === first.ran.RAN_MODE_STORAGE_KEY && ++primaryWrites >= 2) {
+        throw new DOMException('primary mirror unavailable', 'QuotaExceededError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+    expect(backupPayload(window.localStorage.getItem(RAN_MODE_BACKUP_KEY))).toMatchObject({
+      enabled: true,
+      phase: 'active'
+    })
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+
+    expect(await restarted.ran.initializeRanMode()).toBe(true)
+    expect(restarted.ran.$ranModeEnabled.get()).toBe(true)
+  })
+
+  it('preserves an incomplete tombstone when completed-successor staging is truncated', async () => {
+    const { ran } = await loadHarness()
+    const nativeSetItem = Storage.prototype.setItem
+    let backupWrites = 0
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === RAN_MODE_BACKUP_KEY) {
+        backupWrites += 1
+        nativeSetItem.call(this, key, backupWrites === 4 ? value.slice(0, -1) : value)
+
+        return
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      phase: 'inactive'
+    })
+
+    vi.restoreAllMocks()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restarted.ran.$ranModeEnabled.get()).toBe(false)
+  })
+
+  it('keeps a completed predecessor when cleared-successor staging is truncated', async () => {
+    const { ran } = await loadHarness()
+    const nativeSetItem = Storage.prototype.setItem
+    let backupWrites = 0
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === RAN_MODE_BACKUP_KEY) {
+        backupWrites += 1
+        nativeSetItem.call(this, key, backupWrites === 5 ? value.slice(0, -1) : value)
+
+        return
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.enableRanMode()).toBe(true)
+    expect(await ran.disableRanMode()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: true,
+      enabled: false
+    })
+
+    vi.restoreAllMocks()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('completes disable safely with a durable inactive tombstone when cleanup removal fails', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+    expect(await ran.enableRanMode()).toBe(true)
+    const nativeRemoveItem = Storage.prototype.removeItem
+
+    const remove = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function (this: Storage, key) {
+      if (key === ran.RAN_MODE_STORAGE_KEY) {
+        throw new DOMException('storage unavailable', 'SecurityError')
+      }
+
+      nativeRemoveItem.call(this, key)
+    })
+
+    expect(await ran.disableRanMode()).toBe(true)
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+    expect(tree.captureLayoutStateSnapshot()).toEqual(before)
+
+    const completed = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    expect(completed).toMatchObject({
+      completed: true,
+      enabled: false,
+      phase: 'inactive',
+      version: 1
+    })
+    expect(completed.settlementFingerprint).toBe(captureOwnedStorageFingerprint())
+
+    const laterTree = {
+      type: 'group' as const,
+      id: 'later-off-mode-choice',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    tree.applyTree(laterTree, 'later-choice')
+    remove.mockRestore()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restarted.tree.$activePresetId.get()).toBe('later-choice')
+    expect(restarted.tree.$layoutTree.get()).toMatchObject({ id: 'later-off-mode-choice' })
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not restore a stale in-memory snapshot after another peer cleared the transaction', async () => {
+    const { ran, tree } = await loadHarness()
+    expect(await ran.enableRanMode()).toBe(true)
+    window.localStorage.removeItem(ran.RAN_MODE_STORAGE_KEY)
+
+    const peerTree = {
+      type: 'group' as const,
+      id: 'peer-layout-after-ran',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    tree.applyTree(peerTree, 'peer-layout')
+
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+    expect(tree.$activePresetId.get()).toBe('peer-layout')
+    expect(tree.$layoutTree.get()).toMatchObject({ id: 'peer-layout-after-ran' })
+  })
+
+  it('fails closed when neither completion nor cleanup can be persisted', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+    expect(await ran.enableRanMode()).toBe(true)
+    const nativeSetItem = Storage.prototype.setItem
+    const nativeRemoveItem = Storage.prototype.removeItem
+
+    const set = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === RAN_MODE_BACKUP_KEY && backupPayload(value)?.completed === true) {
+        throw new DOMException('completion write unavailable', 'SecurityError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    const remove = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function (this: Storage, key) {
+      if (key === ran.RAN_MODE_STORAGE_KEY) {
+        throw new DOMException('cleanup unavailable', 'SecurityError')
+      }
+
+      nativeRemoveItem.call(this, key)
+    })
+
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(ran.$ranModeEnabled.get()).toBe(true)
+    expect(tree.$activePresetId.get()).toBe(ran.RAN_MODE_PRESET_ID)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      phase: 'inactive'
+    })
+
+    const blockedTree = {
+      type: 'group' as const,
+      id: 'blocked-choice',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    expect(await ran.leaveRanModeForLayoutChange('blocked-choice', blockedTree)).toBe(false)
+    expect(await ran.resetLayoutFromRanMode()).toBe(false)
+    expect(tree.$activePresetId.get()).toBe(ran.RAN_MODE_PRESET_ID)
+
+    set.mockRestore()
+    remove.mockRestore()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restarted.tree.captureLayoutStateSnapshot()).toEqual(before)
+    expect(restarted.ran.$ranModeEnabled.get()).toBe(false)
+    expect(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps a failed restore incomplete and retries the durable tombstone', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+    expect(await ran.enableRanMode()).toBe(true)
+    const nativeClone = globalThis.structuredClone
+    let failRestoreOnce = true
+
+    const clone = vi.spyOn(globalThis, 'structuredClone').mockImplementation((value) => {
+      if (failRestoreOnce) {
+        failRestoreOnce = false
+        throw new DOMException('restore failed', 'DataCloneError')
+      }
+
+      return nativeClone(value)
+    })
+
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(ran.$ranModeEnabled.get()).toBe(true)
+    expect(tree.$activePresetId.get()).toBe(ran.RAN_MODE_PRESET_ID)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      phase: 'inactive'
+    })
+
+    clone.mockRestore()
+    expect(await ran.initializeRanMode()).toBe(false)
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+    expect(tree.captureLayoutStateSnapshot()).toEqual(before)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps settlement incomplete when an owned preference fails durable readback', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+    expect(await ran.enableRanMode()).toBe(true)
+    const nativeSetItem = Storage.prototype.setItem
+
+    const set = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === 'hermes.desktop.layoutTree.v2') {
+        throw new DOMException('layout persistence unavailable', 'SecurityError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(ran.$ranModeEnabled.get()).toBe(true)
+    expect(tree.$activePresetId.get()).toBe(ran.RAN_MODE_PRESET_ID)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      phase: 'inactive'
+    })
+
+    set.mockRestore()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restarted.ran.$ranModeEnabled.get()).toBe(false)
+    expect(restarted.tree.captureLayoutStateSnapshot()).toEqual(before)
+    expect(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not confuse an apparent baseline ABA with completed exit recovery', async () => {
+    const { ran, tree } = await loadHarness()
+    const baseline = tree.captureLayoutStateSnapshot()
+
+    const chosenTree = {
+      type: 'group' as const,
+      id: 'aba-newer-choice',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    expect(await ran.enableRanMode()).toBe(true)
+    const nativeSetItem = Storage.prototype.setItem
+
+    const set = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === RAN_MODE_BACKUP_KEY && backupPayload(value)?.completed === true) {
+        throw new DOMException('completion write unavailable', 'SecurityError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.leaveRanModeForLayoutChange('aba-choice', chosenTree)).toBe(false)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      phase: 'leaving'
+    })
+
+    // An appearance that happens to equal A is not settlement proof. Restart
+    // must still replay the durable, newer exit intent B.
+    tree.restoreLayoutStateSnapshot(baseline)
+    expect(tree.captureLayoutStateSnapshot()).toEqual(baseline)
+    set.mockRestore()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restarted.tree.$activePresetId.get()).toBe('aba-choice')
+    expect(restarted.tree.$layoutTree.get()).toMatchObject({ id: 'aba-newer-choice' })
+    expect(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('ignores a delayed peer tombstone when a newer live record is durable', async () => {
+    const { ran, tree } = await loadHarness()
+    expect(await ran.enableRanMode()).toBe(true)
+    const oldLive = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    const staleTombstone = {
+      completed: false,
+      enabled: false,
+      phase: 'inactive',
+      restorePolicy: 'conditional',
+      snapshot: oldLive.snapshot,
+      transactionId: oldLive.transactionId,
+      version: 1
+    }
+
+    const newerLive = {
+      ...oldLive,
+      transactionId: 'newer-live-transaction',
+      snapshot: {
+        ...oldLive.snapshot,
+        layout: {
+          ...oldLive.snapshot.layout,
+          activePresetId: 'newer-live-baseline'
+        }
+      }
+    }
+
+    window.localStorage.setItem(ran.RAN_MODE_STORAGE_KEY, JSON.stringify(newerLive))
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(staleTombstone),
+        oldValue: JSON.stringify(oldLive),
+        storageArea: window.localStorage
+      })
+    )
+
+    expect(ran.$ranModeEnabled.get()).toBe(true)
+    expect(tree.$activePresetId.get()).toBe(ran.RAN_MODE_PRESET_ID)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBe(JSON.stringify(newerLive))
+  })
+
+  it('reconciles a delayed live event to the durable disabled phase of the same transaction', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+    expect(await ran.enableRanMode()).toBe(true)
+    const live = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    const tombstone = {
+      completed: false,
+      enabled: false,
+      phase: 'inactive',
+      restorePolicy: 'conditional',
+      snapshot: live.snapshot,
+      transactionId: live.transactionId,
+      version: 1
+    }
+
+    const durable = JSON.stringify(tombstone)
+
+    window.localStorage.setItem(ran.RAN_MODE_STORAGE_KEY, durable)
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(live),
+        oldValue: null,
+        storageArea: window.localStorage
+      })
+    )
+
+    await vi.waitFor(() => {
+      expect(ran.$ranModeEnabled.get()).toBe(false)
+      expect(tree.captureLayoutStateSnapshot()).toEqual(before)
+    })
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBe(durable)
+  })
+
+  it('does not resurrect Ran-owned state from a live event after durable cleanup', async () => {
+    const { ran, tree } = await loadHarness()
+    expect(await ran.enableRanMode()).toBe(true)
+    const live = window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)
+
+    const laterTree = {
+      type: 'group' as const,
+      id: 'post-cleanup-choice',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    window.localStorage.removeItem(ran.RAN_MODE_STORAGE_KEY)
+    tree.applyTree(laterTree, 'post-cleanup')
+    const later = tree.captureLayoutStateSnapshot()
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: live,
+        oldValue: null,
+        storageArea: window.localStorage
+      })
+    )
+
+    expect(tree.$activePresetId.get()).toBe('post-cleanup')
+    expect(tree.captureLayoutStateSnapshot()).toEqual(later)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not let a delayed completed peer event overwrite a newer durable preset', async () => {
+    const { ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const live = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    const completed = {
+      ...live,
+      completed: true,
+      enabled: false,
+      phase: 'inactive',
+      restorePolicy: 'conditional'
+    }
+
+    const laterTree = {
+      type: 'group' as const,
+      id: 'newer-preset-after-peer-completion',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    window.localStorage.removeItem(ran.RAN_MODE_STORAGE_KEY)
+    tree.applyTree(laterTree, 'newer-preset')
+    const later = tree.captureLayoutStateSnapshot()
+    const locks = installQueuedLockHarness()
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(completed),
+        oldValue: JSON.stringify(live),
+        storageArea: window.localStorage
+      })
+    )
+
+    await locks.firstStarted
+    expect(locks.requests).toEqual([{ mode: 'exclusive', name: ran.RAN_MODE_LOCK_NAME }])
+    expect(tree.captureLayoutStateSnapshot()).toEqual(later)
+    locks.releaseFirst()
+    await locks.idle()
+
+    expect(tree.captureLayoutStateSnapshot()).not.toEqual(before)
+    expect(tree.captureLayoutStateSnapshot()).toEqual(later)
+    expect(tree.$activePresetId.get()).toBe('newer-preset')
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not let a delayed completed peer event overwrite newer bytes for the same preset id', async () => {
+    const { ran, tree } = await loadHarness()
+
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const live = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    const completed = {
+      ...live,
+      completed: true,
+      enabled: false,
+      phase: 'inactive',
+      restorePolicy: 'conditional'
+    }
+
+    const newerDefaultTree = {
+      type: 'group' as const,
+      id: 'newer-default-generation',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    window.localStorage.removeItem(ran.RAN_MODE_STORAGE_KEY)
+    tree.applyTree(newerDefaultTree, 'default')
+    const later = tree.captureLayoutStateSnapshot()
+    const locks = installQueuedLockHarness()
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(completed),
+        oldValue: JSON.stringify(live),
+        storageArea: window.localStorage
+      })
+    )
+
+    await locks.firstStarted
+    expect(tree.captureLayoutStateSnapshot()).toEqual(later)
+    locks.releaseFirst()
+    await locks.idle()
+
+    expect(tree.captureLayoutStateSnapshot()).toEqual(later)
+    expect(tree.$activePresetId.get()).toBe('default')
+    expect(tree.$layoutTree.get()).toMatchObject({ id: 'newer-default-generation' })
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not let a delayed completed peer event overwrite newer non-layout owned state', async () => {
+    const { ran, review, tree } = await loadHarness()
+
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const live = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    window.localStorage.removeItem(ran.RAN_MODE_STORAGE_KEY)
+    tree.applyTree(live.snapshot.layout.tree, live.snapshot.layout.activePresetId)
+
+    const completed = {
+      ...live,
+      completed: true,
+      enabled: false,
+      phase: 'inactive',
+      restorePolicy: 'conditional',
+      settlementFingerprint: captureOwnedStorageFingerprint()
+    }
+
+    review.$reviewOpen.set(!live.snapshot.reviewOpen)
+
+    const laterReviewOpen = review.$reviewOpen.get()
+    const locks = installQueuedLockHarness()
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(completed),
+        oldValue: JSON.stringify(live),
+        storageArea: window.localStorage
+      })
+    )
+
+    await locks.firstStarted
+    expect(review.$reviewOpen.get()).toBe(laterReviewOpen)
+    locks.releaseFirst()
+    await locks.idle()
+
+    expect(review.$reviewOpen.get()).toBe(laterReviewOpen)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('does not let a delayed completed reset clear newer dismissed-pane state', async () => {
+    const { ran, tree } = await loadHarness()
+
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const live = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    window.localStorage.removeItem(ran.RAN_MODE_STORAGE_KEY)
+    tree.resetLayoutTree()
+
+    const completed = {
+      ...live,
+      completed: true,
+      enabled: false,
+      exit: { kind: 'reset' },
+      phase: 'leaving',
+      restorePolicy: 'conditional',
+      settlementFingerprint: captureOwnedStorageFingerprint()
+    }
+
+    const dismissedPanesKey = 'hermes.desktop.dismissedPanes.v1'
+    const newerDismissedPanes = JSON.stringify(['newer-dismissed-pane'])
+
+    window.localStorage.setItem(dismissedPanesKey, newerDismissedPanes)
+
+    const locks = installQueuedLockHarness()
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(completed),
+        oldValue: JSON.stringify(live),
+        storageArea: window.localStorage
+      })
+    )
+
+    await locks.firstStarted
+    expect(window.localStorage.getItem(dismissedPanesKey)).toBe(newerDismissedPanes)
+    locks.releaseFirst()
+    await locks.idle()
+
+    expect(window.localStorage.getItem(dismissedPanesKey)).toBe(newerDismissedPanes)
+  })
+
+  it.each([
+    ['panes flipped', 'hermes.desktop.panesFlipped', 'false', 'true'],
+    [
+      'composer zones',
+      'hermes.desktop.composerPopout.zones.v1',
+      '{}',
+      JSON.stringify({ newer: { poppedOut: true, position: { bottom: 10, right: 10 } } })
+    ],
+    ['right-rail preview', 'hermes.desktop.rightRailActiveTab', 'file:older', 'file:newer']
+  ])('does not let delayed settlement overwrite newer %s subscriber state', async (_label, key, replayValue, newerValue) => {
+    const { ran, tree } = await loadHarness()
+
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const live = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    window.localStorage.removeItem(ran.RAN_MODE_STORAGE_KEY)
+    tree.applyTree(live.snapshot.layout.tree, live.snapshot.layout.activePresetId)
+
+    const completed = {
+      ...live,
+      completed: true,
+      enabled: false,
+      phase: 'inactive',
+      restorePolicy: 'conditional',
+      settlementFingerprint: captureOwnedStorageFingerprint()
+    }
+
+    const unlisten = tree.$layoutTree.subscribe(() => window.localStorage.setItem(key, replayValue))
+
+    window.localStorage.setItem(key, newerValue)
+
+    const locks = installQueuedLockHarness()
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(completed),
+        oldValue: JSON.stringify(live),
+        storageArea: window.localStorage
+      })
+    )
+
+    await locks.firstStarted
+    expect(window.localStorage.getItem(key)).toBe(newerValue)
+    locks.releaseFirst()
+    await locks.idle()
+    unlisten()
+
+    expect(window.localStorage.getItem(key)).toBe(newerValue)
+  })
+
+  it('blocks reset and preset mutation from a durable incomplete tombstone before initialize', async () => {
+    const first = await loadHarness()
+    expect(await first.ran.enableRanMode()).toBe(true)
+    const nativeSetItem = Storage.prototype.setItem
+
+    const set = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === RAN_MODE_BACKUP_KEY && backupPayload(value)?.completed === true) {
+        throw new DOMException('completion write unavailable', 'SecurityError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await first.ran.disableRanMode()).toBe(false)
+    const tombstone = window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY)
+    set.mockRestore()
+    vi.resetModules()
+
+    const second = await loadHarness()
+    const before = second.tree.captureLayoutStateSnapshot()
+
+    const blockedTree = {
+      type: 'group' as const,
+      id: 'blocked-before-initialize',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    expect(second.ran.$ranModeEnabled.get()).toBe(false)
+    expect(await second.ran.resetLayoutFromRanMode()).toBe(false)
+    await second.presets.applyLayoutPreset('blocked-before-initialize', blockedTree)
+    expect(second.tree.captureLayoutStateSnapshot()).toEqual(before)
+    expect(window.localStorage.getItem(second.ran.RAN_MODE_STORAGE_KEY)).toBe(tombstone)
+  })
+
+  it('rejects a delayed disabled record from an older transaction generation', async () => {
+    const { ran, tree } = await loadHarness()
+    expect(await ran.enableRanMode()).toBe(true)
+    const oldLive = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    const staleTombstone = {
+      completed: false,
+      enabled: false,
+      phase: 'inactive',
+      restorePolicy: 'conditional',
+      snapshot: oldLive.snapshot,
+      transactionId: oldLive.transactionId,
+      version: 1
+    }
+
+    const newerTombstone = {
+      ...staleTombstone,
+      exit: {
+        kind: 'preset',
+        presetId: 'newer-transaction-choice',
+        tree: { type: 'group', id: 'newer-transaction-tree', panes: ['workspace'], active: 'workspace' }
+      },
+      phase: 'leaving',
+      transactionId: 'newer-transaction'
+    }
+
+    const laterTree = {
+      type: 'group' as const,
+      id: 'later-local-choice',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    window.localStorage.setItem(ran.RAN_MODE_STORAGE_KEY, JSON.stringify(newerTombstone))
+    tree.applyTree(laterTree, 'later-local-choice')
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(staleTombstone),
+        oldValue: JSON.stringify(oldLive),
+        storageArea: window.localStorage
+      })
+    )
+
+    expect(tree.$activePresetId.get()).toBe('later-local-choice')
+    expect(tree.$layoutTree.get()).toMatchObject({ id: 'later-local-choice' })
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBe(JSON.stringify(newerTombstone))
+  })
+
+  it('keeps HUD and auxiliary renderers out of primary Ran Mode transactions', async () => {
+    vi.doMock('@/store/windows', async importOriginal => {
+      const actual = await importOriginal<Record<string, unknown>>()
+
+      return { ...actual, isAuxiliaryWindow: () => true }
+    })
+
+    const { presets, ran, tree } = await loadHarness()
+    const before = tree.captureLayoutStateSnapshot()
+
+    const auxiliaryTree = {
+      type: 'group' as const,
+      id: 'auxiliary-choice',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    expect(await ran.enableRanMode()).toBe(false)
+    expect(await ran.initializeRanMode()).toBe(false)
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(await ran.resetLayoutFromRanMode()).toBe(false)
+    expect(await ran.leaveRanModeForLayoutChange('auxiliary-choice', auxiliaryTree)).toBe(false)
+    await presets.applyLayoutPreset('auxiliary-choice', auxiliaryTree)
+    expect(tree.captureLayoutStateSnapshot()).toEqual(before)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps HUD layout state ephemeral instead of mutating primary shared storage', async () => {
+    const primaryTree = {
+      type: 'group' as const,
+      id: 'primary-persisted-tree',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    const durableBefore = {
+      dismissed: JSON.stringify(['primary-dismissed-pane']),
+      paneStates: JSON.stringify({ workspace: { open: true, widthOverride: 640 } }),
+      preset: 'primary-preset',
+      tree: JSON.stringify(primaryTree),
+      userPlaced: JSON.stringify(['primary-user-placed-pane'])
+    }
+
+    window.localStorage.setItem('hermes.desktop.layoutTree.v2', durableBefore.tree)
+    window.localStorage.setItem('hermes.desktop.layoutPreset.active', durableBefore.preset)
+    window.localStorage.setItem('hermes.desktop.dismissedPanes.v1', durableBefore.dismissed)
+    window.localStorage.setItem('hermes.desktop.paneStates.v1', durableBefore.paneStates)
+    window.localStorage.setItem('hermes.desktop.userPlacedPanes.v1', durableBefore.userPlaced)
+
+    vi.doMock('@/store/windows', async importOriginal => {
+      const actual = await importOriginal<Record<string, unknown>>()
+
+      return { ...actual, isAuxiliaryWindow: () => true, isSecondaryWindow: () => false }
+    })
+
+    const { tree } = await loadHarness()
+
+    const hudTree = {
+      type: 'group' as const,
+      id: 'hud-ephemeral-tree',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    tree.applyTree(hudTree, 'hud-ephemeral')
+    tree.resetLayoutTree()
+
+    expect(window.localStorage.getItem('hermes.desktop.layoutTree.v2')).toBe(durableBefore.tree)
+    expect(window.localStorage.getItem('hermes.desktop.layoutPreset.active')).toBe(durableBefore.preset)
+    expect(window.localStorage.getItem('hermes.desktop.dismissedPanes.v1')).toBe(durableBefore.dismissed)
+    expect(window.localStorage.getItem('hermes.desktop.paneStates.v1')).toBe(durableBefore.paneStates)
+    expect(window.localStorage.getItem('hermes.desktop.userPlacedPanes.v1')).toBe(durableBefore.userPlaced)
+  })
+
+  it('keeps auxiliary-owned preferences and composer zones out of primary storage', async () => {
+    vi.doMock('@/store/windows', async importOriginal => {
+      const actual = await importOriginal<Record<string, unknown>>()
+
+      return { ...actual, isAuxiliaryWindow: () => true }
+    })
+
+    const durableBefore = {
+      composer: JSON.stringify({
+        'primary-custom-zone': { poppedOut: true, position: { bottom: 37, right: 53 } }
+      }),
+      flipped: 'true',
+      review: 'true',
+      terminal: 'true',
+      toolView: 'true',
+      statusbar: 'true'
+    }
+
+    window.localStorage.setItem('hermes.desktop.composerPopout.zones.v1', durableBefore.composer)
+    window.localStorage.setItem('hermes.desktop.panesFlipped', durableBefore.flipped)
+    window.localStorage.setItem('hermes.desktop.reviewOpen', durableBefore.review)
+    window.localStorage.setItem('hermes.desktop.terminalTakeover', durableBefore.terminal)
+    window.localStorage.setItem('hermes.desktop.toolView.technical', durableBefore.toolView)
+    window.localStorage.setItem('hermes.desktop.statusbarVisible', durableBefore.statusbar)
+
+    const composer = await import('@/store/composer-popout')
+    const layout = await import('@/store/layout')
+    const review = await import('@/store/review')
+    const statusbar = await import('@/store/statusbar-prefs')
+    const terminal = await import('@/app/right-sidebar/store')
+    const tools = await import('@/store/tool-view')
+
+    expect(composer.$composerPopoutZones.get()).toEqual({})
+    expect(layout.$panesFlipped.get()).toBe(false)
+    expect(review.$reviewOpen.get()).toBe(false)
+    expect(statusbar.$statusbarVisible.get()).toBe(false)
+    expect(terminal.$terminalTakeover.get()).toBe(false)
+    expect(tools.$toolViewMode.get()).toBe('product')
+
+    expect(window.localStorage.getItem('hermes.desktop.reviewOpen')).toBe(durableBefore.review)
+    expect(window.localStorage.getItem('hermes.desktop.terminalTakeover')).toBe(durableBefore.terminal)
+    expect(window.localStorage.getItem('hermes.desktop.toolView.technical')).toBe(durableBefore.toolView)
+
+    composer.pruneComposerPopoutZones([])
+    layout.$panesFlipped.set(false)
+    review.$reviewOpen.set(false)
+    statusbar.$statusbarVisible.set(false)
+    terminal.setTerminalTakeover(false)
+    tools.setToolViewMode('product')
+
+    expect(window.localStorage.getItem('hermes.desktop.composerPopout.zones.v1')).toBe(durableBefore.composer)
+    expect(window.localStorage.getItem('hermes.desktop.panesFlipped')).toBe(durableBefore.flipped)
+    expect(window.localStorage.getItem('hermes.desktop.reviewOpen')).toBe(durableBefore.review)
+    expect(window.localStorage.getItem('hermes.desktop.terminalTakeover')).toBe(durableBefore.terminal)
+    expect(window.localStorage.getItem('hermes.desktop.toolView.technical')).toBe(durableBefore.toolView)
+    expect(window.localStorage.getItem('hermes.desktop.statusbarVisible')).toBe(durableBefore.statusbar)
+  })
+
+  it('does not let a delayed live-record removal overwrite newer non-layout owned state', async () => {
+    const { ran, review } = await loadHarness()
+
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const record = window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)
+    const live = JSON.parse(record ?? '{}')
+    const locks = installQueuedLockHarness()
+
+    window.localStorage.removeItem(ran.RAN_MODE_STORAGE_KEY)
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: null,
+        oldValue: record,
+        storageArea: window.localStorage
+      })
+    )
+
+    await locks.firstStarted
+
+    const laterReviewOpen = !live.snapshot.reviewOpen
+
+    review.$reviewOpen.set(laterReviewOpen)
+    expect(review.$reviewOpen.get()).toBe(laterReviewOpen)
+
+    locks.releaseFirst()
+    await locks.idle()
+
+    expect(review.$reviewOpen.get()).toBe(laterReviewOpen)
+    expect(window.localStorage.getItem('hermes.desktop.reviewOpen')).toBe(String(laterReviewOpen))
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('replays a normally completed peer disable through its full queued storage-event sequence', async () => {
+    const originalComposerZones = {
+      'peer-removed-zone': { poppedOut: true, position: { bottom: 109, right: 131 } }
+    }
+
+    window.localStorage.setItem(COMPOSER_POPOUT_STORAGE_KEY, JSON.stringify(originalComposerZones))
+
+    const first = await loadHarness()
+    const before = first.tree.captureLayoutStateSnapshot()
+
+    expect(await first.ran.enableRanMode()).toBe(true)
+    first.composer.pruneComposerPopoutZones([])
+
+    vi.resetModules()
+    const peer = await loadHarness()
+
+    expect(await peer.ran.initializeRanMode()).toBe(true)
+    expect(peer.ran.$ranModeEnabled.get()).toBe(true)
+
+    const nativeSetItem = Storage.prototype.setItem
+    const nativeRemoveItem = Storage.prototype.removeItem
+    const primaryEvents: Array<{ newValue: null | string; oldValue: null | string }> = []
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      const oldValue = nativeSetItem === Storage.prototype.setItem ? this.getItem(key) : window.localStorage.getItem(key)
+
+      nativeSetItem.call(this, key, value)
+
+      if (key === first.ran.RAN_MODE_STORAGE_KEY && oldValue !== value) {
+        primaryEvents.push({ newValue: value, oldValue })
+      }
+    })
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function (this: Storage, key) {
+      const oldValue = this.getItem(key)
+
+      nativeRemoveItem.call(this, key)
+
+      if (key === first.ran.RAN_MODE_STORAGE_KEY && oldValue !== null) {
+        primaryEvents.push({ newValue: null, oldValue })
+      }
+    })
+
+    expect(await first.ran.disableRanMode()).toBe(true)
+    expect(primaryEvents.length).toBeGreaterThanOrEqual(3)
+
+    vi.restoreAllMocks()
+    const locks = installQueuedLockHarness()
+
+    for (const event of primaryEvents) {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: peer.ran.RAN_MODE_STORAGE_KEY,
+          newValue: event.newValue,
+          oldValue: event.oldValue,
+          storageArea: window.localStorage
+        })
+      )
+    }
+
+    await locks.firstStarted
+    locks.releaseFirst()
+    await vi.waitFor(() => {
+      expect(peer.ran.$ranModeEnabled.get()).toBe(false)
+      expect(peer.tree.captureLayoutStateSnapshot()).toEqual(before)
+      expect(peer.composer.$composerPopoutZones.get()).toEqual(originalComposerZones)
+    })
+    expect(window.localStorage.getItem(COMPOSER_POPOUT_STORAGE_KEY)).toBe(JSON.stringify(originalComposerZones))
+    await locks.idle()
+  })
+
+  it('keeps a completed tombstone inert against a delayed incomplete peer event', async () => {
+    const first = await loadHarness()
+    expect(await first.ran.enableRanMode()).toBe(true)
+
+    const chosenTree = {
+      type: 'group' as const,
+      id: 'peer-explicit-choice',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    const nativeRemoveItem = Storage.prototype.removeItem
+
+    const remove = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function (this: Storage, key) {
+      if (key === first.ran.RAN_MODE_STORAGE_KEY) {
+        throw new DOMException('keep tombstone for peer replay', 'SecurityError')
+      }
+
+      nativeRemoveItem.call(this, key)
+    })
+
+    expect(await first.ran.leaveRanModeForLayoutChange('peer-choice', chosenTree)).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: true,
+      enabled: false,
+      phase: 'leaving'
+    })
+
+    const completed = JSON.parse(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+    const incomplete = { ...completed, completed: false }
+
+    const laterTree = {
+      type: 'group' as const,
+      id: 'later-off-mode-choice-after-completion',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    first.tree.applyTree(laterTree, 'later-choice')
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: first.ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(incomplete),
+        oldValue: null,
+        storageArea: window.localStorage
+      })
+    )
+    expect(first.tree.$activePresetId.get()).toBe('later-choice')
+    expect(first.tree.$layoutTree.get()).toMatchObject({ id: 'later-off-mode-choice-after-completion' })
+    expect(window.localStorage.getItem(first.ran.RAN_MODE_STORAGE_KEY)).toBe(JSON.stringify(completed))
+
+    // A completed tombstone left behind by cleanup failure is now harmless on
+    // restart and must not replay over the explicit choice.
+    remove.mockRestore()
+    vi.resetModules()
+
+    const peer = await loadHarness()
+    expect(await peer.ran.initializeRanMode()).toBe(false)
+    expect(peer.tree.$activePresetId.get()).toBe('later-choice')
+    expect(peer.tree.$layoutTree.get()).toMatchObject({ id: 'later-off-mode-choice-after-completion' })
+    expect(window.localStorage.getItem(peer.ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('applies a completed tombstone only to an active peer from the same transaction', async () => {
+    const { ran, tree } = await loadHarness()
+    expect(await ran.enableRanMode()).toBe(true)
+    const live = JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')
+
+    const peerTree = {
+      type: 'group' as const,
+      id: 'peer-completed-choice',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    const completed = {
+      completed: true,
+      enabled: false,
+      exit: { kind: 'preset', presetId: 'peer-completed', tree: peerTree },
+      phase: 'leaving',
+      restorePolicy: 'conditional',
+      snapshot: live.snapshot,
+      transactionId: live.transactionId,
+      version: 1
+    }
+
+    window.localStorage.setItem(ran.RAN_MODE_STORAGE_KEY, JSON.stringify(completed))
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(completed),
+        oldValue: JSON.stringify(live),
+        storageArea: window.localStorage
+      })
+    )
+
+    await vi.waitFor(() => {
+      expect(ran.$ranModeEnabled.get()).toBe(false)
+      expect(tree.$activePresetId.get()).toBe('peer-completed')
+      expect(tree.$layoutTree.get()).toMatchObject({ id: 'peer-completed-choice' })
+    })
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBe(JSON.stringify(completed))
+
+    const laterTree = { ...peerTree, id: 'later-after-peer-completion' }
+    tree.applyTree(laterTree, 'later-after-peer-completion')
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: ran.RAN_MODE_STORAGE_KEY,
+        newValue: JSON.stringify(completed),
+        oldValue: JSON.stringify(live),
+        storageArea: window.localStorage
+      })
+    )
+
+    await vi.waitFor(() => expect(ran.isRanModeRecoveryIncomplete()).toBe(false))
+    expect(tree.$activePresetId.get()).toBe('later-after-peer-completion')
+    expect(tree.$layoutTree.get()).toMatchObject({ id: 'later-after-peer-completion' })
+  })
+
+  it('restores the baseline while retaining panes contributed during Ran Mode', async () => {
+    const { panes, ran, tree } = await loadHarness()
+    const { registry } = await import('@/contrib/registry')
+    const { findGroupOfPane } = await import('@/components/pane-shell/tree/model')
+
+    expect(await ran.enableRanMode()).toBe(true)
+    registry.register({
+      area: 'panes',
+      data: { placement: 'main' },
+      id: 'workspace',
+      render: () => null,
+      title: 'Workspace'
+    })
+    registry.register({
+      area: 'panes',
+      data: { placement: 'right' },
+      id: 'late-pane',
+      render: () => null,
+      title: 'Late pane'
+    })
+    panes.ensurePaneRegistered('late-pane', { open: true, widthOverride: 333 })
+    tree.adoptContributedPanes()
+    expect(findGroupOfPane(tree.$layoutTree.get()!, 'late-pane')).not.toBeNull()
+
+    expect(await ran.disableRanMode()).toBe(true)
+    expect(findGroupOfPane(tree.$layoutTree.get()!, 'late-pane')).not.toBeNull()
+    expect(panes.$paneStates.get()['late-pane']).toEqual({ open: true, widthOverride: 333 })
+  })
+
+  it('keeps non-reset settlement incomplete when contributed-pane adoption cannot clear dismissed persistence', async () => {
+    const { ran, tree } = await loadHarness()
+    const { registry } = await import('@/contrib/registry')
+    const dismissedKey = 'hermes.desktop.dismissedPanes.v1'
+    const staleDismissed = JSON.stringify(['stale-plugin-pane'])
+
+    expect(await ran.enableRanMode()).toBe(true)
+
+    tree.$dismissedPanes.set(new Set(['stale-plugin-pane']))
+    window.localStorage.setItem(dismissedKey, staleDismissed)
+
+    const unregister = registry.register({
+      area: 'panes',
+      id: 'stale-plugin-pane',
+      source: 'plugin:test',
+      data: { placement: 'right' },
+      render: () => null
+    })
+
+    const nativeRemoveItem = Storage.prototype.removeItem
+
+    const remove = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function (this: Storage, key) {
+      if (key === dismissedKey) {
+        throw new DOMException('dismissed persistence unavailable', 'SecurityError')
+      }
+
+      nativeRemoveItem.call(this, key)
+    })
+
+    expect(await ran.disableRanMode()).toBe(false)
+    expect(tree.$dismissedPanes.get()).toEqual(new Set())
+    expect(window.localStorage.getItem(dismissedKey)).toBe(staleDismissed)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      phase: 'inactive'
+    })
+
+    remove.mockRestore()
+    unregister()
+  })
+
+  it('keeps reset incomplete when a handler final-tree write is dropped', async () => {
+    const { ran, tree } = await loadHarness()
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const handlerTree = {
+      type: 'group' as const,
+      id: 'dropped-reset-handler-tree',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    const unregister = tree.registerLayoutResetHandler(() => tree.applyTree(handlerTree, 'reset-handler'))
+    const nativeSetItem = Storage.prototype.setItem
+
+    const set = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key === 'hermes.desktop.layoutTree.v2') {
+        throw new DOMException('final tree write unavailable', 'SecurityError')
+      }
+
+      nativeSetItem.call(this, key, value)
+    })
+
+    expect(await ran.resetLayoutFromRanMode()).toBe(false)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      exit: { kind: 'reset' },
+      phase: 'leaving'
+    })
+
+    set.mockRestore()
+    unregister()
+  })
+
+  it('verifies a reset handler that persists a concrete final tree', async () => {
+    const { ran, tree } = await loadHarness()
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const handlerTree = {
+      type: 'group' as const,
+      id: 'reset-handler-final-tree',
+      panes: ['workspace'],
+      active: 'workspace'
+    }
+
+    const unregister = tree.registerLayoutResetHandler(() => tree.applyTree(handlerTree, 'reset-handler'))
+
+    expect(await ran.resetLayoutFromRanMode()).toBe(true)
+    expect(tree.$layoutTree.get()).toMatchObject({ id: 'reset-handler-final-tree' })
+    expect(window.localStorage.getItem('hermes.desktop.layoutTree.v2')).toBe(JSON.stringify(tree.$layoutTree.get()))
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+    unregister()
+  })
+
+  it('persists the canonical concrete reset tree for multiple live session tiles and clears dismissed panes across restart', async () => {
+    const { ran, tree } = await loadHarness()
+    const { registry } = await import('@/contrib/registry')
+    const { findGroupOfPane } = await import('@/components/pane-shell/tree/model')
+    const dismissedKey = 'hermes.desktop.dismissedPanes.v1'
+
+    const unregisterPanes = ['session-tile:one', 'session-tile:two'].map(id =>
+      registry.register({ area: 'panes', data: { placement: 'main' }, id, render: () => null, title: id })
+    )
+
+    tree.$dismissedPanes.set(new Set(['pre-dismissed-pane']))
+    window.localStorage.setItem(dismissedKey, JSON.stringify(['pre-dismissed-pane']))
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const unregisterReset = tree.registerLayoutResetHandler(() => {
+      for (const id of ['session-tile:one', 'session-tile:two']) {
+        const current = tree.$layoutTree.get()
+        const mainGroup = current ? findGroupOfPane(current, 'workspace')?.id : null
+
+        if (mainGroup) {
+          tree.moveTreePane(id, { groupId: mainGroup, pos: 'center' })
+        }
+      }
+    })
+
+    expect(await ran.resetLayoutFromRanMode()).toBe(true)
+    expect(window.localStorage.getItem(dismissedKey)).toBeNull()
+    expect(window.localStorage.getItem('hermes.desktop.layoutTree.v2')).toBe(JSON.stringify(tree.$layoutTree.get()))
+    expect(findGroupOfPane(tree.$layoutTree.get()!, 'session-tile:one')).not.toBeNull()
+    expect(findGroupOfPane(tree.$layoutTree.get()!, 'session-tile:two')).not.toBeNull()
+    expect(tree.$activePresetId.get()).toBe('default')
+    expect(tree.$userPlacedPanes.get()).toEqual(new Set())
+    expect(window.localStorage.getItem('hermes.desktop.userPlacedPanes.v1')).toBeNull()
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+
+    unregisterReset()
+    unregisterPanes.forEach(unregister => unregister())
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    const restartedModel = await import('@/components/pane-shell/tree/model')
+
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(restartedModel.findGroupOfPane(restarted.tree.$layoutTree.get()!, 'session-tile:one')).not.toBeNull()
+    expect(restartedModel.findGroupOfPane(restarted.tree.$layoutTree.get()!, 'session-tile:two')).not.toBeNull()
+    expect(restarted.tree.$activePresetId.get()).toBe('default')
+    expect(restarted.tree.$userPlacedPanes.get()).toEqual(new Set())
+    expect(window.localStorage.getItem('hermes.desktop.userPlacedPanes.v1')).toBeNull()
+    expect(restarted.tree.$dismissedPanes.get()).toEqual(new Set())
+  })
+
+  it('keeps reset incomplete when dismissed-pane removal is swallowed and completes it after restart', async () => {
+    const { ran, tree } = await loadHarness()
+    const dismissedKey = 'hermes.desktop.dismissedPanes.v1'
+    const staleDismissed = JSON.stringify(['pre-dismissed-pane'])
+
+    tree.$dismissedPanes.set(new Set(['pre-dismissed-pane']))
+    window.localStorage.setItem(dismissedKey, staleDismissed)
+    expect(await ran.enableRanMode()).toBe(true)
+
+    const nativeRemoveItem = Storage.prototype.removeItem
+
+    const remove = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function (this: Storage, key) {
+      if (key === dismissedKey) {
+        throw new DOMException('dismissed persistence unavailable', 'SecurityError')
+      }
+
+      nativeRemoveItem.call(this, key)
+    })
+
+    expect(await ran.resetLayoutFromRanMode()).toBe(false)
+    expect(window.localStorage.getItem(dismissedKey)).toBe(staleDismissed)
+    expect(JSON.parse(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY) ?? '{}')).toMatchObject({
+      completed: false,
+      enabled: false,
+      exit: { kind: 'reset' }
+    })
+
+    remove.mockRestore()
+    vi.resetModules()
+
+    const restarted = await loadHarness()
+    expect(await restarted.ran.initializeRanMode()).toBe(false)
+    expect(window.localStorage.getItem(dismissedKey)).toBeNull()
+    expect(window.localStorage.getItem(restarted.ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('treats Reset Layout as an explicit choice that exits Ran Mode', async () => {
+    const { ran, statusbar, tools, tree } = await loadHarness()
+    statusbar.$statusbarVisible.set(true)
+    tools.$toolViewMode.set('technical')
+    expect(await ran.enableRanMode()).toBe(true)
+
+    expect(await ran.resetLayoutFromRanMode()).toBe(true)
+    expect(ran.$ranModeEnabled.get()).toBe(false)
+    expect(tree.$activePresetId.get()).toBe('default')
+    expect(statusbar.$statusbarVisible.get()).toBe(true)
+    expect(tools.$toolViewMode.get()).toBe('technical')
+    expect(window.localStorage.getItem(ran.RAN_MODE_STORAGE_KEY)).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/ran-mode.test.ts
+++ b/apps/desktop/src/store/ran-mode.test.ts
@@ -167,6 +167,7 @@ describe('Ran Mode state transaction', () => {
       showArchived: layout.$sidebarShowArchived.get(),
       statusFilter: layout.$sidebarStatusFilter.get()
     })
+
     const upstreamView = {
       filtersActive: true,
       grouping: 'project',

--- a/apps/desktop/src/store/ran-mode.test.ts
+++ b/apps/desktop/src/store/ran-mode.test.ts
@@ -1960,6 +1960,28 @@ describe('Ran Mode state transaction', () => {
     expect(window.localStorage.getItem('hermes.desktop.statusbarVisible')).toBe(durableBefore.statusbar)
   })
 
+  it('isolates panes flipped while preserving upstream right-rail persistence in auxiliary renderers', async () => {
+    vi.doMock('@/store/windows', async importOriginal => {
+      const actual = await importOriginal<Record<string, unknown>>()
+
+      return { ...actual, isAuxiliaryWindow: () => true }
+    })
+
+    window.localStorage.setItem('hermes.desktop.panesFlipped', 'true')
+    window.localStorage.setItem('hermes.desktop.rightRailActiveTab', 'url:https://example.com/primary')
+
+    const layout = await import('@/store/layout')
+
+    expect(layout.$panesFlipped.get()).toBe(false)
+    expect(layout.$rightRailActiveTabId.get()).toBe('url:https://example.com/primary')
+
+    layout.$panesFlipped.set(true)
+    layout.selectRightRailTab('file:C:/work/auxiliary.md')
+
+    expect(window.localStorage.getItem('hermes.desktop.panesFlipped')).toBe('true')
+    expect(window.localStorage.getItem('hermes.desktop.rightRailActiveTab')).toBe('file:C:/work/auxiliary.md')
+  })
+
   it('does not let a delayed live-record removal overwrite newer non-layout owned state', async () => {
     const { ran, review } = await loadHarness()
 

--- a/apps/desktop/src/store/ran-mode.ts
+++ b/apps/desktop/src/store/ran-mode.ts
@@ -1,0 +1,1329 @@
+import { atom } from 'nanostores'
+
+import { $terminalTakeover } from '@/app/right-sidebar/store'
+import { group, groupLeafIds, isLayoutNode, type LayoutNode, split } from '@/components/pane-shell/tree/model'
+import {
+  $dismissedPanes,
+  adoptContributedPanes,
+  applyTree,
+  captureLayoutStateSnapshot,
+  type LayoutStateSnapshot,
+  resetLayoutTree,
+  restoreLayoutStateSnapshot
+} from '@/components/pane-shell/tree/store'
+import {
+  $composerPopoutZones,
+  captureComposerPopoutSnapshot,
+  type ComposerPopoutSnapshot,
+  isComposerPopoutSnapshot,
+  reconcileComposerPopoutSnapshot,
+  restoreComposerPopoutSnapshot
+} from '@/store/composer-popout'
+import { $panesFlipped, $rightRailActiveTabId } from '@/store/layout'
+import { $reviewOpen } from '@/store/review'
+import { $statusbarVisible } from '@/store/statusbar-prefs'
+import { $toolViewMode, type ToolViewMode } from '@/store/tool-view'
+import { isAuxiliaryWindow } from '@/store/windows'
+
+import { $paneStates, type PaneStateSnapshot, setPaneOpen } from './panes'
+
+export const RAN_MODE_PRESET_ID = 'ran-mode'
+export const RAN_MODE_STORAGE_KEY = 'hermes.desktop.ranMode.v1'
+export const RAN_MODE_STORAGE_BACKUP_KEY = `${RAN_MODE_STORAGE_KEY}.backup`
+export const RAN_MODE_LOCK_NAME = 'hermes.desktop.ranMode.journal.v1'
+
+let journalLockHeld = false
+let journalTransitionPending = false
+let lastJournalSequence = 0
+let pendingPeerStorageEvents = 0
+let peerStorageEventChain: Promise<void> = Promise.resolve()
+
+const OWNED_STORAGE_KEYS = {
+  activePreset: 'hermes.desktop.layoutPreset.active',
+  composerPopoutZones: 'hermes.desktop.composerPopout.zones.v1',
+  dismissedPanes: 'hermes.desktop.dismissedPanes.v1',
+  layoutTree: 'hermes.desktop.layoutTree.v2',
+  paneStates: 'hermes.desktop.paneStates.v1',
+  panesFlipped: 'hermes.desktop.panesFlipped',
+  reviewOpen: 'hermes.desktop.reviewOpen',
+  rightRailActiveTab: 'hermes.desktop.rightRailActiveTab',
+  statusbarVisible: 'hermes.desktop.statusbarVisible',
+  terminalTakeover: 'hermes.desktop.terminalTakeover',
+  toolViewTechnical: 'hermes.desktop.toolView.technical',
+  userPlacedPanes: 'hermes.desktop.userPlacedPanes.v1'
+} as const
+
+const OWNED_STORAGE_KEY_LIST = Object.values(OWNED_STORAGE_KEYS)
+
+export const RAN_MODE_TREE = split(
+  'row',
+  [
+    group(['sessions'], { id: 'ran-mode-sessions', minimized: true }),
+    group(['workspace'], { id: 'ran-mode-workspace' })
+  ],
+  [0.08, 1],
+  'ran-mode-root'
+)
+
+interface RanModeSnapshotV1 {
+  composerPopout: ComposerPopoutSnapshot
+  layout: LayoutStateSnapshot
+  paneStates: Record<string, PaneStateSnapshot>
+  reviewOpen: boolean
+  statusbarVisible: boolean
+  terminalTakeover: boolean
+  toolViewMode: ToolViewMode
+}
+
+type RanModeExit =
+  | { kind: 'preset'; presetId: string; tree: LayoutNode }
+  | { kind: 'reset' }
+
+interface RanModeLiveRecordV1 {
+  enabled: true
+  journalSequence?: number
+  ownedStateFingerprint?: string
+  phase: 'active' | 'applying'
+  snapshot: RanModeSnapshotV1
+  transactionId: string
+  version: 1
+}
+
+interface RanModeSettledRecordV1 {
+  completed: boolean
+  enabled: false
+  exit?: RanModeExit
+  journalSequence?: number
+  phase: 'inactive' | 'leaving'
+  restorePolicy: 'conditional' | 'force'
+  settlementFingerprint?: string
+  snapshot: RanModeSnapshotV1
+  transactionId: string
+  version: 1
+}
+
+type RanModeRecordV1 = RanModeLiveRecordV1 | RanModeSettledRecordV1
+
+interface RanModeJournalEnvelopeV2 {
+  checksum: string
+  payload: null | string
+  sequence: number
+  version: 2
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+function isPaneState(value: unknown): value is PaneStateSnapshot {
+  return (
+    isObject(value) &&
+    typeof value.open === 'boolean' &&
+    (value.widthOverride === undefined || typeof value.widthOverride === 'number') &&
+    (value.heightOverride === undefined || typeof value.heightOverride === 'number')
+  )
+}
+
+function isLayoutSnapshot(value: unknown): value is LayoutStateSnapshot {
+  return (
+    isObject(value) &&
+    typeof value.activePresetId === 'string' &&
+    isLayoutNode(value.tree) &&
+    Array.isArray(value.userPlacedPaneIds) &&
+    value.userPlacedPaneIds.every(id => typeof id === 'string')
+  )
+}
+
+function isSnapshot(value: unknown): value is RanModeSnapshotV1 {
+  return (
+    isObject(value) &&
+    isComposerPopoutSnapshot(value.composerPopout) &&
+    isLayoutSnapshot(value.layout) &&
+    isObject(value.paneStates) &&
+    Object.values(value.paneStates).every(isPaneState) &&
+    typeof value.reviewOpen === 'boolean' &&
+    typeof value.statusbarVisible === 'boolean' &&
+    typeof value.terminalTakeover === 'boolean' &&
+    (value.toolViewMode === 'product' || value.toolViewMode === 'technical')
+  )
+}
+
+function isExit(value: unknown): value is RanModeExit {
+  if (!isObject(value) || (value.kind !== 'preset' && value.kind !== 'reset')) {
+    return false
+  }
+
+  return value.kind === 'reset' || (typeof value.presetId === 'string' && isLayoutNode(value.tree))
+}
+
+function isRanModeRecord(value: unknown): value is RanModeRecordV1 {
+  if (!isObject(value)) {
+    return false
+  }
+
+  const journalSequence = value.journalSequence
+
+  if (
+    value.version !== 1 ||
+    (journalSequence !== undefined &&
+      (typeof journalSequence !== 'number' || !Number.isSafeInteger(journalSequence) || journalSequence < 0)) ||
+    typeof value.transactionId !== 'string' ||
+    value.transactionId.length === 0 ||
+    !isSnapshot(value.snapshot)
+  ) {
+    return false
+  }
+
+  if (value.enabled === true) {
+    return (
+      (value.ownedStateFingerprint === undefined || typeof value.ownedStateFingerprint === 'string') &&
+      (value.phase === 'active' || value.phase === 'applying')
+    )
+  }
+
+  if (
+    value.enabled !== false ||
+    typeof value.completed !== 'boolean' ||
+    (value.settlementFingerprint !== undefined && typeof value.settlementFingerprint !== 'string') ||
+    (value.phase !== 'inactive' && value.phase !== 'leaving') ||
+    (value.restorePolicy !== 'conditional' && value.restorePolicy !== 'force')
+  ) {
+    return false
+  }
+
+  return value.phase === 'inactive' ? value.exit === undefined : isExit(value.exit)
+}
+
+interface RecordReadResult {
+  ok: boolean
+  record: RanModeRecordV1 | null
+  sequence: number
+  writable?: boolean
+}
+
+function parseRecord(raw: null | string): RanModeRecordV1 | null {
+  if (raw === null) {
+    return null
+  }
+
+  try {
+    const value: unknown = JSON.parse(raw)
+
+    return isRanModeRecord(value) ? value : null
+  } catch {
+    return null
+  }
+}
+
+function journalChecksum(sequence: number, payload: null | string): string {
+  const source = `${sequence}:${payload ?? '<cleared>'}`
+  let hash = 2166136261
+
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+function serializeEnvelope(sequence: number, payload: null | string): string {
+  return JSON.stringify({ checksum: journalChecksum(sequence, payload), payload, sequence, version: 2 })
+}
+
+function nextJournalSequence(current: number): number {
+  // Preserve ordering after cleanup removes both slots: wall-clock high bits
+  // prevent a delayed predecessor from outranking the next generation, while
+  // the local/current increments cover clock stalls and same-tick transitions.
+  lastJournalSequence = Math.max(lastJournalSequence + 1, current + 1, Date.now() * 1024)
+
+  return lastJournalSequence
+}
+
+function parseEnvelope(raw: null | string): RanModeJournalEnvelopeV2 | null {
+  if (raw === null) {
+    return null
+  }
+
+  try {
+    const value: unknown = JSON.parse(raw)
+
+    if (!isObject(value)) {
+      return null
+    }
+
+    const sequence = value.sequence
+
+    if (
+      value.version !== 2 ||
+      typeof sequence !== 'number' ||
+      !Number.isSafeInteger(sequence) ||
+      sequence < 1 ||
+      (value.payload !== null && typeof value.payload !== 'string') ||
+      typeof value.checksum !== 'string' ||
+      value.checksum !== journalChecksum(value.sequence as number, value.payload as null | string)
+    ) {
+      return null
+    }
+
+    if (value.payload !== null) {
+      const record = parseRecord(value.payload)
+
+      if (!record || record.journalSequence !== value.sequence) {
+        return null
+      }
+    }
+
+    return value as unknown as RanModeJournalEnvelopeV2
+  } catch {
+    return null
+  }
+}
+
+function parseStorageRecord(raw: null | string): RanModeRecordV1 | null {
+  const direct = parseRecord(raw)
+
+  if (direct) {
+    return direct
+  }
+
+  const envelope = parseEnvelope(raw)
+
+  return envelope ? parseRecord(envelope.payload) : null
+}
+
+function removeExactStorageValue(key: string, expected: null | string): boolean {
+  if (!journalLockHeld) {
+    return false
+  }
+
+  try {
+    if (window.localStorage.getItem(key) !== expected) {
+      return false
+    }
+
+    window.localStorage.removeItem(key)
+
+    return window.localStorage.getItem(key) === null
+  } catch {
+    return false
+  }
+}
+
+function readRecord(): RecordReadResult {
+  try {
+    const primaryRaw = window.localStorage.getItem(RAN_MODE_STORAGE_KEY)
+    const backupRaw = window.localStorage.getItem(RAN_MODE_STORAGE_BACKUP_KEY)
+    const primary = parseRecord(primaryRaw)
+    const backup = parseEnvelope(backupRaw)
+    const primaryInvalid = primaryRaw !== null && !primary
+    const backupInvalid = backupRaw !== null && !backup
+
+    if (primaryInvalid && !backup) {
+      if (!journalLockHeld || !removeExactStorageValue(RAN_MODE_STORAGE_KEY, primaryRaw)) {
+        return { ok: false, record: null, sequence: 0 }
+      }
+    }
+
+    if (backupInvalid) {
+      if (!primary || (!journalLockHeld && primaryRaw === null)) {
+        return { ok: false, record: null, sequence: primary?.journalSequence ?? 0 }
+      }
+
+      if (journalLockHeld) {
+        removeExactStorageValue(RAN_MODE_STORAGE_BACKUP_KEY, backupRaw)
+      }
+    }
+
+    const primarySequence = primary?.journalSequence ?? 0
+
+    if (backup && (!primary || backup.sequence >= primarySequence)) {
+      const backupRecord = parseRecord(backup.payload)
+
+      if (journalLockHeld) {
+        let repaired = false
+
+        try {
+          repaired =
+            backup.payload === null
+              ? primaryRaw === null || removeExactStorageValue(RAN_MODE_STORAGE_KEY, primaryRaw)
+              : (() => {
+                  window.localStorage.setItem(RAN_MODE_STORAGE_KEY, backup.payload)
+
+                  return window.localStorage.getItem(RAN_MODE_STORAGE_KEY) === backup.payload
+                })()
+        } catch {
+          // The checksummed successor remains authoritative in the backup slot.
+        }
+
+        if (!repaired) {
+          return { ok: true, record: backupRecord, sequence: backup.sequence, writable: false }
+        }
+
+        removeExactStorageValue(RAN_MODE_STORAGE_BACKUP_KEY, backupRaw)
+      }
+
+      return { ok: true, record: backupRecord, sequence: backup.sequence }
+    }
+
+    if (backup && journalLockHeld) {
+      removeExactStorageValue(RAN_MODE_STORAGE_BACKUP_KEY, backupRaw)
+    }
+
+    return { ok: true, record: primary, sequence: primarySequence }
+  } catch {
+    return { ok: false, record: null, sequence: 0 }
+  }
+}
+
+/**
+ * Stage each successor in a checksummed backup slot before touching the
+ * primary record. A corrupt stage leaves the predecessor intact; a corrupt
+ * primary mirror leaves the validated successor available for restart repair.
+ */
+function persistRecord(record: RanModeRecordV1): boolean {
+  if (!journalLockHeld) {
+    return false
+  }
+
+  const authority = readRecord()
+
+  if (!authority.ok || authority.writable === false) {
+    return false
+  }
+
+  const sequence = nextJournalSequence(authority.sequence)
+  const durableRecord = { ...record, journalSequence: sequence } as RanModeRecordV1
+  const serialized = JSON.stringify(durableRecord)
+  const envelope = serializeEnvelope(sequence, serialized)
+
+  try {
+    window.localStorage.setItem(RAN_MODE_STORAGE_BACKUP_KEY, envelope)
+
+    if (window.localStorage.getItem(RAN_MODE_STORAGE_BACKUP_KEY) !== envelope) {
+      removeExactStorageValue(RAN_MODE_STORAGE_BACKUP_KEY, window.localStorage.getItem(RAN_MODE_STORAGE_BACKUP_KEY))
+
+      return false
+    }
+
+    Object.assign(record, { journalSequence: sequence })
+  } catch {
+    return false
+  }
+
+  try {
+    window.localStorage.setItem(RAN_MODE_STORAGE_KEY, serialized)
+
+    if (window.localStorage.getItem(RAN_MODE_STORAGE_KEY) === serialized) {
+      removeExactStorageValue(RAN_MODE_STORAGE_BACKUP_KEY, envelope)
+    }
+  } catch {
+    // The validated backup is already the authoritative successor. Leave it in
+    // place so restart can repair the primary mirror without losing the phase.
+  }
+
+  return true
+}
+
+/**
+ * Settled records are safe tombstones. Their durable `enabled:false` state is
+ * already sufficient for restart safety, so removal is cleanup only. A failed
+ * or ambiguous removal leaves a harmless record that startup can replay.
+ */
+function removeSettledRecord(record: RanModeSettledRecordV1): void {
+  if (!journalLockHeld) {
+    return
+  }
+
+  try {
+    const authority = readRecord()
+
+    if (
+      !authority.ok ||
+      authority.writable === false ||
+      !authority.record ||
+      authority.record.enabled ||
+      !authority.record.completed ||
+      authority.record.transactionId !== record.transactionId
+    ) {
+      return
+    }
+
+    const cleared = serializeEnvelope(nextJournalSequence(authority.sequence), null)
+
+    window.localStorage.setItem(RAN_MODE_STORAGE_BACKUP_KEY, cleared)
+
+    if (window.localStorage.getItem(RAN_MODE_STORAGE_BACKUP_KEY) !== cleared) {
+      removeExactStorageValue(RAN_MODE_STORAGE_BACKUP_KEY, window.localStorage.getItem(RAN_MODE_STORAGE_BACKUP_KEY))
+
+      return
+    }
+
+    const primary = window.localStorage.getItem(RAN_MODE_STORAGE_KEY)
+
+    if (primary === null || removeExactStorageValue(RAN_MODE_STORAGE_KEY, primary)) {
+      removeExactStorageValue(RAN_MODE_STORAGE_BACKUP_KEY, cleared)
+    }
+  } catch {
+    // Keep the durable disabled tombstone. Never reactivate Ran Mode here.
+  }
+}
+
+const initialRead = isAuxiliaryWindow() ? { ok: true, record: null, sequence: 0 } : readRecord()
+let currentRecord = initialRead.ok ? initialRead.record : null
+
+export const $ranModeEnabled = atom(Boolean(currentRecord?.enabled))
+
+function createTransactionId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+function captureSnapshot(): RanModeSnapshotV1 {
+  return {
+    composerPopout: captureComposerPopoutSnapshot(),
+    layout: captureLayoutStateSnapshot(),
+    paneStates: structuredClone($paneStates.get()),
+    reviewOpen: $reviewOpen.get(),
+    statusbarVisible: $statusbarVisible.get(),
+    terminalTakeover: $terminalTakeover.get(),
+    toolViewMode: $toolViewMode.get()
+  }
+}
+
+function applyLayoutOwnedState(): void {
+  applyTree(structuredClone(RAN_MODE_TREE), RAN_MODE_PRESET_ID)
+  setPaneOpen('chat-sidebar', true)
+  setPaneOpen('file-browser', false)
+  $reviewOpen.set(false)
+  $terminalTakeover.set(false)
+}
+
+function applyUserOwnedDefaults(force: boolean): void {
+  if (force || $statusbarVisible.get() === false) {
+    $statusbarVisible.set(false)
+  }
+
+  if (force || $toolViewMode.get() === 'product') {
+    $toolViewMode.set('product')
+  }
+}
+
+function shouldForceUserOwnedRestore(record: RanModeRecordV1): boolean {
+  return record.enabled ? record.phase === 'applying' : record.restorePolicy === 'force'
+}
+
+function restoreUserOwnedState(record: RanModeRecordV1): void {
+  if (shouldForceUserOwnedRestore(record) || $statusbarVisible.get() === false) {
+    $statusbarVisible.set(record.snapshot.statusbarVisible)
+  }
+
+  if (shouldForceUserOwnedRestore(record) || $toolViewMode.get() === 'product') {
+    $toolViewMode.set(record.snapshot.toolViewMode)
+  }
+}
+
+function restoreNonLayoutState(record: RanModeRecordV1): void {
+  // Snapshot-owned panes return exactly; panes registered while the mode was
+  // active are user/system-owned and remain present.
+  $paneStates.set({ ...$paneStates.get(), ...structuredClone(record.snapshot.paneStates) })
+  $reviewOpen.set(record.snapshot.reviewOpen)
+  $terminalTakeover.set(record.snapshot.terminalTakeover)
+  restoreUserOwnedState(record)
+  restoreComposerPopoutSnapshot(record.snapshot.composerPopout)
+}
+
+function restoreLayoutOwnedState(record: RanModeRecordV1): void {
+  restoreLayoutStateSnapshot(record.snapshot.layout)
+  // Registry entries can arrive while Ran Mode is active (plugins, previews,
+  // session tiles). Re-adopt after restoring the old tree so none disappear.
+  adoptContributedPanes()
+  restoreNonLayoutState(record)
+}
+
+function applyExit(exit: RanModeExit): boolean {
+  if (exit.kind === 'reset') {
+    return resetLayoutTree()
+  } else {
+    applyTree(structuredClone(exit.tree), exit.presetId)
+  }
+
+  return false
+}
+
+function finishSettledRecord(record: RanModeSettledRecordV1): boolean {
+  let resetRequiresPersistedTree = false
+
+  if (record.phase === 'inactive') {
+    restoreLayoutOwnedState(record)
+  } else {
+    restoreNonLayoutState(record)
+    resetRequiresPersistedTree = applyExit(record.exit!)
+  }
+
+  $ranModeEnabled.set(false)
+
+  return resetRequiresPersistedTree
+}
+
+function verifyCurrentOwnedStatePersistence(record: RanModeSettledRecordV1, resetRequiresPersistedTree: boolean): boolean {
+  const layout = captureLayoutStateSnapshot()
+  const serializedLayoutTree = JSON.stringify(layout.tree)
+  const resetSettlement = record.phase === 'leaving' && record.exit?.kind === 'reset'
+  let persistedComposerPopoutZones: string | null
+  let persistedLayoutTree: string | null
+
+  try {
+    persistedComposerPopoutZones = window.localStorage.getItem(OWNED_STORAGE_KEYS.composerPopoutZones)
+    persistedLayoutTree = window.localStorage.getItem(OWNED_STORAGE_KEYS.layoutTree)
+  } catch {
+    return false
+  }
+
+  const expectedLayoutTree = resetSettlement ? (resetRequiresPersistedTree ? serializedLayoutTree : null) : serializedLayoutTree
+
+  const expectedComposerPopout =
+    record.phase === 'inactive'
+      ? record.snapshot.composerPopout
+      : reconcileComposerPopoutSnapshot(record.snapshot.composerPopout, groupLeafIds(layout.tree))
+
+  if (
+    persistedLayoutTree !== expectedLayoutTree ||
+    persistedComposerPopoutZones !== expectedComposerPopout.storageValue ||
+    JSON.stringify($composerPopoutZones.get()) !== JSON.stringify(expectedComposerPopout.zones)
+  ) {
+    return false
+  }
+
+  const dismissedPanes = $dismissedPanes.get()
+  const expectedDismissedPanes = dismissedPanes.size === 0 ? null : JSON.stringify([...dismissedPanes])
+
+  const expected = new Map<string, null | string>([
+    [OWNED_STORAGE_KEYS.activePreset, layout.activePresetId],
+    [OWNED_STORAGE_KEYS.composerPopoutZones, expectedComposerPopout.storageValue],
+    [OWNED_STORAGE_KEYS.dismissedPanes, expectedDismissedPanes],
+    [OWNED_STORAGE_KEYS.layoutTree, expectedLayoutTree],
+    [OWNED_STORAGE_KEYS.paneStates, JSON.stringify($paneStates.get())],
+    [OWNED_STORAGE_KEYS.panesFlipped, String($panesFlipped.get())],
+    [OWNED_STORAGE_KEYS.reviewOpen, String($reviewOpen.get())],
+    [OWNED_STORAGE_KEYS.rightRailActiveTab, $rightRailActiveTabId.get() ?? ''],
+    [OWNED_STORAGE_KEYS.statusbarVisible, String($statusbarVisible.get())],
+    [OWNED_STORAGE_KEYS.terminalTakeover, String($terminalTakeover.get())],
+    [OWNED_STORAGE_KEYS.toolViewTechnical, String($toolViewMode.get() === 'technical')],
+    [
+      OWNED_STORAGE_KEYS.userPlacedPanes,
+      layout.userPlacedPaneIds.length === 0 ? null : JSON.stringify(layout.userPlacedPaneIds)
+    ]
+  ])
+
+  try {
+    return [...expected].every(([key, value]) => window.localStorage.getItem(key) === value)
+  } catch {
+    return false
+  }
+}
+
+function captureOwnedStorageFingerprint(): string | null {
+  try {
+    return JSON.stringify(OWNED_STORAGE_KEY_LIST.map(key => [key, window.localStorage.getItem(key)]))
+  } catch {
+    return null
+  }
+}
+
+function withCurrentOwnedStateFingerprint(record: RanModeLiveRecordV1): RanModeLiveRecordV1 {
+  const ownedStateFingerprint = captureOwnedStorageFingerprint()
+
+  return ownedStateFingerprint === null ? record : { ...record, ownedStateFingerprint }
+}
+
+type CompletionResult =
+  | { status: 'completed'; record: RanModeSettledRecordV1 }
+  | { status: 'failed' }
+  | { status: 'superseded'; record: RanModeRecordV1 | null }
+
+function classifyCompletionOwnership(record: RanModeSettledRecordV1): CompletionResult | null {
+  const durable = readRecord()
+
+  if (!durable.ok) {
+    return { status: 'failed' }
+  }
+
+  if (durable.record?.transactionId !== record.transactionId || durable.record.enabled) {
+    return { record: durable.record, status: 'superseded' }
+  }
+
+  if (durable.record.completed) {
+    return { record: durable.record, status: 'completed' }
+  }
+
+  return null
+}
+
+function completeSettledRecord(record: RanModeSettledRecordV1): CompletionResult {
+  if (record.completed) {
+    return { record, status: 'completed' }
+  }
+
+  const before = classifyCompletionOwnership(record)
+
+  if (before) {
+    return before
+  }
+
+  let resetRequiresPersistedTree: boolean
+
+  try {
+    resetRequiresPersistedTree = finishSettledRecord(record)
+  } catch {
+    // The durable disabled tombstone is the retry contract. Never mark it
+    // complete when any restore/apply step failed; fail-closed recovery keeps
+    // the renderer in Ran Mode until a later initialize can retry the intent.
+    return { status: 'failed' }
+  }
+
+  if (!verifyCurrentOwnedStatePersistence(record, resetRequiresPersistedTree)) {
+    // The underlying preference stores are intentionally best-effort and
+    // swallow quota/permission errors. Do not complete until every owned value
+    // reads back exactly; the disabled tombstone remains the restart retry.
+    return { status: 'failed' }
+  }
+
+  const settlementFingerprint = captureOwnedStorageFingerprint()
+
+  if (settlementFingerprint === null) {
+    return { status: 'failed' }
+  }
+
+  const completed: RanModeSettledRecordV1 = { ...record, completed: true, settlementFingerprint }
+
+  const afterSettlement = classifyCompletionOwnership(record)
+
+  if (afterSettlement) {
+    return afterSettlement
+  }
+
+  return persistRecord(completed) ? { record: completed, status: 'completed' } : { status: 'failed' }
+}
+
+function enterFailClosedRecovery(record: RanModeSettledRecordV1): void {
+  // Storage cannot confirm the disabled outcome. Keep the renderer visibly in
+  // Ran Mode and block all exits/layout choices until restart can replay the
+  // durable tombstone. The snapshot itself remains intact.
+  applyLayoutOwnedState()
+  applyUserOwnedDefaults(true)
+
+  // Never overwrite the durable exit intent with an active record. The
+  // in-memory Ran state is only a fail-closed guard; restart must finish the
+  // preserved tombstone, not re-enter the mode.
+  currentRecord = record
+  $ranModeEnabled.set(true)
+}
+
+function reconcileSupersedingRecord(record: RanModeRecordV1 | null): void {
+  if (record?.enabled) {
+    $ranModeEnabled.set(true)
+    applyLayoutOwnedState()
+    applyUserOwnedDefaults(record.phase === 'applying')
+    currentRecord = withCurrentOwnedStateFingerprint(record)
+  } else if (record && !record.completed) {
+    currentRecord = record
+    enterFailClosedRecovery(record)
+  } else {
+    currentRecord = null
+    $ranModeEnabled.set(false)
+  }
+}
+
+function settleLiveRecord(record: RanModeLiveRecordV1, exit?: RanModeExit): boolean {
+  const settled: RanModeSettledRecordV1 = {
+    completed: false,
+    enabled: false,
+    ...(exit ? { exit, phase: 'leaving' as const } : { phase: 'inactive' as const }),
+    restorePolicy: record.phase === 'applying' ? 'force' : 'conditional',
+    snapshot: record.snapshot,
+    transactionId: record.transactionId,
+    version: 1
+  }
+
+  // Commit the disabled tombstone first. A crash from this point converges to
+  // the intended disable/reset/preset choice during startup.
+  if (!persistRecord(settled)) {
+    return false
+  }
+
+  currentRecord = settled
+  const completion = completeSettledRecord(settled)
+
+  if (completion.status === 'failed') {
+    enterFailClosedRecovery(settled)
+
+    return false
+  }
+
+  if (completion.status === 'superseded') {
+    reconcileSupersedingRecord(completion.record)
+
+    return false
+  }
+
+  currentRecord = completion.record
+  removeSettledRecord(completion.record)
+  currentRecord = null
+
+  return true
+}
+
+function enableRanModeUnlocked(): boolean {
+  if (isAuxiliaryWindow()) {
+    return false
+  }
+
+  const persisted = readRecord()
+
+  if (!persisted.ok) {
+    return false
+  }
+
+  if (persisted.record?.enabled) {
+    $ranModeEnabled.set(true)
+    applyLayoutOwnedState()
+    applyUserOwnedDefaults(persisted.record.phase === 'applying')
+    currentRecord = withCurrentOwnedStateFingerprint(persisted.record)
+
+    return false
+  }
+
+  if (persisted.record) {
+    const completion = completeSettledRecord(persisted.record)
+
+    if (completion.status === 'failed') {
+      enterFailClosedRecovery(persisted.record)
+
+      return false
+    }
+
+    if (completion.status === 'superseded') {
+      reconcileSupersedingRecord(completion.record)
+
+      return false
+    }
+
+    removeSettledRecord(completion.record)
+  }
+
+  const applying: RanModeLiveRecordV1 = {
+    enabled: true,
+    phase: 'applying',
+    snapshot: captureSnapshot(),
+    transactionId: createTransactionId(),
+    version: 1
+  }
+
+  // Write the recovery payload before changing any owned preference. A crash
+  // during apply leaves a recoverable "applying" transaction, never a lost
+  // baseline.
+  if (!persistRecord(applying)) {
+    return false
+  }
+
+  currentRecord = applying
+  $ranModeEnabled.set(true)
+  applyLayoutOwnedState()
+  applyUserOwnedDefaults(true)
+
+  const active = withCurrentOwnedStateFingerprint({ ...applying, phase: 'active' })
+
+  if (persistRecord(active)) {
+    currentRecord = active
+  }
+
+  return true
+}
+
+/** Reconcile a persisted transaction after Desktop startup/restart. */
+function initializeRanModeUnlocked(): boolean {
+  if (isAuxiliaryWindow()) {
+    $ranModeEnabled.set(false)
+
+    return false
+  }
+
+  const persisted = readRecord()
+
+  if (!persisted.ok) {
+    return false
+  }
+
+  currentRecord = persisted.record
+
+  if (!currentRecord) {
+    $ranModeEnabled.set(false)
+
+    return false
+  }
+
+  if (!currentRecord.enabled) {
+    const completion = completeSettledRecord(currentRecord)
+
+    if (completion.status === 'failed') {
+      enterFailClosedRecovery(currentRecord)
+
+      return false
+    }
+
+    if (completion.status === 'superseded') {
+      reconcileSupersedingRecord(completion.record)
+
+      return Boolean(completion.record?.enabled)
+    }
+
+    removeSettledRecord(completion.record)
+    currentRecord = null
+
+    return false
+  }
+
+  const forceUserOwnedDefaults = currentRecord.phase === 'applying'
+  $ranModeEnabled.set(true)
+  applyLayoutOwnedState()
+  applyUserOwnedDefaults(forceUserOwnedDefaults)
+
+  const active = withCurrentOwnedStateFingerprint({ ...currentRecord, phase: 'active' })
+
+  if (currentRecord.phase !== 'active') {
+    if (persistRecord(active)) {
+      currentRecord = active
+    }
+  } else {
+    currentRecord = active
+  }
+
+  return true
+}
+
+function disableRanModeUnlocked(): boolean {
+  if (isAuxiliaryWindow()) {
+    return false
+  }
+
+  const persisted = readRecord()
+
+  if (!persisted.ok) {
+    return false
+  }
+
+  if (!persisted.record?.enabled) {
+    if ($ranModeEnabled.get() && persisted.record && !persisted.record.completed) {
+      return false
+    }
+
+    currentRecord = persisted.record
+    $ranModeEnabled.set(false)
+
+    return false
+  }
+
+  return settleLiveRecord(persisted.record)
+}
+
+/** Apply an explicit preset choice as the durable exit outcome. */
+function leaveRanModeForLayoutChangeUnlocked(presetId: string, tree: LayoutNode): boolean {
+  if (isAuxiliaryWindow()) {
+    return false
+  }
+
+  const persisted = readRecord()
+
+  return Boolean(
+    persisted.ok &&
+      persisted.record?.enabled &&
+      settleLiveRecord(persisted.record, { kind: 'preset', presetId, tree: structuredClone(tree) })
+  )
+}
+
+/** Reset is an explicit user choice, not a hidden Ran Mode rollback. */
+function resetLayoutFromRanModeUnlocked(): boolean {
+  if (isAuxiliaryWindow()) {
+    return false
+  }
+
+  const persisted = readRecord()
+
+  if (!persisted.ok) {
+    return false
+  }
+
+  if (persisted.record?.enabled) {
+    return settleLiveRecord(persisted.record, { kind: 'reset' })
+  }
+
+  if (persisted.record && !persisted.record.completed) {
+    return false
+  }
+
+  resetLayoutTree()
+
+  return true
+}
+
+function applyLayoutPresetWithRanModeUnlocked(presetId: string, tree: LayoutNode): boolean {
+  if (isAuxiliaryWindow()) {
+    return false
+  }
+
+  const persisted = readRecord()
+
+  if (!persisted.ok) {
+    return false
+  }
+
+  if (presetId === RAN_MODE_PRESET_ID) {
+    return enableRanModeUnlocked()
+  }
+
+  if (persisted.record?.enabled) {
+    return settleLiveRecord(persisted.record, {
+      kind: 'preset',
+      presetId,
+      tree: structuredClone(tree)
+    })
+  }
+
+  if (persisted.record && !persisted.record.completed) {
+    return false
+  }
+
+  if (persisted.record) {
+    removeSettledRecord(persisted.record)
+  }
+
+  currentRecord = null
+  $ranModeEnabled.set(false)
+  applyTree(structuredClone(tree), presetId)
+
+  return true
+}
+
+export function isRanModeRecoveryIncomplete(): boolean {
+  if (isAuxiliaryWindow()) {
+    return true
+  }
+
+  if (journalTransitionPending || pendingPeerStorageEvents > 0) {
+    return true
+  }
+
+  const persisted = readRecord()
+
+  return !persisted.ok || Boolean(persisted.record && !persisted.record.enabled && !persisted.record.completed)
+}
+
+async function runJournalTransition(operation: () => boolean): Promise<boolean> {
+  if (isAuxiliaryWindow() || journalTransitionPending || pendingPeerStorageEvents > 0) {
+    return false
+  }
+
+  const locks = globalThis.navigator?.locks
+
+  if (!locks) {
+    return false
+  }
+
+  journalTransitionPending = true
+
+  try {
+    return await locks.request(RAN_MODE_LOCK_NAME, { mode: 'exclusive' }, async () => {
+      journalLockHeld = true
+
+      try {
+        return operation()
+      } finally {
+        journalLockHeld = false
+      }
+    })
+  } catch {
+    return false
+  } finally {
+    journalTransitionPending = false
+  }
+}
+
+async function runPeerJournalTransition(operation: () => boolean): Promise<boolean> {
+  const locks = globalThis.navigator?.locks
+
+  if (!locks) {
+    return false
+  }
+
+  try {
+    return await locks.request(RAN_MODE_LOCK_NAME, { mode: 'exclusive' }, async () => {
+      journalLockHeld = true
+
+      try {
+        return operation()
+      } finally {
+        journalLockHeld = false
+      }
+    })
+  } catch {
+    return false
+  }
+}
+
+export function enableRanMode(): Promise<boolean> {
+  return runJournalTransition(enableRanModeUnlocked)
+}
+
+export function initializeRanMode(): Promise<boolean> {
+  return runJournalTransition(initializeRanModeUnlocked)
+}
+
+export function disableRanMode(): Promise<boolean> {
+  return runJournalTransition(disableRanModeUnlocked)
+}
+
+export function leaveRanModeForLayoutChange(presetId: string, tree: LayoutNode): Promise<boolean> {
+  return runJournalTransition(() => leaveRanModeForLayoutChangeUnlocked(presetId, tree))
+}
+
+export function resetLayoutFromRanMode(): Promise<boolean> {
+  return runJournalTransition(resetLayoutFromRanModeUnlocked)
+}
+
+export function applyLayoutPresetWithRanMode(presetId: string, tree: LayoutNode): Promise<boolean> {
+  return runJournalTransition(() => applyLayoutPresetWithRanModeUnlocked(presetId, tree))
+}
+
+export function toggleRanMode(): Promise<boolean> {
+  return $ranModeEnabled.get() ? disableRanMode() : enableRanMode()
+}
+
+function applyPeerSettlement(record: RanModeSettledRecordV1): void {
+  if (currentRecord?.transactionId !== record.transactionId || !currentRecord.enabled) {
+    return
+  }
+
+  currentRecord = record
+
+  try {
+    // Peer renderers apply the owner-written intent locally but never advance
+    // or remove its durable record.
+    finishSettledRecord(record)
+  } catch {
+    enterFailClosedRecovery(record)
+
+    return
+  }
+
+  currentRecord = null
+}
+
+interface RanModeStorageChange {
+  newValue: string | null
+  oldValue: string | null
+}
+
+function durableLayoutMatchesSettlement(record: RanModeRecordV1): boolean {
+  const expectedPreset =
+    record.enabled
+      ? RAN_MODE_PRESET_ID
+      : record.phase === 'leaving'
+        ? record.exit?.kind === 'preset'
+          ? record.exit.presetId
+          : 'default'
+        : record.snapshot.layout.activePresetId
+
+  const expectedTree =
+    record.enabled
+      ? JSON.stringify(captureLayoutStateSnapshot().tree)
+      : record.phase === 'leaving'
+        ? record.exit?.kind === 'reset'
+          ? null
+          : JSON.stringify(record.exit?.tree)
+        : JSON.stringify(record.snapshot.layout.tree)
+
+  try {
+    const durablePreset = window.localStorage.getItem(OWNED_STORAGE_KEYS.activePreset)
+    const durableTree = window.localStorage.getItem(OWNED_STORAGE_KEYS.layoutTree)
+
+    return durablePreset === expectedPreset && durableTree === expectedTree
+  } catch {
+    return false
+  }
+}
+
+function durableOwnedStateMatchesSettlement(record: RanModeRecordV1): boolean {
+  if (record.enabled || !record.completed || typeof record.settlementFingerprint !== 'string') {
+    return false
+  }
+
+  return captureOwnedStorageFingerprint() === record.settlementFingerprint
+}
+
+function handlePeerStorageChangeUnlocked(event: RanModeStorageChange): boolean {
+  let next = parseStorageRecord(event.newValue)
+  let durable: RanModeRecordV1 | null
+
+  const durableRead = readRecord()
+
+  if (!durableRead.ok) {
+    // Ambiguous storage is not authority to mutate renderer state.
+    return false
+  }
+
+  durable = durableRead.record
+
+  if (next && durable) {
+    if (durable.transactionId !== next.transactionId) {
+      return false
+    }
+
+    // localStorage is the current durable authority. Storage events can lag
+    // behind later writes for the same transaction, so reconcile the durable
+    // phase/intent rather than replaying an older event payload.
+    next = durable
+  }
+
+  if (next && !durable) {
+    // The event lost durable authority before this renderer acquired the lock.
+    // Replaying a stale settlement can overwrite any later owned preference.
+    // Only a completed record whose full durable fingerprint still matches may
+    // replay; otherwise clear local ownership without writing any preference.
+    if (
+      next.enabled ||
+      currentRecord?.transactionId !== next.transactionId ||
+      !currentRecord.enabled ||
+      !durableOwnedStateMatchesSettlement(next)
+    ) {
+      return false
+    }
+
+    applyPeerSettlement(next)
+
+    return true
+  }
+
+  if (next && !next.enabled && next.completed) {
+    // Completed tombstones are inert for an already-off renderer. A peer that
+    // is still actively showing this exact transaction must apply the outcome
+    // locally once; this never mutates the durable tombstone.
+    applyPeerSettlement(next)
+
+    return true
+  }
+
+  if (next?.enabled) {
+    $ranModeEnabled.set(true)
+    applyLayoutOwnedState()
+    applyUserOwnedDefaults(next.phase === 'applying')
+    currentRecord = withCurrentOwnedStateFingerprint(next)
+
+    return true
+  }
+
+  if (next) {
+    if (next.completed) {
+      applyPeerSettlement(next)
+
+      return true
+    }
+
+    if (currentRecord?.transactionId !== next.transactionId || !currentRecord.enabled) {
+      return false
+    }
+
+    applyPeerSettlement(next)
+
+    return true
+  }
+
+  // Backward/failure fallback: both completed and live records require a full
+  // owned-state fingerprint. The active-layout check is retained as a second
+  // guard against a stale live removal replaying over newer preference bytes.
+  const previous = parseStorageRecord(event.oldValue)
+
+  if (durable || !previous || currentRecord?.transactionId !== previous.transactionId) {
+    return false
+  }
+
+  const previousStillOwnsDurableState = previous.enabled
+    ? durableLayoutMatchesSettlement(previous) &&
+      typeof previous.ownedStateFingerprint === 'string' &&
+      captureOwnedStorageFingerprint() === previous.ownedStateFingerprint
+    : durableOwnedStateMatchesSettlement(previous)
+
+  if (!previousStillOwnsDurableState) {
+    currentRecord = null
+    $ranModeEnabled.set(false)
+
+    return false
+  }
+
+  if (previous.enabled && currentRecord.enabled) {
+    try {
+      restoreLayoutOwnedState(previous)
+    } catch {
+      return false
+    }
+  } else if (!previous.enabled && previous.completed && currentRecord.enabled) {
+    applyPeerSettlement(previous)
+  } else if (!previous.enabled && !previous.completed && currentRecord.enabled) {
+    try {
+      finishSettledRecord(previous)
+    } catch {
+      enterFailClosedRecovery(previous)
+
+      return false
+    }
+  }
+
+  currentRecord = null
+  $ranModeEnabled.set(false)
+
+  return true
+}
+
+function handlePeerStorageChange(event: StorageEvent): void {
+  if ((event.key !== RAN_MODE_STORAGE_KEY && event.key !== RAN_MODE_STORAGE_BACKUP_KEY) || isAuxiliaryWindow()) {
+    return
+  }
+
+  const change: RanModeStorageChange = { newValue: event.newValue, oldValue: event.oldValue }
+
+  // Storage mutations from one completed transition emit several ordered
+  // events (incomplete, completed, clear-marker, removal). Never drop later
+  // events merely because an earlier one is waiting for the Web Lock: serialize
+  // the complete stream and re-read durable authority inside every callback.
+  pendingPeerStorageEvents += 1
+
+  const queued = peerStorageEventChain.then(() =>
+    runPeerJournalTransition(() => handlePeerStorageChangeUnlocked(change))
+  )
+
+  peerStorageEventChain = queued.then(
+    () => undefined,
+    () => undefined
+  )
+
+  void queued.then(
+    () => {
+      pendingPeerStorageEvents -= 1
+    },
+    () => {
+      pendingPeerStorageEvents -= 1
+    }
+  )
+}
+
+const STORAGE_LISTENER_KEY = '__hermesRanModeStorageListener__'
+type RanModeWindow = Window & { [STORAGE_LISTENER_KEY]?: (event: StorageEvent) => void }
+
+if (typeof window !== 'undefined') {
+  const ranWindow = window as RanModeWindow
+  const previousListener = ranWindow[STORAGE_LISTENER_KEY]
+
+  if (previousListener) {
+    window.removeEventListener('storage', previousListener)
+  }
+
+  ranWindow[STORAGE_LISTENER_KEY] = handlePeerStorageChange
+  window.addEventListener('storage', handlePeerStorageChange)
+}

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -9,6 +9,7 @@ import { desktopGit } from '@/lib/desktop-git'
 import { isExcludedPath } from '@/lib/excluded-paths'
 import { requestOneShot } from '@/lib/oneshot'
 import { Codecs, persistentAtom } from '@/lib/persisted'
+import { isAuxiliaryWindow } from '@/store/windows'
 
 import { refreshRepoStatus, repoStatusForCwd } from './coding-status'
 import { stampSessionPrBranch } from './pull-requests'
@@ -34,25 +35,30 @@ const TREE_MODE_KEY = 'hermes.desktop.reviewTreeMode'
 const SELECTED_KEY = 'hermes.desktop.reviewSelectedPath'
 const REVIEW_REFRESH_DEBOUNCE_MS = 100
 const SHIP_INFO_STALE_MS = 30_000
+const reviewStorageEnabled = !isAuxiliaryWindow()
 
 // Persisted so the pane stays open across reloads (like the other rail panes).
-export const $reviewOpen = persistentAtom(OPEN_KEY, false, Codecs.bool)
+export const $reviewOpen = reviewStorageEnabled ? persistentAtom(OPEN_KEY, false, Codecs.bool) : atom(false)
 
 // The split-button's remembered default action ('commit' | 'commitPush').
 export type CommitAction = 'commit' | 'commitPush'
 
-export const $reviewCommitDefault = persistentAtom<CommitAction>(COMMIT_DEFAULT_KEY, 'commit', {
-  decode: raw => (raw === 'commitPush' ? 'commitPush' : 'commit'),
-  encode: value => value
-})
+export const $reviewCommitDefault = reviewStorageEnabled
+  ? persistentAtom<CommitAction>(COMMIT_DEFAULT_KEY, 'commit', {
+      decode: raw => (raw === 'commitPush' ? 'commitPush' : 'commit'),
+      encode: value => value
+    })
+  : atom<CommitAction>('commit')
 
 // Changed-file layout: a flat path list (VS Code's default) or a folder tree.
 export type ReviewTreeMode = 'list' | 'tree'
 
-export const $reviewTreeMode = persistentAtom<ReviewTreeMode>(TREE_MODE_KEY, 'tree', {
-  decode: raw => (raw === 'list' ? 'list' : 'tree'),
-  encode: value => value
-})
+export const $reviewTreeMode = reviewStorageEnabled
+  ? persistentAtom<ReviewTreeMode>(TREE_MODE_KEY, 'tree', {
+      decode: raw => (raw === 'list' ? 'list' : 'tree'),
+      encode: value => value
+    })
+  : atom<ReviewTreeMode>('tree')
 
 export function toggleReviewTreeMode(): void {
   $reviewTreeMode.set($reviewTreeMode.get() === 'tree' ? 'list' : 'tree')
@@ -73,7 +79,9 @@ export const $reviewMaxChurn = computed($reviewFiles, files =>
 )
 // Persisted so a relaunch restores the file you were diffing (its diff is
 // re-fetched in refreshReview once the file is confirmed still changed).
-export const $reviewSelectedPath = persistentAtom<null | string>(SELECTED_KEY, null, Codecs.nullableText)
+export const $reviewSelectedPath = reviewStorageEnabled
+  ? persistentAtom<null | string>(SELECTED_KEY, null, Codecs.nullableText)
+  : atom<null | string>(null)
 export const $reviewDiff = atom<null | string>(null)
 export const $reviewDiffLoading = atom(false)
 

--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -1,4 +1,8 @@
+import { atom } from 'nanostores'
+
 import { Codecs, persistentAtom } from '@/lib/persisted'
+
+import { isAuxiliaryWindow } from './windows'
 
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
 const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
@@ -7,7 +11,9 @@ const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
 // — the bar is opt-in. Hiding it unmounts the bar (its 15s status poll goes with
 // it), so the way back is the `view.toggleStatusbar` keybind or the ⌘K row,
 // never the bar itself.
-export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
+export const $statusbarVisible = isAuxiliaryWindow()
+  ? atom(false)
+  : persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
 
 export function toggleStatusbarVisible() {
   $statusbarVisible.set(!$statusbarVisible.get())
@@ -35,13 +41,15 @@ export const STATUSBAR_HIDDEN_BY_DEFAULT: readonly string[] = [
 // staying off. An empty array is a real value — the user turned everything on —
 // so this uses a sanitizing json codec rather than Codecs.stringArray, which
 // drops the key when empty and would resurrect the defaults on next launch.
-export const $statusbarHiddenIds = persistentAtom<string[]>(
-  STATUSBAR_HIDDEN_STORAGE_KEY,
-  [...STATUSBAR_HIDDEN_BY_DEFAULT],
-  Codecs.json<string[]>(value =>
-    Array.isArray(value) ? value.filter((id): id is string => typeof id === 'string' && id.length > 0) : []
-  )
-)
+export const $statusbarHiddenIds = isAuxiliaryWindow()
+  ? atom<string[]>([...STATUSBAR_HIDDEN_BY_DEFAULT])
+  : persistentAtom<string[]>(
+      STATUSBAR_HIDDEN_STORAGE_KEY,
+      [...STATUSBAR_HIDDEN_BY_DEFAULT],
+      Codecs.json<string[]>(value =>
+        Array.isArray(value) ? value.filter((id): id is string => typeof id === 'string' && id.length > 0) : []
+      )
+    )
 
 export function setStatusbarItemVisible(id: string, visible: boolean) {
   const hidden = $statusbarHiddenIds.get()

--- a/apps/desktop/src/store/tool-view.ts
+++ b/apps/desktop/src/store/tool-view.ts
@@ -1,6 +1,7 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { persistBoolean, storedBoolean } from '@/lib/storage'
+import { isAuxiliaryWindow } from '@/store/windows'
 
 export type ToolViewMode = 'product' | 'technical'
 
@@ -9,16 +10,19 @@ type ToolDisclosureStates = Record<string, boolean>
 const TOOL_VIEW_TECHNICAL_STORAGE_KEY = 'hermes.desktop.toolView.technical'
 const TOOL_DISCLOSURE_STORAGE_KEY = 'hermes.desktop.toolDisclosure.v1'
 const MAX_DISCLOSURE_STATES = 240
+const toolViewStorageEnabled = !isAuxiliaryWindow()
 
 export const $toolViewMode = atom<ToolViewMode>(
-  storedBoolean(TOOL_VIEW_TECHNICAL_STORAGE_KEY, false) ? 'technical' : 'product'
+  toolViewStorageEnabled && storedBoolean(TOOL_VIEW_TECHNICAL_STORAGE_KEY, false) ? 'technical' : 'product'
 )
-export const $toolDisclosureStates = atom<ToolDisclosureStates>(loadToolDisclosureStates())
+export const $toolDisclosureStates = atom<ToolDisclosureStates>(toolViewStorageEnabled ? loadToolDisclosureStates() : {})
 const disclosureOpenCache = new Map<string, ReadableAtom<boolean | undefined>>()
 const anyDisclosureOpenCache = new Map<string, ReadableAtom<boolean>>()
 
-$toolViewMode.subscribe(mode => persistBoolean(TOOL_VIEW_TECHNICAL_STORAGE_KEY, mode === 'technical'))
-$toolDisclosureStates.subscribe(persistToolDisclosureStates)
+if (toolViewStorageEnabled) {
+  $toolViewMode.subscribe(mode => persistBoolean(TOOL_VIEW_TECHNICAL_STORAGE_KEY, mode === 'technical'))
+  $toolDisclosureStates.subscribe(persistToolDisclosureStates)
+}
 
 export function setToolViewMode(mode: ToolViewMode) {
   $toolViewMode.set(mode)


### PR DESCRIPTION
## What does this PR do?

### Summary

Ran Mode is an optional Desktop focus preset that reduces visual noise while preserving access to critical running, error, and approval activity. It is a reversible presentation layer on top of the existing Desktop layout architecture.

### Main behavior

- Provides a chat-first focused layout with idempotent enable/disable behavior.
- Snapshots and restores the prior workspace, including composer pop-out placement.
- Recovers coherently after a restart or interrupted transition.
- Collapses settled tool activity while keeping running, error, and approval states visible.
- Prevents auxiliary and HUD windows from mutating primary layout state.
- Adds entry points in Appearance, the command palette, and the layout picker.

### Upstream integration

The implementation preserves current upstream behavior rather than replacing the layout architecture:

- sidebar grouping, ordering, filtering, archive handling, and persisted preferences;
- ordinary and filtered sidebar page-size policy;
- titlebar controls, styling, sizing, glyph scaling, and macOS positioning;
- auxiliary-window presentation and primary-renderer ownership boundaries.

## Related Issue

No linked issue; searches of existing issues and pull requests found no matching Ran Mode or Desktop focus-preset proposal.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added durable Ran Mode state, snapshot/restore, settlement, recovery, and auxiliary-renderer ownership under `apps/desktop/src/store/`.
- Integrated Ran Mode presentation with Desktop settings, titlebar controls, command palette, layout picker, sidebar, status bar, and tool activity surfaces under `apps/desktop/src/app/` and `apps/desktop/src/components/`.
- Added focused unit, integration, startup-observer, composer restoration, and Electron E2E coverage.

## How to Test

1. From `apps/desktop`, run `npm run check:lint` and `npm run check:test:ui`.
2. Run `npm run build`.
3. Run `npx playwright test e2e/ran-mode.spec.ts` and exercise Ran Mode from Appearance, the command palette, and the layout picker.

### Validation performed

- Titlebar: **12/12 passed**
- Ran/auxiliary/layout focused: **82/82 passed**
- Renderer, Electron, and E2E TypeScript: **passed**
- ESLint: **passed with zero errors**
- Full UI suite: **3,753/3,753 passed**
- Production build: **passed**
- Electron Ran Mode E2E: **8/8 passed**

The repository-wide Windows/POSIX platform-contract lane locally reproduced 19 pre-existing baseline failures involving SSH/POSIX path and permission expectations. None are in this Desktop-only change set or were introduced by this candidate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not applicable to this Desktop TypeScript/Electron-only change; the relevant Desktop suites are reported above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the feature is self-describing in Desktop settings and translations
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no CLI configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing architecture is preserved
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — current macOS positioning and upstream layout behavior are preserved
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no agent tools changed

## Scope

Desktop-only. This PR does not change the gateway, messaging integrations, agent tools, skills, dependencies, or configuration.

## Screenshots / Logs

Automated behavior and recovery coverage is included in the focused and Electron E2E suites above.
