### PR TITLE
docs(discord): include thread creation permission

### DIFF
--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -188,7 +188,7 @@ This method requires **Public Bot** to be set to **ON** in Step 2. If you set Pu
 You can construct the invite URL directly using this format:
 
 ```
-https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=274878286912
+https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=309238025280
 ```
 
 Replace `YOUR_APP_ID` with the Application ID from Step 1.
@@ -205,6 +205,7 @@ These are the minimum permissions your bot needs:
 
 ### Recommended Additional Permissions
 
+- **Create Public Threads** — create isolated conversations with `/thread` and auto-threading
 - **Send Messages in Threads** — respond in thread conversations
 - **Add Reactions** — react to messages for acknowledgment
 
@@ -213,7 +214,11 @@ These are the minimum permissions your bot needs:
 | Level | Permissions Integer | What's Included |
 |-------|-------------------|-----------------|
 | Minimal | `117760` | View Channels, Send Messages, Read Message History, Attach Files |
-| Recommended | `274878286912` | All of the above plus Embed Links, Send Messages in Threads, Add Reactions |
+| Recommended | `309238025280` | All of the above plus Embed Links, Create Public Threads, Send Messages in Threads, Add Reactions |
+
+Existing installations do not gain newly requested permissions automatically.
+If you used an older Recommended URL, re-invite the bot with the URL above to
+grant **Create Public Threads**.
 
 ## Step 6: Invite to Your Server
 
@@ -843,6 +848,12 @@ Hermes 0.18 intentionally fails closed on externally reachable adapters. A Disco
 **Cause**: The bot is missing required permissions.
 
 **Fix**: Re-invite the bot with the correct permissions using the URL from Step 5, or manually adjust the bot's role permissions in Server Settings → Roles.
+
+If `/thread` reports Discord error `50001` (`Missing Access`), verify the bot's
+effective permissions in the parent channel. It needs **View Channel**, **Send
+Messages**, **Create Public Threads**, and **Send Messages in Threads**. Check
+the parent category and channel-specific permission overrides as well: an
+explicit deny there can override permissions granted by the server role.
 
 ### Bot is offline
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -188,7 +188,7 @@ This method requires **Public Bot** to be set to **ON** in Step 2. If you set Pu
 You can construct the invite URL directly using this format:
 
 ```
-https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=274878286912
+https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&scope=bot+applications.commands&permissions=309238025280
 ```
 
 Replace `YOUR_APP_ID` with the Application ID from Step 1.
@@ -205,6 +205,7 @@ These are the minimum permissions your bot needs:
 
 ### Recommended Additional Permissions
 
+- **Create Public Threads** — create isolated conversations with `/thread` and auto-threading
 - **Send Messages in Threads** — respond in thread conversations
 - **Add Reactions** — react to messages for acknowledgment
 
@@ -213,7 +214,7 @@ These are the minimum permissions your bot needs:
 | Level | Permissions Integer | What's Included |
 |-------|-------------------|-----------------|
 | Minimal | `117760` | View Channels, Send Messages, Read Message History, Attach Files |
-| Recommended | `274878286912` | All of the above plus Embed Links, Send Messages in Threads, Add Reactions |
+| Recommended | `309238025280` | All of the above plus Embed Links, Create Public Threads, Send Messages in Threads, Add Reactions |
 
 ## Step 6: Invite to Your Server
 
@@ -843,6 +844,12 @@ Hermes 0.18 intentionally fails closed on externally reachable adapters. A Disco
 **Cause**: The bot is missing required permissions.
 
 **Fix**: Re-invite the bot with the correct permissions using the URL from Step 5, or manually adjust the bot's role permissions in Server Settings → Roles.
+
+If `/thread` reports Discord error `50001` (`Missing Access`), verify the bot's
+effective permissions in the parent channel. It needs **View Channel**, **Send
+Messages**, **Create Public Threads**, and **Send Messages in Threads**. Check
+the parent category and channel-specific permission overrides as well: an
+explicit deny there can override permissions granted by the server role.
 
 ### Bot is offline
 


### PR DESCRIPTION
## What does this PR do?

The recommended Discord invite permissions allowed Hermes to send messages in existing threads, but did not allow it to create public threads. As a result, `/thread` and auto-threading could fail even when the bot was installed with the documented recommended permission integer.

This updates the recommended OAuth2 permission integer from `274878286912` to `309238025280`, which preserves every existing permission and adds Discord's `Create Public Threads` bit (`1 << 35`). It also documents the effective parent-channel permissions and channel/category overrides to check when Discord returns `50001 Missing Access`.

## Related Issue

N/A — documentation gap reproduced from a live Discord `/thread` failure where direct thread creation and the seed-message fallback both returned `403 / 50001 Missing Access`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add **Create Public Threads** to the recommended Discord bot permissions.
- Update the manual invite URL and permission table to `309238025280`.
- Add targeted troubleshooting for `/thread` failures with Discord error `50001`, including parent category and channel-specific overrides.

## How to Test

1. Verify the integer delta: `309238025280 - 274878286912 == 34359738368 == 1 << 35`.
2. Run `cd website && npm ci && npm run build:fast`.
3. Confirm the generated Discord page contains `Create Public Threads` and `309238025280`.
4. Run `git diff --check upstream/main...HEAD`.

Verified on Linux with Node.js 26.5.1 / npm 11.17.0. The English Docusaurus build completed successfully. The build emitted the existing `/docs/llms.txt` and `/docs/llms-full.txt` broken-link warnings from the docs landing page; neither is touched by this PR.

Additional baseline checks:

- `npm run typecheck` reports the existing TypeScript 6 `baseUrl` deprecation on both this branch and the exact base commit.
- `npm run lint:diagrams` reports the existing missing `ascii-guard` executable on both this branch and the exact base commit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, documentation-only change
- [ ] I've added tests for my changes — N/A, documentation-only change
- [x] I've tested on my platform: Linux, Docusaurus English production build

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — documentation-only Discord permission change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. The generated Docusaurus page was verified to render the corrected permission name, integer, and troubleshooting guidance.
