### PR TITLE
fix(gateway): preserve single newlines in Teams messages

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -28,6 +28,7 @@ import html
 import json
 import logging
 import os
+import re
 import sys
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
@@ -1214,6 +1215,34 @@ class TeamsAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[teams] send_exec_approval failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e), retryable=True)
+
+    # Bot Framework renders Teams activity text as markdown by default — the
+    # standalone cron sender (``_standalone_send`` above) even sets
+    # ``"textFormat": "markdown"`` explicitly — and markdown collapses a
+    # single ``\n`` between two lines into one run-on line (blank-line-
+    # separated paragraphs survive). ``_LONE_NEWLINE`` matches a run of
+    # exactly one newline (lookaround excludes it from ``\n\n+`` runs) so
+    # ``format_message`` can promote it to a paragraph break; ``_FENCED_BLOCK``
+    # carves out fenced code blocks so newlines inside them are left alone.
+    _LONE_NEWLINE = re.compile(r"(?<!\n)\n(?!\n)")
+    _FENCED_BLOCK = re.compile(r"(```[\s\S]*?```)")
+
+    def format_message(self, content: str) -> str:
+        """Promote lone newlines to blank lines so Teams renders them as breaks.
+
+        Without this, prose sent through ``send()`` reads as fused sentences
+        ("...unread.The inbox was...") because the Bot Framework service
+        applies markdown rendering by default and markdown swallows single
+        ``\\n``. Existing blank-line runs and fenced code block interiors are
+        left untouched.
+        """
+        if not content:
+            return content
+        segments = self._FENCED_BLOCK.split(content)
+        return "".join(
+            segment if segment.startswith("```") else self._LONE_NEWLINE.sub("\n\n", segment)
+            for segment in segments
+        )
 
     async def send(
         self,

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -385,6 +385,77 @@ class TestTeamsSend:
         assert result.message_id == "msg-123"
         mock_app.send.assert_awaited_once_with("conv-id", "Hello")
 
+    @pytest.mark.anyio
+    async def test_send_passes_formatted_text_to_app(self):
+        """send() must hand app.send() the format_message()-transformed text,
+        not the raw content, so lone newlines survive Bot Framework's
+        markdown rendering."""
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        mock_result = MagicMock()
+        mock_result.id = "msg-123"
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(return_value=mock_result)
+        adapter._app = mock_app
+
+        raw = "75 messages arrived in the past week, and none are currently unread.\nThe inbox was busiest on Tuesday."
+        result = await adapter.send("conv-id", raw)
+
+        assert result.success is True
+        mock_app.send.assert_awaited_once_with("conv-id", adapter.format_message(raw))
+        sent_text = mock_app.send.await_args.args[1]
+        assert "unread.\n\nThe inbox" in sent_text
+
+
+# ---------------------------------------------------------------------------
+# Tests: format_message (Teams markdown lone-newline collapse workaround)
+# ---------------------------------------------------------------------------
+
+class TestTeamsFormatMessage:
+
+    def _adapter(self):
+        return TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+
+    def test_lone_newline_is_doubled(self):
+        adapter = self._adapter()
+        result = adapter.format_message("First sentence.\nSecond sentence.")
+        assert result == "First sentence.\n\nSecond sentence."
+
+    def test_existing_blank_line_is_unchanged(self):
+        adapter = self._adapter()
+        content = "First paragraph.\n\nSecond paragraph."
+        assert adapter.format_message(content) == content
+
+    def test_multiple_lone_newlines_all_doubled(self):
+        adapter = self._adapter()
+        content = "One\nTwo\nThree"
+        assert adapter.format_message(content) == "One\n\nTwo\n\nThree"
+
+    def test_fenced_code_block_interior_preserved(self):
+        adapter = self._adapter()
+        content = "Before.\n```\nline one\nline two\n```\nAfter."
+        result = adapter.format_message(content)
+        assert result == "Before.\n\n```\nline one\nline two\n```\n\nAfter."
+
+    def test_empty_content_unchanged(self):
+        adapter = self._adapter()
+        assert adapter.format_message("") == ""
+
+    def test_content_with_no_newline_unchanged(self):
+        adapter = self._adapter()
+        assert adapter.format_message("Hello") == "Hello"
+
+    def test_run_of_three_newlines_is_unchanged(self):
+        # Every newline in "\n\n\n" is adjacent to another newline, so none
+        # qualify as "lone" — a run that already contains a blank line is
+        # left alone rather than growing further.
+        adapter = self._adapter()
+        content = "A\n\n\nB"
+        assert adapter.format_message(content) == content
+
 
 def _make_summary_payload():
     return TeamsMeetingSummaryPayload(


### PR DESCRIPTION
## Bug

Messages sent through the Microsoft Teams platform adapter (`plugins/platforms/teams/adapter.py`) lose single newlines — adjacent sentences fuse together with no space or break between them. For example, a reply built as:

```
75 messages arrived in the past week, and none are currently unread.
The inbox was busiest on Tuesday.
```

renders in Teams as:

```
75 messages arrived in the past week, and none are currently unread.The inbox was busiest on Tuesday.
```

Blank-line-separated paragraphs (`\n\n`) are unaffected — only lone `\n` runs collapse.

## Root cause

`TeamsAdapter.send()` passes the reply text as a bare string to the `microsoft-teams-apps` SDK's `App.send()` / `.reply()`, with no `textFormat` specified. The Bot Framework service defaults untyped activity text to markdown rendering, and markdown treats a single `\n` as insignificant whitespace (it takes `\n\n` to start a new paragraph) — so single line breaks are silently swallowed.

This isn't a guess about the intended rendering mode: the adapter's own out-of-process cron sender (`_standalone_send`, used when `hermes cron` runs as a separate process from the gateway) already sets `"textFormat": "markdown"` explicitly on the activity payload it posts. The live `send()` path was just missing the corresponding client-side handling that markdown rendering requires.

`TeamsAdapter` also didn't override `BasePlatformAdapter.format_message()`, which other adapters (Mattermost, Slack, Discord, etc.) use for exactly this kind of platform-specific text massaging — the base implementation is a no-op passthrough.

## Fix

Add a `format_message()` override to `TeamsAdapter` that promotes every run of exactly one newline to a blank line (`\n` → `\n\n`), outside fenced ` ``` ` code blocks, before the text reaches `send()` (which already calls `self.format_message(content)`). This:

- Fixes the fused-sentence bug for plain prose.
- Leaves existing `\n\n`-separated paragraphs untouched (they already render correctly).
- Leaves fenced code block interiors untouched, so multi-line code snippets aren't reformatted.

**Alternative considered and rejected:** setting `text_format="plain"` on the activity instead of fixing newline handling. This was rejected because it would also disable bold/italic/inline-code rendering, which the adapter's own `platform_hint` documents as supported ("Teams renders a subset of markdown — bold (**text**), italic (*text*), and inline code (`code`) work"). Preserving markdown and making line breaks survive it is the fix that keeps existing formatting intact.

## Testing

- Added `TestTeamsFormatMessage` to `tests/gateway/test_teams.py`: a transform matrix covering lone-newline doubling, unchanged existing blank lines, unchanged fenced code block interiors, unchanged empty/no-newline content, and an unchanged 3-newline run (already contains a blank line).
- Added `test_send_passes_formatted_text_to_app` to `TestTeamsSend`, mirroring the existing `test_send_calls_app_send` mocking, asserting `send()` hands the SDK the `format_message()`-transformed text rather than the raw content.
- `scripts/run_tests.sh tests/gateway/test_teams.py -v` — 31/31 passed (23 pre-existing + 8 new).
- `scripts/run_tests.sh tests/gateway/` — same 4 pre-existing failures present on unmodified `main` (macOS-specific: abstract Unix sockets, readiness-endpoint gateway state, subprocess diagnostic spawning — unrelated to this change and reproduced independently on a clean checkout).
- `ruff check` and `scripts/check-windows-footguns.py` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
