### PR TITLE
fix(mcp): propagate login timeout to transport

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -307,6 +307,16 @@ def _probe_single_server(
         except (TypeError, ValueError):
             connect_timeout = 30.0
 
+    # The override must reach both timeout layers.  asyncio.wait_for below
+    # bounds the overall probe, while MCPServerTask reads connect_timeout from
+    # its config to bound the HTTP client and initialize handshake.  Passing a
+    # longer timeout only to wait_for caused explicit OAuth logins to cancel
+    # the live HTTP request at the server's shorter configured timeout, then
+    # reconnect into a second browser flow while the first callback listener
+    # still owned its port.
+    config = dict(config)
+    config["connect_timeout"] = connect_timeout
+
     _ensure_mcp_loop()
     tools_found: List[Tuple[str, str]] = []
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -528,6 +528,37 @@ class TestProbeEnvResolution:
         assert tools == [("do_thing", "a tool")]
         assert seen["config"]["headers"]["Authorization"] == "Bearer jwt-token-xyz"
 
+    def test_probe_timeout_override_reaches_transport(self, monkeypatch):
+        """OAuth login timeout must replace the transport's shorter timeout."""
+        import hermes_cli.mcp_config as mc
+
+        seen = {}
+
+        class _FakeServer:
+            _tools = []
+
+            async def shutdown(self):
+                return None
+
+        async def _fake_connect(name, config):
+            seen["config"] = config
+            return _FakeServer()
+
+        monkeypatch.setattr("tools.mcp_tool._connect_server", _fake_connect)
+        original = {
+            "url": "https://mcp.example.com/mcp",
+            "connect_timeout": 10,
+        }
+
+        mc._probe_single_server(
+            "oauth-server",
+            original,
+            connect_timeout=315,
+        )
+
+        assert seen["config"]["connect_timeout"] == 315
+        assert original["connect_timeout"] == 10
+
 
 class TestProbeCapabilityGating:
     """The ``details`` probe must not fire prompts/list or resources/list at


### PR DESCRIPTION
## Summary

- propagate the explicit probe timeout into the MCP server config
- keep the outer probe deadline and the HTTP/initialize timeout aligned
- add a regression test that verifies the override reaches the connection layer without mutating the caller config

## Why

The MCP login command raises the outer probe timeout to 315 seconds for interactive OAuth, but the underlying HTTP transport continued using the server's shorter configured timeout. With a 10-second transport timeout, the first browser flow was cancelled and a reconnect started a second flow while the first callback listener still held its port, ending with an OAuth callback port already in use error.

## Validation

- uv run --frozen --extra dev pytest -q tests/hermes_cli/test_mcp_config.py — 39 passed
- uv run --frozen --extra dev ruff check hermes_cli/mcp_config.py tests/hermes_cli/test_mcp_config.py
