### PR TITLE
fix(tools): exclude __PLACEHOLDER__ tokens from secret detection (#82798)

### DIFF
--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -469,7 +469,7 @@ THREAT_PATTERNS = [
      "references other agent configuration files"),
 
     # ── Hardcoded secrets (credentials embedded in the skill itself) ──
-    (r'(?:api[_-]?key|token|secret|password)\s*[=:]\s*["\'][A-Za-z0-9+/=_-]{20,}',
+    (r'(?:api[_-]?key|token|secret|password)\s*[=:]\s*["\'](?!_{2}[A-Z_]+_{2})[A-Za-z0-9+/=_-]{20,}',
      "hardcoded_secret", "critical", "credential_exposure",
      "possible hardcoded API key, token, or secret"),
     (r'-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----',


### PR DESCRIPTION
## Summary

Fixes #82798. The `hardcoded_secret` regex in `skills_guard.py` matches template placeholder tokens like `__PLACEHOLDER_TOKEN__` as CRITICAL credential_exposure, blocking skill installation.

## Root Cause

The regex character class `[A-Za-z0-9+/=_-]` includes underscores, so values like `__PLACEHOLDER_TOKEN__` match the 20+ character minimum. Template placeholders are not real credentials.

## Changes

- `tools/skills_guard.py`: Add negative lookahead `(?!_{2}[A-Z_]+_{2})` after the opening quote to skip values that look like `__UPPERCASE_PLACEHOLDERS__`.

## Testing

Verified that `token = "__PLACEHOLDER_TOKEN__"` no longer matches, while `api_key = "sk-abc123def456ghi789jkl012"` still matches.