### PR TITLE
fix(kanban): support summary-only notifications

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -513,6 +513,7 @@ class GatewayKanbanWatchersMixin:
                             if isinstance(delivery_metadata, dict)
                             else {}
                         )
+                        deliver_artifacts = metadata.pop("deliver_artifacts", True) is not False
                         if sub.get("thread_id") and not metadata.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
                         # Adapters with no push channel (the API server —
@@ -571,7 +572,7 @@ class GatewayKanbanWatchersMixin:
                             # ``send_document`` / ``send_image_file`` uploads
                             # them. Only fires on the ``completed`` event so
                             # we never spam attachments on retries.
-                            if kind == "completed":
+                            if kind == "completed" and deliver_artifacts:
                                 try:
                                     await self._deliver_kanban_artifacts(
                                         adapter=adapter,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,6 +1,7 @@
 import asyncio
 import sqlite3
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 
 from gateway.config import Platform
@@ -127,6 +128,34 @@ def test_kanban_notifier_replays_telegram_dm_topic_delivery_metadata(tmp_path, m
     assert len(adapter.handled) == 1
     assert adapter.handled[0].source.chat_type == "dm"
     assert adapter.handled[0].source.thread_id == "20197"
+
+
+def test_completed_subscription_can_suppress_artifact_delivery(tmp_path, monkeypatch):
+    db_path = tmp_path / "summary-only-completion.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="summary only", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+            delivery_metadata={"deliver_artifacts": False},
+        )
+        kb.complete_task(conn, tid, summary="done /tmp/should-not-upload.pdf")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._deliver_kanban_artifacts = AsyncMock()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    runner._deliver_kanban_artifacts.assert_not_awaited()
 
 
 def test_active_named_profile_subscription_is_delivered(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Kanban completion notifications automatically upload local artifacts referenced by the task result. Some subscriptions are intentionally text-only (for example, fixed operational status callbacks) and need to prevent task-selected files from being sent externally.

This adds an opt-out in existing subscription delivery metadata:

```python
{"deliver_artifacts": False}
```

The notifier removes this internal flag before calling the platform adapter and skips only the artifact-upload phase. Text delivery, cursor handling, retries, wake behavior, and legacy/default artifact delivery are unchanged.

## Safety

- Default remains `True`, preserving existing behavior.
- The internal flag is not forwarded to platform adapters.
- No new model tool or configuration surface.
- Scope is per subscription.

## Verification

```text
uv run --extra dev pytest tests/gateway/test_kanban_notifier.py -q -o 'addopts='
9 passed

uv run --extra dev ruff check gateway/kanban_watchers.py tests/gateway/test_kanban_notifier.py
All checks passed!

git diff --check
passed
```
