### PR TITLE
fix(gateway): offload evaluate_after_turn to thread executor

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19424,10 +19424,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             _bg_procs = None
 
-        decision = mgr.evaluate_after_turn(
-            final_response or "",
-            user_initiated=True,
-            background_processes=_bg_procs,
+        # evaluate_after_turn calls judge_goal() which makes a synchronous
+        # HTTP request to the auxiliary LLM.  Running it on the event-loop
+        # thread would block Discord heartbeats for 10-40 s and cause
+        # connection flaps, so we offload it to a thread-pool executor.
+        # _run_in_executor_with_context (not bare run_in_executor): the
+        # profile secret scope and auxiliary runtime context are contextvars,
+        # and a default-executor hop would drop them — aux-client provider
+        # resolution would then read credentials unscoped and fail under
+        # multiplexing (same pattern as compression in slash_commands.py).
+        decision = await self._run_in_executor_with_context(
+            lambda: mgr.evaluate_after_turn(
+                final_response or "",
+                user_initiated=True,
+                background_processes=_bg_procs,
+            ),
         )
         msg = decision.get("message") or ""
 


### PR DESCRIPTION
## Summary
Offloads `evaluate_after_turn()` to a thread-pool executor so the event loop stays responsive during goal judge calls (which make synchronous HTTP requests to the auxiliary LLM, blocking 10-40s and causing Discord heartbeat timeouts).

Salvage of #29543 by @Angriff36. The original PR used `loop.run_in_executor(None, ...)` (default executor), which drops contextvars — the auxiliary client reads `_RUNTIME_MAIN_CONTEXT` and `_RELAY_AUX_CALL_CONTEXT` to resolve the provider/api_key/base_url. This salvage uses `_run_in_executor_with_context()` instead, which preserves contextvars via `copy_context()`. Same pattern as compression in `gateway/slash_commands.py:4160`.

Also adapts to `background_processes=_bg_procs` parameter added on main since the PR was filed (12,511 commits behind).

## Changes
- `gateway/run.py`: `_post_turn_goal_continuation` — `evaluate_after_turn()` now runs via `self._run_in_executor_with_context(lambda: ...)` instead of inline on the event loop.

## Validation
| | Before | After |
|---|---|---|
| Event loop during goal judge | Blocked 10-40s | Non-blocking |
| Contextvar propagation | N/A (inline) | Preserved via `copy_context()` |
| Gateway tests | 7 passed, 1 skipped | 7 passed, 1 skipped |
| Ruff | clean | clean |
| E2E contextvar test | contextvar DROPPED by default executor | contextvar PRESERVED by `copy_context()` |

Closes #29543

Credit: @Angriff36 — original fix idea and the executor offload approach. Salvaged with contextvar fix + `background_processes` adaptation.
