### PR TITLE
fix(context): show actual compression trigger % in /context

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2475,7 +2475,7 @@ class ContextCompressor(ContextEngine):
     ) -> int:
         """Compute the compaction trigger threshold in tokens.
 
-        The base value is ``effective_input_budget * threshold_percent``, floored
+        The base value is ``context_length * threshold_percent``, floored
         at ``MINIMUM_CONTEXT_LENGTH`` so large-context models don't compress
         prematurely at 50%. BUT that floor degenerates at small windows: for a
         model whose ``context_length`` is at/below the minimum (e.g. a 64K
@@ -2488,18 +2488,11 @@ class ContextCompressor(ContextEngine):
         small model uses most of its context before compacting, but below
         100% so compaction fires before the provider rejects the request.
 
-        The provider reserves ``max_tokens`` of output space out of the same
-        window, so the usable INPUT budget is ``context_length - max_tokens``.
-        With a large ``max_tokens`` (e.g. 65536 on a custom provider) the input
-        budget is materially smaller than the raw window, and a threshold based
-        on the full window lets the session hit a provider 400 before compaction
-        fires (#43547). The percentage and the degenerate-window check below both
-        operate on the effective input budget. ``max_tokens=None`` (provider
-        default) conservatively assumes no reservation (full window).
+        The threshold is a percentage of the full context window (not reduced
+        by the ``max_tokens`` output reservation) so a user-configured
+        threshold_percent matches the percentage shown in /context.
         """
-        effective_window = context_length - (max_tokens or 0)
-        if effective_window <= 0:
-            effective_window = context_length
+        effective_window = context_length
         pct_value = int(effective_window * threshold_percent)
         floored = max(pct_value, MINIMUM_CONTEXT_LENGTH)
         # If flooring pushed the threshold to/over the effective window it can

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3018,7 +3018,7 @@ class ContextCompressor(ContextEngine):
     ) -> int:
         """Compute the compaction trigger threshold in tokens.
 
-        The base value is ``effective_input_budget * threshold_percent``, floored
+        The base value is ``context_length * threshold_percent``, floored
         at ``MINIMUM_CONTEXT_LENGTH`` so large-context models don't compress
         prematurely at 50%. BUT that floor degenerates at small windows: for a
         model whose ``context_length`` is at/below the minimum (e.g. a 64K
@@ -3031,18 +3031,11 @@ class ContextCompressor(ContextEngine):
         small model uses most of its context before compacting, but below
         100% so compaction fires before the provider rejects the request.
 
-        The provider reserves ``max_tokens`` of output space out of the same
-        window, so the usable INPUT budget is ``context_length - max_tokens``.
-        With a large ``max_tokens`` (e.g. 65536 on a custom provider) the input
-        budget is materially smaller than the raw window, and a threshold based
-        on the full window lets the session hit a provider 400 before compaction
-        fires (#43547). The percentage and the degenerate-window check below both
-        operate on the effective input budget. ``max_tokens=None`` (provider
-        default) conservatively assumes no reservation (full window).
+        The threshold is a percentage of the full context window (not reduced
+        by the ``max_tokens`` output reservation) so a user-configured
+        threshold_percent matches the percentage shown in /context.
         """
-        effective_window = context_length - (max_tokens or 0)
-        if effective_window <= 0:
-            effective_window = context_length
+        effective_window = context_length
         pct_value = int(effective_window * threshold_percent)
         floored = max(pct_value, MINIMUM_CONTEXT_LENGTH)
         # If flooring pushed the threshold to/over the effective window it can

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -896,7 +896,15 @@ class GatewaySlashCommandsMixin:
             # Full view — compression / throughput need the live agent.
             if ctx is not None:
                 threshold = getattr(ctx, "threshold_tokens", 0) or 0
-                threshold_pct = (getattr(ctx, "threshold_percent", 0) or 0) * 100
+                # Show the ACTUAL trigger point as a % of the full context
+                # window, not the configured threshold_percent. threshold_tokens
+                # is computed against the effective input budget (context minus
+                # the max_tokens output reservation, #43547), so the configured
+                # percent (e.g. 85%) would misrepresent the real trigger (e.g.
+                # 63% of the window) and look like a bug.
+                threshold_pct = (
+                    (threshold / context_length * 100) if context_length > 0 else 0
+                )
                 lines.append("")
                 if threshold > 0:
                     if used >= threshold:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -818,7 +818,15 @@ class GatewaySlashCommandsMixin:
             # Full view — compression / throughput need the live agent.
             if ctx is not None:
                 threshold = getattr(ctx, "threshold_tokens", 0) or 0
-                threshold_pct = (getattr(ctx, "threshold_percent", 0) or 0) * 100
+                # Show the ACTUAL trigger point as a % of the full context
+                # window, not the configured threshold_percent. threshold_tokens
+                # is computed against the effective input budget (context minus
+                # the max_tokens output reservation, #43547), so the configured
+                # percent (e.g. 85%) would misrepresent the real trigger (e.g.
+                # 63% of the window) and look like a bug.
+                threshold_pct = (
+                    (threshold / context_length * 100) if context_length > 0 else 0
+                )
                 lines.append("")
                 if threshold > 0:
                     if used >= threshold:


### PR DESCRIPTION
## Fix: /context compression threshold % now matches the actual window

### Problem
Two related issues made the auto-compression setting in `/context` misleading:

1. **Display** showed the configured `threshold_percent` (e.g. 85%) even though the actual trigger point was a different fraction of the full window.
2. **Threshold math** computed `threshold_tokens` against the *effective input budget* (`context_length - max_tokens`), so on models with a large `max_tokens` (e.g. 65536 on a custom provider) a configured 85% actually fired at ~63% of the window.

### Fix
- `gateway/slash_commands.py`: display the actual trigger point as a % of the full context window (`threshold_tokens / context_length`) instead of the raw configured percent.
- `agent/context_compressor.py`: compute `threshold_tokens` against the **full context window** (`context_length * threshold_percent`), so a user-configured percentage matches the percentage shown in /context.

### Verification
- `threshold = 217600 = 85.0% of window` (was 161894 = 63.2%)
- 150 compressor/engine tests pass

### Note
This drops the #43547 `max_tokens` output-reservation guard. A large output budget can now push a session past the provider window before compaction fires. Kept as-is per explicit user request.