### PR TITLE
fix(cache): honor custom provider prompt cache capability

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1569,6 +1569,19 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
 
+    try:
+        from hermes_cli.route_identity import normalize_route_base_url
+
+        _route = normalize_route_base_url(agent.base_url)
+        _supports_prompt_cache_key = any(
+            isinstance(entry, dict)
+            and normalize_route_base_url(entry.get("base_url")) == _route
+            and entry.get("supports_prompt_cache_key") is True
+            for entry in getattr(agent, "_custom_providers", [])
+        )
+    except Exception:
+        _supports_prompt_cache_key = False
+
     return _ct.build_kwargs(
         model=agent.model,
         messages=_msgs_for_chat,
@@ -1604,6 +1617,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
+        supports_prompt_cache_key=_supports_prompt_cache_key,
     )
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1326,6 +1326,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
+        "supports_prompt_cache_key",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -1450,6 +1451,10 @@ def _normalize_custom_provider_entry(
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
 
+    supports_prompt_cache_key = entry.get("supports_prompt_cache_key")
+    if isinstance(supports_prompt_cache_key, bool):
+        normalized["supports_prompt_cache_key"] = supports_prompt_cache_key
+
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
@@ -1499,6 +1504,7 @@ def _custom_provider_entry_to_provider_config(
         "discover_models",
         "extra_body",
         "extra_headers",
+        "supports_prompt_cache_key",
         "ssl_ca_cert",
         "ssl_verify",
     ):
@@ -1884,6 +1890,7 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
+    "supports_prompt_cache_key",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.

--- a/tests/agent/test_custom_provider_prompt_cache_key.py
+++ b/tests/agent/test_custom_provider_prompt_cache_key.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import build_api_kwargs
+from hermes_cli.config import _normalize_custom_provider_entry
+
+
+class _RecordingTransport:
+    def build_kwargs(self, **kwargs):
+        return kwargs
+
+
+def test_custom_provider_cache_capability_reaches_chat_transport():
+    provider = _normalize_custom_provider_entry({
+        "name": "cliproxy",
+        "base_url": "https://cliproxy.example/v1",
+        "supports_prompt_cache_key": True,
+    })
+    assert provider is not None
+
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        tools=[],
+        model="deepseek-v4-flash",
+        base_url=provider["base_url"],
+        provider="custom:cliproxy",
+        _base_url_lower=provider["base_url"].lower(),
+        _custom_providers=[provider],
+        providers_allowed=None,
+        providers_ignored=None,
+        providers_order=None,
+        provider_sort=None,
+        provider_require_parameters=False,
+        provider_data_collection=None,
+        session_id="stable-session",
+        max_tokens=None,
+        reasoning_config=None,
+        request_overrides={},
+        _ollama_num_ctx=None,
+        _max_tokens_param=lambda value: {"max_tokens": value},
+        openrouter_min_coding_score=None,
+        _get_transport=lambda: _RecordingTransport(),
+        _is_qwen_portal=lambda: False,
+        _is_openrouter_url=lambda: False,
+        _prepare_messages_for_non_vision_model=lambda messages: messages,
+        _resolved_api_call_timeout=lambda: 30,
+        _supports_reasoning_extra_body=lambda: False,
+        _github_models_reasoning_extra_body=lambda: None,
+    )
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hello"}])
+
+    assert kwargs["supports_prompt_cache_key"] is True

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -647,6 +647,27 @@ class TestPromptCacheKeyCapability:
 
         assert body["prompt_cache_key"] == kwargs["prompt_cache_key"]
 
+    def test_custom_provider_config_capability_reaches_request_body(self, transport):
+        from hermes_cli.config import _normalize_custom_provider_entry
+
+        provider = _normalize_custom_provider_entry({
+            "name": "cliproxy",
+            "base_url": "https://cliproxy.example/v1",
+            "supports_prompt_cache_key": True,
+        })
+        assert provider is not None
+
+        kwargs = transport.build_kwargs(
+            model="cache-model",
+            messages=self._messages(),
+            tools=self._tools(),
+            session_id="stable-session",
+            base_url=provider["base_url"],
+            supports_prompt_cache_key=provider["supports_prompt_cache_key"],
+        )
+
+        assert self._request_body(kwargs)["prompt_cache_key"] == kwargs["prompt_cache_key"]
+
     def test_openai_api_base_url_implies_capability(self, transport):
         """api.openai.com gets the key WITHOUT an explicit flag (exact host)."""
         kwargs = transport.build_kwargs(

--- a/tests/hermes_cli/test_custom_provider_prompt_cache_key.py
+++ b/tests/hermes_cli/test_custom_provider_prompt_cache_key.py
@@ -1,0 +1,22 @@
+from hermes_cli.config import (
+    _VALID_CUSTOM_PROVIDER_FIELDS,
+    _custom_provider_entry_to_provider_config,
+    _normalize_custom_provider_entry,
+)
+
+
+def test_prompt_cache_capability_survives_normalization_and_migration():
+    raw = {
+        "name": "cliproxy",
+        "base_url": "https://cliproxy.example/v1",
+        "supports_prompt_cache_key": True,
+    }
+
+    normalized = _normalize_custom_provider_entry(raw, provider_key="cliproxy")
+    migrated = _custom_provider_entry_to_provider_config(raw, provider_key="cliproxy")
+
+    assert normalized is not None
+    assert normalized["supports_prompt_cache_key"] is True
+    assert migrated is not None
+    assert migrated["supports_prompt_cache_key"] is True
+    assert "supports_prompt_cache_key" in _VALID_CUSTOM_PROVIDER_FIELDS


### PR DESCRIPTION
## Summary

- preserve supports_prompt_cache_key while normalizing and migrating custom providers
- resolve the capability by active custom-provider route before building Chat Completions kwargs
- prove the config-to-transport path emits a stable body-level prompt_cache_key

## Root cause

ProviderProfile and the Chat Completions transport already supported prompt cache keys, but _normalize_custom_provider_entry classified the configured key as unknown and dropped it. Custom providers use the legacy transport path, so the capability never reached _add_prompt_cache_key.

## Validation

- .venv/bin/ruff check hermes_cli/config.py agent/chat_completion_helpers.py tests/agent/test_custom_provider_prompt_cache_key.py tests/hermes_cli/test_custom_provider_prompt_cache_key.py tests/agent/transports/test_chat_completions.py
- scripts/run_tests.sh tests/hermes_cli/test_custom_provider_prompt_cache_key.py tests/agent/test_custom_provider_prompt_cache_key.py tests/agent/transports/test_chat_completions.py -k "prompt_cache or custom_provider_cache_capability" (3 passed)
- git diff --check
- installed exact PR head on Kyber; repeated same-session request through CLIProxy read 36,352 cached tokens out of 36,564 prompt tokens on the second turn (99.4%)

Production delta: +21 lines. This is the required config normalization and active-route capability propagation; existing transport injection is reused unchanged.