### PR TITLE
fix(compressor): thread custom_providers into context-length resolution

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2756,6 +2756,7 @@ def init_agent(
             proactive_prune_min_reclaim_tokens=compression_proactive_prune_min_reclaim,
             min_tail_user_messages=compression_min_tail_users,
             tail_mode=compression_tail_mode,
+            custom_providers=_custom_providers,
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2547,6 +2547,7 @@ def init_agent(
             proactive_prune_min_result_chars=compression_proactive_prune_min_chars,
             proactive_prune_min_reclaim_tokens=compression_proactive_prune_min_reclaim,
             min_tail_user_messages=compression_min_tail_users,
+            custom_providers=_custom_providers,
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2251,6 +2251,7 @@ class ContextCompressor(ContextEngine):
                 api_key=self.api_key,
                 config_context_length=self._config_context_length,
                 provider=self.provider,
+                custom_providers=self.custom_providers,
             )
             # Small-context threshold floor: models under 512K trigger at
             # >=75% so compaction doesn't fire with half the window still
@@ -3076,6 +3077,7 @@ class ContextCompressor(ContextEngine):
         proactive_prune_min_reclaim_tokens: int = 4096,
         min_tail_user_messages: int = 1,
         tail_mode: str = "legacy",
+        custom_providers: list | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -3086,6 +3088,10 @@ class ContextCompressor(ContextEngine):
         # tail + verbatim-user-message summary section + recovery pointers;
         # "legacy" = 0.20*window tail (shipping behavior).
         self.tail_mode = tail_mode if tail_mode in ("legacy", "lean") else "legacy"
+        # Per-model context_length overrides from custom_providers, threaded
+        # into get_model_context_length so a per-model override (e.g. 256K)
+        # isn't skipped in favour of a hardcoded catalog default (128K).
+        self.custom_providers = list(custom_providers) if custom_providers else None
         # Per-model threshold overrides (longest substring match wins).
         # Stored as a plain dict; resolved in _resolve_threshold(), then the
         # small-context floor is applied on top.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1758,6 +1758,7 @@ class ContextCompressor(ContextEngine):
                 api_key=self.api_key,
                 config_context_length=self._config_context_length,
                 provider=self.provider,
+                custom_providers=self.custom_providers,
             )
             # Small-context threshold floor: models under 512K trigger at
             # >=75% so compaction doesn't fire with half the window still
@@ -2532,12 +2533,17 @@ class ContextCompressor(ContextEngine):
         proactive_prune_min_result_chars: int = 8000,
         proactive_prune_min_reclaim_tokens: int = 4096,
         min_tail_user_messages: int = 1,
+        custom_providers: list | None = None,
     ):
         self.model = model
         self.base_url = base_url
         self.api_key = api_key
         self.provider = provider
         self.api_mode = api_mode
+        # Per-model context_length overrides from custom_providers, threaded
+        # into get_model_context_length so a per-model override (e.g. 256K)
+        # isn't skipped in favour of a hardcoded catalog default (128K).
+        self.custom_providers = custom_providers
         # Per-model threshold overrides (longest substring match wins).
         # Stored as a plain dict; resolved in _resolve_threshold(), then the
         # small-context floor is applied on top.

--- a/tests/test_compressor_custom_providers.py
+++ b/tests/test_compressor_custom_providers.py
@@ -1,0 +1,62 @@
+"""Regression tests for custom_providers context-length threading (#83324)."""
+
+from agent.context_compressor import ContextCompressor
+from agent.model_metadata import get_model_context_length
+
+
+def test_custom_providers_override_wins_over_catalog(monkeypatch, tmp_path):
+    """A per-model context_length in custom_providers must beat the hardcoded
+    catalog default for the same model (the #15779 / #83324 gap)."""
+    providers = [
+        {
+            "name": "myproxy",
+            "base_url": "https://proxy.example.com/v1",
+            "api_key": "sk-test",
+            "models": [
+                {"model": "kimi-k2", "context_length": 262144},
+            ],
+        }
+    ]
+    ctx = get_model_context_length(
+        "kimi-k2",
+        base_url="https://proxy.example.com/v1",
+        api_key="sk-test",
+        provider="custom",
+        custom_providers=providers,
+    )
+    assert ctx == 262144
+
+
+def test_compressor_threads_custom_providers(tmp_path, monkeypatch):
+    """ContextCompressor must pass its custom_providers snapshot into
+    _resolve_context_length so per-model overrides apply."""
+    captured = {}
+
+    def fake_resolve(self):
+        from agent import model_metadata
+
+        captured["custom_providers"] = self.custom_providers
+        self._resolved_context_length = model_metadata.get_model_context_length(
+            self.model,
+            base_url=self.base_url,
+            api_key=self.api_key,
+            config_context_length=self._config_context_length,
+            provider=self.provider,
+            custom_providers=self.custom_providers,
+        )
+        return self._resolved_context_length
+
+    monkeypatch.setattr(ContextCompressor, "_resolve_context_length", fake_resolve)
+
+    providers = [{"name": "p1"}]
+    comp = ContextCompressor(
+        model="m",
+        base_url="https://x.example.com/v1",
+        api_key="k",
+        provider="custom",
+        custom_providers=providers,
+    )
+    # Caller mutates the list after construction — compressor view must not change.
+    providers.append({"name": "p2"})
+    comp.context_length
+    assert captured["custom_providers"] == [{"name": "p1"}]


### PR DESCRIPTION
## Problem

`ContextCompressor._resolve_context_length` called `get_model_context_length` **without** `custom_providers`. As a result, a per-model `context_length` override declared in `custom_providers` (e.g. `256000` for `baseten-deepseek-flash`) was skipped, and the hardcoded catalog default (`128000` for the `deepseek` family) won instead.

Symptom: `/context` reports the wrong context window (128K) even though the user configured 256K for their model. The same override is honored on the `/model` switch path (`agent_runtime_helpers`) and in `agent_init`'s config resolution, but the compressor's own deferred resolution path was the one gap.

## Root cause

`agent/context_compressor.py` — `_resolve_context_length()` (deferred, first-access resolution) did not forward `custom_providers` to `get_model_context_length`, so step 0b of that function's resolution order (custom_providers per-model override) never ran.

## Fix

- Add a `custom_providers` parameter to `ContextCompressor.__init__` and store it.
- Thread it into `get_model_context_length` in `_resolve_context_length`.
- Pass `_custom_providers` from `agent_init.py` when constructing the compressor.

## Verification

- With `custom_providers` threaded: compressor resolves **256000** ✓
- Without (old behavior): resolves **128000** (the bug)
- `tests/hermes_cli/test_custom_provider_context_length.py` + `tests/run_agent/test_invalid_context_length_warning.py`: **9/9 pass**