### PR TITLE
Harden gateway runtime cutover preflight

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # A recursively tokenized malformed/binary payload can contain a NUL.
+        # Treat it like any unreadable reference; lifecycle scanning must not
+        # crash the caller while examining an unrelated command.
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2834,6 +2834,21 @@ def _append_node_dir_for_service(
         path_entries.append(resolved_node_dir)
 
 
+def _systemd_runtime_preflight_command(python_path: str, venv_dir: str) -> str:
+    """Build the stdlib-only preflight executed before the gateway launcher.
+
+    This is deliberately a script path rather than ``python -m hermes_cli``:
+    an editable-install finder can itself be the broken component, so the guard
+    must be able to report and block that state before importing Hermes.
+    """
+    runtime_root = Path(venv_dir).parent
+    script = runtime_root / "scripts" / "runtime_preflight.py"
+    return (
+        f"ExecStartPre={python_path} {script} "
+        f"--runtime-root {runtime_root} --venv-root {venv_dir}"
+    )
+
+
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
     python_path = get_python_path()
     working_dir = _stable_service_working_dir()
@@ -2894,16 +2909,19 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         path_entries.extend(_build_wsl_interop_paths(path_entries))
         path_entries.extend(common_bin_paths)
         sane_path = ":".join(path_entries)
+        runtime_preflight = _systemd_runtime_preflight_command(python_path, venv_dir)
         return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=0
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type={systemd_type}
 {systemd_watchdog_directives}User={username}
 Group={group_name}
+{runtime_preflight}
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
@@ -2937,15 +2955,18 @@ WantedBy=multi-user.target
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)
     sane_path = ":".join(path_entries)
+    runtime_preflight = _systemd_runtime_preflight_command(python_path, venv_dir)
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=0
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type={systemd_type}
-{systemd_watchdog_directives}ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
+{systemd_watchdog_directives}{runtime_preflight}
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"

--- a/scripts/runtime_preflight.py
+++ b/scripts/runtime_preflight.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Validate a gateway runtime before a supervisor starts Hermes.
+
+This script deliberately uses only the standard library and is invoked by the
+systemd unit as a file, rather than through the editable Hermes package. That
+lets it diagnose a stale editable-install finder before importing Hermes would
+fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata as metadata
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from urllib.parse import unquote, urlparse
+
+
+class RuntimePreflightError(RuntimeError):
+    """A structural runtime problem that must block gateway startup."""
+
+
+def _under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _text_contains(path: Path, needle: str) -> bool:
+    try:
+        return needle in path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+
+def find_forbidden_references(
+    venv_root: Path,
+    forbidden_roots: tuple[Path, ...],
+    extra_paths: tuple[Path, ...] = (),
+) -> list[Path]:
+    """Return runtime metadata/scripts that retain a forbidden source path."""
+    roots = [venv_root / "bin", venv_root / "Scripts", venv_root / "lib", *extra_paths]
+    matches: list[Path] = []
+    needles = tuple(str(path.resolve()) for path in forbidden_roots)
+    for root in roots:
+        paths = root.rglob("*") if root.is_dir() else (root,)
+        for path in paths:
+            if not path.is_file():
+                continue
+            if (
+                root == venv_root / "lib"
+                and path.name != "direct_url.json"
+                and path.suffix not in {".pth", ".py"}
+            ):
+                continue
+            if any(_text_contains(path, needle) for needle in needles):
+                matches.append(path)
+    return matches
+
+
+def validate_console_scripts(venv_root: Path) -> None:
+    """Reject console scripts whose Python shebang still names another venv."""
+    scripts_dir = venv_root / ("Scripts" if os.name == "nt" else "bin")
+    if not scripts_dir.is_dir():
+        raise RuntimePreflightError("virtualenv scripts directory is missing")
+    expected = str(scripts_dir.resolve())
+    stale: list[Path] = []
+    for path in scripts_dir.iterdir():
+        if not path.is_file():
+            continue
+        try:
+            with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                first_line = handle.readline().strip()
+        except OSError:
+            continue
+        if not first_line.startswith("#!") or "python" not in first_line.lower():
+            continue
+        if first_line.startswith("#!/usr/bin/env "):
+            continue  # explicitly relocatable form
+        if expected not in first_line:
+            stale.append(path)
+    if stale:
+        raise RuntimePreflightError(
+            "console-script shebang does not target this virtualenv: "
+            + ", ".join(map(str, stale[:5]))
+        )
+
+
+def validate_hermes_direct_url(runtime_root: Path, venv_root: Path) -> None:
+    """Require Hermes editable metadata to point at the selected runtime root."""
+    direct_urls = list(
+        (venv_root / "lib").glob(
+            "python*/site-packages/hermes_agent-*.dist-info/direct_url.json"
+        )
+    )
+    if not direct_urls:
+        raise RuntimePreflightError(
+            "Hermes editable-install direct_url.json is missing"
+        )
+    for direct_url in direct_urls:
+        try:
+            payload = json.loads(direct_url.read_text(encoding="utf-8"))
+            source = Path(unquote(urlparse(str(payload.get("url", ""))).path)).resolve()
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise RuntimePreflightError(
+                f"invalid Hermes editable-install metadata: {direct_url}"
+            ) from exc
+        if source != runtime_root.resolve():
+            raise RuntimePreflightError(
+                f"Hermes editable-install source is not the selected runtime: {direct_url}"
+            )
+
+
+def validate_imports(runtime_root: Path, service_workdir: Path) -> None:
+    """Import the gateway's core modules from the real service working directory."""
+    probe = """
+import importlib
+import importlib.metadata as metadata
+import json
+mods = ('hermes_cli', 'gateway', 'gateway.cgroup_cleanup')
+origins = {name: importlib.import_module(name).__file__ for name in mods}
+print(json.dumps({'origins': origins, 'version': metadata.version('hermes-agent')}))
+"""
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    env.pop("PYTHONHOME", None)
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            cwd=service_workdir,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+        payload = json.loads(result.stdout) if result.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        raise RuntimePreflightError("could not execute core import probe") from exc
+    if not payload:
+        raise RuntimePreflightError("core import probe failed")
+    for name, origin in payload["origins"].items():
+        if not origin or not _under(Path(origin), runtime_root):
+            raise RuntimePreflightError(f"{name} resolves outside the selected runtime")
+
+
+def validate_runtime(
+    runtime_root: Path,
+    venv_root: Path,
+    service_workdir: Path,
+    forbidden_roots: tuple[Path, ...],
+    extra_paths: tuple[Path, ...],
+) -> None:
+    if not runtime_root.is_dir() or not venv_root.is_dir():
+        raise RuntimePreflightError("runtime root or virtualenv is missing")
+    stale = find_forbidden_references(venv_root, forbidden_roots, extra_paths)
+    if stale:
+        raise RuntimePreflightError(
+            "forbidden runtime reference: " + ", ".join(map(str, stale[:5]))
+        )
+    validate_console_scripts(venv_root)
+    validate_hermes_direct_url(runtime_root, venv_root)
+    validate_imports(runtime_root, service_workdir)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime-root", type=Path, required=True)
+    parser.add_argument("--venv-root", type=Path, required=True)
+    parser.add_argument("--service-workdir", type=Path, default=Path.cwd())
+    parser.add_argument("--forbid-path", type=Path, action="append", default=[])
+    parser.add_argument("--extra-path", type=Path, action="append", default=[])
+    args = parser.parse_args(argv)
+    try:
+        validate_runtime(
+            args.runtime_root,
+            args.venv_root,
+            args.service_workdir,
+            tuple(args.forbid_path),
+            tuple(args.extra_path),
+        )
+    except RuntimePreflightError as exc:
+        print(f"runtime preflight failed: {exc}", file=sys.stderr)
+        return 1
+    print("runtime preflight passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,15 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_malformed_referenced_path_does_not_crash_guard(self, monkeypatch):
+        from cron import lifecycle_guard
+
+        monkeypatch.setattr(lifecycle_guard.os, "open", lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("embedded null byte")))
+        text, unsafe = lifecycle_guard._read_referenced_script(lifecycle_guard.Path("malformed"))
+
+        assert text is None
+        assert unsafe is False
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -641,6 +641,17 @@ class TestSystemUnitHermesHome:
         hermes_home = str(gateway_cli.get_hermes_home().resolve())
         assert f'HERMES_HOME={hermes_home}' in unit
 
+    @pytest.mark.parametrize("system", [False, True])
+    def test_generated_unit_blocks_broken_runtime_before_gateway_start(self, system):
+        unit = gateway_cli.generate_systemd_unit(system=system)
+
+        assert "StartLimitIntervalSec=300" in unit
+        assert "StartLimitBurst=5" in unit
+        assert "scripts/runtime_preflight.py" in unit
+        assert "--runtime-root" in unit
+        assert "--venv-root" in unit
+        assert unit.index("ExecStartPre=") < unit.index("ExecStart=")
+
 
 class TestSystemUnitRefreshSyncsHermesHome:
     """sudo system refresh must not flip TimeoutStopSec via /root/.hermes."""

--- a/tests/scripts/test_runtime_preflight.py
+++ b/tests/scripts/test_runtime_preflight.py
@@ -1,0 +1,99 @@
+"""Regression coverage for the standalone gateway runtime preflight."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def runtime_preflight():
+    path = Path(__file__).parents[2] / "scripts" / "runtime_preflight.py"
+    spec = importlib.util.spec_from_file_location("runtime_preflight", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _venv(tmp_path: Path) -> Path:
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (
+        venv / "lib" / "python3.11" / "site-packages" / "hermes_agent-0.20.0.dist-info"
+    ).mkdir(parents=True)
+    return venv
+
+
+def _hermes_direct_url(venv: Path) -> Path:
+    return (
+        venv
+        / "lib"
+        / "python3.11"
+        / "site-packages"
+        / "hermes_agent-0.20.0.dist-info"
+        / "direct_url.json"
+    )
+
+
+def test_rejects_staging_reference_in_editable_finder(runtime_preflight, tmp_path):
+    venv = _venv(tmp_path)
+    finder = (
+        venv
+        / "lib"
+        / "python3.11"
+        / "site-packages"
+        / "__editable___hermes_agent_finder.py"
+    )
+    finder.write_text(
+        "MAPPING = {'hermes_cli': '/tmp/stage/hermes_cli'}\n", encoding="utf-8"
+    )
+
+    matches = runtime_preflight.find_forbidden_references(venv, (Path("/tmp/stage"),))
+
+    assert matches == [finder]
+
+
+def test_rejects_moved_console_script_shebang(runtime_preflight, tmp_path):
+    venv = _venv(tmp_path)
+    stale = venv / "bin" / "uvicorn"
+    stale.write_text("#!/tmp/stage/venv/bin/python\n", encoding="utf-8")
+
+    with pytest.raises(runtime_preflight.RuntimePreflightError, match="uvicorn"):
+        runtime_preflight.validate_console_scripts(venv)
+
+
+def test_accepts_permanent_or_relocatable_console_scripts(runtime_preflight, tmp_path):
+    venv = _venv(tmp_path)
+    permanent = venv / "bin" / "hermes"
+    permanent.write_text(f"#!{venv / 'bin' / 'python'}\n", encoding="utf-8")
+    relocatable = venv / "bin" / "tool"
+    relocatable.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+
+    runtime_preflight.validate_console_scripts(venv)
+
+
+def test_rejects_direct_url_for_a_deleted_staging_checkout(runtime_preflight, tmp_path):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    venv = _venv(tmp_path)
+    direct_url = _hermes_direct_url(venv)
+    direct_url.write_text(json.dumps({"url": "file:///tmp/stage"}), encoding="utf-8")
+
+    with pytest.raises(
+        runtime_preflight.RuntimePreflightError, match="selected runtime"
+    ):
+        runtime_preflight.validate_hermes_direct_url(runtime, venv)
+
+
+def test_direct_url_accepts_the_selected_runtime(runtime_preflight, tmp_path):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    venv = _venv(tmp_path)
+    direct_url = _hermes_direct_url(venv)
+    direct_url.write_text(json.dumps({"url": runtime.as_uri()}), encoding="utf-8")
+
+    runtime_preflight.validate_hermes_direct_url(runtime, venv)


### PR DESCRIPTION
## Summary
- generate finite systemd start limiting (five starts per five minutes) instead of an unlimited restart storm
- run a standard-library, standalone runtime preflight before the gateway launcher so stale editable-install metadata or moved console scripts fail before credential resolution
- validate editable `direct_url.json`, console-script shebangs, forbidden staging paths, and core imports from the service working directory
- tolerate malformed referenced paths in the lifecycle guard instead of raising an embedded-NUL exception while tooling is preparing an isolated venv

## Validation
- `ruff check` on all changed files: passed
- `ruff format --check` on new preflight files: passed
- `scripts/run_tests.sh tests/scripts/test_runtime_preflight.py -q`: 5 passed
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -q`: 72 passed
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py -q`: 83 passed

The tests use temporary directories and do not touch Discord, credentials, or production profile data.
