### PR TITLE
fix(curator): report failed LLM reviews instead of no change

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1851,7 +1851,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
 
     def _bounded_summary(value: str, fallback: str = "") -> str:
         text = value or fallback
-        return text[:240] + "…" if len(text) > 240 else text
+        return text[:239] + "…" if len(text) > 240 else text
 
     try:
         from run_agent import AIAgent

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1828,12 +1828,14 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     """Spawn an AIAgent fork to run the curator review prompt.
 
     Returns a dict with:
-      - final: full (untruncated) final response from the reviewer
+      - final: full (untruncated) final response from the reviewer; a failed
+        pass may still retain partial or diagnostic output here
       - summary: short summary suitable for state file (240-char cap)
       - model, provider: what the fork actually ran on
       - tool_calls: list of {name, arguments} for every tool call made during
         the pass (arguments may be truncated for readability)
-      - error: set if the pass failed mid-run; final/summary may still be empty
+      - error: set if the pass failed mid-run; consumers must use this field
+        rather than infer success from whether ``final`` is populated
 
     Never raises; callers get a structured failure instead.
     """

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1961,7 +1961,18 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         if isinstance(conv_result, dict):
             final = str(conv_result.get("final_response") or "").strip()
         result_meta["final"] = final
-        result_meta["summary"] = (final[:240] + "…") if len(final) > 240 else (final or "no change")
+        conversation_error = conv_result.get("error") if isinstance(conv_result, dict) else None
+        conversation_failed = (
+            bool(conv_result.get("failed")) if isinstance(conv_result, dict) else False
+        )
+        if conversation_failed or conversation_error:
+            error = str(conversation_error or "conversation failed")
+            result_meta["error"] = error
+            result_meta["summary"] = f"error ({error})"
+        else:
+            result_meta["summary"] = (
+                (final[:240] + "…") if len(final) > 240 else (final or "no change")
+            )
 
         # Collect tool calls for the report. Walk the forked agent's
         # session messages and extract every tool_call made during the

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1846,11 +1846,16 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         "tool_calls": [],
         "error": None,
     }
+
+    def _bounded_summary(value: str, fallback: str = "") -> str:
+        text = value or fallback
+        return text[:240] + "…" if len(text) > 240 else text
+
     try:
         from run_agent import AIAgent
     except Exception as e:
         result_meta["error"] = f"AIAgent import failed: {e}"
-        result_meta["summary"] = result_meta["error"]
+        result_meta["summary"] = _bounded_summary(result_meta["error"])
         return result_meta
 
     # Resolve provider + model the same way the CLI does, so the curator
@@ -1968,16 +1973,9 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         if conversation_failed or conversation_error:
             error = str(conversation_error or "conversation failed")
             result_meta["error"] = error
-            error_summary = f"error ({error})"
-            result_meta["summary"] = (
-                error_summary[:240] + "…"
-                if len(error_summary) > 240
-                else error_summary
-            )
+            result_meta["summary"] = _bounded_summary(f"error ({error})")
         else:
-            result_meta["summary"] = (
-                (final[:240] + "…") if len(final) > 240 else (final or "no change")
-            )
+            result_meta["summary"] = _bounded_summary(final, "no change")
 
         # Collect tool calls for the report. Walk the forked agent's
         # session messages and extract every tool_call made during the
@@ -2000,7 +1998,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         result_meta["tool_calls"] = _calls
     except Exception as e:
         result_meta["error"] = f"error: {e}"
-        result_meta["summary"] = result_meta["error"]
+        result_meta["summary"] = _bounded_summary(result_meta["error"])
     finally:
         if review_agent is not None:
             try:

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1968,7 +1968,12 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         if conversation_failed or conversation_error:
             error = str(conversation_error or "conversation failed")
             result_meta["error"] = error
-            result_meta["summary"] = f"error ({error})"
+            error_summary = f"error ({error})"
+            result_meta["summary"] = (
+                error_summary[:240] + "…"
+                if len(error_summary) > 240
+                else error_summary
+            )
         else:
             result_meta["summary"] = (
                 (final[:240] + "…") if len(final) > 240 else (final or "no change")

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -809,7 +809,7 @@ def test_review_fork_preserves_structured_conversation_failure(curator_env, monk
     import importlib
     importlib.reload(curator)
     conversation_result = {
-        "final_response": "",
+        "final_response": "partial diagnostic response",
         "failed": True,
         "error": "provider rejected credentials",
     }
@@ -828,6 +828,7 @@ def test_review_fork_preserves_structured_conversation_failure(curator_env, monk
 
     result = curator._run_llm_review("review")
 
+    assert result["final"] == "partial diagnostic response"
     assert result["error"] == "provider rejected credentials"
     assert result["summary"] == "error (provider rejected credentials)"
 
@@ -847,8 +848,6 @@ def test_review_fork_preserves_structured_conversation_failure(curator_env, monk
 
     assert result["error"] == f"error: {long_error}"
     assert result["summary"] == result["error"][:240] + "…"
-
-
 
 
 def test_review_fork_restricts_toolsets_to_skills_and_terminal(curator_env, monkeypatch):

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -837,7 +837,8 @@ def test_review_fork_preserves_structured_conversation_failure(curator_env, monk
     result = curator._run_llm_review("review")
 
     assert result["error"] == long_error
-    assert result["summary"] == f"error ({long_error})"[:240] + "…"
+    assert result["summary"] == f"error ({long_error})"[:239] + "…"
+    assert len(result["summary"]) == 240
 
     class _FailingAgent:
         def __init__(self, **_kwargs):
@@ -847,7 +848,8 @@ def test_review_fork_preserves_structured_conversation_failure(curator_env, monk
     result = curator._run_llm_review("review")
 
     assert result["error"] == f"error: {long_error}"
-    assert result["summary"] == result["error"][:240] + "…"
+    assert result["summary"] == result["error"][:239] + "…"
+    assert len(result["summary"]) == 240
 
 
 def test_review_fork_restricts_toolsets_to_skills_and_terminal(curator_env, monkeypatch):

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -838,6 +838,16 @@ def test_review_fork_preserves_structured_conversation_failure(curator_env, monk
     assert result["error"] == long_error
     assert result["summary"] == f"error ({long_error})"[:240] + "…"
 
+    class _FailingAgent:
+        def __init__(self, **_kwargs):
+            raise RuntimeError(long_error)
+
+    monkeypatch.setattr("run_agent.AIAgent", _FailingAgent)
+    result = curator._run_llm_review("review")
+
+    assert result["error"] == f"error: {long_error}"
+    assert result["summary"] == result["error"][:240] + "…"
+
 
 
 

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -804,6 +804,33 @@ def test_review_fork_uses_runtime_model_and_output_cap(curator_env, monkeypatch)
     assert captured["max_tokens"] == 1234
 
 
+def test_review_fork_preserves_structured_conversation_failure(curator_env, monkeypatch):
+    curator = curator_env["curator"]
+    import importlib
+    importlib.reload(curator)
+
+    class _StubAgent:
+        def __init__(self, **_kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **_kwargs):
+            return {
+                "final_response": "",
+                "failed": True,
+                "error": "provider rejected credentials",
+            }
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgent)
+
+    result = curator._run_llm_review("review")
+
+    assert result["error"] == "provider rejected credentials"
+    assert result["summary"] == "error (provider rejected credentials)"
+
+
 
 
 def test_review_fork_restricts_toolsets_to_skills_and_terminal(curator_env, monkeypatch):

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -808,17 +808,18 @@ def test_review_fork_preserves_structured_conversation_failure(curator_env, monk
     curator = curator_env["curator"]
     import importlib
     importlib.reload(curator)
+    conversation_result = {
+        "final_response": "",
+        "failed": True,
+        "error": "provider rejected credentials",
+    }
 
     class _StubAgent:
         def __init__(self, **_kwargs):
             self._session_messages = []
 
         def run_conversation(self, **_kwargs):
-            return {
-                "final_response": "",
-                "failed": True,
-                "error": "provider rejected credentials",
-            }
+            return conversation_result
 
         def close(self):
             pass
@@ -829,6 +830,13 @@ def test_review_fork_preserves_structured_conversation_failure(curator_env, monk
 
     assert result["error"] == "provider rejected credentials"
     assert result["summary"] == "error (provider rejected credentials)"
+
+    long_error = "provider rejected credentials: " + "x" * 300
+    conversation_result["error"] = long_error
+    result = curator._run_llm_review("review")
+
+    assert result["error"] == long_error
+    assert result["summary"] == f"error ({long_error})"[:240] + "…"
 
 
 


### PR DESCRIPTION
## What does this PR do?

Curator runs now report structured LLM conversation failures as errors instead of recording them as successful `no change` reviews. This preserves the provider failure in `llm_error`, gives operators an accurate bounded summary, and keeps genuinely successful empty reviews distinguishable from non-execution.

### Symptom

When `AIAgent.run_conversation()` returns `failed: true` or an `error` without raising, the curator stores an empty final response, a `no change` summary, and a null `llm_error`.

### Impact

Automated curator reports can classify a review that never completed as a successful unchanged result. Operators and downstream reporting therefore lose the existing failure signal and cannot distinguish provider rejection from a valid review outcome.

### Bug Cause

**Trigger:** `agent/curator.py` / `_run_llm_review()` / a structured conversation result with `failed` or `error`

**Causal chain:**
1. The review fork returns a failure mapping instead of raising an exception.
2. `_run_llm_review()` reads only `final_response`, so the structured failure metadata is discarded.
3. The empty response falls through to `no change`, while the exception-only error branch never runs.

**Why it is wrong:** The caller already receives an authoritative failure signal, but converts it into the same metadata as a successful empty review.

**Working sibling / contrast:** Exceptions raised while constructing or running the review agent already populate the curator error metadata and summary.

**Ruled out:** Report serialization is not the source of the loss because the report already persists `result_meta["error"]`; the value is null before serialization on the structured-failure path.

### Fix

Propagate structured conversation failures into the curator result metadata before applying the successful-response fallback. A shared summary helper now bounds both returned failures and raised exceptions to the documented 240-character limit while retaining the complete error value.

## Related Issue

Closes #83260

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/curator.py` - preserve structured conversation errors and consistently bound review summaries.
- `tests/agent/test_curator.py` - cover failed result mappings, long errors, and raised review-agent failures.

## How to Test

1. Return an empty `final_response` with `failed: true` and a provider error from a stub review agent.
2. Verify the full error is retained and the summary reports failure rather than `no change`, including the long-error bound.
3. Run the related curator test suite:

```bash
scripts/run_tests.sh tests/agent/test_curator.py tests/agent/test_curator_activity.py tests/agent/test_curator_backup.py tests/agent/test_curator_classification.py tests/agent/test_curator_reports.py
```

Result: 56 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related curator tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the mapping and summary behavior is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no tool schema changed

## Screenshots / Logs

N/A - verified by the related automated curator tests.
