### PR TITLE
feat(api): add fixed Hermes observation boundary

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -56,6 +56,7 @@ import sys
 import threading
 import time
 import uuid
+from urllib.parse import urlsplit
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -151,6 +152,9 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
+MAX_OBSERVATION_BYTES = 64 * 1024
+OBSERVATION_ACTION_ID = "observe.ai_country.health"
+OBSERVATION_IDENTITY = "hermes-observer"
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
@@ -1004,6 +1008,8 @@ if AIOHTTP_AVAILABLE:
             cors_headers = adapter._cors_headers_for_origin(origin)
 
         if request.method == "OPTIONS":
+            if request.path == "/v1/observation":
+                return web.Response(status=405)
             if cors_headers is None:
                 return web.Response(status=403)
             return web.Response(status=200, headers=cors_headers)
@@ -1380,6 +1386,12 @@ class APIServerAdapter(BasePlatformAdapter):
             raw_port = os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))
         self._port: int = _coerce_port(raw_port, DEFAULT_PORT)
         self._api_key: str = extra.get("key", _get_scoped_secret("API_SERVER_KEY", ""))
+        # Deliberately environment-only: this secret authenticates one fixed
+        # observation route and is never accepted as generic API authority.
+        self._observation_key: str = os.getenv("HERMES_OBSERVATION_KEY", "")
+        self._observation_target_url: Optional[str] = extra.get(
+            "observation_target_url"
+        )
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )
@@ -1791,6 +1803,15 @@ class APIServerAdapter(BasePlatformAdapter):
             # for the default listener. Named profiles must fail closed rather
             # than inherit the listener owner's key.
             if not is_named_profile:
+                auth_header = request.headers.get("Authorization", "")
+                token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else ""
+                if self._observation_key and token and hmac.compare_digest(
+                    token.encode(), self._observation_key.encode()
+                ):
+                    return web.json_response(
+                        {"error": {"message": "Observation credential is not valid for generic API routes", "type": "gateway_auth_error", "code": "gateway_auth_failed"}},
+                        status=401,
+                    )
                 return None
             logger.warning(
                 "API server rejected request for profile %r: no profile-scoped "
@@ -1812,6 +1833,13 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             token = auth_header[7:].strip()
+            if self._observation_key and hmac.compare_digest(
+                token.encode(), self._observation_key.encode()
+            ):
+                return web.json_response(
+                    {"error": {"message": "Observation credential is not valid for generic API routes", "type": "gateway_auth_error", "code": "gateway_auth_failed"}},
+                    status=401,
+                )
             # Compare as bytes: ``hmac.compare_digest`` raises TypeError on a
             # str containing non-ASCII characters, and ``token`` is the raw
             # client-supplied header. A stray non-ASCII byte in the key would
@@ -1828,6 +1856,117 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response(
             {"error": {"message": "Invalid gateway API key (API_SERVER_KEY)", "type": "gateway_auth_error", "code": "gateway_auth_failed"}},
             status=401,
+        )
+
+    def _check_observation_auth(self, request: "web.Request") -> Optional["web.Response"]:
+        """Authenticate only the dedicated observation principal."""
+        if (
+            not self._observation_key
+            or not self._api_key
+            or hmac.compare_digest(self._observation_key.encode(), self._api_key.encode())
+        ):
+            return web.json_response(
+                {"error": {"message": "Observation authentication is unavailable", "type": "observation_auth_error", "code": "observation_auth_failed"}},
+                status=401,
+            )
+        auth_header = request.headers.get("Authorization", "")
+        token = auth_header[7:].strip() if auth_header.startswith("Bearer ") else ""
+        if not token or not hmac.compare_digest(token.encode(), self._observation_key.encode()):
+            return web.json_response(
+                {"error": {"message": "Invalid observation credential", "type": "observation_auth_error", "code": "observation_auth_failed"}},
+                status=401,
+            )
+        return None
+
+    @staticmethod
+    def _valid_observation_target(value: Any) -> Optional[str]:
+        """Accept only a configured loopback AI Country health URL."""
+        if not isinstance(value, str) or not value:
+            return None
+        try:
+            parsed = urlsplit(value)
+            if parsed.scheme not in {"http", "https"} or parsed.hostname not in {"127.0.0.1", "::1"}:
+                return None
+            if parsed.username or parsed.password or parsed.query or parsed.fragment:
+                return None
+            if parsed.path != "/api/health":
+                return None
+            if parsed.port is not None and not (1 <= parsed.port <= 65535):
+                return None
+        except (TypeError, ValueError):
+            return None
+        return value
+
+    @staticmethod
+    def _sanitize_observation(value: Any) -> Dict[str, Any]:
+        """Return only the bounded health fields used by the canary."""
+        if not isinstance(value, dict):
+            return {}
+        allowed = {"status", "revision", "version", "identity_mode", "adapter_mode", "permission_ceiling"}
+        return {
+            key: item
+            for key, item in value.items()
+            if key in allowed and isinstance(item, (str, int, float, bool))
+        }
+
+    def _observation_audit(self, *, action_id: str, target: str, result: str) -> None:
+        logger.info(
+            "Hermes observation audit identity=%s endpoint=/v1/observation action_id=%s target=%s result=%s",
+            OBSERVATION_IDENTITY,
+            self._clean_log_value(action_id, max_len=80),
+            self._clean_log_value(target, max_len=200),
+            self._clean_log_value(result, max_len=40),
+        )
+
+    async def _handle_observation(self, request: "web.Request") -> "web.Response":
+        """Serve exactly one fixed, side-effect-free AI Country observation."""
+        if request.method != "POST":
+            return web.json_response({"error": "Method not allowed"}, status=405)
+        auth_err = self._check_observation_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+        if not isinstance(body, dict) or set(body) != {"action_id"} or body.get("action_id") != OBSERVATION_ACTION_ID:
+            return web.json_response({"error": "Unsupported observation action"}, status=400)
+
+        target = self._valid_observation_target(self._observation_target_url)
+        if target is None:
+            self._observation_audit(action_id=OBSERVATION_ACTION_ID, target="configured-invalid", result="target_rejected")
+            return web.json_response({"error": "Observation target is not configured"}, status=503)
+
+        try:
+            from aiohttp import ClientSession, ClientTimeout
+
+            async with ClientSession(timeout=ClientTimeout(total=5), trust_env=False) as session:
+                async with session.get(target, allow_redirects=False, headers={"Accept": "application/json"}) as response:
+                    if 300 <= response.status < 400:
+                        self._observation_audit(action_id=OBSERVATION_ACTION_ID, target=target, result="redirect_rejected")
+                        return web.json_response({"error": "Observation target redirect rejected"}, status=502)
+                    if response.status != 200:
+                        self._observation_audit(action_id=OBSERVATION_ACTION_ID, target=target, result="target_error")
+                        return web.json_response({"error": "Observation target unavailable"}, status=502)
+                    raw = await response.content.read(MAX_OBSERVATION_BYTES + 1)
+                    if len(raw) > MAX_OBSERVATION_BYTES:
+                        self._observation_audit(action_id=OBSERVATION_ACTION_ID, target=target, result="target_oversize")
+                        return web.json_response({"error": "Observation target response too large"}, status=502)
+                    observed = self._sanitize_observation(json.loads(raw.decode("utf-8")))
+        except Exception:
+            self._observation_audit(action_id=OBSERVATION_ACTION_ID, target=target, result="target_failure")
+            return web.json_response({"error": "Observation target failed"}, status=502)
+
+        self._observation_audit(action_id=OBSERVATION_ACTION_ID, target=target, result="success")
+        return web.json_response(
+            {
+                "action_id": OBSERVATION_ACTION_ID,
+                "target": "/api/health",
+                "observation_identity": OBSERVATION_IDENTITY,
+                "mutation_capability": "none",
+                "provenance": "real_observation",
+                "observed": observed,
+            }
         )
 
     @staticmethod
@@ -7186,6 +7325,10 @@ class APIServerAdapter(BasePlatformAdapter):
             for method, path, handler in self._http_route_table():
                 self._app.router.add_route(method, path, handler)
                 self._app.router.add_route(method, f"/p/{{profile}}{path}", handler)
+            # Keep this route outside the shared table: that table is mirrored
+            # under /p/{profile}, which would let a caller select a different
+            # profile target or secret scope.
+            self._app.router.add_post("/v1/observation", self._handle_observation)
             # Store the adapter after native routes are registered. Local Hermes-Relay
             # bootstrap shims use this key as a feature-detection hook; registering
             # native routes first lets those shims no-op instead of shadowing the

--- a/tests/gateway/test_api_server_observation.py
+++ b/tests/gateway/test_api_server_observation.py
@@ -1,0 +1,279 @@
+"""Security-property tests for the fixed Hermes observation boundary."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+GENERIC_KEY = "generic-key-for-tests-123456"
+OBSERVATION_KEY = "observation-key-for-tests-123456"
+
+
+def _app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware, security_headers_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/observation", adapter._handle_observation)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    return app
+
+
+async def _target_server(*, redirect: bool = False):
+    calls = {"health": 0, "secret": 0}
+    target = web.Application()
+
+    async def health(request):
+        calls["health"] += 1
+        if redirect:
+            raise web.HTTPFound("/secret")
+        return web.json_response({"status": "ok", "revision": "test-revision"})
+
+    async def secret(request):
+        calls["secret"] += 1
+        return web.json_response({"secret": "must-not-be-followed"})
+
+    target.router.add_get("/api/health", health)
+    target.router.add_get("/secret", secret)
+    server = TestServer(target)
+    await server.start_server()
+    return server, calls
+
+
+async def _client(monkeypatch, *, observation_key=OBSERVATION_KEY, generic_key=GENERIC_KEY, redirect=False):
+    target_server, calls = await _target_server(redirect=redirect)
+    monkeypatch.setenv("HERMES_OBSERVATION_KEY", observation_key or "")
+    adapter = APIServerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "key": generic_key,
+                "observation_target_url": str(target_server.make_url("/api/health")),
+                "cors_origins": ["https://client.example"],
+            },
+        )
+    )
+    client = TestClient(TestServer(_app(adapter)))
+    await client.start_server()
+    return client, target_server, calls, adapter
+
+
+@pytest.mark.asyncio
+async def test_observation_positive_is_fixed_and_audited(monkeypatch, caplog):
+    client, target_server, calls, adapter = await _client(monkeypatch)
+    try:
+        async with client:
+            with caplog.at_level("INFO"):
+                response = await client.post(
+                    "/v1/observation",
+                    json={"action_id": "observe.ai_country.health"},
+                    headers={"Authorization": f"Bearer {OBSERVATION_KEY}"},
+                )
+            assert response.status == 200
+            body = await response.json()
+            assert body["action_id"] == "observe.ai_country.health"
+            assert body["observation_identity"] == "hermes-observer"
+            assert body["mutation_capability"] == "none"
+            assert body["provenance"] == "real_observation"
+            assert body["observed"] == {"status": "ok", "revision": "test-revision"}
+            assert calls == {"health": 1, "secret": 0}
+            assert OBSERVATION_KEY not in caplog.text
+            assert GENERIC_KEY not in caplog.text
+    finally:
+        await target_server.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["get", "put", "patch", "delete", "options"])
+async def test_observation_rejects_unsupported_methods_before_target(monkeypatch, method):
+    client, target_server, calls, _ = await _client(monkeypatch)
+    try:
+        async with client:
+            response = await getattr(client, method)(
+                "/v1/observation",
+                headers={"Authorization": f"Bearer {OBSERVATION_KEY}"},
+            )
+            assert response.status in {404, 405}
+            assert calls == {"health": 0, "secret": 0}
+    finally:
+        await target_server.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"action_id": "unknown"},
+        {"action_id": "observe.ai_country.health", "extra": True},
+        ["observe.ai_country.health"],
+    ],
+)
+async def test_observation_rejects_noncanonical_requests_before_target(monkeypatch, payload):
+    client, target_server, calls, _ = await _client(monkeypatch)
+    try:
+        async with client:
+            response = await client.post(
+                "/v1/observation",
+                data=json.dumps(payload),
+                headers={
+                    "Authorization": f"Bearer {OBSERVATION_KEY}",
+                    "Content-Type": "application/json",
+                },
+            )
+            assert response.status == 400
+            assert calls == {"health": 0, "secret": 0}
+    finally:
+        await target_server.close()
+
+
+@pytest.mark.asyncio
+async def test_observation_rejects_generic_key_and_observation_key_rejects_generic_route(monkeypatch):
+    client, target_server, calls, adapter = await _client(monkeypatch)
+    try:
+        async with client:
+            generic_on_observation = await client.post(
+                "/v1/observation",
+                json={"action_id": "observe.ai_country.health"},
+                headers={"Authorization": f"Bearer {GENERIC_KEY}"},
+            )
+            observation_on_generic = await client.post(
+                "/v1/runs",
+                json={"input": "must not reach agent"},
+                headers={"Authorization": f"Bearer {OBSERVATION_KEY}"},
+            )
+            assert generic_on_observation.status == 401
+            assert observation_on_generic.status == 401
+            assert calls == {"health": 0, "secret": 0}
+            assert adapter._check_auth(MagicMock(headers={})) is not None
+    finally:
+        await target_server.close()
+
+
+@pytest.mark.asyncio
+async def test_observation_missing_or_invalid_key_fails_closed(monkeypatch):
+    for key in (None, "wrong-observation-key"):
+        client, target_server, calls, _ = await _client(monkeypatch, observation_key=key)
+        try:
+            async with client:
+                response = await client.post(
+                    "/v1/observation",
+                    json={"action_id": "observe.ai_country.health"},
+                    headers={"Authorization": f"Bearer {OBSERVATION_KEY}"},
+                )
+                assert response.status == 401
+                assert calls == {"health": 0, "secret": 0}
+        finally:
+            await target_server.close()
+
+
+@pytest.mark.asyncio
+async def test_observation_does_not_follow_redirects(monkeypatch):
+    client, target_server, calls, _ = await _client(monkeypatch, redirect=True)
+    try:
+        async with client:
+            response = await client.post(
+                "/v1/observation",
+                json={"action_id": "observe.ai_country.health"},
+                headers={"Authorization": f"Bearer {OBSERVATION_KEY}"},
+            )
+            assert response.status in {502, 503}
+            assert calls == {"health": 1, "secret": 0}
+    finally:
+        await target_server.close()
+
+
+@pytest.mark.asyncio
+async def test_observation_equal_to_generic_key_fails_closed(monkeypatch):
+    client, target_server, calls, _ = await _client(
+        monkeypatch, observation_key=GENERIC_KEY, generic_key=GENERIC_KEY
+    )
+    try:
+        async with client:
+            response = await client.post(
+                "/v1/observation",
+                json={"action_id": "observe.ai_country.health"},
+                headers={"Authorization": f"Bearer {GENERIC_KEY}"},
+            )
+            assert response.status == 401
+            generic_response = await client.post(
+                "/v1/runs",
+                json={"input": "must not reach agent"},
+                headers={"Authorization": f"Bearer {GENERIC_KEY}"},
+            )
+            assert generic_response.status == 401
+            assert calls == {"health": 0, "secret": 0}
+    finally:
+        await target_server.close()
+
+
+@pytest.mark.asyncio
+async def test_observation_key_cannot_use_generic_route_without_generic_key(monkeypatch):
+    client, target_server, calls, _ = await _client(monkeypatch, generic_key="")
+    try:
+        async with client:
+            response = await client.post(
+                "/v1/runs",
+                json={"input": "must not reach agent"},
+                headers={"Authorization": f"Bearer {OBSERVATION_KEY}"},
+            )
+            assert response.status == 401
+            assert calls == {"health": 0, "secret": 0}
+    finally:
+        await target_server.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_target_fails_closed_before_invocation(monkeypatch):
+    target_server, calls = await _target_server()
+    monkeypatch.setenv("HERMES_OBSERVATION_KEY", OBSERVATION_KEY)
+    adapter = APIServerAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"key": GENERIC_KEY, "observation_target_url": "https://example.com/not-health"},
+        )
+    )
+    client = TestClient(TestServer(_app(adapter)))
+    await client.start_server()
+    try:
+        async with client:
+            response = await client.post(
+                "/v1/observation",
+                json={"action_id": "observe.ai_country.health"},
+                headers={"Authorization": f"Bearer {OBSERVATION_KEY}"},
+            )
+            assert response.status == 503
+            assert calls == {"health": 0, "secret": 0}
+    finally:
+        await client.close()
+        await target_server.close()
+
+
+def test_observation_is_not_in_profile_mirrored_route_table():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": GENERIC_KEY}))
+    paths = {path for _, path, _ in adapter._http_route_table()}
+    assert "/v1/observation" not in paths
+
+
+@pytest.mark.asyncio
+async def test_observation_has_no_profile_prefix_variant(monkeypatch):
+    client, target_server, calls, _ = await _client(monkeypatch)
+    try:
+        async with client:
+            response = await client.post(
+                "/p/default/v1/observation",
+                json={"action_id": "observe.ai_country.health"},
+                headers={"Authorization": f"Bearer {OBSERVATION_KEY}"},
+            )
+            assert response.status == 404
+            assert calls == {"health": 0, "secret": 0}
+    finally:
+        await target_server.close()


### PR DESCRIPTION
## Summary

Adds the smallest Hermes-native observation boundary for the single AI Country health action. This is repository-only implementation and proof; it does not provision a live credential or activate any canary.

## Boundary

- Dedicated `POST /v1/observation` endpoint.
- Separate `HERMES_OBSERVATION_KEY` identity.
- Canonical action: `observe.ai_country.health`.
- Fixed server-side loopback target path: `/api/health`.
- Observation route is outside the profile-mirrored route table.
- Observation key is rejected on generic authenticated routes.
- Equal `HERMES_OBSERVATION_KEY` / `API_SERVER_KEY` fails closed.
- Missing, invalid, or misconfigured observation credentials fail closed.
- No generic run/chat/session/job route, terminal, code execution, delegation, cron, arbitrary tool/provider dispatch, or stronger credential fallback.
- Unsupported methods/actions and redirects are rejected before downstream observation use.
- Audit identity is `hermes-observer`; credential values are never logged.

## Evidence

- Exact reviewed head: `8c7eda2f1fbf9de5fc5fc81b49702a00b053f292`.
- Focused observation tests: `18 passed`.
- Complete API-server family: `449 passed`.
- `git diff --check`: passed.
- Python compilation: passed.
- AGY exact-head verdict: `AGY_OBSERVATION_BOUNDARY_CLEAR`.
- Fresh Codex exact-head verdict: `CODEX_OBSERVATION_BOUNDARY_CLEAR`.

Codex independently inspected the exact code and route/auth paths. Its local pytest attempt could not create `.pytest-cache` in the deliberately read-only detached review worktree; this was a reviewer-environment permission issue, not a test failure. The implementation branch's complete API-server suite passed in the writable worktree.

## Explicit non-scope

- No live observation credential has been provisioned.
- No Hermes service configuration or listener has been changed.
- No AI Country real-Hermes binding or canary approval has changed.
- AI Country remains fake mode with canary approval disabled.
- No Cloudflare/DNS/Access, Home Assistant, deployment, or #73 changes.

After merge, the truthful state is `HERMES_OBSERVATION_BOUNDARY_IMPLEMENTED — LIVE_NEGATIVE_CONTROL_PENDING`; this PR does not claim live same-credential proof.
