### PR TITLE
fix(tools): discover sessions where FTS match is only in tool output (#83170)

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -697,14 +697,17 @@ def _discover(
     link_profile: str = None,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
-    role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
     title_result = _title_match_result(db, query, current_lineage_root)
 
     try:
+        # Discovery: search ALL roles so that sessions where the FTS match
+        # is only in tool output (web search results, JSON, etc.) are still
+        # found.  role_filter is applied later when building the display
+        # window, not at the SQL search level.  (#83170)
         raw_results = db.search_messages(
             query=query,
-            role_filter=role_list,
+            role_filter=None,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             limit=_DISCOVER_SCAN_LIMIT,  # widen so dedup-by-lineage can find
             # distinct sessions AND so interactive matches buried under a wall


### PR DESCRIPTION
## Summary

Discovery search now queries ALL message roles instead of filtering to `user,assistant` at the SQL level. Sessions where the FTS5 match exists only in tool output (web search results, JSON payloads, etc.) were silently excluded because `role_filter` discarded every hit before session grouping.

## Root cause

`_discover()` in `tools/session_search_tool.py` passed `role_filter=role_list` (defaulting to `['user', 'assistant']`) to `db.search_messages()`. The role filter is applied as a SQL `WHERE m.role IN (...)` clause, which means FTS matches in `role=tool` rows are discarded at the database level — before the results are grouped by session.

When a search term appears only in tool output (e.g. web search results stored as tool messages), all FTS hits have `role='tool'`, the SQL filter removes them all, and the discovery returns 0 sessions.

## Fix

Pass `role_filter=None` to `db.search_messages()` in the discovery path so that sessions are found regardless of which message role the FTS match lives in. The `role_filter` parameter is preserved on the function signature for scroll/read shapes; discovery simply passes `None`.

## Changes

- `tools/session_search_tool.py`: Remove `role_list` variable from `_discover()`, pass `role_filter=None` to `db.search_messages()`

## Test plan

- [x] `uv run pytest tests/tools/test_session_search.py` — 39 passed
- [x] `uv run pytest tests/hermes_cli/test_web_server_session_search.py` — 1 passed
- [x] Syntax check via `ast.parse()` — ok

Fixes #83170