### PR TITLE
fix(skills): emit lifecycle events for removals

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -271,6 +271,64 @@ class TestDeleteSkill:
         assert "cannot equal" in result["error"]
         assert (tmp_path / "narrow").exists()
 
+    def test_successful_hard_delete_reports_lifecycle_event(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch(
+                 "tools.skill_usage.telemetry_provenance",
+                 return_value="external",
+             ), \
+             patch("tools.skill_usage.forget") as forget:
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = json.loads(
+                skill_manage(
+                    action="delete",
+                    name="my-skill",
+                    task_id="task-1",
+                    session_id="session-1",
+                )
+            )
+
+        assert result["success"] is True
+        forget.assert_called_once_with(
+            "my-skill",
+            lifecycle_action="deleted",
+            provenance="external",
+            task_id="task-1",
+            session_id="session-1",
+        )
+
+    def test_failed_delete_does_not_report_lifecycle_event(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("tools.skill_usage.forget") as forget:
+            result = json.loads(
+                skill_manage(action="delete", name="missing-skill")
+            )
+
+        assert result["success"] is False
+        forget.assert_not_called()
+
+    def test_curator_archive_does_not_report_deleted(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch(
+                 "tools.skill_manager_tool._delete_skill",
+                 return_value={
+                     "success": True,
+                     "message": "Skill archived.",
+                     "_archived": True,
+                 },
+             ), \
+             patch("tools.skill_usage.forget") as forget:
+            result = json.loads(
+                skill_manage(
+                    action="delete",
+                    name="archived-skill",
+                    absorbed_into="umbrella",
+                )
+            )
+
+        assert result["success"] is True
+        forget.assert_not_called()
+
 # ---------------------------------------------------------------------------
 # write_file / remove_file
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -355,6 +355,48 @@ def test_forget_removes_record(skills_home):
     assert "x" not in load_usage()
 
 
+def test_forget_can_emit_successful_removal_with_preserved_provenance(
+    skills_home,
+    monkeypatch,
+):
+    from hermes_cli import lifecycle
+    from tools.skill_usage import bump_view, forget, load_usage
+
+    events = []
+    monkeypatch.setattr(lifecycle, "has_hook", lambda name: True)
+    monkeypatch.setattr(
+        lifecycle,
+        "invoke_hook",
+        lambda name, **kwargs: events.append((name, kwargs)),
+    )
+    bump_view("x")
+
+    forget(
+        "x",
+        lifecycle_action="deleted",
+        provenance="external",
+        task_id="task-1",
+        session_id="session-1",
+    )
+
+    assert "x" not in load_usage()
+    assert events == [
+        (
+            "on_skill_lifecycle",
+            {
+                "action": "deleted",
+                "skill_name": "x",
+                "provenance": "external",
+                "task_id": "task-1",
+                "session_id": "session-1",
+                "use_count": None,
+                "reused": None,
+                "reuse_after_patch": None,
+            },
+        )
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Provenance filter — the load-bearing safety check
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1289,6 +1289,41 @@ class TestInstallPathSafety:
         assert ok is False
         assert (isolated_skills_dir / "bystander" / "SKILL.md").read_text() == "safe"
 
+    def test_successful_uninstall_reports_lifecycle_event(
+        self,
+        tmp_path,
+        isolated_skills_dir,
+        patch_lock_file,
+    ):
+        from tools.skills_hub import uninstall_skill
+
+        skill_dir = isolated_skills_dir / "hub-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Hub skill\n")
+        lock_path = tmp_path / "lock.json"
+        patch_lock_file(lock_path)
+        HubLockFile().record_install(
+            name="hub-skill",
+            source="github",
+            identifier="owner/repo/hub-skill",
+            trust_level="trusted",
+            scan_verdict="pass",
+            skill_hash="hash",
+            install_path="hub-skill",
+            files=["SKILL.md"],
+        )
+
+        with patch("tools.skill_usage.forget") as forget:
+            ok, _ = uninstall_skill("hub-skill")
+
+        assert ok is True
+        assert not skill_dir.exists()
+        forget.assert_called_once_with(
+            "hub-skill",
+            lifecycle_action="uninstalled",
+            provenance="installed",
+        )
+
 
     def test_install_from_quarantine_rejects_symlinks(self, tmp_path):
         """Skill install must not follow symlinks that leak file contents

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1575,6 +1575,7 @@ def skill_manage(
     if gate_result is not None:
         return gate_result
 
+    delete_provenance = None
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
@@ -1593,6 +1594,15 @@ def skill_manage(
         result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
     elif action == "delete":
+        # Capture provenance before the path disappears. The lifecycle event is
+        # emitted only after a successful hard delete below; curator archives
+        # keep their existing ``archived`` event instead.
+        try:
+            from tools.skill_usage import telemetry_provenance
+
+            delete_provenance = telemetry_provenance(name)
+        except Exception:
+            pass
         result = _delete_skill(name, absorbed_into=absorbed_into)
 
     elif action == "write_file":
@@ -1644,7 +1654,13 @@ def skill_manage(
                 # keeps its usage record as STATE_ARCHIVED so `hermes curator
                 # status`/`restore` still see it. Only a hard delete forgets.
                 if not result.get("_archived"):
-                    forget(name)
+                    forget(
+                        name,
+                        lifecycle_action="deleted",
+                        provenance=delete_provenance,
+                        task_id=task_id,
+                        session_id=session_id,
+                    )
         except Exception:
             pass
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -813,6 +813,7 @@ def _emit_skill_lifecycle(
     action: str,
     *,
     record: Optional[Dict[str, Any]] = None,
+    provenance: Optional[str] = None,
     task_id: Optional[str] = None,
     session_id: Optional[str] = None,
     use_count: Optional[int] = None,
@@ -829,7 +830,7 @@ def _emit_skill_lifecycle(
             "on_skill_lifecycle",
             action=action,
             skill_name=skill_name,
-            provenance=telemetry_provenance(skill_name, record),
+            provenance=provenance or telemetry_provenance(skill_name, record),
             task_id=task_id or "",
             session_id=session_id or "",
             use_count=use_count,
@@ -1050,18 +1051,43 @@ def is_sync_enabled(skill_name: str) -> bool:
     return get_record(skill_name).get("sync") is True
 
 
-def forget(skill_name: str) -> None:
-    """Drop a skill's usage entry entirely. Called when the skill is deleted."""
+def forget(
+    skill_name: str,
+    *,
+    lifecycle_action: Optional[str] = None,
+    provenance: Optional[str] = None,
+    task_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> None:
+    """Drop a skill's usage entry and optionally report a successful removal.
+
+    Callers pass ``lifecycle_action`` only after the authoritative filesystem
+    operation succeeds. The observer is emitted even if sidecar cleanup fails:
+    a telemetry-file error cannot undo a deletion that already happened.
+    """
     if not skill_name:
         return
+    prior_record: Optional[Dict[str, Any]] = None
     try:
         with _usage_file_lock():
             data = load_usage()
             if skill_name in data:
+                raw_record = data.get(skill_name)
+                if isinstance(raw_record, dict):
+                    prior_record = dict(raw_record)
                 del data[skill_name]
                 save_usage(data)
     except Exception as e:
         logger.debug("skill_usage.forget(%s) failed: %s", skill_name, e, exc_info=True)
+    if lifecycle_action:
+        _emit_skill_lifecycle(
+            skill_name,
+            lifecycle_action,
+            record=prior_record,
+            provenance=provenance,
+            task_id=task_id,
+            session_id=session_id,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -4051,6 +4051,21 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
     lock.record_uninstall(skill_name)
     append_audit_log("UNINSTALL", skill_name, entry["source"], entry["trust_level"], "n/a", "user_request")
 
+    try:
+        from tools.skill_usage import forget
+
+        forget(
+            skill_name,
+            lifecycle_action="uninstalled",
+            provenance="installed",
+        )
+    except Exception:
+        logger.debug(
+            "Unable to record skill uninstall lifecycle for %s",
+            skill_name,
+            exc_info=True,
+        )
+
     return True, f"Uninstalled '{skill_name}' from {entry['install_path']}"
 
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -408,7 +408,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_session_end` | Observer | Canonically at each turn finalization; CLI/TUI exits have additional reduced legacy shapes. Return ignored. | Canonical: `session_id`, `task_id`, `turn_id`, `completed`, `failed`, `interrupted`, `turn_exit_reason`, `model`, `platform`; exit paths may add `reason`/`api_request_id` and omit fields. | IDs, model/platform, and outcome; canonical payload has no message body. |
 | `on_session_finalize` | Observer | CLI/TUI/gateway teardown through `finalize_session`; gateway shutdown or expiry may finalize without a reset. Return ignored. | Surface-dependent `session_id`, `platform`, optionally `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
 | `on_session_reset` | Observer | CLI/TUI session boundary and gateway after the replacement session exists; return ignored. | CLI: `session_id`, `platform`, `reason`; TUI: `session_id`, `platform`; gateway: those plus `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
-| `on_skill_lifecycle` | Observer | After an authoritative skill-usage state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
+| `on_skill_lifecycle` | Observer | After an authoritative Hermes skill operation or usage-state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
 | `pre_gateway_dispatch` | Directive/control | Incoming non-internal message before auth/pairing/dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
@@ -1316,7 +1316,15 @@ Fires for a failed provider attempt with status/retry timing, an `error` object,
 
 ### `on_skill_lifecycle`
 
-Fires after an authoritative skill-usage state change. It is observer-only and exposes the local `skill_name`, provenance, correlation IDs, usage count, and reuse flags.
+Fires after an authoritative Hermes skill operation or usage-state change. It
+is observer-only and exposes the local `skill_name`, provenance, correlation
+IDs, usage count, and reuse flags. Actions currently include `loaded`,
+`created`, `installed`, `edited`, `patched`, `deleted`, `uninstalled`, `stale`,
+`archived`, and `restored`.
+
+This observer covers successful operations performed through Hermes. It does
+not watch the filesystem and does not promise to detect edits made directly by
+an editor, Git, a sync client, or another process.
 
 ### Kanban lifecycle observers
 


### PR DESCRIPTION
## Summary

- emit `deleted` after a successful hard delete through `skill_manage`
- emit `uninstalled` after a successful Skills Hub uninstall
- capture the current bounded provenance before removal and keep curator archives on their existing `archived` action
- document the complete observer scope and its filesystem boundary

## Why

The merged `on_skill_lifecycle` observer from #68883 reports skill creation, mutation, loading, and curator transitions, but successful removal paths were silent. Plugins that maintain an external index therefore cannot invalidate a removed skill when Hermes performs the operation.

This extends the existing observer rather than adding another hook. Emission happens only after the authoritative filesystem operation succeeds. Usage-sidecar cleanup remains best-effort because its failure cannot undo a deletion that already occurred.

Removal provenance is captured before the path/Hub lock entry disappears and follows the current bounded `telemetry_provenance` contract (`installed`, `agent_created`, `external`, `local`, or `unknown`).

## Scope

- no filesystem watcher or scan loop
- no promise to detect edits made by Git, editors, sync clients, or other processes
- no per-command plugin-discovery special case; cross-entrypoint hook delivery remains the centralized concern tracked in #64178
- no new pre-operation or mutating hook contract

## Validation

Validated on current `main` (`5eb99eb2844b22ebb723711b8e6a0bbb80bb5f04`):

- `44 passed` across skill usage, hard-delete/archive, and Hub uninstall focused tests
- Ruff checks passed for all changed Python files
- `git diff --check` passed
