### PR TITLE
fix(desktop): use valid C.UTF-8 locale instead of bare UTF-8 charset

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11644,7 +11644,7 @@ function terminalShellEnv() {
   delete env.COLORFGBG
 
   env.COLORTERM = 'truecolor'
-  env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
+  env.LC_CTYPE = env.LC_CTYPE || 'C.UTF-8'
   env.TERM = 'xterm-256color'
   env.TERM_PROGRAM = 'Hermes'
   env.TERM_PROGRAM_VERSION = app.getVersion()


### PR DESCRIPTION
## Summary

Fixes #69265 — the desktop terminal sets `LC_CTYPE=UTF-8`, which is a charset name, not a valid locale. This causes bash to emit `setlocale: LC_CTYPE: cannot change locale (UTF-8)` warnings on every shell start.

## Root cause

`apps/desktop/electron/main.ts` line 11647: `env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'`. The value `UTF-8` is not a locale name on Linux — it's a charset. Bash's `setlocale()` fails to look it up and prints a warning.

## Fix

Changed the fallback from `'UTF-8'` to `'C.UTF-8'` — a valid locale name available on glibc ≥ 2.35 that correctly signals UTF-8 support. Systems that already have `LC_CTYPE` set are unaffected (the `||` only fires when it's unset).

## Verification

- The fix is a single-character change
- No new dependencies or behavior changes
- `LANG` continues to handle locale on properly configured systems; `C.UTF-8` is only the fallback