### PR TITLE
Add trusted same-turn final reply link buttons

### DIFF
--- a/agent/turn_attachments.py
+++ b/agent/turn_attachments.py
@@ -1,0 +1,74 @@
+"""Task-local attachments supplied by trusted plugins for a turn's final reply."""
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any, Iterable
+from urllib.parse import urlsplit
+
+_FINAL_REPLY_METADATA_KEY = "_hermes_final_reply_metadata"
+
+
+@dataclass
+class _Collector:
+    metadata: dict[str, Any] = field(default_factory=dict)
+    lock: Lock = field(default_factory=Lock)
+
+
+_current: ContextVar[_Collector | None] = ContextVar("hermes_turn_attachments", default=None)
+
+
+def begin_turn() -> Token:
+    """Bind a fresh collector to the current task and its child work."""
+    return _current.set(_Collector())
+
+
+def end_turn(token: Token) -> None:
+    _current.reset(token)
+
+
+def attach_final_reply_link_buttons(buttons: Iterable[dict[str, Any]]) -> bool:
+    """Attach validated link buttons to this turn's final platform send.
+
+    This function is intentionally not a model tool. It is exposed only through
+    PluginContext, so model-produced JSON cannot create outbound metadata.
+    """
+    collector = _current.get()
+    if collector is None:
+        return False
+    validated: list[dict[str, Any]] = []
+    for raw in buttons:
+        if not isinstance(raw, dict) or set(raw) - {"text", "kind", "url", "row"}:
+            raise ValueError("invalid final reply link button")
+        text = str(raw.get("text") or "").strip()
+        kind = str(raw.get("kind") or "")
+        url = str(raw.get("url") or "").strip()
+        parsed = urlsplit(url)
+        if (
+            not text or len(text) > 64 or kind not in {"web_app", "url"}
+            or parsed.scheme.lower() != "https" or not parsed.hostname
+            or parsed.username or parsed.password
+        ):
+            raise ValueError("invalid final reply link button")
+        try:
+            row = int(raw.get("row") or 0)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("invalid final reply link button row") from exc
+        if row < 0 or row > 3:
+            raise ValueError("invalid final reply link button row")
+        validated.append({"text": text, "kind": kind, "url": url, "row": row})
+    if not validated or len(validated) > 4:
+        raise ValueError("final reply link buttons must contain 1..4 items")
+    with collector.lock:
+        # One-shot replace semantics avoid duplicates when a tool retries in-turn.
+        collector.metadata["link_buttons"] = validated
+    return True
+
+
+def snapshot() -> dict[str, Any]:
+    collector = _current.get()
+    if collector is None:
+        return {}
+    with collector.lock:
+        return {key: list(value) if isinstance(value, list) else value for key, value in collector.metadata.items()}

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -77,6 +77,17 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     return metadata
 
 
+def _merge_final_reply_metadata(metadata: dict | None, event) -> dict | None:
+    """Merge host-owned, event-local attachments into final sends only."""
+    event_metadata = getattr(event, "metadata", None)
+    extra = event_metadata.get("_hermes_final_reply_metadata") if isinstance(event_metadata, dict) else None
+    if not isinstance(extra, dict) or not extra:
+        return metadata
+    merged = dict(metadata or {})
+    merged.update(extra)
+    return merged
+
+
 def _mark_notify_metadata(metadata: dict | None) -> dict:
     """Clone metadata and mark a user-visible reply as notify-worthy."""
     notify_metadata = dict(metadata) if metadata else {}
@@ -4279,7 +4290,8 @@ class BasePlatformAdapter(ABC):
                 # the existing notify=True marker. Clone once so typing/status
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
-                _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _final_thread_metadata = _merge_final_reply_metadata(_thread_metadata, event)
+                _final_thread_metadata = _mark_notify_metadata(_final_thread_metadata)
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7934,8 +7934,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts[_quick_key] = time.time()
         _run_generation = self._begin_session_run_generation(_quick_key)
 
+        from agent.turn_attachments import begin_turn, end_turn, snapshot
+        _turn_attachment_token = begin_turn()
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            if _agent_result is not None and self._is_session_run_current(_quick_key, _run_generation):
+                _final_reply_metadata = snapshot()
+                if _final_reply_metadata:
+                    if not isinstance(getattr(event, "metadata", None), dict):
+                        event.metadata = {}
+                    event.metadata["_hermes_final_reply_metadata"] = _final_reply_metadata
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a
@@ -7966,6 +7974,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
         finally:
+            end_turn(_turn_attachment_token)
             # Unconditional release covers every exit path. _release_running_agent_state
             # is idempotent (pop-on-absent is harmless) and, called without a
             # run_generation guard, always clears the slot regardless of which

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -218,6 +218,8 @@ class GatewayStreamConsumer:
         if expect_edits:
             meta["expect_edits"] = True
         if final:
+            from agent.turn_attachments import snapshot as _turn_attachment_snapshot
+            meta.update(_turn_attachment_snapshot())
             meta["notify"] = True
         return meta or None
 
@@ -248,6 +250,7 @@ class GatewayStreamConsumer:
         message_id: str,
         content: str,
         finalize: bool = False,
+        metadata: Optional[dict] = None,
     ):
         """Edit via the adapter, passing routing metadata when supported."""
         kwargs = {
@@ -259,14 +262,15 @@ class GatewayStreamConsumer:
         # must accept finalize= even when it is False (guarded by tests).
         kwargs["finalize"] = finalize
 
-        if self.metadata:
+        send_metadata = self.metadata if metadata is None else metadata
+        if send_metadata:
             try:
                 params = inspect.signature(self.adapter.edit_message).parameters
                 if "metadata" in params or any(
                     param.kind is inspect.Parameter.VAR_KEYWORD
                     for param in params.values()
                 ):
-                    kwargs["metadata"] = self.metadata
+                    kwargs["metadata"] = send_metadata
             except (TypeError, ValueError):
                 pass
         return await self.adapter.edit_message(**kwargs)
@@ -536,7 +540,7 @@ class GatewayStreamConsumer:
                         )
                         chunks_delivered = False
                         reply_to = self._message_id or self._initial_reply_to_id
-                        for chunk in chunks:
+                        for chunk_index, chunk in enumerate(chunks):
                             new_id = await self._send_new_chunk(
                                 chunk,
                                 reply_to,
@@ -885,6 +889,7 @@ class GatewayStreamConsumer:
                         result = await self._edit_message(
                             message_id=self._message_id,
                             content=clean_text,
+                            metadata=self._metadata_for_send(final=True),
                         )
                         if result.success:
                             self._last_sent_text = clean_text
@@ -915,7 +920,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
-                    metadata=self._metadata_for_send(final=True),
+                    metadata=self._metadata_for_send(final=chunk_index == len(chunks) - 1),
                 )
                 if result.success:
                     break
@@ -1397,8 +1402,10 @@ class GatewayStreamConsumer:
                     # finalize=True edit even when content is unchanged, so
                     # their streaming UI can transition out of the in-
                     # progress state.  Everyone else short-circuits.
+                    from agent.turn_attachments import snapshot as _turn_attachment_snapshot
+                    _has_final_attachments = bool(_turn_attachment_snapshot()) if finalize and is_turn_final else False
                     if text == self._last_sent_text and not (
-                        finalize and self._adapter_requires_finalize
+                        finalize and (self._adapter_requires_finalize or _has_final_attachments)
                     ):
                         return True
                     # Fresh-final for long-lived previews: when finalizing
@@ -1434,6 +1441,8 @@ class GatewayStreamConsumer:
                         message_id=self._message_id,
                         content=text,
                         finalize=finalize,
+                        metadata=(self._metadata_for_send(final=True)
+                                  if finalize and is_turn_final else self.metadata),
                     )
                     if result.success:
                         self._already_sent = True

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -357,6 +357,15 @@ class PluginContext:
             self.manifest.name, name, " (override)" if override else "",
         )
 
+    def attach_final_reply_link_buttons(self, buttons: list[dict]) -> bool:
+        """Attach trusted link buttons to the current gateway turn's final reply.
+
+        This host capability is deliberately absent from the model tool schema.
+        Calls outside an active gateway turn are ignored.
+        """
+        from agent.turn_attachments import attach_final_reply_link_buttons
+        return attach_final_reply_link_buttons(buttons)
+
     # -- message injection --------------------------------------------------
 
     def inject_message(self, content: str, role: str = "user") -> bool:

--- a/tests/unit/test_turn_attachments.py
+++ b/tests/unit/test_turn_attachments.py
@@ -1,0 +1,90 @@
+import asyncio
+
+import pytest
+
+from agent.turn_attachments import (
+    attach_final_reply_link_buttons, begin_turn, end_turn, snapshot,
+)
+from gateway.platforms.base import _merge_final_reply_metadata
+
+
+def _buttons(url="https://pages.example/p/abc"):
+    return [{"text": "Open", "kind": "web_app", "url": url, "row": 0}]
+
+
+def test_attachment_is_host_bound_and_one_shot():
+    assert attach_final_reply_link_buttons(_buttons()) is False
+    token = begin_turn()
+    try:
+        assert attach_final_reply_link_buttons(_buttons()) is True
+        assert snapshot()["link_buttons"] == _buttons()
+    finally:
+        end_turn(token)
+    assert snapshot() == {}
+
+
+def test_concurrent_turns_do_not_mix():
+    async def turn(url):
+        token = begin_turn()
+        try:
+            await asyncio.sleep(0)
+            attach_final_reply_link_buttons(_buttons(url))
+            await asyncio.sleep(0)
+            return snapshot()
+        finally:
+            end_turn(token)
+    async def run_both():
+        return await asyncio.gather(turn("https://one.example/p/a"), turn("https://two.example/p/b"))
+    one, two = asyncio.run(run_both())
+    assert one["link_buttons"][0]["url"].startswith("https://one.example")
+    assert two["link_buttons"][0]["url"].startswith("https://two.example")
+
+
+def test_rejects_unsafe_link_button():
+    token = begin_turn()
+    try:
+        with pytest.raises(ValueError):
+            attach_final_reply_link_buttons(_buttons("http://pages.example/p/a"))
+    finally:
+        end_turn(token)
+
+
+def test_final_metadata_merge_uses_only_reserved_event_value():
+    event = type("Event", (), {"metadata": {"link_buttons": _buttons(), "_hermes_final_reply_metadata": {"link_buttons": _buttons("https://trusted.example/p/a")}}})()
+    merged = _merge_final_reply_metadata({"thread_id": "1"}, event)
+    assert merged["link_buttons"][0]["url"].startswith("https://trusted.example")
+    assert merged["thread_id"] == "1"
+
+
+def test_streaming_only_attaches_to_final_send():
+    from gateway.stream_consumer import GatewayStreamConsumer
+    token = begin_turn()
+    try:
+        consumer = GatewayStreamConsumer(object(), "chat", metadata={"thread_id": "1"})
+        attach_final_reply_link_buttons(_buttons())
+        assert "link_buttons" not in consumer._metadata_for_send(final=False)
+        assert consumer._metadata_for_send(final=True)["link_buttons"] == _buttons()
+    finally:
+        end_turn(token)
+
+
+def test_streaming_final_edit_carries_attachment():
+    from gateway.stream_consumer import GatewayStreamConsumer
+    class Adapter:
+        async def edit_message(self, **kwargs):
+            self.kwargs = kwargs
+            return type("Result", (), {"success": True, "continuation_message_ids": (), "message_id": "1"})()
+    async def scenario():
+        adapter = Adapter()
+        consumer = GatewayStreamConsumer(adapter, "chat")
+        consumer._message_id = "1"
+        consumer._last_sent_text = "draft"
+        await consumer._send_or_edit("done", finalize=True, is_turn_final=True)
+        return adapter.kwargs
+    token = begin_turn()
+    try:
+        attach_final_reply_link_buttons(_buttons())
+        kwargs = asyncio.run(scenario())
+        assert kwargs["metadata"]["link_buttons"] == _buttons()
+    finally:
+        end_turn(token)


### PR DESCRIPTION
## Summary
- add a trusted, host-owned `PluginContext.attach_final_reply_link_buttons` capability;
- keep attachment state task-local with `ContextVar`, one-shot replacement semantics, validation, and concurrency isolation;
- carry attachments only into the current turn's final ordinary or streaming delivery, including final streaming edits;
- never expose the capability as a model tool or reuse stale metadata across turns.

## Validation
- `python3 -m pytest -q tests/unit/test_turn_attachments.py` — **6 passed**;
- `git diff --check` — clean.

This is the Hermes core half of the active Next Do integration in `msheldyakov/next-t-routine#1481`. No live profile, deployment, restart, or release configuration was changed.
