### PR TITLE
docs(whatsapp): add italic row to markdown conversion table

### DIFF
--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -202,6 +202,7 @@ Standard Markdown in AI responses is automatically converted to WhatsApp's nativ
 | Markdown | WhatsApp | Renders as |
 |----------|----------|------------|
 | `**bold**` | `*bold*` | **bold** |
+| `*italic*` | `_italic_` | *italic* |
 | `~~strikethrough~~` | `~strikethrough~` | ~~strikethrough~~ |
 | `# Heading` | `*Heading*` | Bold text (no native headings) |
 | `[link text](url)` | `link text (url)` | Inline URL |


### PR DESCRIPTION
Fixes #80067 — the whatsapp_common.py converter supports *italic* → _italic_ but the docs table didn't list it. Added the missing row.