### PR TITLE
fix(desktop): show /model in slash-command autocomplete

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -204,7 +204,7 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   },
 
   // Overlay pickers
-  { name: '/model', description: 'Switch the model for this session', surface: picker('model'), hidden: true },
+  { name: '/model', description: 'Switch the model for this session', surface: picker('model') },
   {
     name: '/resume',
     description: 'Resume a saved session',


### PR DESCRIPTION
## Summary

Fixes #82929 — the `/model` command was hidden from the desktop slash-command autocomplete dropdown because it was marked `hidden: true` in `DESKTOP_COMMAND_SPECS`.

## Root cause

In `apps/desktop/src/lib/desktop-slash-commands.ts`, the `/model` command spec had `hidden: true`. The filter at line 458 (`!spec.hidden`) excluded it from the autocomplete suggestions. The command itself worked when typed manually — only the dropdown listing was affected.

## Fix

Removed the `hidden: true` flag from the `/model` command spec. Selecting it opens the model picker overlay as before.

## Notes

Other commands mentioned in the issue (`/config`, `/verbose`, `/statusbar`) are intentionally CLI-only — they live in `NO_DESKTOP_SURFACE` under the `terminal` category and have no desktop surface implementation. They remain excluded.