### PR TITLE
docs(whatsapp): soften read-receipt wording

### DIFF
--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -267,7 +267,7 @@ All interactive prompts gracefully degrade to plain text if the buttons fail to 
 
 Hermes acknowledges inbound messages immediately:
 
-- Your message shows **blue double-checkmarks** as soon as the gateway receives it.
+- Your message shows **blue double-checkmarks** when the gateway marks your message as read.
 - The bot's name in your WhatsApp chat shows **"typing…"** while the agent is preparing a reply.
 - The typing indicator auto-dismisses when the bot's first response message arrives.
 


### PR DESCRIPTION
Fixes #80057 — changed wording to reflect that blue checks appear when the gateway marks the message as read, not instantly on receipt.