### PR TITLE
docs(whatsapp): mark Phase 5 as planned, link template tracking issue

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -22,7 +22,7 @@ Phase scope (this file evolves across phases):
             media download via the Graph media endpoint, voice-note opus
             conversion via ffmpeg with graceful MP3 fallback when ffmpeg
             isn't on PATH. Document text injection for readable types.
-- Phase 5 — 24-hour conversation window + template fallback.
+- Phase 5 — (planned) 24-hour conversation window + template fallback.
 
 Required env vars to enable the adapter:
 - WHATSAPP_CLOUD_PHONE_NUMBER_ID  (the Graph URL path component)

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -309,7 +309,7 @@ Meta only allows **free-form messages** within a 24-hour window after the user's
 
 Hermes warns the agent about this window in its system prompt, so the model knows to mention it when scheduling delayed messages.
 
-Message-template support (the workaround for outside-window sends) is not yet implemented in Hermes. If you need it, please [open an issue](https://github.com/NousResearch/hermes-agent/issues) — it's planned but waiting on a clear demand signal.
+Message-template support (the workaround for outside-window sends) is not yet implemented in Hermes. If you need it, please [open an issue](https://github.com/NousResearch/hermes-agent/issues) — it's planned and tracked in [#45935](https://github.com/NousResearch/hermes-agent/issues/45935).
 
 ### Group chats
 


### PR DESCRIPTION
Fixes #80075. Two changes: (1) mark Phase 5 as (planned) in source docstring, (2) link #45935 in website docs instead of claiming no demand signal.