### PR TITLE
fix(whatsapp): stop oversight replies from reaching contacts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1938,6 +1938,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
                 timed_out = False
+                policy_suppressed = False
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
@@ -2038,6 +2039,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             else:
                                 send_success = _confirm_adapter_delivery(send_result)
                                 send_raw_response = getattr(send_result, "raw_response", None)
+                            policy_suppressed = bool(
+                                isinstance(send_raw_response, dict)
+                                and send_raw_response.get("suppressed")
+                            )
 
                             if not send_success:
                                 if isinstance(send_result, dict):
@@ -2084,7 +2089,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # payload is already assumed delivered (#38922).  Record the
                 # skipped attachments so the drop is visible rather than silently
                 # lost.
-                if adapter_ok and not timed_out and media_files:
+                if adapter_ok and not policy_suppressed and not timed_out and media_files:
                     routed_media_metadata = dict(media_metadata or {})
                     if transport is not None and transport.is_relay:
                         routed_media_metadata["_relay_logical_platform"] = platform.value
@@ -2111,7 +2116,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     logger.warning("Job '%s': %s", job["id"], msg)
                     delivery_errors.append(msg)
 
-                if adapter_ok:
+                if adapter_ok and policy_suppressed:
+                    logger.info(
+                        "Job '%s': delivery to %s:%s suppressed by platform policy",
+                        job["id"], platform_name, chat_id,
+                    )
+                    delivered = True
+                elif adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
                     # Seed the thread session only now that delivery into it
@@ -2238,6 +2249,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
+                continue
+
+            if result and result.get("suppressed"):
+                logger.info(
+                    "Job '%s': delivery to %s:%s suppressed by platform policy",
+                    job["id"], platform_name, chat_id,
+                )
+                delivered = True
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1477,7 +1477,7 @@ def _send_media_via_adapter(
     loop,
     job: dict,
     platform=None,
-) -> None:
+) -> bool:
     """Send extracted MEDIA files as native platform attachments via a live adapter.
 
     Routes each file to the appropriate adapter method (send_voice, send_image_file,
@@ -1510,7 +1510,7 @@ def _send_media_via_adapter(
                     "Job '%s': cannot send media %s, gateway loop unavailable",
                     job.get("id", "?"), media_path,
                 )
-                return
+                return False
             try:
                 result = future.result(timeout=30)
             except TimeoutError:
@@ -1521,8 +1521,12 @@ def _send_media_via_adapter(
                     "Job '%s': media send failed for %s: %s",
                     job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
                 )
+            raw_response = getattr(result, "raw_response", None)
+            if isinstance(raw_response, dict) and raw_response.get("suppressed"):
+                return True
         except Exception as e:
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+    return False
 
 
 def _confirm_adapter_delivery(send_result) -> bool:
@@ -2099,7 +2103,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 routed_media_metadata["user_id"] = logical_home.user_id
                             if logical_home.scope_id:
                                 routed_media_metadata["scope_id"] = logical_home.scope_id
-                    _send_media_via_adapter(
+                    media_suppressed = _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
                         media_files,
@@ -2108,6 +2112,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         job,
                         platform=platform,
                     )
+                    if media_suppressed:
+                        policy_suppressed = True
                 elif timed_out and media_files:
                     msg = (
                         f"{len(media_files)} media attachment(s) not delivered to "

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1596,6 +1596,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:
                     bridged["typing_status_text"] = platform_cfg["typing_status_text"]
+                has_home_channel = isinstance(platform_cfg.get("home_channel"), dict)
                 # Bridge top-level port/host/secret into extra for platforms
                 # whose adapters read these from config.extra (webhook,
                 # msgraph_webhook, api_server).  Without this, YAML like:
@@ -1627,9 +1628,18 @@ def load_gateway_config() -> GatewayConfig:
                             if isinstance(ov_data, dict)
                         }
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
-                if not bridged and not enabled_was_explicit and not has_channel_overrides:
+                if (
+                    not bridged
+                    and not enabled_was_explicit
+                    and not has_channel_overrides
+                    and not has_home_channel
+                ):
                     continue
                 plat_data, extra = _ensure_platform_extra_dict(platforms_data, plat.value)
+                if has_home_channel:
+                    home_channel = dict(platform_cfg["home_channel"])
+                    home_channel.setdefault("platform", plat.value)
+                    plat_data["home_channel"] = home_channel
                 if enabled_was_explicit:
                     plat_data["enabled"] = platform_cfg["enabled"]
                     # Mark the explicit enable/disable so the registry-driven

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -486,10 +486,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._allow_from = self._coerce_allow_list(allow_raw)
         self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
-        read_receipts = config.extra.get("send_read_receipts", False)
-        self._send_read_receipts = (
-            read_receipts if isinstance(read_receipts, bool)
-            else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
+        self._send_read_receipts = _coerce_config_bool(
+            config.extra.get("send_read_receipts"), False
         )
         self._oversight_mode = self._coerce_bool_extra("oversight_mode", False)
         self._respond_as_owner = self._coerce_bool_extra("respond_as_owner", False)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -89,7 +89,18 @@ def _oversight_target_allowed(
             adapter_name,
         )
         return False
-    allowed = to_whatsapp_jid(chat_id) == to_whatsapp_jid(home)
+    target_jid = to_whatsapp_jid(chat_id)
+    home_jid = to_whatsapp_jid(home)
+    individual_domains = {"s.whatsapp.net", "lid"}
+    target_domain = target_jid.rpartition("@")[2].lower()
+    home_domain = home_jid.rpartition("@")[2].lower()
+    if target_domain in individual_domains and home_domain in individual_domains:
+        allowed = (
+            canonical_whatsapp_identifier(target_jid)
+            == canonical_whatsapp_identifier(home_jid)
+        )
+    else:
+        allowed = target_jid == home_jid
     if not allowed:
         logger.warning(
             "[%s] Blocking WhatsApp outbound to non-home chat in oversight mode",
@@ -321,7 +332,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
-from gateway.whatsapp_identity import to_whatsapp_jid
+from gateway.whatsapp_identity import canonical_whatsapp_identifier, to_whatsapp_jid
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -62,6 +62,42 @@ logger = logging.getLogger(__name__)
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
 
+def _coerce_config_bool(value: Any, default: bool = False) -> bool:
+    """Coerce a config boolean without treating ``"false"`` as true."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _oversight_target_allowed(
+    chat_id: str,
+    *,
+    oversight_mode: bool,
+    respond_as_owner: bool,
+    home_channel: str,
+    adapter_name: str,
+) -> bool:
+    """Enforce the oversight no-contact boundary for every bridge sender."""
+    if not oversight_mode or respond_as_owner:
+        return True
+    home = str(home_channel or "").strip()
+    if not home:
+        logger.error(
+            "[%s] Blocking WhatsApp outbound in oversight mode: no home channel configured",
+            adapter_name,
+        )
+        return False
+    allowed = to_whatsapp_jid(chat_id) == to_whatsapp_jid(home)
+    if not allowed:
+        logger.warning(
+            "[%s] Blocking WhatsApp outbound to non-home chat in oversight mode",
+            adapter_name,
+        )
+    return allowed
+
+
 def _listener_pids_on_port(port: int) -> list:
     """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
 
@@ -516,34 +552,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     def _coerce_bool_extra(self, key: str, default: bool) -> bool:
         """Read a boolean adapter option without treating ``"false"`` as true."""
         value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
-        if value is None:
-            return default
-        if isinstance(value, bool):
-            return value
-        return str(value).strip().lower() in {"1", "true", "yes", "on"}
+        return _coerce_config_bool(value, default)
 
     def _oversight_allows_outbound(self, chat_id: str) -> bool:
         """Enforce the oversight no-contact boundary at the transport edge."""
-        if not getattr(self, "_oversight_mode", False):
-            return True
-        if getattr(self, "_respond_as_owner", False):
-            return True
-
-        home = str(getattr(self, "_oversight_home_channel", "") or "").strip()
-        if not home:
-            logger.error(
-                "[%s] Blocking WhatsApp outbound in oversight mode: no home channel configured",
-                self.name,
-            )
-            return False
-
-        allowed = to_whatsapp_jid(chat_id) == to_whatsapp_jid(home)
-        if not allowed:
-            logger.warning(
-                "[%s] Blocking WhatsApp outbound to non-home chat in oversight mode",
-                self.name,
-            )
-        return allowed
+        return _oversight_target_allowed(
+            chat_id,
+            oversight_mode=getattr(self, "_oversight_mode", False),
+            respond_as_owner=getattr(self, "_respond_as_owner", False),
+            home_channel=getattr(self, "_oversight_home_channel", ""),
+            adapter_name=self.name,
+        )
 
     def _oversight_blocked_result(self) -> SendResult:
         """Represent an intentional policy drop as handled, not retryable failure."""
@@ -1772,6 +1791,22 @@ async def _standalone_send(
     ``/send`` message beforehand.
     """
     extra = getattr(pconfig, "extra", {}) or {}
+    home = getattr(getattr(pconfig, "home_channel", None), "chat_id", "")
+    if not _oversight_target_allowed(
+        chat_id,
+        oversight_mode=_coerce_config_bool(extra.get("oversight_mode")),
+        respond_as_owner=_coerce_config_bool(extra.get("respond_as_owner")),
+        home_channel=home,
+        adapter_name="Whatsapp",
+    ):
+        return {
+            "success": True,
+            "platform": "whatsapp",
+            "chat_id": to_whatsapp_jid(chat_id),
+            "message_id": None,
+            "suppressed": True,
+            "reason": "oversight_outbound_policy",
+        }
     try:
         import aiohttp
     except ImportError:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1448,6 +1448,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         key = data.get("readReceiptKey")
         if not isinstance(key, dict):
             return
+        chat_id = data.get("chatId") or key.get("remoteJid") or ""
+        if not self._oversight_allows_outbound(str(chat_id)):
+            return
         try:
             import aiohttp
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -455,6 +455,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             read_receipts if isinstance(read_receipts, bool)
             else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
         )
+        self._oversight_mode = self._coerce_bool_extra("oversight_mode", False)
+        self._respond_as_owner = self._coerce_bool_extra("respond_as_owner", False)
+        self._oversight_home_channel = (
+            str(config.home_channel.chat_id).strip()
+            if config.home_channel and config.home_channel.chat_id
+            else ""
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -505,6 +512,46 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    def _coerce_bool_extra(self, key: str, default: bool) -> bool:
+        """Read a boolean adapter option without treating ``"false"`` as true."""
+        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+    def _oversight_allows_outbound(self, chat_id: str) -> bool:
+        """Enforce the oversight no-contact boundary at the transport edge."""
+        if not getattr(self, "_oversight_mode", False):
+            return True
+        if getattr(self, "_respond_as_owner", False):
+            return True
+
+        home = str(getattr(self, "_oversight_home_channel", "") or "").strip()
+        if not home:
+            logger.error(
+                "[%s] Blocking WhatsApp outbound in oversight mode: no home channel configured",
+                self.name,
+            )
+            return False
+
+        allowed = to_whatsapp_jid(chat_id) == to_whatsapp_jid(home)
+        if not allowed:
+            logger.warning(
+                "[%s] Blocking WhatsApp outbound to non-home chat in oversight mode",
+                self.name,
+            )
+        return allowed
+
+    def _oversight_blocked_result(self) -> SendResult:
+        """Represent an intentional policy drop as handled, not retryable failure."""
+        return SendResult(
+            success=True,
+            message_id=None,
+            raw_response={"suppressed": True, "reason": "oversight_outbound_policy"},
+        )
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -709,6 +756,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 _v = _wenv(_key)
                 if _v:
                     bridge_env[_key] = _v
+            if (
+                not _wenv("WHATSAPP_FORWARD_OWNER_MESSAGES")
+                and "forward_owner_messages" in self.config.extra
+            ):
+                bridge_env["WHATSAPP_FORWARD_OWNER_MESSAGES"] = (
+                    "true"
+                    if self._coerce_bool_extra("forward_owner_messages", False)
+                    else "false"
+                )
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges
@@ -925,6 +981,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         Formats markdown for WhatsApp, splits long messages into chunks
         that preserve code block boundaries, and sends each chunk sequentially.
         """
+        if not self._oversight_allows_outbound(chat_id):
+            return self._oversight_blocked_result()
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -991,6 +1049,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         finalize: bool = False,
     ) -> SendResult:
         """Edit a previously sent message via the WhatsApp bridge."""
+        if not self._oversight_allows_outbound(chat_id):
+            return self._oversight_blocked_result()
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1024,6 +1084,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         file_name: Optional[str] = None,
     ) -> SendResult:
         """Send any media file via bridge /send-media endpoint."""
+        if not self._oversight_allows_outbound(chat_id):
+            return self._oversight_blocked_result()
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1078,6 +1140,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         remain gateway-owned and add text fallback plus explicit confirmation
         semantics before approval prompts are ever mapped onto polls.
         """
+        if not self._oversight_allows_outbound(chat_id):
+            return self._oversight_blocked_result()
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1162,6 +1226,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a native WhatsApp location pin via the Baileys bridge."""
+        if not self._oversight_allows_outbound(chat_id):
+            return self._oversight_blocked_result()
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1267,6 +1333,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
+        if not self._oversight_allows_outbound(chat_id):
+            return
         if not self._running or not self._http_session:
             return
         if await self._check_managed_bridge_exit():
@@ -1838,7 +1906,8 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
     whatsapp_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    take precedence over YAML. Non-secret oversight policy stays in
+    ``PlatformConfig.extra`` instead of being mirrored into environment vars.
     """
     import json as _json
     if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
@@ -1864,7 +1933,11 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
         if isinstance(gaf, list):
             gaf = ",".join(str(v) for v in gaf)
         os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = str(gaf)
-    return None
+    seeded: Dict[str, Any] = {}
+    for key in ("oversight_mode", "respond_as_owner", "forward_owner_messages"):
+        if key in whatsapp_cfg:
+            seeded[key] = whatsapp_cfg[key]
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1478,6 +1478,103 @@ class TestDeliverResultLiveAdapterUnconfirmed:
         standalone_send.assert_awaited_once()
 
 
+class TestDeliverResultPolicySuppression:
+    @staticmethod
+    def _config(platform):
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {}
+        config = MagicMock()
+        config.platforms = {platform: pconfig}
+        return config
+
+    @staticmethod
+    def _job():
+        return {
+            "id": "suppressed-job",
+            "deliver": "origin",
+            "attach_to_session": True,
+            "origin": {
+                "platform": "whatsapp",
+                "chat_id": "15550002222@s.whatsapp.net",
+            },
+        }
+
+    def test_standalone_suppression_is_not_mirrored_or_retried(self):
+        from gateway.config import Platform
+
+        standalone_send = AsyncMock(
+            return_value={
+                "success": True,
+                "suppressed": True,
+                "reason": "oversight_outbound_policy",
+            }
+        )
+        with patch(
+            "gateway.config.load_gateway_config",
+            return_value=self._config(Platform.WHATSAPP),
+        ), patch(
+            "cron.scheduler.load_config",
+            return_value={"cron": {"wrap_response": False}},
+        ), patch(
+            "tools.send_message_tool._send_to_platform",
+            new=standalone_send,
+        ), patch("gateway.mirror.mirror_to_session") as mirror:
+            result = _deliver_result(self._job(), "scheduled result")
+
+        assert result is None
+        standalone_send.assert_awaited_once()
+        mirror.assert_not_called()
+
+    def test_live_suppression_is_not_mirrored_or_retried(self):
+        from concurrent.futures import Future
+
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+
+        adapter = AsyncMock()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        send_result = SendResult(
+            success=True,
+            raw_response={
+                "suppressed": True,
+                "reason": "oversight_outbound_policy",
+            },
+        )
+        completed_future = Future()
+        completed_future.set_result(send_result)
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        standalone_send = AsyncMock(return_value={"success": True})
+        with patch(
+            "gateway.config.load_gateway_config",
+            return_value=self._config(Platform.WHATSAPP),
+        ), patch(
+            "cron.scheduler.load_config",
+            return_value={"cron": {"wrap_response": False}},
+        ), patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=fake_run_coro,
+        ), patch(
+            "tools.send_message_tool._send_to_platform",
+            new=standalone_send,
+        ), patch("gateway.mirror.mirror_to_session") as mirror:
+            result = _deliver_result(
+                self._job(),
+                "scheduled result",
+                adapters={Platform.WHATSAPP: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        standalone_send.assert_not_awaited()
+        mirror.assert_not_called()
+
+
 class TestDeliverOriginUnresolvableIsLocal:
     """Regression for #43014.
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1574,6 +1574,62 @@ class TestDeliverResultPolicySuppression:
         standalone_send.assert_not_awaited()
         mirror.assert_not_called()
 
+    def test_live_media_only_suppression_is_not_mirrored_or_retried(
+        self, tmp_path, monkeypatch
+    ):
+        from concurrent.futures import Future
+
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+
+        media_path = tmp_path / "image.png"
+        media_path.write_bytes(b"image")
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (tmp_path,),
+        )
+        adapter = AsyncMock()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        send_result = SendResult(
+            success=True,
+            raw_response={
+                "suppressed": True,
+                "reason": "oversight_outbound_policy",
+            },
+        )
+        completed_future = Future()
+        completed_future.set_result(send_result)
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        standalone_send = AsyncMock(return_value={"success": True})
+        with patch(
+            "gateway.config.load_gateway_config",
+            return_value=self._config(Platform.WHATSAPP),
+        ), patch(
+            "cron.scheduler.load_config",
+            return_value={"cron": {"wrap_response": False}},
+        ), patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=fake_run_coro,
+        ), patch(
+            "tools.send_message_tool._send_to_platform",
+            new=standalone_send,
+        ), patch("gateway.mirror.mirror_to_session") as mirror:
+            result = _deliver_result(
+                self._job(),
+                f"MEDIA:{media_path}",
+                adapters={Platform.WHATSAPP: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        standalone_send.assert_not_awaited()
+        mirror.assert_not_called()
+
 
 class TestDeliverOriginUnresolvableIsLocal:
     """Regression for #43014.

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -13,6 +13,7 @@ trusts the payload.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from unittest.mock import AsyncMock, MagicMock
 
@@ -123,6 +124,19 @@ def test_oversight_allows_home_chat_with_equivalent_jid_shape():
     adapter = _oversight_adapter(home="+1 (555) 000-1111")
 
     assert adapter._oversight_allows_outbound("15550001111@s.whatsapp.net") is True
+
+
+def test_oversight_allows_home_chat_lid_alias(monkeypatch, tmp_path):
+    mapping_dir = tmp_path / "whatsapp" / "session"
+    mapping_dir.mkdir(parents=True)
+    (mapping_dir / "lid-mapping-999999999999999.json").write_text(
+        json.dumps("15550001111@s.whatsapp.net"),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _oversight_adapter(home="15550001111@s.whatsapp.net")
+
+    assert adapter._oversight_allows_outbound("999999999999999@lid") is True
 
 
 def test_oversight_without_home_channel_fails_closed():

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -192,3 +192,21 @@ def test_documented_oversight_yaml_shape_loads_home_and_policy(monkeypatch, tmp_
     assert config.extra["forward_owner_messages"] is True
 
 
+def test_home_channel_only_does_not_enable_whatsapp(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("WHATSAPP_ENABLED", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        """whatsapp:
+  home_channel:
+    chat_id: "15550001111@s.whatsapp.net"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_gateway_config().platforms[Platform.WHATSAPP]
+
+    assert config.enabled is False
+    assert config.home_channel is not None
+    assert config.home_channel.chat_id == "15550001111@s.whatsapp.net"
+
+

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter, _apply_yaml_config
 
 
 @pytest.fixture(autouse=True)
@@ -91,5 +91,76 @@ def test_from_owner_does_not_double_prefix_when_already_tagged():
     assert event is not None
     assert event.metadata.get("whatsapp_from_owner") is True
     assert event.text == "[owner reply] already tagged"
+
+
+def _oversight_adapter(*, home="15550001111", respond_as_owner=False):
+    adapter = _make_adapter()
+    adapter._oversight_mode = True
+    adapter._oversight_home_channel = home
+    adapter._respond_as_owner = respond_as_owner
+    adapter._running = True
+    adapter._http_session = MagicMock()
+    return adapter
+
+
+def test_oversight_blocks_owner_forwarded_contact_reply_before_transport():
+    adapter = _oversight_adapter()
+
+    result = asyncio.run(
+        adapter.send("15550002222@s.whatsapp.net", "busy/system/agent reply")
+    )
+
+    assert result.success is True
+    assert result.raw_response == {
+        "suppressed": True,
+        "reason": "oversight_outbound_policy",
+    }
+    adapter._http_session.post.assert_not_called()
+
+
+def test_oversight_allows_home_chat_with_equivalent_jid_shape():
+    adapter = _oversight_adapter(home="+1 (555) 000-1111")
+
+    assert adapter._oversight_allows_outbound("15550001111@s.whatsapp.net") is True
+
+
+def test_oversight_without_home_channel_fails_closed():
+    adapter = _oversight_adapter(home="")
+
+    assert adapter._oversight_allows_outbound("15550002222@s.whatsapp.net") is False
+
+
+def test_oversight_explicit_respond_as_owner_allows_contact_outbound():
+    adapter = _oversight_adapter(respond_as_owner=True)
+
+    assert adapter._oversight_allows_outbound("15550002222@s.whatsapp.net") is True
+
+
+def test_oversight_yaml_options_seed_adapter_extra(monkeypatch):
+    for name in (
+        "WHATSAPP_REQUIRE_MENTION",
+        "WHATSAPP_MENTION_PATTERNS",
+        "WHATSAPP_FREE_RESPONSE_CHATS",
+        "WHATSAPP_DM_POLICY",
+        "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_GROUP_POLICY",
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    seeded = _apply_yaml_config(
+        {},
+        {
+            "oversight_mode": True,
+            "respond_as_owner": False,
+            "forward_owner_messages": True,
+        },
+    )
+
+    assert seeded == {
+        "oversight_mode": True,
+        "respond_as_owner": False,
+        "forward_owner_messages": True,
+    }
 
 

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -13,11 +13,12 @@ trusts the payload.
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform, PlatformConfig, load_gateway_config
 from plugins.platforms.whatsapp.adapter import WhatsAppAdapter, _apply_yaml_config
 
 
@@ -162,5 +163,32 @@ def test_oversight_yaml_options_seed_adapter_extra(monkeypatch):
         "respond_as_owner": False,
         "forward_owner_messages": True,
     }
+
+
+def test_documented_oversight_yaml_shape_loads_home_and_policy(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for name in tuple(os.environ):
+        if name.startswith("WHATSAPP_"):
+            monkeypatch.delenv(name, raising=False)
+    (tmp_path / "config.yaml").write_text(
+        """whatsapp:
+  enabled: true
+  oversight_mode: true
+  respond_as_owner: false
+  forward_owner_messages: true
+  home_channel:
+    chat_id: "15550001111@s.whatsapp.net"
+    name: "Owner"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_gateway_config().platforms[Platform.WHATSAPP]
+
+    assert config.home_channel is not None
+    assert config.home_channel.chat_id == "15550001111@s.whatsapp.net"
+    assert config.extra["oversight_mode"] is True
+    assert config.extra["respond_as_owner"] is False
+    assert config.extra["forward_owner_messages"] is True
 
 

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -82,6 +82,19 @@ class TestAdapterInit:
         adapter = WhatsAppAdapter(config)
         assert adapter._reply_prefix == "Bot\\n"
 
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [(True, True), (False, False), ("yes", True), ("false", False)],
+    )
+    def test_read_receipt_boolean_coercion(self, configured, expected):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(
+            PlatformConfig(enabled=True, extra={"send_read_receipts": configured})
+        )
+
+        assert adapter._send_read_receipts is expected
+
 
 class TestReadReceiptPolicyOrdering:
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -107,6 +107,36 @@ class TestReadReceiptPolicyOrdering:
         assert session.post.call_args.kwargs["json"] == {"key": key}
         assert session.post.call_args.args[0].endswith("/read")
 
+    @pytest.mark.asyncio
+    async def test_oversight_blocks_contact_receipt_before_bridge(self):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "send_read_receipts": True,
+                    "oversight_mode": True,
+                    "respond_as_owner": False,
+                },
+                home_channel=SimpleNamespace(
+                    platform=Platform.WHATSAPP,
+                    chat_id="15550001111@s.whatsapp.net",
+                ),
+            )
+        )
+        session = MagicMock()
+        adapter._http_session = session
+        key = {
+            "id": "incoming-1",
+            "remoteJid": "15550002222@s.whatsapp.net",
+            "fromMe": False,
+        }
+
+        await adapter._send_read_receipt({"readReceiptKey": key})
+
+        session.post.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Config version regression guard

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -9,6 +9,7 @@ Covers two layers:
 """
 
 import asyncio
+import json
 import os
 import tempfile
 from types import SimpleNamespace
@@ -18,7 +19,7 @@ import pytest
 
 from gateway.config import Platform
 from plugins.platforms.whatsapp.adapter import _bridge_media_type, _standalone_send
-from tools.send_message_tool import _send_to_platform
+from tools.send_message_tool import _handle_send, _send_to_platform
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +205,40 @@ def test_send_message_path_surfaces_oversight_suppression():
     assert result["suppressed"] is True
     assert result["reason"] == "oversight_outbound_policy"
     session.assert_not_called()
+
+
+def test_suppressed_send_is_not_mirrored_as_delivered():
+    config = SimpleNamespace(
+        platforms={
+            Platform.WHATSAPP: SimpleNamespace(
+                enabled=True,
+                token="",
+                extra={},
+                home_channel=None,
+            )
+        }
+    )
+    suppressed = {
+        "success": True,
+        "suppressed": True,
+        "reason": "oversight_outbound_policy",
+    }
+
+    with patch("gateway.config.load_gateway_config", return_value=config), patch(
+        "tools.send_message_tool._send_to_platform",
+        new=AsyncMock(return_value=suppressed),
+    ), patch("gateway.mirror.mirror_to_session") as mirror:
+        result = json.loads(
+            _handle_send(
+                {
+                    "target": "whatsapp:+15550002222",
+                    "message": "contact",
+                }
+            )
+        )
+
+    assert result == suppressed
+    mirror.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -16,7 +16,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from gateway.config import Platform
 from plugins.platforms.whatsapp.adapter import _bridge_media_type, _standalone_send
+from tools.send_message_tool import _send_to_platform
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +172,33 @@ def test_standalone_oversight_blocks_non_home_before_http():
 
     with patch("aiohttp.ClientSession") as session:
         result = asyncio.run(_standalone_send(config, "15550002222", "contact"))
+
+    assert result["success"] is True
+    assert result["suppressed"] is True
+    assert result["reason"] == "oversight_outbound_policy"
+    session.assert_not_called()
+
+
+def test_send_message_path_surfaces_oversight_suppression():
+    config = SimpleNamespace(
+        token="",
+        extra={
+            "bridge_port": 3000,
+            "oversight_mode": True,
+            "respond_as_owner": False,
+        },
+        home_channel=SimpleNamespace(chat_id="15550001111@s.whatsapp.net"),
+    )
+
+    with patch("aiohttp.ClientSession") as session:
+        result = asyncio.run(
+            _send_to_platform(
+                Platform.WHATSAPP,
+                config,
+                "15550002222",
+                "contact",
+            )
+        )
 
     assert result["success"] is True
     assert result["suppressed"] is True

--- a/tests/tools/test_whatsapp_send_message_media.py
+++ b/tests/tools/test_whatsapp_send_message_media.py
@@ -89,7 +89,7 @@ def _session_with(responses):
 
 
 def _pconfig():
-    return SimpleNamespace(token="", extra={"bridge_port": 3000})
+    return SimpleNamespace(token="", extra={"bridge_port": 3000}, home_channel=None)
 
 
 def _tmpfile(suffix):
@@ -155,3 +155,51 @@ def test_missing_captioned_file_falls_back_to_text():
     assert len(calls) == 1
     assert calls[0][0].endswith("/send")
     assert calls[0][1]["message"] == "floor plan"
+
+
+def test_standalone_oversight_blocks_non_home_before_http():
+    config = SimpleNamespace(
+        token="",
+        extra={
+            "bridge_port": 3000,
+            "oversight_mode": True,
+            "respond_as_owner": False,
+        },
+        home_channel=SimpleNamespace(chat_id="15550001111@s.whatsapp.net"),
+    )
+
+    with patch("aiohttp.ClientSession") as session:
+        result = asyncio.run(_standalone_send(config, "15550002222", "contact"))
+
+    assert result["success"] is True
+    assert result["suppressed"] is True
+    assert result["reason"] == "oversight_outbound_policy"
+    session.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("chat_id", "respond_as_owner"),
+    [
+        ("15550001111@s.whatsapp.net", False),
+        ("15550002222@s.whatsapp.net", True),
+    ],
+)
+def test_standalone_oversight_allows_home_or_explicit_owner_response(
+    chat_id, respond_as_owner
+):
+    config = SimpleNamespace(
+        token="",
+        extra={
+            "bridge_port": 3000,
+            "oversight_mode": True,
+            "respond_as_owner": respond_as_owner,
+        },
+        home_channel=SimpleNamespace(chat_id="15550001111@s.whatsapp.net"),
+    )
+    session_ctx, calls = _session_with([_resp(200, {"messageId": "m1"})])
+
+    with patch("aiohttp.ClientSession", return_value=session_ctx):
+        result = asyncio.run(_standalone_send(config, chat_id, "allowed"))
+
+    assert result["success"] is True
+    assert len(calls) == 1

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -502,7 +502,12 @@ def _handle_send(args):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
 
         # Mirror the sent message into the target's gateway session
-        if isinstance(result, dict) and result.get("success") and mirror_text:
+        if (
+            isinstance(result, dict)
+            and result.get("success")
+            and not result.get("suppressed")
+            and mirror_text
+        ):
             try:
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -185,6 +185,35 @@ whatsapp:
 
 When `send_read_receipts` is `true`, the adapter marks policy-accepted inbound messages as read after DM/group/mention filtering passes. Rejected messages (e.g., from non-allowlisted senders) are not marked read. Disabled by default for privacy. Changing this setting automatically restarts the bridge subprocess on the next connection.
 
+### Oversight mode
+
+Use oversight mode when Hermes should observe private chats but must only send
+generated replies and gateway notices to the owner's home chat:
+
+```yaml
+whatsapp:
+  enabled: true
+  oversight_mode: true
+  forward_owner_messages: true
+  home_channel:
+    chat_id: "15550001111@s.whatsapp.net"
+    name: "Owner"
+  dm_policy: open
+  allow_from: ["*"]
+  group_policy: disabled
+```
+
+The outbound guard is enforced by the WhatsApp adapter, after agent and gateway
+policy hooks. Text, media, polls, locations, edits, and typing indicators are
+silently suppressed for every non-home chat, including busy and system notices.
+If `home_channel.chat_id` is missing, oversight mode fails closed and suppresses
+all adapter-generated outbound traffic. Inbound messages are still available to
+plugins for storage or owner alerts.
+
+Set `respond_as_owner: true` under `whatsapp` only when Hermes is explicitly
+authorized to send to contacts. This disables the oversight outbound guard; it
+should not be enabled for observation-only profiles.
+
 ---
 
 ## Message Formatting & Delivery


### PR DESCRIPTION
## What does this PR do?

WhatsApp oversight profiles can currently send generated replies, busy notices, typing state, read receipts, or media back into a third-party contact chat when owner-forwarded messages are enabled. This violates the observation-only boundary and can expose agent-generated content to contacts without explicit authorization. This change enforces the boundary at every WhatsApp transport entry point while preserving broad inbound observation.

### Symptom

When the owner sends a message in a contact chat and owner forwarding is enabled, Hermes can process that forwarded event and send a generated or gateway response to the contact instead of keeping outbound traffic in the configured home chat.

### Impact

Observation-only WhatsApp profiles can message third-party contacts without an explicit respond-as-owner authorization. The affected paths include normal responses, busy or system notices, edits, media, polls, locations, typing indicators, read receipts, and standalone sends.

### Bug Cause

**Trigger:** `plugins/platforms/whatsapp/adapter.py` / owner-forwarded messages retain the contact chat ID and later reach transport senders.

**Causal chain:**
1. `forward_owner_messages` admits an owner-authored event from a third-party contact chat for observation.
2. Gateway response paths reuse that event's contact chat ID, and the WhatsApp transport previously had no final oversight boundary.
3. Generated content or protocol activity is sent to the contact.

**Why it is wrong:** Oversight mode is observation-only unless `respond_as_owner` is explicitly enabled. Policy hooks above the adapter are not a complete boundary because normal, busy, system, standalone, and protocol-level paths enter the transport independently.

**Working sibling / contrast:** The configured home chat is an authorized outbound destination and remains fully functional. Explicit `respond_as_owner: true` also preserves intentional contact replies.

**Ruled out:** Dropping owner-forwarded inbound events is not an acceptable fix because it would remove the broad DM observation capability that oversight mode is intended to provide.

### Fix

Add a fail-closed target predicate at the WhatsApp transport boundary and apply it to text, edits, media, polls, locations, typing, read receipts, and standalone sends. Load the home channel and oversight policy from YAML, normalize WhatsApp JIDs before comparison, document the supported configuration, and provide an explicit `respond_as_owner` escape hatch.

## Related Issue

Closes #83223

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- `gateway/config.py` - preserve platform home-channel configuration during gateway loading.
- `plugins/platforms/whatsapp/adapter.py` - enforce a fail-closed oversight outbound boundary across all bridge senders.
- `tests/gateway/test_whatsapp_from_owner.py` - cover contact suppression, home delivery, missing-home behavior, explicit authorization, and YAML propagation.
- `tests/gateway/test_whatsapp_reply_prefix.py` - cover oversight read-receipt suppression.
- `tests/tools/test_whatsapp_send_message_media.py` - cover standalone sender policy behavior.
- `website/docs/user-guide/messaging/whatsapp.md` - document oversight mode and explicit respond-as-owner behavior.

## How to Test

1. Configure WhatsApp with `oversight_mode: true`, `forward_owner_messages: true`, and a `home_channel`.
2. Forward owner-authored activity from a non-home contact chat and verify the bridge receives no outbound text, media, typing, or read-receipt request for that contact while home-chat traffic remains allowed.
3. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_from_owner.py tests/gateway/test_whatsapp_reply_prefix.py tests/tools/test_whatsapp_send_message_media.py
```

The final reviewed tip passed 37 focused tests. Real bridge verification confirmed zero non-home requests across live, standalone, and read-receipt paths while home traffic remained allowed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because these keys are documented under the platform YAML configuration
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow contract changed
- [x] I've considered cross-platform impact; the policy logic and JID normalization are platform-independent
- [x] Tool descriptions and schemas are N/A because no model tool contract changed

## Screenshots / Logs

N/A - verified with focused automated tests and a local WhatsApp bridge request capture.
