### PR TITLE
fix(media): clean up partial cache files on failed streamed downloads

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -318,21 +318,29 @@ def save_url_image(
     path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
 
     bytes_written = 0
-    with path.open("wb") as fh:
-        for chunk in response.iter_content(chunk_size=64 * 1024):
-            if not chunk:
-                continue
-            bytes_written += len(chunk)
-            if bytes_written > max_bytes:
-                fh.close()
-                try:
-                    path.unlink()
-                except OSError:
-                    pass
-                raise ValueError(
-                    f"Image at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
-                )
-            fh.write(chunk)
+    try:
+        with path.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                bytes_written += len(chunk)
+                if bytes_written > max_bytes:
+                    fh.close()
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                    raise ValueError(
+                        f"Image at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
+                    )
+                fh.write(chunk)
+    except Exception:
+        # Clean up partial file on any failure (network drop, timeout, etc.)
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
 
     if bytes_written == 0:
         try:

--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -296,21 +296,28 @@ def save_url_video(
     path = _videos_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
 
     bytes_written = 0
-    with path.open("wb") as fh:
-        for chunk in response.iter_content(chunk_size=256 * 1024):
-            if not chunk:
-                continue
-            bytes_written += len(chunk)
-            if bytes_written > max_bytes:
-                fh.close()
-                try:
-                    path.unlink()
-                except OSError:
-                    pass
-                raise ValueError(
-                    f"Video at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
-                )
-            fh.write(chunk)
+    try:
+        with path.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=256 * 1024):
+                if not chunk:
+                    continue
+                bytes_written += len(chunk)
+                if bytes_written > max_bytes:
+                    fh.close()
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                    raise ValueError(
+                        f"Video at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
+                    )
+                fh.write(chunk)
+    except Exception:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
 
     if bytes_written == 0:
         try:


### PR DESCRIPTION
Fixes #83119 — failed streamed downloads in save_url_image and save_url_video now clean up the partial cache file before re-raising.