### PR TITLE
fix(update): preserve dashboard session token on respawn

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -358,6 +358,7 @@ def _kill_stale_dashboard_processes(
     pid_service: dict[int, str | None] = {}
     pid_cmdline: dict[int, list[str]] = {}
     pid_home: dict[int, str | None] = {}
+    pid_session_token: dict[int, str] = {}
     if restart_managed and sys.platform != "win32":
         for pid in pids:
             cg_path = _m()._get_pid_cgroup_path(pid)
@@ -372,6 +373,11 @@ def _kill_stale_dashboard_processes(
                 if cmdline:
                     pid_cmdline[pid] = cmdline
                     pid_home[pid] = _hermes_home_for_pid(pid)
+                    # Same lifetime as the argv: the dashboard session token
+                    # disappears with the process, so capture it pre-kill.
+                    session_token = _m()._dashboard_session_token_for_pid(pid)
+                    if session_token:
+                        pid_session_token[pid] = session_token
 
     killed: list[int] = []
     failed: list[tuple[int, str]] = []
@@ -478,7 +484,31 @@ def _kill_stale_dashboard_processes(
 
         respawn_cmds = _filter_dashboard_respawn_candidates(respawn_candidates)
         if respawn_cmds:
-            failed_cmds = _m()._respawn_dashboard_processes(respawn_cmds)
+            # The filter returns bare argvs (the pid association is dropped),
+            # so re-attach each surviving command's captured session token by
+            # normalized cmdline.  First occurrence wins, matching the
+            # filter's dedupe order.
+            token_by_cmdline: dict[tuple[str, ...], str | None] = {}
+            for pid in killed:
+                cmdline = pid_cmdline.get(pid)
+                if cmdline:
+                    token_by_cmdline.setdefault(
+                        _normalize_dashboard_cmdline(cmdline),
+                        pid_session_token.get(pid),
+                    )
+            respawn_tokens = [
+                token_by_cmdline.get(_normalize_dashboard_cmdline(cmd))
+                for cmd in respawn_cmds
+            ]
+            # Keep the bare-argv call when nothing was captured so existing
+            # callers/mocks of _respawn_dashboard_processes stay valid.
+            if any(respawn_tokens):
+                failed_cmds = _m()._respawn_dashboard_processes(
+                    respawn_cmds,
+                    session_tokens=respawn_tokens,
+                )
+            else:
+                failed_cmds = _m()._respawn_dashboard_processes(respawn_cmds)
             if failed_cmds:
                 unrecovered.extend(p for p in killed if pid_cmdline.get(p) in failed_cmds)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7958,12 +7958,31 @@ def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
         return None
 
 
-def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
+def _dashboard_session_token_for_pid(pid: int) -> str | None:
+    """Return only the non-empty dashboard session token from *pid*, if readable."""
+    try:
+        import psutil
+
+        token = (psutil.Process(pid).environ() or {}).get(
+            "HERMES_DASHBOARD_SESSION_TOKEN"
+        )
+    except Exception:
+        # Process environment inspection is inherently racy and may be denied.
+        return None
+    return token if isinstance(token, str) and token else None
+
+
+def _respawn_dashboard_processes(
+    commands: list[list[str]],
+    *,
+    session_tokens: list[str | None] | None = None,
+) -> list[list[str]]:
     """Best-effort respawn of manually-started dashboards after ``hermes update``.
 
     Spawns each recovered argv detached (new session, output to the profile's
-    ``logs/dashboard-restart.log``).  Returns the commands that failed to
-    spawn; the caller prints the manual hint for those.
+    ``logs/dashboard-restart.log``), preserving a corresponding captured
+    dashboard session token when supplied.  Returns the commands that failed
+    to spawn; the caller prints the manual hint for those.
 
     Callers must pre-filter via ``_filter_dashboard_respawn_candidates`` so
     Desktop ``serve|dashboard --port 0`` backends are not replayed and
@@ -7979,15 +7998,24 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
     except OSError:
         pass
 
-    for command in commands:
+    for index, command in enumerate(commands):
         try:
             # Keep restarted dashboards headless; reopening a browser after a
             # background update is noisy and fails in SSH/headless sessions.
             if "dashboard" in command and "--no-open" not in command:
                 command = [*command, "--no-open"]
+            env = os.environ.copy()
+            session_token = (
+                session_tokens[index]
+                if session_tokens is not None and index < len(session_tokens)
+                else None
+            )
+            if session_token:
+                env["HERMES_DASHBOARD_SESSION_TOKEN"] = session_token
             with open(log_path, "ab") as log_f:
                 subprocess.Popen(
                     command,
+                    env=env,
                     stdin=subprocess.DEVNULL,
                     stdout=log_f,
                     stderr=subprocess.STDOUT,

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -334,6 +334,118 @@ class TestManualBackendRespawn:
     def _live(self):
         return sys.modules["hermes_cli.main"]
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX cmdline capture + respawn")
+    def test_respawn_preserves_only_each_process_session_token(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        live = self._live()
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "updater-token")
+        monkeypatch.setenv("HERMES_TEST_UPDATER_STATE", "updater-value")
+
+        commands = {
+            5555: ["hermes", "dashboard", "--port", "8300"],
+            6666: ["hermes", "serve", "--port", "8400"],
+        }
+        old_environments = {
+            5555: {
+                "HERMES_DASHBOARD_SESSION_TOKEN": "old-dashboard-token",
+                "HERMES_HOME": "/old/dashboard/home",
+                "OLD_PROCESS_ONLY": "must-not-be-forwarded",
+            },
+            6666: {
+                "HERMES_DASHBOARD_SESSION_TOKEN": "second-dashboard-token",
+                "HERMES_HOME": "/old/serve/home",
+                "OLD_PROCESS_ONLY": "must-not-be-forwarded",
+            },
+        }
+        spawned: list[tuple[list[str], dict[str, str]]] = []
+
+        class _FakeProcess:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def environ(self):
+                return old_environments[self.pid]
+
+        class _FakePopen:
+            def __init__(self, command, **kwargs):
+                spawned.append((list(command), dict(kwargs.get("env") or {})))
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=list(commands)), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid",
+                          side_effect=lambda pid: commands[pid]), \
+             patch("psutil.Process", _FakeProcess), \
+             patch.object(live.subprocess, "Popen", _FakePopen), \
+             patch("gateway.status._pid_exists", return_value=False), \
+             patch("os.kill"), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result["unrecovered"] == []
+        assert [command for command, _ in spawned] == [
+            ["hermes", "dashboard", "--port", "8300", "--no-open"],
+            ["hermes", "serve", "--port", "8400"],
+        ]
+        assert [env["HERMES_DASHBOARD_SESSION_TOKEN"] for _, env in spawned] == [
+            "old-dashboard-token",
+            "second-dashboard-token",
+        ]
+        for _, env in spawned:
+            assert env["HERMES_HOME"] == str(hermes_home)
+            assert env["HERMES_TEST_UPDATER_STATE"] == "updater-value"
+            assert "OLD_PROCESS_ONLY" not in env
+
+        output = capsys.readouterr().out
+        assert "old-dashboard-token" not in output
+        assert "second-dashboard-token" not in output
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX cmdline capture + respawn")
+    def test_environment_inspection_failure_still_respawns(
+        self, tmp_path, monkeypatch
+    ):
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "updater-token")
+        spawned_environments: list[dict[str, str]] = []
+
+        class _DeniedProcess:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def environ(self):
+                raise PermissionError("denied")
+
+        class _FakePopen:
+            def __init__(self, command, **kwargs):
+                spawned_environments.append(
+                    dict(kwargs.get("env") or os.environ)
+                )
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[7777]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_dashboard_cmdline_for_pid",
+                          return_value=["hermes", "serve", "--port", "8500"]), \
+             patch("psutil.Process", _DeniedProcess), \
+             patch.object(live.subprocess, "Popen", _FakePopen), \
+             patch("gateway.status._pid_exists", return_value=False), \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result["unrecovered"] == []
+        assert len(spawned_environments) == 1
+        assert spawned_environments[0]["HERMES_DASHBOARD_SESSION_TOKEN"] == "updater-token"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX cmdline capture + respawn")
     def test_argv_capture_failure_falls_back_to_hint(self, capsys):


### PR DESCRIPTION
## Summary

Preserve an explicitly injected `HERMES_DASHBOARD_SESSION_TOKEN` when `hermes update` respawns a manually started `hermes dashboard` or `hermes serve` process.

Without this, the replacement backend can remain HTTP-healthy while Hermes Desktop loses authenticated WebSocket access because the updater inherited different launch-time state than the old backend.

## Root cause

The update path already captures each manual backend's argv before stopping stale code, then respawns that argv after the update. Process-only authentication state was not captured, so the replacement inherited only the updater's environment.

## Changes

- Best-effort read the old backend's non-empty dashboard session token before termination.
- Keep tokens associated with their corresponding PID/respawn command.
- Build each replacement environment from the updater environment and override only the allowlisted token.
- Fall back to existing argv respawn behavior when process environment inspection is unavailable or denied.
- Keep systemd-managed, Electron-managed, Windows, `--stop`, `--no-open`, and failure-reporting paths unchanged.

## Security

- No full old-process environment is retained or forwarded.
- The token is not placed in argv, printed, logged, serialized, or persisted.
- Unrelated variables from the old backend are not copied.

## Tests

- Added regression coverage for two manual backends with distinct tokens.
- Added denied-environment-inspection fallback coverage.
- `29 passed, 3 skipped` in `test_update_stale_dashboard.py` (includes the upstream #78821 respawn-filter tests, unchanged and green).
- `11 passed` across `test_dashboard_lifecycle_flags.py` + `test_lazy_command_exports.py`.
- `git diff --check` passes.

## Rebase note (2026-08-15)

Rebased onto current `main` (post-#78821 respawn filtering). Tokens are now
captured alongside the argv/`HERMES_HOME` pre-kill snapshots and re-attached
to the filtered respawn commands by normalized cmdline (first occurrence wins,
matching the filter's dedupe order). When no token was captured, the respawn
call keeps its original bare-argv form, so existing callers and mocks are
unaffected. New tests also carry the class's POSIX `skipif` markers.

## Platforms

Tested on WSL2/Linux. The existing native-Windows manual-respawn exclusion is unchanged; native macOS and Windows were not exercised locally.

## Related work

This is deliberately narrower than #54034. It does not persist generated session tokens across arbitrary daemon restarts; it preserves an explicitly injected token only across the existing manual update-respawn transaction.