### PR TITLE
fix(desktop): give mermaid diagrams a real size in the expand overlay and on copy

### DIFF
--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
@@ -4,7 +4,7 @@ import mermaid from 'mermaid'
 import { useEffect, useState } from 'react'
 
 import { Zoomable } from '@/components/ui/zoomable'
-import { copySvgAsPng } from '@/lib/svg-image'
+import { copySvgAsPng, normalizeSvgSize } from '@/lib/svg-image'
 import { cn } from '@/lib/utils'
 
 import type { RichFenceProps } from './types'
@@ -63,7 +63,7 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
         const result = await mermaid.render(id, code)
 
         if (!cancelled) {
-          setSvg(result.svg)
+          setSvg(normalizeSvgSize(result.svg))
         }
       } catch {
         if (!cancelled) {

--- a/apps/desktop/src/components/ui/zoomable.test.tsx
+++ b/apps/desktop/src/components/ui/zoomable.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Zoomable } from './zoomable'
+
+afterEach(cleanup)
+
+// Mermaid 11.16 emits `width="100%"` on the root svg; the fixed embed normalizes
+// it (normalizeSvgSize) so the overlay has a real intrinsic size.
+const MERMAID_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="260.34375" height="70" class="flowchart" style="max-width: 260.34375px;" viewBox="0 0 260.34375 70" role="graphics-document document"><rect width="260.34375" height="70" fill="#eee"/></svg>`
+
+describe('Zoomable', () => {
+  it('opens the full-view overlay when the trigger is clicked', () => {
+    render(
+      <Zoomable
+        label="Open diagram"
+        overlay={<div data-testid="overlay" dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} />}
+      >
+        <div data-testid="inline" dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} />
+      </Zoomable>
+    )
+
+    expect(screen.queryByTestId('overlay')).toBeNull()
+    fireEvent.click(screen.getByTitle('Open diagram'))
+    expect(screen.getByTestId('overlay')).toBeTruthy()
+  })
+
+  it('overlay svg carries an explicit pixel width (the blank-dialog contract)', () => {
+    render(
+      <Zoomable
+        label="Open diagram"
+        overlay={<div data-testid="overlay" dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} />}
+      >
+        <div dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} />
+      </Zoomable>
+    )
+
+    fireEvent.click(screen.getByTitle('Open diagram'))
+    const svg = screen.getByTestId('overlay').querySelector('svg')
+
+    expect(svg).toBeTruthy()
+    expect(svg?.getAttribute('width')).toBe('260.34375')
+    expect(svg?.getAttribute('height')).toBe('70')
+  })
+})

--- a/apps/desktop/src/components/ui/zoomable.test.tsx
+++ b/apps/desktop/src/components/ui/zoomable.test.tsx
@@ -14,9 +14,9 @@ describe('Zoomable', () => {
     render(
       <Zoomable
         label="Open diagram"
-        overlay={<div data-testid="overlay" dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} />}
+        overlay={<div dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} data-testid="overlay" />}
       >
-        <div data-testid="inline" dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} />
+        <div dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} data-testid="inline" />
       </Zoomable>
     )
 
@@ -29,7 +29,7 @@ describe('Zoomable', () => {
     render(
       <Zoomable
         label="Open diagram"
-        overlay={<div data-testid="overlay" dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} />}
+        overlay={<div dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} data-testid="overlay" />}
       >
         <div dangerouslySetInnerHTML={{ __html: MERMAID_SVG }} />
       </Zoomable>

--- a/apps/desktop/src/lib/svg-image.test.ts
+++ b/apps/desktop/src/lib/svg-image.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeSvgSize, svgSize } from './svg-image'
+
+// Real mermaid 11.16 render output shape (verified against the installed
+// package): width="100%" + inline style="max-width: Npx" + viewBox.
+const MERMAID_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100%" class="flowchart" style="max-width: 260.34375px;" viewBox="0 0 260.34375 70" role="graphics-document document"><g><rect x="0" y="0" width="260.34375" height="70" fill="#eee"/></g></svg>`
+
+describe('svgSize', () => {
+  it('reads explicit pixel width/height', () => {
+    expect(svgSize('<svg width="312" height="90"><rect/></svg>')).toEqual({ width: 312, height: 90 })
+  })
+
+  it('falls back to the viewBox when width is a percentage (mermaid)', () => {
+    expect(svgSize(MERMAID_SVG)).toEqual({ width: 260.34375, height: 70 })
+  })
+
+  it('falls back to the viewBox when width/height are absent', () => {
+    expect(svgSize('<svg viewBox="0 0 400 100"><rect/></svg>')).toEqual({ width: 400, height: 100 })
+  })
+
+  it('falls back to a default size when nothing usable exists', () => {
+    expect(svgSize('<svg><rect/></svg>')).toEqual({ width: 800, height: 600 })
+  })
+
+  it('treats mixed-unit widths as absent (not parseFloat(100) == 100)', () => {
+    expect(svgSize('<svg width="100%" height="70" viewBox="0 0 500 200"><rect/></svg>')).toEqual({
+      width: 500,
+      height: 200
+    })
+  })
+})
+
+describe('normalizeSvgSize', () => {
+  it('replaces a 100% width with the viewBox pixel size', () => {
+    const out = normalizeSvgSize(MERMAID_SVG)
+
+    expect(out).toContain('width="260.34375"')
+    expect(out).toContain('height="70"')
+    expect(out).not.toContain('width="100%"')
+    // Everything else survives the DOM round-trip.
+    expect(out).toContain('viewBox="0 0 260.34375 70"')
+    expect(out).toContain('role="graphics-document document"')
+  })
+
+  it('leaves svgs without a percentage width untouched', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="312" viewBox="0 0 312 90"><rect/></svg>'
+
+    expect(normalizeSvgSize(svg)).toBe(svg)
+  })
+
+  it('leaves svgs with a percentage width but no viewBox untouched', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="100%"><rect/></svg>'
+
+    expect(normalizeSvgSize(svg)).toBe(svg)
+  })
+})

--- a/apps/desktop/src/lib/svg-image.ts
+++ b/apps/desktop/src/lib/svg-image.ts
@@ -2,10 +2,59 @@
 // SVGs only (inline styles) — mermaid output qualifies. Falls back to copying
 // the SVG markup as text where image clipboard writes aren't permitted.
 
-function svgSize(svg: string): { height: number; width: number } {
+// Mermaid (and other generators) emit `width="100%"` for responsive diagrams.
+// A percentage is not a usable intrinsic size: inside the zoom viewer's
+// shrink-to-fit grid item it can collapse the diagram, and `drawImage` treats
+// parseFloat("100%") as 100 blob pixels (a tiny/broken PNG). Where the root
+// svg's width/height are percentages, substitute the pixel size implied by the
+// viewBox so the diagram keeps a real intrinsic size. Returns the ORIGINAL
+// string when no substitution is needed (no 100% width, or no usable viewBox).
+export function normalizeSvgSize(svg: string): string {
   const el = new DOMParser().parseFromString(svg, 'image/svg+xml').documentElement
-  const width = parseFloat(el.getAttribute('width') || '')
-  const height = parseFloat(el.getAttribute('height') || '')
+
+  if (el.tagName !== 'svg') {
+    return svg
+  }
+
+  const width = el.getAttribute('width')
+  const height = el.getAttribute('height')
+
+  if (width !== '100%' && !(width ?? '').trim().endsWith('%')) {
+    return svg
+  }
+
+  const [, , vbW, vbH] = (el.getAttribute('viewBox') || '').split(/[\s,]+/).map(Number)
+
+  if (!(vbW > 0) || !(vbH > 0)) {
+    return svg
+  }
+
+  el.setAttribute('width', String(vbW))
+  el.setAttribute('height', String(vbH))
+
+  return new XMLSerializer().serializeToString(el)
+}
+
+function parseSvgLength(raw: string | null): number | null {
+  if (!raw) {
+    return null
+  }
+
+  const value = Number.parseFloat(raw)
+
+  // A percentage (e.g. mermaid's width="100%") is not a pixel size — treat it
+  // as absent and fall back to the viewBox.
+  if (!Number.isFinite(value) || raw.trim().endsWith('%')) {
+    return null
+  }
+
+  return value
+}
+
+export function svgSize(svg: string): { height: number; width: number } {
+  const el = new DOMParser().parseFromString(svg, 'image/svg+xml').documentElement
+  const width = parseSvgLength(el.getAttribute('width'))
+  const height = parseSvgLength(el.getAttribute('height'))
 
   if (width && height) {
     return { height, width }


### PR DESCRIPTION
## Problem

Clicking a rendered mermaid diagram in the desktop app to expand it opens a **blank dialog** (issue #82836). Two related failures:

1. **Blank overlay.** Mermaid renders its root `<svg>` with `width="100%"` plus an inline `style="max-width: Npx"` — i.e. **no pixel intrinsic size**. In the `Zoomable` expand viewer the svg sits inside `place-items-center` grid → shrink-to-fit item, so `width:100%` has no definite containing width to resolve against and the diagram collapses to nothing.
2. **Broken copy-as-PNG.** `svgSize()` did `parseFloat('100%')` → `100`, so the PNG canvas came out ~100px wide; the rasterization failed and `copySvgAsPng` fell back to writing the **raw SVG source text** to the clipboard.

## Fix

- **`src/lib/svg-image.ts`** — add `normalizeSvgSize()`: when the root svg's `width`/`height` are percentages, substitute the **pixel size from the viewBox** — the one size mermaid always emits. Done via a `DOMParser`/`XMLSerializer` round-trip (no string regex), and returns the input untouched when nothing needs substituting.
- **`svgSize()`** — treat percentage lengths as absent (fall back to viewBox) instead of `parseFloat`ing them to a bogus 100.
- **`src/components/assistant-ui/embeds/mermaid-embed.tsx`** — run the rendered svg through `normalizeSvgSize` before storing, so both the inline diagram and the expand overlay (and the copy path) see a real intrinsic size.

The inline `max-width` mermaid sets is preserved, so diagrams still scale down to fit their container; only the *intrinsic* size becomes concrete.

## Verification

- `normalizeSvgSize` and `svgSize` unit tests with real mermaid-11.16 output shape (8 tests).
- `Zoomable` open-overlay render test asserting the overlay svg carries an explicit pixel width (2 tests).
- Regression: dialog, chat-messages, alert suites — 62 tests pass.
- `tsc --noEmit` clean.

Closes #82836