### PR TITLE
fix(update): preserve nested desktop build artifacts

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -703,6 +703,16 @@ def _discard_staged(staged) -> None:
             logger.warning("could not remove staging path %s: %s", staging, exc)
 
 
+# Paths (repo-relative) that live INSIDE a swapped top-level entry and must
+# survive it. The ZIP has no build output, so a wholesale ``apps/`` swap would
+# otherwise delete the packaged desktop app and dependencies that the updater
+# intentionally never rebuilds (see the desktop-skip note below).
+NESTED_PRESERVE = (
+    os.path.join("apps", "desktop", "node_modules"),
+    os.path.join("apps", "desktop", "release"),
+)
+
+
 def _commit_staged_replacements(staged) -> None:
     """Phase 2: swap every staged entry into place, rolling back all on failure.
 
@@ -752,6 +762,29 @@ def _commit_staged_replacements(staged) -> None:
                 # so say so rather than swallowing it.
                 logger.warning("rollback failed for %s: %s", dst, exc)
         raise
+    # Only after every swap succeeds may nested artifacts leave the untouched
+    # backups. Each restore is best-effort: these trees are rebuildable, while
+    # turning a successful source update into a failed update is worse.
+    for dst, backup in swapped:
+        if not backup:
+            continue
+        for relative in NESTED_PRESERVE:
+            parts = relative.split(os.sep)
+            if os.path.basename(dst) != parts[0]:
+                continue
+            source = os.path.join(backup, *parts[1:])
+            destination = os.path.join(dst, *parts[1:])
+            if not os.path.exists(source) or os.path.exists(destination):
+                continue
+            try:
+                os.makedirs(os.path.dirname(destination), exist_ok=True)
+                os.rename(source, destination)
+            except OSError as exc:
+                logger.warning(
+                    "could not preserve nested build artifact %s: %s",
+                    relative,
+                    exc,
+                )
     # All swaps succeeded — drop the backups (best-effort, never fatal).
     for _dst, backup in swapped:
         if backup and os.path.isdir(backup):
@@ -849,7 +882,9 @@ def _update_via_zip(args):
                     extracted = candidate
                     break
 
-        # Copy updated files over existing installation, preserving venv/node_modules/.git
+        # Copy updated files over existing installation, preserving top-level
+        # venv/node_modules/.git. Nested build output is restored separately by
+        # _commit_staged_replacements after all swaps succeed.
         preserve = {"venv", "node_modules", ".git", ".env"}
         entries = [i for i in os.listdir(extracted) if i not in preserve]
 

--- a/tests/hermes_cli/test_update_zip_two_phase.py
+++ b/tests/hermes_cli/test_update_zip_two_phase.py
@@ -67,6 +67,55 @@ def test_commit_swaps_every_entry(tmp_path):
     assert not [p for p in os.listdir(live) if "hermes-update" in p]
 
 
+def test_commit_preserves_nested_desktop_build_artifacts(tmp_path):
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"apps": "old"})
+    _live_tree(new, {"apps": "new"})
+    release = live / "apps" / "desktop" / "release"
+    node_modules = live / "apps" / "desktop" / "node_modules"
+    release.mkdir(parents=True)
+    node_modules.mkdir(parents=True)
+    (release / "marker.txt").write_text("original packaged desktop")
+    (node_modules / "x").write_text("original desktop dependencies")
+
+    update_cmd._commit_staged_replacements(_stage_all(live, new, ["apps"]))
+
+    assert (live / "apps" / "version.txt").read_text() == "new"
+    assert (release / "marker.txt").read_text() == "original packaged desktop"
+    assert (node_modules / "x").read_text() == "original desktop dependencies"
+
+
+def test_commit_failure_rolls_back_apps_before_nested_restore(tmp_path, monkeypatch):
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"apps": "old", "tools": "old"})
+    _live_tree(new, {"apps": "new", "tools": "new"})
+    release = live / "apps" / "desktop" / "release"
+    node_modules = live / "apps" / "desktop" / "node_modules"
+    release.mkdir(parents=True)
+    node_modules.mkdir(parents=True)
+    (release / "marker.txt").write_text("original packaged desktop")
+    (node_modules / "x").write_text("original desktop dependencies")
+    staged = _stage_all(live, new, ["apps", "tools"])
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def flaky_rename(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 4:
+            raise OSError("simulated AV interference")
+        return real_rename(src, dst)
+
+    monkeypatch.setattr(update_cmd.os, "rename", flaky_rename)
+    with pytest.raises(OSError):
+        update_cmd._commit_staged_replacements(staged)
+    monkeypatch.undo()
+
+    assert (live / "apps" / "version.txt").read_text() == "old"
+    assert (release / "marker.txt").read_text() == "original packaged desktop"
+    assert (node_modules / "x").read_text() == "original desktop dependencies"
+
+
 def test_failed_swap_rolls_back_every_earlier_swap(tmp_path, monkeypatch):
     """The regression: a mid-loop failure must not leave a mixed-version tree.
 


### PR DESCRIPTION
## Summary

- preserve  and  when the Windows ZIP fallback swaps the top-level  tree
- restore nested artifacts with same-filesystem renames only after all swaps succeed and before backups are deleted
- keep restore failures non-fatal while preserving the existing rollback and ZIP validation guarantees

## Incident

On Windows, a real ZIP-fallback update replaced  with the GitHub source archive, which contains no packaged Electron output. This deleted both the packaged 























┌──────────── Hermes Agent v0.20.0 (2026.8.3) · upstream 03fa32c9 ────────────┐
│                                      Available Tools                        │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀⠀⢀⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    bfl: bfl_flux3_get_result, ...         │
│    ⠀⠀⠀⠀⠀⠀⢀⣠⣴⣾⣿⣿⣇⠸⣿⣿⠇⣸⣿⣿⣷⣦⣄⡀⠀⠀⠀⠀⠀⠀    browser: browser_back, browser_click,  │
│    ⠀⢀⣠⣴⣶⠿⠋⣩⡿⣿⡿⠻⣿⡇⢠⡄⢸⣿⠟⢿⣿⢿⣍⠙⠿⣶⣦⣄⡀⠀    ...                                    │
│    ⠀⠀⠉⠉⠁⠶⠟⠋⠀⠉⠀⢀⣈⣁⡈⢁⣈⣁⡀⠀⠉⠀⠙⠻⠶⠈⠉⠉⠀⠀    clarify: clarify                       │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣴⣿⡿⠛⢁⡈⠛⢿⣿⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    code_execution: execute_code           │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⣿⣦⣤⣈⠁⢠⣴⣿⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    computer_use: computer_use             │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠻⢿⣿⣦⡉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    cronjob: cronjob                       │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠘⢷⣦⣈⠛⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    delegation: delegate_task              │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣴⠦⠈⠙⠿⣦⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    file: patch, read_file, search_files,  │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⣿⣤⡈⠁⢤⣿⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    write_file                             │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⠷⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    (and 11 more toolsets...)              │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⠑⢶⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀                                           │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠁⢰⡆⠈⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    MCP Servers                            │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠳⠈⣡⠞⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    blender (stdio) — 30 tool(s)           │
│    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀    obsidian (stdio) — 14 tool(s)          │
│                                                                             │
│     gpt-5.6-luna · Nous Research     Available Skills                       │
│  C:\c\Users\4acal\hermes-agent-pre…  autonomous-ai-agents:                  │
│   Session: 20260810_075415_766f39    approval-gated-agent-control-planes,   │
│                                      +19 more                               │
│                                      cloud-infrastructure:                  │
│                                      oracle-cloud-console-operations        │
│                                      creative: ai-video-generation, +24     │
│                                      more                                   │
│                                      data-science: jupyter-live-kernel      │
│                                      devops:                                │
│                                      docker-desktop-windows-troubleshooti…  │
│                                      +2 more                                │
│                                      email: email-inbox-triage, himalaya    │
│                                      general: adversarial-ux-test, +4 more  │
│                                      github: codebase-inspection, +7 more   │
│                                      media: gif-search, heartmula, +2 more  │
│                                      mlops: huggingface-hub, +3 more        │
│                                      note-taking: obsidian, +1 more         │
│                                      product:                               │
│                                      autonomous-income-validation, +4 more  │
│                                      productivity: airtable, +18 more       │
│                                      research: arxiv, +21 more              │
│                                      smart-home: govee-light-control, +2    │
│                                      more                                   │
│                                      software-development:                  │
│                                      auditable-local-research-pipelines,    │
│                                      +28 more                               │
│                                                                             │
│                                      40 tools · 153 skills · 2 MCP servers  │
│                                      · /help for commands                   │
└─────────────────────────────────────────────────────────────────────────────┘

Welcome to Hermes Agent! Type your message or /help for commands.
✦ Tip: /new starts a fresh session in place (alias /reset) — fresh session ID, 
clean history, CLI stays open. tree and desktop ; the subsequent backup cleanup permanently removed the only copies.

The updater intentionally skips rebuilding the desktop workspace, so the next launch had to pay for a full dependency install and Electron pack.

## Test plan

- [x] .....................                                                    [100%]
21 passed in 2.34s (21 passed)
- [x] 
- [x] 
- [x] independent pre-commit review: PASS, no blockers

The regression tests cover successful preservation of both nested artifacts while staged source wins, and a partial commit failure that restores the original  tree intact before any nested restore can run.