### PR TITLE
fix(dashboard): send Authorization header in gateway health probe

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1664,6 +1664,9 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     for path in (f"{base}/health/detailed", f"{base}/health"):
         try:
             req = urllib.request.Request(path, method="GET")
+            key = os.getenv("API_SERVER_KEY", "") or ""
+            if key:
+                req.add_header("Authorization", f"Bearer {key}")
             with urllib.request.urlopen(req, timeout=_GATEWAY_HEALTH_TIMEOUT) as resp:
                 if resp.status == 200:
                     body = json.loads(resp.read())


### PR DESCRIPTION
Fixes #83131 — the dashboard health probe now sends the API_SERVER_KEY as a Bearer Authorization header, matching the route requirement.