### PR TITLE
fix(desktop): stop sidebar session refreshes from evicting known rows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10047,7 +10047,14 @@ async function interceptSessionRequestForRemote(request) {
     const requested = (searchParams.get('profile') || 'all').trim() || 'all'
 
     if (requested !== 'all') {
-      return profileHasRemoteOverride(requested) ? remoteSessionList(requested, searchParams) : undefined
+      return profileHasRemoteOverride(requested)
+        ? remoteSessionList(requested, searchParams).catch(error => ({
+            sessions: [],
+            total: 0,
+            profile_totals: {},
+            errors: [{ profile: requested, error: error instanceof Error ? error.message : String(error) }]
+          }))
+        : undefined
     }
 
     return mergeRemoteProfileSessions(searchParams, remoteProfiles)
@@ -10114,7 +10121,11 @@ async function interceptSessionRequestForRemote(request) {
         sessions: rowsOf(messaging),
         total: Number(messaging?.total) || rowsOf(messaging).length
       },
-      errors: []
+      // A dead remote must not read as "no sessions": surface the per-slice
+      // failures so the renderer preserves the rows it already holds (desktop
+      // AGENTS.md: merge, don't clobber). Each slice payload carries its own
+      // errors (primary fetch failure, unreachable remote-override profile).
+      errors: [...(recents?.errors ?? []), ...(cron?.errors ?? []), ...(messaging?.errors ?? [])]
     }
   }
 
@@ -10212,6 +10223,11 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
 
   const base = (await fetchPrimaryProfileSessions(searchParams, fetchJsonForProfile)) as any
 
+  // The primary may have failed into an empty page (fetchPrimaryProfileSessions
+  // surfaces that as errors, never as a silent success) — carry its failures so
+  // the caller can tell "backend down" from "no sessions".
+  const errors = [...(base.errors ?? [])]
+
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.
   const remoteParams = new URLSearchParams(searchParams)
@@ -10226,7 +10242,13 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   // Swap each remote profile's stale local rows/total for the remote's real ones.
   await Promise.all(
     remoteProfiles.map(async name => {
-      const list = await remoteSessionList(name, remoteParams).catch(() => null)
+      const list = await remoteSessionList(name, remoteParams).catch(error => {
+        // Report, don't silently drop: an unreachable remote must not read as
+        // "this profile has no sessions" or the sidebar evicts its rows.
+        errors.push({ profile: name, error: error instanceof Error ? error.message : String(error) })
+
+        return null
+      })
 
       if (!list) {
         delete profileTotals[name] // dead remote → drop its stale local total too
@@ -10244,7 +10266,14 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const recency = s => s?.[order] ?? s?.started_at ?? 0
   merged.sort((a, b) => recency(b) - recency(a))
 
-  return { ...(base as any), sessions: merged.slice(offset, offset + limit), total, profile_totals: profileTotals }
+  return {
+    ...(base as any),
+    sessions: merged.slice(offset, offset + limit),
+    total,
+    profile_totals: profileTotals,
+    // Explicit so the collected remote failures are not lost in the base spread.
+    errors
+  }
 }
 
 ipcMain.handle('hermes:api', async (_event, request) => {

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -26,5 +26,19 @@ test('primary session reads preserve the empty-list fallback', async () => {
     throw new Error('remote unavailable')
   })
 
-  assert.deepEqual(result, { sessions: [], total: 0, profile_totals: {} })
+  assert.deepEqual(result.sessions, [])
+  assert.equal(result.total, 0)
+})
+
+test('primary session reads surface a backend failure as an error, not a silent empty page', async () => {
+  // A sidebar caller merging this page must be able to tell "the backend is
+  // down" apart from "there are no sessions", or a refresh during a backend
+  // blip evicts every known row (desktop AGENTS.md: merge, don't clobber).
+  const result = await fetchPrimaryProfileSessions(new URLSearchParams({ profile: 'all' }), async () => {
+    throw new Error('remote unavailable')
+  })
+
+  assert.equal(result.errors?.length, 1)
+  assert.equal(result.errors?.[0]?.profile, 'primary')
+  assert.match(result.errors?.[0]?.error ?? '', /remote unavailable/)
 })

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -2,6 +2,7 @@ export interface ProfileSessionsResponse {
   sessions: unknown[]
   total: number
   profile_totals: Record<string, number>
+  errors?: Array<{ profile: string; error: string }>
   [key: string]: unknown
 }
 
@@ -13,7 +14,17 @@ export async function fetchPrimaryProfileSessions(
 ): Promise<ProfileSessionsResponse> {
   try {
     return (await fetchJsonForProfile(null, `/api/profiles/sessions?${searchParams}`)) as ProfileSessionsResponse
-  } catch {
-    return { sessions: [], total: 0, profile_totals: {} }
+  } catch (error) {
+    // Surface, don't swallow: a caller that merges this page into the sidebar
+    // must be able to tell "the primary backend is down" apart from "there are
+    // no sessions", or a refresh during a backend blip evicts every known row
+    // (desktop AGENTS.md: merge, don't clobber). 'primary' is a synthetic
+    // profile name the renderer treats as "keep everything we already have".
+    return {
+      sessions: [],
+      total: 0,
+      profile_totals: {},
+      errors: [{ profile: 'primary', error: error instanceof Error ? error.message : String(error) }]
+    }
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -45,11 +45,13 @@ const row = (id: string, over: Partial<SessionInfo> = {}): SessionInfo =>
 const sidebar = (
   recents: { sessions: SessionInfo[]; profiles_truncated?: Record<string, boolean> },
   cron: SessionInfo[] = [],
-  messaging: SessionInfo[] = []
+  messaging: SessionInfo[] = [],
+  errors: SidebarSessionsResponse['errors'] = []
 ): SidebarSessionsResponse => ({
   recents: { sessions: recents.sessions, profiles_truncated: recents.profiles_truncated },
   cron: { sessions: cron },
-  messaging: { sessions: messaging }
+  messaging: { sessions: messaging },
+  ...(errors.length ? { errors } : {})
 })
 
 const listSidebarSessions = vi.fn()
@@ -247,5 +249,135 @@ describe('refreshSessions batches slices into one request', () => {
     })
 
     expect(getCronJobs).toHaveBeenLastCalledWith('all')
+  })
+})
+
+describe('refreshSessions preserves known rows when a profile read errors', () => {
+  it('keeps rows of a profile whose read errored (merge, don\'t clobber)', async () => {
+    // A resolved refresh can be partial: profile 'main' errored server-side so
+    // its rows are missing from the page. They must survive — the failure is a
+    // transient backend condition, not a deletion.
+    setSessions([
+      row('main-1', { profile: 'main' }),
+      row('main-2', { profile: 'main' }),
+      row('work-1', { profile: 'work' })
+    ])
+    listSidebarSessions.mockResolvedValue(
+      sidebar({ sessions: [row('work-1', { profile: 'work' })] }, [], [], [
+        { profile: 'main', error: 'database locked' }
+      ])
+    )
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'main' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    const ids = $sessions.get().map(s => s.id)
+    expect(ids).toContain('main-1')
+    expect(ids).toContain('main-2')
+    expect(ids).toContain('work-1')
+  })
+
+  it('still evicts rows of healthy profiles the page omitted', async () => {
+    // Granularity guard: only the errored profile's rows are protected. A
+    // healthy profile's row that legitimately aged off the page must still go.
+    setSessions([
+      row('main-1', { profile: 'main' }),
+      row('main-2', { profile: 'main' }),
+      row('work-1', { profile: 'work' }),
+      row('work-2', { profile: 'work' })
+    ])
+    listSidebarSessions.mockResolvedValue(
+      sidebar({ sessions: [row('work-1', { profile: 'work' })] }, [], [], [
+        { profile: 'main', error: 'database locked' }
+      ])
+    )
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'main' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    const ids = $sessions.get().map(s => s.id)
+    expect(ids).toContain('main-1')
+    expect(ids).toContain('main-2')
+    expect(ids).toContain('work-1')
+    expect(ids).not.toContain('work-2')
+  })
+
+  it('preserves everything when the error is unscoped (primary backend down)', async () => {
+    setSessions([row('a', { profile: 'default' }), row('b', { profile: 'work' })])
+    listSidebarSessions.mockResolvedValue(
+      sidebar({ sessions: [] }, [], [], [{ profile: 'primary', error: 'backend unreachable' }])
+    )
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('does not resurrect a tombstoned row of an errored profile', async () => {
+    removed.ids = new Set(['main-2'])
+    setSessions([row('main-1', { profile: 'main' }), row('main-2', { profile: 'main' })])
+    listSidebarSessions.mockResolvedValue(
+      sidebar({ sessions: [] }, [], [], [{ profile: 'main', error: 'database locked' }])
+    )
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'main' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.id)).toEqual(['main-1'])
+  })
+})
+
+describe('refreshSessions initial-fetch failure', () => {
+  it('keeps the loading state when the first fetch fails on an empty list', async () => {
+    // Cold-start race: the sidebar refresh fired before the (remote) backend
+    // was ready. A terminal "no sessions yet" would look exactly like data
+    // loss until the user happened to trigger another refresh — keep the
+    // skeletons instead, and resolve them on the next successful refresh.
+    listSidebarSessions.mockRejectedValue(new Error('backend unreachable'))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await expect(result.current.refreshSessions()).rejects.toThrow('backend unreachable')
+    })
+
+    expect($sessionsLoading.get()).toBe(true)
+    expect($sessions.get()).toEqual([])
+
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [row('a')] }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessionsLoading.get()).toBe(false)
+    expect($sessions.get().map(s => s.id)).toEqual(['a'])
+  })
+
+  it('keeps an already-populated list on a failed refresh', async () => {
+    setSessions([row('a'), row('b')])
+    listSidebarSessions.mockRejectedValue(new Error('backend unreachable'))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await expect(result.current.refreshSessions()).rejects.toThrow('backend unreachable')
+    })
+
+    expect($sessions.get().map(s => s.id)).toEqual(['a', 'b'])
+    expect($sessionsLoading.get()).toBe(false)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -112,10 +112,17 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
     const incoming = result.sessions.filter(s => normalizeSessionSource(s.source) === platform)
 
-    setMessagingSessions(prev => [
-      ...prev.filter(s => !inPlatform(s)),
-      ...mergeSessionPage(prev.filter(inPlatform), incoming, sessionsToKeep())
-    ])
+    setMessagingSessions(prev => {
+      const existing = prev.filter(inPlatform)
+      // Same don't-clobber rule as refreshSessions: a read that errored tells us
+      // nothing new, so keep the platform's existing rows alongside whatever
+      // did come back.
+      const keep = (result.errors ?? []).length
+        ? new Set([...sessionsToKeep(), ...existing.map(s => s.id)])
+        : sessionsToKeep()
+
+      return [...prev.filter(s => !inPlatform(s)), ...mergeSessionPage(existing, incoming, keep)]
+    })
 
     const total = result.total ?? incoming.length
     setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
@@ -151,6 +158,8 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       setSessionsLoading(true)
     }
 
+    let succeeded = false
+
     try {
       const limit = $sessionsLimit.get()
 
@@ -177,9 +186,33 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         messagingLimit: MESSAGING_SECTION_LIMIT,
         messagingExclude: MESSAGING_EXCLUDED_SOURCES
       })
+      succeeded = true
 
       if (refreshSessionsRequestRef.current === requestId) {
         const recents = result.recents
+
+        // A refresh that could not read some profile's rows must not evict the
+        // rows we already hold for it (desktop AGENTS.md: merge, don't
+        // clobber). The backend reports per-profile read failures in `errors`;
+        // a transport-level failure throws above and the previous list simply
+        // stays put. But a RESOLVED response can still be partial — a profile
+        // whose DB read failed, or a remote/primary that contributed nothing —
+        // and merging that page as authoritative drops every idle session of
+        // the failed profile until the next successful refresh (the
+        // "sessions disappeared, then came back when I made a new chat" bug).
+        // Preserve rows for the failed profiles; an unscoped error ('primary'
+        // or profile-less, emitted when the whole backend couldn't be read)
+        // preserves everything, since we cannot tell which rows are stale.
+        const errors = result.errors ?? []
+        const unscopedError = errors.some(e => !e?.profile?.trim() || e.profile === 'primary')
+        const erroredProfiles = new Set(
+          errors
+            .map(e => e?.profile?.trim())
+            .filter((p): p is string => Boolean(p) && p !== 'primary')
+            .map(normalizeProfileKey)
+        )
+        const preserve = (s: SessionInfo) =>
+          unscopedError || erroredProfiles.has(normalizeProfileKey(s.profile))
 
         // Drop rows the user just deleted/archived: a refresh can race an
         // in-flight mutation and the backend page still carries the doomed row.
@@ -198,7 +231,24 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         // identity, or every sidebar memo keyed on $sessions recomputes and the
         // whole list re-renders once per turn/broadcast for nothing.
         setSessions(prev => {
-          const next = mergeSessionPage(prev, incoming, sessionsToKeep())
+          const keep = sessionsToKeep()
+
+          if (unscopedError || erroredProfiles.size > 0) {
+            for (const session of prev) {
+              if (
+                tombstones.has(session.id) ||
+                (session._lineage_root_id != null && tombstones.has(session._lineage_root_id))
+              ) {
+                continue
+              }
+
+              if (preserve(session)) {
+                keep.add(session.id)
+              }
+            }
+          }
+
+          const next = mergeSessionPage(prev, incoming, keep)
 
           return sameCronSignature(prev, next) ? prev : next
         })
@@ -230,7 +280,12 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
       }
     } finally {
-      if (showLoading && refreshSessionsRequestRef.current === requestId) {
+      // A failed INITIAL fetch must not paint a terminal "no sessions yet" —
+      // the refresh likely raced the backend coming up (gateway restart,
+      // remote re-mint), and every later refresh trigger (reconnect, new chat,
+      // turn completion, background sync) repopulates the list. Keep the
+      // skeletons until one succeeds; a populated list simply stays put.
+      if (showLoading && refreshSessionsRequestRef.current === requestId && (succeeded || $sessions.get().length > 0)) {
         setSessionsLoading(false)
       }
     }
@@ -256,6 +311,32 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     })
 
     const keep = sessionsToKeep(key)
+
+    // The paged profile's read errored → this page is partial, not
+    // authoritative. Keep the rows we already hold for it so the pager can't
+    // evict known sessions on a transient backend failure.
+    const errors = result.errors ?? []
+    const errored = errors.some(e => {
+      const name = e?.profile?.trim()
+
+      return !name || name === 'primary' || normalizeProfileKey(name) === key
+    })
+
+    if (errored) {
+      const tombstones = $removedSessionIds.get()
+
+      for (const s of $sessions.get()) {
+        if (!inKey(s)) {
+          continue
+        }
+
+        if (tombstones.has(s.id) || (s._lineage_root_id != null && tombstones.has(s._lineage_root_id))) {
+          continue
+        }
+
+        keep.add(s.id)
+      }
+    }
 
     setSessions(prev => [
       ...prev.filter(s => !inKey(s)),

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -256,6 +256,9 @@ def get_profiles_sessions_sidebar(
 
     # cron + messaging are cross-profile; recents is scoped to recents_profile.
     # Scan every profile once regardless (each DB opened a single time).
+    recents_scope = (recents_profile or "all").strip() or "all"
+    errors: List[Dict[str, str]] = []
+
     try:
         infos = profiles_mod.list_profiles()
         targets: List[Tuple[str, Path]] = [(info.name, info.path) for info in infos]
@@ -263,9 +266,16 @@ def get_profiles_sessions_sidebar(
         _log.exception("GET /api/profiles/sessions/sidebar: list_profiles failed")
         targets = []
     if not targets:
+        # Cannot enumerate profiles — the fallback to a bare "default" DB must
+        # not read as "no sessions exist" for the requested scope. Report the
+        # failure so clients preserve the rows they already hold: a refresh
+        # that merges an empty page as authoritative makes every session of a
+        # non-default profile vanish until the next successful refresh.
         targets.append(("default", profiles_mod.get_profile_dir("default")))
+        errors.append(
+            {"profile": "primary" if recents_scope == "all" else recents_scope, "error": "profile enumeration failed"}
+        )
 
-    recents_scope = (recents_profile or "all").strip() or "all"
     recents_exclude_list = [s for s in (recents_exclude or "").split(",") if s.strip()]
     messaging_exclude_list = [s for s in (messaging_exclude or "").split(",") if s.strip()]
 
@@ -277,7 +287,6 @@ def get_profiles_sessions_sidebar(
     cron_rows: List[Dict[str, Any]] = []
     messaging_rows: List[Dict[str, Any]] = []
     recents_truncated: Dict[str, bool] = {}
-    errors: List[Dict[str, str]] = []
     now = time.time()
 
     def _tag(rows: List[Dict[str, Any]], name: str) -> List[Dict[str, Any]]:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -476,6 +476,32 @@ class TestWebServerEndpoints:
             "sidebar-stale"
         ]
 
+    def test_profiles_sidebar_reports_profile_enumeration_failure(self, monkeypatch):
+        """A failed profile enumeration must not read as "no sessions".
+
+        When list_profiles() yields nothing, the sidebar falls back to scanning
+        only the "default" profile. For a non-default recents scope that
+        fallback produces an empty page which, merged as authoritative, would
+        make every session of the real profile vanish until the next successful
+        refresh — so the endpoint must report the failure in ``errors`` for
+        clients to preserve the rows they already hold.
+        """
+        from hermes_cli import profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "list_profiles", lambda: [])
+
+        response = self.client.get(
+            "/api/profiles/sessions/sidebar?recents_profile=main&recents_limit=20"
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["recents"]["sessions"] == []
+        assert any(
+            entry["profile"] == "main" and "enumerat" in entry["error"]
+            for entry in payload["errors"]
+        )
+
     def test_heal_gives_up_when_reconcile_cannot_fix_the_store(self, monkeypatch):
         """A probe failure reconciliation can't cure must not retry forever.
 


### PR DESCRIPTION
## Summary

Fixes the desktop-app behavior where **session chats vanish from the sidebar** — after closing and reopening the client, and sometimes mid-session when switching chats — then come back when the user creates a new chat. No data is lost (state.db is intact); the refresh pipeline was treating *partial or empty* backend responses as authoritative and evicting known rows.

Related: fixes #64157 (issue), supersedes the throw-path-only attempt in #64159 (written against an older tree; its patch no longer applies to current main).

## Root cause

`refreshSessions()` merges a server page into `$sessions` with only working/pinned rows protected (`mergeSessionPage` keep-set). Several failure modes produced a **resolved but partial/empty** response, which then evicted every idle session of the affected profile:

1. **Renderer ignores `result.errors`** — the batched sidebar endpoint (and the legacy per-slice path) report per-profile read failures in `errors`, but `refreshSessions` never read them, so an errored profile's rows were dropped as if deleted.
2. **Electron main swallowed remote failures** — `interceptSessionRequestForRemote` hardcoded `errors: []` for the batched sidebar, `mergeRemoteProfileSessions` caught each dead remote into `null` (contributing nothing, silently), and `fetchPrimaryProfileSessions` returned a silent empty page on any error.
3. **Server silent fallback** — `GET /api/profiles/sessions/sidebar` falls back to scanning only the `default` profile when `list_profiles()` fails; for a non-default `recents_profile` that yields an empty page with no error.
4. **Cold-start race** — the first refresh often fires before the (remote) backend is ready; a thrown fetch flipped `$sessionsLoading` to `false` over an empty list, painting a terminal "no sessions yet" that only cleared when the user happened to trigger another refresh (e.g. creating a new chat).

## Changes

**Renderer — `apps/desktop/src/app/session/hooks/use-session-list-actions.ts`**
- `refreshSessions` honors the response's per-profile `errors`: rows of errored profiles are preserved in the merge (an unscoped/`'primary'` error preserves everything), while healthy profiles' rows are still evicted and optimistic tombstones still honored.
- A failed *initial* fetch (empty list) keeps the loading skeletons instead of painting "no sessions yet"; every later refresh trigger (reconnect, new chat, turn completion, background sync) repopulates it. A populated list still simply stays put.
- `loadMoreSessionsForProfile` / `loadMoreMessagingForPlatform` apply the same preservation when their slice read errored.

**Electron main — `apps/desktop/electron/main.ts`**
- The batched sidebar intercept now aggregates real per-slice errors instead of hardcoding `errors: []`.
- An unreachable remote-override profile degrades to a reported per-profile error instead of throwing and killing the whole sidebar refresh.
- `mergeRemoteProfileSessions` reports failed remotes instead of silently dropping them.

**Electron routing — `apps/desktop/electron/profile-session-routing.ts`**
- `fetchPrimaryProfileSessions` surfaces a backend failure as a `'primary'` error entry rather than a silent empty page, so callers can distinguish "backend down" from "no sessions".

**Server — `hermes_cli/web_routers/profiles.py`**
- The sidebar endpoint reports the default-only profile-scan fallback (profile enumeration failure) in `errors` instead of serving an empty page for the requested scope.

## Testing

- 7 new renderer tests (`use-session-list-actions.test.tsx`): preservation per errored profile, granularity (healthy rows still evicted), unscoped-error preservation, tombstone non-resurrection, initial-fetch loading retention, populated-list retention on failure.
- Updated/extended `profile-session-routing.test.ts` (error surfacing) and `test_web_server.py` (enumeration-failure error).
- Full desktop suite: **480 files / 4509 tests passed** (`vitest run`), plus `tsc -p . && tsc -p tsconfig.electron.json && tsc -p tsconfig.e2e.json` clean.
- Server-side tests: `test_web_server.py -k "sidebar or enumeration"` passes.
