### PR TITLE
fix: never send empty tool_calls arrays to strict providers (#83312)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -650,6 +650,13 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 prev["tool_calls"] = prev_calls + new_calls
             elif prev_calls:
                 prev["tool_calls"] = prev_calls
+            else:
+                # Neither turn carries calls. If the surviving turn kept a
+                # pre-existing empty ``tool_calls`` array, drop the key —
+                # strict providers (DeepSeek) reject ``tool_calls: []`` with
+                # HTTP 400 and the poisoned message fails every subsequent
+                # request in the session (#83312).
+                prev.pop("tool_calls", None)
             # Concatenate plain-text content; leave multimodal (list)
             # content on either side alone to avoid mangling attachment
             # blocks — fall back to keeping the existing content.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -272,6 +272,14 @@ class ChatCompletionsTransport(ProviderTransport):
                 break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                # Strict OpenAI-compatible providers (DeepSeek v4) reject an
+                # assistant message carrying an empty ``tool_calls`` array
+                # outright ("Expected an array with minimum length 1"). The
+                # key must be omitted when there are no calls, so flag the
+                # message for the sanitize pass below.
+                if msg.get("role") == "assistant" and not tool_calls:
+                    needs_sanitize = True
+                    break
                 for tc in tool_calls:
                     if isinstance(tc, dict) and (
                         "call_id" in tc
@@ -327,6 +335,21 @@ class ChatCompletionsTransport(ProviderTransport):
                     out_msg.pop(key, None)
 
             tool_calls = msg.get("tool_calls")
+            # Drop empty ``tool_calls`` arrays on assistant messages before
+            # they reach the wire — strict providers (DeepSeek v4) reject
+            # them with HTTP 400 ("Expected an array with minimum length 1")
+            # and the poisoned message then fails every subsequent request
+            # in the session. This is the final chokepoint before the HTTP
+            # body is serialized, so it catches arrays reintroduced after
+            # earlier sanitizers (e.g. the consecutive-assistant merge in
+            # repair_message_sequence) regardless of the source path.
+            if (
+                msg.get("role") == "assistant"
+                and isinstance(tool_calls, list)
+                and not tool_calls
+            ):
+                mutable_msg().pop("tool_calls", None)
+                tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 copied_tool_calls: list[Any] | None = None
                 for tc_idx, tc in enumerate(tool_calls):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -150,6 +150,45 @@ class TestChatCompletionsBasic:
         assert "extra_content" in msgs[1]["tool_calls"][1]
 
 
+    def test_convert_messages_drops_empty_tool_calls_array(self, transport):
+        """Empty ``tool_calls`` arrays on assistant messages never reach the wire.
+
+        DeepSeek v4 rejects any assistant message carrying ``tool_calls: []``
+        with HTTP 400 ("Expected an array with minimum length 1"), which then
+        fails every subsequent request in the session (#83312). The transport
+        is the final chokepoint before serialization, so it must drop the key
+        even when earlier sanitizers missed it, and it must not mutate the
+        caller's history.
+        """
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "answer", "tool_calls": []},
+        ]
+        result = transport.convert_messages(msgs)
+
+        assert result is not msgs  # dirty history requires a sanitized copy
+        assert "tool_calls" not in result[1]
+        assert result[1]["content"] == "answer"
+        # Original history is untouched — the empty array survives there so
+        # the persisted transcript stays byte-stable.
+        assert msgs[1]["tool_calls"] == []
+
+    def test_convert_messages_keeps_nonempty_tool_calls_identity(self, transport):
+        """A healthy non-empty tool_calls list passes through without a copy."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_1", "type": "function",
+                     "function": {"name": "t", "arguments": "{}"}}
+                ],
+            },
+        ]
+        result = transport.convert_messages(msgs)
+        assert result is msgs
+
+
 
 class TestChatCompletionsBuildKwargs:
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -69,6 +69,43 @@ def test_repair_preserves_user_content_when_one_side_empty():
     assert messages == [{"role": "user", "content": "real message"}]
 
 
+def test_repair_merge_drops_empty_tool_calls_on_surviving_turn():
+    """Consecutive-assistant merge must not preserve ``tool_calls: []``.
+
+    The merge previously kept a pre-existing empty array on the surviving
+    turn when neither side carried calls. Strict providers (DeepSeek v4)
+    reject ``tool_calls: []`` with HTTP 400 and the poisoned message then
+    fails every subsequent request in the session (#83312).
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "assistant", "content": "interim", "tool_calls": []},
+        {"role": "assistant", "content": "final"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert len(messages) == 1
+    assert messages[0]["content"] == "interim\nfinal"
+    assert "tool_calls" not in messages[0]
+
+def test_repair_merge_keeps_nonempty_tool_calls_union():
+    """A real tool_calls union on the surviving turn is preserved."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "call_A", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "assistant", "content": "note"},
+    ]
+
+    AIAgent._repair_message_sequence(agent, messages)
+
+    assert len(messages) == 1
+    assert [tc["id"] for tc in messages[0]["tool_calls"]] == ["call_A"]
+
+
 def test_repair_does_not_rewind_ongoing_dialog_tool_pair():
     """assistant(tool_calls) + tool + user is a VALID pattern (user redirect
     before the model gets its continuation turn). Repair must not touch it —


### PR DESCRIPTION
# Summary

Fixes a session-wedging bug on strict OpenAI-compatible providers (DeepSeek v4): an assistant message carrying `tool_calls: []` (an empty array) is rejected with HTTP 400 (`Invalid 'messages[N].tool_calls': empty array. Expected an array with minimum length 1`), and because the poisoned message stays in replayed history, **every subsequent message to that session fails the same way** until the agent cache is cleared.

# Motivation

We observed this across multiple sessions on DeepSeek. The pre-API sanitizer added for #56980/#58755 (`sanitize_api_messages`) correctly strips `tool_calls: []` when it sees it, but the empty array can be reintroduced *after* that sanitizer — e.g. the consecutive-assistant merge in `repair_message_sequence` explicitly preserves a pre-existing `[]` on the surviving turn (documented in the sanitizer's own comment as a known source). Once it reaches the wire, the failure is non-retryable and permanent for the session.

# Changes

## `agent/transports/chat_completions.py`

`convert_messages()` is the final chokepoint before the HTTP body is serialized. Two additions:

1. **Detection scan** — an assistant message with an empty `tool_calls` list now marks the history dirty, so the sanitize pass runs.
2. **Sanitize pass** — empty `tool_calls` on an assistant message is dropped (key removed entirely) via the existing copy-on-write path, so the caller's in-memory history is never mutated and the persisted transcript stays byte-stable.

This guarantees the wire invariant regardless of which path built the messages (main loop, retries, fallback re-builds, host-fed histories).

## `agent/agent_runtime_helpers.py`

In `repair_message_sequence`, the consecutive-assistant merge unioned `tool_calls` but left a pre-existing `[]` in place when both sides were empty. The merge now pops the key when the union is empty — fixing the documented source of the poison.

## Tests

- `tests/agent/transports/test_chat_completions.py`
  - `test_convert_messages_drops_empty_tool_calls_array` — empty array stripped on the sanitized copy, original untouched.
  - `test_convert_messages_keeps_nonempty_tool_calls_identity` — healthy non-empty `tool_calls` passes through without a copy (no regression to the copy-on-write optimization).
- `tests/run_agent/test_message_sequence_repair.py`
  - `test_repair_merge_drops_empty_tool_calls_on_surviving_turn` — merge pops the key when neither side carries calls.
  - `test_repair_merge_keeps_nonempty_tool_calls_union` — real tool calls are still unioned onto the surviving turn.

# Design decisions

- **Fix at the wire boundary, not only mid-pipeline.** The earlier sanitizer is correct but insufficient — something after it was re-adding the empty array. `convert_messages` runs after every request-builder path, so it is the right place to enforce "no assistant message ever carries an empty `tool_calls` array".
- **Copy-on-write preserved.** The transport only copies messages that actually need stripping, so the common healthy path stays allocation-free.
- **Repair fix addresses the known source** so the poison is not created in the first place; the transport fix is the belt that catches any future path that creates it.

# Backwards compatibility

Zero breaking changes. Messages with non-empty `tool_calls` are untouched (identity-preserving). Empty `tool_calls` is semantically "no tool calls" — omitting the key is the canonical OpenAI shape and is what permissive providers already receive from this codebase's other message builders.

# Testing

- `tests/agent/transports/test_chat_completions.py` — pass
- `tests/run_agent/test_message_sequence_repair.py` — pass
- `tests/run_agent/test_agent_guardrails.py`, `tests/providers/test_transport_parity.py`, related repair/sanitize subsets — pass
- **Real-world replay:** the exact failing payload captured from the production incident (163 messages, `request_dump_1f819f5dbd28_20260808_144115_112720.json` — assistant message 161 with `tool_calls: []`) now passes through `convert_messages()` with zero empty arrays remaining.
