### PR TITLE
fix(api): validate Content-Type in custom endpoint test

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7598,6 +7598,9 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
         try:
             async with httpx.AsyncClient(timeout=httpx.Timeout(8.0)) as client:
                 resp = await client.get(url, headers=headers)
+            content_type = resp.headers.get("content-type", "")
+            if "application/json" not in content_type:
+                return {"ok": False, "reachable": True, "message": f"Endpoint returned {content_type or 'unknown content type'} instead of JSON. Is this an OpenAI-compatible API?"}
             return {"ok": True, "reachable": True, "message": "", "models": _parse_model_ids(resp)}
         except Exception:
             return {"ok": False, "reachable": False, "message": f"Could not reach {url}."}


### PR DESCRIPTION
Fixes #83128 — the endpoint validation now checks Content-Type for application/json before returning success, so SPA catch-all HTML responses don't falsely show a green check.