### PR TITLE
fix(gateway): treat a child-set SO_RCVTIMEO as a spurious stdin EOF, not a peer close

### DIFF
--- a/tests/tui_gateway/test_stdin_recovery.py
+++ b/tests/tui_gateway/test_stdin_recovery.py
@@ -1,0 +1,247 @@
+"""Regression tests for spurious stdin-EOF detection in the TUI gateway.
+
+``tui_gateway/_stdin_recovery.py`` guards the gateway against a child process
+that mutates the **shared open file description** behind fd 0.  Two distinct
+mutations produce the same symptom — an empty ``readline()`` that looks like a
+peer close:
+
+- ``O_NONBLOCK`` set via ``fcntl`` (``EAGAIN`` laundered into ``b''``), and
+- a non-zero ``SO_RCVTIMEO`` set via ``setsockopt``, which expires and returns
+  ``''`` with ``O_NONBLOCK`` **clear**.
+
+The module's docstring and its recovery tail both name the second case, but the
+decision gate only ever inspected ``O_NONBLOCK``, so an ``SO_RCVTIMEO``-only
+mutation was reported as ``stdin EOF (peer closed)`` and the gateway exited
+mid-session.
+
+These tests pin the decision function itself.  ``handle_spurious_eof`` is a pure
+predicate over fd-0 state, so the collaborators (``fcntl``, ``socket``,
+``os.set_blocking``) are stubbed at the module boundary rather than reproducing
+a real kernel ``EAGAIN``.
+
+The fail-safe is the load-bearing case: when fd 0 is **not** a socket the probe
+must report "cannot tell" and the caller must still see a genuine EOF.  Getting
+that wrong would make every real peer close look spurious, so it is covered from
+both directions (``fromfd`` raising ``ENOTSOCK``, as on macOS, and ``getsockopt``
+raising it after a successful ``fromfd``, as on Linux).
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import struct
+
+from tui_gateway import _stdin_recovery
+
+# Same layout the production recovery tail packs with.
+_TIMEVAL = "ll"
+
+
+class _FakeSocket:
+    """Stand-in for the ``socket.fromfd`` dup of fd 0."""
+
+    def __init__(self, rcvtimeo: bytes, getsockopt_error: OSError | None = None) -> None:
+        self.rcvtimeo = rcvtimeo
+        self._getsockopt_error = getsockopt_error
+        self.setsockopt_calls: list[tuple[int, int, bytes]] = []
+        self.close_count = 0
+
+    def getsockopt(self, level: int, optname: int, buflen: int | None = None):
+        if self._getsockopt_error is not None:
+            raise self._getsockopt_error
+        if buflen is None:
+            # Mirrors CPython: without an explicit length an *int* option is
+            # assumed, so only the first ``sizeof(int)`` bytes are read.
+            return struct.unpack("i", self.rcvtimeo[: struct.calcsize("i")])[0]
+        return self.rcvtimeo[:buflen]
+
+    def setsockopt(self, level: int, optname: int, value: bytes) -> None:
+        self.setsockopt_calls.append((level, optname, value))
+        if optname == _FakeSocketModule.SO_RCVTIMEO:
+            # Real ``setsockopt`` mutates the description; later probes must see it.
+            self.rcvtimeo = value
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+class _FakeSocketModule:
+    """Stand-in for the ``socket`` module as bound in ``_stdin_recovery``."""
+
+    AF_UNIX = 1
+    SOCK_STREAM = 1
+    SOL_SOCKET = 0xFFFF
+    SO_RCVTIMEO = 0x1006
+
+    def __init__(
+        self,
+        sock: _FakeSocket | None = None,
+        fromfd_error: OSError | None = None,
+    ) -> None:
+        self.sock = sock
+        self._fromfd_error = fromfd_error
+        self.fromfd_calls = 0
+
+    def fromfd(self, fd: int, family: int, type_: int) -> _FakeSocket:
+        self.fromfd_calls += 1
+        if self._fromfd_error is not None:
+            raise self._fromfd_error
+        assert self.sock is not None
+        return self.sock
+
+
+class _FakeFcntl:
+    """Stand-in for the ``fcntl`` module: ``F_GETFL`` returns fixed flags."""
+
+    F_GETFL = 3
+
+    def __init__(self, flags: int) -> None:
+        self.flags = flags
+
+    def fcntl(self, fd: int, op: int) -> int:
+        return self.flags
+
+
+def _install(monkeypatch, *, nonblock: bool, socket_mod: _FakeSocketModule) -> list:
+    """Bind stub collaborators onto the module; return the set_blocking log."""
+    flags = os.O_RDWR | (os.O_NONBLOCK if nonblock else 0)
+    monkeypatch.setattr(_stdin_recovery, "_HAS_FCNTL", True)
+    monkeypatch.setattr(_stdin_recovery, "_fcntl", _FakeFcntl(flags))
+    monkeypatch.setattr(_stdin_recovery, "_HAS_SOCKET", True)
+    monkeypatch.setattr(_stdin_recovery, "_socket", socket_mod)
+    set_blocking_calls: list[tuple[int, bool]] = []
+    monkeypatch.setattr(
+        _stdin_recovery.os,
+        "set_blocking",
+        lambda fd, blocking: set_blocking_calls.append((fd, blocking)),
+    )
+    return set_blocking_calls
+
+
+def _enotsock() -> OSError:
+    return OSError(errno.ENOTSOCK, "Socket operation on non-socket")
+
+
+def test_rcvtimeo_only_is_spurious(monkeypatch):
+    """A child-set receive timeout with ``O_NONBLOCK`` clear is not a peer close."""
+    sock = _FakeSocket(struct.pack(_TIMEVAL, 0, 500_000))
+    mod = _FakeSocketModule(sock=sock)
+    set_blocking_calls = _install(monkeypatch, nonblock=False, socket_mod=mod)
+    logs: list[str] = []
+
+    result = _stdin_recovery.handle_spurious_eof([], logs.append)
+
+    assert result is True, f"expected spurious-EOF recovery; log_fn saw {logs!r}"
+    assert set_blocking_calls == [(0, True)]
+    cleared = [v for _, opt, v in sock.setsockopt_calls if opt == mod.SO_RCVTIMEO]
+    assert cleared, "recovery must clear SO_RCVTIMEO"
+    assert struct.unpack(_TIMEVAL, cleared[-1]) == (0, 0)
+    assert sock.close_count == mod.fromfd_calls, "every fromfd dup must be closed"
+
+
+def test_no_flags_is_genuine_eof(monkeypatch):
+    """Negative control: both mutations absent still exits the read loop."""
+    sock = _FakeSocket(struct.pack(_TIMEVAL, 0, 0))
+    mod = _FakeSocketModule(sock=sock)
+    set_blocking_calls = _install(monkeypatch, nonblock=False, socket_mod=mod)
+    logs: list[str] = []
+
+    result = _stdin_recovery.handle_spurious_eof([], logs.append)
+
+    assert result is False
+    assert logs == ["stdin EOF (peer closed)"]
+    assert set_blocking_calls == []
+    assert sock.setsockopt_calls == []
+
+
+def test_non_socket_stdin_is_genuine_eof(monkeypatch):
+    """Fail-safe: ``fromfd`` raising ``ENOTSOCK`` must not fake a recovery."""
+    mod = _FakeSocketModule(fromfd_error=_enotsock())
+    set_blocking_calls = _install(monkeypatch, nonblock=False, socket_mod=mod)
+    logs: list[str] = []
+
+    result = _stdin_recovery.handle_spurious_eof([], logs.append)
+
+    assert result is False
+    assert logs == ["stdin EOF (peer closed)"]
+    assert set_blocking_calls == []
+
+
+def test_getsockopt_enotsock_is_genuine_eof(monkeypatch):
+    """Fail-safe, other shape: ``fromfd`` succeeds and ``getsockopt`` raises."""
+    sock = _FakeSocket(b"", getsockopt_error=_enotsock())
+    mod = _FakeSocketModule(sock=sock)
+    set_blocking_calls = _install(monkeypatch, nonblock=False, socket_mod=mod)
+    logs: list[str] = []
+
+    result = _stdin_recovery.handle_spurious_eof([], logs.append)
+
+    assert result is False
+    assert logs == ["stdin EOF (peer closed)"]
+    assert set_blocking_calls == []
+
+
+def test_nonblock_on_non_socket_still_recovers(monkeypatch):
+    """The pre-existing ``O_NONBLOCK`` path is unaffected by the socket probe."""
+    mod = _FakeSocketModule(fromfd_error=_enotsock())
+    set_blocking_calls = _install(monkeypatch, nonblock=True, socket_mod=mod)
+    logs: list[str] = []
+
+    result = _stdin_recovery.handle_spurious_eof([], logs.append)
+
+    assert result is True
+    assert set_blocking_calls == [(0, True)]
+
+
+def test_genuine_close_under_preset_rcvtimeo_costs_one_iteration(monkeypatch):
+    """Bounded worst case: a pre-set timeout delays a real EOF by one pass.
+
+    If the peer really did close while stdin carried a non-zero
+    ``SO_RCVTIMEO``, the first pass recovers and zeroes the timeout; the very
+    next empty ``readline()`` then finds both mutations clear and exits.
+    """
+    sock = _FakeSocket(struct.pack(_TIMEVAL, 5, 0))
+    mod = _FakeSocketModule(sock=sock)
+    _install(monkeypatch, nonblock=False, socket_mod=mod)
+    logs: list[str] = []
+    times: list[float] = []
+
+    assert _stdin_recovery.handle_spurious_eof(times, logs.append) is True
+    assert _stdin_recovery.handle_spurious_eof(times, logs.append) is False
+    assert logs[-1] == "stdin EOF (peer closed)"
+
+
+def test_rcvtimeo_recovery_respects_the_rate_limit(monkeypatch):
+    """A child re-arming the timeout cannot spin the read loop forever."""
+    class _RearmingSocket(_FakeSocket):
+        def setsockopt(self, level, optname, value):
+            super().setsockopt(level, optname, value)
+            self.rcvtimeo = struct.pack(_TIMEVAL, 5, 0)
+
+    sock = _RearmingSocket(struct.pack(_TIMEVAL, 5, 0))
+    mod = _FakeSocketModule(sock=sock)
+    _install(monkeypatch, nonblock=False, socket_mod=mod)
+    logs: list[str] = []
+    times: list[float] = []
+
+    results = [_stdin_recovery.handle_spurious_eof(times, logs.append) for _ in range(12)]
+
+    assert results[: _stdin_recovery.MAX_RECOVERIES_PER_MINUTE] == [
+        True
+    ] * _stdin_recovery.MAX_RECOVERIES_PER_MINUTE
+    assert results[_stdin_recovery.MAX_RECOVERIES_PER_MINUTE] is False
+    assert "recovery rate exceeded" in logs[-1]
+
+
+def test_diagnostic_reports_the_full_receive_timeout(monkeypatch):
+    """Forensics must show sub-second timeouts, not a truncated ``tv_sec``."""
+    packed = struct.pack(_TIMEVAL, 0, 500_000)
+    sock = _FakeSocket(packed)
+    mod = _FakeSocketModule(sock=sock)
+    _install(monkeypatch, nonblock=False, socket_mod=mod)
+
+    diag = _stdin_recovery.diagnose_stdin_state()
+
+    assert "O_NONBLOCK=0" in diag
+    assert f"SO_RCVTIMEO={packed!r}" in diag

--- a/tests/tui_gateway/test_stdin_recovery.py
+++ b/tests/tui_gateway/test_stdin_recovery.py
@@ -37,6 +37,13 @@ from tui_gateway import _stdin_recovery
 # Same layout the production recovery tail packs with.
 _TIMEVAL = "ll"
 
+# ``os.O_NONBLOCK`` is POSIX-only — the repo's platform-safe idiom is
+# ``getattr(os, "O_NONBLOCK", ...)`` (see ``cron/lifecycle_guard.py:430``).
+# Every OS collaborator here is stubbed, so these tests are pure logic and can
+# run anywhere; they only need the stub and the module under test to agree on
+# which bit means "non-blocking", which ``_install`` arranges below.
+_O_NONBLOCK = getattr(os, "O_NONBLOCK", 0o4000)
+
 
 class _FakeSocket:
     """Stand-in for the ``socket.fromfd`` dup of fd 0."""
@@ -105,7 +112,10 @@ class _FakeFcntl:
 
 def _install(monkeypatch, *, nonblock: bool, socket_mod: _FakeSocketModule) -> list:
     """Bind stub collaborators onto the module; return the set_blocking log."""
-    flags = os.O_RDWR | (os.O_NONBLOCK if nonblock else 0)
+    # The module reads ``os.O_NONBLOCK`` to mask the flags; bind the same value
+    # it is being handed so the pair agrees even where the attribute is absent.
+    monkeypatch.setattr(_stdin_recovery.os, "O_NONBLOCK", _O_NONBLOCK, raising=False)
+    flags = os.O_RDWR | (_O_NONBLOCK if nonblock else 0)
     monkeypatch.setattr(_stdin_recovery, "_HAS_FCNTL", True)
     monkeypatch.setattr(_stdin_recovery, "_fcntl", _FakeFcntl(flags))
     monkeypatch.setattr(_stdin_recovery, "_HAS_SOCKET", True)

--- a/tui_gateway/_stdin_recovery.py
+++ b/tui_gateway/_stdin_recovery.py
@@ -52,6 +52,43 @@ _TIMEVAL_SIZE = struct.calcsize(_TIMEVAL_FORMAT)
 MAX_RECOVERIES_PER_MINUTE = 10
 
 
+def _read_stdin_rcvtimeo() -> bytes | None:
+    """Return stdin's raw ``SO_RCVTIMEO`` timeval, or ``None`` if unreadable.
+
+    ``SO_RCVTIMEO`` is a socket option (not a file-status flag), equally shared
+    on the open file description.  A child setting it via ``setsockopt``
+    launders into the same spurious-EOF path as ``O_NONBLOCK`` — but with
+    ``O_NONBLOCK`` clear.
+
+    ``None`` means **"cannot tell"**, not "no timeout": either the ``socket``
+    module is unavailable, or fd 0 is not a socket at all (a tty, or an
+    anonymous pipe), in which case ``fromfd``/``getsockopt`` raises
+    ``ENOTSOCK``.  Callers must treat ``None`` as "nothing detected" so that
+    non-socket stdin keeps its existing behaviour.
+    """
+    if not (_HAS_SOCKET and _socket is not None):
+        return None
+    try:
+        s = _socket.fromfd(0, _socket.AF_UNIX, _socket.SOCK_STREAM)
+    except Exception:
+        # ``ENOTSOCK`` surfaces here on platforms whose socket constructor
+        # validates the descriptor (macOS).
+        return None
+    try:
+        # ``getsockopt`` without an explicit buffer length assumes an *int*
+        # option and reads only ``sizeof(int)`` bytes, truncating
+        # ``struct timeval`` to the low half of ``tv_sec`` — a 500 ms timeout
+        # would then be reported as ``0``.  Read the whole struct.
+        return s.getsockopt(_socket.SOL_SOCKET, _socket.SO_RCVTIMEO, _TIMEVAL_SIZE)
+    except Exception:
+        # ...and here on platforms that defer validation to the option call.
+        return None
+    finally:
+        # ``fromfd`` duped the fd; ``close`` releases the dup without touching
+        # the original fd 0.
+        s.close()
+
+
 def diagnose_stdin_state() -> str:
     """Return a diagnostic string about stdin's current state.
 
@@ -68,28 +105,10 @@ def diagnose_stdin_state() -> str:
             parts.append(f"F_GETFL error: {e}")
     else:
         parts.append("O_NONBLOCK=n/a (no fcntl)")
-    # ``SO_RCVTIMEO`` is a socket option (not a file-status flag), equally
-    # shared on the open file description.  A child setting it via
-    # ``setsockopt`` launders into the same spurious-EOF path with
-    # ``O_NONBLOCK`` clear, so we report it alongside the flag.
-    if _HAS_SOCKET and _socket is not None:
-        try:
-            s = _socket.fromfd(0, _socket.AF_UNIX, _socket.SOCK_STREAM)
-            try:
-                # ``getsockopt`` without an explicit buffer length assumes an
-                # *int* option and reads only ``sizeof(int)`` bytes, truncating
-                # ``struct timeval`` to the low half of ``tv_sec`` — a 500 ms
-                # timeout is then reported as ``0``.  Read the whole struct.
-                tv = s.getsockopt(
-                    _socket.SOL_SOCKET, _socket.SO_RCVTIMEO, _TIMEVAL_SIZE
-                )
-                parts.append(f"SO_RCVTIMEO={tv!r}")
-            finally:
-                # ``fromfd`` duped the fd; ``close`` releases the dup without
-                # touching the original fd 0.
-                s.close()
-        except Exception:
-            pass
+    # Report the shared-description socket timeout alongside the flag.
+    tv = _read_stdin_rcvtimeo()
+    if tv is not None:
+        parts.append(f"SO_RCVTIMEO={tv!r}")
     return ", ".join(parts) if parts else "unknown"
 
 

--- a/tui_gateway/_stdin_recovery.py
+++ b/tui_gateway/_stdin_recovery.py
@@ -5,6 +5,11 @@ lands on the **shared open file description** — not just the child's descripto
 The gateway's next ``read()`` returns ``EAGAIN``, which CPython's buffered
 ``TextIOWrapper`` converts to ``b''`` (apparent EOF), killing the gateway.
 
+``SO_RCVTIMEO`` is the second route to the same symptom.  It is a socket option
+rather than a file-status flag, but it lives on the same shared description, and
+when it expires the read returns ``''`` with ``O_NONBLOCK`` **clear** — so the
+flag alone is not enough to tell tampering from a real peer close.
+
 This module provides:
 - :func:`diagnose_stdin_state` — forensic diagnostic (``O_NONBLOCK`` / ``SO_RCVTIMEO``)
 - :func:`handle_spurious_eof` — check whether an empty ``readline()`` is a genuine
@@ -89,12 +94,28 @@ def _read_stdin_rcvtimeo() -> bytes | None:
         s.close()
 
 
+def _stdin_rcvtimeo_is_set() -> bool:
+    """Return ``True`` only when stdin carries a **non-zero** receive timeout.
+
+    A zeroed timeval means "block forever", which is the default and is not
+    tampering.  An unreadable probe (``None``) is deliberately reported as
+    ``False``: on a tty or an anonymous pipe there is no timeout to detect, and
+    guessing ``True`` there would make every genuine peer-close look spurious.
+
+    The byte-wise test avoids unpacking, so it holds regardless of the
+    platform's timeval width or endianness.
+    """
+    tv = _read_stdin_rcvtimeo()
+    return tv is not None and any(tv)
+
+
 def diagnose_stdin_state() -> str:
     """Return a diagnostic string about stdin's current state.
 
     Used for crash-log forensics when stdin iteration falls through.
-    Distinguishes genuine peer-close (flag clear) from spurious EOF
-    caused by a child setting ``O_NONBLOCK`` on the shared file description.
+    Distinguishes a genuine peer-close from a spurious EOF caused by a child
+    mutating the shared file description — either ``O_NONBLOCK`` or a non-zero
+    ``SO_RCVTIMEO``.
     """
     parts: list[str] = []
     if _HAS_FCNTL and _fcntl is not None:
@@ -138,7 +159,10 @@ def handle_spurious_eof(
     except Exception:
         is_nonblock = False
 
-    if not is_nonblock:
+    # ``SO_RCVTIMEO`` reaches the same symptom by a different route: the read
+    # expires and returns ``''`` with ``O_NONBLOCK`` **clear**, so the flag
+    # alone cannot distinguish it from a peer close.  Probe it too.
+    if not is_nonblock and not _stdin_rcvtimeo_is_set():
         # Genuine peer-close — no subprocess flag tampering detected.
         log_fn("stdin EOF (peer closed)")  # type: ignore[operator]
         return False
@@ -157,7 +181,7 @@ def handle_spurious_eof(
         return False
 
     diag = diagnose_stdin_state()
-    log_fn(f"stdin spurious EOF (subprocess O_NONBLOCK flip), recovering: {diag}")  # type: ignore[operator]
+    log_fn(f"stdin spurious EOF (subprocess O_NONBLOCK / SO_RCVTIMEO), recovering: {diag}")  # type: ignore[operator]
 
     # Clear ``O_NONBLOCK`` on the shared file description.
     os.set_blocking(0, True)

--- a/tui_gateway/_stdin_recovery.py
+++ b/tui_gateway/_stdin_recovery.py
@@ -37,6 +37,13 @@ except ImportError:
 import struct
 
 
+# ``struct timeval`` — ``tv_sec``, ``tv_usec`` — the payload of ``SO_RCVTIMEO``
+# on the platforms this POSIX-only module runs on.  Named once so the probe and
+# the recovery below cannot drift apart.
+_TIMEVAL_FORMAT = "ll"
+_TIMEVAL_SIZE = struct.calcsize(_TIMEVAL_FORMAT)
+
+
 # Rate-limit: at most this many spurious-EOF recoveries per 60-second window.
 # A child aggressively flipping ``O_NONBLOCK`` on the shared fd would otherwise
 # create a tight busy-loop burning CPU.  Exceeding the cap exits the process —
@@ -69,7 +76,13 @@ def diagnose_stdin_state() -> str:
         try:
             s = _socket.fromfd(0, _socket.AF_UNIX, _socket.SOCK_STREAM)
             try:
-                tv = s.getsockopt(_socket.SOL_SOCKET, _socket.SO_RCVTIMEO)
+                # ``getsockopt`` without an explicit buffer length assumes an
+                # *int* option and reads only ``sizeof(int)`` bytes, truncating
+                # ``struct timeval`` to the low half of ``tv_sec`` — a 500 ms
+                # timeout is then reported as ``0``.  Read the whole struct.
+                tv = s.getsockopt(
+                    _socket.SOL_SOCKET, _socket.SO_RCVTIMEO, _TIMEVAL_SIZE
+                )
                 parts.append(f"SO_RCVTIMEO={tv!r}")
             finally:
                 # ``fromfd`` duped the fd; ``close`` releases the dup without
@@ -139,7 +152,11 @@ def handle_spurious_eof(
             s = _socket.fromfd(0, _socket.AF_UNIX, _socket.SOCK_STREAM)
             try:
                 # Zero timeval: tv_sec=0, tv_usec=0 (struct timeval on most platforms)
-                s.setsockopt(_socket.SOL_SOCKET, _socket.SO_RCVTIMEO, struct.pack("ll", 0, 0))
+                s.setsockopt(
+                    _socket.SOL_SOCKET,
+                    _socket.SO_RCVTIMEO,
+                    struct.pack(_TIMEVAL_FORMAT, 0, 0),
+                )
             finally:
                 s.close()
         except Exception:


### PR DESCRIPTION
## This is a sibling follow-up to #67910 (commit `113d9f63b`)

- **What the parent covered:** #67910 hardened the spurious stdin-EOF guard — Windows import guards, the `fromfd` fd leak, the entry/slash-worker duplication, and (item 5 of its own commit message) *"SO_RCVTIMEO not cleared: … Now clears SO_RCVTIMEO alongside O_NONBLOCK."*
- **What the parent did NOT touch:** the **decision gate**. `handle_spurious_eof` still classifies an empty `readline()` on `O_NONBLOCK` alone, so the `SO_RCVTIMEO` clearing it added sits *below* a branch that an `SO_RCVTIMEO`-only mutation can never reach.
- **What this adds:** the detection half — probe the receive timeout alongside the flag, with an explicit fail-safe for non-socket stdin, plus the first direct test coverage this module has had.

## What does this PR do?

`tui_gateway/_stdin_recovery.py` protects the gateway from a child process that mutates the **shared open file description** behind fd 0. Two different mutations produce the identical symptom — an empty `readline()` that looks exactly like the parent closing the pipe:

1. `O_NONBLOCK` set via `fcntl` — the read returns `EAGAIN`, which CPython's buffered `TextIOWrapper` launders into `b''`.
2. A non-zero `SO_RCVTIMEO` set via `setsockopt` — the read expires and returns `''` **with `O_NONBLOCK` clear**.

The module knows this. Its docstring lists `SO_RCVTIMEO` as a first-class concern, the diagnostic reports it, the recovery comment says *"a child set `O_NONBLOCK` (and/or `SO_RCVTIMEO`)"*, and the recovery tail zeroes the option precisely so *"the next `readline()`"* will not time out again.

But the gate only ever inspected the flag:

```python
if not is_nonblock:
    # Genuine peer-close — no subprocess flag tampering detected.
    log_fn("stdin EOF (peer closed)")
    return False
```

So case 2 takes the peer-close branch, the gateway exits mid-session, and the remedy written for that exact case is unreachable from it. The user sees the Ink TUI die with `gateway exited` / `[gateway-exit] stdin EOF (peer closed)` while the parent's pipe is perfectly alive; the session and any in-flight turn are lost. Same path in the slash worker.

**Fix:** probe the timeout too — `if not is_nonblock and not _stdin_rcvtimeo_is_set():`.

### The fail-safe is the load-bearing part

Getting this wrong in the other direction would be far worse than the bug: if the probe guessed "timeout set" whenever it could not tell, every genuine peer close would look spurious and the gateway would refuse to exit. So `_read_stdin_rcvtimeo()` returns `None` — explicitly *"cannot tell"* — whenever fd 0 is not a socket, and `_stdin_rcvtimeo_is_set()` maps `None` to `False`. A tty- or pipe-backed stdin therefore behaves **byte-for-byte as it does today**. `ENOTSOCK` is caught from both places it can surface: `fromfd`, on platforms whose socket constructor validates the descriptor (macOS), and `getsockopt`, on platforms that defer validation to the option call. Both directions are pinned by tests.

The worst case is also bounded when a real peer-close coincides with a pre-existing timeout on a socket stdin: the first pass recovers and zeroes the option, so the very next empty read finds both mutations clear and exits normally — **one extra loop iteration, not a hang**. Recoveries still count against `MAX_RECOVERIES_PER_MINUTE`, so a child re-arming the timeout cannot spin the loop. Both properties have tests.

### Why the probe width had to change first

`diagnose_stdin_state` called `getsockopt(SOL_SOCKET, SO_RCVTIMEO)` with no buffer length. CPython then assumes an *int* option and reads only `sizeof(int)` bytes, truncating `struct timeval` to the low half of `tv_sec`. Measured on macOS against a real `socketpair`:

```
after setsockopt(SO_RCVTIMEO, timeval(0, 500000)):
  no-buflen : 0
  buflen 16 : b'\x00\x00\x00\x00\x00\x00\x00\x00 \xa1\x07\x00\x00\x00\x00\x00'
```

Every timeout under one second reads back as `0`. That is a real (if minor) defect in the shipped forensics on its own, and a gate built on that read would silently miss exactly the sub-second timeouts a well-behaved child is most likely to set — so it is fixed first, in its own commit.

### Blast radius — stated honestly

This is a default-enabled path with no config flag: every POSIX `hermes --tui` user runs `handle_spurious_eof` on every stdin fall-through. **But reaching the bug needs unusual prior state** — a process must call `setsockopt(SO_RCVTIMEO)` on the inherited fd 0, and `scripts/check_subprocess_stdin.py` already forces an explicit `stdin=` on every spawn under `agent/`, `tools/`, `plugins/` and `tui_gateway/`. The realistically exposed population is therefore code the repo does not control: MCP servers, user plugins, and third-party binaries. I am not claiming this hits a whole class of users.

What I do claim is that the class is real and already costly: #14036, #39257 and #67639 are three separate filed issues about the gateway dying on a spurious stdin EOF, the repo carries a dedicated CI guard script for the underlying fd-0 inheritance hazard, and #67910 was merged to fix it — this is the one half of that fix that was left unfinished.

## Related Issue

No open issue. This completes the detection half of #67910 (merged as `113d9f63b`).

Same-class issues, all closed:

- #67639 — spurious TUI "stdin EOF" from `O_NONBLOCK` on a shared open file description
- #39257 — TUI stdin EOF crash when the backend is slow
- #14036 — `--tui` gateway exits 0 mid-turn

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Four atomic commits, in dependency order:

1. **`fix(gateway): read stdin's full SO_RCVTIMEO timeval in the state diagnostic`** — `tui_gateway/_stdin_recovery.py`. Pass an explicit `struct.calcsize("ll")` buffer length to `getsockopt`, and name the timeval layout in one module constant (`_TIMEVAL_FORMAT` / `_TIMEVAL_SIZE`) so the probe and the recovery that zeroes the option cannot drift apart.
2. **`refactor(gateway): factor the stdin SO_RCVTIMEO probe out of diagnose_stdin_state`** — `tui_gateway/_stdin_recovery.py`. Lift the read into `_read_stdin_rcvtimeo() -> bytes | None`, so asking "does stdin carry a child-set timeout?" no longer means rendering a human-readable forensic line and parsing it back. Pure extraction: `diagnose_stdin_state` produces byte-identical output and the `fromfd` dup is still closed on every path.
3. **`fix(gateway): treat a child-set SO_RCVTIMEO as a spurious stdin EOF, not a peer close`** — `tui_gateway/_stdin_recovery.py`. Add `_stdin_rcvtimeo_is_set()` (a byte-wise non-zero test, so it holds regardless of the platform's timeval width or endianness) and widen the gate to `if not is_nonblock and not _stdin_rcvtimeo_is_set():`. Also corrects the now-inaccurate recovery log line and the module/function docstrings.
4. **`test(gateway): cover stdin spurious-EOF detection for SO_RCVTIMEO and the non-socket fail-safe`** — new `tests/tui_gateway/test_stdin_recovery.py`, 8 tests.

Each commit is independently green.

### Sibling-site sweep

`git grep -n "SO_RCVTIMEO\|O_NONBLOCK\|set_blocking(0" -- '*.py'` over `origin/main`, excluding tests, returns four production files. All four are accounted for:

| Site | Disposition |
|---|---|
| `tui_gateway/_stdin_recovery.py` | **The only detection gate in the repo.** Fixed here. |
| `tui_gateway/entry.py:465` | Caller of `handle_spurious_eof` — fixed by this gate change, needs no edit. |
| `tui_gateway/slash_worker.py:157` | Caller of `handle_spurious_eof` — likewise. |
| `cron/lifecycle_guard.py:430`, `tools/process_registry.py:1776` | Excluded: different concern. One opens a *new* fd with `O_RDONLY \| O_NONBLOCK`, the other sets `O_NONBLOCK` on a child's stdout to drain it. Neither involves the shared fd-0 description. |

## How to Test

**Red before / green after**, both directions verified on this branch:

```
# 1. tests only, production file reverted to origin/main
git checkout origin/main -- tui_gateway/_stdin_recovery.py
pytest tests/tui_gateway/test_stdin_recovery.py -q
#   4 failed, 4 passed
#
#   test_rcvtimeo_only_is_spurious:
#     AssertionError: expected spurious-EOF recovery; log_fn saw ['stdin EOF (peer closed)']
#     assert False is True
```

That captured string is emitted from exactly one place — the `if not is_nonblock` branch — so the failure is pinned to the gate itself and not to a fixture artefact. The negative control (`test_no_flags_is_genuine_eof`) and the fail-safe test (`test_non_socket_stdin_is_genuine_eof`) **pass before and after**, so the suite cannot pass vacuously against a gate that always recovers.

`test_diagnostic_reports_the_full_receive_timeout` is red before commit 1 and green after it, independently of the gate change.

```
# 2. with the fix
pytest tests/tui_gateway/test_stdin_recovery.py -q
#   8 passed

# 3. adjacent tui_gateway suites, unaffected
pytest tests/tui_gateway/test_stdin_recovery.py \
       tests/tui_gateway/test_entry_picker_prewarm.py \
       tests/tui_gateway/test_slash_worker_ansi.py \
       tests/tui_gateway/test_entry_sys_path.py \
       tests/tui_gateway/test_slash_worker_sys_path.py \
       tests/tui_gateway/test_subprocess_encoding.py \
       tests/tui_gateway/test_protocol.py -q
#   62 passed

# 4. the repo's own fd-0 CI guard still passes
python3 scripts/check_subprocess_stdin.py
#   ✅ All TUI-context subprocess calls have explicit stdin=
```

`handle_spurious_eof` is a pure predicate over fd-0 state, so the tests stub `fcntl`, `socket` and `os.set_blocking` at the module boundary rather than reproducing a real kernel `EAGAIN`. The fake socket mutates its own stored timeval on `setsockopt`, so a later probe observes what the recovery actually did — that is what makes the "one extra iteration, not a hang" test meaningful rather than tautological.

## Deliberately not changed

- **`tui_gateway/entry.py`** — its call at `:465` already routes through `handle_spurious_eof`, so it is fixed by the gate change; editing it would only add conflict surface.
- **`tui_gateway/slash_worker.py`** — same, at `:157`.
- **`cron/lifecycle_guard.py:430`** — `os.open(path, O_RDONLY | O_NONBLOCK)` on a *new* descriptor it owns; not the shared fd-0 description.
- **`tools/process_registry.py:1776`** — sets `O_NONBLOCK` on a child's stdout to do a non-blocking drain; deliberate, local to that fd, and unrelated to stdin inheritance.
- **The `MAX_RECOVERIES_PER_MINUTE` budget** — reused as-is rather than given the timeout path its own counter, so total recovery work per process is unchanged.

## Related / Positioning

Dedup searches run immediately before opening, and again against the live open queue:

- `gh search prs --state open` on `handle_spurious_eof`, `SO_RCVTIMEO`, `diagnose_stdin_state`, `_stdin_recovery`.
- `gh pr list --state open --limit 300 --json files` matched against `tui_gateway/_stdin_recovery.py` and `tests/tui_gateway/test_stdin_recovery.py`.

The two open PRs that turn up on this file are **#78894** and **#78896**, both for #78820. Both append a new `handle_stdin_oserror` after `handle_spurious_eof` for the case where `readline()` *raises* `OSError` on Windows, and both leave `handle_spurious_eof`'s body and the `O_NONBLOCK` gate untouched. Different failure mode, different region, no overlap in behaviour — the only contact point is the module docstring, which is trivially reconcilable in whichever order they land.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not ticked:** I ran the targeted suites listed under "How to Test" (62 passed) plus `ruff check` and `pyflakes` clean on both touched files, but not the full repo suite locally. CI covers that.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module and function docstrings updated to match the widened gate
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the Windows path is untouched: `handle_spurious_eof` still returns early on `not _HAS_FCNTL` before any socket probe, and the probe is additionally guarded on `_HAS_SOCKET`. Verified on macOS; the non-socket fail-safe is covered from both the `fromfd` and `getsockopt` error shapes so the behaviour does not depend on which platform raises where.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
