### PR TITLE
fix(packaging): ship bundled plugin manifests (#82916)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -408,6 +408,10 @@ hermes_cli = ["observability/schemas/*.json"]
 # topic-setup image disappears. Loaded via Path(__file__).parent / "assets"
 # in gateway/status_phrases.py and gateway/run.py.
 gateway = ["assets/**/*"]
+# Bundled plugin discovery reads these manifests at runtime. Keep them in
+# sealed wheels with the plugin Python modules; without this declaration the
+# wheel contains adapters but discovery finds zero bundled plugins.
+plugins = ["**/plugin.yaml", "**/plugin.yml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_packaging_build_guard.py
+++ b/tests/test_packaging_build_guard.py
@@ -3,6 +3,8 @@
 import os
 import subprocess
 import sys
+import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -69,4 +71,26 @@ def test_artifact_build_allows_explicit_nix_package_build_marker(kind, artifact_
     result = _build_artifact(kind, tmp_path, nix_build=True)
 
     assert result.returncode == 0, result.stderr
-    assert list(tmp_path.glob(artifact_glob))
+    artifacts = list(tmp_path.glob(artifact_glob))
+    assert artifacts
+
+    expected = {
+        path.relative_to(PROJECT_ROOT).as_posix()
+        for pattern in ("plugin.yaml", "plugin.yml")
+        for path in (PROJECT_ROOT / "plugins").rglob(pattern)
+    }
+    assert expected, "expected bundled plugin manifests under plugins/"
+
+    if kind == "wheel":
+        with zipfile.ZipFile(artifacts[0]) as wheel:
+            shipped = set(wheel.namelist())
+    else:
+        with tarfile.open(artifacts[0]) as sdist:
+            shipped = {
+                name.split("/", 1)[1]
+                for name in sdist.getnames()
+                if "/" in name
+            }
+
+    missing = sorted(expected - shipped)
+    assert not missing, f"{kind} omits bundled plugin manifests: {missing}"

--- a/tests/test_packaging_build_guard.py
+++ b/tests/test_packaging_build_guard.py
@@ -55,6 +55,17 @@ def _build_artifact(kind: str, tmp_path, *, nix_build: bool) -> subprocess.Compl
     )
 
 
+@pytest.fixture(scope="module")
+def built_wheel(tmp_path_factory) -> Path:
+    artifact_dir = tmp_path_factory.mktemp("packaging-wheel")
+    result = _build_artifact("wheel", artifact_dir, nix_build=True)
+
+    assert result.returncode == 0, result.stderr
+    wheels = list(artifact_dir.glob("hermes_agent-*.whl"))
+    assert len(wheels) == 1
+    return wheels[0]
+
+
 @pytest.mark.parametrize("kind", ["sdist", "wheel"])
 def test_artifact_build_rejects_nix_development_shell_environment(kind, tmp_path):
     result = _build_artifact(kind, tmp_path, nix_build=False)
@@ -94,3 +105,30 @@ def test_artifact_build_allows_explicit_nix_package_build_marker(kind, artifact_
 
     missing = sorted(expected - shipped)
     assert not missing, f"{kind} omits bundled plugin manifests: {missing}"
+
+
+def test_packaged_platform_manifests_remain_discoverable(built_wheel, tmp_path):
+    install_root = tmp_path / "installed"
+    with zipfile.ZipFile(built_wheel) as wheel:
+        wheel.extractall(install_root)
+
+    from hermes_cli.plugins import PluginManager
+
+    manager = PluginManager()
+    manifests = manager._scan_directory(
+        install_root / "plugins" / "platforms",
+        source="bundled",
+    )
+    discovered = {
+        manager._platform_name_from_manifest(manifest)
+        for manifest in manifests
+        if manifest.kind == "platform"
+    }
+    expected = {
+        path.parent.name
+        for pattern in ("plugin.yaml", "plugin.yml")
+        for path in (PROJECT_ROOT / "plugins" / "platforms").glob(f"*/{pattern}")
+    }
+
+    assert expected <= discovered
+    assert "feishu" in discovered


### PR DESCRIPTION
## Summary

Extends #82977 with a test for manifest discovery.

- Package all bundled plugin manifests in wheel and sdist builds.
- Preserve deferred platform registration and lazy optional SDK loading.
- Add extracted-wheel coverage proving bundled platform and Feishu discovery.

## Test plan

- 54 focused packaging, metadata, and plugin tests
- 1 Feishu platform registry test
- `py_compile` and `git diff --check`
- CodeRabbit committed review: no findings

Closes #82916
