### PR TITLE
fix(desktop): silence Windows 'restricted characters' git warning

### DIFF
--- a/apps/desktop/electron/git-binary.test.ts
+++ b/apps/desktop/electron/git-binary.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { type GitBinaryOptions, resolveGitBinary } from './git-binary'
+
+// Candidate paths the Hermes resolver actually knows about.
+const PROGRAM_FILES_GIT = 'C:\\Program Files\\Git\\cmd\\git.exe' // has a space
+const LOCALAPP_PORTABLE_GIT = 'C:\\Users\\test\\AppData\\Local\\hermes\\git\\cmd\\git.exe' // no space
+
+function makeOpts(overrides: Partial<GitBinaryOptions> = {}): GitBinaryOptions {
+  return {
+    isWindows: true,
+    env: {},
+    fileExists: () => false,
+    findOnPath: () => null,
+    ...overrides
+  }
+}
+
+test('prefers the space-free PortableGit under LOCALAPPDATA over Program Files git', () => {
+  const opts = makeOpts({
+    env: {
+      LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local',
+      ProgramFiles: 'C:\\Program Files'
+    },
+    fileExists: p => p === PROGRAM_FILES_GIT || p === LOCALAPP_PORTABLE_GIT
+  })
+
+  const result = resolveGitBinary(opts)
+
+  assert.equal(result, LOCALAPP_PORTABLE_GIT, 'must prefer the space-free known-install git')
+  assert.ok(!result.includes(' '), 'resolved git must not contain a space')
+})
+
+test('falls back to the space-containing git when it is the only existing candidate and git is not on PATH', () => {
+  const opts = makeOpts({
+    env: { ProgramFiles: 'C:\\Program Files' },
+    fileExists: p => p === PROGRAM_FILES_GIT,
+    findOnPath: () => null
+  })
+
+  // Never break a machine whose sole git is Git for Windows under Program Files.
+  assert.equal(resolveGitBinary(opts), PROGRAM_FILES_GIT)
+})
+
+test('returns bare "git" when the only known-install git has spaces but git resolves on PATH', () => {
+  // This is the real-world case: git lives only under "Program Files" (space) but
+  // `git` is discoverable on PATH. Returning the bare name keeps simple-git quiet
+  // while still spawning a working git from the process PATH.
+  const opts = makeOpts({
+    env: { ProgramFiles: 'C:\\Program Files' },
+    fileExists: p => p === PROGRAM_FILES_GIT,
+    findOnPath: () => 'C:\\Program Files\\Git\\cmd\\git.exe'
+  })
+
+  const result = resolveGitBinary(opts)
+
+  assert.equal(result, 'git', 'must return the bare name to avoid the simple-git space warning')
+  assert.ok(!result.includes(' '), 'bare name has no space')
+})
+
+test('prefers a space-free known-install git over falling back to bare "git"', () => {
+  const opts = makeOpts({
+    env: {
+      LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local',
+      ProgramFiles: 'C:\\Program Files'
+    },
+    fileExists: p => p === PROGRAM_FILES_GIT || p === LOCALAPP_PORTABLE_GIT,
+    findOnPath: () => 'C:\\Program Files\\Git\\cmd\\git.exe'
+  })
+
+  // The explicit space-free path is better than the bare name (no PATH reliance).
+  assert.equal(resolveGitBinary(opts), LOCALAPP_PORTABLE_GIT)
+})
+
+test('uses git on PATH when no known-install candidate exists on disk', () => {
+  const opts = makeOpts({
+    env: { ProgramFiles: 'C:\\Program Files' },
+    fileExists: () => false,
+    findOnPath: () => 'C:\\some\\other\\git.exe'
+  })
+
+  assert.equal(resolveGitBinary(opts), 'git')
+})
+
+test('returns bare "git" when nothing exists and PATH lookup fails', () => {
+  const opts = makeOpts({
+    env: { ProgramFiles: 'C:\\Program Files' },
+    fileExists: () => false,
+    findOnPath: () => null
+  })
+
+  assert.equal(resolveGitBinary(opts), 'git')
+})
+
+test('non-Windows resolves via findOnPath only', () => {
+  const opts = makeOpts({ isWindows: false, findOnPath: () => '/usr/bin/git' })
+
+  assert.equal(resolveGitBinary(opts), '/usr/bin/git')
+})
+
+test('non-Windows returns bare "git" when findOnPath yields nothing', () => {
+  const opts = makeOpts({ isWindows: false, findOnPath: () => null })
+
+  assert.equal(resolveGitBinary(opts), 'git')
+})

--- a/apps/desktop/electron/git-binary.ts
+++ b/apps/desktop/electron/git-binary.ts
@@ -1,0 +1,82 @@
+import path from 'node:path'
+
+export interface GitBinaryOptions {
+  isWindows: boolean
+  env: Record<string, string | undefined>
+  fileExists: (filePath: string) => boolean
+  findOnPath?: (command: string) => string | null
+}
+
+/**
+ * Locate the git executable.
+ *
+ * Resolution order (first match wins), mirroring resolveGitBinary() in main.ts:
+ *   1. PortableGit under %LOCALAPPDATA%\hermes\git\ (install.ps1 / self-managed)
+ *   2. Standard Git for Windows install locations (ProgramFiles, ProgramFiles(x86))
+ *   3. %LOCALAPPDATA%\Programs\Git\ (user-scoped)
+ *   4. git on PATH
+ *
+ * Windows-specific hardening: simple-git's `customBinaryPlugin` validates the
+ * git binary path with a regex that rejects spaces (and other "restricted"
+ * characters). When the resolved git lives under "Program Files" the path
+ * contains a space, and simple-git emits a noisy
+ * `Invalid value supplied for custom binary, restricted characters must be
+ * removed or supply the unsafe.allowUnsafeCustomBinary option` warning on every
+ * spawn — even though the call still works (allowUnsafeCustomBinary is set).
+ *
+ * To keep the console clean we prefer, in order:
+ *   - a known-install candidate whose path has NO spaces, or
+ *   - the bare name "git" (which simple-git treats as space-free and resolves
+ *     via the process PATH), when `git` is discoverable on PATH, or
+ *   - the first existing candidate (even with spaces) as a last resort, so a
+ *     machine whose sole git is Git for Windows under Program Files still works.
+ */
+export function resolveGitBinary(opts: GitBinaryOptions): string {
+  const { isWindows, env, fileExists, findOnPath } = opts
+
+  if (!isWindows) {
+    return findOnPath ? findOnPath('git') || 'git' : 'git'
+  }
+
+  const localAppData = env.LOCALAPPDATA || ''
+  const joinWin = path.win32.join
+
+  const candidates: string[] = []
+
+  if (localAppData) {
+    candidates.push(joinWin(localAppData, 'hermes', 'git', 'cmd', 'git.exe'))
+    candidates.push(joinWin(localAppData, 'hermes', 'git', 'bin', 'git.exe'))
+  }
+
+  candidates.push(joinWin(env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'cmd', 'git.exe'))
+  candidates.push(joinWin(env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'cmd', 'git.exe'))
+
+  if (localAppData) {
+    candidates.push(joinWin(localAppData, 'Programs', 'Git', 'cmd', 'git.exe'))
+  }
+
+  const existing = candidates.filter(fileExists)
+
+  // Prefer a known-install candidate whose path has no spaces.
+  const withoutSpaces = existing.find(c => !c.includes(' '))
+
+  if (withoutSpaces) {
+    return withoutSpaces
+  }
+
+  // No space-free known-install git, but `git` resolves on PATH: return the bare
+  // name so simple-git sees a space-free binary and stays quiet. The spawned
+  // `git` uses the process PATH, which is where findOnPath just found it.
+  if (findOnPath && findOnPath('git')) {
+    return 'git'
+  }
+
+  // Fall back to the first existing candidate (may contain spaces) so a machine
+  // whose only git is under Program Files still functions — at the cost of the
+  // cosmetic warning.
+  if (existing.length > 0) {
+    return existing[0]
+  }
+
+  return 'git'
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -104,6 +104,7 @@ import {
   tuiResumeArgs
 } from './external-terminal'
 import { findGitBash as _findGitBash } from './find-git-bash'
+import { resolveGitBinary as _resolveGitBinary } from './git-binary'
 import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
 import { readDirForIpc } from './fs-read-dir'
@@ -2308,33 +2309,21 @@ function makeDashboardReadyFile() {
 // standard Git-for-Windows locations, then PATH. Cached after first probe.
 let _gitBinaryCache = null
 
+// Delegates to ./git-binary (extracted, unit-tested). That module prefers a
+// space-free git path on Windows so simple-git stops emitting the noisy
+// "Invalid value supplied for custom binary" warning when git lives under
+// "Program Files". Cached after first probe to match the prior behavior.
 function resolveGitBinary() {
   if (_gitBinaryCache) {
     return _gitBinaryCache
   }
 
-  if (!IS_WINDOWS) {
-    _gitBinaryCache = findOnPath('git') || 'git'
-
-    return _gitBinaryCache
-  }
-
-  const localAppData = process.env.LOCALAPPDATA || ''
-  const candidates = []
-
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'cmd', 'git.exe'))
-    candidates.push(path.join(localAppData, 'hermes', 'git', 'bin', 'git.exe'))
-  }
-
-  candidates.push(path.join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Git', 'cmd', 'git.exe'))
-  candidates.push(path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'cmd', 'git.exe'))
-
-  if (localAppData) {
-    candidates.push(path.join(localAppData, 'Programs', 'Git', 'cmd', 'git.exe'))
-  }
-
-  _gitBinaryCache = candidates.find(fileExists) || findOnPath('git') || 'git'
+  _gitBinaryCache = _resolveGitBinary({
+    isWindows: IS_WINDOWS,
+    env: process.env,
+    fileExists,
+    findOnPath
+  })
 
   return _gitBinaryCache
 }


### PR DESCRIPTION
## Problem

On Windows, every git spawn from the desktop app emitted:

```
Invalid value supplied for custom binary, restricted characters must be removed or supply the unsafe.allowUnsafeCustomBinary option
```

This appeared ~17x at startup (every IPC handler that resolves git: worktreeList, branchList, repoStatus, review*, etc.).

## Root cause (corrected)

The prior attempt (#83259) targeted `registerDeepLinkProtocol` — the wrong call site. The real emitter is **simple-git's `customBinaryPlugin`** (`toBinaryConfig`), which validates the git binary path with a regex that rejects spaces (`/^([a-z]:)?([a-z0-9/\_~-]+)$/i`). When the resolved git lives under `Program Files` the absolute path contains a space, so simple-git warns on every spawn (it only avoids the `throw` because `allowUnsafeCustomBinary` is already set — the `console.warn` is unconditional).

`resolveGitBinary()` was returning the absolute path (`C:\Program Files\Git\...\git.exe`), which simple-git then flags.

## Fix

Extracted `resolveGitBinary` into a new, unit-tested `apps/desktop/electron/git-binary.ts` (following the existing `find-git-bash.ts` pattern — deps injected for testability). Resolution order now prefers, in order:

1. a known-install candidate whose path has **no spaces** (e.g. PortableGit under `%LOCALAPPDATA%\hermes\git`), or
2. the bare name `"git"` (space-free; resolved via the process PATH) when `git` is discoverable on PATH, or
3. the first existing candidate as a last resort (a machine whose only git is under `Program Files` still works, at the cost of the cosmetic warning).

`main.ts` delegates to the module (cache + signature unchanged, so the ~17 IPC handlers are unaffected).

## Verification

- 8 unit tests in `git-binary.test.ts` cover: space-free PortableGit preference, space-only fallback, bare-name when git is on PATH, non-Windows, and PATH-only cases. All pass.
- Live desktop build (`npm run pack`) on the reporter's machine: the warning is gone from startup. Remaining startup lines are unrelated, harmless Electron/node deprecation notices (`DEP0180`, `console-message` deprecated).

## Files

- `apps/desktop/electron/git-binary.ts` (new)
- `apps/Desktop/electron/git-binary.test.ts` (new)
- `apps/desktop/electron/main.ts` (delegation only)