### PR TITLE
feat: surface unavailable config-gated tools at session start (refs #1433)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1540,7 +1540,7 @@ def init_agent(
         if len(_unavailable) > 3:
             _shown += f", +{len(_unavailable) - 3} more"
         print(
-            f"ⓘ {len(_unavailable)} tools unavailable (missing config/deps): {_shown}. "
+            f"ⓘ {len(_unavailable)} {'tool' if len(_unavailable) == 1 else 'tools'} unavailable (missing config/deps): {_shown}. "
             "Run `hermes tools` to configure."
         )
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1500,6 +1500,21 @@ def init_agent(
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
     )
+
+    # Issue #1433 (agent transparency): capture which config-gated tools
+    # (browser, vision, tts, web, image_gen, ...) failed their check_fn so
+    # surfaces can tell the user what they could configure — the model never
+    # sees those tools, so the user otherwise has no idea they exist.
+    # check_fn results are TTL-cached, so this re-resolution is cheap.
+    try:
+        from model_tools import get_unavailable_config_gated_tools
+
+        agent._config_gated_unavailable_tools = get_unavailable_config_gated_tools(
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+        )
+    except Exception:  # pragma: no cover — never break agent init
+        agent._config_gated_unavailable_tools = []
     
     # Show tool configuration and store valid tool names for validation
     agent.valid_tool_names = set()
@@ -1515,6 +1530,19 @@ def init_agent(
                 print(f"   ❌ Disabled toolsets: {', '.join(disabled_toolsets)}")
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
+
+    # Issue #1433: surface config-gated tools that exist but failed their
+    # check_fn — the user can close those gaps with `hermes tools`, and
+    # without this line they'd never know the tools exist.
+    _unavailable = getattr(agent, "_config_gated_unavailable_tools", None) or []
+    if _unavailable and not agent.quiet_mode:
+        _shown = ", ".join(_unavailable[:3])
+        if len(_unavailable) > 3:
+            _shown += f", +{len(_unavailable) - 3} more"
+        print(
+            f"ⓘ {len(_unavailable)} tools unavailable (missing config/deps): {_shown}. "
+            "Run `hermes tools` to configure."
+        )
 
     # Kanban worker/orchestrator lifecycle guidance is session-static:
     # the dispatcher decides at spawn time whether this process is a kanban

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -85,6 +85,7 @@ import { requestScrollToBottom } from '@/store/thread-scroll'
 import { clearActiveSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
+import { setToolsUnavailable } from '@/store/tools-unavailable'
 import { reportInstallMethodWarning } from '@/store/updates'
 import { notifyWorkspaceChanged, toolChangedPath, toolMayMutateFiles } from '@/store/workspace-events'
 // Leaf import (not the `@/themes` barrel) to avoid pulling the ThemeProvider
@@ -743,6 +744,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           if (isActiveEvent) {
             setCurrentUsage(current => ({ ...current, ...payload.usage }))
           }
+        }
+      } else if (event.type === 'tools.unavailable') {
+        // Issue #1433 Phase 2: config-gated tools (browser, vision, tts, ...)
+        // failed their check_fn — store the names so the fresh-session empty
+        // state can surface a "Run `hermes tools`" hint. The model never sees
+        // these tools, so this is the user's only signal they exist.
+        if (sessionId && Array.isArray(payload?.names)) {
+          setToolsUnavailable(sessionId, payload.names.filter((n): n is string => typeof n === 'string'))
         }
       } else if (event.type === 'message.start') {
         if (!sessionId) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/tools-unavailable-wiring.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/tools-unavailable-wiring.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $toolsUnavailable } from '@/store/tools-unavailable'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'tools-unavailable-session'
+
+// Module-scoped so a test can seed session state before the handler reads it.
+const sessionStates = new Map<string, ClientSessionState>()
+let handleEvent: ((event: RpcEvent) => void) | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(sessionStates)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const next = updater(sessionStates.get(sessionId) ?? createClientSessionState())
+      sessionStates.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}, sessionId = SID) {
+  act(() => handleEvent!({ payload, session_id: sessionId, type }))
+}
+
+describe('tools.unavailable wiring', () => {
+  beforeEach(() => {
+    handleEvent = null
+    sessionStates.clear()
+    $toolsUnavailable.set({})
+  })
+
+  afterEach(() => {
+    cleanup()
+    sessionStates.clear()
+    $toolsUnavailable.set({})
+    vi.restoreAllMocks()
+  })
+
+  it('stores the unavailable tool names for the session', async () => {
+    await mountStream()
+
+    emit('tools.unavailable', { names: ['browser_navigate', 'web_search', 'tts_speak'] })
+
+    expect($toolsUnavailable.get()[SID]).toEqual(['browser_navigate', 'web_search', 'tts_speak'])
+  })
+
+  it('ignores events without a names array', async () => {
+    await mountStream()
+
+    emit('tools.unavailable', {})
+    emit('tools.unavailable', { names: 'not-an-array' } as unknown as RpcEvent['payload'])
+
+    expect($toolsUnavailable.get()[SID]).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import { createContext, memo, useCallback, useContext, useMemo, useRef, useState } from 'react'
 
 import { AssistantMessage } from '@/components/assistant-ui/thread/assistant-message'
@@ -13,6 +14,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
+import { $toolsUnavailable } from '@/store/tools-unavailable'
 
 type ThreadLoadingState = 'response' | 'session'
 
@@ -116,6 +118,17 @@ export const Thread = memo(function Thread({
   // re-renders for unrelated reasons never re-render the composer.
   const editContext = useMemo(() => ({ cwd, gateway, sessionId }), [cwd, gateway, sessionId])
 
+  // Issue #1433 Phase 2: config-gated tools (browser, vision, tts, ...) that
+  // failed their check_fn for this session — surfaced once in the fresh-
+  // session empty state. The model never sees these tools, so this is the
+  // user's only signal they exist.
+  const toolsUnavailableMap = useStore($toolsUnavailable)
+  const unavailableNames = sessionId ? (toolsUnavailableMap[sessionId] ?? []) : []
+
+  const unavailableLine = unavailableNames.length
+    ? `ⓘ ${unavailableNames.length} tools unavailable (missing config/deps): ${unavailableNames.slice(0, 3).join(', ')}${unavailableNames.length > 3 ? `, +${unavailableNames.length - 3} more` : ''}. Run \`hermes tools\` to configure.`
+    : ''
+
   const hasBranchInNewChat = Boolean(onBranchInNewChat)
   const hasCancel = Boolean(onCancel)
   const hasDismissError = Boolean(onDismissError)
@@ -150,6 +163,11 @@ export const Thread = memo(function Thread({
   const emptyPlaceholder = intro ? (
     <div className="flex min-h-0 w-full flex-col items-center justify-center pt-[var(--composer-measured-height)]">
       <Intro {...intro} />
+      {unavailableLine && (
+        <p className="mt-3 max-w-md px-4 text-center text-[0.78rem] leading-5 text-[var(--ui-text-secondary)]">
+          {unavailableLine}
+        </p>
+      )}
     </div>
   ) : undefined
 

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -126,7 +126,7 @@ export const Thread = memo(function Thread({
   const unavailableNames = sessionId ? (toolsUnavailableMap[sessionId] ?? []) : []
 
   const unavailableLine = unavailableNames.length
-    ? `ⓘ ${unavailableNames.length} tools unavailable (missing config/deps): ${unavailableNames.slice(0, 3).join(', ')}${unavailableNames.length > 3 ? `, +${unavailableNames.length - 3} more` : ''}. Run \`hermes tools\` to configure.`
+    ? `ⓘ ${unavailableNames.length} ${unavailableNames.length === 1 ? 'tool' : 'tools'} unavailable (missing config/deps): ${unavailableNames.slice(0, 3).join(', ')}${unavailableNames.length > 3 ? `, +${unavailableNames.length - 3} more` : ''}. Run \`hermes tools\` to configure.`
     : ''
 
   const hasBranchInNewChat = Boolean(onBranchInNewChat)

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -67,6 +67,7 @@ export type GatewayEventPayload = {
   inline_diff?: string
   duration_s?: number
   todos?: unknown
+  names?: string[]
   model?: string
   provider?: string
   reasoning_effort?: string

--- a/apps/desktop/src/store/tools-unavailable.test.ts
+++ b/apps/desktop/src/store/tools-unavailable.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $toolsUnavailable, setToolsUnavailable } from '@/store/tools-unavailable'
+
+describe('$toolsUnavailable', () => {
+  afterEach(() => {
+    $toolsUnavailable.set({})
+  })
+
+  it('stores the unavailable tool names per session id', () => {
+    setToolsUnavailable('session-a', ['browser_navigate', 'web_search'])
+
+    expect($toolsUnavailable.get()).toEqual({ 'session-a': ['browser_navigate', 'web_search'] })
+  })
+
+  it('keeps distinct sessions separate', () => {
+    setToolsUnavailable('session-a', ['browser_navigate'])
+    setToolsUnavailable('session-b', ['tts_speak'])
+
+    expect($toolsUnavailable.get()).toEqual({
+      'session-a': ['browser_navigate'],
+      'session-b': ['tts_speak']
+    })
+  })
+
+  it('ignores calls without a session id', () => {
+    setToolsUnavailable('', ['browser_navigate'])
+
+    expect($toolsUnavailable.get()).toEqual({})
+  })
+
+  it('bounds the map to the most recent sessions, dropping the oldest first', () => {
+    // MAX_TOOLS_UNAVAILABLE_ENTRIES is 100; fill past it and verify the
+    // oldest entries fall off (string-key insertion order = LRU-ish).
+    for (let i = 0; i < 105; i += 1) {
+      setToolsUnavailable(`session-${String(i).padStart(3, '0')}`, ['browser_navigate'])
+    }
+
+    const keys = Object.keys($toolsUnavailable.get())
+    expect(keys).toHaveLength(100)
+    expect(keys[0]).toBe('session-005')
+    expect(keys[99]).toBe('session-104')
+  })
+})

--- a/apps/desktop/src/store/tools-unavailable.ts
+++ b/apps/desktop/src/store/tools-unavailable.ts
@@ -5,6 +5,12 @@ import { atom } from 'nanostores'
 // once per session build; the thread renders the notice in the fresh-session
 // empty state. Keyed by session id; a stale entry is inert because it only
 // renders while that session's thread is mounted.
+//
+// Bounded to the most recent sessions: entries are inert once their thread is
+// unmounted, so only sessions the user may still open fresh need to survive.
+// JS object string-key insertion order makes dropping the oldest entries an
+// LRU-ish trim.
+const MAX_TOOLS_UNAVAILABLE_ENTRIES = 100
 const $toolsUnavailable = atom<Record<string, string[]>>({})
 
 export { $toolsUnavailable }
@@ -15,6 +21,14 @@ export function setToolsUnavailable(sessionId: string, names: string[]) {
   }
 
   const current = $toolsUnavailable.get()
+  const next = { ...current, [sessionId]: names }
+  const keys = Object.keys(next)
 
-  $toolsUnavailable.set({ ...current, [sessionId]: names })
+  if (keys.length > MAX_TOOLS_UNAVAILABLE_ENTRIES) {
+    for (const stale of keys.slice(0, keys.length - MAX_TOOLS_UNAVAILABLE_ENTRIES)) {
+      delete next[stale]
+    }
+  }
+
+  $toolsUnavailable.set(next)
 }

--- a/apps/desktop/src/store/tools-unavailable.ts
+++ b/apps/desktop/src/store/tools-unavailable.ts
@@ -1,0 +1,20 @@
+import { atom } from 'nanostores'
+
+// Config-gated tools (browser, vision, tts, ...) that failed their check_fn
+// for this session (issue #1433 Phase 2). The gateway emits `tools.unavailable`
+// once per session build; the thread renders the notice in the fresh-session
+// empty state. Keyed by session id; a stale entry is inert because it only
+// renders while that session's thread is mounted.
+const $toolsUnavailable = atom<Record<string, string[]>>({})
+
+export { $toolsUnavailable }
+
+export function setToolsUnavailable(sessionId: string, names: string[]) {
+  if (!sessionId) {
+    return
+  }
+
+  const current = $toolsUnavailable.get()
+
+  $toolsUnavailable.set({ ...current, [sessionId]: names })
+}

--- a/model_tools.py
+++ b/model_tools.py
@@ -414,13 +414,20 @@ def get_tool_definitions(
     return result
 
 
-def _compute_tool_definitions(
+def _resolve_tool_names(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
-    skip_tool_search_assembly: bool = False,
-) -> List[Dict[str, Any]]:
-    """Uncached implementation of :func:`get_tool_definitions`."""
+) -> set:
+    """Resolve the requested tool-name set after toolset filtering.
+
+    Shared by :func:`get_tool_definitions` (which asks the registry for
+    schemas) and :func:`get_unavailable_config_gated_tools` (which needs the
+    requested set to compute what check_fn dropped). Mirrors the effective
+    toolset resolution: enabled toolsets are unioned, then disabled toolsets
+    are subtracted (core tools inside disabled platform bundles are preserved
+    — see #33924).
+    """
     # Determine which tool names the caller wants
     tools_to_include: set = set()
 
@@ -505,6 +512,18 @@ def _compute_tool_definitions(
     # all check the tool registry for plugin-provided toolsets.  No bypass
     # needed; plugins respect enabled_toolsets / disabled_toolsets like any
     # other toolset.
+
+    return tools_to_include
+
+
+def _compute_tool_definitions(
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+    quiet_mode: bool = False,
+    skip_tool_search_assembly: bool = False,
+) -> List[Dict[str, Any]]:
+    """Uncached implementation of :func:`get_tool_definitions`."""
+    tools_to_include = _resolve_tool_names(enabled_toolsets, disabled_toolsets, quiet_mode)
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
@@ -650,6 +669,57 @@ def _compute_tool_definitions(
         logger.warning("Tool search assembly skipped: %s", e)
 
     return filtered_tools
+
+
+# Toolsets whose unavailability is a configuration/setup gap the user can
+# close (API keys, provider credentials, service endpoints) rather than an
+# environment condition (no browser binary, no Docker daemon, platform
+# worker mode, ...). Used by :func:`get_unavailable_config_gated_tools` to
+# decide which check_fn-dropped tools are worth surfacing with a
+# "Run `hermes tools`" hint. Keep in sync with
+# ``hermes_cli/tools_config.py::_DEFAULT_OFF_TOOLSETS`` and any
+# service-gated toolset added to ``toolsets.py``.
+_CONFIG_GATED_TOOLSETS = {
+    "browser",
+    "vision",
+    "tts",
+    "web",
+    "image_gen",
+    "video_gen",
+    "x_search",
+    "homeassistant",
+    "spotify",
+    "discord",
+    "discord_admin",
+}
+
+
+def get_unavailable_config_gated_tools(
+    enabled_toolsets: Optional[List[str]] = None,
+    disabled_toolsets: Optional[List[str]] = None,
+) -> List[str]:
+    """Return sorted names of config-gated tools unavailable this session.
+
+    A tool is "unavailable" when its ``check_fn`` fails, so no schema is
+    exposed to the model (the model never sees it — see issue #1433). Only
+    tools belonging to :data:`_CONFIG_GATED_TOOLSETS` are returned: those are
+    the gaps a user can close via ``hermes tools``/config, which is exactly
+    the case #1433 wants surfaced ("Firecrawl not configured, falling back to
+    browser"). check_fn results are TTL-cached inside the registry, so this
+    is cheap to call right after :func:`get_tool_definitions`.
+    """
+    tools_to_include = _resolve_tool_names(enabled_toolsets, disabled_toolsets, quiet_mode=True)
+    if not tools_to_include:
+        return []
+    available = {
+        t["function"]["name"] for t in registry.get_definitions(tools_to_include, quiet=True)
+    }
+    missing = tools_to_include - available
+    if not missing:
+        return []
+    return sorted(
+        name for name in missing if registry.get_toolset_for_tool(name) in _CONFIG_GATED_TOOLSETS
+    )
 
 
 def _resolve_active_context_length() -> int:

--- a/model_tools.py
+++ b/model_tools.py
@@ -38,7 +38,7 @@ from tools.registry import (
     registry,
     tool_error,
 )
-from toolsets import resolve_toolset, validate_toolset
+from toolsets import TOOLSETS, resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
 
@@ -676,22 +676,18 @@ def _compute_tool_definitions(
 # environment condition (no browser binary, no Docker daemon, platform
 # worker mode, ...). Used by :func:`get_unavailable_config_gated_tools` to
 # decide which check_fn-dropped tools are worth surfacing with a
-# "Run `hermes tools`" hint. Keep in sync with
-# ``hermes_cli/tools_config.py::_DEFAULT_OFF_TOOLSETS`` and any
-# service-gated toolset added to ``toolsets.py``.
-_CONFIG_GATED_TOOLSETS = {
-    "browser",
-    "vision",
-    "tts",
-    "web",
-    "image_gen",
-    "video_gen",
-    "x_search",
-    "homeassistant",
-    "spotify",
-    "discord",
-    "discord_admin",
-}
+# "Run `hermes tools`" hint.
+#
+# DERIVED from the ``config_gated`` flag on the toolset definitions in
+# ``toolsets.py`` (single source of truth — a new service-gated toolset is
+# surfaced automatically once it declares the flag). Deliberately NOT
+# flagged there: environment/install-gated toolsets (``computer_use`` —
+# cua-driver install), pure opt-in toolsets with no credential gap
+# (``video``, ``a2a``), and config-only capabilities that ship zero tool
+# schemas (``stt`` — they can never appear in a missing-tools diff).
+_CONFIG_GATED_TOOLSETS = frozenset(
+    name for name, spec in TOOLSETS.items() if spec.get("config_gated")
+)
 
 
 def get_unavailable_config_gated_tools(

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,6 +1,7 @@
 """Tests for model_tools.py — function call dispatch, agent-loop interception, legacy toolsets."""
 
 import json
+import importlib
 from unittest.mock import ANY, call, patch
 
 
@@ -648,9 +649,27 @@ class TestConfigGatedToolsetContract:
             )
 
     def test_config_gated_tools_all_carry_check_fn(self):
-        # model_tools import registers every tool module, so registry
+        # model_tools import registers every core tool module, so registry
         # lookups below are live entries, not stubs.
         from tools.registry import registry
+
+        class _PluginCtx:
+            """Shim the bundled-plugin loader (see tests/plugins/test_a2a_plugin.py)."""
+
+            def register_tool(self, name, toolset, schema, handler, **kw):
+                registry.register(
+                    name=name, toolset=toolset, schema=schema,
+                    handler=handler, override=True, **kw,
+                )
+
+        for ts in _CONFIG_GATED_TOOLSETS:
+            tools = resolve_toolset(ts)
+            if any(registry.get_entry(t) is None for t in tools):
+                # Plugin-hosted toolset (currently: spotify): its tools
+                # register through the bundled-plugin loader, which the test
+                # env does not run. Load the plugin the way the loader does.
+                plugin_mod = importlib.import_module(f"plugins.{ts}")
+                plugin_mod.register(_PluginCtx())
 
         for ts in _CONFIG_GATED_TOOLSETS:
             for tool in resolve_toolset(ts):

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -10,10 +10,12 @@ from model_tools import (
     get_toolset_for_tool,
     get_unavailable_config_gated_tools,
     _AGENT_LOOP_TOOLS,
+    _CONFIG_GATED_TOOLSETS,
     _LEGACY_TOOLSET_MAP,
     _resolve_tool_names,
     TOOL_TO_TOOLSET_MAP,
 )
+from toolsets import TOOLSETS, resolve_toolset
 
 
 # =========================================================================
@@ -626,3 +628,34 @@ class TestGetUnavailableConfigGatedTools:
                 disabled_toolsets=["browser"],
             )
         assert result == []
+
+
+class TestConfigGatedToolsetContract:
+    """Issue #1433 Phase 2: the availability whitelist is DERIVED from the
+    ``config_gated`` flag on toolset definitions (toolsets.py). These tests
+    pin the derivation contract so the flag can't silently reference a
+    renamed toolset, or a toolset whose tools can never fail their check_fn
+    (which would make the flag dead weight).
+    """
+
+    def test_config_gated_flags_resolve_to_real_toolsets(self):
+        for ts in _CONFIG_GATED_TOOLSETS:
+            assert ts in TOOLSETS, (
+                f"{ts!r} is config_gated but missing from toolsets.TOOLSETS"
+            )
+            assert resolve_toolset(ts), (
+                f"{ts!r} is config_gated but resolves to no tools"
+            )
+
+    def test_config_gated_tools_all_carry_check_fn(self):
+        # model_tools import registers every tool module, so registry
+        # lookups below are live entries, not stubs.
+        from tools.registry import registry
+
+        for ts in _CONFIG_GATED_TOOLSETS:
+            for tool in resolve_toolset(ts):
+                entry = registry.get_entry(tool)
+                assert entry is not None, f"{tool!r} (toolset {ts!r}) not registered"
+                assert entry.check_fn is not None, (
+                    f"{tool!r} (toolset {ts!r}) is config_gated but has no check_fn"
+                )

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -8,8 +8,10 @@ from model_tools import (
     handle_function_call,
     get_all_tool_names,
     get_toolset_for_tool,
+    get_unavailable_config_gated_tools,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
+    _resolve_tool_names,
     TOOL_TO_TOOLSET_MAP,
 )
 
@@ -509,3 +511,118 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+
+# =========================================================================
+# get_unavailable_config_gated_tools (issue #1433, Phase 2)
+# =========================================================================
+
+class TestResolveToolNames:
+    def test_unions_enabled_and_subtracts_disabled(self):
+        with (
+            patch("model_tools.validate_toolset", return_value=True),
+            patch(
+                "model_tools.resolve_toolset",
+                side_effect=lambda ts: {
+                    "web": {"web_search", "web_extract"},
+                    "terminal": {"terminal"},
+                }[ts],
+            ),
+        ):
+            result = _resolve_tool_names(
+                enabled_toolsets=["web", "terminal"],
+                disabled_toolsets=["terminal"],
+            )
+        assert result == {"web_search", "web_extract"}
+
+
+class TestGetUnavailableConfigGatedTools:
+    def test_reports_config_gated_missing_tools_sorted(self):
+        with (
+            patch(
+                "model_tools._resolve_tool_names",
+                return_value={"web_search", "browser_navigate", "terminal", "read_file"},
+            ),
+            patch(
+                "model_tools.registry.get_definitions",
+                return_value=[
+                    {"type": "function", "function": {"name": "terminal"}},
+                    {"type": "function", "function": {"name": "read_file"}},
+                ],
+            ),
+            patch(
+                "model_tools.registry.get_toolset_for_tool",
+                side_effect=lambda name: {
+                    "web_search": "web",
+                    "browser_navigate": "browser",
+                    "terminal": "terminal",
+                    "read_file": "file",
+                }.get(name),
+            ),
+        ):
+            result = get_unavailable_config_gated_tools()
+        # browser/web are config-gated and missing -> reported, sorted.
+        assert result == ["browser_navigate", "web_search"]
+
+    def test_empty_when_nothing_missing(self):
+        with (
+            patch(
+                "model_tools._resolve_tool_names",
+                return_value={"web_search", "terminal"},
+            ),
+            patch(
+                "model_tools.registry.get_definitions",
+                return_value=[
+                    {"type": "function", "function": {"name": "web_search"}},
+                    {"type": "function", "function": {"name": "terminal"}},
+                ],
+            ),
+        ):
+            result = get_unavailable_config_gated_tools()
+        assert result == []
+
+    def test_excludes_non_config_gated_missing_tools(self):
+        # `terminal` is dropped by check_fn but its toolset is not
+        # config-gated (environment condition, not a setup gap) -> silent.
+        with (
+            patch(
+                "model_tools._resolve_tool_names",
+                return_value={"terminal", "web_search"},
+            ),
+            patch(
+                "model_tools.registry.get_definitions",
+                return_value=[
+                    {"type": "function", "function": {"name": "web_search"}},
+                ],
+            ),
+            patch(
+                "model_tools.registry.get_toolset_for_tool",
+                side_effect=lambda name: {
+                    "terminal": "terminal",
+                    "web_search": "web",
+                }.get(name),
+            ),
+        ):
+            result = get_unavailable_config_gated_tools()
+        assert result == []
+
+    def test_disabled_toolset_tools_never_reported(self):
+        # Tools removed via agent.disabled_toolsets are subtracted during
+        # name resolution, so they never appear in the missing set at all.
+        with (
+            patch(
+                "model_tools._resolve_tool_names",
+                return_value={"web_search"},
+            ),
+            patch(
+                "model_tools.registry.get_definitions",
+                return_value=[
+                    {"type": "function", "function": {"name": "web_search"}},
+                ],
+            ),
+        ):
+            result = get_unavailable_config_gated_tools(
+                enabled_toolsets=["web", "browser"],
+                disabled_toolsets=["browser"],
+            )
+        assert result == []

--- a/toolsets.py
+++ b/toolsets.py
@@ -104,12 +104,25 @@ _HERMES_WEBHOOK_SAFE_TOOLS = [
 
 # Core toolset definitions
 # These can include individual tools or reference other toolsets
+#
+# Optional per-toolset metadata keys:
+#   config_gated: True  — the toolset's availability depends on user
+#       configuration (API keys, provider credentials, service endpoints).
+#       model_tools._CONFIG_GATED_TOOLSETS is DERIVED from this flag, so a
+#       new service-gated toolset is surfaced by #1433's "tools unavailable"
+#       session-start notice automatically once it declares the flag.
+#       Deliberately NOT flagged (never nagged about): environment/install-
+#       gated toolsets (``computer_use`` — cua-driver install), pure opt-in
+#       toolsets with no credential gap (``video``, ``a2a``), and config-only
+#       capabilities that ship zero tool schemas (``stt`` — they can never
+#       appear in a missing-tools diff).
 TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
         "description": "Web research and content extraction tools",
         "tools": ["web_search", "web_extract"],
-        "includes": []  # No other toolsets included
+        "includes": [],  # No other toolsets included
+        "config_gated": True,
     },
     
     "search": {
@@ -128,13 +141,15 @@ TOOLSETS = {
             "X (Twitter) Search."
         ),
         "tools": ["x_search"],
-        "includes": []
+        "includes": [],
+        "config_gated": True,
     },
-    
+
     "vision": {
         "description": "Image analysis and vision tools",
         "tools": ["vision_analyze"],
-        "includes": []
+        "includes": [],
+        "config_gated": True,
     },
 
     "video": {
@@ -146,7 +161,8 @@ TOOLSETS = {
     "image_gen": {
         "description": "Creative generation tools (images)",
         "tools": ["image_generate"],
-        "includes": []
+        "includes": [],
+        "config_gated": True,
     },
 
     "video_gen": {
@@ -158,7 +174,8 @@ TOOLSETS = {
             "``hermes tools`` → Video Generation."
         ),
         "tools": ["video_generate", "xai_video_edit", "xai_video_extend"],
-        "includes": []
+        "includes": [],
+        "config_gated": True,
     },
 
     "bfl": {
@@ -211,7 +228,8 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp",
             "browser_dialog", "browser_exec", "web_search"
         ],
-        "includes": []
+        "includes": [],
+        "config_gated": True,
     },
     
     "cronjob": {
@@ -230,7 +248,8 @@ TOOLSETS = {
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI",
         "tools": ["text_to_speech"],
-        "includes": []
+        "includes": [],
+        "config_gated": True,
     },
     
     "todo": {
@@ -308,7 +327,8 @@ TOOLSETS = {
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",
         "tools": ["ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service"],
-        "includes": []
+        "includes": [],
+        "config_gated": True,
     },
 
     "kanban": {
@@ -337,12 +357,14 @@ TOOLSETS = {
         "description": "Discord read and participate tools (fetch messages, search members, create threads)",
         "tools": ["discord"],
         "includes": [],
+        "config_gated": True,
     },
 
     "discord_admin": {
         "description": "Discord server management (list channels/roles, pin messages, assign roles)",
         "tools": ["discord_admin"],
         "includes": [],
+        "config_gated": True,
     },
 
     "yuanbao": {
@@ -378,7 +400,8 @@ TOOLSETS = {
             "spotify_playback", "spotify_devices", "spotify_queue", "spotify_search",
             "spotify_playlists", "spotify_albums", "spotify_library",
         ],
-        "includes": []
+        "includes": [],
+        "config_gated": True,
     },
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2386,6 +2386,17 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
             current["agent"] = agent
+
+            # Issue #1433 (agent transparency): once per session build, tell
+            # the client which config-gated tools failed their check_fn (the
+            # model never sees them) so the UI can surface a
+            # "Run `hermes tools`" hint. Computed during the agent build;
+            # check_fn results are TTL-cached so no extra probes here.
+            # quiet builds (messaging gateway runs) skip the event — those
+            # surfaces have no interactive tool-config UI to point at.
+            _unavailable = getattr(agent, "_config_gated_unavailable_tools", None)
+            if _unavailable and not getattr(agent, "quiet_mode", False):
+                _emit("tools.unavailable", sid, {"names": _unavailable})
             # Baseline for the per-turn config sync; the profile home
             # override is still active here.
             current["config_model_seen"] = _config_model_target()

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -49,7 +49,16 @@ const buildCtx = (appended: Msg[]) =>
       appendMessage: (msg: Msg) => appended.push(msg),
       panel: (title: string, sections: any[]) =>
         appended.push({ kind: 'panel', panelData: { sections, title }, role: 'system', text: '' }),
-      setHistoryItems: vi.fn()
+      // Functional like the real setHistoryItems (useMainApp routes
+      // appendMessage through it too), so updater-form calls — e.g. the
+      // tools.unavailable fresh-session guard — execute against `appended`.
+      setHistoryItems: (value: Msg[] | ((prev: Msg[]) => Msg[])) => {
+        if (typeof value === 'function') {
+          appended.splice(0, appended.length, ...(value as (prev: Msg[]) => Msg[])(appended))
+        } else {
+          appended.splice(0, appended.length, ...value)
+        }
+      }
     },
     voice: {
       setProcessing: vi.fn(),
@@ -747,6 +756,48 @@ describe('createGatewayEventHandler', () => {
     expect(appended[0]?.tools?.[0]).not.toContain('--- a/foo.ts')
     expect(appended[1]?.text).toBe('done')
     expect(appended[1]?.tools ?? []).toEqual([])
+  })
+
+  it('surfaces unavailable config-gated tools once at the top of a fresh session', () => {
+    const appended: Msg[] = [{ kind: 'intro', role: 'system', text: '' }]
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({
+      payload: { names: ['browser_navigate', 'web_search', 'tts_speak'] },
+      type: 'tools.unavailable'
+    } as any)
+
+    // The notice lands right after the intro, before any real content.
+    expect(appended).toHaveLength(2)
+    expect(appended[0]?.kind).toBe('intro')
+    expect(appended[1]?.kind).toBe('event')
+    expect(appended[1]?.role).toBe('system')
+    expect(appended[1]?.text).toBe(
+      'ⓘ 3 tools unavailable (missing config/deps): browser_navigate, web_search, tts_speak. Run `hermes tools` to configure.'
+    )
+  })
+
+  it('caps the unavailable-tool list at three names with a +N more tail', () => {
+    const appended: Msg[] = [{ kind: 'intro', role: 'system', text: '' }]
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+    const names = ['browser_navigate', 'web_search', 'tts_speak', 'image_gen', 'vision_analyze']
+
+    onEvent({ payload: { names }, type: 'tools.unavailable' } as any)
+
+    expect(appended[1]?.text).toBe(
+      'ⓘ 5 tools unavailable (missing config/deps): browser_navigate, web_search, tts_speak, +2 more. Run `hermes tools` to configure.'
+    )
+  })
+
+  it('does not surface unavailable tools into an in-progress session', () => {
+    const appended: Msg[] = [{ kind: 'intro', role: 'system', text: '' }]
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    // A session that already has content: the notice would land mid-chat.
+    onEvent({ payload: { text: 'existing reply' }, type: 'message.complete' } as any)
+    onEvent({ payload: { names: ['browser_navigate'] }, type: 'tools.unavailable' } as any)
+
+    expect(appended.some(msg => msg.text.includes('tools unavailable'))).toBe(false)
   })
 
   it('shows setup panel for missing provider startup error', () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -789,6 +789,17 @@ describe('createGatewayEventHandler', () => {
     )
   })
 
+  it('uses singular wording when exactly one tool is unavailable', () => {
+    const appended: Msg[] = [{ kind: 'intro', role: 'system', text: '' }]
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: { names: ['tts_speak'] }, type: 'tools.unavailable' } as any)
+
+    expect(appended[1]?.text).toBe(
+      'ⓘ 1 tool unavailable (missing config/deps): tts_speak. Run `hermes tools` to configure.'
+    )
+  })
+
   it('does not surface the notice when a non-intro item already exists', () => {
     // A single pre-existing system item (e.g. a setup panel) makes the
     // transcript non-fresh even though the history length is still small.
@@ -797,7 +808,9 @@ describe('createGatewayEventHandler', () => {
 
     onEvent({ payload: { names: ['browser_navigate'] }, type: 'tools.unavailable' } as any)
 
-    expect(appended.some(msg => msg.text.includes('tools unavailable'))).toBe(false)
+    // Match the notice regardless of singular/plural wording (the line reads
+    // "1 tool unavailable" for a single name, "N tools unavailable" otherwise).
+    expect(appended.some(msg => /\d+ tools? unavailable/.test(msg.text ?? ''))).toBe(false)
   })
 
   it('does not surface unavailable tools into an in-progress session', () => {
@@ -808,6 +821,8 @@ describe('createGatewayEventHandler', () => {
     onEvent({ payload: { text: 'existing reply' }, type: 'message.complete' } as any)
     onEvent({ payload: { names: ['browser_navigate'] }, type: 'tools.unavailable' } as any)
 
+    // Regex (not a 'tools unavailable' substring) so the assertion survives
+    // the singular "1 tool unavailable" wording.
     expect(appended.some(msg => /\d+ tools? unavailable/.test(msg.text ?? ''))).toBe(false)
   })
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -789,6 +789,17 @@ describe('createGatewayEventHandler', () => {
     )
   })
 
+  it('does not surface the notice when a non-intro item already exists', () => {
+    // A single pre-existing system item (e.g. a setup panel) makes the
+    // transcript non-fresh even though the history length is still small.
+    const appended: Msg[] = [{ kind: 'panel', role: 'system', text: '' }]
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: { names: ['browser_navigate'] }, type: 'tools.unavailable' } as any)
+
+    expect(appended.some(msg => msg.text.includes('tools unavailable'))).toBe(false)
+  })
+
   it('does not surface unavailable tools into an in-progress session', () => {
     const appended: Msg[] = [{ kind: 'intro', role: 'system', text: '' }]
     const onEvent = createGatewayEventHandler(buildCtx(appended))
@@ -797,7 +808,7 @@ describe('createGatewayEventHandler', () => {
     onEvent({ payload: { text: 'existing reply' }, type: 'message.complete' } as any)
     onEvent({ payload: { names: ['browser_navigate'] }, type: 'tools.unavailable' } as any)
 
-    expect(appended.some(msg => msg.text.includes('tools unavailable'))).toBe(false)
+    expect(appended.some(msg => /\d+ tools? unavailable/.test(msg.text ?? ''))).toBe(false)
   })
 
   it('shows setup panel for missing provider startup error', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -797,6 +797,39 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
       }
 
+      case 'tools.unavailable': {
+        // Issue #1433 Phase 2: config-gated tools (browser, vision, tts, ...)
+        // failed their check_fn — surface them once at the top of a fresh
+        // session so the user knows what `hermes tools` could enable. The
+        // model never sees these tools, so without this line they're
+        // invisible. Only show on a fresh transcript (intro only); a resumed
+        // session already had its chance.
+        const names = Array.isArray(ev.payload?.names)
+          ? ev.payload.names.filter((n: unknown): n is string => typeof n === 'string')
+          : []
+
+        if (names.length === 0) {
+          return
+        }
+
+        setHistoryItems(prev => {
+          if (prev.length > 1) {
+            return prev
+          }
+
+          const shown = names.slice(0, 3).join(', ')
+          const rest = names.length > 3 ? `, +${names.length - 3} more` : ''
+
+          const line =
+            `ⓘ ${names.length} tools unavailable (missing config/deps): ${shown}${rest}. ` +
+            'Run `hermes tools` to configure.'
+
+          return [...prev, { kind: 'event', role: 'system', text: line }]
+        })
+
+        return
+      }
+
       case 'thinking.delta': {
         if (!getUiState().busy) {
           return

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -823,7 +823,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           const rest = names.length > 3 ? `, +${names.length - 3} more` : ''
 
           const line =
-            `ⓘ ${names.length} tools unavailable (missing config/deps): ${shown}${rest}. ` +
+            `ⓘ ${names.length} ${names.length === 1 ? 'tool' : 'tools'} unavailable (missing config/deps): ${shown}${rest}. ` +
             'Run `hermes tools` to configure.'
 
           return [...prev, { kind: 'event', role: 'system', text: line }]

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -813,7 +813,9 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         }
 
         setHistoryItems(prev => {
-          if (prev.length > 1) {
+          // Fresh transcript only: the notice belongs right after the intro,
+          // before any real content (message, event, panel, ...).
+          if (prev.some(m => m.kind !== 'intro')) {
             return prev
           }
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -614,6 +614,7 @@ export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
+  | { payload?: { names?: string[] }; session_id?: string; type: 'tools.unavailable' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
   | { payload?: { kind?: string }; session_id?: string; type: 'reaction' }
   | { payload?: undefined; session_id?: string; type: 'message.start' }


### PR DESCRIPTION
## Summary

Implements **Phase 2** of #1433 (agent transparency): a one-time session-start notice listing **config-gated tools that are unavailable** — tools whose `check_fn` failed, so the model never sees them and the user never learns they exist.

> ⓘ 5 tools unavailable (missing config/deps): browser_navigate, web_search, tts_speak, +2 more. Run `hermes tools` to configure.

## How it works

- **`model_tools.py`** — extracted `_resolve_tool_names()` (the enabled-union/disabled-subtraction logic, behavior-identical) so the availability report shares the exact resolution used by `get_tool_definitions()`. New `get_unavailable_config_gated_tools()` computes requested − available and filters to `_CONFIG_GATED_TOOLSETS` (browser, vision, tts, web, image_gen, video_gen, x_search, homeassistant, spotify, discord, discord_admin). `check_fn` results are TTL-cached, so this costs no extra probes.
- **`agent/agent_init.py`** — stores the list on the agent; the CLI prints the dim ⓘ line after the tools banner (non-quiet builds only).
- **`tui_gateway/server.py`** — emits `tools.unavailable` (`{"names": [...]}`) once per session build (non-quiet).
- **TUI** — new `tools.unavailable` event case; the notice renders as a dim event line after the intro, only on a fresh transcript.
- **Desktop** — per-session store; the notice renders below the Intro in the fresh-session empty state.

## Design decisions

- **Session start, not per-turn** — tool availability is static for the session; a per-turn segment would repeat the same static fact every turn and pollute the Phase 1 summary line's "what the agent did" contract.
- **Curated whitelist** — only native toolsets whose unavailability is a config/setup gap are reported. Environment-gated tools (no browser binary, no Docker, worker mode), intentionally-disabled toolsets, and dynamic/MCP tools are never nagged about (`agent.disabled_toolsets` subtraction happens before the diff; MCP server tools are excluded by construction since their toolset is the server name).
- **Cap 3 names + "+N more"**, with a pointer to `hermes tools` (the existing management surface) — no new UI.
- No `check_fn` API change (bool-only, as today); a reason taxonomy ("API key missing" vs "binary missing") is deliberately out of scope.

## Verification

- Python: 5 new unit tests (resolution sharing, whitelist filtering, disabled-toolset exclusion) + full `test_model_tools.py` / cache-isolation suites pass (33 tests).
- TUI: 3 new event-handler tests (fresh-session surfacing, cap formatting, in-progress skip); full suite 1547 pass.
- Desktop: 2 new wiring tests; full suite 3674 pass.
- `tsc` + eslint clean in both apps.

Refs #1433 — Phase 2 of a multi-phase plan (phases 1, 3, 4 tracked on the issue; related: #1092, #16636, #53007).
