### PR TITLE
fix(desktop): silence Windows 'restricted characters' warning on deeplink registration

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12333,7 +12333,26 @@ function registerDeepLinkProtocol() {
     if (process.defaultApp && process.argv.length >= 2) {
       // Dev: register with the electron exec path + entry script so the OS can
       // relaunch us with the URL.
-      app.setAsDefaultProtocolClient(HERMES_PROTOCOL, process.execPath, [path.resolve(process.argv[1])])
+      // On Windows the Electron registry command validation rejects exec
+      // paths that contain characters it deems "restricted" (e.g. spaces in
+      // AppData-rooted installs). The custom binary here is the electron
+      // runtime itself plus our entry script, so opt into the unsafe-but-fine
+      // path. Mirrors the git-bin handling in electron/git-review-ops.ts.
+      // The `options` 4th arg is supported at runtime (Electron >= 30) but is
+      // not yet reflected in the published type definitions, hence the cast.
+      ;(
+        app.setAsDefaultProtocolClient as unknown as (
+          protocol: string,
+          path?: string,
+          args?: string[],
+          options?: { unsafe?: { allowUnsafeCustomBinary?: boolean } }
+        ) => boolean
+      )(
+        HERMES_PROTOCOL,
+        process.execPath,
+        [path.resolve(process.argv[1])],
+        process.platform === 'win32' ? { unsafe: { allowUnsafeCustomBinary: true } } : undefined
+      )
     } else {
       app.setAsDefaultProtocolClient(HERMES_PROTOCOL)
     }


### PR DESCRIPTION
## Summary
- On Windows, `app.setAsDefaultProtocolClient()` rejects the custom-binary path when it contains characters Electron deems "restricted" (e.g. spaces in `AppData`-rooted installs like `C:\Users\...\AppData\Local\Hermes\...`).
- The call only fires in dev mode (`process.defaultApp`), where we pass `process.execPath` + the entry script. It emits a repeated `Invalid value supplied for custom binary, restricted characters must be removed or supply the unsafe.allowUnsafeCustomBinary option` warning on every `hermes desktop` startup under Windows.
- Opt into `unsafe.allowUnsafeCustomBinary` **on Windows only**, mirroring the existing git-bin handling in `electron/git-review-ops.ts:59`.
- The 4th `options` arg is supported at runtime (Electron >= 30) but is not yet present in the published `@electron/electron` type defs (see `node_modules/electron/electron.d.ts:1627`), so the call is cast through an augmented signature.

## Impact
Cosmetic only — the deeplink (`hermes://`) still registers and works. No behavior change on macOS/Linux (branch left untouched). Deep-link relaunch keeps functioning because the custom binary is the electron runtime itself.

## Test plan
- [x] `npx tsc --build tsconfig.electron.json --noEmit` — clean
- [x] `npx prettier --check electron/main.ts` — clean (applied project `fmt`)
- [x] `npx eslint electron/main.ts` — clean

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)