### PR TITLE
fix(compression): keep same-session handoff when compress_end is degenerate (#83248)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -6599,17 +6599,15 @@ This compaction should PRIORITISE preserving all information related to the focu
         _previous_summary_before_scan = self._previous_summary
         _summary_has_user_turn_before_scan = getattr(self, "_summary_has_user_turn", None)
         # A persisted handoff summary can sit in the protected head after a
-        # resume (commonly immediately after the system prompt). Search from
-        # the first non-system message through the compression window. On the
-        # first compaction after a restart, extend through the full transcript
-        # so summaries that landed in the protected tail or drifted past the
-        # decay probe still rehydrate iterative-summary state instead of being
-        # copied forward as stacked fossils.
+        # resume (commonly immediately after the system prompt), or later in
+        # the live window past a degenerate compress_end (#83248). Always
+        # search the full transcript for handoff rows: the content-prefix
+        # check is cheap, Phase 4 already advances tail_start when
+        # summary_idx >= compress_end, and the #57835 cross-session discard
+        # must only fire after a full-window miss — never after a narrow
+        # scan that could hide a same-session handoff beyond the cut.
         summary_search_start = 1 if messages and messages[0].get("role") == "system" else 0
-        summary_search_end = compress_end
-        if self.compression_count < 1 and not self._previous_summary:
-            summary_search_end = len(messages)
-        summary_search_end = min(len(messages), summary_search_end)
+        summary_search_end = len(messages)
         summary_indices: set[int] = set()
         summary_idx = None
         summary_body = None
@@ -6679,11 +6677,12 @@ This compaction should PRIORITISE preserving all information related to the focu
             if summary_idx >= compress_end:
                 tail_start = summary_idx + 1
         elif self._previous_summary:
-            # No handoff summary found in the current messages, but
+            # Full-window scan found no handoff in the current messages, but
             # _previous_summary is non-empty — it was set by a different
             # (now-ended) session (e.g., a cron job, a prior /new).  Discard
             # it so _generate_summary() does not inject cross-session content
             # into the summarizer prompt via the iterative-update path.
+            # Do not clear based on a compress_end-bounded miss (#83248).
             self._previous_summary = None
             self._summary_has_user_turn = real_user_present
         else:

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -323,6 +323,70 @@ def test_restart_fossil_survives_summary_abort_then_retry():
     ) == 1
 
 
+def test_degenerate_compress_end_keeps_same_session_previous_summary():
+    """Handoff beyond a degenerate compress_end must not clear same-session state.
+
+    Regression for #83248: with compression_count >= 1 and a truthy
+    ``_previous_summary`` from this session's prior compaction, a scan bounded
+    at ``compress_end`` can miss an in-window handoff sitting past the cut.
+    The #57835 cross-session guard then discarded the valid summary and the
+    from-scratch path replaced a rich handoff with a one-turn summary.
+    """
+    compressor = _compressor(protect_first_n=0)
+    rich_summary = (
+        "RICH-SAME-SESSION-HANDOFF\n"
+        "1. completed action alpha\n"
+        "2. completed action beta\n"
+        "3. completed action gamma"
+    )
+    compressor.compression_count = 1
+    compressor._previous_summary = rich_summary
+
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "early turn before cut"},
+        {"role": "assistant", "content": "early answer"},
+        {"role": "user", "content": "mid turn before handoff"},
+        {"role": "assistant", "content": f"{SUMMARY_PREFIX}\n{rich_summary}"},
+        {"role": "user", "content": "post handoff turn"},
+        {"role": "assistant", "content": "post handoff answer"},
+        {"role": "user", "content": "tail request"},
+    ]
+    # Handoff is at index 4; force compress_end=2 so a compress_end-bounded
+    # scan would miss it while still leaving a non-empty middle window.
+    assert ContextCompressor._is_context_summary_message(messages[4])
+
+    previous_at_generate = []
+
+    def _capture(turns, **kwargs):
+        previous_at_generate.append(compressor._previous_summary)
+        return ContextCompressor._with_summary_prefix("updated iterative summary")
+
+    with (
+        patch.object(compressor, "_find_tail_cut_by_tokens", return_value=2),
+        patch.object(compressor, "_generate_summary", side_effect=_capture),
+    ):
+        result = compressor.compress(messages, current_tokens=90_000)
+
+    assert previous_at_generate, "_generate_summary should have run"
+    assert previous_at_generate[0] is not None, (
+        "same-session _previous_summary must not be discarded when a handoff "
+        "exists beyond a degenerate compress_end"
+    )
+    assert "RICH-SAME-SESSION-HANDOFF" in previous_at_generate[0]
+    # Iterative state must remain available after the attempt (either the
+    # prior rich handoff, or the updated summary if the compaction committed).
+    assert compressor._previous_summary is not None
+    stored = compressor._previous_summary or ""
+    assert (
+        "RICH-SAME-SESSION-HANDOFF" in stored
+        or "updated iterative summary" in stored
+    )
+    assert sum(
+        1 for msg in result if ContextCompressor._is_context_summary_message(msg)
+    ) >= 1
+
+
 
 
 def test_forced_leading_merged_summary_strips_live_tail_from_summary_body():


### PR DESCRIPTION
## Summary
- Always scan the full transcript for compaction handoff rows before the #57835 cross-session `_previous_summary` discard, so a degenerate `compress_end` cannot hide an in-window same-session handoff.
- Prevents a rich iterative handoff from being replaced by a thin from-scratch one-turn summary on the second (or later) compaction in the same process.
- Adds a regression test that forces `compress_end` before the handoff index and asserts `_previous_summary` is still present when the summarizer runs.

Fixes #83248

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_context_compressor_cross_session_guard.py -q`
- [ ] Reproduce a multi-compaction session where the handoff sits past a tiny `compress_end` and confirm the iterative `PREVIOUS SUMMARY:` path still runs (no cross-session discard log / no one-turn wipe)