### PR TITLE
feat(cli): render markdown responses with the active skin's palette

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3925,6 +3925,73 @@ def _collect_query_images(query: str | None, image_arg: str | None = None) -> tu
 _OSC_ESCAPE_RE = re.compile(r"\x1b\][\s\S]*?(?:\x07|\x1b\\)")
 
 
+# Rich's Markdown renderer styles itself from the console theme's
+# ``markdown.*`` keys.  Without a theme it falls back to Rich's stock palette
+# (magenta headings, `bold cyan on black` code), so the BODY of a rendered
+# response ignored the active skin entirely — a skin only ever colored the
+# chrome (panel border, labels).  Build the theme from the active skin so
+# `display.final_response_markdown: render` honors it.
+_MARKDOWN_THEME_CACHE: dict = {}
+
+
+def _skin_markdown_theme():
+    """Rich Theme mapping ``markdown.*`` styles onto the active skin.
+
+    Returns None when the skin engine is unavailable, which leaves Rich on its
+    built-in defaults — the pre-existing behavior.
+    """
+    try:
+        from hermes_cli.skin_engine import get_active_skin
+        from rich.theme import Theme
+
+        # get_color() already routes through the light-mode remap
+        # (_install_skin_light_mode_hook), so these need no further adaptation.
+        c = get_active_skin().get_color
+        accent = c("ui_accent") or c("banner_accent") or "#FFBF00"
+        primary = c("ui_primary") or c("banner_title") or accent
+        dim = c("banner_dim") or "#808080"
+        border = c("ui_border") or c("banner_border") or accent
+        code = c("syntax_string") or accent
+        comment = c("syntax_comment") or dim
+
+        key = (accent, primary, dim, border, code, comment)
+        cached = _MARKDOWN_THEME_CACHE.get(key)
+        if cached is not None:
+            return cached
+
+        # inherit=True keeps Rich's defaults for every key left unset, and the
+        # non-color styles (strong/em/s) stay untouched on purpose — bold and
+        # italic are not the skin's to recolor.
+        theme = Theme(
+            {
+                "markdown.h1": f"bold {primary}",
+                "markdown.h2": f"bold {accent}",
+                "markdown.h3": accent,
+                "markdown.h4": f"italic {accent}",
+                "markdown.h5": f"italic {dim}",
+                "markdown.h6": f"dim {dim}",
+                "markdown.code": f"bold {code}",
+                "markdown.code_block": code,
+                "markdown.link": f"underline {accent}",
+                "markdown.link_url": f"underline {dim}",
+                "markdown.block_quote": comment,
+                "markdown.hr": border,
+                "markdown.list": accent,
+                "markdown.item.bullet": f"bold {accent}",
+                "markdown.item.number": accent,
+                "markdown.table.border": border,
+                "markdown.table.header": f"bold {accent}",
+            },
+            inherit=True,
+        )
+        # Keyed on the resolved colors, so editing a skin in place (same name,
+        # new palette) rebuilds instead of serving a stale theme.
+        _MARKDOWN_THEME_CACHE[key] = theme
+        return theme
+    except Exception:
+        return None
+
+
 class ChatConsole:
     """Rich Console adapter for prompt_toolkit's patch_stdout context.
 
@@ -3942,6 +4009,7 @@ class ChatConsole:
             force_terminal=True,
             color_system="truecolor",
             highlight=False,
+            theme=_skin_markdown_theme(),
         )
 
     def print(self, *args, **kwargs):

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -1,7 +1,14 @@
+from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from cli import HermesCLI, _build_compact_banner, _rich_text_from_ansi
+from cli import (
+    ChatConsole,
+    HermesCLI,
+    _build_compact_banner,
+    _rich_text_from_ansi,
+    _skin_markdown_theme,
+)
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
 
@@ -103,6 +110,52 @@ class TestCompactBannerSkinIntegration:
         assert skin.get_color("banner_border") in banner
         assert skin.get_color("banner_title") in banner
         assert skin.get_color("banner_dim") in banner
+
+
+class TestMarkdownThemeSkinIntegration:
+
+    def test_markdown_theme_maps_skin_accent_onto_rich_styles(self):
+        set_active_skin("poseidon")
+        skin = get_active_skin()
+        accent = skin.get_color("ui_accent") or skin.get_color("banner_accent")
+
+        theme = _skin_markdown_theme()
+
+        # Rich normalises hex colors to lowercase when parsing a Style.
+        assert theme is not None
+        assert accent.lower() in str(theme.styles["markdown.h2"]).lower()
+        assert accent.lower() in str(theme.styles["markdown.item.bullet"]).lower()
+
+    def test_rendered_markdown_emits_skin_accent(self):
+        from rich.console import Console
+        from rich.markdown import Markdown
+
+        set_active_skin("poseidon")
+        skin = get_active_skin()
+        accent = skin.get_color("ui_accent") or skin.get_color("banner_accent")
+        red, green, blue = (int(accent[i:i + 2], 16) for i in (1, 3, 5))
+
+        buffer = StringIO()
+        Console(
+            file=buffer,
+            force_terminal=True,
+            color_system="truecolor",
+            width=60,
+            theme=_skin_markdown_theme(),
+        ).print(Markdown("## Heading\n"))
+
+        assert f"38;2;{red};{green};{blue}" in buffer.getvalue()
+
+    def test_chat_console_attaches_the_skin_markdown_theme(self):
+        set_active_skin("poseidon")
+        skin = get_active_skin()
+        accent = skin.get_color("ui_accent") or skin.get_color("banner_accent")
+
+        assert accent.lower() in str(ChatConsole()._inner.get_style("markdown.h2")).lower()
+
+    def test_markdown_theme_falls_back_to_rich_defaults_when_skin_unavailable(self):
+        with patch("hermes_cli.skin_engine.get_active_skin", side_effect=RuntimeError("boom")):
+            assert _skin_markdown_theme() is None
 
 
 


### PR DESCRIPTION
Fixes #83235

## Problem

`ChatConsole` built its Rich Console without a `theme=`, so `rich.markdown.Markdown` styled
itself from Rich's stock defaults — `underline magenta` headings, `bold cyan on black`
inline code. A skin therefore only ever colored the chrome: the panel border
(`response_border`) and the assistant label (`ui_ok`) read the palette, but the response
**body** never did, however complete the skin.

## Change

Build a `rich.theme.Theme` from the active skin and attach it to the Console, mapping the
`markdown.*` keys onto palette keys the skin already defines:

| role | skin key |
|---|---|
| `markdown.h1` | `ui_primary` / `banner_title` |
| `markdown.h2`–`h4`, links, list bullets/numbers, table header | `ui_accent` / `banner_accent` |
| `markdown.code`, `markdown.code_block` | `syntax_string` |
| `markdown.hr`, `markdown.table.border` | `ui_border` / `banner_border` |
| `markdown.block_quote` | `syntax_comment` |
| `markdown.h5`, `h6`, `link_url` | `banner_dim` |

`Theme(..., inherit=True)` keeps Rich's defaults for every key left unset, and the
non-color styles (`markdown.strong` / `em` / `s`) are deliberately untouched — bold,
italic and strike aren't the skin's to recolor.

Colors are read through `SkinConfig.get_color`, which already routes through the
light-mode remap installed by `_install_skin_light_mode_hook`, so no extra adaptation is
needed here.

## Safety

- **Cached on the resolved colors, not the skin name** — editing a skin in place (same
  name, new palette) produces a different cache key and rebuilds, so a live edit can't
  serve a stale theme. `ChatConsole()` is instantiated per print site, so the next render
  picks the change up.
- **Fails open** — any error resolving the skin returns `None`, which `Console(theme=None)`
  accepts, leaving Rich's built-in defaults and the exact previous behavior.

## Testing

Added `TestMarkdownThemeSkinIntegration` to `tests/test_cli_skin_integration.py`:

- the theme maps the skin's accent onto `markdown.h2` / `markdown.item.bullet`
- rendering `## Heading` through a themed Console actually emits the skin accent's
  truecolor SGR sequence (the end-to-end assertion, not just the style table)
- `ChatConsole` attaches the theme
- resolution failure falls back to `None`

```
$ pytest tests/test_cli_skin_integration.py -q
12 passed
```

Also ran the skin/markdown suites together (`tests/test_cli_skin_integration.py`,
`tests/test_yuanbao_markdown.py`): 28 passed. The wider `tests/` run has pre-existing
collection errors from missing optional deps (`aiohttp` and friends) unrelated to this
change, so I scoped the run to the suites that collect cleanly — happy to run anything
else you'd like to see.

## Notes

Related but out of scope: #83233 — `render` is silently ignored while
`display.streaming: true`, so this theme only takes effect on the non-streamed path today.
The two are independent; this PR makes the palette correct wherever `render` does run.