### PR TITLE
fix(providers): route kimi-coding-cn sk-kimi- keys to Kimi Code endpoint in credential pool

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2986,7 +2986,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
             continue
         active_sources.add(source)
         base_url = env_url or pconfig.inference_base_url
-        if provider == "kimi-coding":
+        if provider in {"kimi-coding", "kimi-coding-cn"}:
             base_url = _resolve_kimi_base_url(token, pconfig.inference_base_url, env_url)
         elif provider == "zai":
             base_url = _resolve_zai_base_url(token, pconfig.inference_base_url, env_url)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5564,7 +5564,7 @@ class AIAgent:
                 env_url = get_env_prefer_dotenv(pconfig.base_url_env_var).strip().rstrip("/")
             default_base = (pconfig.inference_base_url or "").strip().rstrip("/")
             base_url = env_url or default_base
-            if self.provider == "kimi-coding":
+            if self.provider in {"kimi-coding", "kimi-coding-cn"}:
                 from hermes_cli.auth import _resolve_kimi_base_url
 
                 base_url = _resolve_kimi_base_url(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -579,6 +579,40 @@ def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
 
 
 
+def test_load_pool_seeds_kimi_coding_cn_sk_kimi_key_routes_to_kimi_code(tmp_path, monkeypatch):
+    """sk-kimi- Kimi Code keys must seed kimi-coding-cn pool entries with the
+    api.kimi.com/coding endpoint, not the legacy moonshot.cn default."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("KIMI_CN_API_KEY", "sk-kimi-seeded-token-1234567890")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("kimi-coding-cn")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.source == "env:KIMI_CN_API_KEY"
+    assert entry.base_url == "https://api.kimi.com/coding"
+
+
+def test_load_pool_seeds_kimi_coding_cn_legacy_key_keeps_moonshot_cn(tmp_path, monkeypatch):
+    """Non-Kimi-Code keys on kimi-coding-cn keep the moonshot.cn default endpoint."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("KIMI_CN_API_KEY", "sk-legacy-moonshot-token-1234567890")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("kimi-coding-cn")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.source == "env:KIMI_CN_API_KEY"
+    assert entry.base_url == "https://api.moonshot.cn/v1"
+
+
+
 def test_load_pool_does_not_persist_env_seeded_secret_value(tmp_path, monkeypatch):
     """Runtime env keys may be used in memory but must not land in auth.json."""
     sentinel = "S3NTINEL_DO_NOT_PERSIST_OPENROUTER"


### PR DESCRIPTION
## Problem

`_seed_from_env` in `agent/credential_pool.py` only applied `_resolve_kimi_base_url` to `kimi-coding`; `kimi-coding-cn` pool entries were always seeded with the legacy `https://api.moonshot.cn/v1` endpoint — even when the configured `KIMI_CN_API_KEY` is a Kimi Code (sk-kimi-) membership key.

Auth-layer resolution (`resolve_api_key_provider_credentials` → `_resolve_kimi_base_url`) already routes **both** `kimi-coding` and `kimi-coding-cn` by key prefix. So runtime pool seeding diverged from auth resolution: every `kimi-coding-cn` request with a Kimi Code key 401'd against moonshot.cn, and the polluted pool entry (wrong base_url + `exhausted` status) short-circuited all later attempts.

## Fix

Apply the same key-prefix endpoint routing to `kimi-coding-cn` in `_seed_from_env`:

- `sk-kimi-*` (Kimi Code membership) keys → `https://api.kimi.com/coding` (Anthropic Messages protocol)
- legacy keys → keep `https://api.moonshot.cn/v1` default

## Testing

- `tests/agent/test_credential_pool.py::test_load_pool_seeds_kimi_coding_cn_sk_kimi_key_routes_to_kimi_code`
- `tests/agent/test_credential_pool.py::test_load_pool_seeds_kimi_coding_cn_legacy_key_keeps_moonshot_cn`
- Full `tests/agent/test_credential_pool.py` + `tests/hermes_cli/test_runtime_provider_resolution.py`: 116 passed
- End-to-end verified on the reporter machine: `hermes chat --provider kimi-coding-cn --model kimi-k3` now completes against api.kimi.com/coding.
