### PR TITLE
fix(ci): merge all duration slices, not one

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,18 +155,22 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download all slice durations
+        # Each slice uploads the same file name (test_durations.json).
+        # With merge-multiple, the parallel downloads write to one path.
+        # This causes two problems: a race can write two JSON documents
+        # into one file, and the last write erases the other slices.
+        # Without merge-multiple, each artifact gets its own directory.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: test-durations-slice-*
           path: durations
-          merge-multiple: true
 
       - name: Merge into single durations file
         run: |
           python3 -c "
           import json, glob, os
           merged = {}
-          for f in glob.glob('durations/*test_durations.json'):
+          for f in glob.glob('durations/*/test_durations.json'):
             with open(f) as fh:
               merged.update(json.load(fh))
           with open('test_durations.json', 'w') as fh:


### PR DESCRIPTION
## What does this PR do?

The `save-durations` job failed on main with this error:

```
json.decoder.JSONDecodeError: Extra data: line 233 column 1 (char 12844)
```

Run: https://github.com/NousResearch/hermes-agent/actions/runs/31382130252/job/93435079123

Each test slice uploads an artifact with the same file name, `test_durations.json`. The download step used `merge-multiple: true`, so all 12 parallel extractions wrote to one path. This caused two faults:

- A race between two extractions wrote two JSON documents into one file. The merge step then failed with "Extra data".
- On green runs, the last write erased the other 11 slices. The merged cache held ~230 of ~2760 file durations. The glob `durations/*test_durations.json` shows the intent: the script expects per-slice files that did not exist.

All 12 artifacts from the failed run are valid JSON. The corruption occurs at download time.

This PR removes `merge-multiple` so each artifact extracts into its own directory. It points the glob at `durations/*/test_durations.json`.

## Related Issue

No issue exists for this failure. The failed run above is the report.

Fixes #N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `.github/workflows/tests.yml`: remove `merge-multiple: true` from the "Download all slice durations" step. Change the merge glob from `durations/*test_durations.json` to `durations/*/test_durations.json`. Add a comment that explains the fault.

## How to Test

The `save-durations` job only runs on main, so no PR run can execute it. I replayed the step locally with the real inputs:

1. Download the 12 slice artifacts from failed run 31382130252.
2. Extract each artifact into its own directory under `durations/`, the layout that `download-artifact` produces without `merge-multiple`.
3. Run the merge script from the workflow. Output: `Merged 2761 file durations`, no error. Each artifact alone holds ~230 durations, so 2761 proves that the merge now includes all 12 slices.

Other checks:

- `actionlint .github/workflows/tests.yml`: exit 0, no findings.
- `scripts/run_tests.sh tests/ci/test_classify_changes.py`: 39 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the one test file that references `tests.yml` (see "How to Test"). The change touches no Python code.
- [ ] I've added tests for my changes — no test can run this job. It is gated on `github.ref == 'refs/heads/main'`. The artifact replay above is the substitute.
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (CI-only, runs on ubuntu-latest)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
