### PR TITLE
fix(image-gen): use Path comparison in Krea test, update upscale docs

### DIFF
--- a/tests/plugins/image_gen/test_krea_provider.py
+++ b/tests/plugins/image_gen/test_krea_provider.py
@@ -166,7 +166,7 @@ class TestGenerate:
             result = KreaImageGenProvider().generate(prompt="A cinematic lamp", upscale=False)
 
         assert result["success"] is True
-        assert result["image"] == "/tmp/krea_krea-2-medium_test.png"
+        assert Path(result["image"]) == Path("/tmp/krea_krea-2-medium_test.png")
         assert result["provider"] == "krea"
         assert result["model"] == "krea-2-medium"
         assert result["aspect_ratio"] == "landscape"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -13,8 +13,9 @@ Architecture:
   aspect_ratio) into the model-specific payload and filters to the
   ``supports`` whitelist so models never receive rejected keys.
 - Upscaling via FAL's Clarity Upscaler is gated per-model via the ``upscale``
-  flag — on for FLUX 2 Pro (backward-compat), off for all faster/newer models
-  where upscaling would either hurt latency or add marginal quality.
+  flag — default-on for most models (including sub-2MP variants) where the
+  quality benefit outweighs the latency cost, off for a small set of models
+  where it would add marginal quality.
 
 Pricing shown in UI strings is as-of the initial commit; we accept drift and
 update when it's noticed.


### PR DESCRIPTION
## Summary

Fixes #82683 — two related issues in the image generation module.

### 1. Krea test: platform-dependent path comparison

`tests/plugins/image_gen/test_krea_provider.py` compared `result[image]` directly against a hardcoded POSIX path string. On Windows, the provider returns the same path with native backslash separators, causing a false test failure even though the generation succeeded.

**Fix:** Compare paths using `pathlib.Path` objects so the assertion works on any platform:
```python
assert Path(result[image]) == Path(/tmp/krea_krea-2-medium_test.png)
```

### 2. Stale upscale policy docs

The module docstring in `tools/image_generation_tool.py` described the older policy where only FLUX 2 Pro had upscale enabled. The catalog now defaults upscale to on for most models (including sub-2MP variants).

**Fix:** Updated the docstring to reflect the current default-on policy.