### PR TITLE
fix(codex): preserve session model in app-server threads

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -682,6 +682,11 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            # Codex homes are service-scoped, while Hermes model selection is
+            # profile/session-scoped. Forward the resolved agent model so the
+            # shared Codex config cannot silently collapse fleet roles onto its
+            # default model.
+            model=getattr(agent, "model", None),
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -277,6 +277,7 @@ class CodexAppServerSession:
         cwd: Optional[str] = None,
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
+        model: Optional[str] = None,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
@@ -286,6 +287,7 @@ class CodexAppServerSession:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
+        self._model = model
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
                 os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
@@ -343,6 +345,8 @@ class CodexAppServerSession:
         # Users who want a write-capable profile configure it in their
         # ~/.codex/config.toml the same way they would for any codex usage.
         params: dict[str, Any] = {"cwd": self._cwd}
+        if self._model:
+            params["model"] = self._model
         result = self._client.request("thread/start", params, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -399,3 +399,43 @@ class TestBridgeWiredInRuntime:
         agent.tool_progress_callback.assert_called_once()
         assert agent.tool_progress_callback.call_args.args[0] == "tool.started"
         assert agent.tool_progress_callback.call_args.args[1] == "exec_command"
+
+
+class TestModelWiredInRuntime:
+    def test_session_constructor_receives_resolved_model(self, monkeypatch):
+        from agent import codex_runtime
+
+        captured: dict = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def run_turn(self, **_kwargs):
+                raise RuntimeError("stop after constructor capture")
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+        agent = SimpleNamespace(
+            model="gpt-5.6-terra",
+            session_cwd=None,
+            _codex_session=None,
+            _interrupt_requested=False,
+            _interrupt_message=None,
+        )
+
+        result = codex_runtime.run_codex_app_server_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="task-1",
+        )
+
+        assert captured["model"] == "gpt-5.6-terra"
+        assert result["completed"] is False

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -162,17 +162,33 @@ class TestLifecycle:
         method_calls = [m for (m, _) in client.requests if m == "thread/start"]
         assert len(method_calls) == 1
 
-    def test_thread_start_passes_cwd_only(self):
+    @pytest.mark.parametrize("model", [None, ""])
+    def test_thread_start_passes_cwd_only(self, model):
         """thread/start carries cwd. We intentionally do NOT pass `permissions`
         on this codex version (experimentalApi-gated + requires matching
         config.toml [permissions] table). Letting codex use its default
         (read-only unless user configures otherwise) is the documented path."""
         client = FakeClient()
-        s = make_session(client, permission_profile="workspace-write")
+        s = make_session(
+            client,
+            model=model,
+            permission_profile="workspace-write",
+        )
         s.ensure_started()
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
+        assert "model" not in params
+
+    def test_thread_start_passes_explicit_model(self):
+        client = FakeClient()
+        s = make_session(client, model="gpt-5.6-terra")
+
+        s.ensure_started()
+
+        method, params = next(r for r in client.requests if r[0] == "thread/start")
+        assert method == "thread/start"
+        assert params == {"cwd": "/tmp", "model": "gpt-5.6-terra"}
 
     def test_close_idempotent(self):
         client = FakeClient()


### PR DESCRIPTION
## Summary
- forward Hermes' resolved per-session model into each newly created Codex app-server thread
- retain Codex's normal default behavior when the model is absent or empty
- cover both transport payloads and runtime-to-session model wiring

## Why
Codex home/auth/configuration is service-scoped, while Hermes model selection is profile/session-scoped. Without an explicit `thread/start` model, profiles with distinct resolved models can silently run Codex's shared default model.

## Validation
- `python -m pytest tests/agent/transports/test_codex_app_server_session.py tests/agent/transports/test_codex_app_server_runtime.py tests/agent/test_codex_app_server_event_bridge.py tests/agent/test_codex_app_server_persist.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_codex_app_server_compaction.py tests/tui_gateway/test_codex_app_server_live_events.py -q` (117 passed)
- `ruff check` on modified files
- `git diff --check`
- independent patch review: no security or logic findings
