### PR TITLE
fix(desktop): account for devicePixelRatio in pet sprite canvas

### DIFF
--- a/apps/desktop/src/components/pet/pet-sprite.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.tsx
@@ -148,6 +148,7 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUn
 
   const drawW = Math.round(frameW * scale)
   const drawH = Math.round(frameH * scale)
+  const dpr = Math.min(window.devicePixelRatio || 1, 2)
 
   const image = useMemo(() => {
     if (!info.spritesheetBase64) {
@@ -175,6 +176,8 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUn
     if (!ctx) {
       return
     }
+
+    ctx.scale(dpr, dpr)
 
     // Track state via subscription, not a prop — no re-render on activity ticks.
     stateRef.current = $petState.get()
@@ -353,15 +356,15 @@ function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUn
       pauseController?.dispose()
       unsubState()
     }
-  }, [image, frameW, frameH, frames, framesByState, framesByRow, loopMs, drawW, drawH, rows, pauseWhenUnfocused])
+  }, [image, frameW, frameH, frames, framesByState, framesByRow, loopMs, drawW, drawH, dpr, rows, pauseWhenUnfocused])
 
   return (
     <canvas
       aria-label={info.displayName ? `${info.displayName} pet` : 'pet'}
-      height={drawH}
+      height={drawH * dpr}
       ref={canvasRef}
       style={{ height: drawH, width: drawW }}
-      width={drawW}
+      width={drawW * dpr}
     />
   )
 }


### PR DESCRIPTION
## Summary

Fixes #83216 — the pet sprite canvas rendered at CSS-size resolution without accounting for `devicePixelRatio`, causing blurry rendering on Retina and other high-DPI displays.

## Root cause

In `apps/desktop/src/components/pet/pet-sprite.tsx`, the `<canvas>` element used `drawW × drawH` for both the internal resolution and CSS layout size. On Retina displays (devicePixelRatio ≥ 2), this meant the canvas had half the pixels needed for crisp rendering.

## Fix

- Added `const dpr = Math.min(window.devicePixelRatio || 1, 2)` (capped at 2 to avoid excessive memory on 3x displays)
- Canvas backing store dimensions: `drawW * dpr × drawH * dpr`
- CSS layout dimensions unchanged: `drawW × drawH`
- Applied `ctx.scale(dpr, dpr)` so existing drawImage coordinates work without changes
- Added `dpr` to the useEffect dependency array