### PR TITLE
fix(dashboard-auth): request offline access for Google OIDC

### DIFF
--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -232,6 +232,12 @@ class SelfHostedOIDCProvider(DashboardAuthProvider):
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
+        # Google only issues refresh tokens when offline access is requested.
+        # Re-consent upgrades grants previously created without it.
+        issuer = str(disco.get("issuer") or self._issuer).rstrip("/")
+        if issuer == "https://accounts.google.com":
+            params["access_type"] = "offline"
+            params["prompt"] = "consent"
         redirect_url = (
             f"{disco['authorization_endpoint']}?{urllib.parse.urlencode(params)}"
         )

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -308,8 +308,33 @@ class TestStartLogin:
         assert params["redirect_uri"] == "https://hermes.example/auth/callback"
         assert params["scope"] == "openid profile email"
         assert params["code_challenge_method"] == "S256"
+        assert "access_type" not in params
+        assert "prompt" not in params
         assert "state" in params
         assert "code_challenge" in params
+
+    def test_google_authorize_url_requests_refresh_token(self, rsa_keypair):
+        provider = oidc_plugin.SelfHostedOIDCProvider(
+            issuer="https://accounts.google.com", client_id=_CLIENT_ID
+        )
+        provider._discovery = {
+            **_DISCOVERY_DOC,
+            "issuer": "https://accounts.google.com",
+            "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        }
+        provider._discovery_fetched_at = time.time()
+
+        result = provider.start_login(
+            redirect_uri="https://hermes.example/auth/callback"
+        )
+        params = dict(
+            urllib.parse.parse_qsl(
+                urllib.parse.urlparse(result.redirect_url).query
+            )
+        )
+
+        assert params["access_type"] == "offline"
+        assert params["prompt"] == "consent"
 
 
     def test_state_in_cookie_matches_url(self, provider):


### PR DESCRIPTION
## Summary

- Add Google’s `access_type=offline` authorization parameter to the bundled self-hosted OIDC provider.
- Add `prompt=consent` so an existing grant created without offline access can receive a refresh token on the next login.
- Leave Nous Portal and non-Google OIDC authorization requests unchanged.

## Scope

This is specific to `plugins/dashboard_auth/self_hosted` when OIDC discovery reports the issuer as `https://accounts.google.com`. It is not a general Hermes Desktop or native OAuth refresh change.

The self-hosted provider advertises Google support, but its generic authorization URL omits the Google extension required for offline access. In that configuration, Google returns the short-lived ID token without a refresh token. Hermes Desktop can store and rotate refresh tokens correctly, but has nothing to refresh when that token expires.

## Validation

- Added a regression test for the Google authorization URL.
- Confirmed non-Google authorization URLs do not receive the Google-specific parameters.
- `tests/plugins/dashboard_auth/test_self_hosted_provider.py`
- `tests/hermes_cli/test_dashboard_auth_native_flow.py`
- 34 tests passed
- `git diff --check` passed

Existing Google sessions created without a refresh token require one new interactive login after this change. Subsequent expiry can use the existing native refresh path.