### PR TITLE
fix(agent): clamp authorization gate lock timeout to prevent OverflowError

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -125,7 +125,7 @@ def _authorization_gate_lock_timeout() -> float:
     try:
         from tools.approval import human_wait_ceiling
 
-        return human_wait_ceiling()
+        return min(human_wait_ceiling(), _AUTHORIZATION_GATE_LOCK_TIMEOUT_S)
     except Exception:
         return _AUTHORIZATION_GATE_LOCK_TIMEOUT_S
 


### PR DESCRIPTION
Fixes #83220 — clamp the concurrent tool dispatch lock timeout to _AUTHORIZATION_GATE_LOCK_TIMEOUT_S (360s) so a huge approvals.timeout cannot overflow threading.Lock.acquire() on macOS.