### PR TITLE
fix(gateway): preserve active work on supervised SIGTERM

### DIFF
--- a/agent/thread_scoped_output.py
+++ b/agent/thread_scoped_output.py
@@ -34,6 +34,16 @@ _installed: dict[str, "_ThreadRoutingStream"] = {}
 # displace and later restore a routing proxy; they must not allocate another
 # permanent /dev/null descriptor every time that happens.
 _sinks: dict[str, TextIO] = {}
+_routing_states: dict[str, "_RoutingState"] = {}
+
+
+class _RoutingState:
+    """Silencing registry shared by every proxy generation for one stream."""
+
+    def __init__(self, sink: TextIO) -> None:
+        self.sink = sink
+        self.silenced: dict[int, int] = {}
+        self.lock = threading.Lock()
 
 
 class _ThreadRoutingStream:
@@ -46,32 +56,27 @@ class _ThreadRoutingStream:
     ``.fileno()`` behave like the underlying stream for the calling thread.
     """
 
-    def __init__(self, passthrough: TextIO, sink: TextIO) -> None:
+    def __init__(self, passthrough: TextIO, state: _RoutingState) -> None:
         self._passthrough = passthrough
-        self._sink = sink
-        # ident -> nesting depth.  A thread is silenced while depth > 0, so
-        # nested ``thread_scoped_silence()`` on the same thread composes
-        # correctly (the inner exit decrements rather than fully clearing).
-        self._silenced: dict[int, int] = {}
-        self._lock = threading.Lock()
+        self._state = state
 
     def _target(self) -> TextIO:
-        if self._silenced.get(threading.get_ident(), 0) > 0:
-            return self._sink
+        if self._state.silenced.get(threading.get_ident(), 0) > 0:
+            return self._state.sink
         return self._passthrough
 
     # --- registration -----------------------------------------------------
     def silence(self, ident: int) -> None:
-        with self._lock:
-            self._silenced[ident] = self._silenced.get(ident, 0) + 1
+        with self._state.lock:
+            self._state.silenced[ident] = self._state.silenced.get(ident, 0) + 1
 
     def unsilence(self, ident: int) -> None:
-        with self._lock:
-            depth = self._silenced.get(ident, 0) - 1
+        with self._state.lock:
+            depth = self._state.silenced.get(ident, 0) - 1
             if depth > 0:
-                self._silenced[ident] = depth
+                self._state.silenced[ident] = depth
             else:
-                self._silenced.pop(ident, None)
+                self._state.silenced.pop(ident, None)
 
     # --- file-like surface ------------------------------------------------
     def write(self, data):  # type: ignore[no-untyped-def]
@@ -118,6 +123,7 @@ def _ensure_installed(attr: str, passthrough: TextIO) -> "_ThreadRoutingStream":
             # temporary replacement. Adopt it instead of wrapping it and
             # growing an unbounded proxy chain.
             _installed[attr] = current
+            _routing_states[attr] = current._state
             return current
         if proxy is not None and current is proxy:
             return proxy
@@ -129,7 +135,11 @@ def _ensure_installed(attr: str, passthrough: TextIO) -> "_ThreadRoutingStream":
         if sink is None or sink.closed:
             sink = open(os.devnull, "w", encoding="utf-8")
             _sinks[attr] = sink
-        proxy = _ThreadRoutingStream(passthrough, sink)
+        state = _routing_states.get(attr)
+        if state is None or state.sink is not sink:
+            state = _RoutingState(sink)
+            _routing_states[attr] = state
+        proxy = _ThreadRoutingStream(passthrough, state)
         setattr(sys, attr, proxy)
         _installed[attr] = proxy
         return proxy

--- a/agent/thread_scoped_output.py
+++ b/agent/thread_scoped_output.py
@@ -30,6 +30,10 @@ _install_lock = threading.Lock()
 # Maps the proxy we installed for a given attribute ("stdout"/"stderr") so we
 # never double-wrap and so we can recover the original stream.
 _installed: dict[str, "_ThreadRoutingStream"] = {}
+# One process-lifetime sink per stream. Temporary process-global redirects can
+# displace and later restore a routing proxy; they must not allocate another
+# permanent /dev/null descriptor every time that happens.
+_sinks: dict[str, TextIO] = {}
 
 
 class _ThreadRoutingStream:
@@ -109,13 +113,22 @@ def _ensure_installed(attr: str, passthrough: TextIO) -> "_ThreadRoutingStream":
     with _install_lock:
         proxy = _installed.get(attr)
         current = getattr(sys, attr, None)
+        if isinstance(current, _ThreadRoutingStream):
+            # A redirect context can restore an older routing proxy after a
+            # temporary replacement. Adopt it instead of wrapping it and
+            # growing an unbounded proxy chain.
+            _installed[attr] = current
+            return current
         if proxy is not None and current is proxy:
             return proxy
         # Capture whatever is currently bound as the passthrough. If a prior
         # global redirect_stdout is active, route non-silenced threads to that
         # stream to preserve the old behavior.
         passthrough = current if current is not None else passthrough
-        sink = open(os.devnull, "w", encoding="utf-8")
+        sink = _sinks.get(attr)
+        if sink is None or sink.closed:
+            sink = open(os.devnull, "w", encoding="utf-8")
+            _sinks[attr] = sink
         proxy = _ThreadRoutingStream(passthrough, sink)
         setattr(sys, attr, proxy)
         _installed[attr] = proxy

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -19,6 +19,16 @@ database:
   # journal_size_limit: 67108864 # cap the WAL/journal file size in bytes
 
 # =============================================================================
+# Runtime Limits
+# =============================================================================
+# Long-running Hermes server processes raise their RLIMIT_NOFILE soft limit to
+# this value when the operating system permits it. The value is clamped to the
+# hard limit and never lowers an already higher soft limit. Set to 0, false, or
+# null to disable the adjustment. Default: 4096.
+runtime:
+  nofile_soft_limit: 4096
+
+# =============================================================================
 # Model Configuration
 # =============================================================================
 model:

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -471,6 +471,45 @@ class DeliveryRouter:
 
         if not target.chat_id:
             raise ValueError(f"No chat ID for {target.platform.value} delivery")
+
+        # Protect Discord task parents before transport selection matters.
+        # This keeps relay fallback from bypassing the native adapter's guard.
+        if target.platform == Platform.DISCORD:
+            discord_config = self.config.platforms.get(Platform.DISCORD)
+            extra = getattr(discord_config, "extra", None)
+            raw = (
+                extra.get("agent_task_forum_channels")
+                if isinstance(extra, dict)
+                else None
+            )
+            if isinstance(raw, list):
+                protected_ids = {
+                    str(value).strip() for value in raw if str(value).strip()
+                }
+            else:
+                protected_ids = {
+                    value.strip() for value in str(raw or "").split(",")
+                    if value.strip()
+                }
+            metadata_thread_id = (metadata or {}).get("thread_id")
+            metadata_message_thread_id = (metadata or {}).get("message_thread_id")
+            if (
+                metadata_thread_id
+                and metadata_message_thread_id
+                and str(metadata_thread_id) != str(metadata_message_thread_id)
+            ):
+                raise ValueError("Conflicting Discord delivery thread metadata")
+            effective_id = str(
+                metadata_thread_id
+                or metadata_message_thread_id
+                or target.thread_id
+                or target.chat_id
+            )
+            if effective_id in protected_ids:
+                raise ValueError(
+                    "Direct delivery to this Discord task channel is blocked; "
+                    "start a live agent task thread instead."
+                )
         
         # Guard: handle oversized cron output.
         #
@@ -640,7 +679,5 @@ class DeliveryRouter:
             if _send_result_failed(result):
                 raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
         return result
-
-
 
 

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -1,5 +1,6 @@
 """Shared gateway restart constants and supervisor detection helpers."""
 
+import math
 import os
 from collections.abc import Mapping
 
@@ -67,10 +68,12 @@ def is_container_restart_context() -> bool:
 
 
 def parse_restart_drain_timeout(raw: object) -> float:
-    """Parse a configured drain timeout, falling back to the shared default."""
+    """Parse a finite drain timeout, falling back to the shared default."""
     try:
         value = float(raw) if str(raw or "").strip() else DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     except (TypeError, ValueError):
+        return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    if not math.isfinite(value):
         return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     return max(0.0, value)
 

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -2,6 +2,7 @@
 
 import math
 import os
+import signal
 from collections.abc import Mapping
 
 from hermes_cli.config import DEFAULT_CONFIG
@@ -53,6 +54,29 @@ def is_gateway_supervisor_process(
         "yes",
         "on",
     }
+
+
+def should_defer_supervised_sigterm_restart(
+    received_signal: int | None,
+    *,
+    planned_stop: bool,
+    planned_takeover: bool,
+    supervised: bool,
+) -> bool:
+    """Whether an unmarked supervisor SIGTERM should preserve active work.
+
+    Service managers restart a gateway by sending SIGTERM, but that signal has
+    no sender identity. For a supervised gateway it is therefore the common
+    restart path, not evidence that in-flight work should be cancelled.
+    Explicit Hermes stops and ``--replace`` takeovers write markers first and
+    intentionally retain their immediate-stop behaviour.
+    """
+    return bool(
+        supervised
+        and received_signal == signal.SIGTERM
+        and not planned_stop
+        and not planned_takeover
+    )
 
 
 def is_container_restart_context() -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26913,6 +26913,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                  Useful for systemd services to avoid restart-loop deadlocks
                  when the previous process hasn't fully exited yet.
     """
+    from hermes_cli.resource_limits import apply_nofile_soft_limit
+
+    apply_nofile_soft_limit()
+
     # Snapshot the checkout revision now, while sys.modules still matches disk,
     # so a later `git pull` under this long-lived process can be detected (and
     # risky work like model switching refused) instead of crashing on a stale

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31,6 +31,7 @@ import faulthandler
 import inspect
 import json
 import logging
+import math
 import os
 import queue
 import re
@@ -8456,8 +8457,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         value = parse_restart_drain_timeout(raw)
         if raw and value == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT:
             try:
-                float(raw)
+                invalid = not math.isfinite(float(raw))
             except (TypeError, ValueError):
+                invalid = True
+            if invalid:
                 logger.warning(
                     "Invalid restart_drain_timeout '%s', using default %.0fs",
                     raw,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2425,8 +2425,10 @@ from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
+    is_gateway_supervisor_process,
     parse_restart_after_turn_timeout,
     parse_restart_drain_timeout,
+    should_defer_supervised_sigterm_restart,
 )
 
 
@@ -27282,6 +27284,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             _shutdown_ctx = None
             logger.debug("snapshot_shutdown_context failed: %s", _e)
 
+        defer_supervised_sigterm_restart = should_defer_supervised_sigterm_restart(
+            received_signal,
+            planned_stop=planned_stop,
+            planned_takeover=planned_takeover,
+            supervised=is_gateway_supervisor_process(),
+        )
+
         if planned_takeover:
             logger.info(
                 "Received %s as a planned --replace takeover — exiting cleanly",
@@ -27291,6 +27300,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logger.info(
                 "Received %s as a planned gateway stop — exiting cleanly",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM/SIGINT",
+            )
+        elif defer_supervised_sigterm_restart:
+            logger.info(
+                "Received %s from an external supervisor — deferring restart "
+                "until active work completes",
+                _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM",
             )
         else:
             _signal_initiated_shutdown = True
@@ -27328,6 +27343,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 )
             except Exception as _e:
                 logger.debug("spawn_async_diagnostic failed: %s", _e)
+        if defer_supervised_sigterm_restart:
+            # launchd/systemd normally restart by SIGTERM. Route that through
+            # the same after-turn wait as /restart and SIGUSR1; otherwise
+            # stop() force-interrupts active tasks after the short drain cap.
+            runner.request_restart(detached=False, via_service=True)
+            return
         asyncio.create_task(runner.stop())
 
     def restart_signal_handler():

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -20,6 +20,11 @@ DEFAULT_CONFIG = {
         "wal_autocheckpoint": None,
         "journal_size_limit": None,
     },
+    # Soft file-descriptor limit for long-running Hermes server processes.
+    # Clamped to the OS hard limit; 0/false/null disables the adjustment.
+    "runtime": {
+        "nofile_soft_limit": 4096,
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -43,6 +43,12 @@ def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None)
 
 
 def _cron_api(**kwargs):
+    # CLI invocations are one-shot processes. Mark them stateless so a manual
+    # run executes synchronously instead of dispatching work to a daemon that
+    # dies as soon as this command returns.
+    from gateway.session_context import declare_stateless_channel
+    declare_stateless_channel()
+
     from tools.cronjob_tools import cronjob as cronjob_tool
 
     return json.loads(cronjob_tool(**kwargs))

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4129,6 +4129,28 @@ def generate_launchd_plist() -> str:
     )
     prog_args_xml = "\n        ".join(prog_args)
 
+    # Persist the configured RLIMIT_NOFILE floor into the service definition
+    # itself. launchd starts children with a soft limit of 256 by default;
+    # without this block every plist rewrite (e.g. `hermes gateway start`)
+    # would silently strip a manually-added limit and reintroduce EMFILE
+    # crashes under load. The in-process floor (resource_limits.py) still
+    # applies as a second layer for non-launchd launches.
+    nofile_block = ""
+    try:
+        from hermes_cli.resource_limits import configured_nofile_soft_limit
+
+        nofile_target = configured_nofile_soft_limit()
+    except Exception:
+        nofile_target = None
+    if nofile_target:
+        nofile_block = f"""
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{nofile_target}</integer>
+    </dict>
+"""
+
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -4175,7 +4197,7 @@ def generate_launchd_plist() -> str:
 
     <key>ExitTimeOut</key>
     <integer>25</integer>
-
+{nofile_block}
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4083,6 +4083,47 @@ def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) 
     return False
 
 
+def _launchd_nofile_soft_limit() -> int | None:
+    """Resolve a safe absolute launchd maxfiles value.
+
+    launchd has no "at least" operator: ``NumberOfFiles`` replaces the
+    inherited soft limit.  Inspect the domain value and never emit a smaller
+    number.  If inheritance cannot be established, omit the plist override;
+    the gateway's early in-process helper still raises its own limit without
+    ever lowering it.
+    """
+    from hermes_cli.resource_limits import (
+        DEFAULT_NOFILE_SOFT_LIMIT,
+        configured_nofile_soft_limit,
+    )
+
+    target = configured_nofile_soft_limit()
+    if target is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["/bin/launchctl", "limit", "maxfiles"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return None
+        fields = result.stdout.split()
+        if len(fields) < 3 or fields[0] != "maxfiles":
+            return None
+        if fields[1].lower() == "unlimited":
+            return None
+        inherited_soft = int(fields[1])
+        if inherited_soft <= 0:
+            return None
+    except (OSError, ValueError, subprocess.SubprocessError):
+        logger.debug("Could not inspect launchd maxfiles inheritance", exc_info=True)
+        return None
+    return max(target, DEFAULT_NOFILE_SOFT_LIMIT, inherited_soft)
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     # Stable cwd anchor — never the volatile source checkout. See
@@ -4137,9 +4178,7 @@ def generate_launchd_plist() -> str:
     # applies as a second layer for non-launchd launches.
     nofile_block = ""
     try:
-        from hermes_cli.resource_limits import configured_nofile_soft_limit
-
-        nofile_target = configured_nofile_soft_limit()
+        nofile_target = _launchd_nofile_soft_limit()
     except Exception:
         nofile_target = None
     if nofile_target:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4118,10 +4118,18 @@ def _launchd_nofile_soft_limit() -> int | None:
         inherited_soft = int(fields[1])
         if inherited_soft <= 0:
             return None
+        inherited_hard = None
+        if fields[2].lower() != "unlimited":
+            inherited_hard = int(fields[2])
+            if inherited_hard <= 0 or inherited_hard < inherited_soft:
+                return None
     except (OSError, ValueError, subprocess.SubprocessError):
         logger.debug("Could not inspect launchd maxfiles inheritance", exc_info=True)
         return None
-    return max(target, DEFAULT_NOFILE_SOFT_LIMIT, inherited_soft)
+    resolved = max(target, DEFAULT_NOFILE_SOFT_LIMIT, inherited_soft)
+    if inherited_hard is not None:
+        resolved = min(resolved, inherited_hard)
+    return resolved
 
 
 def generate_launchd_plist() -> str:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import json
 import logging
+import math
 import os
 import shlex
 import shutil
@@ -15,6 +16,7 @@ import subprocess
 import sys
 import textwrap
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -3289,12 +3291,19 @@ def _get_restart_drain_timeout() -> float:
     if not raw:
         cfg = read_raw_config()
         agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(agent_cfg, Mapping):
+            agent_cfg = {}
         raw = str(
             agent_cfg.get(
                 "restart_drain_timeout", DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
             )
         )
     return parse_restart_drain_timeout(raw)
+
+
+def _get_launchd_exit_timeout() -> int:
+    """Allow a restart drain to finish before launchd forces termination."""
+    return max(30, math.ceil(_get_restart_drain_timeout() + 30))
 
 
 def _get_restart_after_turn_timeout() -> float:
@@ -4143,6 +4152,7 @@ def generate_launchd_plist() -> str:
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
     profile_arg = _profile_arg(hermes_home)
+    exit_timeout = _get_launchd_exit_timeout()
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
     # nvm, cargo, etc.  We prepend venv/bin and node_modules/.bin (matching
@@ -4237,13 +4247,13 @@ def generate_launchd_plist() -> str:
 
     <!-- ThrottleInterval raises launchd's default 10s minimum respawn interval
          to 30s so a crash-looping gateway can't hammer launchd into a rapid
-         respawn storm; ExitTimeOut gives the gateway 25s of graceful-drain
-         headroom before launchd escalates from SIGTERM to SIGKILL on stop. -->
+         respawn storm; ExitTimeOut covers the configured graceful-drain budget
+         plus 30s before launchd escalates from SIGTERM to SIGKILL on stop. -->
     <key>ThrottleInterval</key>
     <integer>30</integer>
 
     <key>ExitTimeOut</key>
-    <integer>25</integer>
+    <integer>{exit_timeout}</integer>
 {nofile_block}
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10360,6 +10360,15 @@ def cmd_dashboard(args):
         else:
             os.execvpe(sys.executable, reexec_argv, env)
 
+    # Apply the final process/profile policy after dashboard routing, but before
+    # importing the web server or opening dashboard state. Applying it before a
+    # named-profile re-exec could leak that profile's higher limit into the
+    # machine/default dashboard, whose lower policy intentionally cannot undo it.
+    # This also covers Desktop SSH's isolated `serve` child, which does not route.
+    from hermes_cli.resource_limits import apply_nofile_soft_limit
+
+    apply_nofile_soft_limit()
+
     if _token_file:
         _ssh_session_token = _read_ssh_session_token_file(_token_file)
 

--- a/hermes_cli/resource_limits.py
+++ b/hermes_cli/resource_limits.py
@@ -1,0 +1,119 @@
+"""Best-effort process resource-limit adjustments for long-running services.
+
+The public helper in this module is shared by the gateway and the dashboard/
+serve entrypoints. It deliberately has no user-facing environment-variable
+control: the target comes from the profile's canonical ``config.yaml`` loader.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+try:  # ``resource`` is POSIX-only (and unavailable on Windows).
+    import resource as _resource
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - Windows only
+    _resource = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NOFILE_SOFT_LIMIT = int(DEFAULT_CONFIG["runtime"]["nofile_soft_limit"])
+_MISSING = object()
+
+
+def _configured_nofile_soft_limit(
+    config: Mapping[str, Any] | None,
+) -> int | None:
+    """Resolve ``runtime.nofile_soft_limit`` from a loaded config.
+
+    A missing key uses the default. Explicit ``0``, ``false``, and ``null``
+    disable the adjustment. Other non-integer or negative values are invalid
+    and are ignored (the caller fails open without changing the process limit).
+    """
+    if config is None:
+        try:
+            # Use Hermes's real, profile-aware loader rather than reading YAML
+            # here. This also applies managed-scope overlays and defaults.
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+        except Exception:
+            logger.debug("Could not load config for RLIMIT_NOFILE", exc_info=True)
+            return None
+
+    if not isinstance(config, Mapping):
+        return None
+
+    runtime = config.get("runtime", _MISSING)
+    if runtime is _MISSING:
+        return DEFAULT_NOFILE_SOFT_LIMIT
+    if not isinstance(runtime, Mapping):
+        return None
+
+    raw_value = runtime.get("nofile_soft_limit", _MISSING)
+    if raw_value is _MISSING:
+        return DEFAULT_NOFILE_SOFT_LIMIT
+    if raw_value is None or raw_value is False:
+        return None
+    if raw_value is True or not isinstance(raw_value, int):
+        return None
+    if raw_value <= 0:
+        return None
+    return raw_value
+
+
+def apply_nofile_soft_limit(
+    config: Mapping[str, Any] | None = None,
+) -> bool:
+    """Raise this process's ``RLIMIT_NOFILE`` soft limit when possible.
+
+    The target defaults to :data:`DEFAULT_NOFILE_SOFT_LIMIT` and can be set with
+    ``runtime.nofile_soft_limit``. The target is clamped to a finite hard limit,
+    never lowers an existing higher soft limit, and returns ``False`` for an
+    explicit opt-out or when the platform/sandbox refuses the operation.
+
+    This is intentionally best-effort. Unsupported platforms, malformed
+    settings, and denied ``setrlimit`` calls must never prevent a server from
+    starting.
+    """
+    if _resource is None:
+        return False
+
+    target = _configured_nofile_soft_limit(config)
+    if target is None:
+        return False
+
+    try:
+        nofile = _resource.RLIMIT_NOFILE
+        current_soft, current_hard = _resource.getrlimit(nofile)
+        # On platforms where RLIM_INFINITY is represented as -1, ordinary
+        # integer ordering would make an unlimited soft limit look lower than
+        # every positive target. Never replace infinity with a finite limit.
+        if current_soft == getattr(_resource, "RLIM_INFINITY", object()):
+            return False
+        if current_soft >= target:
+            return False
+
+        if current_hard == getattr(_resource, "RLIM_INFINITY", object()):
+            new_soft = target
+        else:
+            new_soft = min(target, current_hard)
+        if new_soft <= current_soft:
+            return False
+
+        _resource.setrlimit(nofile, (new_soft, current_hard))
+        return True
+    except Exception:
+        # This helper runs before server startup and must fail open for
+        # unsupported/sandboxed environments and denied resource changes.
+        logger.debug("Could not raise RLIMIT_NOFILE soft limit", exc_info=True)
+        return False
+
+
+__all__ = [
+    "DEFAULT_NOFILE_SOFT_LIMIT",
+    "apply_nofile_soft_limit",
+]

--- a/hermes_cli/resource_limits.py
+++ b/hermes_cli/resource_limits.py
@@ -65,6 +65,18 @@ def _configured_nofile_soft_limit(
     return raw_value
 
 
+def configured_nofile_soft_limit(
+    config: Mapping[str, Any] | None = None,
+) -> int | None:
+    """Public accessor for the resolved ``runtime.nofile_soft_limit`` target.
+
+    Used by service-definition generators (e.g. the launchd plist) so the
+    persisted service limits and the in-process floor share one config knob.
+    Returns ``None`` when the adjustment is disabled or unresolvable.
+    """
+    return _configured_nofile_soft_limit(config)
+
+
 def apply_nofile_soft_limit(
     config: Mapping[str, Any] | None = None,
 ) -> bool:
@@ -116,4 +128,5 @@ def apply_nofile_soft_limit(
 __all__ = [
     "DEFAULT_NOFILE_SOFT_LIMIT",
     "apply_nofile_soft_limit",
+    "configured_nofile_soft_limit",
 ]

--- a/hermes_cli/resource_limits.py
+++ b/hermes_cli/resource_limits.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 from hermes_cli.config_defaults import DEFAULT_CONFIG
 
@@ -20,7 +20,14 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover - Windows only
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_NOFILE_SOFT_LIMIT = int(DEFAULT_CONFIG["runtime"]["nofile_soft_limit"])
+_runtime_defaults_raw = DEFAULT_CONFIG.get("runtime")
+assert isinstance(_runtime_defaults_raw, Mapping)
+_runtime_defaults = cast(Mapping[str, Any], _runtime_defaults_raw)
+_default_nofile_soft_limit = _runtime_defaults.get("nofile_soft_limit")
+assert isinstance(_default_nofile_soft_limit, int) and not isinstance(
+    _default_nofile_soft_limit, bool
+)
+DEFAULT_NOFILE_SOFT_LIMIT = _default_nofile_soft_limit
 _MISSING = object()
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2572,7 +2572,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # too-small _READ_POOL_MAX is diagnosable from a running process
         # instead of inferred from latency.
         self._read_permit_exhausted = 0
-        self._read_conns_lock = threading.Lock()
+        # A condition coordinates pool opens/checkouts with close().  Merely
+        # draining idle entries is insufficient: an opener or checked-out
+        # reader can otherwise outlive close() and publish/use a descriptor
+        # after shutdown has returned.
+        self._read_conns_lock = threading.Condition()
+        self._read_opening = 0
+        self._read_active: set[sqlite3.Connection] = set()
         # Set when close() begins.  _read_ctx checks this under the lock
         # before returning a connection to the pool, so a reader still in
         # flight during the drain closes its own connection instead of
@@ -2847,19 +2853,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 < _READ_OPEN_RETRY_SECONDS
             ):
                 return None
-        # Take the descriptor permit BEFORE the open, so concurrent openers
-        # race for permits rather than for file descriptors. Non-blocking:
-        # losing the race means "use the writer connection", not "wait".
-        if not self._read_permits.acquire(blocking=False):
-            with self._read_conns_lock:
+            # Take the descriptor permit and register the in-flight open while
+            # holding the lifecycle condition. close() then either wins before
+            # this point or waits until this opener finishes; there is no gap
+            # in which it can return and a new connection can appear later.
+            if not self._read_permits.acquire(blocking=False):
                 self._read_permit_exhausted += 1
-            logger.debug(
-                "read pool at capacity (%d) for %s; serving this read from the "
-                "locked writer connection",
-                _READ_POOL_MAX,
-                self.db_path,
-            )
-            return None
+                logger.debug(
+                    "read pool at capacity (%d) for %s; serving this read from the "
+                    "locked writer connection",
+                    _READ_POOL_MAX,
+                    self.db_path,
+                )
+                return None
+            self._read_opening += 1
         # Bound before the try: the except handlers close it if the open
         # half-succeeded, and an unbound name there would raise NameError over
         # the top of the real failure.
@@ -2899,6 +2906,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # writer connection still serves reads until the stamp expires.
             with self._read_conns_lock:
                 self._read_open_failed_at = time.monotonic()
+                self._read_opening -= 1
+                self._read_conns_lock.notify_all()
             logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
             if closed:
                 self._read_permits.release()
@@ -2912,7 +2921,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             closed = self._discard_partial_read_conn(conn)
             if closed:
                 self._read_permits.release()
+            with self._read_conns_lock:
+                self._read_opening -= 1
+                self._read_conns_lock.notify_all()
             raise
+        with self._read_conns_lock:
+            self._read_opening -= 1
+            if self._read_conns_closed:
+                discard = True
+            else:
+                self._read_active.add(conn)
+                discard = False
+            self._read_conns_lock.notify_all()
+        if discard:
+            self._close_read_conn(conn)
+            return None
         return conn
 
     def _discard_partial_read_conn(self, conn) -> bool:
@@ -2950,12 +2973,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         come from there over-releases the BoundedSemaphore, which raises
         ValueError rather than silently widening the ceiling.
         """
+        closed = False
         try:
             conn.close()
         except Exception as exc:
             logger.warning("read-conn close failed for %s: %s", self.db_path, exc)
         else:
-            self._read_permits.release()
+            closed = True
+        try:
+            if closed:
+                self._read_permits.release()
+        finally:
+            with self._read_conns_lock:
+                self._read_active.discard(conn)
+                self._read_conns_lock.notify_all()
 
     def _checkout_read_conn(self) -> Optional[sqlite3.Connection]:
         """Borrow a read connection from the pool, opening one on a miss.
@@ -2973,10 +3004,32 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         if not self._wal_active or self.read_only:
             return None
-        try:
-            return self._read_pool.get_nowait()
-        except queue.Empty:
-            return self._get_read_conn()
+        with self._read_conns_lock:
+            if self._read_conns_closed:
+                return None
+            try:
+                conn = self._read_pool.get_nowait()
+            except queue.Empty:
+                conn = None
+            if conn is not None:
+                self._read_active.add(conn)
+                return conn
+        return self._get_read_conn()
+
+    def _return_read_conn(self, conn: sqlite3.Connection) -> None:
+        """Return an active reader to the idle pool or close it after shutdown."""
+        returned = False
+        with self._read_conns_lock:
+            self._read_active.discard(conn)
+            if not self._read_conns_closed:
+                try:
+                    self._read_pool.put_nowait(conn)
+                    returned = True
+                except queue.Full:
+                    pass
+            self._read_conns_lock.notify_all()
+        if not returned:
+            self._close_read_conn(conn)
 
     @contextmanager
     def _read_ctx(self):
@@ -3001,25 +3054,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             try:
                 yield conn
             finally:
-                returned = False
-                with self._read_conns_lock:
-                    if not self._read_conns_closed:
-                        try:
-                            self._read_pool.put_nowait(conn)
-                            returned = True
-                        except queue.Full:
-                            pass
-                if not returned:
-                    # close() has already drained the pool, so this connection
-                    # is surplus. Close it here — dropping it on the floor is
-                    # what leaked the fd.
-                    #
-                    # queue.Full is now unreachable in practice (permits and
-                    # maxsize are both _READ_POOL_MAX, so there can never be a
-                    # ninth connection to return), but the branch stays: it is
-                    # load-bearing if those two ever drift apart, and a leak is
-                    # the failure mode it prevents.
-                    self._close_read_conn(conn)
+                self._return_read_conn(conn)
             return
         with self._lock:
             yield self._conn
@@ -3537,6 +3572,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # already been drained.
         with self._read_conns_lock:
             self._read_conns_closed = True
+            while self._read_opening or self._read_active:
+                self._read_conns_lock.wait()
         while True:
             try:
                 conn = self._read_pool.get_nowait()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2894,13 +2894,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # Dropping it on the floor still open leaves a live descriptor the
             # tracking registry still counts: the same leak shape this pool
             # exists to fix, one level further down.
-            self._discard_partial_read_conn(conn)
+            closed = self._discard_partial_read_conn(conn)
             # Back off from retrying the open on every query; the locked
             # writer connection still serves reads until the stamp expires.
             with self._read_conns_lock:
                 self._read_open_failed_at = time.monotonic()
             logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
-            self._read_permits.release()
+            if closed:
+                self._read_permits.release()
             return None
         except BaseException:
             # Anything else (a non-sqlite3 extension-load failure, MemoryError,
@@ -2908,25 +2909,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # strand the permit: a stranded permit is not a transient error, it
             # permanently shrinks the read path by one slot for the life of the
             # process.
-            self._discard_partial_read_conn(conn)
-            self._read_permits.release()
+            closed = self._discard_partial_read_conn(conn)
+            if closed:
+                self._read_permits.release()
             raise
         return conn
 
-    def _discard_partial_read_conn(self, conn) -> None:
+    def _discard_partial_read_conn(self, conn) -> bool:
         """Close a connection that failed between open and hand-off.
 
         Separate from _close_read_conn because that one releases a permit and
         this runs on paths that release their own.
         """
         if conn is None:
-            return
+            return True
         try:
             conn.close()
         except Exception as exc:
             logger.warning(
                 "partially-opened read conn close failed for %s: %s", self.db_path, exc
             )
+            return False
+        return True
 
     def _close_read_conn(self, conn) -> None:
         """Close a pooled read connection and release its descriptor permit.
@@ -2937,10 +2941,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         of the fd leak this pool fixes. A close that fails leaks a tracked
         fd, so it must not be invisible.
 
-        The permit is released even when close() raises: the descriptor is
-        already lost at that point, and withholding the permit too would turn
-        one leaked fd into a permanently narrower read path — failing twice for
-        one fault. The warning is the signal that matters.
+        A failed close keeps the permit consumed. The descriptor may still be
+        live, so releasing its permit would let a replacement connection open
+        and violate the hard descriptor ceiling. Degraded pool capacity is the
+        fail-closed outcome until process shutdown.
 
         Pairs with _get_read_conn(). Calling this on a connection that did not
         come from there over-releases the BoundedSemaphore, which raises
@@ -2950,7 +2954,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             conn.close()
         except Exception as exc:
             logger.warning("read-conn close failed for %s: %s", self.db_path, exc)
-        finally:
+        else:
             self._read_permits.release()
 
     def _checkout_read_conn(self) -> Optional[sqlite3.Connection]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import hashlib
 import json
 import logging
 import os
+import queue
 import random
 import re
 import sqlite3
@@ -331,6 +332,11 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+
+# How long SessionDB stops attempting read-only opens after one fails, before
+# probing again. Long enough that a genuinely unreadable file isn't retried per
+# query; short enough that transient fd pressure doesn't strand the read pool.
+_READ_OPEN_RETRY_SECONDS = 60.0
 
 # Import-time snapshot used by _default_db_path() to detect a deliberately
 # re-pointed DEFAULT_DB_PATH (tests monkeypatch the constant directly).
@@ -2516,20 +2522,43 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self.read_only = read_only
 
         self._lock = threading.Lock()
-        # Read-path split (WAL only): recall/browse queries run on per-thread
-        # read-only connections so they never queue behind writer flushes on
-        # self._lock. See _read_ctx().
-        self._read_local = threading.local()
-        # Strong set of all live read connections across all threads.  We
-        # hold a reference so short-lived reader threads' connections are
-        # not GC'd without close() — that would leak tracked fds in
-        # _live_connections.  close() drains this set.
-        self._read_conns: "set[sqlite3.Connection]" = set()
+        # Read-path split (WAL only): recall/browse queries borrow a
+        # read-only connection from a bounded pool so they never queue
+        # behind writer flushes on self._lock. See _read_ctx().
+        #
+        # The pool is BOUNDED because the previous per-thread
+        # (threading.local + strong set) scheme pinned one connection per
+        # (SessionDB x thread) for the life of the process. Starlette
+        # dispatches sync routes on anyio worker threads, so a SessionDB
+        # that is never closed accumulated a connection — and two fds, the
+        # database and its -wal — for every worker thread that ever read,
+        # until the process hit the 256 soft RLIMIT_NOFILE a service manager
+        # hands it and every request failed with EMFILE while the process
+        # stayed alive, so the supervisor's restart-on-exit never fired.
+        # Same bug class as the closing(...) fix in gateway/readiness.py
+        # (#69678 / #69567).
+        self._read_pool: "queue.LifoQueue[sqlite3.Connection]" = queue.LifoQueue(
+            maxsize=8
+        )
         self._read_conns_lock = threading.Lock()
-        # Set when close() begins.  _get_read_conn checks this under the
-        # lock so a reader that finishes opening after the drain finds the
-        # shutdown in progress and closes its own connection immediately.
+        # Set when close() begins.  _read_ctx checks this under the lock
+        # before returning a connection to the pool, so a reader still in
+        # flight during the drain closes its own connection instead of
+        # re-populating a pool nobody will drain again.
         self._read_conns_closed = False
+        # "read-only opens are failing against this file" backoff stamp.
+        # Instance-wide rather than per-thread: with a shared pool the open
+        # is no longer a per-thread event, and retrying a known-bad open on
+        # every query is a syscall storm for no benefit. The locked writer
+        # connection still serves reads while the backoff holds.
+        # Deliberately a TIMESTAMP, not a sticky bool: the likeliest trigger
+        # is transient fd pressure (EMFILE) — the very condition this pool
+        # exists to prevent — and a permanent flag would demote every reader
+        # on this instance to the writer lock for the life of the process.
+        # The gateway shares one SessionDB across every agent, so that turns
+        # a momentary blip into a permanent global convoy. Expires after
+        # _READ_OPEN_RETRY_SECONDS so the read path self-heals.
+        self._read_open_failed_at = 0.0
         self._wal_active = False
         self._write_count = 0
         # One-shot guard for the runtime FTS rebuild recovery on the write
@@ -2760,7 +2789,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # ── Read-path split ──
 
     def _get_read_conn(self) -> Optional[sqlite3.Connection]:
-        """Per-thread read-only connection, or None when unavailable.
+        """Open a fresh read-only connection, or None when unavailable.
+
+        Callers must return the connection to self._read_pool (see
+        _read_ctx); this opens, it does not track.
 
         Only used under WAL: WAL readers see a consistent snapshot and never
         block on (or get blocked by) the writer, so recall/browse queries can
@@ -2774,16 +2806,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         if not self._wal_active or self.read_only:
             return None
-        conn = getattr(self._read_local, "conn", None)
-        if conn is not None:
-            return conn
-        if getattr(self._read_local, "failed", False):
-            return None
+        with self._read_conns_lock:
+            if self._read_conns_closed:
+                return None
+            if (
+                self._read_open_failed_at
+                and time.monotonic() - self._read_open_failed_at
+                < _READ_OPEN_RETRY_SECONDS
+            ):
+                return None
         try:
             conn = _connect_tracked_db(
                 f"file:{self.db_path}?mode=ro",
                 tracking_path=self.db_path,
                 uri=True,
+                # Pooled connections are borrowed by whichever thread runs
+                # the next read, and sqlite3 otherwise refuses cross-thread
+                # use ("SQLite objects created in a thread can only be used
+                # in that same thread") — including on close(), which is how
+                # the old per-thread connections became unclosable and leaked
+                # their fds. Exclusive ownership is enforced by the pool
+                # checkout/return, not by sqlite3. Matches the writer opens.
+                check_same_thread=False,
                 timeout=5.0,
                 isolation_level=None,
             )
@@ -2795,36 +2839,75 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # registry, not the database file, so mode=ro is fine.
             if self._fts_cjk_loaded:
                 load_fts5_cjk_extension(conn)
-            with self._read_conns_lock:
-                if self._read_conns_closed:
-                    # close() already drained — don't register; close
-                    # immediately so no tracked fd leaks.
-                    conn.close()
-                    self._read_local.failed = True
-                    return None
-                self._read_conns.add(conn)
         except sqlite3.Error:
-            # Mark this thread failed so we don't retry the open on every
-            # query; the locked writer connection still serves reads.
-            self._read_local.failed = True
+            # Back off from retrying the open on every query; the locked
+            # writer connection still serves reads until the stamp expires.
+            with self._read_conns_lock:
+                self._read_open_failed_at = time.monotonic()
             logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
             return None
-        self._read_local.conn = conn
         return conn
+
+    def _close_read_conn(self, conn) -> None:
+        """Close a pooled read connection, reporting failures.
+
+        This was a bare ``except Exception: pass``, which silently swallowed
+        the sqlite3.ProgrammingError raised when close() ran on a thread
+        other than the one that opened the connection — the exact signature
+        of the fd leak this pool fixes. A close that fails leaks a tracked
+        fd, so it must not be invisible.
+        """
+        try:
+            conn.close()
+        except Exception as exc:
+            logger.warning("read-conn close failed for %s: %s", self.db_path, exc)
+
+    def _checkout_read_conn(self) -> Optional[sqlite3.Connection]:
+        """Borrow a read connection from the pool, opening one on a miss.
+
+        The single acquisition seam for the read path: the WAL/read_only gate,
+        the pool checkout and the open-on-miss all live here, so there is
+        exactly one place to exercise (and one place for a caller to bypass by
+        accident). Returns None when the read path is unavailable and the
+        caller must fall back to the locked writer connection.
+        """
+        if not self._wal_active or self.read_only:
+            return None
+        try:
+            return self._read_pool.get_nowait()
+        except queue.Empty:
+            return self._get_read_conn()
 
     @contextmanager
     def _read_ctx(self):
         """Yield a connection for read-only statements.
 
-        WAL: a per-thread read-only connection with NO lock — recall queries
-        never convoy behind writer flushes (the gateway shares one SessionDB
-        across every agent, so this lock was a global choke point).
+        WAL: a read-only connection borrowed from a bounded pool with NO
+        lock — recall queries never convoy behind writer flushes (the
+        gateway shares one SessionDB across every agent, so this lock was a
+        global choke point). The connection is checked out for the duration
+        of the block, so no two threads ever touch it concurrently.
         Non-WAL or read-conn failure: the shared writer connection under
         self._lock, byte-for-byte the legacy behavior.
         """
-        conn = self._get_read_conn()
+        conn = self._checkout_read_conn()
         if conn is not None:
-            yield conn
+            try:
+                yield conn
+            finally:
+                returned = False
+                with self._read_conns_lock:
+                    if not self._read_conns_closed:
+                        try:
+                            self._read_pool.put_nowait(conn)
+                            returned = True
+                        except queue.Full:
+                            pass
+                if not returned:
+                    # More concurrent readers than maxsize, or close() has
+                    # already drained: this connection is surplus. Close it
+                    # here — dropping it on the floor is what leaked the fd.
+                    self._close_read_conn(conn)
             return
         with self._lock:
             yield self._conn
@@ -3336,23 +3419,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # (instance, function), so this removes exactly our registration;
         # no-op when the writer never started.
         atexit.unregister(self._drain_token_queue_at_exit)
-        # Close all read-only connections across all threads.  Per-thread
-        # connections live in threading.local() and would otherwise be GC'd
-        # without calling close(), leaking tracked fds in _live_connections.
-        # The strong set holds references so short-lived reader threads'
-        # connections survive until close() drains them.  Setting the closed
-        # flag under the lock prevents a reader from registering a new
-        # connection after the drain.
+        # Drain the read-only connection pool.  Setting the closed flag
+        # under the lock first means a reader still in flight closes its own
+        # connection on release instead of re-populating a pool that has
+        # already been drained.
         with self._read_conns_lock:
             self._read_conns_closed = True
-            read_conns = list(self._read_conns)
-            self._read_conns.clear()
-        for conn in read_conns:
+        while True:
             try:
-                conn.close()
-            except Exception:
-                pass
-        self._read_local.conn = None
+                conn = self._read_pool.get_nowait()
+            except queue.Empty:
+                break
+            self._close_read_conn(conn)
         with self._lock:
             if self._conn:
                 if not self.read_only:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2926,15 +2926,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._read_conns_lock.notify_all()
             raise
         with self._read_conns_lock:
-            self._read_opening -= 1
             if self._read_conns_closed:
                 discard = True
             else:
+                self._read_opening -= 1
                 self._read_active.add(conn)
                 discard = False
-            self._read_conns_lock.notify_all()
+                self._read_conns_lock.notify_all()
         if discard:
-            self._close_read_conn(conn)
+            try:
+                self._close_read_conn(conn)
+            finally:
+                with self._read_conns_lock:
+                    self._read_opening -= 1
+                    self._read_conns_lock.notify_all()
             return None
         return conn
 
@@ -3020,14 +3025,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Return an active reader to the idle pool or close it after shutdown."""
         returned = False
         with self._read_conns_lock:
-            self._read_active.discard(conn)
             if not self._read_conns_closed:
                 try:
                     self._read_pool.put_nowait(conn)
+                    self._read_active.discard(conn)
                     returned = True
                 except queue.Full:
                     pass
-            self._read_conns_lock.notify_all()
+                self._read_conns_lock.notify_all()
         if not returned:
             self._close_read_conn(conn)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -338,6 +338,24 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 # query; short enough that transient fd pressure doesn't strand the read pool.
 _READ_OPEN_RETRY_SECONDS = 60.0
 
+# Hard ceiling on read-only connections ALIVE at once per SessionDB — pooled
+# idle ones and checked-out ones together.
+#
+# Deliberately one constant for both the pool's maxsize and the permit count,
+# because bounding only the pool bounds the wrong thing. A LifoQueue caps how
+# many connections are *returned*; it says nothing about how many are *open*.
+# With an open-on-miss checkout, N readers arriving on an empty pool all miss,
+# all open, and peak at N — the surplus is closed on release, so nothing
+# accumulates forever, but EMFILE is a peak-instant condition and the burst
+# that empties the pool is exactly the burst that exhausts the fd table.
+#
+# So a connection holds a permit for its whole lifetime: acquired in
+# _get_read_conn() before the open, released in _close_read_conn() after the
+# close. Once permits are gone the read path degrades to the locked writer
+# connection instead of opening more descriptors — slower under load, which is
+# the correct trade against a process-wide wedge the supervisor cannot see.
+_READ_POOL_MAX = 8
+
 # Import-time snapshot used by _default_db_path() to detect a deliberately
 # re-pointed DEFAULT_DB_PATH (tests monkeypatch the constant directly).
 _IMPORT_DEFAULT_DB_PATH = DEFAULT_DB_PATH
@@ -2538,8 +2556,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Same bug class as the closing(...) fix in gateway/readiness.py
         # (#69678 / #69567).
         self._read_pool: "queue.LifoQueue[sqlite3.Connection]" = queue.LifoQueue(
-            maxsize=8
+            maxsize=_READ_POOL_MAX
         )
+        # One permit per live read connection, held from before the open in
+        # _get_read_conn() until after the close in _close_read_conn().  This
+        # is what bounds PEAK descriptors; _read_pool alone bounds only the
+        # idle set.  See _READ_POOL_MAX.  Acquired non-blocking on purpose: a
+        # reader that cannot get a permit must degrade to the writer lock, not
+        # queue here — blocking would convert fd exhaustion into a stall, which
+        # is the same outage with a different stack trace.
+        self._read_permits = threading.BoundedSemaphore(_READ_POOL_MAX)
+        # Count of reads that found no permit and fell back to the locked
+        # writer connection. Not load-bearing; it is the only externally
+        # visible signal that the ceiling is actually being reached, so a
+        # too-small _READ_POOL_MAX is diagnosable from a running process
+        # instead of inferred from latency.
+        self._read_permit_exhausted = 0
         self._read_conns_lock = threading.Lock()
         # Set when close() begins.  _read_ctx checks this under the lock
         # before returning a connection to the pool, so a reader still in
@@ -2815,6 +2847,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 < _READ_OPEN_RETRY_SECONDS
             ):
                 return None
+        # Take the descriptor permit BEFORE the open, so concurrent openers
+        # race for permits rather than for file descriptors. Non-blocking:
+        # losing the race means "use the writer connection", not "wait".
+        if not self._read_permits.acquire(blocking=False):
+            with self._read_conns_lock:
+                self._read_permit_exhausted += 1
+            logger.debug(
+                "read pool at capacity (%d) for %s; serving this read from the "
+                "locked writer connection",
+                _READ_POOL_MAX,
+                self.db_path,
+            )
+            return None
+        # Bound before the try: the except handlers close it if the open
+        # half-succeeded, and an unbound name there would raise NameError over
+        # the top of the real failure.
+        conn = None
         try:
             conn = _connect_tracked_db(
                 f"file:{self.db_path}?mode=ro",
@@ -2840,27 +2889,69 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if self._fts_cjk_loaded:
                 load_fts5_cjk_extension(conn)
         except sqlite3.Error:
+            # A partially-constructed connection — _connect_tracked_db
+            # succeeded, the CJK extension load did not — must be closed here.
+            # Dropping it on the floor still open leaves a live descriptor the
+            # tracking registry still counts: the same leak shape this pool
+            # exists to fix, one level further down.
+            self._discard_partial_read_conn(conn)
             # Back off from retrying the open on every query; the locked
             # writer connection still serves reads until the stamp expires.
             with self._read_conns_lock:
                 self._read_open_failed_at = time.monotonic()
             logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
+            self._read_permits.release()
             return None
+        except BaseException:
+            # Anything else (a non-sqlite3 extension-load failure, MemoryError,
+            # KeyboardInterrupt landing between open and return) must not
+            # strand the permit: a stranded permit is not a transient error, it
+            # permanently shrinks the read path by one slot for the life of the
+            # process.
+            self._discard_partial_read_conn(conn)
+            self._read_permits.release()
+            raise
         return conn
 
+    def _discard_partial_read_conn(self, conn) -> None:
+        """Close a connection that failed between open and hand-off.
+
+        Separate from _close_read_conn because that one releases a permit and
+        this runs on paths that release their own.
+        """
+        if conn is None:
+            return
+        try:
+            conn.close()
+        except Exception as exc:
+            logger.warning(
+                "partially-opened read conn close failed for %s: %s", self.db_path, exc
+            )
+
     def _close_read_conn(self, conn) -> None:
-        """Close a pooled read connection, reporting failures.
+        """Close a pooled read connection and release its descriptor permit.
 
         This was a bare ``except Exception: pass``, which silently swallowed
         the sqlite3.ProgrammingError raised when close() ran on a thread
         other than the one that opened the connection — the exact signature
         of the fd leak this pool fixes. A close that fails leaks a tracked
         fd, so it must not be invisible.
+
+        The permit is released even when close() raises: the descriptor is
+        already lost at that point, and withholding the permit too would turn
+        one leaked fd into a permanently narrower read path — failing twice for
+        one fault. The warning is the signal that matters.
+
+        Pairs with _get_read_conn(). Calling this on a connection that did not
+        come from there over-releases the BoundedSemaphore, which raises
+        ValueError rather than silently widening the ceiling.
         """
         try:
             conn.close()
         except Exception as exc:
             logger.warning("read-conn close failed for %s: %s", self.db_path, exc)
+        finally:
+            self._read_permits.release()
 
     def _checkout_read_conn(self) -> Optional[sqlite3.Connection]:
         """Borrow a read connection from the pool, opening one on a miss.
@@ -2870,6 +2961,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         exactly one place to exercise (and one place for a caller to bypass by
         accident). Returns None when the read path is unavailable and the
         caller must fall back to the locked writer connection.
+
+        A pool hit costs no permit — the connection it hands back is already
+        holding one. Only the miss path can open, and only _get_read_conn() can
+        take a permit, so peak live connections is bounded by _READ_POOL_MAX no
+        matter how many threads miss simultaneously.
         """
         if not self._wal_active or self.read_only:
             return None
@@ -2887,8 +2983,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         gateway shares one SessionDB across every agent, so this lock was a
         global choke point). The connection is checked out for the duration
         of the block, so no two threads ever touch it concurrently.
-        Non-WAL or read-conn failure: the shared writer connection under
-        self._lock, byte-for-byte the legacy behavior.
+        Non-WAL, read-conn failure, or _READ_POOL_MAX already reached: the
+        shared writer connection under self._lock, byte-for-byte the legacy
+        behavior.
+
+        That last case is the deliberate degradation. Past the ceiling readers
+        convoy on the writer lock instead of opening descriptors — measurably
+        slower under a burst, and the alternative is EMFILE, which takes the
+        whole process down in a way a restart-on-exit supervisor cannot see.
         """
         conn = self._checkout_read_conn()
         if conn is not None:
@@ -2904,9 +3006,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         except queue.Full:
                             pass
                 if not returned:
-                    # More concurrent readers than maxsize, or close() has
-                    # already drained: this connection is surplus. Close it
-                    # here — dropping it on the floor is what leaked the fd.
+                    # close() has already drained the pool, so this connection
+                    # is surplus. Close it here — dropping it on the floor is
+                    # what leaked the fd.
+                    #
+                    # queue.Full is now unreachable in practice (permits and
+                    # maxsize are both _READ_POOL_MAX, so there can never be a
+                    # ninth connection to return), but the branch stays: it is
+                    # load-bearing if those two ever drift apart, and a leak is
+                    # the failure mode it prevents.
                     self._close_read_conn(conn)
             return
         with self._lock:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3099,7 +3099,37 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not channel:
                     return SendResult(success=False, error=f"Channel {chat_id} not found")
 
-            # Forum channels reject channel.send() — create a thread post instead.
+            # Configured task parents must never receive inert bot-authored
+            # messages.  A task parent may be either a ForumChannel or a
+            # normal TextChannel, so enforce this before the forum-only path.
+            effective_channel_id = str(thread_id or chat_id)
+            is_task_parent = (
+                effective_channel_id in self._get_agent_task_forum_channels()
+            )
+            if is_task_parent:
+                start_agent_task = bool(metadata and metadata.get("start_agent_task"))
+                if thread_id is not None or not start_agent_task:
+                    return SendResult(
+                        success=False,
+                        error=(
+                            "Direct bot delivery to this Discord task channel is blocked. "
+                            "Start a live agent task thread instead."
+                        ),
+                    )
+                if self._is_forum_parent(channel):
+                    result = await self._start_agent_task_in_forum(channel, content)
+                else:
+                    result = await self._start_agent_task_in_text_channel(channel, content)
+                await asyncio.to_thread(
+                    self._record_discord_response,
+                    reply_to=reply_to,
+                    result=result,
+                    content=content,
+                    final=final_delivery,
+                )
+                return result
+
+            # Non-task forum channels use ordinary forum-post delivery.
             if self._is_forum_parent(channel):
                 result = await self._send_to_forum(channel, content)
                 await asyncio.to_thread(
@@ -3190,7 +3220,196 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return result
 
-    async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
+    async def _start_agent_task_in_forum(
+        self,
+        forum_channel: Any,
+        task_text: str,
+    ) -> SendResult:
+        """Create a clearly bot-authored forum post and dispatch a live session."""
+        visible_text = f"🤖 **Hermes started this task**\n\n{task_text}"
+        result = await self._send_to_forum(
+            forum_channel,
+            visible_text,
+            thread_name=_derive_forum_thread_name(task_text),
+        )
+        return await self._dispatch_agent_task_thread(
+            forum_channel,
+            task_text,
+            result,
+        )
+
+    async def _start_agent_task_in_text_channel(
+        self,
+        parent_channel: Any,
+        task_text: str,
+    ) -> SendResult:
+        """Create a standalone public thread without posting in its parent."""
+        thread_name = _derive_forum_thread_name(task_text)
+        thread_channel = None
+        try:
+            thread_channel = await parent_channel.create_thread(
+                name=thread_name,
+                type=discord.ChannelType.public_thread,
+                auto_archive_duration=1440,
+                reason="Hermes live agent task",
+            )
+            starter = await thread_channel.send(
+                content=f"🤖 **Hermes started this task**\n\n{task_text}"
+            )
+        except Exception as exc:
+            logger.error(
+                "[%s] Failed to create live task thread under %s: %s",
+                self.name,
+                getattr(parent_channel, "id", "?"),
+                exc,
+                exc_info=True,
+            )
+            delete_thread = getattr(thread_channel, "delete", None)
+            if callable(delete_thread):
+                try:
+                    await delete_thread(
+                        reason="Hermes task starter failed; removing empty thread"
+                    )
+                except Exception as cleanup_exc:
+                    logger.error(
+                        "[%s] Failed to remove empty task thread %s: %s",
+                        self.name,
+                        getattr(thread_channel, "id", "?"),
+                        cleanup_exc,
+                        exc_info=True,
+                    )
+            return SendResult(
+                success=False,
+                error=f"Live task thread creation failed: {exc}",
+            )
+
+        result = SendResult(
+            success=True,
+            message_id=str(getattr(starter, "id", "") or "") or None,
+            raw_response={
+                "message_ids": [str(getattr(starter, "id", "") or "")],
+                "thread_id": str(getattr(thread_channel, "id", "") or ""),
+            },
+        )
+        return await self._dispatch_agent_task_thread(
+            parent_channel,
+            task_text,
+            result,
+            thread_channel=thread_channel,
+        )
+
+    async def _dispatch_agent_task_thread(
+        self,
+        parent_channel: Any,
+        task_text: str,
+        result: SendResult,
+        *,
+        thread_channel: Any = None,
+    ) -> SendResult:
+        """Bind a newly-created Discord task thread to a live Hermes session."""
+        if not result.success:
+            return result
+
+        raw = result.raw_response if isinstance(result.raw_response, dict) else {}
+        thread_id = str(raw.get("thread_id") or "")
+        if not thread_id:
+            return SendResult(
+                success=False,
+                message_id=result.message_id,
+                error="Task thread was created without a thread id; live session not started.",
+                raw_response=raw,
+            )
+
+        if thread_channel is None:
+            thread_channel = self._client.get_channel(int(thread_id)) if self._client else None
+            if thread_channel is None and self._client:
+                try:
+                    thread_channel = await self._client.fetch_channel(int(thread_id))
+                except Exception:
+                    thread_channel = None
+
+        self._threads.mark(thread_id)
+        guild = (
+            getattr(thread_channel, "guild", None)
+            or getattr(parent_channel, "guild", None)
+        )
+        chat_name = (
+            self._format_thread_chat_name(thread_channel)
+            if thread_channel is not None
+            else f"{getattr(parent_channel, 'name', 'tasks')} / {_derive_forum_thread_name(task_text)}"
+        )
+        source = self.build_source(
+            chat_id=thread_id,
+            chat_name=chat_name,
+            chat_type="thread",
+            user_id="system:hermes-task",
+            user_name="Hermes task launcher",
+            thread_id=thread_id,
+            chat_topic=self._get_effective_topic(
+                thread_channel or parent_channel,
+                is_thread=thread_channel is not None,
+            ),
+            is_bot=True,
+            guild_id=str(getattr(guild, "id", "") or "") or None,
+            parent_chat_id=str(getattr(parent_channel, "id", "") or "") or None,
+            message_id=result.message_id,
+            role_authorized=True,
+        )
+        parent_id = str(getattr(parent_channel, "id", "") or "")
+        event = MessageEvent(
+            text=(
+                "[Hermes-started task; not authored by the user]\n\n"
+                f"{task_text}"
+            ),
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=None,
+            auto_skill=self._resolve_channel_skills(thread_id, parent_id or None),
+            channel_prompt=self._resolve_channel_prompt(thread_id, parent_id or None),
+        )
+        try:
+            await self.handle_message(event)
+        except Exception as exc:
+            logger.error(
+                "[%s] Created task thread %s but failed to dispatch its session: %s",
+                self.name,
+                thread_id,
+                exc,
+                exc_info=True,
+            )
+            cleanup_error = None
+            delete_thread = getattr(thread_channel, "delete", None)
+            if callable(delete_thread):
+                try:
+                    await delete_thread(
+                        reason="Hermes live task dispatch failed; removing inert task thread"
+                    )
+                except Exception as cleanup_exc:
+                    cleanup_error = str(cleanup_exc)
+                    logger.error(
+                        "[%s] Failed to remove inert task thread %s: %s",
+                        self.name,
+                        thread_id,
+                        cleanup_exc,
+                        exc_info=True,
+                    )
+            if cleanup_error:
+                raw = {**raw, "cleanup_error": cleanup_error}
+            return SendResult(
+                success=False,
+                message_id=result.message_id,
+                error=f"Task thread created but live session dispatch failed: {exc}",
+                raw_response=raw,
+            )
+        return result
+
+    async def _send_to_forum(
+        self,
+        forum_channel: Any,
+        content: str,
+        *,
+        thread_name: Optional[str] = None,
+    ) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
 
         Forum channels (type 15) don't support direct messages.  Instead we
@@ -3205,7 +3424,7 @@ class DiscordAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-        thread_name = _derive_forum_thread_name(content)
+        thread_name = thread_name or _derive_forum_thread_name(content)
 
         starter_content = chunks[0] if chunks else thread_name
 
@@ -3352,6 +3571,11 @@ class DiscordAdapter(BasePlatformAdapter):
         re-split, looping forever (the Telegram #48648 lesson).  The complete
         text is delivered when ``finalize=True`` via ``_edit_overflow_split``.
         """
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Editing messages in this Discord task channel is blocked.",
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
         try:
@@ -3573,6 +3797,11 @@ class DiscordAdapter(BasePlatformAdapter):
         message with zero attachments — a silent drop for video/document
         MEDIA tags (#66797).
         """
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Direct media delivery to this Discord task channel is blocked.",
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -3646,6 +3875,13 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return
         if not images:
+            return
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            logger.warning(
+                "[%s] Blocked direct multi-image delivery to task channel %s",
+                self.name,
+                chat_id,
+            )
             return
 
         try:
@@ -3785,6 +4021,11 @@ class DiscordAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send audio as a Discord file attachment."""
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Direct media delivery to this Discord task channel is blocked.",
+            )
         try:
             import io
 
@@ -4999,6 +5240,11 @@ class DiscordAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively as a Discord file attachment."""
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Direct media delivery to this Discord task channel is blocked.",
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -5081,6 +5327,11 @@ class DiscordAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an animated GIF natively as a Discord file attachment."""
+        if str(chat_id) in self._get_agent_task_forum_channels():
+            return SendResult(
+                success=False,
+                error="Direct media delivery to this Discord task channel is blocked.",
+            )
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -5192,6 +5443,13 @@ class DiscordAdapter(BasePlatformAdapter):
         default), and continues — it does NOT die on a single rate-limit
         hit.  Only CancelledError (from stop_typing) stops the loop.
         """
+        chat_id = str(
+            (metadata or {}).get("thread_id")
+            or (metadata or {}).get("message_thread_id")
+            or chat_id
+        )
+        if chat_id in self._get_agent_task_forum_channels():
+            return
         if not self._client:
             return
         # Don't start a duplicate loop
@@ -6264,6 +6522,12 @@ class DiscordAdapter(BasePlatformAdapter):
         """This adapter's DISCORD_NO_THREAD_CHANNELS list (per-profile)."""
         return self._gate_csv_set(self._gate_raw("no_thread_channels", "DISCORD_NO_THREAD_CHANNELS"))
 
+    def _get_agent_task_forum_channels(self) -> set:
+        """Forums where bot-authored posts must launch a real agent session."""
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        raw = extra.get("agent_task_forum_channels") if isinstance(extra, dict) else None
+        return self._gate_csv_set(raw)
+
     def _get_allowed_users(self) -> set:
         """This adapter's DISCORD_ALLOWED_USERS entries (per-profile, cleaned)."""
         raw = self._gate_raw("allow_from", "DISCORD_ALLOWED_USERS")
@@ -6772,6 +7036,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 "thread_name": getattr(thread, "name", None) or name,
             }
         except Exception as direct_error:
+            if str(getattr(parent_channel, "id", "")) in self._get_agent_task_forum_channels():
+                return {
+                    "success": False,
+                    "error": (
+                        "Thread creation failed and the protected task channel "
+                        "does not allow a seed-message fallback."
+                    ),
+                }
             try:
                 seed_content = starter_message or f"\U0001f9f5 Thread created by Hermes: **{name}**"
                 seed_msg = await parent_channel.send(seed_content)
@@ -6843,6 +7115,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 return thread
             except Exception as direct_error:
                 last_direct_error = direct_error
+                if str(getattr(message.channel, "id", "")) in self._get_agent_task_forum_channels():
+                    logger.warning(
+                        "[%s] Auto-thread: refusing seed-message fallback in protected task channel %s",
+                        self.name,
+                        getattr(message.channel, "id", "?"),
+                    )
+                    break
                 try:
                     seed_msg = await message.channel.send(
                         f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
@@ -6994,6 +7273,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name, direct_error,
             )
 
+        # A seed-message fallback would itself be a bot post in the protected
+        # task parent. Fail closed; callers can surface the thread-creation
+        # failure without violating the parent-channel contract.
+        if str(parent_chat_id) in self._get_agent_task_forum_channels():
+            logger.warning(
+                "[%s] Handoff thread: refusing seed-message fallback in task channel %s",
+                self.name,
+                parent_chat_id,
+            )
+            return None
+
         # Fallback: post a seed message and create the thread from it.
         try:
             send = getattr(parent, "send", None)
@@ -7072,6 +7362,9 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -7165,6 +7458,9 @@ class DiscordAdapter(BasePlatformAdapter):
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
 
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
+
             channel = self._client.get_channel(int(target_id))
             if not channel:
                 channel = await self._client.fetch_channel(int(target_id))
@@ -7231,6 +7527,9 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -7337,6 +7636,8 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
             channel = self._client.get_channel(int(target_id))
             if not channel:
                 channel = await self._client.fetch_channel(int(target_id))
@@ -7388,6 +7689,9 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -7449,6 +7753,9 @@ class DiscordAdapter(BasePlatformAdapter):
             target_id = chat_id
             if metadata and metadata.get("thread_id"):
                 target_id = metadata["thread_id"]
+
+            if str(target_id) in self._get_agent_task_forum_channels():
+                return SendResult(success=False, error="Direct task-channel prompts are blocked.")
 
             channel = self._client.get_channel(int(target_id))
             if not channel:
@@ -9568,6 +9875,21 @@ async def _standalone_send(
     ``force_document`` is accepted for signature parity but unused — Discord
     treats every uploaded file as a generic attachment.
     """
+    extra = getattr(pconfig, "extra", None)
+    protected_raw = (
+        extra.get("agent_task_forum_channels")
+        if isinstance(extra, dict)
+        else None
+    )
+    protected_ids = DiscordAdapter._gate_csv_set(protected_raw)
+    if str(thread_id or chat_id) in protected_ids:
+        return {
+            "error": (
+                "Direct standalone delivery to this Discord task channel is blocked. "
+                "Use the running gateway to start a live agent task thread."
+            )
+        }
+
     try:
         import aiohttp
     except ImportError:

--- a/tests/agent/test_thread_scoped_output.py
+++ b/tests/agent/test_thread_scoped_output.py
@@ -131,3 +131,40 @@ def test_temporary_global_redirects_do_not_allocate_new_sinks(monkeypatch):
         assert thread_output._installed == original_proxies
     finally:
         sys.stdout, sys.stderr = original_stdout, original_stderr
+
+
+def test_silence_survives_redirect_restoring_an_older_proxy(monkeypatch):
+    """Silencing is stream-wide, even when a redirect swaps proxy generations."""
+    monkeypatch.setattr(thread_output, "_installed", {})
+    monkeypatch.setattr(thread_output, "_sinks", {})
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    passthrough = io.StringIO()
+    sys.stdout = passthrough
+    entered = threading.Event()
+    release = threading.Event()
+
+    try:
+        with thread_scoped_silence():
+            pass
+
+        def worker():
+            with thread_scoped_silence():
+                entered.set()
+                assert release.wait(timeout=10)
+                print("must-stay-silenced")
+
+        redirected = io.StringIO()
+        with contextlib.redirect_stdout(redirected):
+            thread = threading.Thread(target=worker)
+            thread.start()
+            assert entered.wait(timeout=10)
+
+        release.set()
+        thread.join(timeout=10)
+
+        assert not thread.is_alive()
+        assert "must-stay-silenced" not in passthrough.getvalue()
+        assert "must-stay-silenced" not in redirected.getvalue()
+    finally:
+        release.set()
+        sys.stdout, sys.stderr = original_stdout, original_stderr

--- a/tests/agent/test_thread_scoped_output.py
+++ b/tests/agent/test_thread_scoped_output.py
@@ -7,11 +7,13 @@ context.  This is the property the old process-global
 ``contextlib.redirect_stdout(devnull)`` violated (issue #55769 / #55925).
 """
 
+import contextlib
 import io
 import sys
 import threading
 import time
 
+import agent.thread_scoped_output as thread_output
 from agent.thread_scoped_output import thread_scoped_silence
 
 
@@ -94,3 +96,31 @@ def test_repeated_contexts_never_write_to_a_closed_sink():
             sys.stdout.fileno()
     finally:
         sys.stdout = original
+
+
+def test_temporary_global_redirects_do_not_allocate_new_sinks(monkeypatch):
+    """A displaced proxy is temporary, not a reason to leak another FD pair."""
+    opened_sinks = []
+
+    def fake_open(*_args, **_kwargs):
+        sink = io.StringIO()
+        opened_sinks.append(sink)
+        return sink
+
+    monkeypatch.setattr(thread_output, "_installed", {})
+    monkeypatch.setattr(thread_output, "open", fake_open, raising=False)
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = io.StringIO(), io.StringIO()
+    try:
+        with thread_scoped_silence():
+            pass
+        assert len(opened_sinks) == 2
+
+        for _ in range(20):
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                with thread_scoped_silence():
+                    print("hidden")
+
+        assert len(opened_sinks) == 2
+    finally:
+        sys.stdout, sys.stderr = original_stdout, original_stderr

--- a/tests/agent/test_thread_scoped_output.py
+++ b/tests/agent/test_thread_scoped_output.py
@@ -108,6 +108,7 @@ def test_temporary_global_redirects_do_not_allocate_new_sinks(monkeypatch):
         return sink
 
     monkeypatch.setattr(thread_output, "_installed", {})
+    monkeypatch.setattr(thread_output, "_sinks", {})
     monkeypatch.setattr(thread_output, "open", fake_open, raising=False)
     original_stdout, original_stderr = sys.stdout, sys.stderr
     sys.stdout, sys.stderr = io.StringIO(), io.StringIO()
@@ -115,12 +116,18 @@ def test_temporary_global_redirects_do_not_allocate_new_sinks(monkeypatch):
         with thread_scoped_silence():
             pass
         assert len(opened_sinks) == 2
+        original_proxies = dict(thread_output._installed)
 
         for _ in range(20):
             with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                 with thread_scoped_silence():
                     print("hidden")
 
+        # The redirect restores the original proxies. One final entry adopts
+        # them rather than wrapping them in another proxy generation.
+        with thread_scoped_silence():
+            pass
         assert len(opened_sinks) == 2
+        assert thread_output._installed == original_proxies
     finally:
         sys.stdout, sys.stderr = original_stdout, original_stderr

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -144,6 +144,58 @@ class RecordingAdapter:
 
 
 @pytest.mark.asyncio
+async def test_discord_task_parent_guard_uses_metadata_target_precedence(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                extra={"agent_task_forum_channels": ["protected-parent"]},
+            ),
+        },
+    )
+    router = DeliveryRouter(config, adapters={Platform.DISCORD: adapter})
+    target = DeliveryTarget(
+        platform=Platform.DISCORD,
+        chat_id="ordinary-chat",
+        thread_id="benign-target-thread",
+    )
+
+    with pytest.raises(ValueError, match="task channel"):
+        await router._deliver_to_platform(
+            target,
+            "blocked",
+            metadata={"thread_id": "protected-parent"},
+        )
+
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_discord_task_parent_guard_rejects_conflicting_metadata(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True)},
+    )
+    router = DeliveryRouter(config, adapters={Platform.DISCORD: adapter})
+
+    with pytest.raises(ValueError, match="Conflicting Discord delivery"):
+        await router._deliver_to_platform(
+            DeliveryTarget(platform=Platform.DISCORD, chat_id="ordinary-chat"),
+            "blocked",
+            metadata={"thread_id": "one", "message_thread_id": "two"},
+        )
+
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
 async def test_native_adapter_wins_when_relay_also_fronts_platform(tmp_path, monkeypatch):
     monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
     native = RecordingAdapter()
@@ -327,5 +379,3 @@ async def test_long_output_truncated_for_non_chunking_adapter(tmp_path, monkeypa
     saved_files = list(tmp_path.glob("cron/output/job1_*.txt"))
     assert len(saved_files) == 1
     assert saved_files[0].read_text() == long_content
-
-

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -21,6 +21,7 @@ def _ensure_discord_mock():
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ChannelType = SimpleNamespace(public_thread="public_thread")
     discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
     discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
     discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
@@ -44,7 +45,7 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter, _standalone_send  # noqa: E402
 
 
 @pytest.mark.asyncio
@@ -172,6 +173,241 @@ class TestIsForumParent:
             _discord_mod.ForumChannel = forum_cls
         ch = forum_cls()
         assert adapter._is_forum_parent(ch) is True
+
+
+@pytest.mark.asyncio
+async def test_task_forum_rejects_static_bot_delivery():
+    """Configured task forums must never receive inert bot-authored posts."""
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.create_thread = AsyncMock()
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("999", "do the task")
+
+    assert result.success is False
+    assert "task channel" in (result.error or "").lower()
+    forum_channel.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_text_channel_rejects_static_bot_delivery():
+    """Configured task parents are protected even when they are text channels."""
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    text_channel = SimpleNamespace(
+        id=999,
+        send=AsyncMock(),
+        create_thread=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: text_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("999", "do the task")
+
+    assert result.success is False
+    assert "task channel" in (result.error or "").lower()
+    text_channel.send.assert_not_awaited()
+    text_channel.create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_parent_cannot_be_smuggled_as_thread_id():
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    task_parent = SimpleNamespace(id=999, send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: task_parent,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send(
+        "123",
+        "smuggled delivery",
+        metadata={"thread_id": "999"},
+    )
+
+    assert result.success is False
+    task_parent.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_parent_rejects_direct_media_and_standalone_delivery(tmp_path):
+    pconfig = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    )
+    adapter = DiscordAdapter(pconfig)
+    media_result = await adapter._send_file_attachment(
+        "999",
+        str(tmp_path / "unused.png"),
+    )
+    standalone_result = await _standalone_send(pconfig, "999", "blocked")
+
+    assert media_result.success is False
+    assert "task channel" in (media_result.error or "").lower()
+    assert "error" in standalone_result
+    assert "task channel" in standalone_result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_task_forum_explicit_agent_task_starts_live_thread():
+    """An explicit agent task creates a labeled post and dispatches a session."""
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    starter = SimpleNamespace(id=800)
+    thread_channel = SimpleNamespace(
+        id=777,
+        name="do the task",
+        parent=None,
+        guild=SimpleNamespace(id=55, name="My House"),
+        send=AsyncMock(),
+    )
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.name = "tasks"
+    forum_channel.topic = "Give the agent work."
+    forum_channel.guild = SimpleNamespace(id=55, name="My House")
+    thread_channel.parent = forum_channel
+    forum_channel.create_thread = AsyncMock(return_value=SimpleNamespace(
+        id=777,
+        thread=thread_channel,
+        message=starter,
+    ))
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+    adapter.handle_message = AsyncMock()
+
+    result = await adapter.send(
+        "999",
+        "do the task",
+        metadata={"start_agent_task": True},
+    )
+
+    assert result.success is True
+    call = forum_channel.create_thread.await_args
+    assert call.kwargs["content"].startswith("🤖 **Hermes started this task**")
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "777"
+    assert event.source.thread_id == "777"
+    assert event.source.parent_chat_id == "999"
+    assert event.source.user_id == "system:hermes-task"
+    assert event.source.is_bot is True
+    assert event.source.role_authorized is True
+    assert event.text.startswith("[Hermes-started task; not authored by the user]")
+
+
+@pytest.mark.asyncio
+async def test_task_text_channel_explicit_agent_task_starts_live_thread():
+    """A text task parent creates a standalone live thread without a parent post."""
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    starter = SimpleNamespace(id=800)
+    parent = SimpleNamespace(
+        id=999,
+        name="tasks",
+        topic="Give the agent work.",
+        guild=SimpleNamespace(id=55, name="My House"),
+        send=AsyncMock(),
+    )
+    thread_channel = SimpleNamespace(
+        id=777,
+        name="do the task",
+        parent=parent,
+        guild=parent.guild,
+        send=AsyncMock(return_value=starter),
+    )
+    parent.create_thread = AsyncMock(return_value=thread_channel)
+    adapter._client = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        get_channel=lambda channel_id: parent if channel_id == 999 else thread_channel,
+        fetch_channel=AsyncMock(),
+    )
+    adapter.handle_message = AsyncMock()
+
+    result = await adapter.send(
+        "999",
+        "do the task",
+        metadata={"start_agent_task": True},
+    )
+
+    assert result.success is True
+    parent.send.assert_not_awaited()
+    parent.create_thread.assert_awaited_once()
+    assert (
+        parent.create_thread.await_args.kwargs["type"]
+        == sys.modules["discord"].ChannelType.public_thread
+    )
+    assert thread_channel.send.await_args.kwargs["content"].startswith(
+        "🤖 **Hermes started this task**"
+    )
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "777"
+    assert event.source.parent_chat_id == "999"
+    assert event.source.user_id == "system:hermes-task"
+    assert event.source.role_authorized is True
+
+
+@pytest.mark.asyncio
+async def test_task_text_channel_starter_failure_removes_empty_thread():
+    adapter = DiscordAdapter(PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["999"]},
+    ))
+    parent = SimpleNamespace(
+        id=999,
+        name="tasks",
+        guild=SimpleNamespace(id=55, name="My House"),
+    )
+    thread_channel = SimpleNamespace(
+        id=777,
+        send=AsyncMock(side_effect=RuntimeError("starter failed")),
+        delete=AsyncMock(),
+    )
+    parent.create_thread = AsyncMock(return_value=thread_channel)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _channel_id: parent,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send(
+        "999",
+        "do the task",
+        metadata={"start_agent_task": True},
+    )
+
+    assert result.success is False
+    assert "starter failed" in (result.error or "")
+    thread_channel.delete.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -416,5 +652,3 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-
-

--- a/tests/gateway/test_restart_after_turn.py
+++ b/tests/gateway/test_restart_after_turn.py
@@ -1,9 +1,12 @@
 """Unit tests for in-band restart after-turn deferral helpers (#77184)."""
 
+import signal
+
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT,
     parse_restart_after_turn_timeout,
     resolve_restart_exit_wait_budget,
+    should_defer_supervised_sigterm_restart,
 )
 from gateway.run import GatewayRunner
 
@@ -21,6 +24,25 @@ def test_resolve_restart_exit_wait_budget_covers_both_phases():
     assert resolve_restart_exit_wait_budget(0, 0, headroom=15) == 15.0
     assert resolve_restart_exit_wait_budget(180, 21600, headroom=15) == 180 + 21600 + 15
     assert resolve_restart_exit_wait_budget("bad", "bad", headroom="x") == 0.0
+
+
+def test_supervised_unmarked_sigterm_uses_restart_path():
+    """A launchd restart must not truncate a live turn at the drain cap."""
+    assert should_defer_supervised_sigterm_restart(
+        signal.SIGTERM, planned_stop=False, planned_takeover=False, supervised=True
+    ) is True
+    assert should_defer_supervised_sigterm_restart(
+        signal.SIGTERM, planned_stop=True, planned_takeover=False, supervised=True
+    ) is False
+    assert should_defer_supervised_sigterm_restart(
+        signal.SIGTERM, planned_stop=False, planned_takeover=True, supervised=True
+    ) is False
+    assert should_defer_supervised_sigterm_restart(
+        signal.SIGTERM, planned_stop=False, planned_takeover=False, supervised=False
+    ) is False
+    assert should_defer_supervised_sigterm_restart(
+        signal.SIGINT, planned_stop=False, planned_takeover=False, supervised=True
+    ) is False
 
 
 def test_load_restart_after_turn_timeout_preserves_zero(tmp_path, monkeypatch):

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import shutil
 import subprocess
 from datetime import datetime
@@ -12,6 +13,20 @@ from gateway.platforms.base import MessageEvent, MessageType
 from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
 from gateway.session import SessionEntry, build_session_key
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+@pytest.mark.parametrize("raw_timeout", ["inf", "nan", "1e309"])
+def test_load_restart_drain_timeout_warns_for_nonfinite_values(
+    monkeypatch, caplog, raw_timeout
+):
+    monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", raw_timeout)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        value = gateway_run.GatewayRunner._load_restart_drain_timeout()
+
+    assert value == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    assert "Invalid restart_drain_timeout" in caplog.text
+    assert raw_timeout in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -295,6 +295,15 @@ class TestGeneratedSystemdUnits:
         )
         assert gateway_cli._launchd_nofile_soft_limit() == 4096
 
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *_a, **_k: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="maxfiles 256 1024\n", stderr=""
+            ),
+        )
+        assert gateway_cli._launchd_nofile_soft_limit() == 1024
+
     def test_launchd_limit_omits_absolute_override_when_domain_is_unknown(self, monkeypatch):
         """Failing to inspect inheritance must not risk lowering a higher limit."""
         import hermes_cli.resource_limits as resource_limits

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -233,8 +233,15 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
-    def test_launchd_plist_has_gateway_file_descriptor_headroom(self):
+    def test_launchd_plist_has_gateway_file_descriptor_headroom(self, monkeypatch):
         """launchd's 256-file default is below a normal busy gateway footprint."""
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *_a, **_k: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="maxfiles 256 unlimited\n", stderr=""
+            ),
+        )
         plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode())
 
         assert plist["SoftResourceLimits"]["NumberOfFiles"] >= 4096
@@ -248,12 +255,60 @@ class TestGeneratedSystemdUnits:
         monkeypatch.setattr(
             resource_limits, "configured_nofile_soft_limit", lambda config=None: 65536
         )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *_a, **_k: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="maxfiles 256 unlimited\n", stderr=""
+            ),
+        )
 
         plist = gateway_cli.generate_launchd_plist()
 
         assert "<key>SoftResourceLimits</key>" in plist
         assert "<key>NumberOfFiles</key>" in plist
         assert "<integer>65536</integer>" in plist
+
+    def test_launchd_limit_never_lowers_domain_or_safe_floor(self, monkeypatch):
+        """launchd accepts an absolute limit, so resolve a non-lowering value."""
+        import hermes_cli.resource_limits as resource_limits
+
+        monkeypatch.setattr(
+            resource_limits, "configured_nofile_soft_limit", lambda config=None: 64
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *_a, **_k: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="maxfiles 8192 unlimited\n", stderr=""
+            ),
+        )
+
+        assert gateway_cli._launchd_nofile_soft_limit() == 8192
+
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *_a, **_k: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="maxfiles 256 unlimited\n", stderr=""
+            ),
+        )
+        assert gateway_cli._launchd_nofile_soft_limit() == 4096
+
+    def test_launchd_limit_omits_absolute_override_when_domain_is_unknown(self, monkeypatch):
+        """Failing to inspect inheritance must not risk lowering a higher limit."""
+        import hermes_cli.resource_limits as resource_limits
+
+        monkeypatch.setattr(
+            resource_limits, "configured_nofile_soft_limit", lambda config=None: 4096
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *_a, **_k: (_ for _ in ()).throw(OSError("launchctl unavailable")),
+        )
+
+        assert gateway_cli._launchd_nofile_soft_limit() is None
 
     def test_launchd_plist_omits_nofile_block_when_disabled(self, monkeypatch):
         """runtime.nofile_soft_limit: 0/false/null disables the adjustment; the

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -237,11 +237,36 @@ class TestGeneratedSystemdUnits:
         """launchd's 256-file default is below a normal busy gateway footprint."""
         plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode())
 
-        assert plist["SoftResourceLimits"]["NumberOfFiles"] >= 8192
-        assert (
-            plist["HardResourceLimits"]["NumberOfFiles"]
-            >= plist["SoftResourceLimits"]["NumberOfFiles"]
+        assert plist["SoftResourceLimits"]["NumberOfFiles"] >= 4096
+
+    def test_launchd_plist_persists_configured_nofile_soft_limit(self, monkeypatch):
+        """The generated plist must carry SoftResourceLimits/NumberOfFiles so a
+        plist rewrite by `hermes gateway start` cannot strip the FD floor and
+        reintroduce EMFILE crashes (launchd default soft limit is 256)."""
+        import hermes_cli.resource_limits as resource_limits
+
+        monkeypatch.setattr(
+            resource_limits, "configured_nofile_soft_limit", lambda config=None: 65536
         )
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>SoftResourceLimits</key>" in plist
+        assert "<key>NumberOfFiles</key>" in plist
+        assert "<integer>65536</integer>" in plist
+
+    def test_launchd_plist_omits_nofile_block_when_disabled(self, monkeypatch):
+        """runtime.nofile_soft_limit: 0/false/null disables the adjustment; the
+        plist must then not contain a SoftResourceLimits block at all."""
+        import hermes_cli.resource_limits as resource_limits
+
+        monkeypatch.setattr(
+            resource_limits, "configured_nofile_soft_limit", lambda config=None: None
+        )
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "SoftResourceLimits" not in plist
 
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -231,6 +232,16 @@ class TestGeneratedSystemdUnits:
 
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
+
+    def test_launchd_plist_has_gateway_file_descriptor_headroom(self):
+        """launchd's 256-file default is below a normal busy gateway footprint."""
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode())
+
+        assert plist["SoftResourceLimits"]["NumberOfFiles"] >= 8192
+        assert (
+            plist["HardResourceLimits"]["NumberOfFiles"]
+            >= plist["SoftResourceLimits"]["NumberOfFiles"]
+        )
 
 
 
@@ -1995,4 +2006,3 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is False
         assert list_calls["n"] >= 1
-

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,5 +1,6 @@
 """Tests for gateway service management helpers."""
 
+import math
 import os
 import plistlib
 import subprocess
@@ -18,6 +19,127 @@ from gateway.restart import (
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
 )
+
+
+class TestLaunchdExitTimeout:
+    @pytest.mark.parametrize(
+        ("drain_timeout", "expected_exit_timeout"),
+        [
+            (DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT, 30),
+            (0, 30),
+            (12.25, 43),
+            (900, 930),
+        ],
+        ids=["default", "zero", "fractional", "configured-900"],
+    )
+    def test_exit_timeout_tracks_drain_timeout_with_headroom(
+        self, monkeypatch, drain_timeout, expected_exit_timeout
+    ):
+        monkeypatch.setattr(
+            gateway_cli, "_get_restart_drain_timeout", lambda: drain_timeout
+        )
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["ExitTimeOut"] == expected_exit_timeout
+
+    def test_drain_timeout_change_marks_hardcoded_exit_timeout_as_drift(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 900)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(
+            gateway_cli.generate_launchd_plist().replace(
+                "<key>ExitTimeOut</key>\n    <integer>930</integer>",
+                "<key>ExitTimeOut</key>\n    <integer>25</integer>",
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
+    @pytest.mark.parametrize(
+        ("source", "raw_timeout"),
+        [
+            ("env", "inf"),
+            ("env", "nan"),
+            ("env", "1e309"),
+            ("config", "inf"),
+            ("config", "nan"),
+            ("config", "1e309"),
+        ],
+    )
+    def test_exit_timeout_nonfinite_values_fall_back_to_default(
+        self, monkeypatch, source, raw_timeout
+    ):
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
+        if source == "env":
+            monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", raw_timeout)
+        else:
+            monkeypatch.setattr(
+                gateway_cli,
+                "read_raw_config",
+                lambda: {"agent": {"restart_drain_timeout": raw_timeout}},
+            )
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["ExitTimeOut"] == max(
+            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
+        )
+
+    def test_exit_timeout_nonmapping_agent_config_falls_back_to_default(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {"agent": []})
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert plist["ExitTimeOut"] == max(
+            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
+        )
+
+    def test_drain_timeout_nonfinite_config_keeps_default_plist_current(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"agent": {"restart_drain_timeout": "1e309"}},
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_exit_timeout_nonfinite_env_installs_with_default(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_RESTART_DRAIN_TIMEOUT", "nan")
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli, "_refuse_temp_home_service_write", lambda *_args: False
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_bootstrap", lambda *_args, **_kwargs: None
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_clear_launchd_unsupported_marker", lambda: None
+        )
+
+        gateway_cli.launchd_install(force=True)
+
+        plist = plistlib.loads(plist_path.read_bytes())
+        assert plist["ExitTimeOut"] == max(
+            30, math.ceil(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30)
+        )
 
 
 class TestUserSystemdPrivateSocketPreflight:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -709,7 +709,7 @@ class TestFTS5Search:
             # _get_read_conn opens one pool member; return it before the
             # searches so both calls deterministically borrow the traced
             # connection under the bounded-pool contract.
-            db._read_pool.put_nowait(read_conn)
+            db._return_read_conn(read_conn)
         for conn in traced_connections:
             conn.set_trace_callback(statements.append)
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4469,6 +4469,7 @@ class TestPerformancePragmasEndToEnd:
         )
         db_path = home / "state.db"
         db = SessionDB(db_path=db_path)
+        rconn = None
         try:
             # Writer connection.
             assert self._read(db._conn) == self.CONFIGURED
@@ -4477,6 +4478,8 @@ class TestPerformancePragmasEndToEnd:
             assert rconn is not None, "WAL reader expected on local filesystem"
             assert self._read(rconn) == self.CONFIGURED
         finally:
+            if rconn is not None:
+                db._close_read_conn(rconn)
             db.close()
 
         # Read-only cross-profile attach.
@@ -4494,12 +4497,15 @@ class TestPerformancePragmasEndToEnd:
         home = self._fresh_home(tmp_path, monkeypatch, config_text=None)
         db_path = home / "state.db"
         db = SessionDB(db_path=db_path)
+        rconn = None
         try:
             assert self._read(db._conn) == defaults
             rconn = db._get_read_conn()
             if rconn is not None:
                 assert self._read(rconn) == defaults
         finally:
+            if rconn is not None:
+                db._close_read_conn(rconn)
             db.close()
 
         ro = SessionDB(db_path=db_path, read_only=True)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -702,10 +702,14 @@ class TestFTS5Search:
         db.append_message("s1", role="user", content="after")
 
         statements = []
-        read_conn = db._get_read_conn() or db._conn
+        read_conn = db._get_read_conn()
         traced_connections = [db._conn]
-        if read_conn is not db._conn:
+        if read_conn is not None:
             traced_connections.append(read_conn)
+            # _get_read_conn opens one pool member; return it before the
+            # searches so both calls deterministically borrow the traced
+            # connection under the bounded-pool contract.
+            db._read_pool.put_nowait(read_conn)
         for conn in traced_connections:
             conn.set_trace_callback(statements.append)
 

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,0 +1,283 @@
+"""Tests for configurable RLIMIT_NOFILE startup handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import resource_limits
+
+
+class _FakeResource:
+    RLIMIT_NOFILE = 7
+    RLIM_INFINITY = 2**63 - 1
+
+    def __init__(self, soft: int, hard: int) -> None:
+        self.limits = (soft, hard)
+        self.set_calls: list[tuple[int, tuple[int, int]]] = []
+
+    def getrlimit(self, resource: int) -> tuple[int, int]:
+        assert resource == self.RLIMIT_NOFILE
+        return self.limits
+
+    def setrlimit(self, resource: int, limits: tuple[int, int]) -> None:
+        assert resource == self.RLIMIT_NOFILE
+        self.set_calls.append((resource, limits))
+        self.limits = limits
+
+
+def test_real_config_loader_reads_runtime_nofile_setting(monkeypatch, tmp_path):
+    """The helper uses the canonical config loader, not a second YAML parser."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "runtime:\n  nofile_soft_limit: 2048\n",
+        encoding="utf-8",
+    )
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit() is True
+    assert fake_resource.set_calls == [
+        (fake_resource.RLIMIT_NOFILE, (2048, 4096)),
+    ]
+
+
+def test_default_is_clamped_to_hard_limit(monkeypatch):
+    fake_resource = _FakeResource(soft=256, hard=1024)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is True
+    assert fake_resource.limits == (1024, 1024)
+
+
+def test_never_lowers_an_already_higher_soft_limit(monkeypatch):
+    fake_resource = _FakeResource(soft=8192, hard=16384)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit(
+        {"runtime": {"nofile_soft_limit": 4096}}
+    ) is False
+    assert fake_resource.set_calls == []
+    assert fake_resource.limits == (8192, 16384)
+
+
+@pytest.mark.parametrize("disabled", [0, False, None])
+def test_explicit_values_disable(monkeypatch, disabled):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit(
+        {"runtime": {"nofile_soft_limit": disabled}}
+    ) is False
+    assert fake_resource.set_calls == []
+
+
+def test_unsupported_platform_is_a_safe_noop(monkeypatch):
+    monkeypatch.setattr(resource_limits, "_resource", None)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is False
+
+
+@pytest.mark.parametrize("invalid", [True, -1, 4096.0, "4096", object()])
+def test_invalid_values_are_safe_noops(monkeypatch, invalid):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit(
+        {"runtime": {"nofile_soft_limit": invalid}}
+    ) is False
+    assert fake_resource.set_calls == []
+
+
+def test_setrlimit_denial_is_a_safe_noop(monkeypatch):
+    class _DeniedResource(_FakeResource):
+        def setrlimit(self, resource: int, limits: tuple[int, int]) -> None:
+            raise PermissionError("simulated EPERM")
+
+    fake_resource = _DeniedResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is False
+    assert fake_resource.limits == (256, 4096)
+
+
+def test_never_lowers_an_unlimited_soft_limit(monkeypatch):
+    fake_resource = _FakeResource(soft=-1, hard=-1)
+    fake_resource.RLIM_INFINITY = -1
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is False
+    assert fake_resource.set_calls == []
+    assert fake_resource.limits == (-1, -1)
+
+
+@pytest.mark.asyncio
+async def test_gateway_startup_applies_limit_before_gateway_initialization(monkeypatch):
+    import gateway.code_skew
+    import gateway.run as gateway_run
+
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_nofile_soft_limit",
+        lambda: calls.append("limit"),
+    )
+
+    class _StopStartup(Exception):
+        pass
+
+    def stop_after_limit():
+        calls.append("gateway-init")
+        raise _StopStartup
+
+    monkeypatch.setattr(gateway.code_skew, "record_boot_fingerprint", stop_after_limit)
+
+    with pytest.raises(_StopStartup):
+        await gateway_run.start_gateway()
+
+    assert calls == ["limit", "gateway-init"]
+
+
+def test_serve_startup_applies_limit_before_web_server(monkeypatch):
+    from hermes_cli import main as cli_main
+    import hermes_cli.plugins
+    import hermes_cli.web_server
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_nofile_soft_limit",
+        lambda: calls.append("limit"),
+    )
+    monkeypatch.setattr(cli_main, "_sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setattr(cli_main, "_build_web_ui", lambda *args, **kwargs: True)
+    monkeypatch.setattr(cli_main, "_maybe_setup_dashboard_auth_interactively", lambda args: None)
+    monkeypatch.setattr(hermes_cli.plugins, "discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        hermes_cli.web_server,
+        "start_server",
+        lambda **kwargs: calls.append("server"),
+    )
+
+    args = SimpleNamespace(
+        status=False,
+        stop=False,
+        headless_backend=True,
+        ssh_owner_nonce=None,
+        ssh_session_token_file=None,
+        host="127.0.0.1",
+        port=0,
+        no_open=True,
+        insecure=False,
+        open_profile="",
+        isolated=True,
+        skip_build=False,
+    )
+
+    cli_main.cmd_dashboard(args)
+
+    assert calls == ["limit", "server"]
+
+
+def test_named_profile_reroute_defers_limit_to_final_process(monkeypatch, tmp_path):
+    """The launcher profile must not leak its limit across machine re-exec."""
+    from hermes_cli import main as cli_main
+    import hermes_cli.profiles
+    import hermes_constants
+    from tools.environments import local as local_environment
+
+    calls: list[str] = []
+    exec_call: dict[str, object] = {}
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_nofile_soft_limit",
+        lambda: calls.append("limit"),
+    )
+    monkeypatch.setattr(
+        hermes_cli.profiles,
+        "get_active_profile_name",
+        lambda: "worker",
+    )
+    monkeypatch.setattr(cli_main, "_dashboard_listening", lambda *args: False)
+    monkeypatch.setattr(
+        local_environment,
+        "build_subprocess_env",
+        lambda **kwargs: {},
+    )
+    monkeypatch.setattr(
+        hermes_constants,
+        "get_default_hermes_root",
+        lambda: tmp_path,
+    )
+
+    class _ExecCalled(Exception):
+        pass
+
+    def stop_at_exec(executable, argv, env):
+        exec_call.update(executable=executable, argv=argv, env=env)
+        raise _ExecCalled
+
+    monkeypatch.setattr(cli_main.os, "execvpe", stop_at_exec)
+
+    args = SimpleNamespace(
+        status=False,
+        stop=False,
+        headless_backend=True,
+        ssh_owner_nonce=None,
+        ssh_session_token_file=None,
+        host="127.0.0.1",
+        port=0,
+        no_open=True,
+        insecure=False,
+        open_profile="",
+        isolated=False,
+        skip_build=False,
+    )
+
+    with pytest.raises(_ExecCalled):
+        cli_main.cmd_dashboard(args)
+
+    assert calls == []
+    assert exec_call["argv"][1:5] == ["-m", "hermes_cli.main", "-p", "default"]
+    assert exec_call["env"]["HERMES_HOME"] == str(tmp_path)
+
+
+@pytest.mark.parametrize("lifecycle_flag", ["status", "stop"])
+def test_dashboard_lifecycle_flags_skip_limit_adjustment(monkeypatch, lifecycle_flag):
+    """Informational/stop-only commands must not mutate process limits."""
+    from hermes_cli import main as cli_main
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_nofile_soft_limit",
+        lambda: calls.append("limit"),
+    )
+    monkeypatch.setattr(cli_main, "_scan_dashboard_processes", lambda: [])
+    monkeypatch.setattr(cli_main, "_find_stale_dashboard_pids", lambda: [])
+
+    args = SimpleNamespace(
+        status=lifecycle_flag == "status",
+        stop=lifecycle_flag == "stop",
+        headless_backend=False,
+        ssh_owner_nonce=None,
+        ssh_session_token_file=None,
+        host="127.0.0.1",
+        port=0,
+        no_open=True,
+        insecure=False,
+        open_profile="",
+        isolated=False,
+        skip_build=False,
+    )
+
+    with pytest.raises(SystemExit):
+        cli_main.cmd_dashboard(args)
+
+    assert calls == []

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -173,7 +173,7 @@ def test_never_lowers_an_unlimited_soft_limit(monkeypatch):
     assert fake_resource.limits == (-1, -1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_gateway_startup_applies_limit_before_gateway_initialization(monkeypatch):
     import gateway.code_skew
     import gateway.run as gateway_run

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
 from types import SimpleNamespace
 
 import pytest
@@ -53,6 +57,19 @@ def test_default_is_clamped_to_hard_limit(monkeypatch):
     assert fake_resource.limits == (1024, 1024)
 
 
+def test_finite_soft_limit_raises_when_hard_limit_is_infinite(monkeypatch):
+    fake_resource = _FakeResource(soft=256, hard=_FakeResource.RLIM_INFINITY)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is True
+    assert fake_resource.set_calls == [
+        (
+            fake_resource.RLIMIT_NOFILE,
+            (4096, fake_resource.RLIM_INFINITY),
+        ),
+    ]
+
+
 def test_never_lowers_an_already_higher_soft_limit(monkeypatch):
     fake_resource = _FakeResource(soft=8192, hard=16384)
     monkeypatch.setattr(resource_limits, "_resource", fake_resource)
@@ -81,6 +98,36 @@ def test_unsupported_platform_is_a_safe_noop(monkeypatch):
     assert resource_limits.apply_nofile_soft_limit({}) is False
 
 
+def test_fresh_process_import_without_posix_resource_is_a_safe_noop():
+    code = textwrap.dedent(
+        """
+        import importlib.util
+        import pathlib
+        import sys
+
+        sys.modules["resource"] = None
+        module_path = pathlib.Path(sys.argv[1])
+        spec = importlib.util.spec_from_file_location(
+            "hermes_cli._resource_limits_without_posix_resource",
+            module_path,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        assert module._resource is None
+        assert module.apply_nofile_soft_limit({}) is False
+        """
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", code, resource_limits.__file__],
+        check=True,
+        cwd=Path(resource_limits.__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+
 @pytest.mark.parametrize("invalid", [True, -1, 4096.0, "4096", object()])
 def test_invalid_values_are_safe_noops(monkeypatch, invalid):
     fake_resource = _FakeResource(soft=256, hard=4096)
@@ -102,6 +149,18 @@ def test_setrlimit_denial_is_a_safe_noop(monkeypatch):
 
     assert resource_limits.apply_nofile_soft_limit({}) is False
     assert fake_resource.limits == (256, 4096)
+
+
+def test_getrlimit_failure_is_a_safe_noop(monkeypatch):
+    class _BrokenResource(_FakeResource):
+        def getrlimit(self, resource: int) -> tuple[int, int]:
+            raise OSError("simulated getrlimit failure")
+
+    fake_resource = _BrokenResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_nofile_soft_limit({}) is False
+    assert fake_resource.set_calls == []
 
 
 def test_never_lowers_an_unlimited_soft_limit(monkeypatch):

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -19,6 +19,16 @@ The contract pinned here: reads borrow from a BOUNDED pool, connections are
 returned and reused, surplus connections are closed rather than dropped, and
 ``close()`` actually closes them from whatever thread it runs on.
 
+Bounded means bounded at PEAK, not merely at rest. Pooling returns behind a
+``maxsize`` LifoQueue while opening unconditionally on a miss still lets a
+burst of N simultaneous readers on a cold pool open N descriptors before
+closing the surplus -- which is the exact shape of the production incident,
+since the burst that exhausts the pool is the burst that exhausts the fd
+table. Peak is held down by a permit acquired before the open and released
+after the close; past the ceiling readers degrade to the locked writer
+connection. Tests that join their workers before counting cannot see any of
+this, so the peak assertions use a barrier.
+
 These assert on the pool/registry counts, never on ``lsof``: SQLite's unix VFS
 parks a closed descriptor on a per-inode reuse list while any connection still
 holds POSIX locks on that inode, so raw descriptor counts lag the real
@@ -58,7 +68,14 @@ def _read(db):
 
 @pytest.mark.requires_wal
 def test_read_pool_is_bounded_across_many_threads(db):
-    """150 short-lived reader threads must not pin 150 connections."""
+    """150 short-lived reader threads must not pin 150 connections.
+
+    NOTE: this measures the pool AT REST -- every worker is joined before the
+    count is taken, so by construction it cannot observe how many connections
+    were open simultaneously. It is a real assertion about accumulation and a
+    non-assertion about peak. See
+    test_peak_live_connections_bounded_under_simultaneous_burst for the peak.
+    """
     maxsize = db._read_pool.maxsize
     assert maxsize > 0, "read pool must be bounded"
 
@@ -225,3 +242,145 @@ def test_fallback_to_locked_writer_when_read_conn_unavailable(db, monkeypatch):
     monkeypatch.setattr(db, "_checkout_read_conn", lambda: None)
     assert db.get_session("s1")["id"] == "s1"
     assert db.search_messages("graphiti", limit=5)
+
+
+@pytest.mark.requires_wal
+def test_peak_live_connections_bounded_under_simultaneous_burst(db):
+    """N readers checked out AT THE SAME INSTANT must not open N connections.
+
+    This is the assertion the join-then-count test above cannot make. A
+    LifoQueue with a maxsize bounds how many connections are RETURNED, not how
+    many are OPEN: with an open-on-miss checkout, 64 readers arriving on a cold
+    pool opened 64 descriptors and only then closed 56 of them on release.
+    Bounded at rest, unbounded at peak -- and EMFILE is a peak-instant
+    condition, so the process could still wedge exactly as it did in
+    production.
+
+    The barrier is the whole point: every worker holds its connection until all
+    of them have checked out, so the count below IS the simultaneous peak
+    rather than a sample of it.
+    """
+    from hermes_state import _READ_POOL_MAX
+
+    n = 64
+    assert n > _READ_POOL_MAX, "burst must exceed the ceiling to test anything"
+
+    ready = threading.Barrier(n + 1)
+    release = threading.Event()
+    checked_out = []
+    fell_back = []
+    lock = threading.Lock()
+
+    def worker():
+        conn = db._checkout_read_conn()
+        with lock:
+            (checked_out if conn is not None else fell_back).append(conn)
+        ready.wait(timeout=30)      # everyone is now holding whatever they got
+        release.wait(timeout=30)
+        if conn is not None:
+            db._close_read_conn(conn)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+
+    ready.wait(timeout=30)
+    # ---- the instant every worker is simultaneously checked out ----
+    peak_live = _live_count(db.db_path)
+    peak_checked_out = len(checked_out)
+    release.set()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert peak_checked_out <= _READ_POOL_MAX, (
+        f"{peak_checked_out} connections checked out at once; the ceiling is "
+        f"{_READ_POOL_MAX}. Peak is unbounded -- the pool bounds returns, not opens."
+    )
+    # +1 for the writer connection SessionDB always holds.
+    assert peak_live <= _READ_POOL_MAX + 1, (
+        f"{peak_live} live connections at peak, ceiling is {_READ_POOL_MAX} (+1 writer)"
+    )
+    assert fell_back, "with n > ceiling some readers must degrade to the writer path"
+    assert len(checked_out) + len(fell_back) == n, "every worker must be accounted for"
+
+
+@pytest.mark.requires_wal
+def test_exhausted_permits_fall_back_to_the_writer_connection(db):
+    """Past the ceiling the read path degrades, it does not fail or block.
+
+    A reader that cannot get a permit must serve from the locked writer
+    connection. Blocking instead would convert descriptor exhaustion into a
+    stall -- the same outage with a different stack trace.
+    """
+    from hermes_state import _READ_POOL_MAX
+
+    held = [db._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
+    assert all(c is not None for c in held), "the first _READ_POOL_MAX must succeed"
+    try:
+        assert db._checkout_read_conn() is None, "ceiling must refuse the next open"
+        with db._read_ctx() as conn:
+            assert conn is db._conn, "must fall back to the shared writer connection"
+            assert conn.execute("SELECT 1").fetchone()[0] == 1, "fallback must work"
+    finally:
+        for c in held:
+            db._close_read_conn(c)
+
+    # Permits come back: the read path recovers once the burst drains.
+    recovered = db._checkout_read_conn()
+    assert recovered is not None, "permits must be released back after close"
+    db._close_read_conn(recovered)
+
+
+@pytest.mark.requires_wal
+def test_permits_are_not_stranded_by_a_failed_open(db, monkeypatch):
+    """A failed open must return its permit, or the ceiling ratchets to zero.
+
+    A permit leaked per failure is not a transient error: it permanently
+    shrinks the read path, so a burst of transient open failures would silently
+    demote every later read to the writer lock for the life of the process.
+    """
+    import sqlite3 as _sqlite3
+
+    import hermes_state as _hs
+    from hermes_state import _READ_POOL_MAX
+
+    def boom(*a, **kw):
+        raise _sqlite3.OperationalError("simulated open failure")
+
+    monkeypatch.setattr(_hs, "_connect_tracked_db", boom)
+    for _ in range(_READ_POOL_MAX * 3):
+        assert db._get_read_conn() is None
+        db._read_open_failed_at = 0.0    # defeat the backoff so every call opens
+    monkeypatch.undo()
+
+    db._read_open_failed_at = 0.0
+    held = [db._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
+    try:
+        assert all(c is not None for c in held), (
+            "permits were stranded by failed opens -- the ceiling ratcheted down"
+        )
+    finally:
+        for c in held:
+            if c is not None:
+                db._close_read_conn(c)
+
+
+@pytest.mark.requires_wal
+def test_close_returns_every_permit(db):
+    """close() must release the permits its drained connections held."""
+    from hermes_state import _READ_POOL_MAX
+
+    held = [db._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
+    for c in held:
+        db._read_pool.put_nowait(c)
+    assert db._read_pool.qsize() == _READ_POOL_MAX
+
+    db.close()
+    assert db._read_pool.qsize() == 0
+    assert _live_count(db.db_path) == 0
+    # BoundedSemaphore raises on over-release, so draining exactly
+    # _READ_POOL_MAX permits proves close() released neither too few nor too
+    # many.
+    for _ in range(_READ_POOL_MAX):
+        assert db._read_permits.acquire(blocking=False), "close() stranded a permit"
+    assert not db._read_permits.acquire(blocking=False), "close() over-released"

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -1,0 +1,227 @@
+"""The SessionDB read path must not leak one connection per (SessionDB x thread).
+
+``_get_read_conn`` used to cache a read-only connection in ``threading.local()``
+and pin it in a strong set (``_read_conns``) that was only ever drained by
+``close()``. Starlette dispatches sync routes on anyio worker threads, so a
+SessionDB that is never closed -- the dashboard's module-global ``_db`` and
+the per-session ``session_db`` handles -- gained a connection, and a file
+descriptor, for every worker thread that ever served a read. In production
+that walked into the 256 soft ``RLIMIT_NOFILE`` a service manager hands the
+process, after which every request failed with ``OSError`` EMFILE while the
+process stayed alive, so the supervisor's restart-on-exit never fired.
+
+Worse, those connections were opened WITHOUT ``check_same_thread=False`` (both
+writer opens pass it), so ``close()`` on them raised ``ProgrammingError`` from
+a different thread and the bare ``except Exception: pass`` hid it -- leaving
+``hermes_cli.sqlite_safe_read``'s registry permanently over-counted as well.
+
+The contract pinned here: reads borrow from a BOUNDED pool, connections are
+returned and reused, surplus connections are closed rather than dropped, and
+``close()`` actually closes them from whatever thread it runs on.
+
+These assert on the pool/registry counts, never on ``lsof``: SQLite's unix VFS
+parks a closed descriptor on a per-inode reuse list while any connection still
+holds POSIX locks on that inode, so raw descriptor counts lag the real
+connection count and make such assertions flaky.
+"""
+
+import threading
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _live_count(path) -> int:
+    """Live-connection count the tracking registry holds for *path*."""
+    import hermes_cli.sqlite_safe_read as mod
+
+    with mod._live_lock:
+        return mod._live_connections.get(mod._key(path), 0)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session(session_id="s1", source="cli", model="m")
+    d.append_message("s1", role="user", content="hello graphiti world")
+    d.append_message("s1", role="assistant", content="the neo4j daemon is healthy")
+    yield d
+    d.close()
+
+
+def _read(db):
+    db.get_session("s1")
+    db.search_messages("graphiti", limit=5)
+    db.get_messages("s1")
+
+
+@pytest.mark.requires_wal
+def test_read_pool_is_bounded_across_many_threads(db):
+    """150 short-lived reader threads must not pin 150 connections."""
+    maxsize = db._read_pool.maxsize
+    assert maxsize > 0, "read pool must be bounded"
+
+    for _ in range(6):
+        threads = [threading.Thread(target=_read, args=(db,)) for _ in range(25)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert db._read_pool.qsize() <= maxsize
+
+    # The pre-fix code held 151 connections here (150 readers + main thread).
+    assert db._read_pool.qsize() <= maxsize
+    # +1 for the writer connection SessionDB always holds.
+    assert _live_count(db.db_path) <= maxsize + 1
+
+
+@pytest.mark.requires_wal
+def test_read_conn_returned_to_pool_and_reused(db):
+    """Sequential reads on one thread reuse a pooled connection, not a new one."""
+    with db._read_ctx() as conn:
+        first = conn
+    assert db._read_pool.qsize() >= 1, "connection was not returned to the pool"
+    with db._read_ctx() as conn:
+        assert conn is first, "pooled connection was not reused"
+
+
+@pytest.mark.requires_wal
+def test_pooled_conn_is_usable_from_another_thread(db):
+    """A pooled connection is handed between threads, so it must not be
+    bound to its creating thread (check_same_thread=False)."""
+    with db._read_ctx() as conn:
+        borrowed = conn
+
+    errors = []
+
+    def use_it():
+        try:
+            borrowed.execute("SELECT 1").fetchone()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t = threading.Thread(target=use_it)
+    t.start()
+    t.join()
+    assert not errors, f"pooled connection unusable off-thread: {errors}"
+
+
+@pytest.mark.requires_wal
+def test_close_drains_pool_from_a_foreign_thread(tmp_path):
+    """close() must actually close pooled connections, including ones opened
+    on threads that have since exited -- the swallowed ProgrammingError."""
+    d = SessionDB(db_path=tmp_path / "state2.db")
+    d.create_session(session_id="s1", source="cli", model="m")
+
+    # Populate the pool from a worker thread, then let that thread die.
+    t = threading.Thread(target=lambda: d.get_session("s1"))
+    t.start()
+    t.join()
+    assert d._read_pool.qsize() >= 1
+
+    d.close()
+    assert d._read_pool.qsize() == 0
+    # Registry back to zero proves the closes succeeded rather than raising
+    # ProgrammingError into a bare except.
+    assert _live_count(d.db_path) == 0
+
+
+@pytest.mark.requires_wal
+def test_reader_after_close_does_not_repopulate_pool(db):
+    """A read racing close() must close its connection, not refill the pool."""
+    db.close()
+    assert db._read_pool.qsize() == 0
+    # A read arriving after the drain must not open-and-requeue a connection
+    # that nothing will ever close again.
+    with db._read_ctx():
+        pass
+    assert db._read_pool.qsize() == 0
+
+
+def test_reads_are_still_correct_under_concurrency(db):
+    """Pooling must not corrupt results when threads share connections."""
+    results = []
+    errors = []
+
+    def reader():
+        try:
+            results.append(db.get_session("s1")["id"])
+            results.append(len(db.get_messages("s1")))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=reader) for _ in range(12)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, f"concurrent reads failed: {errors}"
+    assert results.count("s1") == 12
+    assert results.count(2) == 12
+
+
+@pytest.mark.requires_wal
+def test_read_open_failure_backs_off_but_recovers(db):
+    """A failed read-only open must not permanently demote the read path.
+
+    The first version of this fix used a sticky instance-wide boolean
+    (``_read_open_failed``). Its likeliest trigger is transient fd pressure --
+    EMFILE, the very condition this pool exists to prevent -- and because the
+    gateway shares ONE SessionDB across every agent, a single blip would have
+    convoyed every subsequent reader behind the writer lock for the life of
+    the process. The stamp must expire.
+    """
+    import time as _time
+
+    from hermes_state import _READ_OPEN_RETRY_SECONDS
+
+    baseline = db._get_read_conn()
+    assert baseline is not None, "baseline read open should succeed"
+    db._close_read_conn(baseline)
+
+    db._read_open_failed_at = _time.monotonic()
+    assert db._get_read_conn() is None, "should back off immediately after a failure"
+
+    db._read_open_failed_at = _time.monotonic() - (_READ_OPEN_RETRY_SECONDS + 1)
+    recovered = db._get_read_conn()
+    assert recovered is not None, "read path must self-heal once the window expires"
+    db._close_read_conn(recovered)
+
+
+@pytest.mark.requires_wal
+def test_checkout_seam_is_the_single_acquisition_point(db):
+    """``_read_ctx`` must acquire via ``_checkout_read_conn`` and nothing else.
+
+    If a future edit re-inlines the pool checkout into ``_read_ctx``, patching
+    ``_get_read_conn`` silently exercises nothing whenever the pool is warm --
+    which is exactly how the writer-lock fallback test below would rot into a
+    no-op without failing.
+    """
+    calls = []
+    original = db._checkout_read_conn
+
+    def _spy():
+        calls.append(1)
+        return original()
+
+    db._checkout_read_conn = _spy
+    try:
+        with db._read_ctx():
+            pass
+    finally:
+        db._checkout_read_conn = original
+    assert calls, "_read_ctx must route acquisition through _checkout_read_conn"
+
+
+def test_fallback_to_locked_writer_when_read_conn_unavailable(db, monkeypatch):
+    """With no read connection available, reads still work under self._lock.
+
+    Patched at the acquisition SEAM rather than at ``_get_read_conn``: the
+    pool is consulted first, so a patched ``_get_read_conn`` is never reached
+    while the pool holds a connection and this test would pass while
+    exercising nothing.
+    """
+    monkeypatch.setattr(db, "_checkout_read_conn", lambda: None)
+    assert db.get_session("s1")["id"] == "s1"
+    assert db.search_messages("graphiti", limit=5)

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -230,6 +230,91 @@ def test_close_waits_for_checked_out_reader_before_returning(db, monkeypatch):
     assert _live_count(db.db_path) == 0
 
 
+@pytest.mark.requires_wal
+def test_close_waits_for_post_shutdown_open_to_physically_close(db, monkeypatch):
+    """An opener losing to close remains counted until conn.close finishes."""
+    import hermes_state as _hs
+
+    real_connect = _hs._connect_tracked_db
+    real_close = db._close_read_conn
+    open_started = threading.Event()
+    allow_open = threading.Event()
+    physical_close_started = threading.Event()
+    allow_physical_close = threading.Event()
+
+    def blocked_connect(*args, **kwargs):
+        open_started.set()
+        assert allow_open.wait(timeout=10)
+        return real_connect(*args, **kwargs)
+
+    def blocked_close(conn):
+        physical_close_started.set()
+        assert allow_physical_close.wait(timeout=10)
+        real_close(conn)
+
+    monkeypatch.setattr(_hs, "_connect_tracked_db", blocked_connect)
+    monkeypatch.setattr(db, "_close_read_conn", blocked_close)
+
+    worker = threading.Thread(target=db._get_read_conn)
+    worker.start()
+    assert open_started.wait(timeout=10)
+    close_returned = threading.Event()
+    closer = threading.Thread(target=lambda: (db.close(), close_returned.set()))
+    closer.start()
+    allow_open.set()
+    assert physical_close_started.wait(timeout=10)
+
+    returned_before_physical_close = close_returned.wait(timeout=2)
+    allow_physical_close.set()
+    worker.join(timeout=10)
+    closer.join(timeout=10)
+
+    assert not returned_before_physical_close
+    assert not worker.is_alive() and not closer.is_alive()
+    assert _live_count(db.db_path) == 0
+
+
+@pytest.mark.requires_wal
+def test_close_waits_for_returned_reader_to_physically_close(db, monkeypatch):
+    """A checked-out reader stays active through its shutdown-path close."""
+    real_close = db._close_read_conn
+    reader_active = threading.Event()
+    leave_context = threading.Event()
+    physical_close_started = threading.Event()
+    allow_physical_close = threading.Event()
+
+    def blocked_close(conn):
+        physical_close_started.set()
+        assert allow_physical_close.wait(timeout=10)
+        real_close(conn)
+
+    monkeypatch.setattr(db, "_close_read_conn", blocked_close)
+
+    def reader():
+        with db._read_ctx() as conn:
+            conn.execute("SELECT 1").fetchone()
+            reader_active.set()
+            assert leave_context.wait(timeout=10)
+
+    worker = threading.Thread(target=reader)
+    worker.start()
+    assert reader_active.wait(timeout=10)
+    close_returned = threading.Event()
+    closer = threading.Thread(target=lambda: (db.close(), close_returned.set()))
+    closer.start()
+    leave_context.set()
+    assert physical_close_started.wait(timeout=10)
+
+    returned_before_physical_close = close_returned.wait(timeout=2)
+    allow_physical_close.set()
+    worker.join(timeout=10)
+    closer.join(timeout=10)
+
+    assert not returned_before_physical_close
+    assert not worker.is_alive() and not closer.is_alive()
+    assert _live_count(db.db_path) == 0
+
+
 def test_reads_are_still_correct_under_concurrency(db):
     """Pooling must not corrupt results when threads share connections."""
     results = []

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -384,3 +384,43 @@ def test_close_returns_every_permit(db):
     for _ in range(_READ_POOL_MAX):
         assert db._read_permits.acquire(blocking=False), "close() stranded a permit"
     assert not db._read_permits.acquire(blocking=False), "close() over-released"
+
+
+def test_failed_close_does_not_widen_the_descriptor_ceiling(db):
+    """A connection that failed to close still owns its descriptor permit."""
+
+    class UnclosableConnection:
+        def close(self):
+            raise OSError("simulated close failure")
+
+    db._read_permits = threading.BoundedSemaphore(1)
+    assert db._read_permits.acquire(blocking=False)
+
+    db._close_read_conn(UnclosableConnection())
+
+    assert not db._read_permits.acquire(blocking=False)
+
+
+@pytest.mark.requires_wal
+def test_failed_partial_open_close_keeps_its_descriptor_permit(db, monkeypatch):
+    """A half-open connection with a failed close must also fail closed."""
+    import sqlite3 as _sqlite3
+
+    import hermes_state as _hs
+
+    class UnclosableConnection:
+        row_factory = None
+
+        def close(self):
+            raise OSError("simulated close failure")
+
+    monkeypatch.setattr(_hs, "_connect_tracked_db", lambda *_a, **_k: UnclosableConnection())
+    monkeypatch.setattr(
+        _hs,
+        "apply_database_pragmas",
+        lambda *_a, **_k: (_ for _ in ()).throw(_sqlite3.OperationalError("init failed")),
+    )
+    db._read_permits = threading.BoundedSemaphore(1)
+
+    assert db._get_read_conn() is None
+    assert not db._read_permits.acquire(blocking=False)

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -156,6 +156,80 @@ def test_reader_after_close_does_not_repopulate_pool(db):
     assert db._read_pool.qsize() == 0
 
 
+@pytest.mark.requires_wal
+def test_read_open_racing_close_is_discarded(db, monkeypatch):
+    """An opener that crossed the pre-open gate must still honor close()."""
+    import hermes_state as _hs
+
+    real_connect = _hs._connect_tracked_db
+    open_started = threading.Event()
+    allow_open = threading.Event()
+    result = []
+
+    def blocked_connect(*args, **kwargs):
+        open_started.set()
+        assert allow_open.wait(timeout=10), "test did not release blocked read open"
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(_hs, "_connect_tracked_db", blocked_connect)
+    worker = threading.Thread(target=lambda: result.append(db._get_read_conn()))
+    worker.start()
+    assert open_started.wait(timeout=10), "read open never reached the race window"
+
+    close_returned = threading.Event()
+    closer = threading.Thread(target=lambda: (db.close(), close_returned.set()))
+    closer.start()
+    returned_before_open = close_returned.wait(timeout=2)
+    allow_open.set()
+    worker.join(timeout=10)
+    closer.join(timeout=10)
+
+    assert not worker.is_alive() and not closer.is_alive()
+    assert not returned_before_open, "close returned while a read open was still in flight"
+    assert result == [None], "a reader opened after SessionDB.close() completed"
+    assert _live_count(db.db_path) == 0, "the post-close reader remained tracked/open"
+
+
+@pytest.mark.requires_wal
+def test_close_waits_for_checked_out_reader_before_returning(db, monkeypatch):
+    """close() cannot return while a checked-out reader can still start work."""
+    checked_out = threading.Event()
+    allow_handoff = threading.Event()
+    original_checkout = db._checkout_read_conn
+    query_completed = threading.Event()
+
+    def blocked_checkout():
+        conn = original_checkout()
+        checked_out.set()
+        assert allow_handoff.wait(timeout=10), "test did not release checkout handoff"
+        return conn
+
+    monkeypatch.setattr(db, "_checkout_read_conn", blocked_checkout)
+
+    def reader():
+        with db._read_ctx() as conn:
+            conn.execute("SELECT 1").fetchone()
+            query_completed.set()
+
+    worker = threading.Thread(target=reader)
+    worker.start()
+    assert checked_out.wait(timeout=10)
+
+    close_returned = threading.Event()
+    closer = threading.Thread(target=lambda: (db.close(), close_returned.set()))
+    closer.start()
+    returned_before_handoff = close_returned.wait(timeout=2)
+    allow_handoff.set()
+    worker.join(timeout=10)
+    closer.join(timeout=10)
+
+    assert not worker.is_alive() and not closer.is_alive()
+    assert not returned_before_handoff, "close returned before an active checkout drained"
+    assert query_completed.is_set()
+    assert close_returned.is_set()
+    assert _live_count(db.db_path) == 0
+
+
 def test_reads_are_still_correct_under_concurrency(db):
     """Pooling must not corrupt results when threads share connections."""
     results = []
@@ -372,7 +446,7 @@ def test_close_returns_every_permit(db):
 
     held = [db._checkout_read_conn() for _ in range(_READ_POOL_MAX)]
     for c in held:
-        db._read_pool.put_nowait(c)
+        db._return_read_conn(c)
     assert db._read_pool.qsize() == _READ_POOL_MAX
 
     db.close()

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -8,6 +8,7 @@ per-thread read-only connection under WAL, never touch self._lock, and fall
 back to the legacy locked path when WAL or the read connection is missing.
 """
 
+import gc
 import threading
 
 import pytest
@@ -37,6 +38,25 @@ def test_read_conn_is_per_thread(db):
     t1.start(); t2.start(); t1.join(); t2.join()
     assert conns[1] is not None and conns[2] is not None
     assert conns[1] is not conns[2]
+
+
+@pytest.mark.requires_wal
+def test_short_lived_reader_threads_release_their_connections(db):
+    """A long-running gateway must not retain one SQLite FD pair per worker.
+
+    Gateway/webhook work uses short-lived threads.  The read connection is
+    thread-scoped, so the thread's exit is also the connection's ownership
+    boundary; retaining those connections until gateway shutdown eventually
+    exhausts macOS launchd's file-descriptor limit.
+    """
+    for _ in range(40):
+        thread = threading.Thread(target=lambda: db.get_session("s1"))
+        thread.start()
+        thread.join(timeout=5.0)
+        assert not thread.is_alive()
+
+    gc.collect()
+    assert len(db._read_conns) <= 8
 
 
 def test_read_conn_reused_within_thread(db):

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -1,11 +1,12 @@
-"""Tests for the SessionDB read-path split (per-thread read-only connections).
+"""Tests for the SessionDB read-path split (pooled read-only connections).
 
 The gateway shares ONE SessionDB across every agent, so recall/browse reads
 used to queue behind writer flushes on self._lock — a measured production
 convoy (a 0.2s FTS query stretched to 112s while 6-8 concurrent turns
 flushed tool results). These tests pin the new contract: reads run on a
-per-thread read-only connection under WAL, never touch self._lock, and fall
-back to the legacy locked path when WAL or the read connection is missing.
+read-only connection borrowed from a bounded pool under WAL, never touch
+self._lock, and fall back to the legacy locked path when WAL or the read
+connection is missing.
 """
 
 import gc
@@ -41,14 +42,8 @@ def test_read_conn_is_per_thread(db):
 
 
 @pytest.mark.requires_wal
-def test_short_lived_reader_threads_release_their_connections(db):
-    """A long-running gateway must not retain one SQLite FD pair per worker.
-
-    Gateway/webhook work uses short-lived threads.  The read connection is
-    thread-scoped, so the thread's exit is also the connection's ownership
-    boundary; retaining those connections until gateway shutdown eventually
-    exhausts macOS launchd's file-descriptor limit.
-    """
+def test_short_lived_reader_threads_use_the_bounded_pool(db):
+    """A long-running gateway must not retain one SQLite FD pair per worker."""
     for _ in range(40):
         thread = threading.Thread(target=lambda: db.get_session("s1"))
         thread.start()
@@ -56,11 +51,21 @@ def test_short_lived_reader_threads_release_their_connections(db):
         assert not thread.is_alive()
 
     gc.collect()
-    assert len(db._read_conns) <= 8
+    assert db._read_pool.qsize() <= 8
 
 
-def test_read_conn_reused_within_thread(db):
-    assert db._get_read_conn() is db._get_read_conn()
+def test_read_conn_reused_via_pool(db):
+    """Reuse is now the pool's job, not a per-thread memo.
+
+    The old contract (``_get_read_conn()`` returns the same object twice on one
+    thread) was the leak: that memo pinned one unclosable connection per
+    (SessionDB x thread) forever. ``_get_read_conn`` now always opens a fresh
+    connection and reuse happens via checkout/return, so assert on that.
+    """
+    with db._read_ctx() as first:
+        assert first is not None
+    with db._read_ctx() as second:
+        assert second is first, "sequential readers must reuse the pooled conn"
 
 
 @pytest.mark.requires_wal

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -37,8 +37,13 @@ def test_read_conn_is_per_thread(db):
     t1 = threading.Thread(target=grab, args=(1,))
     t2 = threading.Thread(target=grab, args=(2,))
     t1.start(); t2.start(); t1.join(); t2.join()
-    assert conns[1] is not None and conns[2] is not None
-    assert conns[1] is not conns[2]
+    try:
+        assert conns[1] is not None and conns[2] is not None
+        assert conns[1] is not conns[2]
+    finally:
+        for conn in conns.values():
+            if conn is not None:
+                db._close_read_conn(conn)
 
 
 @pytest.mark.requires_wal

--- a/tests/tools/test_send_message_task_forum.py
+++ b/tests/tools/test_send_message_task_forum.py
@@ -1,0 +1,63 @@
+"""Behavior tests for Discord task-forum routing in send_message."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from tools.send_message_tool import _send_to_platform
+
+
+@pytest.mark.asyncio
+async def test_static_delivery_to_task_forum_is_blocked():
+    """Cron/lifecycle callers cannot create inert task-forum posts."""
+    pconfig = SimpleNamespace(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["tasks-parent"]},
+    )
+
+    result = await _send_to_platform(
+        Platform.DISCORD,
+        pconfig,
+        "tasks-parent",
+        "inert task",
+    )
+
+    assert "error" in result
+    assert "task forum" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_explicit_agent_task_uses_live_adapter(monkeypatch):
+    """Agent-initiated work is routed to the live session-start path."""
+    recorded = {}
+
+    class Adapter:
+        async def send(self, *, chat_id, content, metadata=None):
+            recorded.update(chat_id=chat_id, content=content, metadata=metadata)
+            return SimpleNamespace(
+                success=True,
+                message_id="starter",
+                raw_response={"thread_id": "task-thread"},
+            )
+
+    runner = SimpleNamespace(adapters={Platform.DISCORD: Adapter()})
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+    pconfig = SimpleNamespace(
+        enabled=True,
+        token="***",
+        extra={"agent_task_forum_channels": ["tasks-parent"]},
+    )
+
+    result = await _send_to_platform(
+        Platform.DISCORD,
+        pconfig,
+        "tasks-parent",
+        "real task",
+        start_agent_task=True,
+    )
+
+    assert result["success"] is True
+    assert result["thread_id"] == "task-thread"
+    assert recorded["metadata"] == {"start_agent_task": True}

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -487,6 +487,11 @@ def _handle_send(args):
 
     try:
         from model_tools import _run_async
+        start_agent_task = (
+            platform_name == "discord"
+            and thread_id is None
+            and _is_discord_agent_task_forum(pconfig, chat_id)
+        )
         result = _run_async(
             _send_to_platform(
                 platform,
@@ -496,13 +501,19 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                start_agent_task=start_agent_task,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
 
         # Mirror the sent message into the target's gateway session
-        if isinstance(result, dict) and result.get("success") and mirror_text:
+        if (
+            isinstance(result, dict)
+            and result.get("success")
+            and mirror_text
+            and not start_agent_task
+        ):
             try:
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env
@@ -685,6 +696,19 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
+def _is_discord_agent_task_forum(pconfig, chat_id) -> bool:
+    """Return whether ``chat_id`` is configured as an agent-only task forum."""
+    extra = getattr(pconfig, "extra", None)
+    raw = extra.get("agent_task_forum_channels") if isinstance(extra, dict) else None
+    if isinstance(raw, (list, tuple, set)):
+        configured = {str(value).strip() for value in raw if str(value).strip()}
+    else:
+        configured = {
+            value.strip() for value in str(raw or "").split(",") if value.strip()
+        }
+    return str(chat_id) in configured
+
+
 async def _send_via_adapter(
     platform,
     pconfig,
@@ -694,6 +718,7 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    start_agent_task=False,
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -726,6 +751,8 @@ async def _send_via_adapter(
                     metadata["thread_id"] = thread_id
                 if platform_name == "ntfy" and chat_id:
                     metadata["publish_topic"] = chat_id
+                if start_agent_task:
+                    metadata["start_agent_task"] = True
                 if not metadata:
                     metadata = None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
@@ -734,8 +761,19 @@ async def _send_via_adapter(
             except Exception as e:
                 return {"error": f"Plugin platform send failed: {e}"}
             if result.success:
-                return {"success": True, "message_id": result.message_id}
+                response = {"success": True, "message_id": result.message_id}
+                if isinstance(getattr(result, "raw_response", None), dict):
+                    response.update(result.raw_response)
+                return response
             return {"error": f"Adapter send failed: {result.error}"}
+
+    if start_agent_task:
+        return {
+            "error": (
+                "Starting a live Discord task requires the running gateway; "
+                "static task-forum delivery is blocked."
+            )
+        }
 
     entry = None
     try:
@@ -780,7 +818,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    start_agent_task=False,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -870,6 +917,31 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # historically went straight to the HTTP path; we preserve that by
     # explicitly invoking the registry hook here so behavior is unchanged.
     if platform == Platform.DISCORD:
+        is_task_forum = thread_id is None and _is_discord_agent_task_forum(
+            pconfig, chat_id
+        )
+        if is_task_forum and not start_agent_task:
+            return {
+                "error": (
+                    "Direct bot delivery to this Discord task forum is blocked. "
+                    "Use a live agent task thread instead."
+                )
+            }
+        if start_agent_task:
+            if media_files:
+                return {
+                    "error": (
+                        "Live Discord task-thread starts currently require a text-only "
+                        "prompt; attach files after the thread starts."
+                    )
+                }
+            return await _send_via_adapter(
+                platform,
+                pconfig,
+                chat_id,
+                message,
+                start_agent_task=True,
+            )
         from gateway.platform_registry import platform_registry
         entry = platform_registry.get("discord")
         if entry is None or entry.standalone_sender_fn is None:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -69,6 +69,24 @@ cannot override, via a system-level managed directory. See
 [Managed Scope](/user-guide/managed-scope).
 :::
 
+## Runtime Limits
+
+Long-running Hermes server surfaces (including the gateway and
+`hermes serve --isolated`) apply the configured `RLIMIT_NOFILE` soft limit
+during startup when the operating system supports it:
+
+```yaml
+runtime:
+  nofile_soft_limit: 4096
+```
+
+The default is `4096`. Hermes clamps the target to the operating system's hard
+limit and never lowers a process that already has a higher soft limit. Set the
+value to `0`, `false`, or `null` to disable the adjustment. On Windows and in
+sandboxes
+where the limit cannot be changed, startup continues without changing the
+limit.
+
 ## Environment Variable Substitution
 
 You can reference environment variables in `config.yaml` using `${VAR_NAME}` syntax:


### PR DESCRIPTION
## What\nRoute unmarked SIGTERM received by a supervised gateway through the existing after-turn restart path instead of immediately entering the short force-drain path.\n\n## Why\nLaunchd restarts were interrupting live Discord task threads and cron work after 30 seconds. Explicit planned stops and --replace takeovers keep their immediate-stop behavior.\n\n## Validation\n- 110 focused signal/restart/resume/cron-drain tests\n- Python compilation for changed modules\n- git diff --check\n\n## Residual\nThe unrelated macOS shutdown-forensics test currently fails because its helper invokes the Linux timeout command, which is not installed on this host.