### PR TITLE
fix(desktop): honor userBubble theme color in light mode

### DIFF
--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -173,7 +173,7 @@ const mixesFor = (isDark: boolean): Record<string, string> => ({
   '--theme-mix-sidebar': '100%',
   '--theme-mix-card': isDark ? '38%' : '22%',
   '--theme-mix-elevated': isDark ? '46%' : '28%',
-  '--theme-mix-bubble': isDark ? '46%' : '0%'
+  '--theme-mix-bubble': isDark ? '46%' : '28%'
 })
 
 function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {


### PR DESCRIPTION
## Summary

Fixes #82886 — the `userBubble` theme token was a no-op in light mode because `--theme-mix-bubble` was hardcoded to `0%`.

## Root cause

In `apps/desktop/src/themes/context.tsx`, the `mixesFor()` function set `--theme-mix-bubble` to `0%` for light mode. Combined with the CSS `color-mix()` usage, a 0% mix means the bubble-seed color is dropped entirely and the bubble falls back to the neutral-card background — making user and assistant bubbles visually indistinguishable.

Dark mode worked fine at 46%.

## Fix

Changed the light-mode value from `0%` to `28%`, matching `--theme-mix-elevated`'s light-mode value. This gives the configured `userBubble` color visible effect while keeping the tint subtle.

## Verification

- One-line CSS variable change
- No behavioral impact on dark mode (unchanged at 46%)
- Consistent with other mix values in light mode (card: 22%, elevated: 28%)