### PR TITLE
fix(doctor): skip false warning for builtin memory provider

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2919,6 +2919,8 @@ def run_doctor(args):
                 check_ok(f"{_active_memory_provider} provider active")
             elif _provider:
                 check_warn(f"{_active_memory_provider} configured but not available", "run: hermes memory status")
+            elif _active_memory_provider in ("", "builtin"):
+                check_ok("built-in memory active")
             else:
                 check_warn(f"{_active_memory_provider} plugin not found", "run: hermes memory setup")
         except Exception as _e:


### PR DESCRIPTION
Fixes #75647 — hermes doctor no longer warns about missing plugin when memory.provider is empty or builtin.