### PR TITLE
fix(hooks): surface pre_llm_call fields at top level of hook payload

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -686,6 +686,13 @@ def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
         "cwd": cwd,
         "extra": extras,
     }
+    # pre_llm_call advertises user-facing fields at the top level per the
+    # wire-protocol docstring.  Lift them out of extras so hook authors
+    # can read them directly rather than fishing through payload["extra"].
+    if event == "pre_llm_call":
+        for _key in ("user_message", "turn_id", "is_first_turn"):
+            if _key in extras:
+                payload[_key] = extras.pop(_key)
     return json.dumps(payload, ensure_ascii=False, default=str)
 
 


### PR DESCRIPTION
Fixes #83281 — lift user_message, turn_id, and is_first_turn to the top level of the pre_llm_call hook payload so hooks following the documented wire protocol receive them.