### PR TITLE
chore: add Angriff36 to AUTHOR_MAP for PR #29543 salvage

### DIFF
--- a/contributors/emails/unashamed366@gmail.com
+++ b/contributors/emails/unashamed366@gmail.com
@@ -1,0 +1,1 @@
+Angriff36


### PR DESCRIPTION
## Summary
Adds contributor email mapping for @Angriff36 (PR #29543) before salvage.

## Changes
- contributors/emails/unashamed366@gmail.com: Angriff36