### PR TITLE
fix(auth): tolerate legacy Codex suppression data

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1715,11 +1715,29 @@ def write_credential_pool(
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:
-    """Mark a credential source as suppressed so it won't be re-seeded."""
+    """Mark a credential source as suppressed so it won't be re-seeded.
+
+    Older auth stores may represent a provider's suppressed sources as a
+    mapping.  Treat its keys as source names and migrate the value to the
+    canonical list form before appending the requested source.
+    """
     with _auth_store_lock():
         auth_store = _load_auth_store()
-        suppressed = auth_store.setdefault("suppressed_sources", {})
-        provider_list = suppressed.setdefault(provider_id, [])
+        suppressed = auth_store.get("suppressed_sources")
+        if not isinstance(suppressed, dict):
+            suppressed = {}
+            auth_store["suppressed_sources"] = suppressed
+
+        raw_sources = suppressed.get(provider_id)
+        if isinstance(raw_sources, list):
+            provider_list = raw_sources
+        elif isinstance(raw_sources, dict):
+            provider_list = [str(name) for name in raw_sources]
+            suppressed[provider_id] = provider_list
+        else:
+            provider_list = []
+            suppressed[provider_id] = provider_list
+
         if source not in provider_list:
             provider_list.append(source)
         _save_auth_store(auth_store)
@@ -1745,8 +1763,15 @@ def unsuppress_credential_source(provider_id: str, source: str) -> bool:
         suppressed = auth_store.get("suppressed_sources")
         if not isinstance(suppressed, dict):
             return False
-        provider_list = suppressed.get(provider_id)
-        if not isinstance(provider_list, list) or source not in provider_list:
+        raw_sources = suppressed.get(provider_id)
+        if isinstance(raw_sources, dict):
+            provider_list = [str(name) for name in raw_sources]
+            suppressed[provider_id] = provider_list
+        elif isinstance(raw_sources, list):
+            provider_list = raw_sources
+        else:
+            return False
+        if source not in provider_list:
             return False
         provider_list.remove(source)
         if not provider_list:

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -521,6 +521,36 @@ def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     assert entries[0]["priority"] == 0
 
 
+def test_auth_remove_codex_migrates_legacy_dict_suppression(tmp_path, monkeypatch):
+    """Removing a Codex credential must tolerate legacy dict suppression data."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    store = _codex_pool_only_store()
+    primary = store["credential_pool"]["openai-codex"][0]
+    primary.update({"id": "codex-qb", "label": "qb"})
+    store["suppressed_sources"] = {"openai-codex": {"legacy": True}}
+    _write_auth_store(tmp_path, store)
+
+    from hermes_cli.auth_commands import auth_remove_command
+
+    class _Args:
+        provider = "openai-codex"
+        target = "qb"
+
+    auth_remove_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text(encoding="utf-8"))
+    assert payload.get("credential_pool", {}).get("openai-codex", []) == []
+    assert payload["suppressed_sources"]["openai-codex"] == [
+        "legacy",
+        "device_code",
+        "manual:device_code",
+    ]
+
+    from agent.credential_pool import load_pool
+
+    assert load_pool("openai-codex").peek() is None
+
+
 def test_clear_provider_auth_removes_provider_pool_entries(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(


### PR DESCRIPTION
## What does this PR do?

Makes `hermes auth remove openai-codex ...` tolerant of legacy auth stores where `suppressed_sources[provider]` is a mapping rather than the current list format.

The affected code now migrates mapping keys into the canonical list before suppressing or unsuppressing a source. This preserves existing suppression markers and prevents credential removal from crashing with `AttributeError: 'dict' object has no attribute 'append'`.

Supersedes #80581, whose `feat/oauth-profile-switching` branch has stale, mixed history. This replacement is a single current-main-based `fix/` commit.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py`: normalize legacy mapping-shaped provider suppression state in both `suppress_credential_source` and `unsuppress_credential_source`.
- `tests/hermes_cli/test_auth_commands.py`: add a regression test for removing a Codex credential from a legacy store.

## How to Test

1. Reproduce the failure by applying only the regression test to current `origin/main`:
   ```text
   18 passed, 1 failed
   AttributeError: 'dict' object has no attribute 'append'
   ```
2. Run the auth-command test module with this fix:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py -q
   ```
   Result: `19 passed`.
3. Exercise the actual CLI against a disposable `HERMES_HOME` containing fake Codex credential data and legacy suppression state:
   ```bash
   hermes auth remove openai-codex qb
   ```
   Result: credential removal completed and persisted the canonical suppression list:
   ```text
   ["legacy", "device_code", "manual:device_code"]
   ```
4. Full-suite note:
   ```bash
   scripts/run_tests.sh
   ```
   This auth code was included in a full-suite run that failed only in unrelated modules. The failing-file set was then rerun on untouched `origin/main`, reproducing 20 failures across 10 files plus a 300-second timeout in `tests/cli/test_worktree.py`. The changed auth module and its test do not appear in the failure set.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Blocked by pre-existing upstream failures documented above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 13.7.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression result:

```text
18 passed, 1 failed before the production change
19 passed, 0 failed after the production change
```

The Windows checker reports 12 existing bare-encoding calls elsewhere in `tests/hermes_cli/test_auth_commands.py`; this diff adds none and its new file read uses `encoding="utf-8"`.
