### PR TITLE
fix(compression): preserve active tasks through background process completions

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -177,6 +177,7 @@ MAX_ITERATIONS_SUMMARY_REQUEST = (
     "Please provide a final response summarizing what you've found and accomplished so far, "
     "without calling any more tools."
 )
+_BACKGROUND_PROCESS_NOTIFICATION_PREFIX = "[IMPORTANT: Background process "
 
 
 def _fresh_compaction_message_copy(msg: Dict[str, Any]) -> Dict[str, Any]:
@@ -4582,7 +4583,8 @@ This compaction should PRIORITISE preserving all information related to the focu
         """Recognize internal user-role rows after SessionDB projection.
 
         SessionDB preserves role/content but not underscore-prefixed metadata,
-        so the stable todo and continuation content markers are authoritative.
+        so stable runtime-notification, todo, and continuation content markers
+        are authoritative.
         """
         if not isinstance(message, dict) or message.get("role") != "user":
             return False
@@ -4618,6 +4620,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             _LENGTH_CONTINUATION_NETWORK_STUB,
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
         } or text.startswith(
+            _BACKGROUND_PROCESS_NOTIFICATION_PREFIX
+        ) or text.startswith(
             TODO_INJECTION_HEADER + "\n"
         ) or text.startswith(
             _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -21,6 +21,7 @@ from agent.conversation_compression import (
     compress_context,
 )
 from hermes_state import SessionDB
+from tools.process_registry import format_process_notification
 from tools.todo_tool import TODO_INJECTION_HEADER
 
 
@@ -235,6 +236,52 @@ def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
     idx = compressor._find_last_user_message_idx(messages, head_end=0)
     assert idx == 0, "nudge was selected as the anchor instead of the human task"
     assert messages[idx]["content"] == human["content"]
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        pytest.param(
+            {
+                "type": "completion",
+                "session_id": "proc_build",
+                "command": "scripts/run_tests.sh tests/agent/",
+                "exit_code": 0,
+                "output": "42 passed",
+            },
+            id="completion",
+        ),
+        pytest.param(
+            {
+                "type": "watch_match",
+                "session_id": "proc_server",
+                "command": "python server.py",
+                "pattern": "Application startup complete",
+                "output": "Application startup complete",
+            },
+            id="watch_match",
+        ),
+    ],
+)
+def test_background_process_notifications_do_not_become_compaction_anchors(
+    compressor, event
+):
+    notification = format_process_notification(event)
+    assert notification is not None
+    process_turn = {"role": "user", "content": notification}
+    human = {"role": "user", "content": "Refactor the auth module and add tests."}
+    messages = [
+        human,
+        {"role": "assistant", "content": "Working on it."},
+        process_turn,
+    ]
+
+    assert ContextCompressor._is_synthetic_compression_user_turn(process_turn) is True
+    assert ContextCompressor._transcript_has_real_user_turn([process_turn]) is False
+    assert compressor._derive_auto_focus_topic(messages) == (
+        "Recent user focus:\n- Refactor the auth module and add tests."
+    )
+    assert compressor._find_last_user_message_idx(messages, head_end=0) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Background-process completion and watch notifications no longer replace the user's active task in context-compaction focus or tail anchoring. Without this fix, raw command details, process IDs, and output samples can dominate a generated summary and displace the task the user actually asked Hermes to continue.

### Symptom

When a background process finishes or matches a watched output pattern before compaction, its synthetic user-role notification can become the latest focus topic and tail anchor instead of the preceding human request.

### Impact

Affected sessions can resume from a process-status report rather than the active user task after compaction, producing an off-topic summary and losing the correct continuation anchor.

### Bug Cause

**Trigger:** `agent/context_compressor.py` / `ContextCompressor._is_synthetic_compression_user_turn` when a user-role row starts with the background-process notification prefix.

**Causal chain:**
1. The process registry formats completion and watch-match events as stable `[IMPORTANT: Background process ...]` notifications.
2. Session projection preserves their user role and content, but the compressor classifier did not recognize that content as runtime scaffolding.
3. Auto-focus admitted the process details and tail selection treated the notification as the latest actionable user turn.

**Why it is wrong:** The notification reports runtime state and is not a user-authored task, so it must not establish summary provenance, focus, or continuation position.

**Working sibling / contrast:** Existing continuation, retry, maximum-iteration, and todo runtime markers are already classified as synthetic before those same focus and anchor paths run.

**Ruled out:** SessionDB projection is not the root cause. Preserving role and content is expected; the compressor already uses stable content markers because underscore-prefixed metadata does not survive projection.

### Fix

Classify every producer-backed background-process notification variant by its stable prefix as a synthetic compression user turn. The shared classifier now excludes completion and watch-match notifications from real-user provenance, auto-focus, and tail-anchor selection.

## Related Issue

Fixes #83249

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` - recognize background-process notifications as synthetic user turns.
- `tests/agent/test_context_compressor_zero_user_provenance.py` - generate completion and watch-match notifications through the production formatter and verify focus, provenance, and tail anchoring.

## How to Test

1. Run the focused producer-backed regression for both notification variants.
2. Run the related context-compressor provenance test file.

```bash
scripts/run_tests.sh tests/agent/test_context_compressor_zero_user_provenance.py
```

Result: 26 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - no user-facing configuration or workflow changes
- [x] `cli-config.yaml.example`: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changes
- [x] Cross-platform impact considered: the classifier is platform-independent
- [x] Tool descriptions/schemas: N/A - no tool behavior or schema changed

## Screenshots / Logs

N/A - automated regression coverage exercises the producer and both affected compaction paths.
