### PR TITLE
fix(cli): catch KeyboardInterrupt in sessions browse picker

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1288,7 +1288,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
         curses.wrapper(_curses_browse)
         return result_holder[0]
 
-    except Exception:
+    except (Exception, KeyboardInterrupt):
         pass
 
     # Fallback: numbered list (Windows without curses, etc.)


### PR DESCRIPTION
Fixes #83256 — KeyboardInterrupt is a BaseException, not Exception, so Ctrl+C in the curses picker was not caught. Changed the except clause to catch both.