### PR TITLE
fix(gateway): restart macOS launchd gateway fleet

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -97,6 +97,59 @@ class ProfileGatewayProcess:
     pid: int
 
 
+def _expected_launchd_gateway_labels() -> set[str]:
+    """Return exact launchd labels for the default and registered named profiles."""
+    base_label = "ai.hermes.gateway"
+    try:
+        from hermes_cli.profiles import list_profiles
+
+        return {
+            base_label if profile.is_default else f"{base_label}-{profile.name}"
+            for profile in list_profiles()
+        }
+    except (ImportError, OSError):
+        return {get_launchd_label()}
+
+
+def _list_launchd_gateway_services() -> list[tuple[str, str, int | None]]:
+    """Return loaded Hermes launchd labels, domains, and live PIDs."""
+    uid = os.getuid()  # windows-footgun: ok — macOS-only caller
+    domains = (f"gui/{uid}", f"user/{uid}")
+    services: list[tuple[str, str, int | None]] = []
+
+    for label in sorted(_expected_launchd_gateway_labels()):
+        for domain in domains:
+            try:
+                result = subprocess.run(
+                    ["launchctl", "print", f"{domain}/{label}"],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=5,
+                )
+            except subprocess.TimeoutExpired:
+                continue
+            except FileNotFoundError:
+                return []
+            if result.returncode != 0:
+                continue
+            services.append(
+                (label, domain, _parse_launchd_pid_from_list_output(result.stdout))
+            )
+    return services
+
+
+def get_launchd_gateway_services() -> list[tuple[str, str, int | None]]:
+    """Return loaded launchd gateway services as ``(label, domain, pid)``."""
+    return _list_launchd_gateway_services()
+
+
+def get_launchd_gateway_labels() -> list[str]:
+    """Return unique loaded launchd labels owned by Hermes gateway profiles."""
+    return list(dict.fromkeys(label for label, _domain, _pid in get_launchd_gateway_services()))
+
+
 def _get_service_pids() -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
 
@@ -146,33 +199,9 @@ def _get_service_pids() -> set:
 
     # --- launchd (macOS) ---
     if is_macos():
-        try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
-                timeout=5,
-            )
-            if result.returncode == 0:
-                # Try plist format first (macOS 26+): "PID" = <N>;
-                pid = _parse_launchd_pid_from_list_output(result.stdout)
-                if pid is not None and pid > 0:
-                    pids.add(pid)
-                else:
-                    # Fall back to legacy tab-separated format:
-                    # "PID\tStatus\tLabel"
-                    for line in result.stdout.strip().splitlines():
-                        parts = line.split()
-                        if len(parts) >= 3 and parts[2] == label:
-                            try:
-                                pid = int(parts[0])
-                                if pid > 0:
-                                    pids.add(pid)
-                            except ValueError:
-                                pass
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pass
+        for _label, _domain, pid in get_launchd_gateway_services():
+            if pid is not None and pid > 0:
+                pids.add(pid)
 
     return pids
 
@@ -1283,15 +1312,15 @@ def _parse_launchd_pid_from_list_output(output: str) -> int | None:
     """
     for line in output.splitlines():
         stripped = line.strip()
-        if stripped.startswith('"PID"') or stripped.startswith("PID"):
-            parts = stripped.split("=", 1)
-            if len(parts) == 2:
-                val = parts[1].strip().rstrip(";").strip('"')
-                try:
-                    pid = int(val)
-                    return pid if pid > 0 else None
-                except ValueError:
-                    return None
+        parts = stripped.split("=", 1)
+        key = parts[0].strip().strip('"').casefold()
+        if key == "pid" and len(parts) == 2:
+            val = parts[1].strip().rstrip(";").strip('"')
+            try:
+                pid = int(val)
+                return pid if pid > 0 else None
+            except ValueError:
+                return None
     return None
 
 
@@ -3713,12 +3742,12 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
-# Cached launchd domain result — probing is cheap but should only run once per
-# process invocation (each ``hermes gateway start/stop/status`` call).
-_resolved_launchd_domain: str | None = None
+# Cached launchd domain results, keyed by service label. Different profile
+# gateways can be loaded in different bootstrap domains (gui vs user).
+_resolved_launchd_domain: dict[str, str] | None = None
 
 
-def _launchd_domain() -> str:
+def _launchd_domain(label: str | None = None) -> str:
     """Return the launchd domain that actually manages the gateway service.
 
     Probes ``gui/<uid>`` first (Aqua sessions), then ``user/<uid>``
@@ -3731,11 +3760,14 @@ def _launchd_domain() -> str:
     See #40831, #23387.
     """
     global _resolved_launchd_domain
-    if _resolved_launchd_domain is not None:
-        return _resolved_launchd_domain
+    label = label or get_launchd_label()
+    if _resolved_launchd_domain is None:
+        _resolved_launchd_domain = {}
+    cached_domain = _resolved_launchd_domain.get(label)
+    if cached_domain is not None:
+        return cached_domain
 
     uid = os.getuid()  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
-    label = get_launchd_label()
     gui_domain = f"gui/{uid}"
     user_domain = f"user/{uid}"
 
@@ -3747,7 +3779,7 @@ def _launchd_domain() -> str:
             timeout=5,
             capture_output=True,
         )
-        _resolved_launchd_domain = gui_domain
+        _resolved_launchd_domain[label] = gui_domain
         return gui_domain
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
         pass
@@ -3760,7 +3792,7 @@ def _launchd_domain() -> str:
             timeout=5,
             capture_output=True,
         )
-        _resolved_launchd_domain = user_domain
+        _resolved_launchd_domain[label] = user_domain
         return user_domain
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
         pass
@@ -3775,14 +3807,14 @@ def _launchd_domain() -> str:
             timeout=5,
         )
         if "Aqua" in (result.stdout or ""):
-            _resolved_launchd_domain = gui_domain
+            _resolved_launchd_domain[label] = gui_domain
             return gui_domain
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
     # 4. Default to user/<uid> (matches the pre-probing behavior for
     #    Background/SSH sessions and is the recommended domain on macOS 26+).
-    _resolved_launchd_domain = user_domain
+    _resolved_launchd_domain[label] = user_domain
     return user_domain
 
 
@@ -4608,17 +4640,43 @@ def _wait_for_gateway_exit(
     return True
 
 
-def launchd_restart():
-    label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+def launchd_restart(
+    label: str | None = None,
+    *,
+    domain: str | None = None,
+    pid: int | None = None,
+):
+    explicit_label = label is not None
+    label = label or get_launchd_label()
+    domain = domain or _launchd_domain(label)
+    target = f"{domain}/{label}"
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
     try:
-        pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
+        if pid is None and explicit_label:
+            pid = next(
+                (
+                    service_pid
+                    for service_label, service_domain, service_pid in get_launchd_gateway_services()
+                    if service_label == label and service_domain == domain
+                ),
+                None,
+            )
+        elif pid is None:
+            pid = get_running_pid()
+        restart_requested = False
+        if pid is not None:
+            if explicit_label:
+                restart_requested = _graceful_restart_via_sigusr1(
+                    pid, drain_timeout
+                )
+            else:
+                restart_requested = _request_gateway_self_restart(pid)
+        if restart_requested:
             print("✓ Service restart requested")
-            _clear_launchd_unsupported_marker()
+            if not explicit_label:
+                _clear_launchd_unsupported_marker()
             return
         if pid is not None:
             # Announce the drain BEFORE waiting on it. This wait can run for
@@ -4636,26 +4694,36 @@ def launchd_restart():
             except (ProcessLookupError, PermissionError, OSError):
                 pid = None
             if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
+                if explicit_label:
+                    exited = _wait_for_pid_exit(pid, drain_timeout)
+                else:
+                    exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
                 if not exited:
                     print(
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
-        _clear_launchd_unsupported_marker()
+        if not explicit_label:
+            _clear_launchd_unsupported_marker()
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
             # Not a "job unloaded" code. If the domain is fundamentally
             # unmanageable (error 5), degrade to detached; the old process was
             # already drained/terminated above. Otherwise re-raise.
             if _launchctl_domain_unsupported(e.returncode):
+                if explicit_label:
+                    raise
                 _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
                 return
             raise
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
-        plist_path = get_launchd_plist_path()
+        plist_path = (
+            _launchd_user_home() / "Library" / "LaunchAgents" / f"{label}.plist"
+            if explicit_label
+            else get_launchd_plist_path()
+        )
         try:
             # Restart is the one path where the job is almost always still
             # registered (we just drained it), so a plain bootstrap would hit
@@ -4668,7 +4736,7 @@ def launchd_restart():
                 timeout=90,
             )
             subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+                ["launchctl", "bootstrap", domain, str(plist_path)],
                 check=True,
                 timeout=30,
             )
@@ -4676,10 +4744,13 @@ def launchd_restart():
         except subprocess.CalledProcessError as e2:
             if not _launchctl_domain_unsupported(e2.returncode):
                 raise
+            if explicit_label:
+                raise
             _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
             return
         print("✓ Service restarted")
-        _clear_launchd_unsupported_marker()
+        if not explicit_label:
+            _clear_launchd_unsupported_marker()
 
 
 def launchd_status(deep: bool = False):

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3475,6 +3475,27 @@ def _for_each_systemd_gateway_unit(
         except subprocess.TimeoutExpired as exc:
             on_unit_timeout(svc_name, exc)
 
+
+def _restart_launchd_gateway_fleet(
+    restarted_services: list[str], failed_units: list[str]
+) -> None:
+    """Restart every loaded Hermes launchd gateway, isolating per-label failures."""
+    from hermes_cli import gateway as gateway_cli
+
+    for label, domain, pid in gateway_cli.get_launchd_gateway_services():
+        target = f"{domain}/{label}"
+        try:
+            gateway_cli.launchd_restart(label, domain=domain, pid=pid)
+            restarted_services.append(target)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            failed_units.append(target)
+            detail = (getattr(exc, "stderr", "") or "").strip() or str(exc)
+            print(
+                f"  ⚠ Failed to restart {target}: {detail}; "
+                "continuing with remaining gateways"
+            )
+
+
 def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
     """Print an explicit incomplete-update warning for unrestarted units."""
     if not failed_units:
@@ -5511,30 +5532,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             # --- Launchd services (macOS) ---
             if is_macos():
-                try:
-                    from hermes_cli.gateway import (
-                        launchd_restart,
-                        get_launchd_label,
-                        get_launchd_plist_path,
-                    )
-
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
-                except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
-                    pass
+                _restart_launchd_gateway_fleet(
+                    restarted_services, failed_or_stale_units
+                )
 
             # --- Manual (non-service) gateways ---
             # Kill any remaining gateway processes not managed by a service.

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -1,0 +1,149 @@
+"""Regression coverage for macOS launchd gateway fleet restarts."""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import hermes_cli.gateway as gateway
+import hermes_cli.update_cmd as update_cmd
+
+
+def test_get_service_pids_includes_every_loaded_launchd_gateway(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        gateway,
+        "_expected_launchd_gateway_labels",
+        lambda: {"ai.hermes.gateway", "ai.hermes.gateway-roz-ops"},
+    )
+
+    monkeypatch.setattr(gateway.os, "getuid", lambda: 501)
+    calls: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        target = cmd[-1]
+        calls.append(target)
+        if target == "gui/501/ai.hermes.gateway":
+            return SimpleNamespace(returncode=0, stdout="pid = 101\n")
+        if target == "user/501/ai.hermes.gateway":
+            return SimpleNamespace(returncode=0, stdout="pid = 303\n")
+        if target == "user/501/ai.hermes.gateway-roz-ops":
+            return SimpleNamespace(returncode=0, stdout="pid = 202\n")
+        return SimpleNamespace(returncode=1, stdout="")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._get_service_pids() == {101, 202, 303}
+    assert "gui/501/ai.hermes.gateway" in calls
+    assert "user/501/ai.hermes.gateway" in calls
+    assert "user/501/ai.hermes.gateway-roz-ops" in calls
+    assert all("fleet-update-watch" not in target for target in calls)
+
+
+def test_launchd_domain_is_cached_per_gateway_label(monkeypatch):
+    gateway._resolved_launchd_domain = None
+    monkeypatch.setattr(gateway.os, "getuid", lambda: 501)
+    calls: list[str] = []
+
+    def fake_run(cmd, check=False, **kwargs):
+        target = cmd[-1]
+        calls.append(target)
+        if target in {
+            "gui/501/ai.hermes.gateway",
+            "user/501/ai.hermes.gateway-roz-ops",
+        }:
+            return SimpleNamespace(returncode=0, stdout="")
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._launchd_domain("ai.hermes.gateway") == "gui/501"
+    assert gateway._launchd_domain("ai.hermes.gateway-roz-ops") == "user/501"
+    assert "gui/501/ai.hermes.gateway-roz-ops" in calls
+    assert "user/501/ai.hermes.gateway-roz-ops" in calls
+
+
+def test_launchd_restart_uses_the_requested_labels_pid(monkeypatch):
+    monkeypatch.setattr(
+        gateway,
+        "_list_launchd_gateway_services",
+        lambda: [
+            ("ai.hermes.gateway", "gui/501", 101),
+            ("ai.hermes.gateway-roz-ops", "user/501", 202),
+        ],
+    )
+    monkeypatch.setattr(gateway, "_launchd_domain", lambda label=None: "gui/501")
+    requested: list[tuple[int, float]] = []
+    monkeypatch.setattr(gateway, "_get_restart_drain_timeout", lambda: 42.0)
+    monkeypatch.setattr(
+        gateway,
+        "_graceful_restart_via_sigusr1",
+        lambda pid, drain_timeout: requested.append((pid, drain_timeout)) or True,
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_request_gateway_self_restart",
+        lambda pid: (_ for _ in ()).throw(
+            AssertionError("explicit fleet restart must use the drain-aware path")
+        ),
+    )
+
+    gateway.launchd_restart(
+        "ai.hermes.gateway-roz-ops", domain="user/501", pid=202
+    )
+
+    assert requested == [(202, 42.0)]
+
+
+def test_restart_launchd_gateway_fleet_continues_after_one_failure(monkeypatch):
+    restart_fleet = getattr(update_cmd, "_restart_launchd_gateway_fleet", None)
+    assert callable(restart_fleet), "macOS update path needs a launchd fleet helper"
+
+    services = [
+        ("ai.hermes.gateway", "gui/501", 101),
+        ("ai.hermes.gateway", "user/501", 303),
+        ("ai.hermes.gateway-roz-ops", "gui/501", 202),
+    ]
+    attempted: list[tuple[str, str, int | None]] = []
+
+    monkeypatch.setattr(gateway, "get_launchd_gateway_services", lambda: services)
+
+    def fake_restart(label: str, *, domain: str, pid: int | None):
+        attempted.append((label, domain, pid))
+        if label == "ai.hermes.gateway" and domain == "user/501":
+            raise subprocess.TimeoutExpired(["launchctl", "kickstart", label], 5)
+
+    monkeypatch.setattr(gateway, "launchd_restart", fake_restart)
+
+    restarted: list[str] = []
+    failed: list[str] = []
+    restart_fleet(restarted, failed)
+
+    assert attempted == services
+    assert restarted == [
+        "gui/501/ai.hermes.gateway",
+        "gui/501/ai.hermes.gateway-roz-ops",
+    ]
+    assert failed == ["user/501/ai.hermes.gateway"]
+
+
+def test_restart_launchd_gateway_fleet_skips_when_none_are_loaded(monkeypatch):
+    restart_fleet = getattr(update_cmd, "_restart_launchd_gateway_fleet", None)
+    assert callable(restart_fleet), "macOS update path needs a launchd fleet helper"
+
+    monkeypatch.setattr(gateway, "get_launchd_gateway_services", lambda: [])
+    monkeypatch.setattr(
+        gateway,
+        "launchd_restart",
+        lambda label=None, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not restart")
+        ),
+    )
+
+    restarted: list[str] = []
+    failed: list[str] = []
+    restart_fleet(restarted, failed)
+
+    assert restarted == []
+    assert failed == []


### PR DESCRIPTION
## What changed

- discover every loaded macOS launchd gateway for the default and registered named profiles by probing both `gui/<uid>` and `user/<uid>`
- preserve `(domain, label, PID)` identity so duplicate labels loaded in both domains are restarted independently
- drain each exact gateway PID with SIGUSR1 before launchd fallback restart
- restart each loaded gateway after a successful `hermes update`, preserving the existing drain-aware restart path
- key launchd domain detection by service label so profile gateways split across `gui/<uid>` and `user/<uid>` restart correctly
- include every launchd-managed gateway PID in service-process classification so the manual fallback does not race launchd
- isolate per-label failures and surface an incomplete-update warning while continuing through the fleet

## Why

On macOS, the updater previously restarted only the active profile's launchd label. Named-profile gateways could remain alive across a shared-checkout update and retain stale modules while new imports came from disk, causing mixed-generation `ImportError` failures. The later manual sweep also only recognized the active launchd PID as service-owned, so it could treat named launchd gateways as manual processes.

## How to test

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_update_launchd_fleet_restart.py \
  tests/hermes_cli/test_gateway_service.py \
  tests/hermes_cli/test_update_fleet_restart_timeout.py \
  tests/hermes_cli/test_gateway_external_supervisor.py \
  tests/test_code_skew.py \
  tests/test_stale_utils_module_import.py \
  -q -o 'addopts='
```

Result on macOS: `98 passed, 1 skipped` (the skipped test is Linux-only).

Additional checks:

```bash
uv run --extra dev ruff check hermes_cli/gateway.py hermes_cli/update_cmd.py tests/hermes_cli/test_update_launchd_fleet_restart.py
python -m py_compile hermes_cli/gateway.py hermes_cli/update_cmd.py tests/hermes_cli/test_update_launchd_fleet_restart.py
git diff --cached --check
```

All passed.

## Platform tested

- macOS 26.6
- live read-only `launchctl print` discovery with the default gateway and two named-profile gateways loaded
