### PR TITLE
fix(plugins): warn when plugins.enabled is a string instead of a list

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -794,6 +794,16 @@ def _get_enabled_set() -> set:
         if not isinstance(plugins_cfg, dict):
             return set()
         enabled = plugins_cfg.get("enabled", [])
+        if isinstance(enabled, str):
+            import logging
+            _log = logging.getLogger(__name__)
+            _log.warning(
+                "plugins.enabled is a string (%r) instead of a list. "
+                "All user plugin APIs are unmounted. "
+                "Fix: remove the quotes around the value in config.yaml.",
+                enabled,
+            )
+            return set()
         return set(enabled) if isinstance(enabled, list) else set()
     except Exception:
         return set()


### PR DESCRIPTION
Fixes #83308 — _get_enabled_set() now logs a clear warning when plugins.enabled is a YAML string instead of a list, helping users diagnose silently unmounted plugins.